### PR TITLE
Add support for variable feature batch size to enable planning for Request-Only features

### DIFF
--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -411,7 +411,7 @@ class TestEnumerators(unittest.TestCase):
             output_data_type_size = sharding_option.tensor.element_size()
 
             input_sizes, output_sizes = _calculate_dp_shard_io_sizes(
-                batch_size=self.batch_size,
+                batch_sizes=[self.batch_size] * sharding_option.num_inputs,
                 input_lengths=self.constraints[sharding_option.name].pooling_factors,
                 emb_dim=sharding_option.tensor.shape[1],
                 num_shards=self.world_size,
@@ -464,7 +464,7 @@ class TestEnumerators(unittest.TestCase):
             output_data_type_size = sharding_option.tensor.element_size()
 
             input_sizes, output_sizes = _calculate_tw_shard_io_sizes(
-                batch_size=self.batch_size,
+                batch_sizes=[self.batch_size] * sharding_option.num_inputs,
                 world_size=self.world_size,
                 input_lengths=self.constraints[sharding_option.name].pooling_factors,
                 emb_dim=sharding_option.tensor.shape[1],

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -267,7 +267,8 @@ class ParameterConstraints:
     pooling_factors: List[float] = field(
         default_factory=lambda: [POOLING_FACTOR]
     )  # Embedding Tables
-    num_objects: Optional[List[float]] = None  # Number of objects per sample in batch
+    num_objects: Optional[List[float]] = None  # number of objects per sample in batch
+    batch_sizes: Optional[List[int]] = None  # batch size per input feature
 
 
 class PlannerError(Exception):


### PR DESCRIPTION
Summary: Allow users to specify batch size for each input feature in parameter constraints. This enables planning support for Request-Only features that have a batch size of 1.

Differential Revision: D36557164

