### PR TITLE
[bugfix] Fix error on empty sharders

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -523,7 +523,7 @@ class EmbeddingStorageEstimator(ShardEstimator):
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
     ) -> None:
-        if not sharder_map:
+        if sharder_map is None:
             raise ValueError("sharder map not provided for storage estimator")
 
         for sharding_option in sharding_options:


### PR DESCRIPTION
When passing a empty sharder list to DMP, the `sharder_map` will be a empty dict, which would return `True` for `not sharder_map`. In our experience, it's beneficial to support passing empty `sharders` to DMP to align the performance.