### PR TITLE
Add grid search proposer

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,7 +16,7 @@ jobs:
           architecture: x64
           packages: |
             ufmt==1.3.2
-            black==21.9b0
+            black==22.3.0
             usort==1.0.2
       - name: Checkout Torchrec
         uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,5 @@ repos:
     hooks:
       - id: ufmt
         additional_dependencies:
-          - black == 21.9b0
+          - black == 22.3.0
           - usort == 1.0

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 from functools import reduce
 from typing import cast, Dict, List, Optional, Tuple, Union
 
@@ -17,7 +16,11 @@ from torchrec.distributed.planner.constants import MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
 from torchrec.distributed.planner.perf_models import NoopPerfModel
-from torchrec.distributed.planner.proposers import GreedyProposer, UniformProposer
+from torchrec.distributed.planner.proposers import (
+    GreedyProposer,
+    GridSearchProposer,
+    UniformProposer,
+)
 from torchrec.distributed.planner.stats import EmbeddingStats
 from torchrec.distributed.planner.storage_reservations import (
     HeuristicalStorageReservation,
@@ -29,7 +32,6 @@ from torchrec.distributed.planner.types import (
     PerfModel,
     PlannerError,
     Proposer,
-    Shard,
     ShardingOption,
     Stats,
     Storage,
@@ -135,6 +137,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             )
         else:
             self._proposers = [
+                GridSearchProposer(),
                 GreedyProposer(),
                 GreedyProposer(use_depth=False),
                 UniformProposer(),

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -6,9 +6,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import itertools
+import logging
+import math
 from typing import cast, Dict, List, Optional, Tuple
 
 from torchrec.distributed.planner.types import Proposer, ShardingOption
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+MAX_PROPOSALS: int = int(1e4)
 
 
 class GreedyProposer(Proposer):
@@ -153,6 +160,72 @@ class UniformProposer(Proposer):
         self._proposal_index += 1
 
 
+class GridSearchProposer(Proposer):
+    def __init__(self, max_proposals: int = MAX_PROPOSALS) -> None:
+        self._max_proposals: int = max_proposals
+        self._sharding_options_by_fqn: Dict[str, List[ShardingOption]] = {}
+        self._proposal_index: int = 0
+        self._proposals: List[List[int]] = []
+
+    def load(self, search_space: List[ShardingOption]) -> None:
+        self._reset()
+        for sharding_option in search_space:
+            fqn = sharding_option.fqn
+            if fqn not in self._sharding_options_by_fqn:
+                self._sharding_options_by_fqn[fqn] = []
+            self._sharding_options_by_fqn[fqn].append(sharding_option)
+
+        for sharding_options in self._sharding_options_by_fqn.values():
+            sharding_options.sort(key=lambda x: _sharding_option_score(x))
+
+        _prune_sharding_options(self._sharding_options_by_fqn)
+
+        total_proposals = math.prod(
+            [
+                len(sharding_options)
+                for sharding_options in self._sharding_options_by_fqn.values()
+            ]
+        )
+        if total_proposals > self._max_proposals:
+            logger.info(
+                "Skipping grid search proposer as there are too many proposals.\n"
+                f"Total proposals to search: {total_proposals}\n"
+                f"Max proposals allowed: {self._max_proposals}\n"
+            )
+            return
+        sharding_options_by_fqn_indices = [
+            range(len(sharding_options))
+            for sharding_options in self._sharding_options_by_fqn.values()
+        ]
+        self._proposals = list(itertools.product(*sharding_options_by_fqn_indices))
+
+    def _reset(self) -> None:
+        self._sharding_options_by_fqn = {}
+        self._proposal_index = 0
+        self._proposals = []
+
+    def propose(self) -> Optional[List[ShardingOption]]:
+        if self._proposals and self._proposal_index < len(self._proposals):
+            proposal_indices = self._proposals[self._proposal_index]
+            return [
+                sharding_options[index]
+                for index, sharding_options in zip(
+                    proposal_indices, self._sharding_options_by_fqn.values()
+                )
+            ]
+        else:
+            return None
+
+    def feedback(
+        self,
+        partitionable: bool,
+        plan: Optional[List[ShardingOption]] = None,
+        perf_rating: Optional[float] = None,
+    ) -> None:
+        # static strategy, ignore feedback and just provide next proposal
+        self._proposal_index += 1
+
+
 def _sharding_option_score(
     sharding_option: ShardingOption, use_depth: bool = True
 ) -> float:
@@ -161,3 +234,33 @@ def _sharding_option_score(
         if use_depth
         else sum([cast(float, shard.perf) for shard in sharding_option.shards])
     )
+
+
+def _prune_sharding_options(
+    sorted_sharding_options_by_fqn: Dict[str, List[ShardingOption]]
+) -> None:
+    """
+    Prunes sharding options for each embedding table by sharding type.
+
+    Keeps sharding options for each sharding type with the lowest perf or with less HBM
+    memory usage.
+    """
+    for fqn in sorted_sharding_options_by_fqn:
+        pruned_sharding_options = []
+        sharding_type_to_min_hbm = {}
+        sharding_options = sorted_sharding_options_by_fqn[fqn]
+        for sharding_option in sharding_options:
+            if sharding_option.sharding_type not in sharding_type_to_min_hbm:
+                pruned_sharding_options.append(sharding_option)
+                sharding_type_to_min_hbm[
+                    sharding_option.sharding_type
+                ] = sharding_option.total_storage.hbm
+            elif (
+                sharding_option.total_storage.hbm
+                < sharding_type_to_min_hbm[sharding_option.sharding_type]
+            ):
+                pruned_sharding_options.append(sharding_option)
+                sharding_type_to_min_hbm[
+                    sharding_option.sharding_type
+                ] = sharding_option.total_storage.hbm
+        sorted_sharding_options_by_fqn[fqn] = pruned_sharding_options

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -7,16 +7,10 @@
 
 import logging
 from collections import defaultdict
-from typing import Any, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Tuple, Union
 
 from torchrec.distributed.planner.constants import BIGINT_DTYPE
-from torchrec.distributed.planner.types import (
-    ParameterConstraints,
-    ShardingOption,
-    Stats,
-    Storage,
-    Topology,
-)
+from torchrec.distributed.planner.types import ShardingOption, Stats, Storage, Topology
 from torchrec.distributed.planner.utils import bytes_to_gb, bytes_to_mb
 from torchrec.distributed.types import ParameterSharding, ShardingPlan, ShardingType
 

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -102,7 +102,7 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         with self.assertRaises(PlannerError):
             self.planner.plan(module=model, sharders=[TWvsRWSharder()])
 
-        self.assertEqual(self.planner._num_proposals, 3)
+        self.assertEqual(self.planner._num_proposals, 4)
 
     def test_fail_then_rerun(self) -> None:
         tables = [


### PR DESCRIPTION
Summary:
Add support for a proposer that does grid search of all possible proposals

Since a grid search is computationally expensive it only executes when the number number of possible proposals is under a threshold

Differential Revision: D35942564

