### PR TITLE
Fix row alignment for quant embeddings

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -136,6 +136,7 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag):
                 pooling_mode=self._pooling,
                 feature_table_map=self._feature_table_map,
                 output_dtype=SparseType.FP32,
+                row_alignment=16,
                 **(fused_params or {}),
             )
         )
@@ -233,6 +234,7 @@ class QuantBatchedEmbedding(BaseBatchedEmbedding):
                 pooling_mode=PoolingMode.NONE,
                 feature_table_map=self._feature_table_map,
                 output_dtype=SparseType.FP32,
+                row_alignment=16,
                 **(fused_params or {}),
             )
         )

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -180,6 +180,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                 pooling_mode=pooling_type_to_pooling_mode(emb_config.pooling),
                 weight_lists=[table_name_to_quantized_weights[emb_config.name]],
                 device=device,
+                row_alignment=16,
             )
             self.embedding_bags.append(emb_module)
             if not emb_config.feature_names:


### PR DESCRIPTION
Summary: We can quantize and run predictions on different hardware. Fix row alignment so weights can be transferred easily.

Differential Revision: D35131266

