### PR TITLE
Add ShardedFusedEmbeddingBagCollection and FusedEmbeddingBagCollectionSharder

### DIFF
--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Iterator, List, Optional, Type
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    EmbeddingComputeKernel,
+)
+from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
+from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
+from torchrec.distributed.types import ParameterSharding, ShardingEnv, ShardingType
+from torchrec.distributed.utils import append_prefix
+from torchrec.modules.fused_embedding_modules import (
+    convert_optimizer_type_and_kwargs,
+    FusedEmbeddingBagCollection,
+)
+
+
+class ShardedFusedEmbeddingBagCollection(
+    ShardedEmbeddingBagCollection,
+):
+    def __init__(
+        self,
+        module: FusedEmbeddingBagCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        optimizer_type = module.optimizer_type
+        optimizer_kwargs = module.optimizer_kwargs
+
+        fused_params = {}
+        emb_opt_type_and_kwargs = convert_optimizer_type_and_kwargs(
+            optimizer_type, optimizer_kwargs, device=device
+        )
+        assert emb_opt_type_and_kwargs is not None
+        (emb_optim_type, emb_opt_kwargs) = emb_opt_type_and_kwargs
+        fused_params.update(emb_opt_kwargs)
+
+        super().__init__(
+            module=module,
+            table_name_to_parameter_sharding=table_name_to_parameter_sharding,
+            fused_params=fused_params,
+            env=env,
+            device=device,
+        )
+
+        for index, (sharding, lookup) in enumerate(
+            zip(self._sharding_type_to_sharding.values(), self._lookups)
+        ):
+            if isinstance(sharding, DpPooledEmbeddingSharding):
+                self._lookups[index] = DistributedDataParallel(
+                    module=lookup,
+                    device_ids=[device],
+                    process_group=env.process_group,
+                    gradient_as_bucket_view=True,
+                    broadcast_buffers=False,
+                    static_graph=True,
+                )
+                self._lookups[index]._register_fused_optim(
+                    optimizer_type, **optimizer_kwargs
+                )
+                # TODO - We need a way to get this optimizer back (and add to optims) so it
+                # can be checkpointed.
+                # We need to ensure that a checkpoint from DDP and a checkpoint from a
+                # model parallel version are compatible.
+
+    def sharded_parameter_names(self, prefix: str = "") -> Iterator[str]:
+        # different than ShardedEmbeddingBagCollection - we consider DDP to be "sharded", so that it doesn't get wrapped up in ddp again
+        # semantics of this is actually "parameters that don't need to have their gradients reduced"
+        for lookup, _ in zip(self._lookups, self._sharding_type_to_sharding.keys()):
+            for name, _ in lookup.named_parameters(
+                append_prefix(prefix, "embedding_bags")
+            ):
+                yield name
+
+
+class FusedEmbeddingBagCollectionSharder(
+    BaseEmbeddingSharder[FusedEmbeddingBagCollection]
+):
+    def shard(
+        self,
+        module: FusedEmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedEmbeddingBagCollection:
+
+        return ShardedFusedEmbeddingBagCollection(module, params, env, device)
+
+    def shardable_parameters(
+        self, module: FusedEmbeddingBagCollection
+    ) -> Dict[str, nn.Parameter]:
+
+        params = {
+            name.split(".")[-2]: param
+            for name, param in module.state_dict().items()
+            if name.endswith(".weight")
+        }
+        return params
+
+    @property
+    def module_type(self) -> Type[FusedEmbeddingBagCollection]:
+        return FusedEmbeddingBagCollection
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.DATA_PARALLEL.value,
+            ShardingType.TABLE_WISE.value,
+            ShardingType.COLUMN_WISE.value,
+            ShardingType.TABLE_COLUMN_WISE.value,
+        ]
+        if compute_device_type in {"cuda"}:
+            types += [
+                ShardingType.ROW_WISE.value,
+                ShardingType.TABLE_ROW_WISE.value,
+            ]
+
+        return types
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        ret = []
+        if sharding_type != ShardingType.DATA_PARALLEL.value:
+            ret += [
+                EmbeddingComputeKernel.BATCHED_FUSED.value,
+            ]
+            if compute_device_type in {"cuda"}:
+                ret += [
+                    EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
+                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+                ]
+        else:
+            ret.append(EmbeddingComputeKernel.BATCHED_DENSE.value)
+        return ret

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -19,6 +19,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
     sharder_name,
@@ -49,6 +50,7 @@ _DDP_STATE_DICT_PREFIX = "module."
 def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
     return [
         cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
+        cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -19,6 +19,7 @@ from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionSharder,
     EmbeddingBagSharder,
 )
+from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
@@ -689,6 +690,22 @@ class TestEBCSharder(EmbeddingBagCollectionSharder):
     @property
     def fused_params(self) -> Optional[Dict[str, Any]]:
         return self._fused_params
+
+
+class TestFusedEBCSharder(FusedEmbeddingBagCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+    ) -> None:
+        super().__init__()
+        self._sharding_type = sharding_type
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
 
 
 class TestEBSharder(EmbeddingBagSharder):

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict, List, Optional
+
+import hypothesis.strategies as st
+import torch
+import torch.nn as nn
+from hypothesis import given, settings, Verbosity
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+
+from torchrec.distributed.test_utils.test_model import TestFusedEBCSharder
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict, SharderType
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.fused_embedding_modules import (
+    fuse_embedding_optimizer,
+    FusedEmbeddingBagCollection,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+
+def sharding_single_rank(
+    rank: int,
+    world_size: int,
+    unsharded_model: nn.Module,
+    kjt_input: KeyedJaggedTensor,
+    sharders: List[ModuleSharder[nn.Module]],
+    backend: str,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input = kjt_input.to(ctx.device)
+        unsharded_model = unsharded_model.to(ctx.device)
+
+        # Shard model.
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        plan: ShardingPlan = planner.collective_plan(unsharded_model, sharders, ctx.pg)
+
+        sharded_model = DistributedModelParallel(
+            unsharded_model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=sharders,
+            device=ctx.device,
+        )
+
+        # Load model state from the global model.
+        copy_state_dict(sharded_model.state_dict(), unsharded_model.state_dict())
+
+        unsharded_model_pred = unsharded_model(kjt_input).values().detach().clone()
+        sharded_pred = sharded_model(kjt_input).values().detach().clone()
+
+        # Compare predictions of sharded vs unsharded models.
+        torch.testing.assert_allclose(sharded_pred, unsharded_model_pred)
+
+
+@skip_if_asan_class
+class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharder_type=st.sampled_from(
+            [
+                SharderType.EMBEDDING_BAG_COLLECTION.value,
+            ]
+        ),
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                # ShardingType.DATA_PARALLEL.value,
+                # Data parallel checkpointing not yet supported
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_fused_ebc(
+        self,
+        sharder_type: str,
+        sharding_type: str,
+    ) -> None:
+
+        fused_ebc = FusedEmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="table_0",
+                    feature_names=["feature_0", "feature_1"],
+                    embedding_dim=8,
+                    num_embeddings=10,
+                )
+            ],
+            optimizer_type=torch.optim.SGD,
+            optimizer_kwargs={"lr": 0.02},
+            device=torch.device("cuda"),
+        )
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [3]          [4]         [5,6,7]
+        #
+
+        kjt_input = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            lengths=torch.LongTensor([2, 0, 1, 1, 1, 3]),
+        )
+
+        self._run_multi_process_test(
+            callable=sharding_single_rank,
+            world_size=2,
+            unsharded_model=fused_ebc,
+            kjt_input=kjt_input,
+            sharders=[TestFusedEBCSharder(sharding_type=sharding_type)],
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharder_type=st.sampled_from(
+            [
+                SharderType.EMBEDDING_BAG_COLLECTION.value,
+            ]
+        ),
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                # ShardingType.DATA_PARALLEL.value,
+                # Data parallel checkpointing not yet supported
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_fused_ebc_module_replace(
+        self,
+        sharder_type: str,
+        sharding_type: str,
+    ) -> None:
+
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="table_0",
+                    feature_names=["feature_0", "feature_1"],
+                    embedding_dim=8,
+                    num_embeddings=10,
+                )
+            ],
+        )
+
+        fused_ebc = fuse_embedding_optimizer(
+            ebc,
+            optimizer_type=torch.optim.SGD,
+            optimizer_kwargs={"lr": 0.02},
+            device=torch.device("cuda"),
+        )
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [3]          [4]         [5,6,7]
+        #
+
+        kjt_input = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            lengths=torch.LongTensor([2, 0, 1, 1, 1, 3]),
+        )
+
+        self._run_multi_process_test(
+            callable=sharding_single_rank,
+            world_size=2,
+            unsharded_model=fused_ebc,
+            kjt_input=kjt_input,
+            sharders=[TestFusedEBCSharder(sharding_type=sharding_type)],
+            backend="nccl",
+        )


### PR DESCRIPTION
Summary:
[RFC] prototype for now

This does the logic of swapping out FusedEmbeddingBagCollection w/ ShardedFusedEmbeddingBagCollection.
For non-batched_fused kernels, we register a backward hook, either manually, or via _register_fused_optim from DDP.
There is currently a gap in the ability to checkpoint the optims from DDP, but this is a WIP

Implementation decisions:

Currently we do all of this in FusedShardedEmbeddingBagCollection. If we REALLY wanted to make things as modular as possible, we would implement BatchedFusedDenseGroupedLookup, and use that as a lookup instead of BatchedDens. But that might be a bit of overkill :p

We choose to manually wrap the data_parallel tables with DistributedDataParallel, and add these tables to sharded_parameter_names, which are then ignored in the DefaultDDPWrapper

Reviewed By: divchenko

Differential Revision: D36482467

