### PR TITLE
Add SequenceEmbeddingShardingSpec and associated ops for ESUHM.

### DIFF
--- a/torchrec/distributed/sharding/sparse_embedding_sharding_spec.py
+++ b/torchrec/distributed/sharding/sparse_embedding_sharding_spec.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Type
+
+import torch
+import torch.distributed._shard.sharded_tensor.metadata as sharded_tensor_meta
+from torch.distributed import ProcessGroup
+from torch.distributed._shard._utils import narrow_tensor
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.partial_tensor import _PartialTensor
+from torch.distributed._shard.replicated_tensor import ReplicatedTensor
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._shard.sharding_spec import ShardingSpec
+from torch.distributed._shard.sharding_spec.api import custom_sharding_spec_op
+from torch.distributed._shard.sharding_spec.chunk_sharding_spec_ops.softmax import (
+    sharded_softmax as chunk_sharding_spec_softmax,
+)
+
+
+@dataclass
+class SparseEmbeddingShardingSpec(ShardingSpec):
+    """
+    Custom ShardingSpec to represent sharded output of sequence
+    embedding lookups. This is typically a tensor of shape (B, N, D) where B
+    is batch size, N is the sequence length and D is the embedding dim. The
+    Tensor is typically sharded on dimension N, since embedding lookups
+    can be sharded arbitrarily based on input, the Tensor is not sharded
+    uniformly on N and is pretty arbitrary. As an example if N is 10 and we
+    have 4 shards, the indices along dimension N could be sharded as follows
+    in a non-contiguous manner: ``[0,3,5], [1,2,4,7], [6,9], [8]``
+
+    In addition to this, it is
+    important to keep track of the ordering of elements along dimension N
+    since that is important in terms of applying positional encoding
+    information.
+
+    Args:
+        dim (int):
+            The dimension to shard on
+        indices (torch.LongTensor):
+            The indices along the sharded dimension representing the order of
+            elements along that dimension. Should have the same size as the
+            sharded dimension.
+        lengths (torch.LongTensor):
+            The lengths of each shard along the sharded dimension. Should
+            have the same size as ``placements``.
+        placement(List[torch.distributed._remote_device]):
+            Specifies the placement of each shard of the Tensor. The size of
+            the list represents the number of shards to be created. This is a
+            list of :class:`torch.distributed._remote_device`'s.
+    """
+
+    dim: int
+    indices: torch.LongTensor
+    lengths: torch.LongTensor
+    placements: List[torch.distributed._remote_device]
+
+    def build_metadata(
+        self,
+        tensor_sizes: torch.Size,
+        tensor_properties: sharded_tensor_meta.TensorProperties,
+    ) -> sharded_tensor_meta.ShardedTensorMetadata:
+        shard_metadatas: List[ShardMetadata] = []
+        offset = 0
+        for idx, placement in enumerate(self.placements):
+            shard_offsets = [0 for _ in tensor_sizes]
+            shard_offsets[self.dim] = offset
+            offset += self.lengths[idx].item()
+
+            shard_lengths = list(copy.deepcopy(tensor_sizes))
+            shard_lengths[self.dim] = self.lengths[idx].item()
+
+            shard_metadatas.append(
+                ShardMetadata(shard_offsets, shard_lengths, placement)
+            )
+
+        return sharded_tensor_meta.ShardedTensorMetadata(
+            shard_metadatas, tensor_sizes, tensor_properties
+        )
+
+    def shard(
+        self,
+        tensor: torch.Tensor,
+        src_rank: int = 0,
+        # pyre-ignore[11]
+        process_group: ProcessGroup = None,
+    ) -> "ShardedTensor":
+        raise NotImplementedError("Not Supported!")
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.nn.functional.linear)
+def handle_linear(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> ShardedTensor:
+    input = args[0]
+    weight = args[1]
+    bias = args[2]
+
+    if (
+        isinstance(input, ShardedTensor)
+        and isinstance(weight, torch.Tensor)
+        and bias is None
+    ):
+        # pyre-ignore[16]
+        sharding_dim = input.sharding_spec().dim
+        # pyre-ignore[6]
+        if sharding_dim != len(input.size()) - 1:
+            # pyre-ignore[6]
+            size = list(input.size())
+            size[-1] = weight.size()[0]
+            return ShardedTensor._init_from_local_tensor(
+                input.local_tensor().matmul(weight.t()),
+                input.sharding_spec(),
+                size,
+                process_group=input._process_group,
+            )
+        else:
+            raise RuntimeError(
+                "Sharding on last dim not supported for torch.nn.functional.linear"
+            )
+    else:
+        raise RuntimeError(
+            f"torch.nn.functional.linear not supported for args: {args} and kwargs: {kwargs}"
+        )
+
+
+def _dispatch_handle_add(lhs: ShardedTensor, rhs: ReplicatedTensor) -> ShardedTensor:
+    # pyre-ignore[16]
+    reordered_rhs = rhs.index_select(
+        # pyre-ignore[16]
+        lhs.sharding_spec().dim,
+        # pyre-ignore[16]
+        lhs.sharding_spec().indices,
+    )
+    narrowed_rhs = narrow_tensor(reordered_rhs, lhs.local_shards()[0].metadata)
+    return ShardedTensor._init_from_local_tensor(
+        lhs.local_tensor() + narrowed_rhs,
+        lhs.sharding_spec(),
+        # pyre-ignore[6]
+        lhs.size(),
+        process_group=lhs._process_group,
+    )
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.Tensor.__add__)
+def handle_add(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> ShardedTensor:
+    lhs = args[0]
+    rhs = args[1]
+
+    # Adding ReplicatedTensor(B, 1, D) to ShardedTensor(B, N, D) sharded on dimension N.
+    if isinstance(lhs, ShardedTensor) and isinstance(rhs, ReplicatedTensor):
+        return _dispatch_handle_add(lhs, rhs)
+    elif isinstance(lhs, ReplicatedTensor) and isinstance(rhs, ShardedTensor):
+        return _dispatch_handle_add(rhs, lhs)
+    elif isinstance(lhs, ShardedTensor) and isinstance(rhs, ShardedTensor):
+        if lhs.size() == rhs.size() and lhs.sharding_spec() == rhs.sharding_spec():
+            return ShardedTensor._init_from_local_tensor(
+                lhs.local_tensor() + rhs.local_tensor(),
+                lhs.sharding_spec(),
+                # pyre-ignore[6]
+                lhs.size(),
+                process_group=lhs._process_group,
+            )
+    raise RuntimeError(f"torch.add not supported for args: {args} and kwargs: {kwargs}")
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.Tensor.__getitem__)
+def handle_getitem(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> ShardedTensor:
+    st = args[0]
+    key = args[1]
+    sharding_dim = st.sharding_spec().dim
+    if isinstance(key, int) or isinstance(key, slice):
+        if sharding_dim != 0:
+            new_size = list(st.size())
+            if isinstance(key, int):
+                new_size.pop(0)
+            else:
+                step = 1 if key.step is None else key.step
+                new_size[0] = (key.stop - key.start - 1) // step + 1
+            return ShardedTensor._init_from_local_tensor(
+                st.local_tensor()[key],
+                st.sharding_spec(),
+                new_size,
+                process_group=st._process_group,
+            )
+    if isinstance(key, tuple):
+        local_tensor = st.local_tensor()
+        new_size = list(st.size())
+        for dim, elem in enumerate(key):
+            if not isinstance(elem, slice):
+                raise RuntimeError(
+                    f"Only slices supported in __getitem__ for tuples, found: {elem}"
+                )
+
+            if elem.start is None and elem.stop is None and elem.step is None:
+                # Preserve this dim and continue
+                continue
+            elif dim == sharding_dim:
+                raise RuntimeError("Slicing on sharding dim not supported!")
+            else:
+                step = 1 if elem.step is None else elem.step
+                indices = torch.LongTensor(list(range(elem.start, elem.stop, step))).to(
+                    local_tensor.device
+                )
+                local_tensor = local_tensor.index_select(dim, indices)
+                new_size[dim] = (elem.stop - elem.start - 1) // step + 1
+
+        return ShardedTensor._init_from_local_tensor(
+            local_tensor, st.sharding_spec(), new_size, process_group=st._process_group
+        )
+
+    raise RuntimeError(
+        f"__getitem__ not supported for args: {args} and kwargs: {kwargs}"
+    )
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.Tensor.transpose)
+def sharded_transpose(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> ShardedTensor:
+    input = args[0]
+    dim0 = args[1]
+    dim1 = args[2]
+
+    res_size = list(input.size())
+    tmp = res_size[dim0]
+    res_size[dim0] = res_size[dim1]
+    res_size[dim1] = tmp
+    sharding_spec = copy.deepcopy(input.sharding_spec())
+
+    local_shard = torch.transpose(input.local_tensor(), dim0, dim1)
+    if sharding_spec.dim == dim0:
+        sharding_spec.dim = dim1
+    elif sharding_spec.dim == dim1:
+        sharding_spec.dim = dim0
+
+    return ShardedTensor._init_from_local_tensor(
+        local_shard.contiguous(),
+        sharding_spec,
+        res_size,
+        process_group=input._process_group,
+    )
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.bmm)
+def sharded_bmm(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> _PartialTensor:
+    st1 = args[0]
+    st2 = args[1]
+    spec1 = st1.sharding_spec()
+    spec2 = st2.sharding_spec()
+    if (
+        torch.equal(spec1.indices, spec2.indices)
+        and torch.equal(spec1.lengths, spec2.lengths)
+        and spec1.placements == spec2.placements
+        and spec1.dim == 2
+        and spec2.dim == 1
+    ):
+        return _PartialTensor(
+            torch.bmm(st1.local_tensor(), st2.local_tensor()),
+            st1._process_group,
+            torch.distributed.distributed_c10d.ReduceOp.SUM,
+        )
+
+    raise RuntimeError(f"torch.bmm not supported for args: {args} and kwargs: {kwargs}")
+
+
+# pyre-ignore[56]
+@custom_sharding_spec_op(SparseEmbeddingShardingSpec, torch.nn.functional.softmax)
+def sharded_softmax(
+    types: Tuple[Type[torch.Tensor], ...],
+    # pyre-ignore[2]
+    args: Sequence[Any] = (),
+    kwargs: Optional[Mapping[str, Any]] = None,
+) -> ShardedTensor:
+    # Reuse ChunkShardingSpec softmax
+    return chunk_sharding_spec_softmax(types, args, kwargs)

--- a/torchrec/distributed/tests/test_sparse_embedding_sharding_spec.py
+++ b/torchrec/distributed/tests/test_sparse_embedding_sharding_spec.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+import random
+import unittest
+from typing import Callable
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed._shard.api import _collect_local_shard, _reshard_output
+from torch.distributed._shard.replicated_tensor import ReplicatedTensor
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._shard.sharding_spec import ChunkShardingSpec
+from torch.nn.parallel._replicated_tensor_ddp_utils import _ddp_replicated_tensor
+from torch.nn.parallel.distributed import DistributedDataParallel
+from torchrec.distributed.sharding.sparse_embedding_sharding_spec import (
+    SparseEmbeddingShardingSpec,
+)
+from torchrec.fb.feed.modules.user_history_arch import SparseSequenceEsuhmArch
+from torchrec.test_utils import get_free_port, seed_and_log, skip_if_asan_class
+
+TEST_GPU_NUM = int(os.getenv("TEST_GPU_NUM", 4))
+
+
+@skip_if_asan_class
+class SparseEmbeddingShardingSpecTest(unittest.TestCase):
+    @seed_and_log
+    def setUp(self) -> None:
+        os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+        os.environ["NCCL_SOCKET_IFNAME"] = "lo"
+
+    @classmethod
+    def _test_sparse_sequence_esuhm_arch(cls, rank: int, world_size: int) -> None:
+        device = torch.device(f"cuda:{rank}")
+        torch.distributed.init_process_group(
+            rank=rank, world_size=world_size, backend="nccl"
+        )
+        pg = torch.distributed.distributed_c10d._get_default_group()
+
+        B = TEST_GPU_NUM
+        N = 5
+        D = 4
+
+        # full
+        torch.manual_seed(0)
+        m = SparseSequenceEsuhmArch(
+            d_model=D,
+            hidden_dim=2,
+            max_seq_len=N,
+            pass_target_emb_from_seq=0,
+            apply_softmax=True,
+        ).to(device)
+        LR = 0.01
+        opt = torch.optim.SGD(m.parameters(), lr=LR)
+
+        # sharded
+        torch.manual_seed(0)
+        m_sharded = SparseSequenceEsuhmArch(
+            d_model=D,
+            hidden_dim=2,
+            max_seq_len=N,
+            pass_target_emb_from_seq=0,
+            apply_softmax=True,
+        ).to(device)
+        # Adjust learning rate for DDP.
+        sharded_opt = torch.optim.SGD(m_sharded.parameters(), lr=LR * world_size)
+        with _ddp_replicated_tensor(True):
+            m_sharded = DistributedDataParallel(m_sharded)
+
+        # Resharding for output.
+        placements = [
+            torch.distributed._remote_device(f"rank:{r}/cuda:{r}")
+            for r in range(world_size)
+        ]
+        # pyre-ignore[28]
+        reshard_spec = ChunkShardingSpec(
+            dim=0,
+            placements=placements,
+        )
+        m_sharded = _collect_local_shard(_reshard_output(m_sharded, reshard_spec))
+
+        # Multiple iterations to test different splits of SparseEmbeddingShardingSpec.
+        ITERATIONS = 1000
+        for iter in range(ITERATIONS):
+            torch.manual_seed(iter)
+            source_embs = torch.rand(B, N, D, dtype=torch.float, device=device)
+            target_embs = torch.rand(B, D, dtype=torch.float, device=device)
+
+            # single train step
+            res = m(source_embs, target_embs)
+            loss = res.view(B, -1).sum(dim=1).mean()
+            loss.backward()
+            opt.step()
+            opt.zero_grad()
+
+            # sharded
+
+            # split on N arbitrarily
+            random.seed(iter)
+            splits = [0 for _ in range(world_size)]
+            for _ in range(N):
+                idx = random.randint(0, world_size - 1)
+                splits[idx] += 1
+
+            lengths = copy.deepcopy(splits)
+            splits.insert(0, 0)
+            splits = np.cumsum(splits)
+
+            start = splits[rank]
+            end = splits[rank + 1]
+
+            # re-order and split source_embs
+            loc_source_embs = source_embs.clone()
+            permutation = torch.randperm(N).to(device)
+            loc_source_embs = loc_source_embs[:, permutation, :]
+            loc_source_embs = loc_source_embs[:, start:end, :]
+            loc_source_embs = loc_source_embs.contiguous().detach()
+
+            # create sharded source_embs and replicated target_embs
+            sharding_spec = SparseEmbeddingShardingSpec(
+                dim=1,
+                indices=permutation,
+                lengths=torch.LongTensor(lengths).to(device),
+                placements=placements,
+            )
+            sharded_source_embs = ShardedTensor._init_from_local_tensor(
+                loc_source_embs, sharding_spec, (B, N, D), process_group=pg
+            )
+            replicated_target_embs = ReplicatedTensor(target_embs, process_group=pg)
+
+            # single train step
+            sharded_res = m_sharded(sharded_source_embs, replicated_target_embs)
+            loss = sharded_res.view(B, -1).sum(dim=1).mean()
+            loss.backward()
+            sharded_opt.step()
+            sharded_opt.zero_grad()
+
+            sharded_res_list = [
+                torch.zeros_like(sharded_res) for _ in range(world_size)
+            ]
+            dist.all_gather(sharded_res_list, sharded_res)
+
+            # pyre-ignore[16]
+            final_sharded_res = torch.cat(sharded_res_list).view_as(res)
+            torch.testing.assert_allclose(res, final_sharded_res)
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < TEST_GPU_NUM,
+        f"Not enough GPUs, this test requires at least {TEST_GPU_NUM} GPUs",
+    )
+    def test_sparse_sequence_esuhm_arch(self) -> None:
+        self._run_multi_process_test(
+            # pyre-ignore[6]
+            SparseEmbeddingShardingSpecTest._test_sparse_sequence_esuhm_arch,
+            TEST_GPU_NUM,
+        )
+
+    def _run_multi_process_test(
+        self,
+        callable: Callable[[], None],
+        world_size: int,
+    ) -> None:
+        mp.spawn(callable, args=(world_size,), nprocs=world_size)


### PR DESCRIPTION
Summary:
As per the design in
https://docs.google.com/document/d/17s7FPbR6WIvaupW6AP3XpCXDHzlZvI2xJ1tKPgmwH_E,
adding an extension to our ShardingSpec to enable a custom ShardingSpec with
custom ops.

Key Highlihts include:

1) Added SequenceEmbeddingShardingSpec which is able to represent the sharding
configuration of outputs of embedding lookups.
2) Added appropriate ops to SequenceEmbeddingShardingSpec to enable ESUHM
3) Added a unit test where using ShardedTensor for source_embeddings and
ReplicatedTensor for target_embeddings produces the same result as a locally
run ESUHM module.

Reviewed By: zhangruiskyline

Differential Revision: D34984252

