### PR TITLE
ResourceManager limits batches allocated onto gpu

### DIFF
--- a/torchrec/inference/include/torchrec/inference/ResourceManager.h
+++ b/torchrec/inference/include/torchrec/inference/ResourceManager.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include <folly/small_vector.h>
+#include <glog/logging.h>
+
+namespace torchrec {
+
+/**
+ * ResourceManager can be used to limit in-flight batches
+ * allocated onto GPUs to prevent OOMing.
+ */
+class ResourceManager {
+ public:
+  ResourceManager(
+      int worldSize,
+      size_t maxOutstandingBatches,
+      int logFrequency = 100);
+
+  // Returns whether batches can be allocated onto a device based on
+  // slack provided (ms) and maxOutstandingBatches_).
+  bool occupyDevice(int gpuIdx, std::chrono::milliseconds slack);
+
+  void release(int gpuIdx);
+
+ private:
+  folly::small_vector<int> gpuToOutstandingBatches_;
+  // Helpful for tuning
+  folly::small_vector<int> allTimeHigh_;
+  const size_t maxOutstandingBatches_;
+  const int logFrequency_;
+  // Align as 64B to avoid false sharing
+  alignas(64) std::mutex mu_;
+};
+
+class ResourceManagerGuard {
+ public:
+  ResourceManagerGuard(
+      std::weak_ptr<ResourceManager> resourceManager,
+      int gpuIdx)
+      : resourceManager_(std::move(resourceManager)), gpuIdx_(gpuIdx) {}
+
+  ~ResourceManagerGuard() {
+    std::shared_ptr rm = resourceManager_.lock();
+    if (rm != nullptr) {
+      rm->release(gpuIdx_);
+    }
+  }
+
+ private:
+  std::weak_ptr<ResourceManager> resourceManager_;
+  const int gpuIdx_;
+};
+
+} // namespace torchrec

--- a/torchrec/inference/src/ResourceManager.cpp
+++ b/torchrec/inference/src/ResourceManager.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <thread>
+
+#include <folly/Random.h>
+#include <folly/String.h>
+#include <folly/small_vector.h>
+#include <glog/logging.h>
+
+#include "torchrec/inference/ResourceManager.h"
+
+namespace torchrec {
+
+ResourceManager::ResourceManager(
+    int worldSize,
+    size_t maxOutstandingBatches,
+    int logFrequency)
+    : gpuToOutstandingBatches_(worldSize),
+      allTimeHigh_(worldSize),
+      maxOutstandingBatches_(maxOutstandingBatches),
+      logFrequency_(logFrequency) {}
+
+bool ResourceManager::occupyDevice(
+    int gpuIdx,
+    std::chrono::milliseconds slack) {
+  const auto startTime = std::chrono::steady_clock::now();
+  std::chrono::milliseconds waitedFor = std::chrono::milliseconds(0);
+
+  // Exit loop once time expires or device selected.
+  while (true) {
+    {
+      // With lock, try to get device.
+      std::lock_guard<std::mutex> lock(mu_);
+      if (gpuToOutstandingBatches_[gpuIdx] < maxOutstandingBatches_) {
+        // GPU has too many outstanding batches. Try again later.
+
+        // Pick GPU and update stats.
+        LOG_EVERY_N(INFO, logFrequency_)
+            << "Picked device " << gpuIdx << ", with load "
+            << gpuToOutstandingBatches_[gpuIdx]
+            << " -- gpuToOutstandingBatches_ list <"
+            << folly::join(",", gpuToOutstandingBatches_) << ">. "
+            << " -- all time highs: <" << folly::join(",", allTimeHigh_)
+            << ">. "
+            << "Waited: " << waitedFor.count()
+            << " ms. Slack: " << slack.count() << " ms.";
+
+        gpuToOutstandingBatches_[gpuIdx] += 1;
+        if (gpuToOutstandingBatches_[gpuIdx] > allTimeHigh_[gpuIdx]) {
+          allTimeHigh_[gpuIdx] = gpuToOutstandingBatches_[gpuIdx];
+        }
+
+        // Successfully grabbed a GPU slot.
+        return true;
+      }
+    }
+    // GPU has too many outstanding batches;
+    // Sleep & wait before retrying to get a slot in GPU.
+    LOG_EVERY_N(WARNING, logFrequency_)
+        << "maxOutstandingBatches_ reached for device " << gpuIdx
+        << "! Waiting for " << waitedFor.count() << " ms... "
+        << "Current gpuToOutstandingBatches <"
+        << folly::join(",", gpuToOutstandingBatches_) << ">.";
+
+    // Sleep to avoid busy waiting
+    /* sleep override */
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    waitedFor = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - startTime);
+    if (waitedFor >= slack) {
+      // We have used up all the slack -- requests should time out.
+      LOG(WARNING) << "Timing out a batch of requests after slack of "
+                   << slack.count() << " ms was exceeded!";
+      return false;
+    }
+  }
+}
+
+void ResourceManager::release(int gpuIdx) {
+  std::lock_guard<std::mutex> lock(mu_);
+  gpuToOutstandingBatches_[gpuIdx] -= 1;
+}
+
+} // namespace torchrec


### PR DESCRIPTION
Summary:
ResourceManager controls the number of oustanding/in-flight requests allocated onto the gpu.

**currently**
Mimics D34699787, which uses a lock and load balances by searching for the device with the minimum outstanding requests

The **all time high** outstanding requests that a device sees is also logged along with the **slack** (amount of time you have before queue timeout) is reported to help tune **max_outstanding_batches**

Differential Revision: D35452017

