### PR TITLE
add parallelization to EmbeddingShardingPlanner

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -140,15 +140,15 @@ class GreedyPerfPartitioner(Partitioner):
             # in the example is just for clarity).
         """
 
-        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
-        self._topology: Topology = copy.deepcopy(storage_constraint)
+        _topology: Topology = copy.deepcopy(storage_constraint)
         plan = copy.deepcopy(proposal)
-        # pyre-ignore [16]
-        self._host_level_devices = self._get_host_level_devices()
+        _host_level_devices = GreedyPerfPartitioner._get_host_level_devices(_topology)
 
         # first partition the uniform sharding options (RW & DP)
         uniform_sharding_options = _get_uniform_sharding_options(plan)
-        self._uniform_partition(uniform_sharding_options, self._topology.devices)
+        GreedyPerfPartitioner._uniform_partition(
+            uniform_sharding_options, _topology.devices
+        )
 
         # group the rest sharding options by colocation type (co-host, co-device, none)
         # and sort the groups by storage in reverse order
@@ -159,7 +159,9 @@ class GreedyPerfPartitioner(Partitioner):
                 sharding_option_group.sharding_options[0].partition_by
                 == PartitionByType.HOST.value
             ):
-                self._cohost_partition(sharding_option_group)
+                GreedyPerfPartitioner._cohost_partition(
+                    sharding_option_group, _host_level_devices
+                )
             elif (
                 sharding_option_group.sharding_options[0].partition_by
                 == PartitionByType.DEVICE.value
@@ -167,17 +169,20 @@ class GreedyPerfPartitioner(Partitioner):
                 assert (
                     len(sharding_option_group.sharding_options) == 1
                 ), f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}"
-                self._device_partition(
-                    sharding_option_group.sharding_options[0], self._topology.devices
+                GreedyPerfPartitioner._device_partition(
+                    sharding_option_group.sharding_options[0], _topology.devices
                 )
             else:
                 raise RuntimeError(
                     f"Unexpected sharding option group {sharding_option_group}"
                 )
+        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
+        self._topology: Topology = _topology
         return plan
 
+    @staticmethod
     def _device_partition(
-        self, sharding_option: ShardingOption, devices: List[DeviceHardware]
+        sharding_option: ShardingOption, devices: List[DeviceHardware]
     ) -> None:
         for shard in sharding_option.shards:
             sorted_devices = sorted(devices, key=lambda device: device.perf)
@@ -194,9 +199,12 @@ class GreedyPerfPartitioner(Partitioner):
                     f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}"
                 )
 
-    def _cohost_partition(self, sharding_option_group: ShardingOptionGroup) -> None:
-        # pyre-ignore [16]
-        sorted_host_level_devices = _sort_devices_by_perf(self._host_level_devices)
+    @staticmethod
+    def _cohost_partition(
+        sharding_option_group: ShardingOptionGroup,
+        _host_level_devices: List[List[DeviceHardware]],
+    ) -> None:
+        sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
         for devices in sorted_host_level_devices:
             host_devices = copy.deepcopy(devices)
             host_storage = Storage(hbm=0, ddr=0)
@@ -212,12 +220,16 @@ class GreedyPerfPartitioner(Partitioner):
                         sharding_option.sharding_type
                         == ShardingType.TABLE_ROW_WISE.value
                     ):
-                        self._uniform_partition([sharding_option], host_devices)
+                        GreedyPerfPartitioner._uniform_partition(
+                            [sharding_option], host_devices
+                        )
                     elif (
                         sharding_option.sharding_type
                         == ShardingType.TABLE_COLUMN_WISE.value
                     ):
-                        self._device_partition(sharding_option, host_devices)
+                        GreedyPerfPartitioner._device_partition(
+                            sharding_option, host_devices
+                        )
                     else:
                         raise RuntimeError(
                             f"unexpected cohost sharding type: {sharding_option.sharding_type}"
@@ -236,21 +248,20 @@ class GreedyPerfPartitioner(Partitioner):
             f"can't find a host for sharding option group {sharding_option_group}"
         )
 
-    def _get_host_level_devices(self) -> List[List[DeviceHardware]]:
-        # pyre-ignore [16]
-        num_hosts: int = self._topology.world_size // self._topology.local_world_size
+    @staticmethod
+    def _get_host_level_devices(_topology: Topology) -> List[List[DeviceHardware]]:
+        num_hosts: int = _topology.world_size // _topology.local_world_size
         host_level_devices: List[List[DeviceHardware]] = []
         for i in range(num_hosts):
-            devices_in_host = self._topology.devices[
-                i
-                * self._topology.local_world_size : (i + 1)
-                * self._topology.local_world_size
+            devices_in_host = _topology.devices[
+                i * _topology.local_world_size : (i + 1) * _topology.local_world_size
             ]
             host_level_devices.append(devices_in_host)
         return host_level_devices
 
+    @staticmethod
     def _uniform_partition(
-        self, sharding_options: List[ShardingOption], devices: List[DeviceHardware]
+        sharding_options: List[ShardingOption], devices: List[DeviceHardware]
     ) -> None:
         for sharding_option in sharding_options:
             if sharding_option.num_shards != len(devices):

--- a/torchrec/distributed/planner/tests/test_parallelized_planners.py
+++ b/torchrec/distributed/planner/tests/test_parallelized_planners.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import cast, List
+
+import torch
+from torch import nn
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+
+from torchrec.distributed.planner.parallelized_planners import (
+    ParallelizedEmbeddingShardingPlanner,
+)
+
+from torchrec.distributed.planner.types import PlannerError, Topology
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+
+class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [ShardingType.ROW_WISE.value, ShardingType.TABLE_WISE.value]
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+
+
+class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [ShardingType.TABLE_WISE.value]
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+
+
+class TestParallelizedEmbeddingShardingPlanner(unittest.TestCase):
+    def setUp(self) -> None:
+        compute_device = "cuda"
+        self.topology = Topology(
+            world_size=2, hbm_cap=1024 * 1024 * 2, compute_device=compute_device
+        )
+        self.planner = ParallelizedEmbeddingShardingPlanner(topology=self.topology)
+
+    def test_tw_solution(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(4)
+        ]
+        model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+        sharding_plan = self.planner.plan(module=model, sharders=[TWvsRWSharder()])
+        expected_ranks = [[0], [0], [1], [1]]
+        ranks = [
+            cast(List[int], param_shard.ranks)
+            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+        ]
+
+        self.assertEqual(sorted(expected_ranks), sorted(ranks))
+
+    def test_hidden_rw_solution(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(3)
+        ]
+        model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+        sharding_plan = self.planner.plan(module=model, sharders=[TWvsRWSharder()])
+        expected_ranks = [[0], [0, 1], [1]]
+        ranks = [
+            cast(List[int], param_shard.ranks)
+            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+        ]
+
+        self.assertEqual(sorted(expected_ranks), sorted(ranks))
+
+    def test_never_fit(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=10000000,
+                embedding_dim=10000000,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+
+        with self.assertRaises(PlannerError):
+            self.planner.plan(module=model, sharders=[TWvsRWSharder()])
+
+        self.assertEqual(self.planner._num_proposals, 4)
+
+    def test_fail_then_rerun(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=4096,
+                embedding_dim=128,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(1)
+        ]
+        model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+
+        with self.assertRaises(PlannerError):
+            self.planner.plan(module=model, sharders=[TWSharder()])
+
+        sharding_plan = self.planner.plan(module=model, sharders=[TWvsRWSharder()])
+        expected_ranks = [[0, 1]]
+        ranks = [
+            cast(List[int], param_shard.ranks)
+            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+        ]
+
+        self.assertEqual(sorted(expected_ranks), sorted(ranks))


### PR DESCRIPTION
Summary:
Currently, planner is running in a single threaded process. To improve the planner's runtime and scalability, this diff creates a new class that includes EmbeddingShardingPlanner with the addition of multi-processing.

This is done by first making a proposals' list from a list of proposers, and then grouping the list into a user's custom cpu number of lists, or into an automatically calculated cpu count with the help of os library.

Grouped prosolals are distributed and simultaneously worked on. The best plan is chosen according to their performance.

Differential Revision: D36841610

