### PR TITLE
Add assertion for pooling factor, num object, and batch size constraints provided to planner

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -75,6 +75,13 @@ class EmbeddingPerfEstimator(ShardEstimator):
                 and self._constraints[sharding_option.name].batch_sizes
                 else [sharding_option.batch_size] * sharding_option.num_inputs
             )
+
+            assert (
+                len(sharding_option.input_lengths)
+                == len(num_objects)
+                == len(batch_sizes)
+            ), "Provided `pooling_factors`, `num_objects`, and `batch_sizes` constraints must match."
+
             shard_perfs = perf_func_emb_wall_time(
                 shard_sizes=[shard.size for shard in sharding_option.shards],
                 compute_kernel=sharding_option.compute_kernel,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -258,6 +258,9 @@ class PartitionByType(Enum):
 class ParameterConstraints:
     """
     Stores user provided constraints around the sharding plan.
+
+    If provided, `pooling_factors`, `num_objects`, and `batch_sizes` must match in
+    length, as per sample.
     """
 
     sharding_types: Optional[List[str]] = None
@@ -266,7 +269,7 @@ class ParameterConstraints:
     caching_ratio: Optional[float] = None  # UVM caching
     pooling_factors: List[float] = field(
         default_factory=lambda: [POOLING_FACTOR]
-    )  # Embedding Tables
+    )  # average number of embedding lookups required per sample
     num_objects: Optional[List[float]] = None  # number of objects per sample in batch
     batch_sizes: Optional[List[int]] = None  # batch size per input feature
 


### PR DESCRIPTION
Summary: The pooling_factors, num_objects, and batch_sizes provided to the planner from ParameterConstraints must match in length as per input.

Differential Revision: D36717996

