### PR TITLE
add external fbgemm lib path 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,9 +126,7 @@ def main(argv: List[str]) -> None:
             print(out)
 
         # the path to find all the packages
-        fbgemm_install_base = glob.glob(
-            fbgemm_gpu_install_dir
-        )[0]
+        fbgemm_install_base = glob.glob(fbgemm_gpu_install_dir)[0]
         packages.extend(find_packages(fbgemm_install_base))
         # to include the fbgemm_gpu.so
         fbgemm_gpu_package_dir = glob.glob(

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         help="if fbgemm_gpu will be installed with cpu_only flag",
     )
     parser.add_argument(
-        "--fbgemm_gpu_dir",
+        "--fbgemm_gpu_dir_override",
         type=str,
-        default="third_party/fbgemm/fbgemm_gpu",
-        help="the directory of external fbgemm_gpu path. Only applicable when skip_fbgemm is enabled.",
+        default=None,
+        help="the alternative directory of external fbgemm_gpu path.",
     )
     return parser.parse_known_args(argv)
 
@@ -95,13 +95,17 @@ def main(argv: List[str]) -> None:
 
     packages = find_packages(exclude=("*tests",))
     fbgemm_gpu_package_dir = []
-    fbgemm_install_dir = os.path.join(args.fbgemm_gpu_dir, "_skbuild/*/cmake-install")
+
+    fbgemm_gpu_dir = "third_party/fbgemm/fbgemm_gpu"
+    if args.fbgemm_gpu_dir_override is not None:
+        fbgemm_gpu_dir = args.fbgemm_gpu_dir_override
+    fbgemm_install_dir = os.path.join(fbgemm_gpu_dir, "_skbuild/*/cmake-install")
 
     if "clean" in unknown:
         print("Running clean for fbgemm_gpu first")
         out = check_output(
             [sys.executable, "setup.py", "clean"],
-            cwd="third_party/fbgemm/fbgemm_gpu",
+            cwd=fbgemm_gpu_dir,
         )
     # install/build
     else:
@@ -116,7 +120,7 @@ def main(argv: List[str]) -> None:
             fbgemm_kw_args = cuda_arch_arg if not args.cpu_only else "--cpu_only"
             out = check_output(
                 [sys.executable, "setup.py", "build", fbgemm_kw_args],
-                cwd="third_party/fbgemm/fbgemm_gpu",
+                cwd=fbgemm_gpu_dir,
                 env=my_env,
             )
             print(out)

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ def main(argv: List[str]) -> None:
 
         # the path to find all the packages
         fbgemm_install_base = glob.glob(
-            fbgemm_install_dir
+            fbgemm_gpu_install_dir
         )[0]
         packages.extend(find_packages(fbgemm_install_base))
         # to include the fbgemm_gpu.so

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         help="if fbgemm_gpu will be installed with cpu_only flag",
     )
     parser.add_argument(
-        "--fbgemm_install_dir",
+        "--fbgemm_gpu_dir",
         type=str,
-        default="third_party/fbgemm/fbgemm_gpu/_skbuild/*/cmake-install",
-        help="the directory of external fbgemm_gpu install path. Only applicable when skip_fbgemm is enabled.",
+        default="third_party/fbgemm/fbgemm_gpu",
+        help="the directory of external fbgemm_gpu path. Only applicable when skip_fbgemm is enabled.",
     )
     return parser.parse_known_args(argv)
 
@@ -95,6 +95,7 @@ def main(argv: List[str]) -> None:
 
     packages = find_packages(exclude=("*tests",))
     fbgemm_gpu_package_dir = []
+    fbgemm_install_dir = os.path.join(args.fbgemm_gpu_dir, "_skbuild/*/cmake-install")
 
     if "clean" in unknown:
         print("Running clean for fbgemm_gpu first")
@@ -122,12 +123,12 @@ def main(argv: List[str]) -> None:
 
         # the path to find all the packages
         fbgemm_install_base = glob.glob(
-            args.fbgemm_install_dir
+            fbgemm_install_dir
         )[0]
         packages.extend(find_packages(fbgemm_install_base))
         # to include the fbgemm_gpu.so
         fbgemm_gpu_package_dir = glob.glob(
-            os.path.join(args.fbgemm_install_dir, "fbgemm_gpu")
+            os.path.join(fbgemm_install_dir, "fbgemm_gpu")
         )[0]
 
     sys.argv = [sys.argv[0]] + unknown

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         action="store_true",
         help="if fbgemm_gpu will be installed with cpu_only flag",
     )
+    parser.add_argument(
+        "--fbgemm_install_dir",
+        type=str,
+        default="third_party/fbgemm/fbgemm_gpu/_skbuild/*/cmake-install",
+        help="the directory of external fbgemm_gpu install path. Only applicable when skip_fbgemm is enabled.",
+    )
     return parser.parse_known_args(argv)
 
 
@@ -116,12 +122,12 @@ def main(argv: List[str]) -> None:
 
         # the path to find all the packages
         fbgemm_install_base = glob.glob(
-            "third_party/fbgemm/fbgemm_gpu/_skbuild/*/cmake-install"
+            args.fbgemm_install_dir
         )[0]
         packages.extend(find_packages(fbgemm_install_base))
         # to include the fbgemm_gpu.so
         fbgemm_gpu_package_dir = glob.glob(
-            "third_party/fbgemm/fbgemm_gpu/_skbuild/*/cmake-install/fbgemm_gpu"
+            os.path.join(args.fbgemm_install_dir, "fbgemm_gpu")
         )[0]
 
     sys.argv = [sys.argv[0]] + unknown

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ def main(argv: List[str]) -> None:
     fbgemm_gpu_dir = "third_party/fbgemm/fbgemm_gpu"
     if args.fbgemm_gpu_dir_override is not None:
         fbgemm_gpu_dir = args.fbgemm_gpu_dir_override
-    fbgemm_install_dir = os.path.join(fbgemm_gpu_dir, "_skbuild/*/cmake-install")
+    fbgemm_gpu_install_dir = os.path.join(fbgemm_gpu_dir, "_skbuild/*/cmake-install")
 
     if "clean" in unknown:
         print("Running clean for fbgemm_gpu first")
@@ -132,7 +132,7 @@ def main(argv: List[str]) -> None:
         packages.extend(find_packages(fbgemm_install_base))
         # to include the fbgemm_gpu.so
         fbgemm_gpu_package_dir = glob.glob(
-            os.path.join(fbgemm_install_dir, "fbgemm_gpu")
+            os.path.join(fbgemm_gpu_install_dir, "fbgemm_gpu")
         )[0]
 
     sys.argv = [sys.argv[0]] + unknown


### PR DESCRIPTION
If skip_fbgemm is enabled,  the fbgemm submodule in third_party will not be built and installed as dependency. Instead, some pre-installed fbgemm lib is used. So I think we should allow user to pass the external fbgemm lib path before doing the build.