### PR TITLE
Reinstate ufmt pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,10 @@ repos:
         exclude: packaging/.*
       - id: end-of-file-fixer
 
-# TODO: re-enable after https://github.com/omnilib/ufmt/issues/56 is resolved
-#  - repo: https://github.com/omnilib/ufmt
-#    rev: v1.3.0
-#    hooks:
-#      - id: ufmt
-#        additional_dependencies:
-#          - black == 21.9b0
-#          - usort == 0.6.4
+  - repo: https://github.com/omnilib/ufmt
+    rev: v1.3.2
+    hooks:
+      - id: ufmt
+        additional_dependencies:
+          - black == 21.9b0
+          - usort == 0.6.4


### PR DESCRIPTION
Since https://github.com/omnilib/ufmt/issues/56 is resolved, so I re-enable this hook, and upgrade it to v1.3.2 as https://github.com/pytorch/vision/pull/5460 .