### PR TITLE
Properly set up GPU/CUDA environment for CI

### DIFF
--- a/.github/workflows/install_nvidia_utils_linux.sh
+++ b/.github/workflows/install_nvidia_utils_linux.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eou pipefail
+
+DISTRIBUTION=$(. /etc/os-release;echo $ID$VERSION_ID) \
+DRIVER_FN="NVIDIA-Linux-x86_64-510.60.02.run"
+YUM_REPO_URL="https://nvidia.github.io/nvidia-docker/${DISTRIBUTION}/nvidia-docker.repo"
+
+install_nvidia_docker2_amzn2() {
+    (
+        set -x
+        # Needed for yum-config-manager
+        sudo yum install -y yum-utils
+        sudo yum-config-manager --add-repo "${YUM_REPO_URL}"
+        sudo yum install -y nvidia-docker2
+        sudo systemctl restart docker
+    )
+}
+
+install_nvidia_driver_amzn2() {
+    (
+        set -x
+        sudo yum groupinstall -y "Development Tools"
+        # ensure our kernel install is the same as our underlying kernel,
+        # groupinstall "Development Tools" has a habit of mismatching kernel headers
+        sudo yum install -y "kernel-devel-uname-r == $(uname -r)"
+        sudo curl -fsL -o /tmp/nvidia_driver "https://s3.amazonaws.com/ossci-linux/nvidia_driver/$DRIVER_FN"
+        sudo /bin/bash /tmp/nvidia_driver -s --no-drm || (sudo cat /var/log/nvidia-installer.log && false)
+        sudo rm -fv /tmp/nvidia_driver
+        nvidia-smi
+    )
+}
+
+# Install container toolkit based on distribution
+echo "== Installing nvidia container toolkit for ${DISTRIBUTION} =="
+case "${DISTRIBUTION}" in
+    amzn*)
+        install_nvidia_docker2_amzn2
+        ;;
+    *)
+        echo "ERROR: Unknown distribution ${DISTRIBUTION}"
+        exit 1
+        ;;
+esac
+
+echo "== Installing nvidia driver ${DRIVER_FN} =="
+case "${DISTRIBUTION}" in
+    amzn*)
+        install_nvidia_driver_amzn2
+        ;;
+    *)
+        echo "ERROR: Unknown distribution ${DISTRIBUTION}"
+        exit 1
+        ;;
+esac

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -180,6 +180,11 @@ jobs:
         sudo yum install -y cuda-11-3
         sudo yum install -y cuda-drivers
         sudo yum install -y libcudnn8-devel
+    - name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
+      run: |
+        sudo bash .github/workflows/install_nvidia_utils_linux.sh
+        sudo echo "GPU_FLAG=--gpus all" >> "${GITHUB_ENV}"
+        sudo nvidia-smi
     - name: setup Path
       run: |
         echo /usr/local/cuda-11.3/bin >> $GITHUB_PATH


### PR DESCRIPTION
Summary:
ATT

Pytorch distributed when writing some GPU unit tests noticed that they didn't have access to GPUs. After some investigation they found that these additional lines were included in the main PyTorch CI. After adding them, we should be able to see GPUs

Differential Revision: D35736829

