### PR TITLE
Bump up black version to 22.3.0

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,7 +16,7 @@ jobs:
           architecture: x64
           packages: |
             ufmt==1.3.2
-            black==21.9b0
+            black==22.3.0
             usort==1.0.2
       - name: Checkout Torchrec
         uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,5 @@ repos:
     hooks:
       - id: ufmt
         additional_dependencies:
-          - black == 21.9b0
-          - usort == 1.0
+          - black == 22.3.0
+          - usort == 1.0.2


### PR DESCRIPTION
Summary:
Internal pyfmt is changing to use black version 22.3.0

The torchrec repo has already been formatted with version 22.3.0: https://github.com/pytorch/torchrec/commit/dbda2363ae29c8900ee087bab4e5d924263fb88a

Bump up our CI pre-commit formatter to match the new version.

Differential Revision: D36336658

