### PR TITLE
PyTorch testing, remove deprecated assert_allclose

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -776,3 +776,20 @@ class TestETCSharder(EmbeddingTowerCollectionSharder):
     @property
     def fused_params(self) -> Optional[Dict[str, Any]]:
         return self._fused_params
+
+
+def _get_default_rtol_and_atol(
+    actual: torch.Tensor, expected: torch.Tensor
+) -> Tuple[float, float]:
+    """
+    default tolerance values for torch.testing.assert_close,
+    consistent with the values of torch.testing.assert_allclose
+    """
+    _DTYPE_PRECISIONS = {
+        torch.float16: (1e-3, 1e-3),
+        torch.float32: (1e-4, 1e-5),
+        torch.float64: (1e-5, 1e-8),
+    }
+    actual_rtol, actual_atol = _DTYPE_PRECISIONS.get(actual.dtype, (0.0, 0.0))
+    expected_rtol, expected_atol = _DTYPE_PRECISIONS.get(expected.dtype, (0.0, 0.0))
+    return max(actual_rtol, expected_rtol), max(actual_atol, expected_atol)

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -26,6 +26,7 @@ from torchrec.distributed.test_utils.test_model import (
     ModelInput,
     TestSparseNNBase,
 )
+from torchrec.distributed.test_utils.test_model import _get_default_rtol_and_atol
 from torchrec.distributed.types import (
     ShardingType,
     ShardingPlan,
@@ -280,7 +281,10 @@ class ModelParallelTestBase(unittest.TestCase):
         )
 
         # Compare predictions of sharded vs unsharded models.
-        torch.testing.assert_allclose(global_pred, torch.cat(all_local_pred))
+        rtol, atol = _get_default_rtol_and_atol(global_pred, torch.cat(all_local_pred))
+        torch.testing.assert_close(
+            global_pred, torch.cat(all_local_pred), rtol=rtol, atol=atol
+        )
 
         if _INTRA_PG is not None:
             dist.destroy_process_group(_INTRA_PG)
@@ -441,4 +445,5 @@ class InferenceModelParallelTestBase(unittest.TestCase):
             global_pred = global_model(local_input)
 
         # Compare predictions of sharded vs unsharded models.
-        torch.testing.assert_allclose(global_pred, shard_pred)
+        rtol, atol = _get_default_rtol_and_atol(global_pred, shard_pred)
+        torch.testing.assert_close(global_pred, shard_pred, rtol=rtol, atol=atol)

--- a/torchrec/distributed/tests/test_fused_optim.py
+++ b/torchrec/distributed/tests/test_fused_optim.py
@@ -27,6 +27,7 @@ from torchrec.distributed.test_utils.test_model import (
     TestEBCSharder,
     TestEBSharder,
 )
+from torchrec.distributed.test_utils.test_model import _get_default_rtol_and_atol
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     ModelParallelTestBase,
     _copy_state_dict,
@@ -301,6 +302,6 @@ class ModelParallelTest(ModelParallelTestBase):
         )
 
         # Compare predictions of sharded vs unsharded models.
-        torch.testing.assert_allclose(
-            global_pred.cpu(), torch.cat(all_local_pred).cpu()
-        )
+        actual, expected = global_pred.cpu(), torch.cat(all_local_pred).cpu()
+        rtol, atol = _get_default_rtol_and_atol(actual, expected)
+        torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -11,18 +11,13 @@ from typing import List, Optional, Any, Dict, cast
 import torch
 from torch import nn
 from torch import quantization as quant
-from torchrec.distributed.embedding_lookup import (
-    GroupedEmbeddingBag,
-    BatchedFusedEmbeddingBag,
-    BatchedDenseEmbeddingBag,
-    QuantBatchedEmbeddingBag,
-)
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel, ModuleSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.quant_embeddingbag import (
     QuantEmbeddingBagCollectionSharder,
 )
 from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.test_utils.test_model import _get_default_rtol_and_atol
 from torchrec.distributed.types import ShardedModule, ShardingType, ShardingEnv
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
@@ -107,9 +102,9 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             list(module_copy.named_buffers()) + list(module_copy.named_parameters()),
         ):
             self.assertEquals(name, name_copy)
-            torch.testing.assert_allclose(
-                buffer.detach().cpu(), buffer_copy.detach().cpu()
-            )
+            actual, expected = buffer.detach().cpu(), buffer_copy.detach().cpu()
+            rtol, atol = _get_default_rtol_and_atol(actual, expected)
+            torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
             self.assertEquals(buffer.detach().device, device)
             self.assertEquals(buffer_copy.detach().device, device_copy)
 


### PR DESCRIPTION
Summary: Removed deprecated assert_allclose and replaced with assert_close

Differential Revision: D35399215

