### PR TITLE
create multiple streams for each torch.deploy thread

### DIFF
--- a/examples/dlrm/modules/dlrm_predict.py
+++ b/examples/dlrm/modules/dlrm_predict.py
@@ -19,7 +19,7 @@ from torchrec.datasets.criteo import (  # noqa
 from torchrec.inference.model_packager import load_pickle_config
 from torchrec.inference.modules import (
     PredictFactory,
-    MultistreamPredictModule,
+    PredictModule,
     quantize_embeddings,
 )
 from torchrec.models.dlrm import DLRM
@@ -43,7 +43,7 @@ class DLRMModelConfig:
     over_arch_layer_sizes: List[int]
 
 
-class DLRMPredictModule(MultistreamPredictModule):
+class DLRMPredictModule(PredictModule):
     """
     nn.Module to wrap DLRM model to use for inference.
 

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -114,9 +114,12 @@ void GPUExecutor::process(int idx) {
 
   // set device guard again to the correct device again because set_device is
   // thread-local
+  std::vector<c10::cuda::CUDAStream> streams;
+  for (size_t i = 0; i < worldSize_; ++i) {
+    streams.push_back(at::cuda::getStreamFromPool(/* isHighPriority */ true, i));
+  }
+  at::cuda::CUDAMultiStreamGuard streamGuard(streams);
   at::cuda::CUDAGuard deviceGuard(rank_);
-  auto stream = at::cuda::getStreamFromPool(true, rank_);
-  at::cuda::CUDAStreamGuard streamGuard(stream);
 
   while (true) {
     std::shared_ptr<PredictionBatch> batch;


### PR DESCRIPTION
Summary:
since TorchRec needs to access all GPU from one torch.deploy thread, we should create one stream per GPU to avoid using the default streams to access other GPUs

also remove MultistreamPredictModule to let C++ control stream management

Reviewed By: 842974287

Differential Revision: D34647821

