### PR TITLE
added pruning to greedy proposer

### DIFF
--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -45,6 +45,8 @@ class GreedyProposer(Proposer):
                 key=lambda x: _sharding_option_score(x, self._use_depth)
             )
 
+        _prune_sharding_options(self._sharding_options_by_fqn)
+
         self._current_proposal = {
             fqn: 0 for fqn in self._sharding_options_by_fqn.keys()
         }


### PR DESCRIPTION
Summary: pruning sharding options in the greedy proposer like we did in the grid search proposer to reduce the search space. -> by so, number of proposals decrease and thus planner runtime is sped up

Differential Revision: D36530232

