### PR TITLE
Use EXACT_SGD to avoid race condition

### DIFF
--- a/torchrec/modules/fused_embedding_bag_collection.py
+++ b/torchrec/modules/fused_embedding_bag_collection.py
@@ -275,16 +275,10 @@ def convert_optimizer_type_and_kwargs(
     if isinstance(optimizer_type, EmbOptimType):
         return (optimizer_type, optimizer_kwargs)
     if optimizer_type == torch.optim.SGD:
-        if device_type == "cuda":
-            return (
-                EmbOptimType.EXACT_SGD,
-                optimizer_kwargs,
-            )
-        else:
-            return (
-                EmbOptimType.SGD,
-                optimizer_kwargs,
-            )
+        return (
+            EmbOptimType.EXACT_SGD,
+            optimizer_kwargs,
+        )
     # TODO the below might not be perfect, will clean up
     # if optimizer_type == torch.optim.Adam:
     # return (


### PR DESCRIPTION
Summary: currently in unit tests we fail about 1/10 runs because we're using SGD instead of EXACT_SGD for CPU based runs

Reviewed By: bigning

Differential Revision: D36652712

