### PR TITLE
Fix DMP state_dict implementation for FSDP and DDP

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -575,9 +575,8 @@ class ModelParallelStateDictTest(unittest.TestCase):
         m1, m2 = models
 
         # load the second's (m2's) with the first (m1's) state_dict
-        m2.load_state_dict(
-            cast("OrderedDict[str, torch.Tensor]", m1.state_dict()), strict=False
-        )
+        m2.load_state_dict(cast("OrderedDict[str, torch.Tensor]", m1.state_dict()))
+
         # validate the models are equivalent
         with torch.no_grad():
             loss1, pred1 = m1(batch)
@@ -618,7 +617,6 @@ class ModelParallelStateDictTest(unittest.TestCase):
         m2.load_state_dict(
             cast("OrderedDict[str, torch.Tensor]", m1.state_dict(prefix="alpha")),
             prefix="alpha",
-            strict=False,
         )
 
         # validate the models are equivalent


### PR DESCRIPTION
Summary:
Current implementation of `state_dict` in DistributedModelParallel only calls the submodule implementations of state_dict for ShardedModule. We want this to be the case for FSDP and DDP, which override state_dict, so we use the state_dict implementation on DMP wrapped module directly.

Since the nn.Module `state_dict` calls the `state_dict` method internally it allows overidden implementations to execute properly. nn.Module's `load_state_dict`, however, does not do the same, instead calling an internal api `_load_from_state_dict` when recursing on the children module.

The DMP implementation of `load_state_dict` similarly calls the internal api on children modules, but for ShardedModule calls the `load_state_dict` that has a specific implementation.

To allow the `load_state_dict` reimplementation to support FSDP, we will call the module's load_state_dict post hooks (to be implemented) inside DMP's `load_state_dict`, which will allow FSDP modules to be properly loaded.

Reviewed By: rohan-varma

Differential Revision: D35481411

