### PR TITLE
Change module walk to use `_fsdp_wrapped_module` instead of `module`

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -129,6 +129,8 @@ def get_unwrapped_module(module: nn.Module) -> nn.Module:
     ):
         if isinstance(module, DistributedModelParallel):
             module = module._dmp_wrapped_module
+        elif isinstance(module, FullyShardedDataParallel):
+            module = module._fsdp_wrapped_module
         else:
             module = module.module
     return module


### PR DESCRIPTION
Summary: This fixes the TorchRec module walk after https://github.com/pytorch/pytorch/pull/78671 changed `FullyShardeDataParallel.module` to return the inner wrapped module instead of the `FlattenParamsWrapper`.

Differential Revision: D36941682

