### PR TITLE
Add torchrec.optim.RowWiseAdagrad

### DIFF
--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -40,7 +40,7 @@ class ShardedFusedEmbeddingBagCollection(
 
         fused_params = {}
         emb_opt_type_and_kwargs = convert_optimizer_type_and_kwargs(
-            optimizer_type, optimizer_kwargs, device=device
+            optimizer_type, optimizer_kwargs
         )
         assert emb_opt_type_and_kwargs is not None
         (emb_optim_type, emb_opt_kwargs) = emb_opt_type_and_kwargs

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Iterator, List, Optional, Type
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    EmbeddingComputeKernel,
+)
+from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
+from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
+from torchrec.distributed.types import ParameterSharding, ShardingEnv, ShardingType
+from torchrec.distributed.utils import append_prefix
+from torchrec.modules.fused_embedding_modules import (
+    convert_optimizer_type_and_kwargs,
+    FusedEmbeddingBagCollection,
+)
+
+
+class ShardedFusedEmbeddingBagCollection(
+    ShardedEmbeddingBagCollection,
+):
+    def __init__(
+        self,
+        module: FusedEmbeddingBagCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        optimizer_type = module.optimizer_type
+        optimizer_kwargs = module.optimizer_kwargs
+
+        fused_params = {}
+        emb_opt_type_and_kwargs = convert_optimizer_type_and_kwargs(
+            optimizer_type, optimizer_kwargs, device=device
+        )
+        assert emb_opt_type_and_kwargs is not None
+        (emb_optim_type, emb_opt_kwargs) = emb_opt_type_and_kwargs
+        fused_params.update(emb_opt_kwargs)
+
+        super().__init__(
+            module=module,
+            table_name_to_parameter_sharding=table_name_to_parameter_sharding,
+            fused_params=fused_params,
+            env=env,
+            device=device,
+        )
+
+        for index, (sharding, lookup) in enumerate(
+            zip(self._sharding_type_to_sharding.values(), self._lookups)
+        ):
+            if isinstance(sharding, DpPooledEmbeddingSharding):
+                self._lookups[index] = DistributedDataParallel(
+                    module=lookup,
+                    device_ids=[device],
+                    process_group=env.process_group,
+                    gradient_as_bucket_view=True,
+                    broadcast_buffers=False,
+                    static_graph=True,
+                )
+                self._lookups[index]._register_fused_optim(
+                    optimizer_type, **optimizer_kwargs
+                )
+                # TODO - We need a way to get this optimizer back (and add to optims) so it
+                # can be checkpointed.
+                # We need to ensure that a checkpoint from DDP and a checkpoint from a
+                # model parallel version are compatible.
+
+    def sharded_parameter_names(self, prefix: str = "") -> Iterator[str]:
+        # different than ShardedEmbeddingBagCollection - we consider DDP to be "sharded", so that it doesn't get wrapped up in ddp again
+        # semantics of this is actually "parameters that don't need to have their gradients reduced"
+        for lookup, _ in zip(self._lookups, self._sharding_type_to_sharding.keys()):
+            for name, _ in lookup.named_parameters(
+                append_prefix(prefix, "embedding_bags")
+            ):
+                yield name
+
+
+class FusedEmbeddingBagCollectionSharder(
+    BaseEmbeddingSharder[FusedEmbeddingBagCollection]
+):
+    def shard(
+        self,
+        module: FusedEmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedEmbeddingBagCollection:
+
+        return ShardedFusedEmbeddingBagCollection(module, params, env, device)
+
+    def shardable_parameters(
+        self, module: FusedEmbeddingBagCollection
+    ) -> Dict[str, nn.Parameter]:
+
+        params = {
+            name.split(".")[-2]: param
+            for name, param in module.state_dict().items()
+            if name.endswith(".weight")
+        }
+        return params
+
+    @property
+    def module_type(self) -> Type[FusedEmbeddingBagCollection]:
+        return FusedEmbeddingBagCollection
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.DATA_PARALLEL.value,
+            ShardingType.TABLE_WISE.value,
+            ShardingType.COLUMN_WISE.value,
+            ShardingType.TABLE_COLUMN_WISE.value,
+        ]
+        if compute_device_type in {"cuda"}:
+            types += [
+                ShardingType.ROW_WISE.value,
+                ShardingType.TABLE_ROW_WISE.value,
+            ]
+
+        return types
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        ret = []
+        if sharding_type != ShardingType.DATA_PARALLEL.value:
+            ret += [
+                EmbeddingComputeKernel.BATCHED_FUSED.value,
+            ]
+            if compute_device_type in {"cuda"}:
+                ret += [
+                    EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
+                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+                ]
+        else:
+            ret.append(EmbeddingComputeKernel.BATCHED_DENSE.value)
+        return ret

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -19,6 +19,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
     sharder_name,
@@ -49,6 +50,7 @@ _DDP_STATE_DICT_PREFIX = "module."
 def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
     return [
         cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
+        cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -19,6 +19,7 @@ from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionSharder,
     EmbeddingBagSharder,
 )
+from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
@@ -689,6 +690,22 @@ class TestEBCSharder(EmbeddingBagCollectionSharder):
     @property
     def fused_params(self) -> Optional[Dict[str, Any]]:
         return self._fused_params
+
+
+class TestFusedEBCSharder(FusedEmbeddingBagCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+    ) -> None:
+        super().__init__()
+        self._sharding_type = sharding_type
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
 
 
 class TestEBSharder(EmbeddingBagSharder):

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict, List, Optional
+
+import hypothesis.strategies as st
+import torch
+import torch.nn as nn
+from hypothesis import given, settings, Verbosity
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+
+from torchrec.distributed.test_utils.test_model import TestFusedEBCSharder
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict, SharderType
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.fused_embedding_modules import (
+    fuse_embedding_optimizer,
+    FusedEmbeddingBagCollection,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+
+def sharding_single_rank(
+    rank: int,
+    world_size: int,
+    unsharded_model: nn.Module,
+    kjt_input: KeyedJaggedTensor,
+    sharders: List[ModuleSharder[nn.Module]],
+    backend: str,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input = kjt_input.to(ctx.device)
+        unsharded_model = unsharded_model.to(ctx.device)
+
+        # Shard model.
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        plan: ShardingPlan = planner.collective_plan(unsharded_model, sharders, ctx.pg)
+
+        sharded_model = DistributedModelParallel(
+            unsharded_model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=sharders,
+            device=ctx.device,
+        )
+
+        # Load model state from the global model.
+        copy_state_dict(sharded_model.state_dict(), unsharded_model.state_dict())
+
+        unsharded_model_pred = unsharded_model(kjt_input).values().detach().clone()
+        sharded_pred = sharded_model(kjt_input).values().detach().clone()
+
+        # Compare predictions of sharded vs unsharded models.
+        torch.testing.assert_allclose(sharded_pred, unsharded_model_pred)
+
+
+@skip_if_asan_class
+class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharder_type=st.sampled_from(
+            [
+                SharderType.EMBEDDING_BAG_COLLECTION.value,
+            ]
+        ),
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                # ShardingType.DATA_PARALLEL.value,
+                # Data parallel checkpointing not yet supported
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_fused_ebc(
+        self,
+        sharder_type: str,
+        sharding_type: str,
+    ) -> None:
+
+        fused_ebc = FusedEmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="table_0",
+                    feature_names=["feature_0", "feature_1"],
+                    embedding_dim=8,
+                    num_embeddings=10,
+                )
+            ],
+            optimizer_type=torch.optim.SGD,
+            optimizer_kwargs={"lr": 0.02},
+            device=torch.device("cuda"),
+        )
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [3]          [4]         [5,6,7]
+        #
+
+        kjt_input = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            lengths=torch.LongTensor([2, 0, 1, 1, 1, 3]),
+        )
+
+        self._run_multi_process_test(
+            callable=sharding_single_rank,
+            world_size=2,
+            unsharded_model=fused_ebc,
+            kjt_input=kjt_input,
+            sharders=[TestFusedEBCSharder(sharding_type=sharding_type)],
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharder_type=st.sampled_from(
+            [
+                SharderType.EMBEDDING_BAG_COLLECTION.value,
+            ]
+        ),
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                # ShardingType.DATA_PARALLEL.value,
+                # Data parallel checkpointing not yet supported
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_fused_ebc_module_replace(
+        self,
+        sharder_type: str,
+        sharding_type: str,
+    ) -> None:
+
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="table_0",
+                    feature_names=["feature_0", "feature_1"],
+                    embedding_dim=8,
+                    num_embeddings=10,
+                )
+            ],
+        )
+
+        fused_ebc = fuse_embedding_optimizer(
+            ebc,
+            optimizer_type=torch.optim.SGD,
+            optimizer_kwargs={"lr": 0.02},
+            device=torch.device("cuda"),
+        )
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [3]          [4]         [5,6,7]
+        #
+
+        kjt_input = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            lengths=torch.LongTensor([2, 0, 1, 1, 1, 3]),
+        )
+
+        self._run_multi_process_test(
+            callable=sharding_single_rank,
+            world_size=2,
+            unsharded_model=fused_ebc,
+            kjt_input=kjt_input,
+            sharders=[TestFusedEBCSharder(sharding_type=sharding_type)],
+            backend="nccl",
+        )

--- a/torchrec/optim/__init__.py
+++ b/torchrec/optim/__init__.py
@@ -10,7 +10,9 @@
 Torchrec contains a special optimizer called KeyedOptimizer. KeyedOptimizer exposes the state_dict with meaningful keys- it enables  loading both
 torch.tensor and `ShardedTensor <https://github.com/pytorch/pytorch/issues/55207>`_ in place, and it prohibits loading an empty state into already initialized KeyedOptimizer and vise versa.
 
-It also contains several modules wrapping KeyedOptimizer, called CombinedOptimizer and OptimizerWrapper
+It also contains
+- several modules wrapping KeyedOptimizer, called CombinedOptimizer and OptimizerWrapper
+- Optimizers used in RecSys: e.g. rowwise adagrad/adam/etc
 """
 
 from torchrec.optim.clipping import GradientClipping, GradientClippingOptimizer  # noqa
@@ -21,6 +23,13 @@ from torchrec.optim.keyed import (  # noqa
     KeyedOptimizerWrapper,
     OptimizerWrapper,
 )
+from torchrec.optim.rowwise_adagrad import RowWiseAdagrad  # noqa
 from torchrec.optim.warmup import WarmupOptimizer, WarmupPolicy, WarmupStage  # noqa
 
-from . import clipping, fused, keyed, warmup  # noqa  # noqa  # noqa  # noqa
+from . import (  # noqa  # noqa  # noqa  # noqa
+    clipping,
+    fused,
+    keyed,
+    rowwise_adagrad,
+    warmup,
+)

--- a/torchrec/optim/rowwise_adagrad.py
+++ b/torchrec/optim/rowwise_adagrad.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+from typing import Any, Dict, Iterable, List
+
+import torch
+from torch import Tensor
+
+from torch.optim.optimizer import Optimizer
+
+
+class RowWiseAdagrad(Optimizer):
+    r"""Implements Row wise Adagrad algorithm. This is an extension of the Adagrad algorithm
+    https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py, for use with
+    EmbeddingBag parameters, where we want the adaptive learning rate to be the same within an
+    embedding row. Since we only need to store state for an embedding row, rather than every single
+    parameter, we can have drastic memory savings (factor of embedding_dim).
+
+    Note that this implementation does not currently support sparse gradients.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 1e-2)
+        lr_decay (float, optional): learning rate decay (default: 0)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-10)
+        maximize (bool, optional): maximize the params based on the objective, instead of
+            minimizing (default: False)
+    """
+
+    def __init__(
+        self,
+        params: Iterable[torch.nn.Parameter],
+        lr: float = 1e-2,
+        lr_decay: float = 0.0,
+        weight_decay: float = 0.0,
+        initial_accumulator_value: float = 0.0,
+        eps: float = 1e-10,
+        *,
+        maximize: bool = False,
+    ) -> None:
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= lr_decay:
+            raise ValueError("Invalid lr_decay value: {}".format(lr_decay))
+        if not 0.0 <= weight_decay:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+        if not 0.0 <= initial_accumulator_value:
+            raise ValueError(
+                "Invalid initial_accumulator_value value: {}".format(
+                    initial_accumulator_value
+                )
+            )
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+
+        defaults = dict(
+            lr=lr,
+            lr_decay=lr_decay,
+            eps=eps,
+            weight_decay=weight_decay,
+            initial_accumulator_value=initial_accumulator_value,
+            maximize=maximize,
+        )
+        super().__init__(params, defaults)
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                state = self.state[p]
+                state["step"] = torch.tensor(0.0)
+                init_value = (
+                    complex(initial_accumulator_value, initial_accumulator_value)
+                    if torch.is_complex(p)
+                    else initial_accumulator_value
+                )
+                state["sum"] = (
+                    torch.full_like(p, init_value, memory_format=torch.preserve_format)
+                    .mean(axis=1)
+                    .view(-1, 1)
+                )
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        super().__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault("maximize", False)
+
+        state_values = list(self.state.values())
+        step_is_tensor = (len(state_values) != 0) and torch.is_tensor(
+            state_values[0]["step"]
+        )
+        if not step_is_tensor:
+            for s in state_values:
+                s["step"] = torch.tensor(float(s["step"]))
+
+    def share_memory(self) -> None:
+        for group in self.param_groups:
+            for p in group["params"]:
+                state = self.state[p]
+                state["sum"].share_memory_()
+
+    @torch.no_grad()
+    # pyre-ignore
+    def step(self, closure=None) -> torch.Tensor:
+        """Performs a single optimization step.
+        Args:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params_with_grad = []
+            grads = []
+            state_sums = []
+            state_steps = []
+
+            for p in group["params"]:
+                if p.grad is not None:
+                    params_with_grad.append(p)
+                    grads.append(p.grad)
+                    state = self.state[p]
+                    state_sums.append(state["sum"])
+                    state_steps.append(state["step"])
+
+            adagrad(
+                params_with_grad,
+                grads,
+                state_sums,
+                state_steps,
+                lr=group["lr"],
+                weight_decay=group["weight_decay"],
+                lr_decay=group["lr_decay"],
+                eps=group["eps"],
+                maximize=group["maximize"],
+            )
+
+        return loss
+
+
+def adagrad(
+    params: List[Tensor],
+    grads: List[Tensor],
+    state_sums: List[Tensor],
+    state_steps: List[Tensor],
+    # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
+    # setting these as kwargs for now as functional API is compiled by torch/distributed/optim
+    *,
+    lr: float,
+    weight_decay: float,
+    lr_decay: float,
+    eps: float,
+    maximize: bool,
+) -> None:
+    r"""Functional API that performs Adagrad algorithm computation.
+    See :class:`~torch.optim.Adagrad` for details.
+    """
+
+    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+        raise RuntimeError(
+            "API has changed, `state_steps` argument must contain a list of singleton tensors"
+        )
+
+    _single_tensor_adagrad(
+        params,
+        grads,
+        state_sums,
+        state_steps,
+        lr=lr,
+        weight_decay=weight_decay,
+        lr_decay=lr_decay,
+        eps=eps,
+        maximize=maximize,
+    )
+
+
+def _single_tensor_adagrad(
+    params: List[Tensor],
+    grads: List[Tensor],
+    state_sums: List[Tensor],
+    state_steps: List[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    lr_decay: float,
+    eps: float,
+    maximize: bool,
+) -> None:
+
+    for (param, grad, state_sum, step_t) in zip(params, grads, state_sums, state_steps):
+        if grad.is_sparse:
+            raise RuntimeError("RowWise adagrad cannot be used with sparse gradients")
+        # update step
+        step_t += 1
+        step = step_t.item()
+        grad = grad if not maximize else -grad
+
+        row_wise_grad = grad.mean(axis=1).view(-1, 1)
+        if weight_decay != 0:
+
+            grad = grad.add(param, alpha=weight_decay)
+            row_wise_grad = grad.add(param, alpha=weight_decay)
+
+        clr = lr / (1 + (step - 1) * lr_decay)
+
+        state_sum.addcmul_(row_wise_grad, row_wise_grad, value=1)
+        std = state_sum.sqrt().add_(eps)
+        param.addcdiv_(row_wise_grad, std, value=-clr)

--- a/torchrec/optim/tests/test_rowwise_adagrad.py
+++ b/torchrec/optim/tests/test_rowwise_adagrad.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+import torch
+import torchrec
+
+
+class RowWiseAdagradTest(unittest.TestCase):
+    def test_optim(self) -> None:
+        embedding_bag = torch.nn.EmbeddingBag(num_embeddings=4, embedding_dim=4)
+        opt = torchrec.optim.RowWiseAdagrad(embedding_bag.parameters())
+        index, offsets = torch.tensor([0, 3]), torch.tensor([0, 1])
+        embedding_bag_out = embedding_bag(index, offsets)
+        opt.zero_grad()
+        embedding_bag_out.sum().backward()
+
+    def test_optim_equivalence(self) -> None:
+        # If rows are initialized to be the same and uniform, then RowWiseAdagrad and canonical Adagrad are identical
+        rowwise_embedding_bag = torch.nn.EmbeddingBag(num_embeddings=4, embedding_dim=4)
+        embedding_bag = torch.nn.EmbeddingBag(num_embeddings=4, embedding_dim=4)
+        state_dict = {
+            "weight": torch.Tensor(
+                [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
+            )
+        }
+        rowwise_embedding_bag.load_state_dict(state_dict)
+        embedding_bag.load_state_dict(state_dict)
+
+        row_wise_opt = torchrec.optim.RowWiseAdagrad(rowwise_embedding_bag.parameters())
+        opt = torch.optim.Adagrad(embedding_bag.parameters())
+
+        index, offsets = torch.tensor([0, 3]), torch.tensor([0, 1])
+
+        for _ in range(5):
+            row_wise_opt.zero_grad()
+            opt.zero_grad()
+
+            embedding_bag(index, offsets).sum().backward()
+            opt.step()
+
+            rowwise_embedding_bag(index, offsets).sum().backward()
+            row_wise_opt.step()
+
+            torch.testing.assert_close(
+                embedding_bag.state_dict()["weight"],
+                rowwise_embedding_bag.state_dict()["weight"],
+            )


### PR DESCRIPTION
Summary:
fuse_embedding_module interface accepts

1. Regular PyTorch Optimizers

These will get converted to fused_params, and will be used to create the optimizer used in data_parallel _register_optim_hook. However, this will not be able to represent optims that don't exist in pytorch core (such as row_wise adagrad, etc)

2. torchrec.optim.RowWise Adagrad. Canonical pytorch optimizer implementation, and maps to EXACT_ROWWISE_ADAGRAD for kernel fusion

^ for the above implementation, I haven't found a good reason to support sparse grads yet (can't imagine it will be used with EmbeddingBag(sparse=True), so left that out for now.

Reviewed By: divchenko

Differential Revision: D36902535

