### PR TITLE
Fix dlrm feature-interaction triu_indices

### DIFF
--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -187,8 +187,8 @@ class InteractionArch(nn.Module):
     def __init__(self, num_sparse_features: int) -> None:
         super().__init__()
         self.F: int = num_sparse_features
-        self.triu_indices: torch.Tensor = torch.triu_indices(
-            self.F + 1, self.F + 1, offset=1
+        self.triu_indices: torch.Tensor = self.F - torch.fliplr(
+            torch.triu_indices(self.F + 1, self.F + 1, offset=1)
         )
 
     def forward(


### PR DESCRIPTION
Change triu_indices to match  FB dlrm oss (https://github.com/facebookresearch/dlrm/blob/9c2fda79afbc09e277c17e420bffe510125b4f70/dlrm_s_pytorch.py#L491-L493) 
and Nvidia dlrm (https://github.com/NVIDIA/DeepLearningExamples/blob/690233ca8eaf11b9fb7b9dfdb5346ce149f17cea/PyTorch/Recommendation/DLRM/dlrm/nn/interactions.py#L50-L53)