### PR TITLE
constraint the sharding types for sequential sharder

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -530,6 +530,14 @@ class EmbeddingCollectionSharder(BaseEmbeddingSharder[M]):
             for name, param in module.embeddings.named_parameters()
         }
 
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.DATA_PARALLEL.value,
+            ShardingType.TABLE_WISE.value,
+            ShardingType.ROW_WISE.value,
+        ]
+        return types
+
     @property
     def module_type(self) -> Type[EmbeddingCollection]:
         return EmbeddingCollection


### PR DESCRIPTION
Summary: sequential sharder will sometimes pick CW sharding but it's not support actually, so we did the constraint at this time

Reviewed By: bigning

Differential Revision: D34872780

