### PR TITLE
Move notation from model to __init__.py

### DIFF
--- a/torchrec/models/__init__.py
+++ b/torchrec/models/__init__.py
@@ -15,6 +15,13 @@ Along with the overall model, the individual architectures of each layer are als
 provided (e.g. `SparseArch`, `DenseArch`, `InteractionArch`, and `OverArch`).
 
 Examples can be found within each model.
+
+The following notation is used throughout the documentation for the models:
+
+- F: number of sparse features
+- D: embedding_dimension of sparse features
+- B: batch size
+- num_features: number of dense features
 """
 
 from . import deepfm  # noqa

--- a/torchrec/models/deepfm.py
+++ b/torchrec/models/deepfm.py
@@ -224,13 +224,6 @@ class SimpleDeepFMNN(nn.Module):
     The module assumes all sparse features have the same embedding dimension
     (i.e, each EmbeddingBagConfig uses the same embedding_dim)
 
-    The following notation is used throughout the documentation for the models:
-
-    F: number of sparse features
-    D: embedding_dimension of sparse features
-    B: batch size
-    num_features: number of dense features
-
     Args:
         num_dense_features (int): the number of input dense features.
         embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags

--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -257,13 +257,6 @@ class DLRM(nn.Module):
     The module assumes all sparse features have the same embedding dimension
     (i.e. each EmbeddingBagConfig uses the same embedding_dim).
 
-    The following notation is used throughout the documentation for the models:
-
-    F: number of sparse features
-    D: embedding_dimension of sparse features
-    B: batch size
-    num_features: number of dense features
-
     Args:
         embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
             used to define SparseArch.


### PR DESCRIPTION
Summary:
In the public docs, I thought that the model class docs would show up on a different page than the __init__.py docs for the models directory. It doesn't, they show up in the same page, so we don't need to repeat the notation information.

Also the notation shows up all in one line:

{F703712065}

bullet points would be nicer.

Differential Revision: D34390595

