### PR TITLE
allow different return types for predict module

### DIFF
--- a/torchrec/inference/CMakeLists.txt
+++ b/torchrec/inference/CMakeLists.txt
@@ -33,7 +33,8 @@ include_directories(include/)
 add_library(inference SHARED
   src/Batching.cpp
   src/BatchingQueue.cpp
-  src/GPUExecutor.cpp)
+  src/GPUExecutor.cpp
+  src/ResultSplit.cpp)
 
 target_link_libraries(inference
   ${TORCH_DEPLOY_LIB_PATH}

--- a/torchrec/inference/include/torchrec/inference/BatchingQueue.h
+++ b/torchrec/inference/include/torchrec/inference/BatchingQueue.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <queue>
+#include <string>
 #include <unordered_map>
 
 #include <ATen/ATen.h>
@@ -37,7 +38,7 @@ struct RequestContext {
 };
 
 struct PredictionBatch {
-  size_t batch_size;
+  size_t batchSize;
 
   c10::Dict<std::string, at::Tensor> forwardArgs;
 
@@ -61,7 +62,7 @@ class BatchingQueue {
     int numMemPinnerThreads = 4;
     int maxBatchSize = 2000;
     // For feature name to BatchingFunc name.
-    std::unordered_map<std::string, std::string> batchingMetadata;
+    const std::unordered_map<std::string, std::string>& batchingMetadata;
   };
 
   BatchingQueue(const BatchingQueue&) = delete;

--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -20,6 +20,7 @@
 #include <torch/csrc/deploy/deploy.h> // @manual
 
 #include "torchrec/inference/BatchingQueue.h"
+#include "torchrec/inference/ResultSplit.h"
 
 namespace torchrec {
 
@@ -29,7 +30,8 @@ class GPUExecutor {
       std::shared_ptr<torch::deploy::InterpreterManager> manager,
       torch::deploy::ReplicatedObj model,
       int rank,
-      int worldSize);
+      int worldSize,
+      std::shared_ptr<torchrec::ResultSplitFunc> func);
   GPUExecutor(GPUExecutor&& executor) noexcept = default;
   GPUExecutor& operator=(GPUExecutor&& executor) noexcept = default;
   ~GPUExecutor();
@@ -47,6 +49,7 @@ class GPUExecutor {
 
   folly::MPMCQueue<std::shared_ptr<PredictionBatch>> batches_;
   std::vector<std::thread> processThreads_;
+  std::shared_ptr<torchrec::ResultSplitFunc> resultSplitFunc_;
 };
 
 } // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/ResultSplit.h
+++ b/torchrec/inference/include/torchrec/inference/ResultSplit.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+#include <c10/util/Registry.h>
+
+namespace torchrec {
+
+class ResultSplitFunc {
+ public:
+  virtual ~ResultSplitFunc() = default;
+
+  virtual c10::IValue splitResult(
+      c10::IValue /* result */,
+      const size_t& /* offset */,
+      const size_t& /* length */) = 0;
+};
+
+/**
+ * TorchRecResultSplitFuncRegistry is used to register custom result split
+ * functions.
+ */
+C10_DECLARE_REGISTRY(TorchRecResultSplitFuncRegistry, ResultSplitFunc);
+
+#define REGISTER_TORCHREC_RESULTSPLIT_FUNC(name, ...) \
+  C10_REGISTER_CLASS(TorchRecResultSplitFuncRegistry, name, __VA_ARGS__);
+
+c10::IValue splitDictOfTensor(
+    c10::IValue result,
+    const size_t& offset,
+    const size_t& length);
+
+} // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include "ATen/core/ivalue.h"
 
 #include <folly/io/IOBuf.h>
 
@@ -35,7 +36,8 @@ struct FloatFeatures {
 };
 
 // TODO: Change the input format to torch::IValue.
-using Feature = std::variant<SparseFeatures, FloatFeatures>;
+// Currently only dense batching function support IValue.
+using Feature = std::variant<SparseFeatures, FloatFeatures, c10::IValue>;
 
 struct PredictionRequest {
   uint32_t batch_size;

--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -45,8 +45,7 @@ struct PredictionRequest {
 };
 
 struct PredictionResponse {
-  // Task name to prediction Tensor
-  std::map<std::string, folly::IOBuf> predictions;
+  c10::IValue predictions;
 };
 
 } // namespace torchrec

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -67,6 +67,12 @@ class PredictFactory(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def result_metadata(self) -> str:
+        """
+        Returns a string which represents the result type. This information is used for result split.
+        """
+        pass
 
 class PredictModule(nn.Module):
     """
@@ -105,12 +111,12 @@ class PredictModule(nn.Module):
         return self._module
 
     @abc.abstractmethod
-    def predict_forward(
-        self, batch: Dict[str, torch.Tensor]
-    ) -> Dict[str, torch.Tensor]:
+    # pyre-fixme[3]
+    def predict_forward(self, batch: Dict[str, torch.Tensor]) -> Any:
         pass
 
-    def forward(self, batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    # pyre-fixme[3]
+    def forward(self, batch: Dict[str, torch.Tensor]) -> Any:
         if self._device is None:
             self._device = torch.device("cuda", torch.cuda.current_device())
         with torch.cuda.device(self._device), torch.inference_mode():
@@ -136,12 +142,12 @@ class MultistreamPredictModule(PredictModule):
         self._stream: Optional[torch.cuda.streams.Stream] = None
 
     @abc.abstractmethod
-    def predict_forward(
-        self, batch: Dict[str, torch.Tensor]
-    ) -> Dict[str, torch.Tensor]:
+    # pyre-fixme[3]
+    def predict_forward(self, batch: Dict[str, torch.Tensor]) -> Any:
         pass
 
-    def forward(self, batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    # pyre-fixme[3]
+    def forward(self, batch: Dict[str, torch.Tensor]) -> Any:
         if self._stream is None:
             # Lazily initialize stream to make sure it's created in the correct device.
             self._stream = (

--- a/torchrec/inference/src/ResultSplit.cpp
+++ b/torchrec/inference/src/ResultSplit.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torchrec/inference/ResultSplit.h"
+
+#include <c10/core/ScalarType.h>
+#include <folly/Range.h>
+#include <folly/container/Enumerate.h>
+#include <folly/io/Cursor.h>
+
+#include "ATen/Functions.h"
+#include "torchrec/inference/Types.h"
+
+namespace torchrec {
+
+C10_DEFINE_REGISTRY(TorchRecResultSplitFuncRegistry, ResultSplitFunc);
+
+c10::IValue splitDictOfTensor(
+    c10::IValue result,
+    const size_t& offset,
+    const size_t& length) {
+  const auto& dict = result.toGenericDict();
+  c10::impl::GenericDict pred(c10::StringType::get(), c10::TensorType::get());
+  pred.reserve(dict.size());
+
+  for (auto& entry : dict) {
+    const auto& key = entry.key();
+    const auto& value = entry.value();
+    TORCH_CHECK(value.isTensor());
+    const auto& tensor = value.toTensor();
+    pred.insert(key, tensor.slice(0, offset, offset + length));
+  }
+  return pred;
+}
+
+class DictOfTensorResultSplitFunc : public ResultSplitFunc {
+ public:
+  c10::IValue splitResult(
+      c10::IValue result,
+      const size_t& offset,
+      const size_t& length) override {
+    return splitDictOfTensor(result, offset, length);
+  }
+};
+
+REGISTER_TORCHREC_RESULTSPLIT_FUNC(dict_of_tensor, DictOfTensorResultSplitFunc);
+
+} // namespace torchrec

--- a/torchrec/inference/tests/ResultSplitTest.cpp
+++ b/torchrec/inference/tests/ResultSplitTest.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torchrec/inference/ResultSplit.h"
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+template <typename T>
+void checkTensor(const at::Tensor& tensor, const std::vector<T>& expected) {
+  EXPECT_EQ(tensor.sizes(), at::ArrayRef({(long)expected.size()}));
+  for (int i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(tensor[i].item<T>(), expected[i]) << "pos: " << i;
+  }
+}
+
+TEST(ResultSplitTest, SplitDictOfTensor) {
+  c10::impl::GenericDict pred(c10::StringType::get(), c10::TensorType::get());
+  pred.insert("par", at::tensor({0, 1, 2}));
+  pred.insert("foo", at::tensor({3, 4, 5}));
+
+  auto splitResult = torchrec::splitDictOfTensor(pred, 0, 2);
+  checkTensor<float>(
+      splitResult.toGenericDict().at("par").toTensor(), {0., 1.});
+  checkTensor<float>(
+      splitResult.toGenericDict().at("foo").toTensor(), {3., 4.});
+}


### PR DESCRIPTION
Summary: Currently predict module needs to return a dict (string -> tensor). This diff allows users to create predict module with any output type but they'll need to provide a result split function used by GPUExecutor to split the batched results.

Reviewed By: zyan0

Differential Revision: D34525672

