### PR TITLE
Add comparison operators for Storage instead of using dataclass default

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -50,6 +50,9 @@ class Storage:
     def __hash__(self) -> int:
         return hash((self.hbm, self.ddr))
 
+    def fits_in(self, other: "Storage") -> bool:
+        return self.hbm <= other.hbm and self.ddr <= other.ddr
+
 
 @dataclass
 class DeviceHardware:


### PR DESCRIPTION
Summary:
The dataclass provided comparison operators have some undesirable behavior when using it for storage comparison.

```
s1 = Storage(hbm=5, ddr=1)
s2 = Storage(hbm=3, ddr=2)

# with default dataclass(order=True)
$ s1 >= s2
True

# with manual override, in this diff
$ s1 >= s2
False
```

Due to priority on first ordered item (hbm in this case) the default GE operator will allow the second item (ddr) to be less than the corresponding field on the item compared to.

This can cause the partitioner to disregard DDR cap when placing shards.

Differential Revision: D36559130

