### PR TITLE
destroy process group after initialization in test

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -335,6 +335,8 @@ class ModelParallelTest(ModelParallelTestShared):
             backend="gloo",
         )
 
+
+class ModelParallelSparseOnlyTest(unittest.TestCase):
     def test_sharding_ebc_as_top_level(self) -> None:
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
@@ -370,6 +372,7 @@ class ModelParallelTest(ModelParallelTestShared):
         model = DistributedModelParallel(ebc, device=curr_device)
 
         self.assertTrue(isinstance(model.module, ShardedEmbeddingBagCollection))
+        dist.destroy_process_group()
 
 
 class ModelParallelStateDictTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
test_sharding_ebc_as_top_level is failing in OSS CI (https://github.com/pytorch/torchrec/runs/5521548711?check_suite_focus=true) because we're not closing the process_group.

Properly destroy pg

Also, move test case into own class because we're not re-using any of the ModelParallelTestBase functionality

Reviewed By: dstaay-fb

Differential Revision: D34875966

