### PR TITLE
Update Dockerfile to use pytorch mirror

### DIFF
--- a/torchrec/datasets/scripts/nvt/Dockerfile
+++ b/torchrec/datasets/scripts/nvt/Dockerfile
@@ -1,6 +1,6 @@
 FROM nvcr.io/nvidia/merlin/merlin-pytorch-training:nightly
 
 RUN conda install -y pytorch cudatoolkit=11.3 -c pytorch-nightly \
-    && pip install torchrec-nightly
+    && pip install --pre torchrec_nightly -f https://download.pytorch.org/whl/nightly/torchrec_nightly/index.html
 
 WORKDIR /app


### PR DESCRIPTION
Summary: Fix pip install command to point to pytorch.org mirror

Reviewed By: RenfeiChen-FB

Differential Revision: D37122924

