### PR TITLE
Benchmark: compare EBCs' performances

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,124 @@
+# TorchRec Benchmarks for `EmbeddingBag`
+
+We evaluate the performance of two EmbeddingBagCollection modules:
+
+1. `EmbeddingBagCollection` (EBC) ([code](https://github.com/pytorch/torchrec/blob/main/torchrec/modules/embedding_modules.py#L67)): a simple module backed by [torch.nn.EmbeddingBag](https://pytorch.org/docs/stable/generated/torch.nn.EmbeddingBag.html).
+
+2. `FusedEmbeddingBagCollection` (Fused EBC) ([code](https://github.com/pytorch/torchrec/blob/main/torchrec/modules/fused_embedding_bag_collection.py#L299)): a module backed by [FBGEMM](https://github.com/pytorch/FBGEMM) kernels which enables more efficient, high-performance operations on embedding tables. It is equipped with a fused optimizer, and UVM caching/management that makes much larger memory available for GPUs.
+
+
+## Module architecture and running setup
+
+We chose the embedding tables (sparse arch) in ML Perf [DLRM](https://github.com/facebookresearch/dlrm/tree/main/torchrec_dlrm) as the model to compare the performance difference between EBC and Fused EBC. Below are the settings on the embedding tables:
+```
+num_embeddings_per_feature = [45833188, 36746, 17245, 7413, 20243, 3, 7114, 1441, 62, 29275261, 1572176, 345138, 10, 2209, 11267, 128, 4, 974, 14, 48937457, 11316796, 40094537, 452104, 12606, 104, 35]
+embedding_dim_size = 128
+```
+
+Other setup includes:
+-   Optimizer: Stochastic Gradient Descent (SGD)
+-   Dataset: Random dataset ([code](https://github.com/pytorch/torchrec/blob/main/torchrec/datasets/random.py))
+-   CUDA 11.7, NCCL 2.11.4.
+-   AWS EC2 instance with 8 16GB NVIDIA Tesla V100
+
+
+## How to run
+
+After the installation of Torchrec (see "Binary" in the "Installation" section,  [link](https://github.com/pytorch/torchrec)), run the following command under the benchmark directory (/torchrec/torchrec/benchmarks):
+
+```
+python ebc_benchmarks.py [--mode MODE] [--cpu_only]
+```
+
+where `MODE` can be specified as `ebc_comparison_dlrm` (default) / `fused_ebc_uvm` / `ebc_comparison_scaling` to see different comparisons.
+
+
+## Results
+
+### Methodology
+
+To ease the reading, we use "DLRM EMB" to abbreviate "DLRM embedding tables" from below. Since 1 GPU can't accommondate the full sized tables in DLRM, we need to reduce the `embedding_dim` of the 5 largest tables to some degree (see the "Note" column in the following tables for the reduction degree). For the metrics, we use the average training time over 100 epochs to represent the performance of each module. `speedup` (defined as `training time using EBC` divided by `training time using Fused EBC`) is also computed to demonstrate the degree of improvement from EBC to Fused EBC.
+
+### 1. Comparison between EBC and FusedEBC on DLRM EMB (`ebc_comparison_dlrm`)
+
+We see that Fused EBC has much faster training efficiency compared to EBC. The speedup from EBC to Fused EBC is 13X, 18X and 23X when the DLRM EMB is reduced by 128 times, 64 times and 32 times, respectively.
+
+| Module | Time to train one epoch | Note |
+| ------ | ---------------------- | ---- |
+| EBC | 0.267 (+/- 0.002) second | DLRM EMB with sizes of the 5 largest tables reduced by 128 times |
+| EBC | 0.332 (+/- 0.002) second | DLRM EMB with sizes of the 5 largest tables reduced by 64 times |
+| EBC | 0.462 (+/- 0.002) second | DLRM EMB with sizes of the 5 largest tables reduced by 32 times |
+| Fused EBC | 0.019 (+/- 0.001) second | DLRM EMB with sizes of the 5 largest tables reduced by 128 times |
+| Fused EBC | 0.019 (+/- 0.001) second | DLRM EMB with sizes of the 5 largest tables reduced by 64 times |
+| Fused EBC | 0.019 (+/- 0.009) second | DLRM EMB with sizes of the 5 largest tables reduced by 32 times |
+
+### 2. Full sized DLRM EMB w/ UVM/UVM-caching w/ FusedEBC (`fused_ebc_uvm`)
+
+Here, we demonstrate the advantage of UVM/UVM-caching with Fused EBC. With UVM caching enabled, we can put larger sized tables in DLRM EMB in Fused EBC without significant sacrifice on the efficiency. With UVM enabled, we can allocate full sized DLRM EMB in UVM, with expected slower training performance because of the extra sync points between host and GPU (see [this example](https://github.com/pytorch/torchrec/blob/main/examples/sharding/uvm.ipynb) for more UVM explanation/usage).
+
+| Module | Time to train one epoch | Note |
+| ------ | ---------------------- | ---- |
+|Fused EBC with UVM caching | 0.06 (+/- 0.37) second | DLRM EMB with size of the 5 largest tables reduced by 2 |
+|Fused EBC with UVM | 0.62 (+/- 5.34) second | full sized DLRM EMB |
+
+The above performance comparison is also put in a bar chart for better visualization.
+![EBC_benchmarks_dlrm_emb](EBC_benchmarks_dlrm_emb.png)
+
+
+### 3. Comparison between EBC and fused_EBC on different sized embedding tables (`ebc_comparison_scaling`)
+
+Here, we study how the scaling on the embedding table affects the performance difference between EBC and Fused EBC. In doing so, we vary three parameters, `num_tables`, `embedding_dim` and `num_embeddings`, and present `speedup` from EBC to Fused EBC in the following tables. In each table, we observe that `embedding_dim` and `num_embeddings` do not have significant effect on speedup. However, as `num_tables` increases, the improvement from EBC to Fused EBC becomes higher (speedup increases), suggesting the benefit of Fused EBC when it is to deal with many embedding tables.
+
+
+-  `num_tables` = 10
+
+|||——————|——————| `embedding_dim` |——————|——————|—————>|
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+||| **4** | **8** | **16** | **32** | **64** | **128** |
+|&#124;|    **4** | 2.87 | 2.79 | 2.79 | 2.79 | 2.76 | 2.8 |
+|&#124;|    **8** | 2.71 | 3.11 | 2.97 | 3.02 | 2.99 | 2.95 |
+|&#124;|   **16** | 2.98 | 2.97 | 2.98 | 2.97 | 3.0 | 3.05 |
+|&#124;|   **32** | 3.01 | 2.95 | 2.99 | 2.98 | 2.98 | 3.01 |
+|&#124;|   **64** | 3.0 | 3.02 | 3.0 | 2.97 | 2.96 | 2.97 |
+|**`num_embeddings`**|  **128** | 3.03 | 2.96 | 3.02 | 3.0 | 3.02 | 3.05 |
+|&#124;|  **256** | 3.01 | 2.95 | 3.0 | 3.03 | 3.05 | 3.02 |
+|&#124;| **1024** | 3.0 | 3.05 | 3.05 | 3.08 | 5.89 | 3.07 |
+|&#124;| **2048** | 2.99 | 3.03 | 3.0 | 3.05 | 3.0 | 3.06 |
+|&#124;| **4096** | 3.0 | 3.03 | 3.05 | 3.02 | 3.07 | 3.05 |
+|V|      **8192** | 3.0 | 3.08 | 3.04 | 3.02 | 3.09 | 3.1 |
+
+
+-  `num_tables` = 100
+
+|||——————|——————| `embedding_dim` |——————|——————|—————>|
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+||| **4** | **8** | **16** | **32** | **64** | **128** |
+|&#124;|    **4** | 10.33 | 10.36 | 10.26 | 10.24 | 10.28 | 10.24 |
+|&#124;|    **8** | 10.34 | 10.47 | 10.29 | 10.25 | 10.23 | 10.19 |
+|&#124;|   **16** | 10.18 | 10.36 | 10.2 | 10.28 | 10.25 | 10.26 |
+|&#124;|   **32** | 10.41 | 10.2 | 10.19 | 10.2 | 10.04 | 9.89 |
+|&#124;|   **64** | 9.93 | 9.9 | 9.73 | 9.89 | 10.17 | 10.16 |
+|**`num_embeddings`**|  **128** | 10.32 | 10.11 | 10.12 | 10.08 | 10.01 | 10.05 |
+|&#124;|  **256** | 10.57 | 8.39 | 10.36 | 10.21 | 10.14 | 10.43 |
+|&#124;| **1024** | 10.39 | 9.67 | 8.46 | 10.23 | 10.29 | 10.11 |
+|&#124;| **2048** | 10.0 | 9.74 | 10.0 | 9.67 | 10.08 | 11.87 |
+|&#124;| **4096** | 9.94 | 9.82 | 10.17 | 9.66 | 9.87 | 9.95 |
+|V|      **8192** | 9.81 | 10.23 | 10.12 | 10.18 | 10.36 | 9.57 |
+
+
+-  `num_tables` = 1000
+
+|||——————|——————| `embedding_dim` |——————|——————|—————>|
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+||| **4** | **8** | **16** | **32** | **64** | **128** |
+|&#124;|    **4** | 13.81 | 13.56 | 13.33 | 13.33 | 13.24 | 12.86 |
+|&#124;|    **8** | 13.44 | 13.4 | 13.39 | 13.41 | 13.39 | 13.09 |
+|&#124;|   **16** | 12.55 | 12.88 | 13.22 | 13.19 | 13.27 | 12.95 |
+|&#124;|   **32** | 13.17 | 12.84 | 12.8 | 12.78 | 13.13 | 13.07 |
+|&#124;|   **64** | 13.06 | 12.84 | 12.84 | 12.9 | 12.83 | 12.89 |
+|**`num_embeddings`**|  **128**| 13.14 | 13.04 | 13.16 | 13.21 | 13.08 | 12.91 |
+|&#124;|  **256** | 13.71 | 13.59 | 13.76 | 13.24 | 13.36 | 13.59 |
+|&#124;| **1024** | 13.24 | 13.29 | 13.56 | 13.64 | 13.68 | 13.79 |
+|&#124;| **2048** | 13.2 | 13.19 | 13.35 | 12.44 | 13.32 | 13.17 |
+|&#124;| **4096** | 12.96 | 13.24 | 12.51 | 12.99 | 12.47 | 12.34 |
+|V|      **8192** | 12.84 | 13.32 | 13.27 | 13.06 | 12.35 | 12.58 |

--- a/benchmarks/ebc_benchmarks.py
+++ b/benchmarks/ebc_benchmarks.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import sys
+from typing import List, Tuple
+
+import torch
+from fbgemm_gpu.split_table_batched_embeddings_ops import EmbeddingLocation
+from torchrec.github.benchmarks import ebc_benchmarks_utils
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.fused_embedding_modules import FusedEmbeddingBagCollection
+
+# Reference: https://github.com/facebookresearch/dlrm/blob/main/torchrec_dlrm/README.MD
+DLRM_NUM_EMBEDDINGS_PER_FEATURE = [
+    45833188,
+    36746,
+    17245,
+    7413,
+    20243,
+    3,
+    7114,
+    1441,
+    62,
+    29275261,
+    1572176,
+    345138,
+    10,
+    2209,
+    11267,
+    128,
+    4,
+    974,
+    14,
+    48937457,
+    11316796,
+    40094537,
+    452104,
+    12606,
+    104,
+    35,
+]
+
+
+def get_shrunk_dlrm_num_embeddings(reduction_degree: int) -> List[int]:
+    return [
+        num_emb if num_emb < 10000000 else int(num_emb / reduction_degree)
+        for num_emb in DLRM_NUM_EMBEDDINGS_PER_FEATURE
+    ]
+
+
+def main(argv: List[str]) -> None:
+    args = parse_args(argv)
+
+    if not args.cpu_only and torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+
+    if args.mode == "ebc_comparison_dlrm":
+        print("Running EBC vs. FusedEBC on DLRM EMB")
+
+        for reduction_degree in [128, 64, 32]:
+            embedding_bag_configs: List[EmbeddingBagConfig] = [
+                EmbeddingBagConfig(
+                    name=f"ebc_{idx}",
+                    embedding_dim=128,
+                    num_embeddings=num_embeddings,
+                    feature_names=[f"ebc_{idx}_feat_1"],
+                )
+                for idx, num_embeddings in enumerate(
+                    get_shrunk_dlrm_num_embeddings(reduction_degree)
+                )
+            ]
+            (
+                ebc_time_avg,
+                ebc_time_std,
+                fused_ebc_time_avg,
+                fused_ebc_time_std,
+                speedup,
+            ) = get_ebc_comparison(embedding_bag_configs, device)
+
+            print(f"when DLRM EMB is reduced by {reduction_degree} times:")
+            print(f"ebc_time = {ebc_time_avg} +/- {ebc_time_std} sec")
+            print(f"fused_ebc_time = {fused_ebc_time_avg} +/- {fused_ebc_time_std} sec")
+            print(f"speedup = {speedup}")
+
+    elif args.mode == "fused_ebc_uvm":
+        print("Running DLRM EMB on FusedEBC with UVM/UVM-caching")
+        embedding_bag_configs: List[EmbeddingBagConfig] = [
+            EmbeddingBagConfig(
+                name=f"ebc_{idx}",
+                embedding_dim=128,
+                num_embeddings=num_embeddings,
+                feature_names=[f"ebc_{idx}_feat_1"],
+            )
+            for idx, num_embeddings in enumerate(get_shrunk_dlrm_num_embeddings(2))
+        ]
+        fused_ebc_time_avg, fused_ebc_time_std = get_fused_ebc_uvm_time(
+            embedding_bag_configs, device, EmbeddingLocation.MANAGED_CACHING
+        )
+        print(
+            f"FusedEBC with UVM caching on DLRM: {fused_ebc_time_avg} +/- {fused_ebc_time_std} sec"
+        )
+
+        embedding_bag_configs: List[EmbeddingBagConfig] = [
+            EmbeddingBagConfig(
+                name=f"ebc_{idx}",
+                embedding_dim=128,
+                num_embeddings=num_embeddings,
+                feature_names=[f"ebc_{idx}_feat_1"],
+            )
+            for idx, num_embeddings in enumerate(DLRM_NUM_EMBEDDINGS_PER_FEATURE)
+        ]
+        fused_ebc_time_avg, fused_ebc_time_std = get_fused_ebc_uvm_time(
+            embedding_bag_configs, device, EmbeddingLocation.MANAGED
+        )
+        print(
+            f"FusedEBC with UVM management on DLRM: {fused_ebc_time_avg} plus/minus {fused_ebc_time_std} sec"
+        )
+
+    elif args.mode == "ebc_comparison_scaling":
+        print("Running EBC vs. FusedEBC scaling experiment")
+
+        num_tables_list = [10, 100, 1000]
+        embedding_dim_list = [4, 8, 16, 32, 64, 128]
+        num_embeddings_list = [4, 8, 16, 32, 64, 128, 256, 1024, 2048, 4096, 8192]
+
+        for num_tables in num_tables_list:
+            for num_embeddings in num_embeddings_list:
+                for embedding_dim in embedding_dim_list:
+                    embedding_bag_configs: List[EmbeddingBagConfig] = [
+                        EmbeddingBagConfig(
+                            name=f"ebc_{idx}",
+                            embedding_dim=embedding_dim,
+                            num_embeddings=num_embeddings,
+                            feature_names=[f"ebc_{idx}_feat_1"],
+                        )
+                        for idx in range(num_tables)
+                    ]
+                    ebc_time, _, fused_ebc_time, _, speedup = get_ebc_comparison(
+                        embedding_bag_configs, device, epochs=3
+                    )
+                    print(
+                        f"EBC num_tables = {num_tables}, num_embeddings = {num_embeddings}, embedding_dim = {embedding_dim}:"
+                    )
+                    print(
+                        f"ebc_time = {ebc_time} sec, fused_ebc_time = {fused_ebc_time} sec, speedup = {speedup}"
+                    )
+
+
+def get_fused_ebc_uvm_time(
+    embedding_bag_configs: List[EmbeddingBagConfig],
+    device: torch.device,
+    location: EmbeddingLocation,
+    epochs: int = 100,
+) -> Tuple[float, float]:
+
+    fused_ebc = FusedEmbeddingBagCollection(
+        tables=embedding_bag_configs,
+        optimizer_type=torch.optim.SGD,
+        optimizer_kwargs={"lr": 0.02},
+        device=device,
+        location=location,
+    )
+
+    dataset = ebc_benchmarks_utils.get_random_dataset(
+        batch_size=64,
+        num_batches=10,
+        num_dense_features=1024,
+        embedding_bag_configs=embedding_bag_configs,
+    )
+
+    fused_ebc_time_avg, fused_ebc_time_std = ebc_benchmarks_utils.train(
+        model=fused_ebc,
+        optimizer=None,
+        dataset=dataset,
+        device=device,
+        epochs=epochs,
+    )
+
+    return fused_ebc_time_avg, fused_ebc_time_std
+
+
+def get_ebc_comparison(
+    embedding_bag_configs: List[EmbeddingBagConfig],
+    device: torch.device,
+    epochs: int = 100,
+) -> Tuple[float, float, float, float, float]:
+
+    # Simple EBC module wrapping a list of nn.EmbeddingBag
+    ebc = EmbeddingBagCollection(
+        tables=embedding_bag_configs,
+        device=device,
+    )
+    optimizer = torch.optim.SGD(ebc.parameters(), lr=0.02)
+
+    # EBC with fused optimizer backed by fbgemm SplitTableBatchedEmbeddingBagsCodegen
+    fused_ebc = FusedEmbeddingBagCollection(
+        tables=embedding_bag_configs,
+        optimizer_type=torch.optim.SGD,
+        optimizer_kwargs={"lr": 0.02},
+        device=device,
+    )
+
+    dataset = ebc_benchmarks_utils.get_random_dataset(
+        batch_size=64,
+        num_batches=10,
+        num_dense_features=1024,
+        embedding_bag_configs=embedding_bag_configs,
+    )
+
+    ebc_time_avg, ebc_time_std = ebc_benchmarks_utils.train(
+        model=ebc,
+        optimizer=optimizer,
+        dataset=dataset,
+        device=device,
+        epochs=epochs,
+    )
+    fused_ebc_time_avg, fused_ebc_time_std = ebc_benchmarks_utils.train(
+        model=fused_ebc,
+        optimizer=None,
+        dataset=dataset,
+        device=device,
+        epochs=epochs,
+    )
+    speedup = ebc_time_avg / fused_ebc_time_avg
+
+    return ebc_time_avg, ebc_time_std, fused_ebc_time_avg, fused_ebc_time_std, speedup
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TorchRec ebc benchmarks")
+    parser.add_argument(
+        "--cpu_only",
+        action="store_true",
+        default=False,
+        help="specify whether to use cpu",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="ebc_comparison_dlrm",
+        help="specify 'ebc_comparison_dlrm', 'ebc_comparison_scaling' or 'fused_ebc_uvm'",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/benchmarks/ebc_benchmarks_utils.py
+++ b/benchmarks/ebc_benchmarks_utils.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+import torch
+from torch.utils.data.dataset import IterableDataset
+from torchrec.datasets.random import RandomRecDataset
+from torchrec.datasets.utils import Batch
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+
+def get_random_dataset(
+    batch_size: int,
+    num_batches: int,
+    num_dense_features: int,
+    embedding_bag_configs: List[EmbeddingBagConfig],
+    pooling_factors: Optional[Dict[str, int]] = None,
+) -> IterableDataset[Batch]:
+
+    if pooling_factors is None:
+        pooling_factors = {}
+
+    keys = []
+    ids_per_features = []
+    hash_sizes = []
+
+    for table in embedding_bag_configs:
+        for feature_name in table.feature_names:
+            keys.append(feature_name)
+            # guess a pooling factor here
+            ids_per_features.append(pooling_factors.get(feature_name, 64))
+            hash_sizes.append(table.num_embeddings)
+
+    return RandomRecDataset(
+        keys=keys,
+        batch_size=batch_size,
+        hash_sizes=hash_sizes,
+        ids_per_features=ids_per_features,
+        num_dense=num_dense_features,
+        num_batches=num_batches,
+    )
+
+
+def train_one_epoch(
+    model: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    dataset: IterableDataset[Batch],
+    device: torch.device,
+) -> float:
+
+    start_time = time.perf_counter()
+
+    for data in dataset:
+        sparse_features = data.sparse_features.to(device)
+
+        pooled_embeddings = model(sparse_features)
+        optimizer.zero_grad()
+
+        vals = []
+        for _name, param in pooled_embeddings.to_dict().items():
+            vals.append(param)
+        torch.cat(vals, dim=1).sum().backward()
+        # pyre-ignore[20]
+        optimizer.step()
+
+    end_time = time.perf_counter()
+
+    return end_time - start_time
+
+
+def train_one_epoch_fused_optimizer(
+    model: torch.nn.Module,
+    dataset: IterableDataset[Batch],
+    device: torch.device,
+) -> float:
+
+    start_time = time.perf_counter()
+
+    for data in dataset:
+        sparse_features = data.sparse_features.to(device)
+        fused_pooled_embeddings = model(sparse_features)
+
+        fused_vals = []
+        for _name, param in fused_pooled_embeddings.to_dict().items():
+            fused_vals.append(param)
+        torch.cat(fused_vals, dim=1).sum().backward()
+
+    end_time = time.perf_counter()
+
+    return end_time - start_time
+
+
+def train(
+    model: torch.nn.Module,
+    optimizer: Optional[torch.optim.Optimizer],
+    dataset: IterableDataset[Batch],
+    device: torch.device,
+    epochs: int = 100,
+) -> Tuple[float, float]:
+
+    training_time = []
+    for _ in range(epochs):
+        if optimizer:
+            training_time.append(train_one_epoch(model, optimizer, dataset, device))
+        else:
+            training_time.append(
+                train_one_epoch_fused_optimizer(model, dataset, device)
+            )
+
+    return np.mean(training_time), np.std(training_time)


### PR DESCRIPTION
Summary:
Compare the efficiency of EBC based on the following classes in github/benchmarks:

(1) nn.EmbeddingBag EBC
(2) SplitTableBatched EBC (with optimizer fusion) from D36396172 (https://github.com/pytorch/torchrec/commit/34f17b2e0a871eb89d138b8636408d5fc5eb93c4)

(Todo) in addition to the above two classes, put the following class in fb/benchmarks
(3) DenseTableBatched EBC (ref: D36394471)

Reviewed By: YLGH

Differential Revision: D36694744

