### PR TITLE
Update optimizer storage calculation

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -771,7 +771,14 @@ def _calculate_storage_specific_sizes(
     ]
 
     optimizer_sizes: List[int] = [
-        tensor_size * 2 if sharding_type == ShardingType.DATA_PARALLEL.value else 0
+        tensor_size * 2
+        if compute_kernel
+        in {
+            EmbeddingComputeKernel.DENSE.value,
+            EmbeddingComputeKernel.SPARSE.value,
+            EmbeddingComputeKernel.BATCHED_DENSE.value,
+        }
+        else 0
         for tensor_size in tensor_sizes
     ]
 

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -239,7 +239,7 @@ class TWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value, EmbeddingComputeKernel.SPARSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class RWSharder(EmbeddingBagCollectionSharder):
@@ -249,7 +249,7 @@ class RWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class UVMCachingRWSharder(EmbeddingBagCollectionSharder):
@@ -269,7 +269,7 @@ class TWRWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class CWSharder(EmbeddingBagCollectionSharder):
@@ -279,7 +279,7 @@ class CWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class TWCWSharder(EmbeddingBagCollectionSharder):
@@ -289,7 +289,7 @@ class TWCWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class DPSharder(EmbeddingBagCollectionSharder):
@@ -299,7 +299,7 @@ class DPSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value, EmbeddingComputeKernel.SPARSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class AllTypesSharder(EmbeddingBagCollectionSharder):
@@ -663,7 +663,7 @@ class TestEnumerators(unittest.TestCase):
             self.assertNotIn(sharding_option.compute_kernel, unexpected_compute_kernels)
 
     def test_tower_sharding(self) -> None:
-        # five tabels
+        # five tables
         # tower_0: tables[2], tables[3]
         # tower_1: tables[0]
         # sparse_arch:

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -17,9 +17,6 @@ from torchrec.distributed.planner.types import Topology, PlannerError
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
-from torchrec.modules.embedding_modules import (
-    EmbeddingBagCollection,
-)
 
 
 class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -29,7 +26,7 @@ class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -39,7 +36,7 @@ class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
 
 
 class TestEmbeddingShardingPlanner(unittest.TestCase):


### PR DESCRIPTION
Summary: The batched fused compute kernel uses rowwise adagrad optimizer which uses very little space. For other compute kernels, they will use other optimizers i.e. adam

Differential Revision: D35680223

