### PR TITLE
add batch size to response

### DIFF
--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -49,6 +49,7 @@ struct PredictionRequest {
 };
 
 struct PredictionResponse {
+  uint32_t batchSize;
   c10::IValue predictions;
   // If set, the result is an exception.
   std::optional<folly::exception_wrapper> exception;

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -207,6 +207,7 @@ void GPUExecutor::process(int idx) {
               CHECK(!predictions.isNone());
               CHECK_LT(offset, batch->batchSize);
               auto response = std::make_unique<PredictionResponse>();
+              response->batchSize = context.batchSize;
               response->predictions = resultSplitFunc->splitResult(
                   predictions, offset, context.batchSize, batch->batchSize);
               context.promise.setValue(std::move(response));


### PR DESCRIPTION
Summary: Add a field to prediction response to store the batch size.

Reviewed By: zyan0

Differential Revision: D36348878

