### PR TITLE
Filter out batch_fused from available kernels if fused_params is not explicitly set and contains optimizer

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -265,15 +265,14 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
             EmbeddingComputeKernel.BATCHED_DENSE.value,
         ]
         if sharding_type != ShardingType.DATA_PARALLEL.value:
-            ret += [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
-                EmbeddingComputeKernel.SPARSE.value,
-            ]
-            if compute_device_type in {"cuda"}:
-                ret += [
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
-                ]
+            ret.append(EmbeddingComputeKernel.SPARSE.value)
+            if self._fused_params is not None and "optimizer" in self._fused_params:
+                ret.append(EmbeddingComputeKernel.BATCHED_FUSED.value)
+                if compute_device_type in {"cuda"}:
+                    ret += [
+                        EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
+                        EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+                    ]
         return ret
 
     @property


### PR DESCRIPTION
Summary:
ATT

One common mishap with current optimizer fusion is that planner may select batch_fused even if fused_parmas is empty (thus optimizer defaults to SGD). This is dangerous as it changes the model's behavior without the author knowing.

Ideally fused params aren't being passed in at the sharder level, but inferred from the module itself, but this is a step in the right direction (i hope)

Differential Revision: D36180601

