### PR TITLE
change ResultSplit to allow variable sizes and add DictOfTensorsResultSplitFunc

### DIFF
--- a/torchrec/inference/include/torchrec/inference/ResultSplit.h
+++ b/torchrec/inference/include/torchrec/inference/ResultSplit.h
@@ -19,8 +19,9 @@ class ResultSplitFunc {
 
   virtual c10::IValue splitResult(
       c10::IValue /* result */,
-      const size_t& /* offset */,
-      const size_t& /* length */) = 0;
+      size_t /* nOffset */,
+      size_t /* nLength */,
+      size_t /* nTotalLength */) = 0;
 };
 
 /**
@@ -34,7 +35,14 @@ C10_DECLARE_REGISTRY(TorchRecResultSplitFuncRegistry, ResultSplitFunc);
 
 c10::IValue splitDictOfTensor(
     c10::IValue result,
-    const size_t& offset,
-    const size_t& length);
+    size_t nOffset,
+    size_t nLength,
+    size_t nTotalLength);
+
+c10::IValue splitDictOfTensors(
+    c10::IValue result,
+    size_t nOffset,
+    size_t nLength,
+    size_t nTotalLength);
 
 } // namespace torchrec

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -208,7 +208,7 @@ void GPUExecutor::process(int idx) {
 
               auto response = std::make_unique<PredictionResponse>();
               response->predictions = resultSplitFunc->splitResult(
-                  predictions, offset, context.batchSize);
+                  predictions, offset, context.batchSize, batch->batchSize);
               context.promise.setValue(std::move(response));
             }
             offset += context.batchSize;

--- a/torchrec/inference/tests/ResultSplitTest.cpp
+++ b/torchrec/inference/tests/ResultSplitTest.cpp
@@ -23,9 +23,54 @@ TEST(ResultSplitTest, SplitDictOfTensor) {
   pred.insert("par", at::tensor({0, 1, 2}));
   pred.insert("foo", at::tensor({3, 4, 5}));
 
-  auto splitResult = torchrec::splitDictOfTensor(pred, 0, 2);
+  auto splitResult = torchrec::splitDictOfTensor(pred, 0, 2, 3);
   checkTensor<float>(
       splitResult.toGenericDict().at("par").toTensor(), {0., 1.});
   checkTensor<float>(
       splitResult.toGenericDict().at("foo").toTensor(), {3., 4.});
+}
+
+TEST(ResultSplitTest, SplitDictOfTensorVariableLength) {
+  c10::impl::GenericDict pred(c10::StringType::get(), c10::TensorType::get());
+  pred.insert("par", at::tensor({0, 1, 2}));
+  pred.insert("foo", at::tensor({3, 4, 5, 6, 7, 8}));
+
+  auto splitResult = torchrec::splitDictOfTensor(pred, 0, 2, 3);
+  checkTensor<float>(
+      splitResult.toGenericDict().at("par").toTensor(), {0., 1.});
+  checkTensor<float>(
+      splitResult.toGenericDict().at("foo").toTensor(), {3., 4., 5., 6.});
+}
+
+TEST(ResultSplitTest, SplitDictOfTensors) {
+  c10::impl::GenericDict pred(
+      c10::StringType::get(),
+      c10::TupleType::create(
+          {c10::TensorType::get(),
+           c10::TensorType::get(),
+           c10::TensorType::get()}));
+  pred.insert(
+      "par",
+      c10::ivalue::Tuple::create(
+          {at::tensor({0, 1, 2, 3}), at::tensor({4, 5}), at::tensor({6, 7})}));
+  pred.insert(
+      "foo",
+      c10::ivalue::Tuple::create(
+          {at::tensor({8, 9}),
+           at::tensor({10, 11}),
+           at::tensor({12, 13, 14, 15})}));
+
+  auto splitResult = torchrec::splitDictOfTensors(pred, 1, 1, 2);
+  {
+    auto tuple = splitResult.toGenericDict().at("par").toTuple();
+    checkTensor<float>(tuple->elements()[0].toTensor(), {2., 3.});
+    checkTensor<float>(tuple->elements()[1].toTensor(), {5.});
+    checkTensor<float>(tuple->elements()[2].toTensor(), {7.});
+  }
+  {
+    auto tuple = splitResult.toGenericDict().at("foo").toTuple();
+    checkTensor<float>(tuple->elements()[0].toTensor(), {9.});
+    checkTensor<float>(tuple->elements()[1].toTensor(), {11.});
+    checkTensor<float>(tuple->elements()[2].toTensor(), {14., 15.});
+  }
 }


### PR DESCRIPTION
Summary:
* allow variable element size per batch
* added result split for dict of two tensors

Reviewed By: yinghai

Differential Revision: D34942463

