### PR TITLE
add record_function to Awaitables wait() implementation for profiling

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -21,6 +21,8 @@ from typing import (
     Iterator,
 )
 
+from torch.autograd.profiler import record_function
+
 try:
     # For python 3.6 and below, GenericMeta will be used by
     # other metaclasses (i.e. AwaitableMeta) for customized
@@ -114,9 +116,10 @@ class Awaitable(abc.ABC, Generic[W]):
         pass
 
     def wait(self) -> W:
-        ret: W = self._wait_impl()
-        for callback in self.callbacks:
-            ret = callback(ret)
+        with record_function(f"## {self.__class__.__name__} wait() ##"):
+            ret: W = self._wait_impl()
+            for callback in self.callbacks:
+                ret = callback(ret)
         return ret
 
     @property


### PR DESCRIPTION
Summary:
Due to torchrec's delaying of computation until wait() call, it's currently tricky to understand the flow of computation/comms (e.g, answer kennyhorror recent quesiton about index/split ops).

This diffs adds profling record_function to wait() to show which classes's wait() the ops are occuring in when profiling

Differential Revision: D35555938

