### PR TITLE
fix batching queue test

### DIFF
--- a/torchrec/inference/tests/BatchingQueueTest.cpp
+++ b/torchrec/inference/tests/BatchingQueueTest.cpp
@@ -59,7 +59,6 @@ TEST(BatchingQueueTest, Basic) {
       batchQueueCbs,
       BatchingQueue::Config{.batchingMetadata = {{"float_features", "dense"}}},
       1);
-  auto guard = folly::makeGuard([&] { queue.stop(); });
 
   queue.add(
       createRequest(2, 2),


### PR DESCRIPTION
Summary: We add call to `stop()` in destructor of BatchingQueue. Removing the scope guard in the unit test.

Differential Revision: D34524545

