### PR TITLE
Optimize distributed embedding module for large embeddings

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -147,15 +147,13 @@ def _construct_jagged_tensors(
     embedding_names: List[str],
 ) -> Dict[str, JaggedTensor]:
     ret: Dict[str, JaggedTensor] = {}
-    offset_per_key = features.offset_per_key()
+    length_per_key = features.length_per_key()
     lengths = features.lengths().view(-1, features.stride())
+    values_per_key = embeddings.split(length_per_key)
     for i, key in enumerate(features.keys()):
-        start = offset_per_key[i]
-        end = offset_per_key[i + 1]
-        i_lengths = lengths[i]
         ret[key] = JaggedTensor(
-            lengths=i_lengths,
-            values=embeddings[start:end, :],
+            lengths=lengths[i],
+            values=values_per_key[i],
         )
     return ret
 


### PR DESCRIPTION
Summary:
At the moment TorchRec is using Slice operator to split results of all-to-all communication into JaggedTensors. The problem with this approach that Slice backward operator is operating on dense gradients, which can result in a pretty slow backward pass if there is a large all-to-all operator and large number of embeddings involved.

Replacing this operator to a single Slice operator improves efficiency of the test job by ~2x, compared to the existing implementation.

Differential Revision: D35570058

