### PR TITLE
Some changes on trec inference

### DIFF
--- a/torchrec/inference/BatchingQueue.cpp
+++ b/torchrec/inference/BatchingQueue.cpp
@@ -255,4 +255,8 @@ void BatchingQueue::processCallback(int gpuIdx) {
   }
 }
 
+BatchingQueue::~BatchingQueue() {
+  stop();
+}
+
 } // namespace torchrec

--- a/torchrec/inference/BatchingQueue.h
+++ b/torchrec/inference/BatchingQueue.h
@@ -71,6 +71,7 @@ class BatchingQueue {
       std::vector<BatchQueueCb> cbs,
       const Config& config,
       int worldSize);
+  ~BatchingQueue();
 
   void add(
       std::shared_ptr<PredictionRequest> request,

--- a/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/GPUExecutor.h
@@ -26,7 +26,7 @@ namespace torchrec {
 class GPUExecutor {
  public:
   GPUExecutor(
-      torch::deploy::InterpreterManager& manager,
+      std::shared_ptr<torch::deploy::InterpreterManager> manager,
       torch::deploy::ReplicatedObj model,
       int rank,
       int worldSize);
@@ -40,7 +40,7 @@ class GPUExecutor {
 
  private:
   // torch deploy
-  torch::deploy::InterpreterManager& manager_;
+  std::shared_ptr<torch::deploy::InterpreterManager> manager_;
   torch::deploy::ReplicatedObj model_;
   int rank_;
   int worldSize_;


### PR DESCRIPTION
Call stop() when destruct BatchingQueue().

Switch from storing a reference of torch deploy interpreter manager to a shared pointer that points to the manager,

Reviewed By: yinghai

Differential Revision: D34305608