### PR TITLE
whl is in dist for torchrec CPU

### DIFF
--- a/.github/workflows/nightly_build_cpu.yml
+++ b/.github/workflows/nightly_build_cpu.yml
@@ -145,7 +145,7 @@ jobs:
           echo "AWS_ACCESS_KEY_ID is not set, exiting upload"
         exit 1
         fi
-        for pkg in torchrec_nightly_cpu*.whl; do
+        for pkg in dist/*.whl; do
           aws s3 cp "$pkg" "$S3_PATH" --acl public-read
         done
     # Disable because of PyPi 200MB limit. Request: https://github.com/pypa/pypi-support/issues/1913


### PR DESCRIPTION
Summary:
currently failing with

"The user-provided path torchrec_nightly_cpu*.whl does not exist."

Differential Revision: D36563839

