### PR TITLE
add moveToHost in ResultSplit

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -486,17 +486,7 @@ class ShardedEmbeddingTowerCollection(
         # create mapping of logical towers to physical towers
         tables_per_lt: List[Set[str]] = []
         for tower in module.towers:
-            lt_tables = set(tower_sharder.shardable_parameters(tower).keys())
-            tables_per_lt.append(lt_tables)
-            # check the tables in a logical tower are on same physical tower
-            found_physical_tower = False
-            for pt_tables in tables_per_pt:
-                if lt_tables.issubset(pt_tables):
-                    found_physical_tower = True
-                    break
-            assert (
-                found_physical_tower
-            ), f"tables in a logical tower must be in the same physical tower, logical tower tables: {lt_tables}, tables_per_pt: {tables_per_pt}"
+            tables_per_lt.append(set(tower_sharder.shardable_parameters(tower).keys()))
 
         logical_to_physical_order: List[List[int]] = [
             [] for _ in range(self._cross_pg_world_size)

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -29,7 +29,6 @@ from torchrec.distributed.planner.types import (
 )
 from torchrec.distributed.planner.utils import sharder_name
 from torchrec.distributed.types import ModuleSharder, ShardingType
-from torchrec.modules.embedding_tower import EmbeddingTowerCollection, EmbeddingTower
 
 
 class EmbeddingEnumerator(Enumerator):
@@ -86,17 +85,10 @@ class EmbeddingEnumerator(Enumerator):
         }
         sharding_options: List[ShardingOption] = []
 
-        named_modules_queue = [("", module)]
-        while named_modules_queue:
-            child_path, child_module = named_modules_queue.pop()
+        for child_path, child_module in module.named_modules():
             sharder_key = sharder_name(type(child_module))
             sharder = sharder_map.get(sharder_key, None)
             if not sharder:
-                for n, m in child_module.named_children():
-                    if child_path != "":
-                        named_modules_queue.append((child_path + "." + n, m))
-                    else:
-                        named_modules_queue.append((n, m))
                 continue
 
             for name, param in sharder.shardable_parameters(child_module).items():
@@ -127,12 +119,6 @@ class EmbeddingEnumerator(Enumerator):
                             sharding_type=sharding_type,
                             col_wise_shard_dim=col_wise_shard_dim,
                         )
-                        dependency = None
-                        if isinstance(child_module, EmbeddingTower):
-                            dependency = child_path
-                        elif isinstance(child_module, EmbeddingTowerCollection):
-                            tower_index = _get_tower_index(name, child_module)
-                            dependency = child_path + ".tower_" + str(tower_index)
                         sharding_options.append(
                             ShardingOption(
                                 name=name,
@@ -149,7 +135,6 @@ class EmbeddingEnumerator(Enumerator):
                                     Shard(size=size, offset=offset)
                                     for size, offset in zip(shard_sizes, shard_offsets)
                                 ],
-                                dependency=dependency,
                             )
                         )
 
@@ -328,15 +313,3 @@ def _calculate_cw_shard_sizes_and_offsets(
         [0, block_size * rank] for rank in range(num_col_wise_shards)
     ]
     return shard_sizes, shard_offsets
-
-
-def _get_tower_index(name: str, child_module: EmbeddingTowerCollection) -> int:
-    for i, tower in enumerate(child_module.towers):
-        for n, m in tower.named_modules():
-            if isinstance(m, nn.Embedding) or isinstance(m, nn.EmbeddingBag):
-                table_name = n.split(".")[-1]
-                if name == table_name:
-                    return i
-    raise RuntimeError(
-        f"couldn't get the tower index for table {name}, tower collection: {child_module}"
-    )

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -6,9 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-from dataclasses import dataclass
-from typing import List, cast
+from typing import List, Tuple, Optional, Dict, cast
 
+from torchrec.distributed.planner.constants import MAX_SIZE
 from torchrec.distributed.planner.types import (
     Partitioner,
     Topology,
@@ -21,58 +21,163 @@ from torchrec.distributed.planner.types import (
 from torchrec.distributed.types import ShardingType
 
 
-def _sort_devices_by_perf(
-    devices: List[List[DeviceHardware]],
-) -> List[List[DeviceHardware]]:
-    def _get_perf_sum(device_list: List[DeviceHardware]) -> float:
-        perf = 0
-        for device in device_list:
-            perf += device.perf
-        return perf
-
-    return sorted(devices, key=_get_perf_sum)
-
-
-def _get_uniform_sharding_options(
+def greedy_partition(
+    num_partitions: int,
     sharding_options: List[ShardingOption],
-) -> List[ShardingOption]:
-    uniform_sharding_options: List[ShardingOption] = []
-    for sharding_option in sharding_options:
-        if sharding_option.partition_by == PartitionByType.UNIFORM.value:
-            uniform_sharding_options.append(sharding_option)
-    return uniform_sharding_options
+    shard_idxes: Optional[List[Tuple[int, int]]] = None,
+    partition_sums: Optional[List[float]] = None,
+    mem_cap: Optional[List[Storage]] = None,
+) -> List[List[Tuple[int, int]]]:
+    """
+    Divides indices among `num_partitions` partitions in a greedy fashion based on perf
+    weights associated with each [option_idx, shard_idx].
+
+    Returns:
+        List[List[Tuple[int, int]]]: list of indices of (option_idx, shard_idx) that should be allocated to each partition.
+
+    Example::
+
+        sharding_options = [
+            [0,1,2,3] with perfs [10,20,30,40]
+            [0,1] with perfs [200,300]
+        ]
+        # with num_partitions=3
+
+        # The final output would be:
+        [
+            partition_0 = [(1,1)], with a perf of 300
+            partition_1 = [(1,0)], with a perf of 200
+            partition_2 = [(0,0),(0,1),(0,2),(0,3)], with a perf of 100 (10+20+30+40)
+        ]
+    """
+
+    if shard_idxes is None:
+        shard_idxes = []
+        for option_idx, sharding_option in enumerate(sharding_options):
+            for shard_idx in range(sharding_option.num_shards):
+                shard_idxes.append((option_idx, shard_idx))
+
+    def _to_comparable(order_shard_idx: Tuple[int, int]) -> Tuple[float, Storage]:
+        sharding_option: ShardingOption = sharding_options[order_shard_idx[0]]
+        return (
+            cast(float, sharding_option.shards[order_shard_idx[1]].perf),
+            cast(Storage, sharding_option.shards[order_shard_idx[1]].storage),
+        )
+
+    # A correct implementation of the greedy algorithm processes items in descending
+    # value order. Here, we sort in ascending order, but we'll pop items in descending
+    # order below.
+    sorted_shard_idxes = sorted(
+        shard_idxes, key=lambda order_shard_idx: _to_comparable(order_shard_idx)
+    )
+
+    partitions = [[] for p in range(num_partitions)]
+    if partition_sums is None:
+        partition_sums = [0.0] * num_partitions
+
+    partition_size_sums = [Storage(hbm=0, ddr=0) for _ in range(num_partitions)]
+
+    if mem_cap is None:
+        mem_cap = [Storage(hbm=MAX_SIZE, ddr=MAX_SIZE) for _ in range(num_partitions)]
+
+    assert len(partition_size_sums) == len(
+        mem_cap
+    ), "partition_size_sums and mem_cap must have the same dimensions"
+
+    """
+    Successively add remaining pairs to the partition with the minimum sum.
+    """
+    while sorted_shard_idxes:
+        # Remove values from largest to smallest so the algorithm is correct.
+        option_idx, shard_idx = sorted_shard_idxes.pop()
+        storage_size = cast(
+            Storage, sharding_options[option_idx].shards[shard_idx].storage
+        )
+        perf = cast(float, sharding_options[option_idx].shards[shard_idx].perf)
+
+        min_sum = MAX_SIZE
+        min_partition_idx = -1
+        for partition_idx in range(num_partitions):
+            partition_mem_cap: Storage = mem_cap[partition_idx]
+            partition_size_sum: Storage = partition_size_sums[partition_idx]
+            if (
+                partition_mem_cap.hbm >= partition_size_sum.hbm + storage_size.hbm
+            ) and (partition_mem_cap.ddr >= partition_size_sum.ddr + storage_size.ddr):
+                if partition_sums[partition_idx] < min_sum:
+                    min_sum = partition_sums[partition_idx]
+                    min_partition_idx = partition_idx
+
+        if min_partition_idx == -1:
+            raise PlannerError(
+                f"Table of size {storage_size} GB cannot be added to any rank. partition_size_sums: {partition_size_sums}. mem_cap: {mem_cap}."
+            )
+
+        partitions[min_partition_idx].append((option_idx, shard_idx))
+
+        partition_size_sums[min_partition_idx] += storage_size
+        partition_sums[min_partition_idx] += perf
+
+    return partitions
 
 
-@dataclass
-class ShardingOptionGroup:
-    sharding_options: List[ShardingOption]
-    storage_sum: Storage
-
-
-def _group_and_sort_non_uniform_sharding_options(
+def uniform_partition(
+    num_partitions: int,
     sharding_options: List[ShardingOption],
-) -> List[ShardingOptionGroup]:
-    sharding_option_groups_by_dependency = {}
+    mem_cap: List[Storage],
+    shard_idxes: Optional[List[Tuple[int, int]]] = None,
+) -> List[List[Tuple[int, int]]]:
+    """
+    Assigns one shard to each rank.
+
+    Example::
+
+        sharding_options = [
+            [0,1,2,3],
+            [0,1,2,3],
+        ]
+        # with num_partitions=4
+
+        # The final output would be:
+        [
+            partition_0 = [(0,0),(1,0)]
+            partition_1 = [(0,1),(1,1)]
+            partition_2 = [(0,2),(1,2)]
+            partition_3 = [(0,3),(1,3)]
+        ]
+    """
+
+    partition_size_sums = [Storage(hbm=0, ddr=0) for _ in range(num_partitions)]
+
+    if shard_idxes is None:
+        shard_idxes = []
+        for option_idx, sharding_option in enumerate(sharding_options):
+            for shard_idx in range(sharding_option.num_shards):
+                shard_idxes.append((option_idx, shard_idx))
+
+    partitions: List[List[Tuple[int, int]]] = [[] for _ in range(num_partitions)]
+    for option_idx, shard_idx in shard_idxes:
+        storage_size = cast(
+            Storage, sharding_options[option_idx].shards[shard_idx].storage
+        )
+        if partition_size_sums[shard_idx] + storage_size > mem_cap[shard_idx]:
+            raise PlannerError(
+                f"Table of size {storage_size} GB cannot be added to any rank. partition_size_sums: {partition_size_sums}. mem_cap: {mem_cap}."
+            )
+        partition_size_sums[shard_idx] += storage_size
+        partitions[shard_idx].append((option_idx, shard_idx))
+
+    return partitions
+
+
+def _group_sharding_options(
+    sharding_options: List[ShardingOption],
+) -> Dict[str, List[ShardingOption]]:
+    partition_by_groups = {}
     for sharding_option in sharding_options:
-        if sharding_option.partition_by == PartitionByType.UNIFORM.value:
-            continue
-
-        group_key = sharding_option.dependency or sharding_option.fqn
-        if group_key not in sharding_option_groups_by_dependency:
-            sharding_option_groups_by_dependency[group_key] = ShardingOptionGroup(
-                [sharding_option], sharding_option.total_storage
-            )
-        else:
-            sharding_option_groups_by_dependency[group_key].sharding_options.append(
-                sharding_option
-            )
-            sharding_option_groups_by_dependency[
-                group_key
-            ].storage_sum += sharding_option.total_storage
-    sharding_option_groups = list(sharding_option_groups_by_dependency.values())
-
-    sharding_option_groups.sort(key=lambda group: group.storage_sum, reverse=True)
-    return sharding_option_groups
+        if sharding_option.partition_by not in partition_by_groups:
+            partition_by_groups[sharding_option.partition_by] = []
+        partition_by_groups[sharding_option.partition_by].append(sharding_option)
+    return partition_by_groups
 
 
 class GreedyPerfPartitioner(Partitioner):
@@ -144,127 +249,242 @@ class GreedyPerfPartitioner(Partitioner):
         # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
         self._topology: Topology = copy.deepcopy(storage_constraint)
         plan = copy.deepcopy(proposal)
-        # pyre-ignore [16]
-        self._host_level_devices = self._get_host_level_devices()
 
-        # first partition the uniform sharding options (RW & DP)
-        uniform_sharding_options = _get_uniform_sharding_options(plan)
-        self._uniform_partition(uniform_sharding_options, self._topology.devices)
+        grouped_sharding_options = _group_sharding_options(plan)
 
-        # group the rest sharding options by colocation type (co-host, co-device, none)
-        # and sort the groups by storage in reverse order
-        sharding_option_groups = _group_and_sort_non_uniform_sharding_options(plan)
-
-        for sharding_option_group in sharding_option_groups:
-            if (
-                sharding_option_group.sharding_options[0].partition_by
-                == PartitionByType.HOST.value
-            ):
-                self._cohost_partition(sharding_option_group)
-            elif (
-                sharding_option_group.sharding_options[0].partition_by
-                == PartitionByType.DEVICE.value
-            ):
-                assert (
-                    len(sharding_option_group.sharding_options) == 1
-                ), f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}"
-                self._device_partition(
-                    sharding_option_group.sharding_options[0], self._topology.devices
-                )
-            else:
-                raise RuntimeError(
-                    f"Unexpected sharding option group {sharding_option_group}"
-                )
+        if PartitionByType.UNIFORM.value in grouped_sharding_options:
+            self._partition_by_uniform(
+                grouped_sharding_options[PartitionByType.UNIFORM.value]
+            )
+        if PartitionByType.HOST.value in grouped_sharding_options:
+            self._partition_by_host(
+                grouped_sharding_options[PartitionByType.HOST.value]
+            )
+        if PartitionByType.DEVICE.value in grouped_sharding_options:
+            self._partition_by_device(
+                grouped_sharding_options[PartitionByType.DEVICE.value]
+            )
         return plan
 
-    def _device_partition(
-        self, sharding_option: ShardingOption, devices: List[DeviceHardware]
-    ) -> None:
-        for shard in sharding_option.shards:
-            sorted_devices = sorted(devices, key=lambda device: device.perf)
-            success = False
-            for device in sorted_devices:
-                if device.storage >= shard.storage:
-                    shard.rank = device.rank
-                    device.storage -= cast(Storage, shard.storage)
-                    device.perf += cast(float, shard.perf)
-                    success = True
-                    break
-            if not success:
-                raise PlannerError(
-                    f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}"
-                )
-
-    def _cohost_partition(self, sharding_option_group: ShardingOptionGroup) -> None:
-        # pyre-ignore [16]
-        sorted_host_level_devices = _sort_devices_by_perf(self._host_level_devices)
-        for devices in sorted_host_level_devices:
-            host_devices = copy.deepcopy(devices)
-            host_storage = Storage(hbm=0, ddr=0)
-            for device in host_devices:
-                host_storage += device.storage
-            if host_storage < sharding_option_group.storage_sum:
-                continue
-
-            success = True
-            for sharding_option in sharding_option_group.sharding_options:
-                try:
-                    if (
-                        sharding_option.sharding_type
-                        == ShardingType.TABLE_ROW_WISE.value
-                    ):
-                        self._uniform_partition([sharding_option], host_devices)
-                    elif (
-                        sharding_option.sharding_type
-                        == ShardingType.TABLE_COLUMN_WISE.value
-                    ):
-                        self._device_partition(sharding_option, host_devices)
-                    else:
-                        raise RuntimeError(
-                            f"unexpected cohost sharding type: {sharding_option.sharding_type}"
-                        )
-                except PlannerError:
-                    success = False
-                    break
-            if success:
-                # successfully found a host and partitioned on that host
-                # need to update the devices
-                for device, device_copy in zip(devices, host_devices):
-                    device.storage = device_copy.storage
-                    device.perf = device_copy.perf
-                return
-        raise PlannerError(
-            f"can't find a host for sharding option group {sharding_option_group}"
+    def _partition_by_uniform(self, sharding_options: List[ShardingOption]) -> None:
+        partitions = uniform_partition(
+            # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+            num_partitions=self._topology.world_size,
+            sharding_options=sharding_options,
+            mem_cap=[device.storage for device in self._topology.devices],
         )
+        self._update_shards(partitions, sharding_options)
 
-    def _get_host_level_devices(self) -> List[List[DeviceHardware]]:
-        # pyre-ignore [16]
+    def _partition_by_device(self, sharding_options: List[ShardingOption]) -> None:
+        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+        partition_sums = [float(device.perf) for device in self._topology.devices]
+        mem_cap: List[Storage] = [device.storage for device in self._topology.devices]
+        partitions = greedy_partition(
+            num_partitions=self._topology.world_size,
+            sharding_options=sharding_options,
+            partition_sums=partition_sums,
+            mem_cap=mem_cap,
+        )
+        self._update_shards(partitions, sharding_options)
+
+    def _partition_by_host(self, sharding_options: List[ShardingOption]) -> None:
+        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
         num_hosts: int = self._topology.world_size // self._topology.local_world_size
-        host_level_devices: List[List[DeviceHardware]] = []
+
+        host_level_devices: Dict[int, List[DeviceHardware]] = {}
         for i in range(num_hosts):
             devices_in_host = self._topology.devices[
                 i
                 * self._topology.local_world_size : (i + 1)
                 * self._topology.local_world_size
             ]
-            host_level_devices.append(devices_in_host)
-        return host_level_devices
+            host_level_devices[i] = devices_in_host
 
-    def _uniform_partition(
-        self, sharding_options: List[ShardingOption], devices: List[DeviceHardware]
+        self._uniform_partition_by_host(
+            sharding_options=sharding_options,
+            host_level_devices=host_level_devices,
+        )
+        self._greedy_partition_by_host(
+            sharding_options=sharding_options,
+            host_level_devices=host_level_devices,
+        )
+
+    def _uniform_partition_by_host(
+        self,
+        sharding_options: List[ShardingOption],
+        host_level_devices: Dict[int, List[DeviceHardware]],
     ) -> None:
-        for sharding_option in sharding_options:
-            if sharding_option.num_shards != len(devices):
-                raise RuntimeError(
-                    f"For a uniform partition, the number of shards ({sharding_option.num_shards}) must equal the number of devices ({len(devices)})"
+        shard_idxes = []
+        for option_idx, _ in enumerate(sharding_options):
+            if (
+                _base_partition_by(sharding_options[option_idx].sharding_type)
+                == PartitionByType.UNIFORM.value
+            ):
+                # only take the first shard from each sharding option. We can infer the rest
+                shard_idxes.append((option_idx, 0))
+        if not shard_idxes:
+            return
+
+        mem_cap: List[Storage] = []
+        partition_sums = []
+
+        for _host, devices in host_level_devices.items():
+            # mem_cap of a host is the min of the storage of all devices on that host for uniform case.
+            mem_cap.append(min([device.storage for device in devices]))
+            # perf of a host is the max across all of its devices for uniform case. Typically this should be zero at entry point.
+            partition_sums.append(max([float(device.perf) for device in devices]))
+
+        host_level_partitions: List[List[Tuple[int, int]]] = greedy_partition(
+            num_partitions=len(host_level_devices),
+            sharding_options=sharding_options,
+            shard_idxes=shard_idxes,
+            partition_sums=partition_sums,
+            mem_cap=mem_cap,
+        )
+        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+        partitions: List[List[Tuple[int, int]]] = [[] for _ in self._topology.devices]
+
+        for host_idx, host_partition in enumerate(host_level_partitions):
+            self._uniform_device_level_partition(
+                partitions=partitions,
+                sharding_options=sharding_options,
+                option_idxes=[option_idx for option_idx, _ in host_partition],
+                host_level_devices=host_level_devices[host_idx],
+                host_idx=host_idx,
+            )
+
+        self._update_shards(partitions, sharding_options)
+
+    def _greedy_partition_by_host(
+        self,
+        sharding_options: List[ShardingOption],
+        host_level_devices: Dict[int, List[DeviceHardware]],
+    ) -> None:
+        shard_idxes = []
+        for option_idx, _ in enumerate(sharding_options):
+            if (
+                _base_partition_by(sharding_options[option_idx].sharding_type)
+                == PartitionByType.DEVICE.value
+            ):
+                # only take the first shard from each sharding option. We can infer the rest
+                shard_idxes.append((option_idx, 0))
+        if not shard_idxes:
+            return
+
+        mem_cap: List[Storage] = []
+        partition_sums = []
+
+        for _host, devices in host_level_devices.items():
+            # mem_cap of a host is the sum of the storage of all devices on that host for greedy case.
+            storage_sum = Storage(hbm=0, ddr=0)
+            for device in devices:
+                storage_sum += device.storage
+            mem_cap.append(storage_sum)
+            # perf of a host is the min across all of its devices for greedy case. Typically this should be zero at entry point.
+            partition_sums.append(min([float(device.perf) for device in devices]))
+
+        host_level_partitions: List[List[Tuple[int, int]]] = greedy_partition(
+            num_partitions=len(host_level_devices),
+            sharding_options=sharding_options,
+            shard_idxes=shard_idxes,
+            partition_sums=partition_sums,
+            mem_cap=mem_cap,
+        )
+        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+        partitions: List[List[Tuple[int, int]]] = [[] for _ in self._topology.devices]
+
+        for host_idx, host_partition in enumerate(host_level_partitions):
+            self._greedy_device_level_partition(
+                partitions=partitions,
+                sharding_options=sharding_options,
+                option_idxes=[option_idx for option_idx, _ in host_partition],
+                host_level_devices=host_level_devices[host_idx],
+                host_idx=host_idx,
+            )
+
+        self._update_shards(partitions, sharding_options)
+
+    def _uniform_device_level_partition(
+        self,
+        partitions: List[List[Tuple[int, int]]],
+        sharding_options: List[ShardingOption],
+        option_idxes: List[int],
+        host_level_devices: List[DeviceHardware],
+        host_idx: int,
+    ) -> None:
+        shard_idxes = []
+        for option_idx in option_idxes:
+            for shard_idx in range(sharding_options[option_idx].num_shards):
+                shard_idxes.append((option_idx, shard_idx))
+
+        device_level_partitions: List[List[Tuple[int, int]]] = uniform_partition(
+            # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+            num_partitions=self._topology.local_world_size,
+            sharding_options=sharding_options,
+            mem_cap=[device.storage for device in host_level_devices],
+            shard_idxes=shard_idxes,
+        )
+
+        for device_idx, device_partition in enumerate(device_level_partitions):
+            for option_idx, shard_idx in device_partition:
+                partitions[
+                    self._topology.local_world_size * host_idx + device_idx
+                ].append((option_idx, shard_idx))
+
+    def _greedy_device_level_partition(
+        self,
+        partitions: List[List[Tuple[int, int]]],
+        sharding_options: List[ShardingOption],
+        option_idxes: List[int],
+        host_level_devices: List[DeviceHardware],
+        host_idx: int,
+    ) -> None:
+        shard_idxes = []
+        for option_idx in option_idxes:
+            for shard_idx in range(sharding_options[option_idx].num_shards):
+                shard_idxes.append((option_idx, shard_idx))
+
+        device_level_partitions: List[List[Tuple[int, int]]] = greedy_partition(
+            # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+            num_partitions=self._topology.local_world_size,
+            sharding_options=sharding_options,
+            shard_idxes=shard_idxes,
+            partition_sums=[float(device.perf) for device in host_level_devices],
+            mem_cap=[device.storage for device in host_level_devices],
+        )
+
+        for device_idx, device_partition in enumerate(device_level_partitions):
+            for option_idx, shard_idx in device_partition:
+                partitions[
+                    self._topology.local_world_size * host_idx + device_idx
+                ].append((option_idx, shard_idx))
+
+    def _update_shards(
+        self,
+        partitions: List[List[Tuple[int, int]]],
+        sharding_options: List[ShardingOption],
+    ) -> None:
+        """
+        Updates the ranks of the shards as well as device perfs.
+        """
+        for partition_idx, partition in enumerate(partitions):
+            for [option_idx, shard_idx] in partition:
+                sharding_options[option_idx].shards[shard_idx].rank = partition_idx
+                # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+                self._topology.devices[partition_idx].storage -= (
+                    sharding_options[option_idx].shards[shard_idx].storage
                 )
-            for i in range(len(devices)):
-                storage_needed = cast(Storage, sharding_option.shards[i].storage)
-                if storage_needed > devices[i].storage:
-                    raise PlannerError(
-                        f"Shard of size {storage_needed} bytes does not fit on any rank. Device memory cap: {devices[i].storage}."
-                    )
-                else:
-                    sharding_option.shards[i].rank = devices[i].rank
-                    devices[i].storage -= storage_needed
-                    devices[i].perf += cast(float, sharding_option.shards[i].perf)
+                self._topology.devices[partition_idx].perf += (
+                    sharding_options[option_idx].shards[shard_idx].perf
+                )
+
+
+def _base_partition_by(sharding_type: str) -> str:
+    if sharding_type == ShardingType.TABLE_ROW_WISE.value:
+        return PartitionByType.UNIFORM.value
+    elif sharding_type == ShardingType.TABLE_COLUMN_WISE.value:
+        return PartitionByType.DEVICE.value
+    else:
+        raise ValueError(
+            f"Sharding type provided must have a partition_by value of HOST: {sharding_type}"
+        )

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -8,7 +8,7 @@
 import abc
 from dataclasses import field, dataclass
 from enum import Enum
-from typing import Optional, List, Dict, Tuple, Union, cast
+from typing import Optional, List, Dict, Tuple, Union
 
 import torch
 from torch import nn
@@ -194,7 +194,6 @@ class ShardingOption:
     # relevant to planner output, must be populated if sharding option
     # part of final solution
     shards: List[Shard] = field(default_factory=list)
-    dependency: Optional[str] = None
 
     @property
     def fqn(self) -> str:
@@ -211,13 +210,6 @@ class ShardingOption:
     @property
     def num_inputs(self) -> int:
         return len(self.input_lengths)
-
-    @property
-    def total_storage(self) -> Storage:
-        storage: Storage = Storage(hbm=0, ddr=0)
-        for shard in self.shards:
-            storage += cast(Storage, shard.storage)
-        return storage
 
     def __hash__(self) -> int:
         return hash(

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -518,31 +518,29 @@ class TestTowerSparseNN(TestSparseNNBase):
         # TODO: after adding planner support for tower_module, we can random assign
         # tables to towers, but for now the match planner default layout
         self.tower_0 = EmbeddingTower(
-            embedding_module=EmbeddingBagCollection(tables=[tables[2], tables[3]]),
-            interaction_module=TestTowerInteraction(tables=[tables[2], tables[3]]),
+            embedding_module=EmbeddingBagCollection(tables=[tables[0], tables[2]]),
+            interaction_module=TestTowerInteraction(tables=[tables[0], tables[2]]),
         )
         self.tower_1 = EmbeddingTower(
-            embedding_module=EmbeddingBagCollection(tables=[tables[0]]),
-            interaction_module=TestTowerInteraction(tables=[tables[0]]),
+            embedding_module=EmbeddingBagCollection(tables=[tables[1]]),
+            interaction_module=TestTowerInteraction(tables=[tables[1]]),
         )
-        self.sparse_arch = TestSparseArch(
-            [tables[1]],
-            # pyre-ignore [16]
-            [weighted_tables[0]],
-            sparse_device,
+        self.tower_2 = EmbeddingTower(
+            embedding_module=EmbeddingBagCollection(
+                # pyre-ignore [16]
+                tables=[weighted_tables[0]],
+                is_weighted=True,
+            ),
+            interaction_module=TestTowerInteraction(tables=[weighted_tables[0]]),
         )
-        self.sparse_arch_feature_names: List[str] = (
-            tables[1].feature_names + weighted_tables[0].feature_names
-        )
-
         self.over = nn.Linear(
             in_features=8
             # pyre-ignore [16]
             + self.tower_0.interaction.linear.out_features
             # pyre-ignore [16]
             + self.tower_1.interaction.linear.out_features
-            + tables[1].embedding_dim * len(tables[1].feature_names)
-            + weighted_tables[0].embedding_dim * len(weighted_tables[0].feature_names),
+            # pyre-ignore [16]
+            + self.tower_2.interaction.linear.out_features,
             out_features=16,
             device=dense_device,
         )
@@ -554,12 +552,9 @@ class TestTowerSparseNN(TestSparseNNBase):
         dense_r = self.dense(input.float_features)
         tower_0_r = self.tower_0(input.idlist_features)
         tower_1_r = self.tower_1(input.idlist_features)
-        sparse_arch_r = self.sparse_arch(input.idlist_features, input.idscore_features)
-        sparse_arch_r = torch.cat(
-            [sparse_arch_r[f] for f in self.sparse_arch_feature_names], dim=1
-        )
+        tower_2_r = self.tower_2(input.idscore_features)
 
-        sparse_r = torch.cat([tower_0_r, tower_1_r, sparse_arch_r], dim=1)
+        sparse_r = torch.cat([tower_0_r, tower_1_r, tower_2_r], dim=1)
         over_r = self.over(torch.cat([dense_r, sparse_r], dim=1))
         pred = torch.sigmoid(torch.mean(over_r, dim=1))
         if self.training:

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -225,7 +225,6 @@ class ModelParallelTestBase(unittest.TestCase):
         TODO: may need to add some checks that only does this if we're running on a
         single GPU (which should be most cases).
         """
-
         for group in plan.plan:
             for _, parameter_sharding in plan.plan[group].items():
                 if (

--- a/torchrec/inference/include/torchrec/inference/Exception.h
+++ b/torchrec/inference/include/torchrec/inference/Exception.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <folly/futures/Promise.h>
+
+#include "torchrec/inference/Types.h"
+
+namespace torchrec {
+
+void handleException(
+    folly::Promise<std::unique_ptr<PredictionResponse>>& promise,
+    const std::string& msg);
+
+} // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/ResultSplit.h
+++ b/torchrec/inference/include/torchrec/inference/ResultSplit.h
@@ -22,6 +22,8 @@ class ResultSplitFunc {
       size_t /* nOffset */,
       size_t /* nLength */,
       size_t /* nTotalLength */) = 0;
+
+  virtual c10::IValue moveToHost(c10::IValue /* result */) = 0;
 };
 
 /**

--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -10,11 +10,13 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <variant>
 #include <vector>
-#include "ATen/core/ivalue.h"
 
+#include <ATen/core/ivalue.h>
+#include <folly/ExceptionWrapper.h>
 #include <folly/io/IOBuf.h>
 
 namespace torchrec {
@@ -46,6 +48,8 @@ struct PredictionRequest {
 
 struct PredictionResponse {
   c10::IValue predictions;
+  // If set, the result is an exception.
+  std::optional<folly::exception_wrapper> exception;
 };
 
 using PredictionException = std::runtime_error;

--- a/torchrec/inference/src/BatchingQueue.cpp
+++ b/torchrec/inference/src/BatchingQueue.cpp
@@ -33,6 +33,7 @@
 #include <folly/io/Cursor.h>
 #include <glog/logging.h>
 
+#include "torchrec/inference/Exception.h"
 #include "torchrec/inference/Types.h"
 
 using namespace std::chrono_literals;
@@ -131,8 +132,7 @@ void BatchingQueue::createBatch() {
 
         if (std::chrono::steady_clock::now() - front.addedTime >=
             config_.queueTimeout) {
-          PredictionException ex("Batching queue timeout");
-          front.context.promise.setException(std::move(ex));
+          handleException(front.context.promise, "Batching queue timeout");
           queue.pop();
           continue;
         }

--- a/torchrec/inference/src/Exception.cpp
+++ b/torchrec/inference/src/Exception.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torchrec/inference/Exception.h"
+
+#include <memory>
+#include <string>
+
+#include "torchrec/inference/Types.h"
+
+namespace torchrec {
+
+void handleException(
+    folly::Promise<std::unique_ptr<PredictionResponse>>& promise,
+    const std::string& msg) {
+  auto ex = folly::make_exception_wrapper<PredictionException>(msg);
+  auto response = std::make_unique<PredictionResponse>();
+  response->exception = std::move(ex);
+  promise.setValue(std::move(response));
+}
+
+} // namespace torchrec


### PR DESCRIPTION
Summary: Remove enforcement of the predict module to return a CPU tensor; let ResultSplit handle the device to host move

Reviewed By: divchenko

Differential Revision: D35190427

