### PR TITLE
Show correct module num args

### DIFF
--- a/torchrec/linter/module_linter.py
+++ b/torchrec/linter/module_linter.py
@@ -179,7 +179,7 @@ def check_class_definition(python_path: str, node: ast.ClassDef) -> None:
                     "TorchRec module has too many constructor arguments",
                     "TorchRec module can have at most {} constructor arguments, but this module has {}.".format(
                         MAX_NUM_ARGS_IN_MODULE_CTOR,
-                        len(functions[function_name][1]),
+                        num_args,
                     ),
                 )
         if function_name in functions:


### PR DESCRIPTION
Summary:
Currently we just see something like
```
TorchRec module can have at most 5 constructor arguments, but this module
    has 1.
```

Seems to be printing the wrong thing. Fixing this here.

But also this seems like too strict of a requirement. What's the best practice to avoid have less constructor args?

Reviewed By: joshuadeng

Differential Revision: D34725032

