### PR TITLE
ATT

### DIFF
--- a/examples/nvt_dataloader/README.md
+++ b/examples/nvt_dataloader/README.md
@@ -1,0 +1,18 @@
+# Running torchrec using NVTabular DataLoader
+
+First run nvtabular preprocessing to first convert the criteo TSV files to parquet, and perform offline preprocessing. For example
+```
+cd torchrec/torchrce/datasets/scripts/nvt/
+python 01_nvt_preproc.py -i /data/criteo_1tb/ -o /data/criteo_1tb/
+python 02_nvt_preproc.py -b /data/criteo_1tb/ --num_embeddings_per_feature 45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35
+
+ls /data/criteo_1tb/criteo_preproc/*/*.parquet
+>>> /data/criteo_1tb/criteo_preproc/day_0/part_0.parquet
+>>> /data/criteo_1tb/criteo_preproc/day_1/part_0.parquet
+```
+
+To run locally
+```
+torchx run -s local_cwd dist.ddp -j 1x8 --script train_torchrec.py -- \
+ --num_embeddings_per_feature 45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35 --over_arch_layer_sizes 1024,1024,512,256,1 --train_path /data/criteo_1tb/criteo_preproc/ --batch_size 4096
+```

--- a/examples/nvt_dataloader/dlrm_train.py
+++ b/examples/nvt_dataloader/dlrm_train.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from torchrec.datasets.utils import Batch
+from torchrec.models.dlrm import DLRM
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+
+class DLRMTrain(nn.Module):
+    """
+    nn.Module to wrap DLRM model to use with train_pipeline.
+
+    DLRM Recsys model from "Deep Learning Recommendation Model for Personalization and
+    Recommendation Systems" (https://arxiv.org/abs/1906.00091). Processes sparse
+    features by learning pooled embeddings for each feature. Learns the relationship
+    between dense features and sparse features by projecting dense features into the
+    same embedding space. Also, learns the pairwise relationships between sparse
+    features.
+
+    The module assumes all sparse features have the same embedding dimension
+    (i.e, each EmbeddingBagConfig uses the same embedding_dim)
+
+    Args:
+        embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
+            used to define SparseArch.
+        dense_in_features (int): the dimensionality of the dense input features.
+        dense_arch_layer_sizes (list[int]): the layer sizes for the DenseArch.
+        over_arch_layer_sizes (list[int]): the layer sizes for the OverArch. NOTE: The
+            output dimension of the InteractionArch should not be manually specified
+            here.
+        dense_device: (Optional[torch.device]).
+
+    Example::
+
+        ebc = EmbeddingBagCollection(config=ebc_config)
+        model = DLRMTrain(
+           embedding_bag_collection=ebc,
+           dense_in_features=100,
+           dense_arch_layer_sizes=[20],
+           over_arch_layer_sizes=[5, 1],
+        )
+    """
+
+    def __init__(
+        self,
+        embedding_bag_collection: EmbeddingBagCollection,
+        dense_in_features: int,
+        dense_arch_layer_sizes: List[int],
+        over_arch_layer_sizes: List[int],
+        dense_device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self.model = DLRM(
+            embedding_bag_collection=embedding_bag_collection,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=dense_arch_layer_sizes,
+            over_arch_layer_sizes=over_arch_layer_sizes,
+            dense_device=dense_device,
+        )
+        self.loss_fn: nn.Module = nn.BCEWithLogitsLoss()
+
+    def forward(
+        self, batch: Batch
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        """
+        Args:
+            batch: batch used with criteo and random data from torchrec.datasets
+        Returns:
+            Tuple[loss, Tuple[loss, logits, labels]]
+        """
+        logits = self.model(batch.dense_features, batch.sparse_features)
+        logits = logits.squeeze()
+        loss = self.loss_fn(logits, batch.labels.float())
+
+        return loss, (loss.detach(), logits.detach(), batch.labels.detach())

--- a/examples/nvt_dataloader/nvt_criteo_dataloader.py
+++ b/examples/nvt_dataloader/nvt_criteo_dataloader.py
@@ -1,78 +1,110 @@
-import torch
-from torch.utils.data import DataLoader
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
-from typing import List
-
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.datasets.utils import Batch
+from typing import Dict, List
 
 import nvtabular as nvt
+import torch
 from nvtabular.loader.torch import TorchAsyncItr
+from torch.utils.data import DataLoader
 
 from torchrec.datasets.criteo import (
+    CAT_FEATURE_COUNT,
     DEFAULT_CAT_NAMES,
     DEFAULT_INT_NAMES,
     DEFAULT_LABEL_NAME,
 )
+from torchrec.datasets.utils import Batch
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
-def seed_fn():
-    """
-    Generate consistent dataloader shuffle seeds across workers
-    Reseeds each worker's dataloader each epoch to get fresh a shuffle
-    that's consistent across workers.
+class NvtCriteoDataloader:
+    def __init__(
+        self,
+        paths: List[str],
+        batch_size: int,
+        world_size: int,
+        rank: int,
+    ):
+        self.paths = paths
+        self.batch_size = batch_size
+        self.world_size = world_size
+        self.rank = rank
+        self._num_ids_in_batch: int = CAT_FEATURE_COUNT * batch_size
+        self.keys: List[str] = DEFAULT_CAT_NAMES
+        self.lengths: torch.Tensor = torch.ones(
+            (self._num_ids_in_batch,), dtype=torch.int32
+        )
+        self.offsets: torch.Tensor = torch.arange(
+            0, self._num_ids_in_batch + 1, dtype=torch.int32
+        )
+        self.stride = batch_size
+        self.length_per_key: List[int] = CAT_FEATURE_COUNT * [batch_size]
+        self.offset_per_key: List[int] = [
+            batch_size * i for i in range(CAT_FEATURE_COUNT + 1)
+        ]
+        self.index_per_key: Dict[str, int] = {
+            key: i for (i, key) in enumerate(self.keys)
+        }
 
-    TODO there is something wrong with the seed_fn example. Return 0 for now
-    """
-    return 0
+    def seed_fn(self):
+        """
+        Generate consistent dataloader shuffle seeds across workers
+        Reseeds each worker's dataloader each epoch to get fresh a shuffle
+        that's consistent across workers.
 
+        TODO there is something wrong with the seed_fn example. Return 0 for now
+        """
+        return 0
 
-def get_nvt_criteo_dataloader(
-    paths: List[str],
-    batch_size: int,
-    world_size: int,
-    rank: int,
-):
-    dataset = TorchAsyncItr(
-        nvt.Dataset(paths, part_size="144MB"),
-        batch_size=batch_size,
-        cats=DEFAULT_CAT_NAMES,
-        conts=DEFAULT_INT_NAMES,
-        labels=[DEFAULT_LABEL_NAME],
-        device=rank,
-        global_size=world_size,
-        global_rank=rank,
-        shuffle=True,
-        seed_fn=seed_fn,
-    )
-
-    def collate_fn(attr_dict):
-        batch_features, labels = attr_dict
-        # We know that all categories are one-hot. However, this may not generalize
-        # We should work with nvidia to allow nvtabular to natively transform to
-        # a KJT format.
-        return Batch(
-            dense_features=torch.cat(
-                [batch_features[feature] for feature in DEFAULT_INT_NAMES], dim=1
-            ),
-            sparse_features=KeyedJaggedTensor.from_lengths_sync(
-                keys=DEFAULT_CAT_NAMES,
-                values=torch.cat(
-                    [batch_features[feature] for feature in DEFAULT_CAT_NAMES]
-                ).view(-1),
-                lengths=torch.ones(
-                    (len(DEFAULT_CAT_NAMES) * batch_size), dtype=torch.int32
-                ),
-            ),
-            labels=labels,
+    def get_nvt_criteo_dataloader(self):
+        dataset = TorchAsyncItr(
+            nvt.Dataset(self.paths, engine="parquet", part_size="144MB"),
+            batch_size=self.batch_size,
+            cats=DEFAULT_CAT_NAMES,
+            conts=DEFAULT_INT_NAMES,
+            labels=[DEFAULT_LABEL_NAME],
+            device=self.rank,
+            global_size=self.world_size,
+            global_rank=self.rank,
+            shuffle=True,
+            seed_fn=self.seed_fn,
         )
 
-    # Don't pin memory since the batches are already on cuda!
-    # Num worker is set to zero as well, because it is on GPU
-    return DataLoader(
-        dataset,
-        batch_size=None,
-        collate_fn=collate_fn,
-        pin_memory=False,
-        num_workers=0,
-    )
+        def collate_fn(attr_dict):
+            batch_features, labels = attr_dict
+            # We know that all categories are one-hot. However, this may not generalize
+            # We should work with nvidia to allow nvtabular to natively transform to
+            # a KJT format.
+            return Batch(
+                dense_features=torch.cat(
+                    [batch_features[feature] for feature in DEFAULT_INT_NAMES], dim=1
+                ),
+                sparse_features=KeyedJaggedTensor(
+                    keys=DEFAULT_CAT_NAMES,
+                    values=torch.cat(
+                        [batch_features[feature] for feature in DEFAULT_CAT_NAMES]
+                    ).view(-1),
+                    lengths=self.lengths,
+                    offsets=self.offsets,
+                    stride=self.stride,
+                    length_per_key=self.length_per_key,
+                    offset_per_key=self.offset_per_key,
+                    index_per_key=self.index_per_key,
+                ),
+                labels=labels,
+            )
+
+        # Don't pin memory since the batches are already on cuda!
+        # Num worker is set to zero as well, because it is on GPU
+        return DataLoader(
+            dataset,
+            batch_size=None,
+            collate_fn=collate_fn,
+            pin_memory=False,
+            num_workers=0,
+        )

--- a/examples/nvt_dataloader/nvt_criteo_dataloader.py
+++ b/examples/nvt_dataloader/nvt_criteo_dataloader.py
@@ -1,0 +1,78 @@
+import torch
+from torch.utils.data import DataLoader
+
+from typing import List
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.datasets.utils import Batch
+
+import nvtabular as nvt
+from nvtabular.loader.torch import TorchAsyncItr
+
+from torchrec.datasets.criteo import (
+    DEFAULT_CAT_NAMES,
+    DEFAULT_INT_NAMES,
+    DEFAULT_LABEL_NAME,
+)
+
+
+def seed_fn():
+    """
+    Generate consistent dataloader shuffle seeds across workers
+    Reseeds each worker's dataloader each epoch to get fresh a shuffle
+    that's consistent across workers.
+
+    TODO there is something wrong with the seed_fn example. Return 0 for now
+    """
+    return 0
+
+
+def get_nvt_criteo_dataloader(
+    paths: List[str],
+    batch_size: int,
+    world_size: int,
+    rank: int,
+):
+    dataset = TorchAsyncItr(
+        nvt.Dataset(paths, part_size="144MB"),
+        batch_size=batch_size,
+        cats=DEFAULT_CAT_NAMES,
+        conts=DEFAULT_INT_NAMES,
+        labels=[DEFAULT_LABEL_NAME],
+        device=rank,
+        global_size=world_size,
+        global_rank=rank,
+        shuffle=True,
+        seed_fn=seed_fn,
+    )
+
+    def collate_fn(attr_dict):
+        batch_features, labels = attr_dict
+        # We know that all categories are one-hot. However, this may not generalize
+        # We should work with nvidia to allow nvtabular to natively transform to
+        # a KJT format.
+        return Batch(
+            dense_features=torch.cat(
+                [batch_features[feature] for feature in DEFAULT_INT_NAMES], dim=1
+            ),
+            sparse_features=KeyedJaggedTensor.from_lengths_sync(
+                keys=DEFAULT_CAT_NAMES,
+                values=torch.cat(
+                    [batch_features[feature] for feature in DEFAULT_CAT_NAMES]
+                ).view(-1),
+                lengths=torch.ones(
+                    (len(DEFAULT_CAT_NAMES) * batch_size), dtype=torch.int32
+                ),
+            ),
+            labels=labels,
+        )
+
+    # Don't pin memory since the batches are already on cuda!
+    # Num worker is set to zero as well, because it is on GPU
+    return DataLoader(
+        dataset,
+        batch_size=None,
+        collate_fn=collate_fn,
+        pin_memory=False,
+        num_workers=0,
+    )

--- a/examples/nvt_dataloader/train_torchrec.py
+++ b/examples/nvt_dataloader/train_torchrec.py
@@ -1,0 +1,246 @@
+import argparse
+from collections import defaultdict
+import glob
+import logging
+import os
+import sys
+
+from typing import cast, List
+from pyre_extensions import none_throws
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+from torchrec import EmbeddingBagCollection
+import torchrec.distributed as trec_dist
+from torchrec.distributed import TrainPipelineSparseDist
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.types import ModuleSharder
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.metrics.throughput import ThroughputMetric
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
+import torchrec.optim as trec_optim
+
+from torchrec.datasets.criteo import (
+    DEFAULT_CAT_NAMES,
+    DEFAULT_INT_NAMES,
+)
+
+from dlrm_train import DLRMTrain
+from nvt_criteo_dataloader import get_nvt_criteo_dataloader
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="torchrec dlrm example trainer")
+    parser.add_argument(
+        "--epochs", type=int, default=1, help="number of epochs to train"
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="local batch size to use for training",
+    )
+    parser.add_argument(
+        "--num_embeddings",
+        type=int,
+        default=100_000,
+        help="max_ind_size. The number of embeddings in each embedding table. Defaults"
+        " to 100_000 if num_embeddings_per_feature is not supplied.",
+    )
+    parser.add_argument(
+        "--num_embeddings_per_feature",
+        type=str,
+        default=None,
+        help="Comma separated max_ind_size per sparse feature. The number of embeddings"
+        " in each embedding table. 26 values are expected for the Criteo dataset.",
+    )
+    parser.add_argument(
+        "--dense_arch_layer_sizes",
+        type=str,
+        default="512,256,128",
+        help="Comma separated layer sizes for dense arch.",
+    )
+    parser.add_argument(
+        "--over_arch_layer_sizes",
+        type=str,
+        default="1024,1024,512,256,1",
+        help="Comma separated layer sizes for over arch.",
+    )
+    parser.add_argument(
+        "--embedding_dim",
+        type=int,
+        default=128,
+        help="Size of each embedding.",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=15.0,
+        help="Learning rate.",
+    )
+    parser.add_argument(
+        "--train_path",
+        type=str,
+        default="/data/criteo_1tb/criteo_preproc",
+        help="Location for parquet datafiles",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]):
+    args = parse_args(argv)
+
+    rank = int(os.environ["LOCAL_RANK"])
+    if torch.cuda.is_available():
+        device: torch.device = torch.device(f"cuda:{rank}")
+        backend = "nccl"
+        torch.cuda.set_device(device)
+    else:
+        device: torch.device = torch.device("cpu")
+        backend = "gloo"
+
+    if not torch.distributed.is_initialized():
+        dist.init_process_group(backend=backend)
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    num_embeddings_per_feature = None
+    if args.num_embeddings_per_feature is not None:
+        num_embeddings_per_feature = list(
+            map(int, args.num_embeddings_per_feature.split(","))
+        )
+
+    train_paths = sorted(glob.glob(os.path.join(args.train_path, "*", "*.parquet")))
+
+    train_loader = get_nvt_criteo_dataloader(
+        train_paths,
+        batch_size=args.batch_size,
+        world_size=world_size,
+        rank=rank,
+    )
+
+    eb_configs = [
+        EmbeddingBagConfig(
+            name=f"t_{feature_name}",
+            embedding_dim=args.embedding_dim,
+            num_embeddings=none_throws(num_embeddings_per_feature)[feature_idx]
+            if num_embeddings_per_feature is not None
+            else args.num_embeddings,
+            feature_names=[feature_name],
+        )
+        for feature_idx, feature_name in enumerate(DEFAULT_CAT_NAMES)
+    ]
+
+    train_model = DLRMTrain(
+        embedding_bag_collection=EmbeddingBagCollection(
+            tables=eb_configs, device=torch.device("meta")
+        ),
+        dense_in_features=len(DEFAULT_INT_NAMES),
+        dense_arch_layer_sizes=list(map(int, args.dense_arch_layer_sizes.split(","))),
+        over_arch_layer_sizes=list(map(int, args.over_arch_layer_sizes.split(","))),
+        dense_device=device,
+    )
+
+    # Enable optimizer fusion
+    fused_params = {
+        "learning_rate": args.learning_rate,
+        "optimizer": OptimType.EXACT_ROWWISE_ADAGRAD,
+    }
+
+    sharders = cast(
+        List[ModuleSharder[nn.Module]],
+        [
+            EmbeddingBagCollectionSharder(fused_params=fused_params),
+        ],
+    )
+
+    pg = dist.GroupMember.WORLD
+    constraints = defaultdict(lambda: trec_dist.planner.ParameterConstraints())
+    for embedding_bag_config in eb_configs:
+        constraints[embedding_bag_config.name].sharding_types = ["row_wise"]
+        constraints[embedding_bag_config.name].kernel_types = ["batched_fused"]
+
+    hbm_cap = torch.cuda.get_device_properties(device).total_memory
+    local_world_size = trec_dist.comm.get_local_size(world_size)
+    model = DistributedModelParallel(
+        module=train_model,
+        device=device,
+        env=trec_dist.ShardingEnv.from_process_group(pg),
+        plan=trec_dist.planner.EmbeddingShardingPlanner(
+            topology=trec_dist.planner.Topology(
+                world_size=world_size,
+                compute_device=device.type,
+                local_world_size=local_world_size,
+                hbm_cap=hbm_cap,
+                batch_size=args.batch_size,
+            ),
+            storage_reservation=trec_dist.planner.storage_reservations.HeuristicalStorageReservation(
+                percentage=0.25,
+            ),
+            constraints=constraints,
+        ).collective_plan(train_model, sharders, pg),
+        sharders=sharders,
+    )
+
+    non_fused_optimizer = KeyedOptimizerWrapper(
+        dict(model.named_parameters()),
+        lambda params: torch.optim.Adagrad(params, lr=args.learning_rate),
+    )
+
+    opt = trec_optim.keyed.CombinedOptimizer(
+        [non_fused_optimizer, model.fused_optimizer]
+    )
+
+    train_pipeline = TrainPipelineSparseDist(
+        model,
+        opt,
+        device,
+    )
+
+    throughput = ThroughputMetric(
+        batch_size=args.batch_size,
+        world_size=world_size,
+        window_seconds=30,
+        warmup_steps=10,
+    )
+
+    for epoch in range(args.epochs):
+        logger.info(f"Starting epoch {epoch}")
+        it = iter(train_loader)
+        step = 0
+        losses = []
+        while True:
+            try:
+                loss, _logits, _labels = train_pipeline.progress(it)
+                # predictions = logits.sigmoid()
+                # labels = labels.int()
+                # ne_metric.update(predictions=predictions, labels=labels, weights=None)
+
+                throughput.update()
+                losses.append(loss)
+
+                if step % 100 == 0 and step != 0:
+                    throughput_val = throughput.compute()
+                    if rank == 0:
+                        print("step", step)
+                        print("throughput", throughput_val)
+                        print(
+                            "binary cross entropy loss",
+                            torch.mean(torch.stack(losses)) / (args.batch_size),
+                        )
+                    losses = []
+                step += 1
+
+            except StopIteration:
+                print("Reached stop iteration")
+                break
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/torchrec/datasets/scripts/nvt/01_nvt_preproc.py
+++ b/torchrec/datasets/scripts/nvt/01_nvt_preproc.py
@@ -12,22 +12,14 @@ import time
 
 import numpy as np
 import nvtabular as nvt
-from torchrec.datasets.criteo import DAYS, DEFAULT_COLUMN_NAMES, DEFAULT_LABEL_NAME
+from torchrec.datasets.criteo import DAYS, DEFAULT_COLUMN_NAMES, DEFAULT_LABEL_NAME, DEFAULT_INT_NAMES, DEFAULT_CAT_NAMES
 from utils.dask import setup_dask
 
-dtypes = {c: np.int32 for c in DEFAULT_COLUMN_NAMES[:14] + [DEFAULT_LABEL_NAME]}
-dtypes.update({c: "hex" for c in DEFAULT_COLUMN_NAMES[14:]})
+dtypes = {c: np.int32 for c in DEFAULT_INT_NAMES + [DEFAULT_LABEL_NAME]}
+dtypes.update({c: "hex" for c in DEFAULT_CAT_NAMES})
 
 
 def convert_tsv_to_parquet(input_path: str, output_base_path: str):
-    config = {
-        "engine": "csv",
-        "names": DEFAULT_COLUMN_NAMES,
-        "part_memory_fraction": 1,
-        "sep": "\t",
-        "dtypes": dtypes,
-    }
-
     output_path = os.path.join(output_base_path, "criteo_parquet")
     if os.path.exists(output_path):
         shutil.rmtree(output_path)
@@ -35,7 +27,14 @@ def convert_tsv_to_parquet(input_path: str, output_base_path: str):
 
     input_paths = [os.path.join(input_path, f"day_{day}") for day in range(DAYS)]
 
-    tsv_dataset = nvt.Dataset(input_paths, **config)
+    tsv_dataset = nvt.Dataset(
+        input_paths, 
+        engine="csv",
+        names=DEFAULT_COLUMN_NAMES,
+        part_memory_fraction= 0.1,
+        sep="\t",
+        dtypes=dtypes,
+    )
 
     tsv_dataset.to_parquet(
         output_path,

--- a/torchrec/datasets/scripts/nvt/02_nvt_preproc.py
+++ b/torchrec/datasets/scripts/nvt/02_nvt_preproc.py
@@ -13,19 +13,30 @@ import time
 import numpy as np
 import nvtabular as nvt
 from torchrec.datasets.criteo import (
-    DAYS,
     DEFAULT_CAT_NAMES,
-    DEFAULT_COLUMN_NAMES,
     DEFAULT_INT_NAMES,
     DEFAULT_LABEL_NAME,
 )
+
 from utils.dask import setup_dask
 
 
-def process_criteo_day(input_path, output_path, day):
+def process_criteo_day(input_path, output_path, day, num_embeddings_per_feature):
     input_dataset = nvt.Dataset(os.path.join(input_path, f"day_{day}.parquet"))
 
-    cat_features = DEFAULT_CAT_NAMES >> nvt.ops.FillMissing()
+    cat_features = (
+        DEFAULT_CAT_NAMES
+        >> nvt.ops.FillMissing()
+        >> nvt.ops.HashBucket(
+            {
+                cat_name: num_embeddings
+                for cat_name, num_embeddings in zip(
+                    DEFAULT_CAT_NAMES, num_embeddings_per_feature
+                )
+            }
+        )
+    )
+
     cont_features = (
         DEFAULT_INT_NAMES
         >> nvt.ops.FillMissing()
@@ -37,10 +48,8 @@ def process_criteo_day(input_path, output_path, day):
 
     workflow.fit(input_dataset)
 
-    target_dtypes = {
-        c: np.float32 for c in DEFAULT_COLUMN_NAMES[:14] + [DEFAULT_LABEL_NAME]
-    }
-    target_dtypes.update({c: "hex" for c in DEFAULT_COLUMN_NAMES[14:]})
+    target_dtypes = {c: np.float32 for c in DEFAULT_INT_NAMES + [DEFAULT_LABEL_NAME]}
+    target_dtypes.update({c: np.int64 for c in DEFAULT_CAT_NAMES})
 
     workflow.transform(input_dataset).to_parquet(
         output_path=os.path.join(output_path, f"day_{day}"),
@@ -54,6 +63,21 @@ def process_criteo_day(input_path, output_path, day):
 def parse_args():
     parser = argparse.ArgumentParser(description="Preprocess criteo dataset")
     parser.add_argument("--base_path", "-b", dest="base_path", help="Base path")
+    parser.add_argument(
+        "--num_embeddings",
+        type=int,
+        default=100_000,
+        help="max_ind_size. The number of embeddings in each embedding table. Defaults"
+        " to 100_000 if num_embeddings_per_feature is not supplied.",
+    )
+    parser.add_argument(
+        "--num_embeddings_per_feature",
+        type=str,
+        default=None,
+        help="Comma separated max_ind_size per sparse feature. The number of embeddings"
+        " in each embedding table. 26 values are expected for the Criteo dataset.",
+    )
+    parser.add_argument("--days", "-d", type=int, default=26, help="days to process")
 
     args = parser.parse_args()
 
@@ -63,6 +87,17 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
+    num_embeddings_per_feature = [args.num_embeddings] * len(DEFAULT_CAT_NAMES)
+    if args.num_embeddings_per_feature is not None:
+        maybe_num_embeddings_per_feature = list(
+            map(int, args.num_embeddings_per_feature.split(","))
+        )
+        if len(maybe_num_embeddings_per_feature) != len(DEFAULT_CAT_NAMES):
+            raise ValueError(
+                f"num_embedding_per_feature must have exactly {len(DEFAULT_CAT_NAMES)} values"
+            )
+        num_embeddings_per_feature = maybe_num_embeddings_per_feature
+        
     dask_workdir = os.path.join(args.base_path, "dask_workdir")
     client = setup_dask(dask_workdir)
 
@@ -77,6 +112,6 @@ if __name__ == "__main__":
     ), f"Criteo parquet path {input_path} does not exist"
 
     start_time = time.time()
-    for day in range(DAYS):
-        process_criteo_day(input_path, output_path, day)
+    for day in range(args.days):
+        process_criteo_day(input_path, output_path, day, num_embeddings_per_feature)
     print(f"Processing took {time.time()-start_time:.2f} sec")


### PR DESCRIPTION
See README

# Running torchrec using NVTabular DataLoader

First run nvtabular preprocessing to first convert the criteo TSV files to parquet, and perform offline preprocessing. For example
```
cd torchrec/torchrce/datasets/scripts/nvt/
python 01_nvt_preproc.py -i /data/criteo_1tb/ -o /data/criteo_1tb/
python 02_nvt_preproc.py -b /data/criteo_1tb/ --num_embeddings_per_feature 45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35
ls /data/criteo_1tb/criteo_preproc/*/*.parquet
>>> /data/criteo_1tb/criteo_preproc/day_0/part_0.parquet
>>> /data/criteo_1tb/criteo_preproc/day_1/part_0.parquet
```

To run locally
```
torchx run -s local_cwd dist.ddp -j 1x8 --script train_torchrec.py -- \
 --num_embeddings_per_feature 45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35 --over_arch_layer_sizes 1024,1024,512,256,1 --train_path /data/criteo_1tb/criteo_preproc/ --batch_size 4096
```

