### PR TITLE
Back out "add DLRMTrain module to torchrec/models/dlrm.py as it is resused in multiple examples"

### DIFF
--- a/examples/ray/dlrm_train.py
+++ b/examples/ray/dlrm_train.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from torchrec.datasets.utils import Batch
+from torchrec.models.dlrm import DLRM
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+
+class DLRMTrain(nn.Module):
+    """
+    nn.Module to wrap DLRM model to use with train_pipeline.
+
+    DLRM Recsys model from "Deep Learning Recommendation Model for Personalization and
+    Recommendation Systems" (https://arxiv.org/abs/1906.00091). Processes sparse
+    features by learning pooled embeddings for each feature. Learns the relationship
+    between dense features and sparse features by projecting dense features into the
+    same embedding space. Also, learns the pairwise relationships between sparse
+    features.
+
+    The module assumes all sparse features have the same embedding dimension
+    (i.e, each EmbeddingBagConfig uses the same embedding_dim)
+
+    Args:
+        embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
+            used to define SparseArch.
+        dense_in_features (int): the dimensionality of the dense input features.
+        dense_arch_layer_sizes (list[int]): the layer sizes for the DenseArch.
+        over_arch_layer_sizes (list[int]): the layer sizes for the OverArch. NOTE: The
+            output dimension of the InteractionArch should not be manually specified
+            here.
+        dense_device: (Optional[torch.device]).
+
+    Example::
+
+        ebc = EmbeddingBagCollection(config=ebc_config)
+        model = DLRMTrain(
+           embedding_bag_collection=ebc,
+           dense_in_features=100,
+           dense_arch_layer_sizes=[20],
+           over_arch_layer_sizes=[5, 1],
+        )
+    """
+
+    def __init__(
+        self,
+        embedding_bag_collection: EmbeddingBagCollection,
+        dense_in_features: int,
+        dense_arch_layer_sizes: List[int],
+        over_arch_layer_sizes: List[int],
+        dense_device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self.model = DLRM(
+            embedding_bag_collection=embedding_bag_collection,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=dense_arch_layer_sizes,
+            over_arch_layer_sizes=over_arch_layer_sizes,
+            dense_device=dense_device,
+        )
+        self.loss_fn: nn.Module = nn.BCEWithLogitsLoss()
+
+    def forward(
+        self, batch: Batch
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        """
+        Args:
+            batch: batch used with criteo and random data from torchrec.datasets
+        Returns:
+            Tuple[loss, Tuple[loss, logits, labels]]
+        """
+        logits = self.model(batch.dense_features, batch.sparse_features)
+        logits = logits.squeeze()
+        loss = self.loss_fn(logits, batch.labels.float())
+
+        return loss, (loss.detach(), logits.detach(), batch.labels.detach())

--- a/examples/ray/train_torchrec.py
+++ b/examples/ray/train_torchrec.py
@@ -11,6 +11,7 @@ import os
 from typing import cast, List, Optional
 
 import torch
+from dlrm_train import DLRMTrain
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
 from torch import distributed as dist, nn
 from torch.utils.data import DataLoader
@@ -20,7 +21,6 @@ from torchrec.distributed import TrainPipelineSparseDist
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.types import ModuleSharder
-from torchrec.models.dlrm import DLRMTrain
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.optim.keyed import KeyedOptimizerWrapper

--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -5,11 +5,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import torch
 from torch import nn
-from torchrec.datasets.utils import Batch
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.mlp import MLP
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
@@ -402,72 +401,3 @@ class DLRM(nn.Module):
         )
         logits = self.over_arch(concatenated_dense)
         return logits
-
-
-class DLRMTrain(nn.Module):
-    """
-    nn.Module to wrap DLRM model to use with train_pipeline.
-
-    DLRM Recsys model from "Deep Learning Recommendation Model for Personalization and
-    Recommendation Systems" (https://arxiv.org/abs/1906.00091). Processes sparse
-    features by learning pooled embeddings for each feature. Learns the relationship
-    between dense features and sparse features by projecting dense features into the
-    same embedding space. Also, learns the pairwise relationships between sparse
-    features.
-
-    The module assumes all sparse features have the same embedding dimension
-    (i.e, each EmbeddingBagConfig uses the same embedding_dim)
-
-    Args:
-        embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
-            used to define SparseArch.
-        dense_in_features (int): the dimensionality of the dense input features.
-        dense_arch_layer_sizes (list[int]): the layer sizes for the DenseArch.
-        over_arch_layer_sizes (list[int]): the layer sizes for the OverArch. NOTE: The
-            output dimension of the InteractionArch should not be manually specified
-            here.
-        dense_device: (Optional[torch.device]).
-
-    Example::
-
-        ebc = EmbeddingBagCollection(config=ebc_config)
-        model = DLRMTrain(
-           embedding_bag_collection=ebc,
-           dense_in_features=100,
-           dense_arch_layer_sizes=[20],
-           over_arch_layer_sizes=[5, 1],
-        )
-    """
-
-    def __init__(
-        self,
-        embedding_bag_collection: EmbeddingBagCollection,
-        dense_in_features: int,
-        dense_arch_layer_sizes: List[int],
-        over_arch_layer_sizes: List[int],
-        dense_device: Optional[torch.device] = None,
-    ) -> None:
-        super().__init__()
-        self.model = DLRM(
-            embedding_bag_collection=embedding_bag_collection,
-            dense_in_features=dense_in_features,
-            dense_arch_layer_sizes=dense_arch_layer_sizes,
-            over_arch_layer_sizes=over_arch_layer_sizes,
-            dense_device=dense_device,
-        )
-        self.loss_fn: nn.Module = nn.BCEWithLogitsLoss()
-
-    def forward(
-        self, batch: Batch
-    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
-        """
-        Args:
-            batch: batch used with criteo and random data from torchrec.datasets
-        Returns:
-            Tuple[loss, Tuple[loss, logits, labels]]
-        """
-        logits = self.model(batch.dense_features, batch.sparse_features)
-        logits = logits.squeeze()
-        loss = self.loss_fn(logits, batch.labels.float())
-
-        return loss, (loss.detach(), logits.detach(), batch.labels.detach())

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -9,16 +9,8 @@ import unittest
 
 import torch
 from torch.testing import FileCheck  # @manual
-from torchrec.datasets.utils import Batch
 from torchrec.fx import symbolic_trace
-from torchrec.models.dlrm import (
-    choose,
-    DenseArch,
-    DLRM,
-    DLRMTrain,
-    InteractionArch,
-    SparseArch,
-)
+from torchrec.models.dlrm import choose, DenseArch, DLRM, InteractionArch, SparseArch
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -521,40 +513,3 @@ class DLRMTest(unittest.TestCase):
 
         logits = scripted_gm(features, sparse_features)
         self.assertEqual(logits.size(), (B, 1))
-
-
-class DLRMTrainTest(unittest.TestCase):
-    def test_basic(self) -> None:
-        B = 2
-        D = 8
-        dense_in_features = 100
-
-        eb1_config = EmbeddingBagConfig(
-            name="t2",
-            embedding_dim=D,
-            num_embeddings=100,
-            feature_names=["f2"],
-        )
-
-        ebc = EmbeddingBagCollection(tables=[eb1_config])
-        dlrm = DLRMTrain(
-            embedding_bag_collection=ebc,
-            dense_in_features=dense_in_features,
-            dense_arch_layer_sizes=[20, D],
-            over_arch_layer_sizes=[5, 1],
-        )
-
-        features = torch.rand((B, dense_in_features))
-        sparse_features = KeyedJaggedTensor.from_offsets_sync(
-            keys=["f2"],
-            values=torch.tensor(range(3)),
-            offsets=torch.tensor([0, 2, 3]),
-        )
-        batch = Batch(
-            dense_features=features,
-            sparse_features=sparse_features,
-            labels=torch.randint(2, (B,)),
-        )
-
-        _, (_, logits, _) = dlrm(batch)
-        self.assertEqual(logits.size(), (B,))


### PR DESCRIPTION
Summary:
Original commit changeset: bce2a4a8c625

Original Phabricator Diff: D36617207 (https://github.com/pytorch/torchrec/commit/99ccaa414a57279f0d99d1324618db746759e35e)

Reviewed By: rkindi

Differential Revision: D36709447

