### PR TITLE
Add column wise sharding support for EmbeddingCollection (sequence embeddings)

### DIFF
--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -126,6 +126,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ("fused", "table_wise"): [0.001880471390093715],
             ("fused_uvm", "table_wise"): [0.25958192114736517],
             ("fused_uvm_caching", "table_wise"): [0.060433813055248066],
+            ("fused", "column_wise"): [0.001880471390093715],
+            ("fused_uvm", "column_wise"): [0.25958192114736517],
+            ("fused_uvm_caching", "column_wise"): [0.060433813055248066],
             ("fused", "row_wise"): [
                 0.0007915177871551004,
                 0.0007915177871551004,

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Optional
+
+import torch
+from torchrec.distributed.embedding_lookup import GroupedEmbeddingsLookup
+from torchrec.distributed.embedding_sharding import (
+    BaseEmbeddingLookup,
+    BaseSparseFeaturesDist,
+)
+from torchrec.distributed.embedding_types import (
+    BaseGroupedFeatureProcessor,
+    SparseFeatures,
+)
+from torchrec.distributed.sharding.cw_sharding import BaseCwEmbeddingSharding
+from torchrec.distributed.sharding.sequence_sharding import BaseSequenceEmbeddingDist
+from torchrec.distributed.sharding.tw_sequence_sharding import TwSequenceEmbeddingDist
+from torchrec.distributed.sharding.tw_sharding import TwSparseFeaturesDist
+
+
+class CwSequenceEmbeddingSharding(
+    BaseCwEmbeddingSharding[SparseFeatures, torch.Tensor]
+):
+    """
+    Shards sequence (unpooled) embeddings column-wise, i.e.. a given embedding is
+    partitioned along its columns and placed on specified ranks.
+    """
+
+    def create_input_dist(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> BaseSparseFeaturesDist[SparseFeatures]:
+        return TwSparseFeaturesDist(
+            self._pg,
+            self._id_list_features_per_rank(),
+            self._id_score_list_features_per_rank(),
+            device if device is not None else self._device,
+        )
+
+    def create_lookup(
+        self,
+        device: Optional[torch.device] = None,
+        fused_params: Optional[Dict[str, Any]] = None,
+        feature_processor: Optional[BaseGroupedFeatureProcessor] = None,
+    ) -> BaseEmbeddingLookup:
+        assert feature_processor is None
+        return GroupedEmbeddingsLookup(
+            grouped_configs=self._grouped_embedding_configs,
+            fused_params=fused_params,
+            pg=self._pg,
+            device=device if device is not None else self._device,
+        )
+
+    def create_output_dist(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> BaseSequenceEmbeddingDist[torch.Tensor]:
+        return TwSequenceEmbeddingDist(
+            self._pg,
+            self._id_list_features_per_rank(),
+            device if device is not None else self._device,
+        )

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import SequenceEmbeddingAllToAll
+from torchrec.distributed.dist_data import SequenceEmbeddingsAllToAll
 from torchrec.distributed.embedding_lookup import GroupedEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingLookup,
@@ -48,7 +48,7 @@ class RwSequenceEmbeddingDist(BaseSequenceEmbeddingDist[torch.Tensor]):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self._dist = SequenceEmbeddingAllToAll(pg, [num_features] * pg.size(), device)
+        self._dist = SequenceEmbeddingsAllToAll(pg, [num_features] * pg.size(), device)
 
     def forward(
         self,

--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -20,8 +20,8 @@ from torchrec.streamable import Multistreamable
 @dataclass
 class SequenceShardingContext(Multistreamable):
     """
-    Stores KJTAllToAll context and reuses it in SequenceEmbeddingAllToAll.
-    SequenceEmbeddingAllToAll has the same comm pattern as KJTAllToAll.
+    Stores KJTAllToAll context and reuses it in SequenceEmbeddingsAllToAll.
+    SequenceEmbeddingsAllToAll has the same comm pattern as KJTAllToAll.
 
     Attributes:
         features_before_input_dist (Optional[KeyedJaggedTensor]): stores the original

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -9,7 +9,10 @@ from typing import Any, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import EmbeddingsAllToOne, SequenceEmbeddingAllToAll
+from torchrec.distributed.dist_data import (
+    EmbeddingsAllToOne,
+    SequenceEmbeddingsAllToAll,
+)
 from torchrec.distributed.embedding_lookup import (
     GroupedEmbeddingsLookup,
     InferGroupedEmbeddingsLookup,
@@ -92,7 +95,7 @@ class TwSequenceEmbeddingDist(BaseSequenceEmbeddingDist[torch.Tensor]):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self._dist = SequenceEmbeddingAllToAll(pg, features_per_rank, device)
+        self._dist = SequenceEmbeddingsAllToAll(pg, features_per_rank, device)
 
     def forward(
         self,

--- a/torchrec/distributed/sharding/twcw_sharding.py
+++ b/torchrec/distributed/sharding/twcw_sharding.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -5,8 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from enum import Enum
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Type
 
 import torch.distributed as dist  # noqa
 import torch.nn as nn


### PR DESCRIPTION
Summary:
Support for CW sharding in EmbeddingCollection.

Added logic to stitch feature outputs with local embedding dim after output dist to match original dim.
Respects the correct order according to sharding as the output loses order of shards (provides it in order based on rank).

Differential Revision: D36944684

