### PR TITLE
Rename EmbeddingComputeKernel.BATCHED_XXX to EmbeddingComputeKernel.XXX

### DIFF
--- a/examples/inference/dlrm_predict.py
+++ b/examples/inference/dlrm_predict.py
@@ -157,7 +157,7 @@ class DLRMPredictFactory(PredictFactory):
         for feature_name in self.model_config.id_list_features_keys:
             constraints[f"t_{feature_name}"] = ParameterConstraints(
                 sharding_types=[ShardingType.TABLE_WISE.value],
-                compute_kernels=[EmbeddingComputeKernel.BATCHED_QUANT.value],
+                compute_kernels=[EmbeddingComputeKernel.QUANT.value],
             )
 
         module = quantize_embeddings(module, dtype=torch.qint8, inplace=True)

--- a/examples/retrieval/two_tower_retrieval.py
+++ b/examples/retrieval/two_tower_retrieval.py
@@ -162,7 +162,7 @@ def infer(
     for feature_name in two_tower_column_names:
         constraints[f"t_{feature_name}"] = ParameterConstraints(
             sharding_types=[ShardingType.TABLE_WISE.value],
-            compute_kernels=[EmbeddingComputeKernel.BATCHED_QUANT.value],
+            compute_kernels=[EmbeddingComputeKernel.QUANT.value],
         )
 
     quant_model = trec_infer.modules.quantize_embeddings(

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -87,9 +87,9 @@ def get_state_dict(
         key = get_key_from_embedding_table(embedding_table)
         assert embedding_table.local_rows == param.size(0)
         if embedding_table.compute_kernel not in [
-            EmbeddingComputeKernel.BATCHED_QUANT,
-            EmbeddingComputeKernel.BATCHED_QUANT_UVM,
-            EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING,
+            EmbeddingComputeKernel.QUANT,
+            EmbeddingComputeKernel.QUANT_UVM,
+            EmbeddingComputeKernel.QUANT_UVM_CACHING,
         ]:
             assert embedding_table.local_cols == param.size(1)
         # for inference there is no pg, all tensors are local

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -96,13 +96,13 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Tensor])
         def _create_lookup(
             config: GroupedEmbeddingConfig,
         ) -> BaseEmbedding:
-            if config.compute_kernel == EmbeddingComputeKernel.BATCHED_DENSE:
+            if config.compute_kernel == EmbeddingComputeKernel.DENSE:
                 return BatchedDenseEmbedding(
                     config=config,
                     pg=pg,
                     device=device,
                 )
-            elif config.compute_kernel == EmbeddingComputeKernel.BATCHED_FUSED:
+            elif config.compute_kernel == EmbeddingComputeKernel.FUSED:
                 return BatchedFusedEmbedding(
                     config=config,
                     pg=pg,
@@ -218,13 +218,13 @@ class GroupedPooledEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Te
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
         ) -> BaseEmbedding:
-            if config.compute_kernel == EmbeddingComputeKernel.BATCHED_DENSE:
+            if config.compute_kernel == EmbeddingComputeKernel.DENSE:
                 return BatchedDenseEmbeddingBag(
                     config=config,
                     pg=pg,
                     device=device,
                 )
-            elif config.compute_kernel == EmbeddingComputeKernel.BATCHED_FUSED:
+            elif config.compute_kernel == EmbeddingComputeKernel.FUSED:
                 return BatchedFusedEmbeddingBag(
                     config=config,
                     pg=pg,

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -421,28 +421,24 @@ def group_tables(
                 for is_weighted in [True, False]:
                     for has_feature_processor in [True, False]:
                         for compute_kernel in [
-                            EmbeddingComputeKernel.BATCHED_DENSE,
-                            EmbeddingComputeKernel.BATCHED_FUSED,
-                            EmbeddingComputeKernel.BATCHED_QUANT,
+                            EmbeddingComputeKernel.DENSE,
+                            EmbeddingComputeKernel.FUSED,
+                            EmbeddingComputeKernel.QUANT,
                         ]:
                             grouped_tables: List[ShardedEmbeddingTable] = []
                             grouped_score_tables: List[ShardedEmbeddingTable] = []
                             for table in embedding_tables:
                                 compute_kernel_type = table.compute_kernel
                                 if table.compute_kernel in [
-                                    EmbeddingComputeKernel.BATCHED_FUSED_UVM,
-                                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING,
+                                    EmbeddingComputeKernel.FUSED_UVM,
+                                    EmbeddingComputeKernel.FUSED_UVM_CACHING,
                                 ]:
-                                    compute_kernel_type = (
-                                        EmbeddingComputeKernel.BATCHED_FUSED
-                                    )
+                                    compute_kernel_type = EmbeddingComputeKernel.FUSED
                                 elif table.compute_kernel in [
-                                    EmbeddingComputeKernel.BATCHED_QUANT_UVM,
-                                    EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING,
+                                    EmbeddingComputeKernel.QUANT_UVM,
+                                    EmbeddingComputeKernel.QUANT_UVM_CACHING,
                                 ]:
-                                    compute_kernel_type = (
-                                        EmbeddingComputeKernel.BATCHED_QUANT
-                                    )
+                                    compute_kernel_type = EmbeddingComputeKernel.QUANT
                                 if (
                                     table.data_type == data_type
                                     and table.pooling == pooling

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -44,32 +44,32 @@ class OptimType(Enum):
 
 @unique
 class EmbeddingComputeKernel(Enum):
-    BATCHED_DENSE = "batched_dense"
-    BATCHED_FUSED = "batched_fused"
-    BATCHED_FUSED_UVM = "batched_fused_uvm"
-    BATCHED_FUSED_UVM_CACHING = "batched_fused_uvm_caching"
-    BATCHED_QUANT = "batched_quant"
-    BATCHED_QUANT_UVM = "batched_quant_uvm"
-    BATCHED_QUANT_UVM_CACHING = "batched_quant_uvm_caching"
+    DENSE = "dense"
+    FUSED = "fused"
+    FUSED_UVM = "fused_uvm"
+    FUSED_UVM_CACHING = "fused_uvm_caching"
+    QUANT = "quant"
+    QUANT_UVM = "quant_uvm"
+    QUANT_UVM_CACHING = "quant_uvm_caching"
 
 
 def compute_kernel_to_embedding_location(
     compute_kernel: EmbeddingComputeKernel,
 ) -> EmbeddingLocation:
     if compute_kernel in [
-        EmbeddingComputeKernel.BATCHED_DENSE,
-        EmbeddingComputeKernel.BATCHED_FUSED,
-        EmbeddingComputeKernel.BATCHED_QUANT,
+        EmbeddingComputeKernel.DENSE,
+        EmbeddingComputeKernel.FUSED,
+        EmbeddingComputeKernel.QUANT,
     ]:
         return EmbeddingLocation.DEVICE
     elif compute_kernel in [
-        EmbeddingComputeKernel.BATCHED_FUSED_UVM,
-        EmbeddingComputeKernel.BATCHED_QUANT_UVM,
+        EmbeddingComputeKernel.FUSED_UVM,
+        EmbeddingComputeKernel.QUANT_UVM,
     ]:
         return EmbeddingLocation.MANAGED
     elif compute_kernel in [
-        EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING,
-        EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING,
+        EmbeddingComputeKernel.FUSED_UVM_CACHING,
+        EmbeddingComputeKernel.QUANT_UVM_CACHING,
     ]:
         return EmbeddingLocation.MANAGED_CACHING
     else:
@@ -144,7 +144,7 @@ class ShardedMetaConfig(ShardedConfig):
 
 @dataclass
 class EmbeddingAttributes:
-    compute_kernel: EmbeddingComputeKernel = EmbeddingComputeKernel.BATCHED_DENSE
+    compute_kernel: EmbeddingComputeKernel = EmbeddingComputeKernel.DENSE
 
 
 @dataclass
@@ -261,16 +261,16 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         ret = [
-            EmbeddingComputeKernel.BATCHED_DENSE.value,
+            EmbeddingComputeKernel.DENSE.value,
         ]
         if sharding_type != ShardingType.DATA_PARALLEL.value:
             ret += [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
             if compute_device_type in {"cuda"}:
                 ret += [
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+                    EmbeddingComputeKernel.FUSED_UVM.value,
+                    EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                 ]
         return ret
 
@@ -287,8 +287,8 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         """
         tensor_bytes = tensor.element_size() * tensor.nelement()
         if compute_kernel in {
-            EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-            EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+            EmbeddingComputeKernel.FUSED_UVM.value,
+            EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
         }:
             assert compute_device_type in {"cuda"}
             return {ParameterStorage.DDR.value: tensor_bytes}
@@ -336,12 +336,12 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         ret = [
-            EmbeddingComputeKernel.BATCHED_QUANT.value,
+            EmbeddingComputeKernel.QUANT.value,
         ]
         if compute_device_type in {"cuda"}:
             ret += [
-                EmbeddingComputeKernel.BATCHED_QUANT_UVM.value,
-                EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING.value,
+                EmbeddingComputeKernel.QUANT_UVM.value,
+                EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
             ]
         return ret
 
@@ -358,8 +358,8 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         """
         tensor_bytes = tensor.element_size() * tensor.nelement() + tensor.shape[0] * 4
         if compute_kernel in {
-            EmbeddingComputeKernel.BATCHED_QUANT_UVM.value,
-            EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING.value,
+            EmbeddingComputeKernel.QUANT_UVM.value,
+            EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
         }:
             assert compute_device_type in {"cuda"}
             return {ParameterStorage.DDR.value: tensor_bytes}

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -136,13 +136,13 @@ class FusedEmbeddingBagCollectionSharder(
         ret = []
         if sharding_type != ShardingType.DATA_PARALLEL.value:
             ret += [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
             if compute_device_type in {"cuda"}:
                 ret += [
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-                    EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
+                    EmbeddingComputeKernel.FUSED_UVM.value,
+                    EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                 ]
         else:
-            ret.append(EmbeddingComputeKernel.BATCHED_DENSE.value)
+            ret.append(EmbeddingComputeKernel.DENSE.value)
         return ret

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -56,20 +56,20 @@ def kernel_bw_lookup(
     caching_ratio = caching_ratio if caching_ratio else UVM_CACHING_RATIO
     lookup = {
         # CPU
-        ("cpu", EmbeddingComputeKernel.BATCHED_DENSE.value): 0.5 * DDR_MEM_BW,
-        ("cpu", EmbeddingComputeKernel.BATCHED_FUSED.value): 1 * DDR_MEM_BW,
-        ("cpu", EmbeddingComputeKernel.BATCHED_QUANT.value): 1 * DDR_MEM_BW,
+        ("cpu", EmbeddingComputeKernel.DENSE.value): 0.5 * DDR_MEM_BW,
+        ("cpu", EmbeddingComputeKernel.FUSED.value): 1 * DDR_MEM_BW,
+        ("cpu", EmbeddingComputeKernel.QUANT.value): 1 * DDR_MEM_BW,
         # CUDA
-        ("cuda", EmbeddingComputeKernel.BATCHED_DENSE.value): 0.5 * HBM_MEM_BW,
-        ("cuda", EmbeddingComputeKernel.BATCHED_FUSED.value): 1 * HBM_MEM_BW,
-        ("cuda", EmbeddingComputeKernel.BATCHED_FUSED_UVM.value): DDR_MEM_BW / 10,
-        ("cuda", EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value): (
+        ("cuda", EmbeddingComputeKernel.DENSE.value): 0.5 * HBM_MEM_BW,
+        ("cuda", EmbeddingComputeKernel.FUSED.value): 1 * HBM_MEM_BW,
+        ("cuda", EmbeddingComputeKernel.FUSED_UVM.value): DDR_MEM_BW / 10,
+        ("cuda", EmbeddingComputeKernel.FUSED_UVM_CACHING.value): (
             caching_ratio * HBM_MEM_BW + (1 - caching_ratio) * DDR_MEM_BW
         )
         / 10,
-        ("cuda", EmbeddingComputeKernel.BATCHED_QUANT.value): 1 * HBM_MEM_BW,
-        ("cuda", EmbeddingComputeKernel.BATCHED_QUANT_UVM.value): DDR_MEM_BW / 10,
-        ("cuda", EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING.value): (
+        ("cuda", EmbeddingComputeKernel.QUANT.value): 1 * HBM_MEM_BW,
+        ("cuda", EmbeddingComputeKernel.QUANT_UVM.value): DDR_MEM_BW / 10,
+        ("cuda", EmbeddingComputeKernel.QUANT_UVM_CACHING.value): (
             caching_ratio * HBM_MEM_BW + (1 - caching_ratio) * DDR_MEM_BW
         )
         / 10,

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -191,13 +191,11 @@ class EmbeddingEnumerator(Enumerator):
                     set(constrained_compute_kernels) & set(compute_kernels)
                 )
 
-        if EmbeddingComputeKernel.BATCHED_DENSE.value in filtered_compute_kernels:
+        if EmbeddingComputeKernel.DENSE.value in filtered_compute_kernels:
             if (
-                EmbeddingComputeKernel.BATCHED_FUSED.value in filtered_compute_kernels
+                EmbeddingComputeKernel.FUSED.value in filtered_compute_kernels
             ):  # always false for data_parallel
-                filtered_compute_kernels.remove(
-                    EmbeddingComputeKernel.BATCHED_DENSE.value
-                )
+                filtered_compute_kernels.remove(EmbeddingComputeKernel.DENSE.value)
 
         if not filtered_compute_kernels:
             raise RuntimeError(

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -657,8 +657,8 @@ def calculate_shard_storages(
     ddr_storage: int = tensor_storage.get("ddr", 0)
 
     if compute_kernel in {
-        EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
-        EmbeddingComputeKernel.BATCHED_QUANT_UVM_CACHING.value,
+        EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+        EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
     }:
         hbm_storage = round(ddr_storage * caching_ratio)
 
@@ -961,9 +961,7 @@ def _calculate_storage_specific_sizes(
     ]
 
     optimizer_sizes: List[int] = [
-        tensor_size * 2
-        if compute_kernel == EmbeddingComputeKernel.BATCHED_DENSE.value
-        else 0
+        tensor_size * 2 if compute_kernel == EmbeddingComputeKernel.DENSE.value else 0
         for tensor_size in tensor_sizes
     ]
 

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -231,7 +231,7 @@ class TWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class RWSharder(EmbeddingBagCollectionSharder):
@@ -241,7 +241,7 @@ class RWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class UVMCachingRWSharder(EmbeddingBagCollectionSharder):
@@ -251,7 +251,7 @@ class UVMCachingRWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value]
+        return [EmbeddingComputeKernel.FUSED_UVM_CACHING.value]
 
 
 class TWRWSharder(EmbeddingBagCollectionSharder):
@@ -261,7 +261,7 @@ class TWRWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class CWSharder(EmbeddingBagCollectionSharder):
@@ -271,7 +271,7 @@ class CWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class TWCWSharder(EmbeddingBagCollectionSharder):
@@ -281,7 +281,7 @@ class TWCWSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class DPSharder(EmbeddingBagCollectionSharder):
@@ -291,7 +291,7 @@ class DPSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class AllTypesSharder(EmbeddingBagCollectionSharder):
@@ -309,11 +309,11 @@ class AllTypesSharder(EmbeddingBagCollectionSharder):
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
         return [
-            EmbeddingComputeKernel.BATCHED_DENSE.value,
-            EmbeddingComputeKernel.BATCHED_FUSED.value,
-            EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-            EmbeddingComputeKernel.BATCHED_FUSED_UVM_CACHING.value,
-            EmbeddingComputeKernel.BATCHED_QUANT.value,
+            EmbeddingComputeKernel.DENSE.value,
+            EmbeddingComputeKernel.FUSED.value,
+            EmbeddingComputeKernel.FUSED_UVM.value,
+            EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            EmbeddingComputeKernel.QUANT.value,
         ]
 
 
@@ -324,7 +324,7 @@ class TowerTWRWSharder(EmbeddingTowerSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TowerCollectionTWRWSharder(EmbeddingTowerCollectionSharder):
@@ -334,7 +334,7 @@ class TowerCollectionTWRWSharder(EmbeddingTowerCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TestEnumerators(unittest.TestCase):
@@ -602,8 +602,8 @@ class TestEnumerators(unittest.TestCase):
                 ShardingType.COLUMN_WISE.value,
             ],
             compute_kernels=[
-                EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.FUSED_UVM.value,
+                EmbeddingComputeKernel.DENSE.value,
             ],
         )
         constraints = {
@@ -631,8 +631,8 @@ class TestEnumerators(unittest.TestCase):
             ShardingType.COLUMN_WISE.value,
         }
         expected_compute_kernels = {
-            EmbeddingComputeKernel.BATCHED_FUSED_UVM.value,
-            EmbeddingComputeKernel.BATCHED_DENSE.value,
+            EmbeddingComputeKernel.FUSED_UVM.value,
+            EmbeddingComputeKernel.DENSE.value,
         }
         unexpected_sharding_types = (
             set(sharder.sharding_types(self.compute_device)) - expected_sharding_types

--- a/torchrec/distributed/planner/tests/test_parallelized_planners.py
+++ b/torchrec/distributed/planner/tests/test_parallelized_planners.py
@@ -30,7 +30,7 @@ class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -40,7 +40,7 @@ class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class TestParallelizedEmbeddingShardingPlanner(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -33,7 +33,7 @@ class RWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -43,7 +43,7 @@ class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TWRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -53,7 +53,7 @@ class TWRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TWCWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -63,7 +63,7 @@ class TWCWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class HostLevelSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -73,7 +73,7 @@ class HostLevelSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 class TestGreedyPerfPartitioner(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -26,7 +26,7 @@ class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
@@ -36,7 +36,7 @@ class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_FUSED.value]
+        return [EmbeddingComputeKernel.FUSED.value]
 
 
 class TestEmbeddingShardingPlanner(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -100,24 +100,24 @@ class TestProposers(unittest.TestCase):
 
         expected_output = [
             [
-                ("table_0", "row_wise", "batched_fused"),
-                ("table_1", "row_wise", "batched_fused"),
+                ("table_0", "row_wise", "fused"),
+                ("table_1", "row_wise", "fused"),
             ],
             [
-                ("table_0", "table_row_wise", "batched_fused"),
-                ("table_1", "row_wise", "batched_fused"),
+                ("table_0", "table_row_wise", "fused"),
+                ("table_1", "row_wise", "fused"),
             ],
             [
-                ("table_1", "row_wise", "batched_fused"),
-                ("table_0", "data_parallel", "batched_dense"),
+                ("table_1", "row_wise", "fused"),
+                ("table_0", "data_parallel", "dense"),
             ],
             [
-                ("table_1", "table_row_wise", "batched_fused"),
-                ("table_0", "data_parallel", "batched_dense"),
+                ("table_1", "table_row_wise", "fused"),
+                ("table_0", "data_parallel", "dense"),
             ],
             [
-                ("table_0", "data_parallel", "batched_dense"),
-                ("table_1", "data_parallel", "batched_dense"),
+                ("table_0", "data_parallel", "dense"),
+                ("table_1", "data_parallel", "dense"),
             ],
         ]
 
@@ -182,68 +182,68 @@ class TestProposers(unittest.TestCase):
                 (
                     "table_1",
                     "data_parallel",
-                    "batched_dense",
+                    "dense",
                 ),
                 (
                     "table_2",
                     "data_parallel",
-                    "batched_dense",
+                    "dense",
                 ),
                 (
                     "table_3",
                     "data_parallel",
-                    "batched_dense",
+                    "dense",
                 ),
             ],
             [
                 (
                     "table_1",
                     "table_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_2",
                     "table_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_3",
                     "table_wise",
-                    "batched_fused",
+                    "fused",
                 ),
             ],
             [
                 (
                     "table_1",
                     "row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_2",
                     "row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_3",
                     "row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
             ],
             [
                 (
                     "table_1",
                     "table_row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_2",
                     "table_row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
                 (
                     "table_3",
                     "table_row_wise",
-                    "batched_fused",
+                    "fused",
                 ),
             ],
         ]
@@ -270,10 +270,10 @@ class TestProposers(unittest.TestCase):
 
         """
         All sharding types but DP will have 3 possible compute kernels after pruning:
-            - batched_fused
-            - batched_fused_uvm_caching
-            - batched_fused_uvm
-        DP will have 1 possible compute kernel: batched_dense
+            - fused
+            - fused_uvm_caching
+            - fused_uvm
+        DP will have 1 possible compute kernel: dense
         So the total number of pruned options will be:
             (num_sharding_types - 1) * 3 + 1 = 16
         """
@@ -283,7 +283,7 @@ class TestProposers(unittest.TestCase):
             sharding_options
         ) in self.grid_search_proposer._sharding_options_by_fqn.values():
             # number of sharding types after pruning is number of sharding types * 3
-            # 3 compute kernels batched_fused/batched_dense, batched_fused_uvm_caching, batched_fused_uvm
+            # 3 compute kernels fused/dense, fused_uvm_caching, fused_uvm
             self.assertEqual(len(sharding_options), num_pruned_options)
 
         num_proposals = 0
@@ -309,7 +309,7 @@ class TestProposers(unittest.TestCase):
                     batch_size=8,
                     sharding_type="row_wise",
                     partition_by="DEVICE",
-                    compute_kernel="batched_fused",
+                    compute_kernel="fused",
                     shards=[],
                 )
             ]

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -46,40 +46,40 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         )
 
         expected_perfs = {
-            ("batched_dense", "data_parallel"): [
+            ("dense", "data_parallel"): [
                 0.0004935158269195386,
                 0.0004935158269195386,
             ],
-            ("batched_fused", "table_wise"): [0.0011095368078055323],
-            ("batched_fused_uvm", "table_wise"): [0.1729105033126532],
-            ("batched_fused_uvm_caching", "table_wise"): [0.040145097917908434],
-            ("batched_fused", "column_wise"): [0.0011095368078055323],
-            ("batched_fused_uvm", "column_wise"): [0.1729105033126532],
-            ("batched_fused_uvm_caching", "column_wise"): [0.040145097917908434],
-            ("batched_fused", "table_column_wise"): [0.0011095368078055323],
-            ("batched_fused_uvm", "table_column_wise"): [0.1729105033126532],
-            ("batched_fused_uvm_caching", "table_column_wise"): [0.040145097917908434],
-            ("batched_fused", "row_wise"): [
+            ("fused", "table_wise"): [0.0011095368078055323],
+            ("fused_uvm", "table_wise"): [0.1729105033126532],
+            ("fused_uvm_caching", "table_wise"): [0.040145097917908434],
+            ("fused", "column_wise"): [0.0011095368078055323],
+            ("fused_uvm", "column_wise"): [0.1729105033126532],
+            ("fused_uvm_caching", "column_wise"): [0.040145097917908434],
+            ("fused", "table_column_wise"): [0.0011095368078055323],
+            ("fused_uvm", "table_column_wise"): [0.1729105033126532],
+            ("fused_uvm_caching", "table_column_wise"): [0.040145097917908434],
+            ("fused", "row_wise"): [
                 0.00043569201211068144,
                 0.00043569201211068144,
             ],
-            ("batched_fused_uvm", "row_wise"): [
+            ("fused_uvm", "row_wise"): [
                 0.054393095128676475,
                 0.054393095128676475,
             ],
-            ("batched_fused_uvm_caching", "row_wise"): [
+            ("fused_uvm_caching", "row_wise"): [
                 0.012695561962491483,
                 0.012695561962491483,
             ],
-            ("batched_fused", "table_row_wise"): [
+            ("fused", "table_row_wise"): [
                 0.00043569201211068144,
                 0.00043569201211068144,
             ],
-            ("batched_fused_uvm", "table_row_wise"): [
+            ("fused_uvm", "table_row_wise"): [
                 0.054393095128676475,
                 0.054393095128676475,
             ],
-            ("batched_fused_uvm_caching", "table_row_wise"): [
+            ("fused_uvm_caching", "table_row_wise"): [
                 0.012695561962491483,
                 0.012695561962491483,
             ],
@@ -119,19 +119,19 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         )
 
         expected_perfs = {
-            ("batched_dense", "data_parallel"): [
+            ("dense", "data_parallel"): [
                 0.002677347614879459,
                 0.002677347614879459,
             ],
-            ("batched_fused", "table_wise"): [0.001880471390093715],
-            ("batched_fused_uvm", "table_wise"): [0.25958192114736517],
-            ("batched_fused_uvm_caching", "table_wise"): [0.060433813055248066],
-            ("batched_fused", "row_wise"): [
+            ("fused", "table_wise"): [0.001880471390093715],
+            ("fused_uvm", "table_wise"): [0.25958192114736517],
+            ("fused_uvm_caching", "table_wise"): [0.060433813055248066],
+            ("fused", "row_wise"): [
                 0.0007915177871551004,
                 0.0007915177871551004,
             ],
-            ("batched_fused_uvm", "row_wise"): [0.1036341050091912, 0.1036341050091912],
-            ("batched_fused_uvm_caching", "row_wise"): [
+            ("fused_uvm", "row_wise"): [0.1036341050091912, 0.1036341050091912],
+            ("fused_uvm_caching", "row_wise"): [
                 0.024158779217047007,
                 0.024158779217047007,
             ],

--- a/torchrec/distributed/tests/test_fused_optim.py
+++ b/torchrec/distributed/tests/test_fused_optim.py
@@ -71,7 +71,7 @@ class ModelParallelTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
         optim_type=st.sampled_from(
@@ -110,7 +110,7 @@ class ModelParallelTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
         optim_type=st.sampled_from(

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -74,8 +74,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -115,7 +115,7 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.DENSE.value,
             ]
         ),
     )
@@ -150,8 +150,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -194,8 +194,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -227,8 +227,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -263,8 +263,8 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -308,9 +308,9 @@ class ModelParallelTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.DENSE.value,
                 # TODO dp+batch_fused is numerically buggy in cpu
-                # EmbeddingComputeKernel.BATCHED_FUSED.value,
+                # EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -702,8 +702,8 @@ class ModelParallelStateDictTest(unittest.TestCase):
         ),
         kernel_type=st.sampled_from(
             [
-                # EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                # EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -736,7 +736,7 @@ class ModelParallelStateDictTest(unittest.TestCase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -48,8 +48,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         sharding_type=st.just(ShardingType.TABLE_ROW_WISE.value),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
         local_size=st.sampled_from([2]),
@@ -91,8 +91,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
         local_size=st.sampled_from([2]),
@@ -132,8 +132,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -170,8 +170,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -187,7 +187,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
                         sharding_type=ShardingType.TABLE_WISE.value,
-                        kernel_type=EmbeddingComputeKernel.BATCHED_QUANT.value,
+                        kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
             ],
@@ -225,7 +225,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
                         sharding_type=ShardingType.TABLE_WISE.value,
-                        kernel_type=EmbeddingComputeKernel.BATCHED_QUANT.value,
+                        kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
             ],

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -76,7 +76,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_QUANT.value,
+                EmbeddingComputeKernel.QUANT.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_quantize.py
+++ b/torchrec/distributed/tests/test_quantize.py
@@ -130,8 +130,8 @@ class QuantizeKernelTest(unittest.TestCase):
     @given(
         compute_kernel=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE,
-                EmbeddingComputeKernel.BATCHED_FUSED,
+                EmbeddingComputeKernel.DENSE,
+                EmbeddingComputeKernel.FUSED,
             ]
         ),
         dtype=st.sampled_from(
@@ -166,8 +166,8 @@ class QuantizeKernelTest(unittest.TestCase):
     @given(
         compute_kernel=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE,
-                EmbeddingComputeKernel.BATCHED_FUSED,
+                EmbeddingComputeKernel.DENSE,
+                EmbeddingComputeKernel.FUSED,
             ]
         ),
         dtype=st.sampled_from(

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -41,8 +41,8 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )
@@ -71,7 +71,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
+                EmbeddingComputeKernel.DENSE.value,
             ]
         ),
     )
@@ -100,8 +100,8 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
@@ -52,8 +52,8 @@ class SequenceModelParallelHierarchicalTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.BATCHED_DENSE.value,
-                EmbeddingComputeKernel.BATCHED_FUSED.value,
+                EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
             ]
         ),
     )

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -76,7 +76,7 @@ class TestCustomEBCSharder(EmbeddingBagCollectionSharder):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [EmbeddingComputeKernel.BATCHED_DENSE.value]
+        return [EmbeddingComputeKernel.DENSE.value]
 
 
 @dataclass
@@ -247,7 +247,7 @@ class TrainPipelineSparseDistTest(unittest.TestCase):
                     ModuleSharder[nn.Module],
                     TestEBCSharder(
                         sharding_type=ShardingType.TABLE_WISE.value,
-                        kernel_type=EmbeddingComputeKernel.BATCHED_DENSE.value,
+                        kernel_type=EmbeddingComputeKernel.DENSE.value,
                     ),
                 )
             ],

--- a/torchrec/inference/README.md
+++ b/torchrec/inference/README.md
@@ -196,7 +196,7 @@ INFO:<torch_package_0>.torchrec.distributed.planner.stats:# Input: MB/iteration,
 INFO:<torch_package_0>.torchrec.distributed.planner.stats:# HBM: est. peak memory usage for shards - parameter, comms, optimizer, and gradients             #
 INFO:<torch_package_0>.torchrec.distributed.planner.stats:#                                                                                                 #
 INFO:<torch_package_0>.torchrec.distributed.planner.stats:# Compute Kernels:                                                                                #
-INFO:<torch_package_0>.torchrec.distributed.planner.stats:#   batched_quant: 26                                                                             #
+INFO:<torch_package_0>.torchrec.distributed.planner.stats:#   quant: 26                                                                             #
 ````
 
 `nvidia-smi` output should also show allocation of the model onto the gpu:

--- a/torchrec/inference/docs/inference.rst
+++ b/torchrec/inference/docs/inference.rst
@@ -222,7 +222,7 @@ Run server. Update `CUDA_VISABLE_DEVICES` depending on the world size.
     INFO:<torch_package_0>.torchrec.distributed.planner.stats:# HBM: est. peak memory usage for shards - parameter, comms, optimizer, and gradients             #
     INFO:<torch_package_0>.torchrec.distributed.planner.stats:#                                                                                                 #
     INFO:<torch_package_0>.torchrec.distributed.planner.stats:# Compute Kernels:                                                                                #
-    INFO:<torch_package_0>.torchrec.distributed.planner.stats:#   batched_quant: 26                                                                             #
+    INFO:<torch_package_0>.torchrec.distributed.planner.stats:#   quant: 26                                                                             #
 
 ``nvidia-smi`` output should also show allocation of the model onto the gpu:
 


### PR DESCRIPTION
Summary: EmbeddingComputeKernel is BATCHED by default. Remove BATCHED from the EmbeddingComputeKernel enum.

Differential Revision: D37030584

