### PR TITLE
Fix quant uvm caching storage calculation

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -636,7 +636,10 @@ def calculate_shard_storages(
     hbm_storage: int = tensor_storage.get("hbm", 0)
     ddr_storage: int = tensor_storage.get("ddr", 0)
 
-    if compute_kernel == EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value:
+    if compute_kernel in {
+        EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+        EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING.value,
+    }:
         hbm_storage = round(ddr_storage * caching_ratio)
 
     hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(


### PR DESCRIPTION
Summary: Need to add HBM storage used by batched quant uvm caching to storage estimate

Reviewed By: YazhiGao

Differential Revision: D36523446

