### PR TITLE
Fix forward torchrec tracer issue with proxying buffers

### DIFF
--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -150,6 +150,8 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
 
 
 class Tracer(torch.fx.Tracer):
+    proxy_buffer_attributes = False
+
     def __init__(self, unsharded_module_names: List[str]) -> None:
         super().__init__()
         self._unsharded_module_names = unsharded_module_names


### PR DESCRIPTION
Summary:
Disable tracing buffers (introduced in https://github.com/pytorch/pytorch/pull/73612) in torchrec train_pipeline.Tracer

This was causing failures in the following test: https://www.internalfb.com/intern/testinfra/diagnostics/5066549672053905.562950011720831.1646546163/

Note that this is a stop-gap solution. In general, buffers should probably be traced. The issue is introduced because the model being traced is mutating an attribute of the module, which is generally unsafe within a functional tracing context:

https://www.internalfb.com/code/fbsource/[830447276a410da5c1a796647782a639a6968054]/fbcode/hpc/torchrec/models/ads/ads_10x_2021h1_jun_v0.py?lines=6626

Differential Revision: D34741803

