### PR TITLE
calculating and adding planner runtime to planner summary

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import reduce
+from time import perf_counter
 from typing import cast, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -149,6 +150,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         self._debug = debug
         self._num_proposals: int = 0
         self._num_plans: int = 0
+        self._start_time: float = 0
 
     def collective_plan(
         self,
@@ -176,6 +178,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
 
         self._num_proposals = 0
         self._num_plans = 0
+        self._start_time = perf_counter()
         best_plan = None
         lowest_storage = Storage(MAX_SIZE, MAX_SIZE)
         best_perf_rating = MAX_SIZE
@@ -255,11 +258,13 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         if best_plan:
             sharding_plan = _to_sharding_plan(best_plan, self._topology)
 
+            end_time = perf_counter()
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
+                run_time=end_time - self._start_time,
                 best_plan=best_plan,
                 debug=self._debug,
             )

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -32,6 +32,7 @@ class EmbeddingStats(Stats):
         topology: Topology,
         num_proposals: int,
         num_plans: int,
+        run_time: float,
         best_plan: List[ShardingOption],
         debug: bool = False,
     ) -> None:
@@ -46,6 +47,7 @@ class EmbeddingStats(Stats):
             topology (Topology): device topology.
             num_proposals (int): number of proposals evaluated.
             num_plans (int): number of proposals successfully partitioned.
+            run_time (float): time program needed to execute (in seconds).
             best_plan (List[ShardingOption]): plan with expected performance.
             debug (bool): whether to enable debug mode.
         """
@@ -191,7 +193,8 @@ class EmbeddingStats(Stats):
 
         iter_text = (
             f"--- Evalulated {num_proposals} proposal(s), "
-            f"found {num_plans} possible plan(s) ---"
+            f"found {num_plans} possible plan(s), "
+            f"ran for {run_time:.2f}s ---"
         )
         logger.info(f"#{iter_text: ^{width-2}}#")
 

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -405,6 +405,7 @@ class Stats(abc.ABC):
         topology: Topology,
         num_proposals: int,
         num_plans: int,
+        run_time: float,
         best_plan: List[ShardingOption],
         debug: bool = False,
     ) -> None:


### PR DESCRIPTION
Summary:
created a script that calculates a runtime of a planner. this is done with "perf_counter" function from "time" library. the calculated runtime is then passed to "stats.py" to output time in auto planner summary.

to calculate runtime start time is defined and initialized in _init definition (here precision is lost by little amount). end time is defined and initialized after we know that best plan is found and just before stats are transferred to "stats.py".

runtime is given in seconds with 2 decimal points precision.

alternatives:
- using "timeit/default_timer" function from "timeit" instead of "perf_counter" function from "time" library
- calculating and wrapping start and end time just around the EmbeddingShardingPlanner

why the committed approach is chosen over the above-mentioned alternatives:
- "perf_counter" is shown to have better precision than both "timeit" and "default_timer" functions. ("default_timer" uses "perf_counter" as its base)
- even though precision is lost, sending runtime to "stats.py" is simpler this way and lost precision is negligible

Differential Revision: D36392606

