### PR TITLE
Fix no table issue in embedding tower

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -520,7 +520,7 @@ class ShardedEmbeddingTowerCollection(
                 if lt_tables.issubset(pt_tables):
                     logical_to_physical_order[i].append(j)
                     found = True
-            if not found:
+            if not found and pt_tables:
                 raise RuntimeError(
                     f"Could not find any towers with features: {pt_tables}"
                 )


### PR DESCRIPTION
Summary: Based on planner choice, there could be chance that certain node will not have embedding tower at all, we should skip the tower check in this case

Differential Revision: D36316965

