### PR TITLE
Change LR part-way through an epoch

### DIFF
--- a/examples/dlrm/dlrm_main.py
+++ b/examples/dlrm/dlrm_main.py
@@ -162,6 +162,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         default=False,
         help="Shuffle each batch during training.",
     )
+    parser.add_argument(
+        "--validation_freq_within_epoch",
+        type=int,
+        default=None,
+        help="Frequency at which validation will be run within an epoch.",
+    )
     parser.set_defaults(pin_memory=None)
     return parser.parse_args(argv)
 
@@ -190,7 +196,7 @@ def _evaluate(
         stage (str): "val" or "test".
 
     Returns:
-        None.
+        Tuple[float, float]: auroc and accuracy result
     """
     model = train_pipeline._model
     model.eval()
@@ -219,8 +225,9 @@ def _evaluate(
     for _ in tqdm(iter(int, 1), desc=f"Evaluating {stage} set"):
         try:
             _loss, logits, labels = train_pipeline.progress(combined_iterator)
-            auroc(logits, labels)
-            accuracy(logits, labels)
+            preds = torch.sigmoid(logits)
+            auroc(preds, labels)
+            accuracy(preds, labels)
         except StopIteration:
             break
     auroc_result = auroc.compute().item()
@@ -236,6 +243,7 @@ def _train(
     train_pipeline: TrainPipelineSparseDist,
     iterator: Iterator[Batch],
     next_iterator: Iterator[Batch],
+    within_epoch_val_dataloader: DataLoader,
     epoch: int,
 ) -> None:
     """
@@ -245,11 +253,15 @@ def _train(
         args (argparse.Namespace): parsed command line args.
         train_pipeline (TrainPipelineSparseDist): pipelined model.
         iterator (Iterator[Batch]): Iterator used for training batches.
-        next_iterator (Iterator[Batch]): Iterator used for validation batches. Used to
-            queue up the next TRAIN_PIPELINE_STAGES - 1 batches before train_val_test
-            switches to validation mode. This is done so that when validation starts,
-            the first output train_pipeline generates an output for is the 1st
-            validation batch (as opposed to a buffered train batch).
+        next_iterator (Iterator[Batch]): Iterator used for validation batches
+            in between epochs. Used to queue up the next TRAIN_PIPELINE_STAGES - 1
+            batches before train_val_test switches to validation mode. This is done
+            so that when validation starts, the first output train_pipeline generates
+            an output for is the 1st validation batch (as opposed to a buffered train
+            batch).
+        within_epoch_val_dataloader (DataLoader): Dataloader to create iterators for
+            validation within an epoch. This is only used if
+            args.validation_freq_within_epoch is specified.
         epoch (int): Which epoch the model is being trained on.
 
     Returns:
@@ -277,9 +289,20 @@ def _train(
     )
 
     # Infinite iterator instead of while-loop to leverage tqdm progress bar.
-    for _ in tqdm(iter(int, 1), desc=f"Epoch {epoch}"):
+    for it in tqdm(itertools.count(), desc=f"Epoch {epoch}"):
         try:
             train_pipeline.progress(combined_iterator)
+            if (
+                args.validation_freq_within_epoch
+                and it % args.validation_freq_within_epoch == 0
+            ):
+                _evaluate(
+                    args,
+                    train_pipeline,
+                    iter(within_epoch_val_dataloader),
+                    iterator,
+                    "val",
+                )
         except StopIteration:
             break
 
@@ -323,7 +346,9 @@ def train_val_test(
     test_iterator = iter(test_dataloader)
     for epoch in range(args.epochs):
         val_iterator = iter(val_dataloader)
-        _train(args, train_pipeline, train_iterator, val_iterator, epoch)
+        _train(
+            args, train_pipeline, train_iterator, val_iterator, val_dataloader, epoch
+        )
         train_iterator = iter(train_dataloader)
         val_next_iterator = (
             test_iterator if epoch == args.epochs - 1 else train_iterator


### PR DESCRIPTION
Summary:
- NVIDIA uses a LR schedule to achieve 0.8025 in 1 epoch. Without it, they achieve 0.799 (cc: yqhu). They ramp up their LR from 0 to 26 and ramp back down to 0 when they're approaching 0.8025
- I tried using a CyclicLR scheduler from pytorch in TrainPipelineDist but there wasn't a clear way of discerning when you're approaching 0.8025, and the LR would be too high usually when in that range.
- The fastest solution I could think of was to validate every 5000 iterations, when approaching 0.801, bring down LR immediately from 15 to 0.1. This enabled us to achieve an AUROC of 0.8026 in 1 epoch.

Update - new approach
 ---
- part way through the first epoch (e.g. 80% through), drop the learning rate.
- We determine how far into an epoch we are by dividing the current iteration number but the total number of samples each trainer should see in 1 epoch

Differential Revision: D35116012

