### PR TITLE
run unit tests on python 3.7

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -43,14 +43,14 @@ jobs:
         git submodule sync
         git submodule update --init --recursive
         git log
-    # manually install python3.8 since self-hosted machine does not support the python action feature
+    # manually install python3.7 since self-hosted machine does not support the python action feature
     - name: check amazon-linux-extras
       run: |
         sudo yum install -y amazon-linux-extras
         amazon-linux-extras | grep -i python
     - name: update python
       run: |
-        sudo amazon-linux-extras install python3.8
+        sudo amazon-linux-extras install python3.7
     - name: Update pip
       run: |
         sudo yum update -y
@@ -59,10 +59,10 @@ jobs:
     - name: create virtual env
       run: |
         sudo pip3 install --upgrade virtualenv
-        virtualenv build_binary_3.8 -p python3.8
+        virtualenv build_binary_3.7 -p python3.7
     - name: check python version
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python --version
     - name: Install CUDA 11.3
       shell: bash
@@ -84,16 +84,16 @@ jobs:
     - name: Install PyTorch
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
     - name: Install Dependencies
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install -r requirements.txt
     - name: Test Installation of dependencies
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python3 -c "import torch.distributed"
         echo "torch.distributed succeeded"
         python3 -c "import skbuild"
@@ -102,7 +102,7 @@ jobs:
         echo "numpy succeeded"
     - name: Build TorchRec
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         rm -r dist || true
         python setup.py bdist_wheel --package_name torchrec-test --TORCH_CUDA_ARCH_LIST '7.0;8.0'
     - name: Upload wheel as GHA artifact
@@ -161,14 +161,14 @@ jobs:
         git submodule sync
         git submodule update --init --recursive
         git log
-    # manually install python3.8 since self-hosted machine does not support the python action feature
+    # manually install python3.7 since self-hosted machine does not support the python action feature
     - name: check amazon-linux-extras
       run: |
         sudo yum install -y amazon-linux-extras
         amazon-linux-extras | grep -i python
     - name: update python
       run: |
-        sudo amazon-linux-extras install python3.8
+        sudo amazon-linux-extras install python3.7
     - name: Update pip
       run: |
         sudo yum update -y
@@ -177,10 +177,10 @@ jobs:
     - name: create virtual env
       run: |
         sudo pip3 install --upgrade virtualenv
-        virtualenv build_binary_3.8 -p python3.8
+        virtualenv build_binary_3.7 -p python3.7
     - name: check python version
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python --version
     - name: Install CUDA 11.3
       shell: bash
@@ -202,16 +202,16 @@ jobs:
     - name: Install PyTorch
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
     - name: Install Dependencies
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install -r requirements.txt
     - name: Test Installation of dependencies
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python3 -c "import torch.distributed"
         echo "torch.distributed succeeded"
         python3 -c "import skbuild"
@@ -227,17 +227,17 @@ jobs:
       run: ls -R
     - name: Install TorchRec
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         rm -r dist || true
         pip3 install torchrec_test-*.whl
     - name: Test fbgemm_gpu and torchrec installation
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python3 -c "import fbgemm_gpu"
         python3 -c "import torchrec"
     - name: Test with pytest
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install pytest
         python3 -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -64,14 +64,14 @@ jobs:
         git submodule sync
         git submodule update --init --recursive
         git log
-    # manually install python3.8 since self-hosted machine does not support the python action feature
+    # manually install python3.7 since self-hosted machine does not support the python action feature
     - name: check amazon-linux-extras
       run: |
         sudo yum install -y amazon-linux-extras
         amazon-linux-extras | grep -i python
     - name: update python
       run: |
-        sudo amazon-linux-extras install python3.8
+        sudo amazon-linux-extras install python3.7
     - name: Update pip
       run: |
         sudo yum update -y
@@ -80,10 +80,10 @@ jobs:
     - name: create virtual env
       run: |
         sudo pip3 install --upgrade virtualenv
-        virtualenv build_binary_3.8 -p python3.8
+        virtualenv build_binary_3.7 -p python3.7
     - name: check python version
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python --version
     - name: Install gcc
       shell: bash
@@ -95,16 +95,16 @@ jobs:
     - name: Install PyTorch
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     - name: Install Dependencies
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install -r requirements.txt
     - name: Test Installation of dependencies
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python3 -c "import torch.distributed"
         echo "torch.distributed succeeded"
         python3 -c "import skbuild"
@@ -113,21 +113,21 @@ jobs:
         echo "numpy succeeded"
     - name: Build TorchRec
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         rm -r dist || true
         python setup.py bdist_wheel --package_name torchrec-test-cpu --cpu_only
     - name: Install TorchRec
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install dist/torchrec_test_cpu-*.whl
     - name: Test fbgemm_gpu and torchrec installation
       shell: bash
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         python3 -c "import fbgemm_gpu"
         python3 -c "import torchrec"
     - name: Test with pytest
       run: |
-        source build_binary_3.8/bin/activate
+        source build_binary_3.7/bin/activate
         pip3 install pytest
         python3 -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors -k 'not test_sharding_gloo_cw'


### PR DESCRIPTION
Summary:
we sometimes fail binary build (https://github.com/pytorch/torchrec/runs/6288714900?check_suite_focus=true) because of unit tests failure for python 3.7. however, we don't run unit tests on 3.7, so we fail to catch on diff land.

This moves tests to run on 3.7. Long term, we should run on 3.7/3.8/3.9 (cc YLGH we should refactor GHA to do the matrix)

Reviewed By: fegin, zyan0, yachyv7

Differential Revision: D36138351

