### PR TITLE
discarding unwanted sharding_type-kernel combinations

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -22,11 +22,7 @@ from torchrec.distributed.batched_embedding_kernel import (
     BatchedFusedEmbedding,
     BatchedFusedEmbeddingBag,
 )
-from torchrec.distributed.embedding_kernel import (
-    BaseEmbedding,
-    GroupedEmbedding,
-    GroupedEmbeddingBag,
-)
+from torchrec.distributed.embedding_kernel import BaseEmbedding
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingLookup,
     BaseGroupedFeatureProcessor,
@@ -96,20 +92,6 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Tensor])
                     pg=pg,
                     device=device,
                     fused_params=fused_params,
-                )
-            elif config.compute_kernel == EmbeddingComputeKernel.DENSE:
-                return GroupedEmbedding(
-                    config=config,
-                    sparse=False,
-                    pg=pg,
-                    device=device,
-                )
-            elif config.compute_kernel == EmbeddingComputeKernel.SPARSE:
-                return GroupedEmbedding(
-                    config=config,
-                    sparse=True,
-                    pg=pg,
-                    device=device,
                 )
             else:
                 raise ValueError(
@@ -232,20 +214,6 @@ class GroupedPooledEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Te
                     pg=pg,
                     device=device,
                     fused_params=fused_params,
-                )
-            elif config.compute_kernel == EmbeddingComputeKernel.DENSE:
-                return GroupedEmbeddingBag(
-                    config=config,
-                    pg=pg,
-                    sparse=False,
-                    device=device,
-                )
-            elif config.compute_kernel == EmbeddingComputeKernel.SPARSE:
-                return GroupedEmbeddingBag(
-                    config=config,
-                    pg=pg,
-                    sparse=True,
-                    device=device,
                 )
             else:
                 raise ValueError(

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -421,8 +421,6 @@ def group_tables(
                 for is_weighted in [True, False]:
                     for has_feature_processor in [True, False]:
                         for compute_kernel in [
-                            EmbeddingComputeKernel.DENSE,
-                            EmbeddingComputeKernel.SPARSE,
                             EmbeddingComputeKernel.BATCHED_DENSE,
                             EmbeddingComputeKernel.BATCHED_FUSED,
                             EmbeddingComputeKernel.BATCHED_QUANT,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -43,8 +43,6 @@ class OptimType(Enum):
 
 @unique
 class EmbeddingComputeKernel(Enum):
-    DENSE = "dense"
-    SPARSE = "sparse"
     BATCHED_DENSE = "batched_dense"
     BATCHED_FUSED = "batched_fused"
     BATCHED_FUSED_UVM = "batched_fused_uvm"
@@ -144,7 +142,7 @@ class ShardedMetaConfig(ShardedConfig):
 
 @dataclass
 class EmbeddingAttributes:
-    compute_kernel: EmbeddingComputeKernel = EmbeddingComputeKernel.DENSE
+    compute_kernel: EmbeddingComputeKernel = EmbeddingComputeKernel.BATCHED_DENSE
 
 
 @dataclass
@@ -261,13 +259,11 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         ret = [
-            EmbeddingComputeKernel.DENSE.value,
             EmbeddingComputeKernel.BATCHED_DENSE.value,
         ]
         if sharding_type != ShardingType.DATA_PARALLEL.value:
             ret += [
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
-                EmbeddingComputeKernel.SPARSE.value,
             ]
             if compute_device_type in {"cuda"}:
                 ret += [

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -56,14 +56,10 @@ def kernel_bw_lookup(
     caching_ratio = caching_ratio if caching_ratio else UVM_CACHING_RATIO
     lookup = {
         # CPU
-        ("cpu", EmbeddingComputeKernel.DENSE.value): 0.35 * DDR_MEM_BW,
-        ("cpu", EmbeddingComputeKernel.SPARSE.value): 0.35 * DDR_MEM_BW,
         ("cpu", EmbeddingComputeKernel.BATCHED_DENSE.value): 0.5 * DDR_MEM_BW,
         ("cpu", EmbeddingComputeKernel.BATCHED_FUSED.value): 1 * DDR_MEM_BW,
         ("cpu", EmbeddingComputeKernel.BATCHED_QUANT.value): 1 * DDR_MEM_BW,
         # CUDA
-        ("cuda", EmbeddingComputeKernel.DENSE.value): 0.35 * HBM_MEM_BW,
-        ("cuda", EmbeddingComputeKernel.SPARSE.value): 0.35 * HBM_MEM_BW,
         ("cuda", EmbeddingComputeKernel.BATCHED_DENSE.value): 0.5 * HBM_MEM_BW,
         ("cuda", EmbeddingComputeKernel.BATCHED_FUSED.value): 1 * HBM_MEM_BW,
         ("cuda", EmbeddingComputeKernel.BATCHED_FUSED_UVM.value): DDR_MEM_BW / 10,

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -45,6 +45,8 @@ class GreedyProposer(Proposer):
                 key=lambda x: _sharding_option_score(x, self._use_depth)
             )
 
+        _prune_sharding_options(self._sharding_options_by_fqn)
+
         self._current_proposal = {
             fqn: 0 for fqn in self._sharding_options_by_fqn.keys()
         }

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -947,12 +947,7 @@ def _calculate_storage_specific_sizes(
 
     optimizer_sizes: List[int] = [
         tensor_size * 2
-        if compute_kernel
-        in {
-            EmbeddingComputeKernel.DENSE.value,
-            EmbeddingComputeKernel.SPARSE.value,
-            EmbeddingComputeKernel.BATCHED_DENSE.value,
-        }
+        if compute_kernel == EmbeddingComputeKernel.BATCHED_DENSE.value
         else 0
         for tensor_size in tensor_sizes
     ]

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -309,8 +309,6 @@ class AllTypesSharder(EmbeddingBagCollectionSharder):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         return [
-            EmbeddingComputeKernel.DENSE.value,
-            EmbeddingComputeKernel.SPARSE.value,
             EmbeddingComputeKernel.BATCHED_DENSE.value,
             EmbeddingComputeKernel.BATCHED_FUSED.value,
             EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
@@ -326,7 +324,7 @@ class TowerTWRWSharder(EmbeddingTowerSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TowerCollectionTWRWSharder(EmbeddingTowerCollectionSharder):
@@ -336,7 +334,7 @@ class TowerCollectionTWRWSharder(EmbeddingTowerCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TestEnumerators(unittest.TestCase):
@@ -604,7 +602,6 @@ class TestEnumerators(unittest.TestCase):
                 ShardingType.COLUMN_WISE.value,
             ],
             compute_kernels=[
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
             ],
@@ -634,7 +631,6 @@ class TestEnumerators(unittest.TestCase):
             ShardingType.COLUMN_WISE.value,
         }
         expected_compute_kernels = {
-            EmbeddingComputeKernel.SPARSE.value,
             EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
             EmbeddingComputeKernel.BATCHED_DENSE.value,
         }

--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -33,7 +33,7 @@ class RWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -43,7 +43,7 @@ class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TWRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -53,7 +53,7 @@ class TWRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TWCWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -63,7 +63,7 @@ class TWCWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class HostLevelSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -73,7 +73,7 @@ class HostLevelSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 class TestGreedyPerfPartitioner(unittest.TestCase):

--- a/torchrec/distributed/sharding/dp_sequence_sharding.py
+++ b/torchrec/distributed/sharding/dp_sequence_sharding.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Optional
 import torch
 from torchrec.distributed.embedding_lookup import GroupedEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
-    BaseEmbeddingDist,
     BaseEmbeddingLookup,
     BaseSparseFeaturesDist,
 )

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -12,7 +12,6 @@ import torch.distributed as dist
 from torchrec.distributed.dist_data import SequenceEmbeddingAllToAll
 from torchrec.distributed.embedding_lookup import GroupedEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
-    BaseEmbeddingDist,
     BaseEmbeddingLookup,
     BaseSparseFeaturesDist,
 )

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -69,14 +69,12 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_sharding_nccl_rw(
         self,
         sharder_type: str,
@@ -110,12 +108,11 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_dp(
         self, sharder_type: str, sharding_type: str, kernel_type: str
     ) -> None:
@@ -146,8 +143,6 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
@@ -192,8 +187,6 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
@@ -227,8 +220,6 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
@@ -265,8 +256,6 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
@@ -312,10 +301,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 # TODO dp+batch_fused is numerically buggy in cpu
-                # EmbeddingComputeKernel.SPARSE.value,
                 # EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
@@ -646,8 +633,6 @@ class ModelParallelStateDictTest(unittest.TestCase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 # EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -48,15 +48,13 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         sharding_type=st.just(ShardingType.TABLE_ROW_WISE.value),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
         local_size=st.sampled_from([2]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_sharding_nccl_twrw(
         self,
         sharder_type: str,
@@ -93,15 +91,13 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
         local_size=st.sampled_from([2]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_sharding_nccl_twcw(
         self,
         sharder_type: str,
@@ -136,14 +132,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_embedding_tower_nccl(
         self,
         sharding_type: str,
@@ -176,14 +170,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_embedding_tower_collection_nccl(
         self,
         sharding_type: str,

--- a/torchrec/distributed/tests/test_quantize.py
+++ b/torchrec/distributed/tests/test_quantize.py
@@ -13,13 +13,11 @@ import torch
 import torch.distributed as dist
 import torch.quantization as quant
 from hypothesis import given, settings, Verbosity
-from torchrec.distributed.embedding_kernel import GroupedEmbeddingBag
 from torchrec.distributed.embedding_lookup import (
     BatchedDenseEmbedding,
     BatchedDenseEmbeddingBag,
     BatchedFusedEmbedding,
     BatchedFusedEmbeddingBag,
-    GroupedEmbedding,
     GroupedEmbeddingsLookup,
     GroupedPooledEmbeddingsLookup,
 )
@@ -48,20 +46,16 @@ def quantize_sharded_embeddings(
     return quant.quantize_dynamic(
         module,
         qconfig_spec={
-            GroupedEmbeddingBag: qconfig,
             BatchedFusedEmbeddingBag: qconfig,
             BatchedDenseEmbeddingBag: qconfig,
             BatchedDenseEmbedding: qconfig,
             BatchedFusedEmbedding: qconfig,
-            GroupedEmbedding: qconfig,
         },
         mapping={
-            GroupedEmbeddingBag: QuantBatchedEmbeddingBag,
             BatchedFusedEmbeddingBag: QuantBatchedEmbeddingBag,
             BatchedDenseEmbeddingBag: QuantBatchedEmbeddingBag,
             BatchedDenseEmbedding: QuantBatchedEmbedding,
             BatchedFusedEmbedding: QuantBatchedEmbedding,
-            GroupedEmbedding: QuantBatchedEmbedding,
         },
         inplace=False,
     )
@@ -138,8 +132,6 @@ class QuantizeKernelTest(unittest.TestCase):
             [
                 EmbeddingComputeKernel.BATCHED_DENSE,
                 EmbeddingComputeKernel.BATCHED_FUSED,
-                EmbeddingComputeKernel.DENSE,
-                EmbeddingComputeKernel.SPARSE,
             ]
         ),
         dtype=st.sampled_from(
@@ -150,7 +142,7 @@ class QuantizeKernelTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=12, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
     def test_quantize_embedding_bag_kernels(
         self, compute_kernel: EmbeddingComputeKernel, dtype: torch.dtype
     ) -> None:
@@ -176,8 +168,6 @@ class QuantizeKernelTest(unittest.TestCase):
             [
                 EmbeddingComputeKernel.BATCHED_DENSE,
                 EmbeddingComputeKernel.BATCHED_FUSED,
-                EmbeddingComputeKernel.DENSE,
-                EmbeddingComputeKernel.SPARSE,
             ]
         ),
         dtype=st.sampled_from(
@@ -188,7 +178,7 @@ class QuantizeKernelTest(unittest.TestCase):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=12, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
     def test_quantize_embedding_kernels(
         self, compute_kernel: EmbeddingComputeKernel, dtype: torch.dtype
     ) -> None:

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -42,8 +42,8 @@ class SequenceModelParallelTest(ModelParallelTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
+                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
     )
@@ -72,7 +72,7 @@ class SequenceModelParallelTest(ModelParallelTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.BATCHED_DENSE.value,
             ]
         ),
     )
@@ -101,8 +101,8 @@ class SequenceModelParallelTest(ModelParallelTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
+                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
@@ -53,8 +53,6 @@ class SequenceModelParallelHierarchicalTest(ModelParallelTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
-                EmbeddingComputeKernel.SPARSE.value,
                 EmbeddingComputeKernel.BATCHED_DENSE.value,
                 EmbeddingComputeKernel.BATCHED_FUSED.value,
             ]

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -76,7 +76,7 @@ class TestCustomEBCSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.DENSE.value]
+        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
 
 
 @dataclass
@@ -245,7 +245,7 @@ class TrainPipelineSparseDistTest(unittest.TestCase):
                     ModuleSharder[nn.Module],
                     TestEBCSharder(
                         sharding_type=ShardingType.TABLE_WISE.value,
-                        kernel_type=EmbeddingComputeKernel.DENSE.value,
+                        kernel_type=EmbeddingComputeKernel.BATCHED_DENSE.value,
                     ),
                 )
             ],


### PR DESCRIPTION
Summary:
-> this diff discards bad sharding_type-kernel combinations from enumerator; by so, we make sure that we never consider bad sharding plans: "data-parallel" sharding type is never with "batched-fused","batched-fused-uvm", or "batched-fused-uvm-caching" and other sharding types are never with "batched-dense" in combination

this change will also increase the speed of overall planner runtime as number of combinations are decreased

Differential Revision: D36565724

