### PR TITLE
Add the should_validate_update flag for states update input checking

### DIFF
--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -89,6 +89,7 @@ class AUCMetricTest(unittest.TestCase):
         task_names: List[str],
         fused_update_limit: int = 0,
         compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
     ) -> None:
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
@@ -104,6 +105,7 @@ class AUCMetricTest(unittest.TestCase):
             test_clazz=TestAUCMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=should_validate_update,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -127,6 +129,7 @@ class AUCMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_auc,
         )
@@ -139,6 +142,7 @@ class AUCMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_auc,
         )

--- a/torchrec/metrics/tests/test_calibration.py
+++ b/torchrec/metrics/tests/test_calibration.py
@@ -57,6 +57,7 @@ class CalibrationMetricTest(unittest.TestCase):
         task_names: List[str],
         fused_update_limit: int = 0,
         compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
     ) -> None:
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
@@ -72,6 +73,7 @@ class CalibrationMetricTest(unittest.TestCase):
             test_clazz=TestCalibrationMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=should_validate_update,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -107,6 +109,7 @@ class CalibrationMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_calibration,
         )
@@ -119,6 +122,7 @@ class CalibrationMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_calibration,
         )

--- a/torchrec/metrics/tests/test_ctr.py
+++ b/torchrec/metrics/tests/test_ctr.py
@@ -51,6 +51,7 @@ class CTRMetricTest(unittest.TestCase):
         task_names: List[str],
         fused_update_limit: int = 0,
         compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
     ) -> None:
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
@@ -66,6 +67,7 @@ class CTRMetricTest(unittest.TestCase):
             test_clazz=TestCTRMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=should_validate_update,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -95,6 +97,7 @@ class CTRMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ctr,
         )
@@ -107,6 +110,7 @@ class CTRMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ctr,
         )

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -371,13 +371,12 @@ class MetricModuleTest(unittest.TestCase):
             device=torch.device("cpu"),
         )
         # Default NEMetric's dtype is
-        #   float64 (8 bytes) * 16 tensors of size 1 + unit8 (1 byte) * 2 tensors of size 1 = 130 bytes
+        #   float64 (8 bytes) * 16 tensors of size 1 = 128 bytes
         #       Tensors in NeMetricComputation:
-        #           NE metric specific attributes: 8 in _default, 8 actual attribute values: 4 attributes, 4 window
-        #           RecMetric's has_valid_update attribute: 1 in _default, 1 actual attribute value
-        self.assertEqual(metric_module.get_memory_usage(), 130)
+        #           8 in _default, 8 specific attributes: 4 attributes, 4 window
+        self.assertEqual(metric_module.get_memory_usage(), 128)
         metric_module.update(gen_test_batch(128))
-        self.assertEqual(metric_module.get_memory_usage(), 162)
+        self.assertEqual(metric_module.get_memory_usage(), 160)
 
     def test_calibration_memory_usage(self) -> None:
         mock_optimizer = MockOptimizer()
@@ -399,13 +398,12 @@ class MetricModuleTest(unittest.TestCase):
             device=torch.device("cpu"),
         )
         # Default calibration metric dtype is
-        #   float64 (8 bytes) * 8 tensors of size 1 + uint8 (1 byte) * 2 tensors of size 1 = 66 bytes
+        #   float64 (8 bytes) * 8 tensors, size 1 = 64 bytes
         #       Tensors in CalibrationMetricComputation:
-        #           Calibration metric attributes: 4 in _default, 4 actual attribute values: 2 attribute, 2 window
-        #           RecMetric's has_valid_update attribute: 1 in _default, 1 actual attribute value
-        self.assertEqual(metric_module.get_memory_usage(), 66)
+        #           4 in _default, 4 specific attributes: 2 attribute, 2 window
+        self.assertEqual(metric_module.get_memory_usage(), 64)
         metric_module.update(gen_test_batch(128))
-        self.assertEqual(metric_module.get_memory_usage(), 82)
+        self.assertEqual(metric_module.get_memory_usage(), 80)
 
     def test_auc_memory_usage(self) -> None:
         mock_optimizer = MockOptimizer()
@@ -426,11 +424,11 @@ class MetricModuleTest(unittest.TestCase):
             state_metrics_mapping={StateMetricEnum.OPTIMIZERS: mock_optimizer},
             device=torch.device("cpu"),
         )
-        # 3 (tensors) * 8 (double) + 1 (tensor) * 2 (uint8)
-        self.assertEqual(metric_module.get_memory_usage(), 26)
+        # 3 (tensors) * 8 (double)
+        self.assertEqual(metric_module.get_memory_usage(), 24)
         metric_module.update(gen_test_batch(128))
-        # 24 (initial states) + 3 (tensors) * 128 (batch_size) * 8 (double) + 1 (tensor) * 2 (uint8)
-        self.assertEqual(metric_module.get_memory_usage(), 3098)
+        # 24 (initial states) + 3 (tensors) * 128 (batch_size) * 8 (double)
+        self.assertEqual(metric_module.get_memory_usage(), 3096)
 
     def test_check_memory_usage(self) -> None:
         mock_optimizer = MockOptimizer()

--- a/torchrec/metrics/tests/test_mse.py
+++ b/torchrec/metrics/tests/test_mse.py
@@ -74,6 +74,7 @@ class MSEMetricTest(unittest.TestCase):
         task_names: List[str],
         fused_update_limit: int = 0,
         compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
     ) -> None:
         rank = int(os.environ["RANK"])
         world_size = int(os.environ["WORLD_SIZE"])
@@ -89,6 +90,7 @@ class MSEMetricTest(unittest.TestCase):
             test_clazz=TestMSEMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=should_validate_update,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -118,6 +120,7 @@ class MSEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_mse,
         )
@@ -130,6 +133,7 @@ class MSEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_mse,
         )
@@ -155,6 +159,7 @@ class MSEMetricTest(unittest.TestCase):
             test_clazz=TestRMSEMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -177,6 +182,7 @@ class MSEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_mse,
         )
@@ -189,6 +195,7 @@ class MSEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_mse,
         )

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -69,6 +69,7 @@ class NEMetricTest(unittest.TestCase):
         task_names: List[str],
         fused_update_limit: int = 0,
         compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
         batch_window_size: int = 5,
     ) -> None:
         rank = int(os.environ["RANK"])
@@ -85,6 +86,7 @@ class NEMetricTest(unittest.TestCase):
             test_clazz=TestNEMetric,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=False,
+            should_validate_update=should_validate_update,
             world_size=world_size,
             my_rank=rank,
             task_names=task_names,
@@ -122,6 +124,7 @@ class NEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ne,
         )
@@ -134,6 +137,7 @@ class NEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ne,
         )
@@ -146,6 +150,7 @@ class NEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=5,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ne,
         )
@@ -157,6 +162,7 @@ class NEMetricTest(unittest.TestCase):
             task_names=["t1", "t2", "t3"],
             fused_update_limit=100,
             compute_on_all_ranks=False,
+            should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=self._test_ne_large_window_size,
         )
@@ -170,6 +176,7 @@ class NEMetricTest(unittest.TestCase):
         #     task_names=["t1", "t2", "t3"],
         #     fused_update_limit=5,
         #     compute_on_all_ranks=False,
+        #     should_validate_update=False,
         #     world_size=WORLD_SIZE,
         #     entry_point=self._test_ne,
         # )
@@ -181,6 +188,7 @@ class NEMetricTest(unittest.TestCase):
         #     task_names=["t1", "t2", "t3"],
         #     fused_update_limit=100,
         #     compute_on_all_ranks=False,
+        #     should_validate_update=False,
         #     world_size=WORLD_SIZE,
         #     entry_point=self._test_ne_large_window_size,
         # )

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -74,6 +74,7 @@ class RecMetricTest(unittest.TestCase):
             compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             window_size=100,
             fused_update_limit=0,
+            should_validate_update=True,
         )
         mse_computation = mse._metrics_computations[0]
 
@@ -131,6 +132,7 @@ class RecMetricTest(unittest.TestCase):
             compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             window_size=100,
             fused_update_limit=0,
+            should_validate_update=True,
         )
         ne_computation = ne._metrics_computations
 

--- a/torchrec/metrics/tests/test_utils.py
+++ b/torchrec/metrics/tests/test_utils.py
@@ -209,6 +209,7 @@ def rec_metric_value_test_helper(
     test_clazz: Optional[Type[TestMetric]],
     fused_update_limit: int,
     compute_on_all_ranks: bool,
+    should_validate_update: bool,
     world_size: int,
     my_rank: int,
     task_names: List[str],
@@ -248,6 +249,7 @@ def rec_metric_value_test_helper(
             window_size=window_size,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=compute_on_all_ranks,
+            should_validate_update=should_validate_update,
         )
         for i in range(nsteps):
             labels, predictions, weights = parse_task_model_outputs(
@@ -321,6 +323,7 @@ def rec_metric_value_test_launcher(
     task_names: List[str],
     fused_update_limit: int,
     compute_on_all_ranks: bool,
+    should_validate_update: bool,
     world_size: int,
     entry_point: Callable[..., None],
     test_nsteps: int = 1,
@@ -338,6 +341,7 @@ def rec_metric_value_test_launcher(
             test_clazz=None,
             fused_update_limit=fused_update_limit,
             compute_on_all_ranks=compute_on_all_ranks,
+            should_validate_update=should_validate_update,
             world_size=1,
             my_rank=0,
             task_names=task_names,
@@ -351,6 +355,7 @@ def rec_metric_value_test_launcher(
             task_names,
             fused_update_limit,
             compute_on_all_ranks,
+            should_validate_update,
         )
 
 


### PR DESCRIPTION
Summary:
In `rec_metric.py`'s `_update(...)` function, the following 2 if-statements let the has_valid_weights tensor to be passed from GPU to CPU, which leads to CPU-GPU synchronization. This can cause performance reduction. So in this diff, instead of open this feature to all models, we gate the update input checking feature with the `should_validate_update` flag
- `if torch.any(has_valid_weights)`
- `if has_valid_weights[0]`

Differential Revision: D36992375

