### PR TITLE
Format imports to satisfy CI lint

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -25,11 +25,11 @@ from torchrec.distributed.planner import (
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.types import (
+    ModuleCopyMixin,
     ModuleSharder,
     ShardedModule,
     ShardingEnv,
     ShardingPlan,
-    ModuleCopyMixin,
 )
 from torchrec.distributed.utils import (
     add_prefix_to_state_dict,

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -18,10 +18,10 @@ from torchrec.distributed.test_utils.test_model import (
     TestSparseNN,
 )
 from torchrec.distributed.types import (
-    ShardedModule,
-    ShardingType,
-    ShardingEnv,
     ModuleCopyMixin,
+    ShardedModule,
+    ShardingEnv,
+    ShardingType,
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -358,7 +358,7 @@ class ShardingEnv:
 
 class ModuleCopyMixin:
     """
-    A mixin to allow modules to override copy behaviros in DMP.
+    A mixin to allow modules to override copy behaviors in DMP.
     """
 
     def copy(self, device: torch.device) -> nn.Module:
@@ -410,13 +410,24 @@ class ShardedModule(abc.ABC, nn.Module, Generic[CompIn, DistOut, Out], ModuleCop
     ) -> LazyAwaitable[Out]:
         """
         In case of multiple output distributions it makes sense to override this method
-        and initiate output distibution as soon as the corresponding compute completes.
+        and initiate the output distibution as soon as the corresponding compute
+        completes.
         """
         output = self.compute(ctx, input)
         return self.output_dist(ctx, output)
 
     # pyre-ignore[2]
     def forward(self, *input, **kwargs) -> LazyAwaitable[Out]:
+        """
+        Executes the input dist, compute, and output dist steps.
+
+        Args:
+            *input: input.
+            **kwargs: keyword arguments.
+
+        Returns:
+            LazyAwaitable[Out]: awaitable of output from output dist.
+        """
         ctx = self.create_context()
         dist_input = self.input_dist(ctx, *input, **kwargs).wait()
         return self.compute_and_output_dist(ctx, dist_input)
@@ -483,7 +494,7 @@ class ModuleSharder(abc.ABC, Generic[M]):
 
     def sharding_types(self, compute_device_type: str) -> List[str]:
         """
-        List of supported sharding types. See ShardingType for well-known examples.
+        List of supported sharding types. See `ShardingType` for well-known examples.
         """
         return [ShardingType.DATA_PARALLEL.value]
 
@@ -491,7 +502,7 @@ class ModuleSharder(abc.ABC, Generic[M]):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         """
-        List of supported compute kernels for a given sharding_type and compute device.
+        List of supported compute kernels for a given sharding type and compute device.
         """
 
         return [ComputeKernel.DEFAULT.value]
@@ -516,8 +527,8 @@ class ModuleSharder(abc.ABC, Generic[M]):
 class ShardingPlan:
     """
     Representation of sharding plan.
-    Attributes:
 
+    Attributes:
         plan (Dict[str, Dict[str, ParameterSharding]]): dict keyed by module path of
             dict of parameter sharding specs keyed by parameter name.
     """


### PR DESCRIPTION
Summary: New usort version requires relative imports to be in sorted order. We do not yet sort internally, but the switch will happen this weekend.

Differential Revision: D36347977

