### PR TITLE
DLRM return prediciton values

### DIFF
--- a/examples/dlrm/dlrm_main.py
+++ b/examples/dlrm/dlrm_main.py
@@ -218,8 +218,9 @@ def _evaluate(
     for _ in tqdm(iter(int, 1), desc=f"Evaluating {stage} set"):
         try:
             _loss, logits, labels = train_pipeline.progress(combined_iterator)
-            auroc(logits, labels)
-            accuracy(logits, labels)
+            predictions = logits.sigmoid()
+            auroc(predictions, labels)
+            accuracy(predictions, labels)
         except StopIteration:
             break
     auroc_result = auroc.compute().item()

--- a/examples/dlrm/modules/dlrm_train.py
+++ b/examples/dlrm/modules/dlrm_train.py
@@ -80,4 +80,8 @@ class DLRMTrain(nn.Module):
         logits = logits.squeeze()
         loss = self.loss_fn(logits, batch.labels.float())
 
-        return loss, (loss.detach(), logits.detach(), batch.labels.detach())
+        return loss, (
+            loss.detach(),
+            logits.detach(),
+            batch.labels.detach(),
+        )


### PR DESCRIPTION
Summary:
Return the prediction values, not just the logits from the pipeline.

From the docs of AUROC and Accuracy:

```
Forward accepts

    - ``preds`` (float tensor): ``(N, ...)`` (binary) or ``(N, C, ...)`` (multiclass) tensor
      with probabilities, where C is the number of classes.
```

In reality it's expecting the probabilities (where the boundary is 0.5). Right now we're returning logits (where boundary for positive is 0). Maybe there are some cases where DLRMTrain model is outputting logits in the region (0, 0.5), which we tag as negative label, but it's actually positive.

Reviewed By: colin2328

Differential Revision: D34968264

