### PR TITLE
create list of all proposals from list of proposers

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -253,7 +253,6 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                     proposer.feedback(partitionable=False)
 
                 proposal = proposer.propose()
-
         if best_plan:
             sharding_plan = _to_sharding_plan(best_plan, self._topology)
 


### PR DESCRIPTION
Summary:
-> this diff creates new function (proposers_to_proposals_list) that takes in list of proposers and returns list of all proposals in all of those proposers, discarding duplicates

this is done by iterating through proposers and associated proposals (using propose function) and adding it to new list (also keeping track of already seen proposals with their keys to discard duplicates)

Differential Revision: D36701285

