### PR TITLE
Modifying interaction layer to include 2 MLPs in DLRM

### DIFF
--- a/examples/ray/train_torchrec.py
+++ b/examples/ray/train_torchrec.py
@@ -20,7 +20,7 @@ from torchrec.distributed import TrainPipelineSparseDist
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.types import ModuleSharder
-from torchrec.models.dlrm import DLRMTrain
+from torchrec.models.dlrm import DLRM, DLRMTrain
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.optim.keyed import KeyedOptimizerWrapper
@@ -82,7 +82,7 @@ def train(
         )
         for feature_idx, feature_name in enumerate(DEFAULT_CAT_NAMES)
     ]
-    train_model = DLRMTrain(
+    dlrm_model = DLRM(
         embedding_bag_collection=EmbeddingBagCollection(
             tables=eb_configs, device=torch.device("meta")
         ),
@@ -91,6 +91,7 @@ def train(
         over_arch_layer_sizes=over_arch_layer_sizes,
         dense_device=device,
     )
+    train_model = DLRMTrain(dlrm_model)
 
     # Enable optimizer fusion
     fused_params = {

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -8,6 +8,7 @@
 import unittest
 
 import torch
+from torch import nn
 from torch.testing import FileCheck  # @manual
 from torchrec.datasets.utils import Batch
 from torchrec.fx import symbolic_trace
@@ -16,7 +17,9 @@ from torchrec.models.dlrm import (
     DenseArch,
     DLRM,
     DLRMTrain,
+    DLRMV2,
     InteractionArch,
+    InteractionV2Arch,
     SparseArch,
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -537,12 +540,360 @@ class DLRMTrainTest(unittest.TestCase):
         )
 
         ebc = EmbeddingBagCollection(tables=[eb1_config])
-        dlrm = DLRMTrain(
+        dlrm_module = DLRM(
             embedding_bag_collection=ebc,
             dense_in_features=dense_in_features,
             dense_arch_layer_sizes=[20, D],
             over_arch_layer_sizes=[5, 1],
         )
+        dlrm = DLRMTrain(dlrm_module)
+
+        features = torch.rand((B, dense_in_features))
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f2"],
+            values=torch.tensor(range(3)),
+            offsets=torch.tensor([0, 2, 3]),
+        )
+        batch = Batch(
+            dense_features=features,
+            sparse_features=sparse_features,
+            labels=torch.randint(2, (B,)),
+        )
+
+        _, (_, logits, _) = dlrm(batch)
+        self.assertEqual(logits.size(), (B,))
+
+
+class InteractionV2ArchTest(unittest.TestCase):
+    def test_basic(self) -> None:
+        D = 3
+        B = 10
+        keys = ["f1", "f2"]
+        F = len(keys)
+        F1 = 2
+        F2 = 2
+        I1 = DenseArch(
+            in_features=2 * D + D,
+            layer_sizes=[2 * D, F1 * D],
+        )
+        I2 = DenseArch(
+            in_features=2 * D + D,
+            layer_sizes=[2 * D, F2 * D],
+        )
+        inter_arch = InteractionV2Arch(
+            num_sparse_features=F,
+            interaction_branch1=I1,
+            interaction_branch2=I2,
+        )
+
+        dense_features = torch.rand((B, D))
+
+        sparse_features = torch.rand((B, F, D))
+        concat_dense = inter_arch(dense_features, sparse_features)
+        #  B X (D + F1 * F2)
+        self.assertEqual(concat_dense.size(), (B, D + F1 * F2))
+
+    def test_larger(self) -> None:
+        D = 8
+        B = 20
+        keys = ["f1", "f2", "f3", "f4"]
+        F = len(keys)
+        F1 = 4
+        F2 = 4
+        I1 = DenseArch(
+            in_features=4 * D + D,
+            layer_sizes=[4 * D, F1 * D],  # F1 = 4
+        )
+        I2 = DenseArch(
+            in_features=4 * D + D,
+            layer_sizes=[4 * D, F2 * D],  # F2 = 4
+        )
+        inter_arch = InteractionV2Arch(
+            num_sparse_features=F,
+            interaction_branch1=I1,
+            interaction_branch2=I2,
+        )
+
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+
+        concat_dense = inter_arch(dense_features, sparse_features)
+        #  B X (D + F1 * F2)
+        self.assertEqual(concat_dense.size(), (B, D + F1 * F2))
+
+    def test_correctness(self) -> None:
+        D = 4
+        B = 3
+        keys = [
+            "f1",
+            "f2",
+            "f3",
+            "f4",
+        ]
+        F = len(keys)
+        F1 = 5
+        F2 = 5
+        I1 = nn.Identity()
+        I2 = nn.Identity()
+        inter_arch = InteractionV2Arch(
+            num_sparse_features=F,
+            interaction_branch1=I1,
+            interaction_branch2=I2,
+        )
+        torch.manual_seed(0)
+
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+
+        concat_dense = inter_arch(dense_features, sparse_features)
+        #  B X (D + F1 * F2)
+        self.assertEqual(concat_dense.size(), (B, D + F1 * F2))
+
+        expected = torch.tensor(
+            [
+                [
+                    0.4963,
+                    0.7682,
+                    0.0885,
+                    0.1320,
+                    0.5057,
+                    0.6874,
+                    0.5756,
+                    0.8082,
+                    0.6656,
+                    0.5402,
+                    0.3672,
+                    0.5765,
+                    0.8837,
+                    0.2710,
+                    0.7540,
+                    0.9349,
+                    0.7424,
+                    1.0666,
+                    0.7297,
+                    1.3209,
+                    1.2713,
+                    1.2888,
+                    1.9248,
+                    0.9367,
+                    0.4865,
+                    0.7688,
+                    0.9932,
+                    1.3475,
+                    0.8313,
+                ],
+                [
+                    0.3074,
+                    0.6341,
+                    0.4901,
+                    0.8964,
+                    1.0706,
+                    0.8757,
+                    1.0621,
+                    1.3669,
+                    0.6122,
+                    0.9342,
+                    0.7316,
+                    0.7294,
+                    1.0603,
+                    0.3866,
+                    0.2011,
+                    0.2153,
+                    0.3768,
+                    0.3638,
+                    0.2154,
+                    1.0712,
+                    0.8293,
+                    1.3000,
+                    1.4564,
+                    0.8369,
+                    0.3655,
+                    0.4440,
+                    0.6148,
+                    1.0776,
+                    0.5871,
+                ],
+                [
+                    0.4556,
+                    0.6323,
+                    0.3489,
+                    0.4017,
+                    0.7294,
+                    1.3899,
+                    0.9493,
+                    0.6186,
+                    0.7565,
+                    0.9535,
+                    1.5688,
+                    0.8992,
+                    0.7077,
+                    1.0088,
+                    1.1206,
+                    1.9778,
+                    1.1639,
+                    0.8642,
+                    1.1966,
+                    1.1827,
+                    1.8592,
+                    1.3003,
+                    0.9441,
+                    1.1177,
+                    0.4730,
+                    0.7631,
+                    0.4304,
+                    0.3937,
+                    0.3230,
+                ],
+            ]
+        )
+
+        self.assertTrue(
+            torch.allclose(
+                concat_dense,
+                expected,
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+
+
+class DLRMV2Test(unittest.TestCase):
+    def test_basic(self) -> None:
+        torch.manual_seed(0)
+        B = 2
+        D = 8
+        dense_in_features = 100
+
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        sparse_nn = DLRMV2(
+            embedding_bag_collection=ebc,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=[20, D],
+            interaction_branch1_layer_sizes=[3 * D + D, 4 * D],
+            interaction_branch2_layer_sizes=[3 * D + D, 4 * D],
+            over_arch_layer_sizes=[5, 1],
+        )
+        self.assertTrue(isinstance(sparse_nn.inter_arch, InteractionV2Arch))
+
+        features = torch.rand((B, dense_in_features))
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f3", "f2"],
+            values=torch.tensor([1, 2, 4, 5, 4, 3, 2, 9, 1, 2, 3]),
+            offsets=torch.tensor([0, 2, 4, 6, 8, 10, 11]),
+        )
+
+        logits = sparse_nn(
+            dense_features=features,
+            sparse_features=sparse_features,
+        )
+        self.assertEqual(logits.size(), (B, 1))
+
+        expected_logits = torch.tensor([[-0.0036], [-0.0260]])
+        self.assertTrue(
+            torch.allclose(
+                logits,
+                expected_logits,
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+
+    def test_dense_size(self) -> None:
+        torch.manual_seed(0)
+        D = 8
+        dense_in_features = 100
+
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        with self.assertRaises(ValueError):
+            sparse_nn = DLRMV2(  # noqa
+                embedding_bag_collection=ebc,
+                dense_in_features=dense_in_features,
+                dense_arch_layer_sizes=[20, D + 1],
+                interaction_branch1_layer_sizes=[3 * D + D, 4 * D],
+                interaction_branch2_layer_sizes=[3 * D + D, 4 * D],
+                over_arch_layer_sizes=[5, 1],
+            )
+
+    def test_interaction_size(self) -> None:
+        torch.manual_seed(0)
+        D = 8
+        dense_in_features = 100
+
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        with self.assertRaises(ValueError):
+            sparse_nn = DLRMV2(
+                embedding_bag_collection=ebc,
+                dense_in_features=dense_in_features,
+                dense_arch_layer_sizes=[20, D],
+                interaction_branch1_layer_sizes=[3 * D + D, 4 * D + 1],
+                interaction_branch2_layer_sizes=[3 * D + D, 4 * D],
+                over_arch_layer_sizes=[5, 1],
+            )
+
+        with self.assertRaises(ValueError):
+            sparse_nn = DLRMV2(  # noqa
+                embedding_bag_collection=ebc,
+                dense_in_features=dense_in_features,
+                dense_arch_layer_sizes=[20, D],
+                interaction_branch1_layer_sizes=[3 * D + D, 4 * D],
+                interaction_branch2_layer_sizes=[3 * D + D, 4 * D + 1],
+                over_arch_layer_sizes=[5, 1],
+            )
+
+
+class DLRMV2TrainTest(unittest.TestCase):
+    def test_basic(self) -> None:
+        B = 2
+        D = 8
+        dense_in_features = 100
+
+        eb1_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+
+        ebc = EmbeddingBagCollection(tables=[eb1_config])
+        dlrmv2_module = DLRMV2(
+            embedding_bag_collection=ebc,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=[20, D],
+            over_arch_layer_sizes=[5, 1],
+            interaction_branch1_layer_sizes=[80, 40],
+            interaction_branch2_layer_sizes=[80, 48],
+        )
+        dlrm = DLRMTrain(dlrmv2_module)
 
         features = torch.rand((B, dense_in_features))
         sparse_features = KeyedJaggedTensor.from_offsets_sync(


### PR DESCRIPTION
Summary: This diff adds 2 MLPs to the interaction layer in DLRM for MLPerf update. New DLRM module called DLRMV2 can be realized by --dlrmv2 argument. Additional arguments for the interaction MLPs are --interaction_branch1_layer_sizes and --interaction_branch2_layer_sizes to pass in the MLP sizes. The output dimension of the interaction MLPs must be a multiple of the embedding dimension.

Differential Revision: D35861688

