### PR TITLE
Criteo preprocessing improvements

### DIFF
--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -199,10 +199,11 @@ class BinaryCriteoUtils:
         """
 
         def row_mapper(row: List[str]) -> Tuple[List[int], List[int], int]:
-            label = safe_cast(row[0], int, 0)
-            dense = [safe_cast(row[i], int, 0) for i in range(1, 1 + INT_FEATURE_COUNT)]
+            # Missing values are mapped to zero for both dense and sparse features
+            label = int(row[0] or "0")
+            dense = [int(row[i] or "0") for i in range(1, 1 + INT_FEATURE_COUNT)]
             sparse = [
-                int(safe_cast(row[i], str, "0") or "0", 16)
+                int(row[i] or "0", 16)
                 for i in range(
                     1 + INT_FEATURE_COUNT, 1 + INT_FEATURE_COUNT + CAT_FEATURE_COUNT
                 )

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -632,7 +632,7 @@ class InMemoryBinaryCriteoIterDataPipe(IterableDataset):
     the entire dataset into memory to prevent disk speed from affecting throughout. Each
     rank reads only the data for the portion of the dataset it is responsible for.
 
-    The torchrec/datasets/scripts/preprocess_criteo.py script can be used to convert
+    The torchrec/datasets/scripts/npy_preproc_criteo.py script can be used to convert
     the Criteo tsv files to the npy files expected by this dataset.
 
     Args:


### PR DESCRIPTION
I'm using the fact how Criteo dataset looks like to improve preprocessing:
* there is no need to cast sparse features to `str` first  as `csv.reader` [here](https://github.com/pytorch/torchrec/blob/50ff0973d5d01ec80fe36ba5f1d524c92c799836/torchrec/datasets/utils.py#L216) produces a list strings 
* we can replace missing values -- empty strings -- to zeros right away and then cast features to int avoiding try/catch block in `safe_cast` helper function.

This results in a decent 15% speedup according to my measurements. It is a non-negligible time saving as the preprocessing is a long job. Moreover, I think that this is slightly more transparent in how .npy files are produced.