### PR TITLE
Log total proposals for grid search proposer in scientific notation if too large

### DIFF
--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -187,6 +187,11 @@ class GridSearchProposer(Proposer):
             ]
         )
         if total_proposals > self._max_proposals:
+            total_proposals = (
+                "{:.2e}".format(total_proposals)
+                if total_proposals > 1e6
+                else total_proposals
+            )
             logger.info(
                 "Skipping grid search proposer as there are too many proposals.\n"
                 f"Total proposals to search: {total_proposals}\n"


### PR DESCRIPTION
Summary: Search spaces are exponentially large without constraints in place. When logging the number can overflow the screen.

Differential Revision: D36349421

