### PR TITLE
Fix test failed by multiple process group initialization

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -344,7 +344,7 @@ class ModelParallelTest(ModelParallelTestShared):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    def test_sharding_nccl_module_as_top_level(self) -> None:
+    def test_top_lovel_shardable_module_is_sharded_nccl(self) -> None:
         backend = "nccl"
         device = torch.device("cuda:0")
         pg = init_distributed_single_host(
@@ -379,7 +379,7 @@ class ModelParallelTest(ModelParallelTestShared):
             dist.destroy_process_group(_CROSS_PG)
         dist.destroy_process_group(pg)
 
-    def test_sharding_gloo_module_as_top_level(self) -> None:
+    def test_top_lovel_shardable_module_is_sharded_gloo(self) -> None:
         backend = "gloo"
         device = torch.device("cpu")
         pg = init_distributed_single_host(

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -345,16 +345,13 @@ class ModelParallelTest(ModelParallelTestShared):
         "Not enough GPUs, this test requires at least two GPUs",
     )
     def test_sharding_nccl_module_as_top_level(self) -> None:
-        rank = 0
-        world_size = 1
-        local_size = 1
         backend = "nccl"
-        device = torch.device(f"cuda:{rank}")
+        device = torch.device("cuda:0")
         pg = init_distributed_single_host(
-            rank=rank,
-            world_size=world_size,
+            rank=0,
+            world_size=1,
             backend=backend,
-            local_size=local_size
+            local_size=1,
         )
 
         embedding_dim = 128
@@ -383,16 +380,13 @@ class ModelParallelTest(ModelParallelTestShared):
         dist.destroy_process_group(pg)
 
     def test_sharding_gloo_module_as_top_level(self) -> None:
-        rank = 0
-        world_size = 1
-        local_size = 1
         backend = "gloo"
         device = torch.device("cpu")
         pg = init_distributed_single_host(
-            rank=rank,
-            world_size=world_size,
+            rank=0,
+            world_size=1,
             backend=backend,
-            local_size=local_size
+            local_size=1,
         )
 
         embedding_dim = 128

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -341,12 +341,9 @@ class ModelParallelTest(ModelParallelTestShared):
         )
 
     def test_sharding_ebc_as_top_level(self) -> None:
-        os.environ["RANK"] = "0"
-        os.environ["WORLD_SIZE"] = "1"
-        os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = str("localhost")
-        os.environ["MASTER_PORT"] = str(get_free_port())
-        os.environ["NCCL_SOCKET_IFNAME"] = "lo"
+        rank = 0
+        world_size = 1
+        local_size = 1
 
         if torch.cuda.is_available():
             curr_device = torch.device("cuda:0")
@@ -357,7 +354,10 @@ class ModelParallelTest(ModelParallelTestShared):
             backend = "gloo"
 
         pg = init_distributed_single_host(
-            rank=0, world_size=1, backend=backend, local_size=1
+            rank=rank,
+            world_size=world_size,
+            backend=backend,
+            local_size=local_size
         )
 
         embedding_dim = 128


### PR DESCRIPTION
Summary:
Unit tests are currently failed, because process group is initialized multiple times without cleanup.
I also updated the test case to work both nccl and gloo backend.