### PR TITLE
Create a unit test for weights = 0

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -138,6 +138,13 @@ class RecMetricComputation(Metric, abc.ABC):
             self._batch_window_buffers = {}
         else:
             self._batch_window_buffers = None
+        self._add_state(
+            "has_valid_update",
+            torch.zeros(self._n_tasks, dtype=torch.uint8),
+            add_window_state=False,
+            dist_reduce_fx=lambda x: torch.any(x, dim=0).byte(),
+            persistent=True,
+        )
 
     @staticmethod
     def get_window_state_name(state_name: str) -> str:
@@ -339,8 +346,17 @@ class RecMetric(nn.Module, abc.ABC):
         for metric_report in getattr(
             self._metrics_computations[0], compute_scope + "compute"
         )():
-            for task, metric_value in zip(self._tasks, metric_report.value):
-                yield task, metric_report.name, metric_value, compute_scope + metric_report.metric_prefix.value
+            for task, metric_value, has_valid_update in zip(
+                self._tasks,
+                metric_report.value,
+                self._metrics_computations[0].has_valid_update,
+            ):
+                valid_metric_value = (
+                    metric_value
+                    if has_valid_update > 0
+                    else torch.zeros_like(metric_value)
+                )
+                yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value
 
     def _unfused_tasks_iter(self, compute_scope: str) -> ComputeIterType:
         for task, metric_computation in zip(self._tasks, self._metrics_computations):
@@ -348,7 +364,12 @@ class RecMetric(nn.Module, abc.ABC):
             for metric_report in getattr(
                 metric_computation, compute_scope + "compute"
             )():
-                yield task, metric_report.name, metric_report.value, compute_scope + metric_report.metric_prefix.value
+                valid_metric_value = (
+                    metric_report.value
+                    if metric_computation.has_valid_update[0] > 0
+                    else torch.zeros_like(metric_report.value)
+                )
+                yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value
 
     def _fuse_update_buffers(self) -> Dict[str, RecModelOutput]:
         def fuse(outputs: List[RecModelOutput]) -> RecModelOutput:
@@ -398,6 +419,9 @@ class RecMetric(nn.Module, abc.ABC):
             self._default_weights[predictions.size()] = weights
         return weights
 
+    def _check_nonempty_weights(self, weights: torch.Tensor) -> torch.Tensor:
+        return torch.gt(torch.count_nonzero(weights, dim=-1), 0)
+
     def _update(
         self,
         *,
@@ -416,9 +440,14 @@ class RecMetric(nn.Module, abc.ABC):
                 else:
                     assert isinstance(weights, torch.Tensor)
                     weights = weights.view(-1, self._batch_size)
-                self._metrics_computations[0].update(
-                    predictions=predictions, labels=labels, weights=weights
-                )
+                has_valid_weights = self._check_nonempty_weights(weights)
+                if torch.any(has_valid_weights):
+                    self._metrics_computations[0].update(
+                        predictions=predictions, labels=labels, weights=weights
+                    )
+                    self._metrics_computations[0].has_valid_update.logical_or_(
+                        has_valid_weights
+                    ).byte()
             else:
                 for task, metric_ in zip(self._tasks, self._metrics_computations):
                     if task.name not in predictions:
@@ -433,11 +462,14 @@ class RecMetric(nn.Module, abc.ABC):
                         task_weights = self._create_default_weights(task_predictions)
                     else:
                         task_weights = weights[task.name].view(1, -1)
-                    metric_.update(
-                        predictions=task_predictions,
-                        labels=task_labels,
-                        weights=task_weights,
-                    )
+                    has_valid_weights = self._check_nonempty_weights(task_weights)
+                    if torch.any(has_valid_weights):
+                        metric_.update(
+                            predictions=task_predictions,
+                            labels=task_labels,
+                            weights=task_weights,
+                        )
+                        metric_.has_valid_update.logical_or_(has_valid_weights).byte()
 
     def update(
         self,

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -8,30 +8,23 @@
 import unittest
 
 import torch
-from torchrec.metrics.metrics_config import (
-    DefaultTaskInfo,
-)
-from torchrec.metrics.model_utils import (
-    parse_task_model_outputs,
-)
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.model_utils import parse_task_model_outputs
+from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.rec_metric import RecComputeMode
-from torchrec.metrics.tests.test_utils import gen_test_batch
+from torchrec.metrics.tests.test_utils import gen_test_tasks, gen_test_batch
 
 
 class RecMetricTest(unittest.TestCase):
     def setUp(self) -> None:
         # Create testing labels, predictions and weights
         model_output = gen_test_batch(128)
-        model_output["weight"] = torch.ones_like(model_output["label"])
-        labels, predictions, weights = parse_task_model_outputs(
-            [DefaultTaskInfo], model_output
-        )
         self.labels, self.predictions, self.weights = parse_task_model_outputs(
             [DefaultTaskInfo], model_output
         )
 
-    def test_optional_weight(self) -> None:
+    def test_optional_weights(self) -> None:
         ne1 = NEMetric(
             world_size=1,
             my_rank=0,
@@ -51,15 +44,13 @@ class RecMetricTest(unittest.TestCase):
             fused_update_limit=0,
         )
 
-        model_output = gen_test_batch(128)
-        model_output["weight"] = torch.ones_like(model_output["label"])
-        labels, predictions, weights = parse_task_model_outputs(
-            [DefaultTaskInfo], model_output
-        )
+        default_weights = {
+            k: torch.ones_like(self.labels[k]) for k in self.weights.keys()
+        }
         ne1.update(
             predictions=self.predictions,
             labels=self.labels,
-            weights=self.weights,
+            weights=default_weights,
         )
         ne2.update(
             predictions=self.predictions,
@@ -72,6 +63,101 @@ class RecMetricTest(unittest.TestCase):
         self.assertTrue(ne1.weighted_num_samples == ne2.weighted_num_samples)
         self.assertTrue(ne1.pos_labels == ne2.pos_labels)
         self.assertTrue(ne1.neg_labels == ne2.neg_labels)
+
+    def test_zero_weights(self) -> None:
+        # Test if weights = 0 for an update
+        mse = MSEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=128,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        mse_computation = mse._metrics_computations[0]
+
+        zero_weights = {
+            k: torch.zeros_like(self.weights[k]) for k in self.weights.keys()
+        }
+        mse.update(
+            predictions=self.predictions,
+            labels=self.labels,
+            weights=zero_weights,
+        )
+        self.assertEqual(mse_computation.error_sum, torch.tensor(0.0))
+        self.assertEqual(mse_computation.weighted_num_samples, torch.tensor(0.0))
+
+        res = mse.compute()
+        self.assertEqual(res["mse-DefaultTask|lifetime_mse"], torch.tensor(0.0))
+        self.assertEqual(res["mse-DefaultTask|lifetime_rmse"], torch.tensor(0.0))
+
+        mse.update(
+            predictions=self.predictions,
+            labels=self.labels,
+            weights=self.weights,
+        )
+        self.assertGreater(mse_computation.error_sum, torch.tensor(0.0))
+        self.assertGreater(mse_computation.weighted_num_samples, torch.tensor(0.0))
+
+        res = mse.compute()
+        self.assertGreater(res["mse-DefaultTask|lifetime_mse"], torch.tensor(0.0))
+        self.assertGreater(res["mse-DefaultTask|lifetime_rmse"], torch.tensor(0.0))
+
+        # Test if weights = 0 for one task of an update
+        task_names = ["t1", "t2"]
+        tasks = gen_test_tasks(task_names)
+        _model_output = [
+            gen_test_batch(
+                label_name=task.label_name,
+                prediction_name=task.prediction_name,
+                weight_name=task.weight_name,
+                batch_size=128,
+            )
+            for task in tasks
+        ]
+        model_output = {k: v for d in _model_output for k, v in d.items()}
+        labels, predictions, weights = parse_task_model_outputs(tasks, model_output)
+        partial_zero_weights = {
+            "t1": torch.zeros_like(weights["t1"]),
+            "t2": weights["t2"],
+        }
+
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=128,
+            tasks=tasks,
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        ne_computation = ne._metrics_computations
+
+        ne.update(
+            predictions=predictions,
+            labels=labels,
+            weights=partial_zero_weights,
+        )
+        self.assertEqual(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
+        self.assertEqual(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
+        self.assertGreater(ne_computation[1].cross_entropy_sum, torch.tensor(0.0))
+        self.assertGreater(ne_computation[1].weighted_num_samples, torch.tensor(0.0))
+
+        res = ne.compute()
+        self.assertEqual(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
+        self.assertGreater(res["ne-t2|lifetime_ne"], torch.tensor(0.0))
+
+        ne.update(
+            predictions=predictions,
+            labels=labels,
+            weights=weights,
+        )
+        self.assertGreater(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
+        self.assertGreater(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
+
+        res = ne.compute()
+        self.assertGreater(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
 
     def test_compute(self) -> None:
         # Rank 0 does computation.


### PR DESCRIPTION
Summary:
For a multi-task multi-label (MTML) model, sometimes we intentionally set weights = 0 for the model effectively ignore the data. In terms of metrics calculation, we should
- ignore this update if weights for all tasks are 0
- ignore the metric result and output 0 (metric's default value) if the weights for a tasks are 0

The test_zero_weights test covers the following 2 scenarios
- when the weights for the whole input data are 0s, in which case we need to ignore the update
- when the weights for one task are 0s, in which case we should still update but mask the metric result for the task with 0 weights

This diff also improves the existing test_optional_weights test by removing some redundant implementation

Differential Revision: D36077576

