### PR TITLE
Remove DMP state dict override and use post hook

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -91,7 +91,7 @@ def _gen_model_and_input(
 
 
 def _copy_state_dict(
-    loc: Dict[str, Union[torch.Tensor, ShardedTensor]],
+    loc: Dict[str, torch.Tensor],
     glob: Dict[str, torch.Tensor],
 ) -> None:
     for name, tensor in loc.items():

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -575,7 +575,7 @@ class ModelParallelStateDictTest(unittest.TestCase):
         m1, m2 = models
 
         # load the second's (m2's) with the first (m1's) state_dict
-        m2.load_state_dict(cast("OrderedDict[str, torch.Tensor]", m1.state_dict()))
+        m2.load_state_dict(m1.state_dict())
 
         # validate the models are equivalent
         with torch.no_grad():
@@ -614,10 +614,7 @@ class ModelParallelStateDictTest(unittest.TestCase):
         (m1, m2), batch = self._generate_dmps_and_batch(sharders)
 
         # load the second's (m2's) with the first (m1's) state_dict
-        m2.load_state_dict(
-            cast("OrderedDict[str, torch.Tensor]", m1.state_dict(prefix="alpha")),
-            prefix="alpha",
-        )
+        m2.load_state_dict(m1.state_dict(prefix="alpha"), prefix="alpha")
 
         # validate the models are equivalent
         sd1 = m1.state_dict()


### PR DESCRIPTION
Summary: Instead of overriding nn.Module's state dict implementation, satisfy DMP state dict needs by stripping DMP/DDP prefixes through a post hook.

Differential Revision: D35826663

