### PR TITLE
improve batching performance

### DIFF
--- a/torchrec/inference/include/torchrec/inference/BatchingQueue.h
+++ b/torchrec/inference/include/torchrec/inference/BatchingQueue.h
@@ -90,7 +90,6 @@ class BatchingQueue {
   struct BatchingQueueEntry {
     std::vector<std::shared_ptr<PredictionRequest>> requests;
     std::vector<RequestContext> contexts;
-    size_t numTimedOutRequests = 0;
   };
 
   struct BatchQueueEntry {


### PR DESCRIPTION
Summary:
* set startTime from actual request to prevent using now after creating a full batch
* wake up more often if batch is not full to handle burst of requests

Reviewed By: 842974287

Differential Revision: D35407972

