### PR TITLE
Initial Observer interface to consolidate instrumentation for OSS and internal

### DIFF
--- a/torchrec/inference/include/torchrec/inference/BatchingQueue.h
+++ b/torchrec/inference/include/torchrec/inference/BatchingQueue.h
@@ -29,6 +29,7 @@
 #include <folly/io/async/EventBaseThread.h>
 #include <folly/synchronization/Baton.h>
 #include "torchrec/inference/Batching.h"
+#include "torchrec/inference/Observer.h"
 #include "torchrec/inference/ResourceManager.h"
 #include "torchrec/inference/Types.h"
 
@@ -92,6 +93,7 @@ class BatchingQueue {
       std::vector<BatchQueueCb> cbs,
       const Config& config,
       int worldSize,
+      std::unique_ptr<IBatchingQueueObserver> observer,
       std::shared_ptr<ResourceManager> resourceManager = nullptr);
   ~BatchingQueue();
 
@@ -118,6 +120,8 @@ class BatchingQueue {
 
   void pinMemory(int gpuIdx);
 
+  void observeBatchCompletion(size_t batchSizeBytes, size_t numRequests);
+
   const Config config_;
 
   // Batching func name to batching func instance.
@@ -132,6 +136,7 @@ class BatchingQueue {
       batchingQueues_;
   std::atomic<bool> stopping_;
   int worldSize_;
+  std::unique_ptr<IBatchingQueueObserver> observer_;
   std::shared_ptr<ResourceManager> resourceManager_;
 };
 

--- a/torchrec/inference/include/torchrec/inference/Observer.h
+++ b/torchrec/inference/include/torchrec/inference/Observer.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <string>
+
+namespace torchrec {
+
+class IBatchingQueueObserver {
+ public:
+  // Record the amount of time an entry of PredictionRequests
+  // in the batching queue waits before they are read and allocated
+  // onto a GPU device.
+  virtual void recordBatchingQueueLatency(
+      double value,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) = 0;
+
+  // Record the amount of time it takes for a batching function
+  // to execute.
+  virtual void recordBatchingFuncLatency(
+      double value,
+      std::string batchingFuncName,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) = 0;
+
+  // Record the amount of time it takes to create a batch of
+  // requests.
+  virtual void recordBatchCreationLatency(
+      double value,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) = 0;
+
+  // Increment the number of batching queue timeouts experienced.
+  virtual void addBatchingQueueTimeoutCount(double value) = 0;
+
+  // Increment the number of times a GPU could not be chosen
+  // for allocation.
+  virtual void addGPUBusyCount(double value) = 0;
+
+  // Increment the number of requests entering the batching queue.
+  virtual void addRequestsCount(double value) = 0;
+
+  // Increment the number of bytes of tensors moved to cuda.
+  virtual void addBytesMovedToGPUCount(double value) = 0;
+
+  // Increment the number of batches processed by the batching
+  // queue (moved onto the GPU executor).
+  virtual void addBatchesProcessedCount(double value) = 0;
+
+  // Increment the number of requests processed by the batching
+  // queue (moved onto the GPU executor).
+  virtual void addRequestsProcessedCount(double value) = 0;
+
+  // The obervations that should be made when a batch is completed.
+  virtual void observeBatchCompletion(
+      size_t batchSizeBytes,
+      size_t numRequests) {
+    addBytesMovedToGPUCount(batchSizeBytes);
+    addBatchesProcessedCount(1);
+    addRequestsProcessedCount(numRequests);
+  }
+
+  virtual ~IBatchingQueueObserver() {}
+};
+
+// Can be used for testing or for opt-ing out of observation.
+class EmptyBatchingQueueObserver : public IBatchingQueueObserver {
+ public:
+  void recordBatchingQueueLatency(
+      double value,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) override {
+    (void)value, (void)now;
+  }
+
+  void recordBatchingFuncLatency(
+      double value,
+      std::string batchingFuncName,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) override {
+    (void)value, (void)batchingFuncName, (void)now;
+  }
+
+  void recordBatchCreationLatency(
+      double value,
+      std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now()) override {
+    (void)value, (void)now;
+  }
+
+  void addBatchingQueueTimeoutCount(double value) override {
+    (void)value;
+  }
+
+  void addGPUBusyCount(double value) override {
+    (void)value;
+  }
+
+  void addRequestsCount(double value) override {
+    (void)value;
+  }
+
+  void addBytesMovedToGPUCount(double value) override {
+    (void)value;
+  }
+
+  void addBatchesProcessedCount(double value) override {
+    (void)value;
+  }
+
+  void addRequestsProcessedCount(double value) override {
+    (void)value;
+  }
+};
+
+} // namespace torchrec

--- a/torchrec/inference/tests/BatchingQueueTest.cpp
+++ b/torchrec/inference/tests/BatchingQueueTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "torchrec/inference/BatchingQueue.h"
+#include "torchrec/inference/Observer.h"
 
 #include <memory>
 #include <thread>
@@ -54,10 +55,13 @@ TEST(BatchingQueueTest, Basic) {
   std::vector<BatchQueueCb> batchQueueCbs;
   batchQueueCbs.push_back(
       [&](std::shared_ptr<PredictionBatch> batch) { res = batch; });
+  std::unique_ptr<IBatchingQueueObserver> batchingQueueObserver =
+      std::make_unique<EmptyBatchingQueueObserver>();
   BatchingQueue queue(
       batchQueueCbs,
       BatchingQueue::Config{.batchingMetadata = {{"float_features", "dense"}}},
-      /* worldSize */ 1);
+      /* worldSize */ 1,
+      std::move(batchingQueueObserver));
 
   queue.add(
       createRequest(2, 2),


### PR DESCRIPTION
Summary:
Introduces `Observer` interface to enable instrumentation **within** the inference library. Lets us use fb303 internally and any generic observer in OSS.

Shows an example of how to use the observer by instrumenting the time spent in the batching queue using fb303 counter.

# next diff
- add GPUExecutor observer

Differential Revision: D36826702

