### PR TITLE
Refactor model_parallel_test_base

### DIFF
--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import multiprocessing
+import os
+import unittest
+from typing import Callable, Optional
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.comm import _CROSS_PG, _INTRA_PG
+from torchrec.test_utils import (
+    get_free_port,
+    init_distributed_single_host,
+    seed_and_log,
+)
+
+
+class MultiProcessContext:
+    def __init__(
+        self,
+        rank: int,
+        world_size: int,
+        backend: str = "gloo",
+        local_size: Optional[int] = None,
+    ) -> None:
+
+        self.rank = rank
+        self.world_size = world_size
+        self.backend = backend
+        self.local_size = local_size
+
+        if backend == "nccl":
+            device = torch.device(f"cuda:{rank}")
+            torch.cuda.set_device(device)
+        else:
+            device = torch.device("cpu")
+        self.device: torch.device = device
+        torch.use_deterministic_algorithms(True)
+        if torch.cuda.is_available():
+            torch.backends.cudnn.allow_tf32 = False
+            torch.backends.cuda.matmul.allow_tf32 = False
+        # pyre-ignore
+        self.pg: Optional[dist.ProcessGroup] = None
+
+    # pyre-ignore
+    def __enter__(self):
+        """
+        Override local_size after pg construction because unit test device count is
+        larger than local_size setup. This can be problematic for twrw because we have
+        ShardedTensor placement check.
+
+        TODO (T108556130) Mock out functions in comm.py instead of overriding env vars
+        """
+
+        os.environ["LOCAL_WORLD_SIZE"] = str(self.local_size or self.world_size)
+        if self.local_size is not None:
+            os.environ["LOCAL_RANK"] = str(self.rank % self.local_size)
+
+        self.pg = init_distributed_single_host(
+            rank=self.rank,
+            world_size=self.world_size,
+            backend=self.backend,
+            local_size=self.local_size,
+        )
+        return self
+
+    # pyre-ignore
+    def __exit__(self, exc_type, exc_instance, traceback) -> None:
+        if _INTRA_PG is not None:
+            dist.destroy_process_group(_INTRA_PG)
+        if _CROSS_PG is not None:
+            dist.destroy_process_group(_CROSS_PG)
+        dist.destroy_process_group(self.pg)
+        torch.use_deterministic_algorithms(False)
+        if torch.cuda.is_available():
+            torch.backends.cudnn.allow_tf32 = True
+
+
+class MultiProcessTestBase(unittest.TestCase):
+    @seed_and_log
+    def setUp(self) -> None:
+        os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+        os.environ["NCCL_SOCKET_IFNAME"] = "lo"
+
+        torch.use_deterministic_algorithms(True)
+        if torch.cuda.is_available():
+            torch.backends.cudnn.allow_tf32 = False
+            torch.backends.cuda.matmul.allow_tf32 = False
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
+    def tearDown(self) -> None:
+        torch.use_deterministic_algorithms(False)
+        del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_SOCKET_IFNAME"]
+        if torch.cuda.is_available():
+            os.unsetenv("CUBLAS_WORKSPACE_CONFIG")
+        super().tearDown()
+
+    def _run_multi_process_test(
+        self,
+        *,
+        callable: Callable[
+            ...,
+            None,
+        ],
+        world_size: int,
+        # pyre-ignore
+        **kwargs,
+    ) -> None:
+        ctx = multiprocessing.get_context("forkserver")
+        processes = []
+        for rank in range(world_size):
+            kwargs["rank"] = rank
+            kwargs["world_size"] = world_size
+            p = ctx.Process(
+                target=callable,
+                kwargs=kwargs,
+            )
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join()
+            self.assertEqual(0, p.exitcode)

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -8,48 +8,19 @@
 from enum import Enum
 from typing import Dict, List, Optional, Type, Union
 
+import torch.distributed as dist  # noqa
+import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from torch import nn
 from torchrec.distributed.planner import ParameterConstraints
-from torchrec.distributed.test_utils.test_model import (
-    TestEBCSharder,
-    TestEBSharder,
-    TestETCSharder,
-    TestETSharder,
-    TestSparseNN,
-    TestSparseNNBase,
-)
-from torchrec.distributed.test_utils.test_model_parallel_base import (
-    ModelParallelTestBase,
-)
+from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
+from torchrec.distributed.test_utils.test_model import TestSparseNN, TestSparseNNBase
+from torchrec.distributed.test_utils.test_sharding import sharding_single_rank_test
 from torchrec.distributed.types import ModuleSharder
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.test_utils import seed_and_log
 
 
-class SharderType(Enum):
-    EMBEDDING_BAG = "embedding_bag"
-    EMBEDDING_BAG_COLLECTION = "embedding_bag_collection"
-    EMBEDDING_TOWER = "embedding_tower"
-    EMBEDDING_TOWER_COLLECTION = "embedding_tower_collection"
-
-
-def create_test_sharder(
-    sharder_type: str, sharding_type: str, kernel_type: str
-) -> Union[TestEBSharder, TestEBCSharder, TestETSharder, TestETCSharder]:
-    if sharder_type == SharderType.EMBEDDING_BAG.value:
-        return TestEBSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
-    elif sharder_type == SharderType.EMBEDDING_BAG_COLLECTION.value:
-        return TestEBCSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
-    elif sharder_type == SharderType.EMBEDDING_TOWER.value:
-        return TestETSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
-    elif sharder_type == SharderType.EMBEDDING_TOWER_COLLECTION.value:
-        return TestETCSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
-    else:
-        raise ValueError(f"Sharder not supported {sharder_type}")
-
-
-class ModelParallelTestShared(ModelParallelTestBase):
+class ModelParallelTestShared(MultiProcessTestBase):
     @seed_and_log
     def setUp(self) -> None:
         super().setUp()
@@ -90,8 +61,7 @@ class ModelParallelTestShared(ModelParallelTestBase):
         model_class: Type[TestSparseNNBase] = TestSparseNN,
     ) -> None:
         self._run_multi_process_test(
-            # pyre-ignore [6]
-            callable=self._test_sharding_single_rank,
+            callable=sharding_single_rank_test,
             world_size=world_size,
             local_size=local_size,
             model_class=model_class,

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -5,16 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import multiprocessing
 import os
 import unittest
-from typing import Callable, cast, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, cast, Dict, List, Optional
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
-from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from torchrec.distributed.comm import _CROSS_PG, _INTRA_PG
 from torchrec.distributed.embedding_types import EmbeddingTableConfig
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import (
@@ -24,343 +20,15 @@ from torchrec.distributed.planner import (
 )
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
-    ModelInput,
     TestSparseNNBase,
 )
-from torchrec.distributed.types import (
-    ModuleSharder,
-    ShardedTensor,
-    ShardingEnv,
-    ShardingPlan,
-    ShardingType,
+from torchrec.distributed.test_utils.test_sharding import (
+    copy_state_dict,
+    gen_model_and_input,
 )
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig
-from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
-from torchrec.test_utils import (
-    get_free_port,
-    init_distributed_single_host,
-    seed_and_log,
-)
-
-
-def _generate_inputs(
-    world_size: int,
-    tables: List[EmbeddingTableConfig],
-    weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
-    batch_size: int = 4,
-    num_float_features: int = 16,
-) -> Tuple[ModelInput, List[ModelInput]]:
-    return ModelInput.generate(
-        batch_size=batch_size,
-        world_size=world_size,
-        num_float_features=num_float_features,
-        tables=tables,
-        weighted_tables=weighted_tables or [],
-    )
-
-
-def _gen_model_and_input(
-    model_class: TestSparseNNBase,
-    tables: List[EmbeddingTableConfig],
-    embedding_groups: Dict[str, List[str]],
-    world_size: int,
-    weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
-    num_float_features: int = 16,
-    dense_device: Optional[torch.device] = None,
-    sparse_device: Optional[torch.device] = None,
-) -> Tuple[nn.Module, List[Tuple[ModelInput, List[ModelInput]]]]:
-    torch.manual_seed(0)
-
-    model = model_class(
-        tables=cast(List[BaseEmbeddingConfig], tables),
-        num_float_features=num_float_features,
-        weighted_tables=cast(List[BaseEmbeddingConfig], weighted_tables),
-        embedding_groups=embedding_groups,
-        dense_device=dense_device,
-        sparse_device=sparse_device,
-    )
-    inputs = [
-        _generate_inputs(
-            world_size=world_size,
-            tables=tables,
-            weighted_tables=weighted_tables,
-            num_float_features=num_float_features,
-        )
-    ]
-    return (model, inputs)
-
-
-def _copy_state_dict(
-    loc: Dict[str, Union[torch.Tensor, ShardedTensor]],
-    glob: Dict[str, torch.Tensor],
-) -> None:
-    for name, tensor in loc.items():
-        assert name in glob
-        global_tensor = glob[name]
-        if isinstance(global_tensor, ShardedTensor):
-            global_tensor = global_tensor.local_shards()[0].tensor
-        if isinstance(tensor, ShardedTensor):
-            for local_shard in tensor.local_shards():
-                assert global_tensor.ndim == local_shard.tensor.ndim
-                shard_meta = local_shard.metadata
-                t = global_tensor.detach()
-                if t.ndim == 1:
-                    t = t[
-                        shard_meta.shard_offsets[0] : shard_meta.shard_offsets[0]
-                        + local_shard.tensor.shape[0]
-                    ]
-                elif t.ndim == 2:
-                    t = t[
-                        shard_meta.shard_offsets[0] : shard_meta.shard_offsets[0]
-                        + local_shard.tensor.shape[0],
-                        shard_meta.shard_offsets[1] : shard_meta.shard_offsets[1]
-                        + local_shard.tensor.shape[1],
-                    ]
-                else:
-                    raise ValueError("Tensors with ndim > 2 are not supported")
-                local_shard.tensor.copy_(t)
-        else:
-            tensor.copy_(global_tensor)
-
-
-class ModelParallelTestBase(unittest.TestCase):
-    @seed_and_log
-    def setUp(self) -> None:
-        os.environ["MASTER_ADDR"] = str("localhost")
-        os.environ["MASTER_PORT"] = str(get_free_port())
-        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
-        os.environ["NCCL_SOCKET_IFNAME"] = "lo"
-
-        torch.use_deterministic_algorithms(True)
-        if torch.cuda.is_available():
-            torch.backends.cudnn.allow_tf32 = False
-            torch.backends.cuda.matmul.allow_tf32 = False
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-
-    def tearDown(self) -> None:
-        torch.use_deterministic_algorithms(False)
-        del os.environ["GLOO_DEVICE_TRANSPORT"]
-        del os.environ["NCCL_SOCKET_IFNAME"]
-        if torch.cuda.is_available():
-            os.unsetenv("CUBLAS_WORKSPACE_CONFIG")
-        super().tearDown()
-
-    @classmethod
-    def _test_sharding_single_rank(
-        cls,
-        rank: int,
-        world_size: int,
-        model_class: TestSparseNNBase,
-        embedding_groups: Dict[str, List[str]],
-        tables: List[EmbeddingTableConfig],
-        sharders: List[ModuleSharder[nn.Module]],
-        backend: str,
-        optim: EmbOptimType,
-        weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
-        constraints: Optional[Dict[str, ParameterConstraints]] = None,
-        local_size: Optional[int] = None,
-    ) -> None:
-        torch.use_deterministic_algorithms(True)
-        if torch.cuda.is_available():
-            torch.backends.cudnn.allow_tf32 = False
-            torch.backends.cuda.matmul.allow_tf32 = False
-
-        """
-        Override local_size after pg construction because unit test device count is
-        larger than local_size setup. This can be problematic for twrw because we have
-        ShardedTensor placement check.
-
-        TODO (T108556130) Mock out functions in comm.py instead of overriding env vars
-        """
-        os.environ["LOCAL_WORLD_SIZE"] = str(local_size or world_size)
-        if local_size is not None:
-            os.environ["LOCAL_RANK"] = str(rank % local_size)
-        if backend == "nccl":
-            device = torch.device(f"cuda:{rank}")
-            torch.cuda.set_device(device)
-        else:
-            device = torch.device("cpu")
-        pg = init_distributed_single_host(
-            rank=rank,
-            world_size=world_size,
-            backend=backend,
-            local_size=local_size,
-        )
-
-        # Generate model & inputs.
-        (global_model, inputs) = _gen_model_and_input(
-            model_class=model_class,
-            tables=tables,
-            weighted_tables=weighted_tables,
-            embedding_groups=embedding_groups,
-            world_size=world_size,
-            num_float_features=16,
-        )
-        global_model = global_model.to(device)
-        global_input = inputs[0][0].to(device)
-        local_input = inputs[0][1][rank].to(device)
-
-        # Shard model.
-        local_model = model_class(
-            tables=cast(List[BaseEmbeddingConfig], tables),
-            weighted_tables=cast(List[BaseEmbeddingConfig], weighted_tables),
-            embedding_groups=embedding_groups,
-            dense_device=device,
-            sparse_device=torch.device("meta"),
-            num_float_features=16,
-        )
-
-        planner = EmbeddingShardingPlanner(
-            topology=Topology(world_size, device.type, local_world_size=local_size),
-            constraints=constraints,
-        )
-        plan: ShardingPlan = planner.collective_plan(local_model, sharders, pg)
-        """
-        Simulating multiple nodes on a single node. However, metadata information and
-        tensor placement must still be consistent. Here we overwrite this to do so.
-
-        NOTE:
-            inter/intra process groups should still behave as expected.
-
-        TODO: may need to add some checks that only does this if we're running on a
-        single GPU (which should be most cases).
-        """
-
-        for group in plan.plan:
-            for _, parameter_sharding in plan.plan[group].items():
-                if (
-                    parameter_sharding.sharding_type
-                    in {
-                        ShardingType.TABLE_ROW_WISE.value,
-                        ShardingType.TABLE_COLUMN_WISE.value,
-                    }
-                    and device.type != "cpu"
-                ):
-                    sharding_spec = parameter_sharding.sharding_spec
-                    if sharding_spec is not None:
-                        # pyre-ignore
-                        for shard in sharding_spec.shards:
-                            placement = shard.placement
-                            rank: Optional[int] = placement.rank()
-                            assert rank is not None
-                            shard.placement = torch.distributed._remote_device(
-                                f"rank:{rank}/cuda:{rank}"
-                            )
-
-        local_model = DistributedModelParallel(
-            local_model,
-            env=ShardingEnv.from_process_group(pg),
-            plan=plan,
-            sharders=sharders,
-            device=device,
-        )
-
-        dense_optim = KeyedOptimizerWrapper(
-            dict(local_model.named_parameters()),
-            lambda params: torch.optim.SGD(params, lr=0.1),
-        )
-        local_opt = CombinedOptimizer([local_model.fused_optimizer, dense_optim])
-
-        # Load model state from the global model.
-        _copy_state_dict(local_model.state_dict(), global_model.state_dict())
-
-        # Run a single training step of the sharded model.
-        local_pred = cls._gen_full_pred_after_one_step(
-            local_model, local_opt, local_input
-        )
-        all_local_pred = []
-        for _ in range(world_size):
-            all_local_pred.append(torch.empty_like(local_pred))
-        dist.all_gather(all_local_pred, local_pred, group=pg)
-
-        # Run second training step of the unsharded model.
-        assert optim == EmbOptimType.EXACT_SGD
-        global_opt = torch.optim.SGD(global_model.parameters(), lr=0.1)
-        global_pred = cls._gen_full_pred_after_one_step(
-            global_model, global_opt, global_input
-        )
-
-        # Compare predictions of sharded vs unsharded models.
-        rtol, atol = _get_default_rtol_and_atol(global_pred, torch.cat(all_local_pred))
-        torch.testing.assert_close(
-            global_pred, torch.cat(all_local_pred), rtol=rtol, atol=atol
-        )
-
-        if _INTRA_PG is not None:
-            dist.destroy_process_group(_INTRA_PG)
-        if _CROSS_PG is not None:
-            dist.destroy_process_group(_CROSS_PG)
-        dist.destroy_process_group(pg)
-
-        torch.use_deterministic_algorithms(False)
-        if torch.cuda.is_available():
-            torch.backends.cudnn.allow_tf32 = True
-            torch.backends.cuda.matmul.allow_tf32 = True
-
-    def _run_multi_process_test(
-        self,
-        callable: Callable[
-            [int, int, List[ModuleSharder[nn.Module]], List[torch.Tensor]], None
-        ],
-        world_size: int,
-        sharders: List[ModuleSharder[nn.Module]],
-        tables: List[EmbeddingTableConfig],
-        backend: str,
-        optim: EmbOptimType,
-        model_class: Type[TestSparseNNBase],
-        embedding_groups: Optional[Dict[str, List[str]]] = None,
-        weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
-        constraints: Optional[Dict[str, ParameterConstraints]] = None,
-        local_size: Optional[int] = None,
-    ) -> None:
-        ctx = multiprocessing.get_context("forkserver")
-        processes = []
-        for rank in range(world_size):
-            p = ctx.Process(
-                target=callable,
-                args=(
-                    rank,
-                    world_size,
-                    model_class,
-                    embedding_groups,
-                    tables,
-                    sharders,
-                    backend,
-                    optim,
-                    weighted_tables,
-                    constraints,
-                ),
-                kwargs={
-                    "local_size": local_size,
-                },
-            )
-            p.start()
-            processes.append(p)
-
-        for p in processes:
-            p.join()
-            self.assertEqual(0, p.exitcode)
-
-    @classmethod
-    def _gen_full_pred_after_one_step(
-        cls,
-        model: nn.Module,
-        opt: torch.optim.Optimizer,
-        input: ModelInput,
-    ) -> torch.Tensor:
-        # Run a single training step of the global model.
-        opt.zero_grad()
-        model.train(True)
-        loss, _ = model(input)
-        loss.backward()
-        # pyre-fixme[20]: Argument `closure` expected.
-        opt.step()
-
-        # Run a forward pass of the global model.
-        with torch.no_grad():
-            model.train(False)
-            full_pred = model(input)
-            return full_pred
+from torchrec.test_utils import seed_and_log
 
 
 class InferenceModelParallelTestBase(unittest.TestCase):
@@ -394,7 +62,7 @@ class InferenceModelParallelTestBase(unittest.TestCase):
         torch.cuda.set_device(cuda_device)
 
         # Generate model & inputs.
-        (global_model, inputs) = _gen_model_and_input(
+        (global_model, _inputs) = gen_model_and_input(
             model_class=model_class,
             tables=tables,
             weighted_tables=weighted_tables,
@@ -405,7 +73,7 @@ class InferenceModelParallelTestBase(unittest.TestCase):
             sparse_device=cuda_device,
         )
         global_model = quantize_callable(global_model)
-        local_input = inputs[0][1][default_rank].to(cuda_device)
+        local_input = _inputs[0][1][default_rank].to(cuda_device)
 
         # Shard model.
         local_model = model_class(
@@ -434,7 +102,7 @@ class InferenceModelParallelTestBase(unittest.TestCase):
         )
 
         # Load model state from the global model.
-        _copy_state_dict(local_model.state_dict(), global_model.state_dict())
+        copy_state_dict(local_model.state_dict(), global_model.state_dict())
 
         # Run a single training step of the sharded model.
         with torch.inference_mode():

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum
+from typing import cast, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from fbgemm_gpu.split_embedding_configs import EmbOptimType
+from torchrec.distributed.embedding_types import EmbeddingTableConfig
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+from torchrec.distributed.test_utils.multi_process import MultiProcessContext
+from torchrec.distributed.test_utils.test_model import (
+    ModelInput,
+    TestEBCSharder,
+    TestEBSharder,
+    TestETCSharder,
+    TestETSharder,
+    TestSparseNNBase,
+)
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import BaseEmbeddingConfig
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
+
+
+class SharderType(Enum):
+    EMBEDDING_BAG = "embedding_bag"
+    EMBEDDING_BAG_COLLECTION = "embedding_bag_collection"
+    EMBEDDING_TOWER = "embedding_tower"
+    EMBEDDING_TOWER_COLLECTION = "embedding_tower_collection"
+
+
+def create_test_sharder(
+    sharder_type: str, sharding_type: str, kernel_type: str
+) -> Union[TestEBSharder, TestEBCSharder, TestETSharder, TestETCSharder]:
+    if sharder_type == SharderType.EMBEDDING_BAG.value:
+        return TestEBSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
+    elif sharder_type == SharderType.EMBEDDING_BAG_COLLECTION.value:
+        return TestEBCSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
+    elif sharder_type == SharderType.EMBEDDING_TOWER.value:
+        return TestETSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
+    elif sharder_type == SharderType.EMBEDDING_TOWER_COLLECTION.value:
+        return TestETCSharder(sharding_type, kernel_type, {"learning_rate": 0.1})
+    else:
+        raise ValueError(f"Sharder not supported {sharder_type}")
+
+
+def generate_inputs(
+    world_size: int,
+    tables: List[EmbeddingTableConfig],
+    weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
+    batch_size: int = 4,
+    num_float_features: int = 16,
+) -> Tuple[ModelInput, List[ModelInput]]:
+    return ModelInput.generate(
+        batch_size=batch_size,
+        world_size=world_size,
+        num_float_features=num_float_features,
+        tables=tables,
+        weighted_tables=weighted_tables or [],
+    )
+
+
+def gen_model_and_input(
+    model_class: TestSparseNNBase,
+    tables: List[EmbeddingTableConfig],
+    embedding_groups: Dict[str, List[str]],
+    world_size: int,
+    weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
+    num_float_features: int = 16,
+    dense_device: Optional[torch.device] = None,
+    sparse_device: Optional[torch.device] = None,
+) -> Tuple[nn.Module, List[Tuple[ModelInput, List[ModelInput]]]]:
+    torch.manual_seed(0)
+
+    model = model_class(
+        tables=cast(List[BaseEmbeddingConfig], tables),
+        num_float_features=num_float_features,
+        weighted_tables=cast(List[BaseEmbeddingConfig], weighted_tables),
+        embedding_groups=embedding_groups,
+        dense_device=dense_device,
+        sparse_device=sparse_device,
+    )
+    inputs = [
+        generate_inputs(
+            world_size=world_size,
+            tables=tables,
+            weighted_tables=weighted_tables,
+            num_float_features=num_float_features,
+        )
+    ]
+    return (model, inputs)
+
+
+def copy_state_dict(
+    loc: Dict[str, Union[torch.Tensor, ShardedTensor]],
+    glob: Dict[str, torch.Tensor],
+) -> None:
+    for name, tensor in loc.items():
+        assert name in glob
+        global_tensor = glob[name]
+        if isinstance(global_tensor, ShardedTensor):
+            global_tensor = global_tensor.local_shards()[0].tensor
+        if isinstance(tensor, ShardedTensor):
+            for local_shard in tensor.local_shards():
+                assert global_tensor.ndim == local_shard.tensor.ndim
+                shard_meta = local_shard.metadata
+                t = global_tensor.detach()
+                if t.ndim == 1:
+                    t = t[
+                        shard_meta.shard_offsets[0] : shard_meta.shard_offsets[0]
+                        + local_shard.tensor.shape[0]
+                    ]
+                elif t.ndim == 2:
+                    t = t[
+                        shard_meta.shard_offsets[0] : shard_meta.shard_offsets[0]
+                        + local_shard.tensor.shape[0],
+                        shard_meta.shard_offsets[1] : shard_meta.shard_offsets[1]
+                        + local_shard.tensor.shape[1],
+                    ]
+                else:
+                    raise ValueError("Tensors with ndim > 2 are not supported")
+                local_shard.tensor.copy_(t)
+        else:
+            tensor.copy_(global_tensor)
+
+
+def sharding_single_rank_test(
+    rank: int,
+    world_size: int,
+    model_class: TestSparseNNBase,
+    embedding_groups: Dict[str, List[str]],
+    tables: List[EmbeddingTableConfig],
+    sharders: List[ModuleSharder[nn.Module]],
+    backend: str,
+    optim: EmbOptimType,
+    weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        # Generate model & inputs.
+        (global_model, inputs) = gen_model_and_input(
+            model_class=model_class,
+            tables=tables,
+            weighted_tables=weighted_tables,
+            embedding_groups=embedding_groups,
+            world_size=world_size,
+            num_float_features=16,
+        )
+        global_model = global_model.to(ctx.device)
+        global_input = inputs[0][0].to(ctx.device)
+        local_input = inputs[0][1][rank].to(ctx.device)
+
+        # Shard model.
+        local_model = model_class(
+            tables=cast(List[BaseEmbeddingConfig], tables),
+            weighted_tables=cast(List[BaseEmbeddingConfig], weighted_tables),
+            embedding_groups=embedding_groups,
+            dense_device=ctx.device,
+            sparse_device=torch.device("meta"),
+            num_float_features=16,
+        )
+
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        plan: ShardingPlan = planner.collective_plan(local_model, sharders, ctx.pg)
+        """
+        Simulating multiple nodes on a single node. However, metadata information and
+        tensor placement must still be consistent. Here we overwrite this to do so.
+
+        NOTE:
+            inter/intra process groups should still behave as expected.
+
+        TODO: may need to add some checks that only does this if we're running on a
+        single GPU (which should be most cases).
+        """
+
+        for group in plan.plan:
+            for _, parameter_sharding in plan.plan[group].items():
+                if (
+                    parameter_sharding.sharding_type
+                    in {
+                        ShardingType.TABLE_ROW_WISE.value,
+                        ShardingType.TABLE_COLUMN_WISE.value,
+                    }
+                    and ctx.device.type != "cpu"
+                ):
+                    sharding_spec = parameter_sharding.sharding_spec
+                    if sharding_spec is not None:
+                        # pyre-ignore
+                        for shard in sharding_spec.shards:
+                            placement = shard.placement
+                            rank: Optional[int] = placement.rank()
+                            assert rank is not None
+                            shard.placement = torch.distributed._remote_device(
+                                f"rank:{rank}/cuda:{rank}"
+                            )
+
+        local_model = DistributedModelParallel(
+            local_model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=sharders,
+            device=ctx.device,
+        )
+
+        dense_optim = KeyedOptimizerWrapper(
+            dict(local_model.named_parameters()),
+            lambda params: torch.optim.SGD(params, lr=0.1),
+        )
+        local_opt = CombinedOptimizer([local_model.fused_optimizer, dense_optim])
+
+        # Load model state from the global model.
+        copy_state_dict(local_model.state_dict(), global_model.state_dict())
+
+        # Run a single training step of the sharded model.
+        local_pred = gen_full_pred_after_one_step(local_model, local_opt, local_input)
+
+        all_local_pred = []
+        for _ in range(world_size):
+            all_local_pred.append(torch.empty_like(local_pred))
+        dist.all_gather(all_local_pred, local_pred, group=ctx.pg)
+
+        # Run second training step of the unsharded model.
+        assert optim == EmbOptimType.EXACT_SGD
+        global_opt = torch.optim.SGD(global_model.parameters(), lr=0.1)
+        global_pred = gen_full_pred_after_one_step(
+            global_model, global_opt, global_input
+        )
+
+        # Compare predictions of sharded vs unsharded models.
+        torch.testing.assert_allclose(global_pred, torch.cat(all_local_pred))
+
+
+def gen_full_pred_after_one_step(
+    model: nn.Module,
+    opt: torch.optim.Optimizer,
+    input: ModelInput,
+) -> torch.Tensor:
+    # Run a single training step of the global model.
+    opt.zero_grad()
+    model.train(True)
+    loss, _ = model(input)
+    loss.backward()
+    # pyre-fixme[20]: Argument `closure` expected.
+    opt.step()
+
+    # Run a forward pass of the global model.
+    with torch.no_grad():
+        model.train(False)
+        full_pred = model(input)
+        return full_pred

--- a/torchrec/distributed/tests/test_fused_optim.py
+++ b/torchrec/distributed/tests/test_fused_optim.py
@@ -21,6 +21,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import ParameterConstraints
+from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     TestEBCSharder,
@@ -28,10 +29,10 @@ from torchrec.distributed.test_utils.test_model import (
     TestSparseNN,
     TestSparseNNBase,
 )
-from torchrec.distributed.test_utils.test_model_parallel_base import (
-    _copy_state_dict,
-    _gen_model_and_input,
-    ModelParallelTestBase,
+from torchrec.distributed.test_utils.test_sharding import (
+    copy_state_dict,
+    gen_full_pred_after_one_step,
+    gen_model_and_input,
 )
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
@@ -55,7 +56,7 @@ def create_test_sharder(
 
 
 @skip_if_asan_class
-class ModelParallelTest(ModelParallelTestBase):
+class ModelParallelTest(MultiProcessTestBase):
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -179,7 +180,6 @@ class ModelParallelTest(ModelParallelTestBase):
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
     ) -> None:
         self._run_multi_process_test(
-            # pyre-ignore [6]
             callable=self._test_optim_single_rank,
             world_size=world_size,
             local_size=local_size,
@@ -231,7 +231,7 @@ class ModelParallelTest(ModelParallelTestBase):
             global_pg = dist.new_group(ranks=[1], backend=backend)
 
         # Generate model & inputs.
-        (global_model, inputs) = _gen_model_and_input(
+        (global_model, inputs) = gen_model_and_input(
             model_class=model_class,
             tables=tables,
             weighted_tables=weighted_tables,
@@ -252,7 +252,7 @@ class ModelParallelTest(ModelParallelTestBase):
 
         # Run single step of unsharded model to populate optimizer states.
         global_opt = torch.optim.SGD(global_model.parameters(), lr=0.1)
-        cls._gen_full_pred_after_one_step(global_model, global_opt, global_input)
+        gen_full_pred_after_one_step(global_model, global_opt, global_input)
 
         # Shard model.
         local_model = model_class(
@@ -272,19 +272,17 @@ class ModelParallelTest(ModelParallelTestBase):
         local_opt = torch.optim.SGD(local_model.parameters(), lr=0.1)
 
         # Load model & optimizer states from the global model.
-        _copy_state_dict(local_model.state_dict(), global_model.state_dict())
+        copy_state_dict(local_model.state_dict(), global_model.state_dict())
         for param_name, local_state in local_model.fused_optimizer.state_dict()[
             "state"
         ].items():
             global_state = global_model.fused_optimizer.state_dict()["state"][
                 param_name
             ]
-            _copy_state_dict(local_state, global_state)
+            copy_state_dict(local_state, global_state)
 
         # Run a single training step of the sharded model.
-        local_pred = cls._gen_full_pred_after_one_step(
-            local_model, local_opt, local_input
-        )
+        local_pred = gen_full_pred_after_one_step(local_model, local_opt, local_input)
         all_local_pred = []
         for _ in range(world_size):
             all_local_pred.append(torch.empty_like(local_pred))
@@ -292,7 +290,7 @@ class ModelParallelTest(ModelParallelTestBase):
 
         # Run second training step of the unsharded model.
         global_opt = torch.optim.SGD(global_model.parameters(), lr=0.1)
-        global_pred = cls._gen_full_pred_after_one_step(
+        global_pred = gen_full_pred_after_one_step(
             global_model, global_opt, global_input
         )
 

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -32,9 +32,9 @@ from torchrec.distributed.planner import (
     Topology,
 )
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
-from torchrec.distributed.test_utils.test_model_parallel import (
+from torchrec.distributed.test_utils.test_model_parallel import ModelParallelTestShared
+from torchrec.distributed.test_utils.test_sharding import (
     create_test_sharder,
-    ModelParallelTestShared,
     SharderType,
 )
 from torchrec.distributed.types import (
@@ -82,9 +82,11 @@ class ModelParallelTest(ModelParallelTestShared):
         kernel_type: str,
     ) -> None:
         self._test_sharding(
-            # pyre-ignore[6]
             sharders=[
-                create_test_sharder(sharder_type, sharding_type, kernel_type),
+                cast(
+                    ModuleSharder[nn.Module],
+                    create_test_sharder(sharder_type, sharding_type, kernel_type),
+                ),
             ],
             backend="nccl",
         )

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -15,9 +15,9 @@ from torchrec.distributed.test_utils.test_model import (
     TestTowerCollectionSparseNN,
     TestTowerSparseNN,
 )
-from torchrec.distributed.test_utils.test_model_parallel import (
+from torchrec.distributed.test_utils.test_model_parallel import ModelParallelTestShared
+from torchrec.distributed.test_utils.test_sharding import (
     create_test_sharder,
-    ModelParallelTestShared,
     SharderType,
 )
 from torchrec.distributed.types import ShardingType

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -14,10 +14,9 @@ import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import given, settings, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.distributed.test_utils.test_model import TestSparseNNBase
-from torchrec.distributed.test_utils.test_model_parallel_base import (
-    ModelParallelTestBase,
-)
+from torchrec.distributed.test_utils.test_sharding import sharding_single_rank_test
 from torchrec.distributed.tests.test_sequence_model import (
     TestEmbeddingCollectionSharder,
     TestSequenceSparseNN,
@@ -28,7 +27,7 @@ from torchrec.test_utils import seed_and_log, skip_if_asan_class
 
 
 @skip_if_asan_class
-class SequenceModelParallelTest(ModelParallelTestBase):
+class SequenceModelParallelTest(MultiProcessTestBase):
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -146,14 +145,12 @@ class SequenceModelParallelTest(ModelParallelTestBase):
         model_class: Type[TestSparseNNBase] = TestSequenceSparseNN,
     ) -> None:
         self._run_multi_process_test(
-            # pyre-ignore [6]
-            callable=self._test_sharding_single_rank,
+            callable=sharding_single_rank_test,
             world_size=world_size,
             local_size=local_size,
             model_class=model_class,
             tables=self.tables,
             embedding_groups=self.embedding_groups,
-            # pyre-fixme[6]
             sharders=sharders,
             optim=EmbOptimType.EXACT_SGD,
             backend=backend,

--- a/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
@@ -13,13 +13,12 @@ import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.distributed.test_utils.test_model import TestSparseNNBase
-from torchrec.distributed.test_utils.test_model_parallel import (
+from torchrec.distributed.test_utils.test_sharding import (
     create_test_sharder,
     SharderType,
-)
-from torchrec.distributed.test_utils.test_model_parallel_base import (
-    ModelParallelTestBase,
+    sharding_single_rank_test,
 )
 from torchrec.distributed.tests.test_sequence_model import (
     TestEmbeddingCollectionSharder,
@@ -32,7 +31,7 @@ from torchrec.test_utils import seed_and_log, skip_if_asan_class
 
 
 @skip_if_asan_class
-class SequenceModelParallelHierarchicalTest(ModelParallelTestBase):
+class SequenceModelParallelHierarchicalTest(MultiProcessTestBase):
     """
     Testing hierarchical sharding types.
 
@@ -102,14 +101,12 @@ class SequenceModelParallelHierarchicalTest(ModelParallelTestBase):
         model_class: Type[TestSparseNNBase] = TestSequenceSparseNN,
     ) -> None:
         self._run_multi_process_test(
-            # pyre-ignore [6]
-            callable=self._test_sharding_single_rank,
+            callable=sharding_single_rank_test,
             world_size=world_size,
             local_size=local_size,
             model_class=model_class,
             tables=self.tables,
             embedding_groups=self.embedding_groups,
-            # pyre-fixme[6]
             sharders=sharders,
             optim=EmbOptimType.EXACT_SGD,
             backend=backend,


### PR DESCRIPTION
Summary:
Motivation is that we want to have some unit tests that cover modules (rather than a giant model).

This refactor just move some multi process set up code out of test_model_parallel => test_utils/multi_process and change dependencies

This will be reused by test_ebc_parallel/test_ec_parallel

Differential Revision: D35582856

