### PR TITLE
Add inference docs to torchrec.docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,6 +38,7 @@ TorchRec API
    torchrec.distributed.planner.rst
    torchrec.distributed.sharding.rst
    torchrec.fx.rst
+   torchrec.inference.rst
    torchrec.models.rst
    torchrec.modules.rst
    torchrec.optim.rst

--- a/docs/source/torchrec.inference.rst
+++ b/docs/source/torchrec.inference.rst
@@ -1,0 +1,28 @@
+torchrec.inference
+===========
+
+.. automodule:: torchrec.inference
+
+torchrec.inference.model_packager
+------------------
+
+.. automodule:: torchrec.inference.model_packager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+torchrec.inference.modules
+------------------
+
+.. automodule:: torchrec.inference.modules
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: torchrec.inference
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Summary: We have docstrings for torchrec.inferennce python API (model_packager and modules) but they weren't exposed in the public docs. This does that.

Reviewed By: zyan0

Differential Revision: D36709138

