### PR TITLE
Rename ta.DataFrame/Column to ta.dataframe/column (#218)

### DIFF
--- a/examples/datasets/criteo_dataframes.py
+++ b/examples/datasets/criteo_dataframes.py
@@ -103,6 +103,6 @@ def criteo_dataframes_from_tsv(
 
     datapipe = CriteoIterDataPipe(paths, row_mapper=_torcharrow_row_mapper)
     datapipe = dp.iter.Batcher(datapipe, batch_size)
-    datapipe = dp.iter.Mapper(datapipe, lambda batch: ta.DataFrame(batch, dtype=DTYPE))
+    datapipe = dp.iter.Mapper(datapipe, lambda batch: ta.dataframe(batch, dtype=DTYPE))
 
     return datapipe


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/torcharrow/pull/218

This is the first step; in follow-up diff will rename IDataFrame/IColumn -> DataFrame/Column

Reviewed By: OswinC

Differential Revision: D34411896

