### PR TITLE
Avoid using math.prod

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -500,7 +500,7 @@ class RecMetric(nn.Module, abc.ABC):
             attribute = attributes_q.popleft()
             if isinstance(attribute, torch.Tensor):
                 tensor_map[attribute] = (
-                    math.prod(attribute.shape) * attribute.element_size()
+                    attribute.size().numel() * attribute.element_size()
                 )
             elif isinstance(attribute, WindowBuffer):
                 attributes_q.extend(attribute.buffers)


### PR DESCRIPTION
Summary: Python 3.7 does not have math.prod

Differential Revision: D36138034

