### PR TITLE
change partitioner class methods to function

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -7,12 +7,11 @@
 
 import copy
 from dataclasses import dataclass
-from typing import cast, List
+from typing import cast, List, Tuple
 
 from torchrec.distributed.planner.types import (
     DeviceHardware,
     PartitionByType,
-    Partitioner,
     PlannerError,
     ShardingOption,
     Storage,
@@ -75,206 +74,187 @@ def _group_and_sort_non_uniform_sharding_options(
     return sharding_option_groups
 
 
-class GreedyPerfPartitioner(Partitioner):
+def partition(
+    proposal: List[ShardingOption],
+    storage_constraint: Topology,
+) -> Tuple[List[ShardingOption], Topology]:
     """
-    Greedy Partitioner
+    Places sharding options on topology based on each sharding option's
+    `partition_by` attribute.
+    The topology, storage, and perfs are updated at the end of the placement.
+
+    Args:
+        proposal (List[ShardingOption]): list of populated sharding options.
+        storage_constraint (Topology): device topology.
+
+    Returns:
+        List[ShardingOption]: list of sharding options for selected plan.
+
+    Example::
+
+        sharding_options = [
+                ShardingOption(partition_by="uniform",
+                        shards=[
+                            Shards(storage=1, perf=1),
+                            Shards(storage=1, perf=1),
+                        ]),
+                ShardingOption(partition_by="uniform",
+                        shards=[
+                            Shards(storage=2, perf=2),
+                            Shards(storage=2, perf=2),
+                        ]),
+                ShardingOption(partition_by="device",
+                        shards=[
+                            Shards(storage=3, perf=3),
+                            Shards(storage=3, perf=3),
+                        ])
+                ShardingOption(partition_by="device",
+                        shards=[
+                            Shards(storage=4, perf=4),
+                            Shards(storage=4, perf=4),
+                        ]),
+            ]
+        topology = Topology(world_size=2)
+
+        # First [sharding_options[0] and sharding_options[1]] will be placed on the
+        # topology with the uniform strategy, resulting in
+
+        topology.devices[0].perf = (1,2)
+        topology.devices[1].perf = (1,2)
+
+        # Finally sharding_options[2] and sharding_options[3]] will be placed on the
+        # topology with the device strategy (see docstring of `partition_by_device` for
+        # more details).
+
+        topology.devices[0].perf = (1,2) + (3,4)
+        topology.devices[1].perf = (1,2) + (3,4)
+
+        # The topology updates are done after the end of all the placements (the other
+        # in the example is just for clarity).
     """
 
-    def partition(
-        self,
-        proposal: List[ShardingOption],
-        storage_constraint: Topology,
-    ) -> List[ShardingOption]:
-        """
-        Places sharding options on topology based on each sharding option's
-        `partition_by` attribute.
-        The topology, storage, and perfs are updated at the end of the placement.
+    _topology: Topology = copy.deepcopy(storage_constraint)
+    plan = copy.deepcopy(proposal)
+    _host_level_devices = _get_host_level_devices(_topology)
 
-        Args:
-            proposal (List[ShardingOption]): list of populated sharding options.
-            storage_constraint (Topology): device topology.
+    # first partition the uniform sharding options (RW & DP)
+    uniform_sharding_options = _get_uniform_sharding_options(plan)
+    _uniform_partition(uniform_sharding_options, _topology.devices)
 
-        Returns:
-            List[ShardingOption]: list of sharding options for selected plan.
+    # group the rest sharding options by colocation type (co-host, co-device, none)
+    # and sort the groups by storage in reverse order
+    sharding_option_groups = _group_and_sort_non_uniform_sharding_options(plan)
 
-        Example::
+    for sharding_option_group in sharding_option_groups:
+        if (
+            sharding_option_group.sharding_options[0].partition_by
+            == PartitionByType.HOST.value
+        ):
+            _cohost_partition(sharding_option_group, _host_level_devices)
+        elif (
+            sharding_option_group.sharding_options[0].partition_by
+            == PartitionByType.DEVICE.value
+        ):
+            assert (
+                len(sharding_option_group.sharding_options) == 1
+            ), f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}"
+            _device_partition(
+                sharding_option_group.sharding_options[0], _topology.devices
+            )
+        else:
+            raise RuntimeError(
+                f"Unexpected sharding option group {sharding_option_group}"
+            )
+    return (plan, _topology)
 
-            sharding_options = [
-                    ShardingOption(partition_by="uniform",
-                            shards=[
-                                Shards(storage=1, perf=1),
-                                Shards(storage=1, perf=1),
-                            ]),
-                    ShardingOption(partition_by="uniform",
-                            shards=[
-                                Shards(storage=2, perf=2),
-                                Shards(storage=2, perf=2),
-                            ]),
-                    ShardingOption(partition_by="device",
-                            shards=[
-                                Shards(storage=3, perf=3),
-                                Shards(storage=3, perf=3),
-                            ])
-                    ShardingOption(partition_by="device",
-                            shards=[
-                                Shards(storage=4, perf=4),
-                                Shards(storage=4, perf=4),
-                            ]),
-                ]
-            topology = Topology(world_size=2)
 
-            # First [sharding_options[0] and sharding_options[1]] will be placed on the
-            # topology with the uniform strategy, resulting in
+def _device_partition(
+    sharding_option: ShardingOption, devices: List[DeviceHardware]
+) -> None:
+    for shard in sharding_option.shards:
+        sorted_devices = sorted(devices, key=lambda device: device.perf)
+        success = False
+        for device in sorted_devices:
+            if cast(Storage, shard.storage).fits_in(device.storage):
+                shard.rank = device.rank
+                device.storage -= cast(Storage, shard.storage)
+                device.perf += cast(float, shard.perf)
+                success = True
+                break
+        if not success:
+            raise PlannerError(
+                f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}"
+            )
 
-            topology.devices[0].perf = (1,2)
-            topology.devices[1].perf = (1,2)
 
-            # Finally sharding_options[2] and sharding_options[3]] will be placed on the
-            # topology with the device strategy (see docstring of `partition_by_device` for
-            # more details).
+def _cohost_partition(
+    sharding_option_group: ShardingOptionGroup,
+    _host_level_devices: List[List[DeviceHardware]],
+) -> None:
+    sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
+    for devices in sorted_host_level_devices:
+        host_devices = copy.deepcopy(devices)
+        host_storage = Storage(hbm=0, ddr=0)
+        for device in host_devices:
+            host_storage += device.storage
+        if not sharding_option_group.storage_sum.fits_in(host_storage):
+            continue
 
-            topology.devices[0].perf = (1,2) + (3,4)
-            topology.devices[1].perf = (1,2) + (3,4)
+        success = True
+        for sharding_option in sharding_option_group.sharding_options:
+            try:
+                if sharding_option.sharding_type == ShardingType.TABLE_ROW_WISE.value:
+                    _uniform_partition([sharding_option], host_devices)
+                elif (
+                    sharding_option.sharding_type
+                    == ShardingType.TABLE_COLUMN_WISE.value
+                ):
+                    _device_partition(sharding_option, host_devices)
+                else:
+                    raise RuntimeError(
+                        f"unexpected cohost sharding type: {sharding_option.sharding_type}"
+                    )
+            except PlannerError:
+                success = False
+                break
+        if success:
+            # successfully found a host and partitioned on that host
+            # need to update the devices
+            for device, device_copy in zip(devices, host_devices):
+                device.storage = device_copy.storage
+                device.perf = device_copy.perf
+            return
+    raise PlannerError(
+        f"can't find a host for sharding option group {sharding_option_group}"
+    )
 
-            # The topology updates are done after the end of all the placements (the other
-            # in the example is just for clarity).
-        """
 
-        _topology: Topology = copy.deepcopy(storage_constraint)
-        plan = copy.deepcopy(proposal)
-        _host_level_devices = GreedyPerfPartitioner._get_host_level_devices(_topology)
+def _get_host_level_devices(_topology: Topology) -> List[List[DeviceHardware]]:
+    num_hosts: int = _topology.world_size // _topology.local_world_size
+    host_level_devices: List[List[DeviceHardware]] = []
+    for i in range(num_hosts):
+        devices_in_host = _topology.devices[
+            i * _topology.local_world_size : (i + 1) * _topology.local_world_size
+        ]
+        host_level_devices.append(devices_in_host)
+    return host_level_devices
 
-        # first partition the uniform sharding options (RW & DP)
-        uniform_sharding_options = _get_uniform_sharding_options(plan)
-        GreedyPerfPartitioner._uniform_partition(
-            uniform_sharding_options, _topology.devices
-        )
 
-        # group the rest sharding options by colocation type (co-host, co-device, none)
-        # and sort the groups by storage in reverse order
-        sharding_option_groups = _group_and_sort_non_uniform_sharding_options(plan)
-
-        for sharding_option_group in sharding_option_groups:
-            if (
-                sharding_option_group.sharding_options[0].partition_by
-                == PartitionByType.HOST.value
-            ):
-                GreedyPerfPartitioner._cohost_partition(
-                    sharding_option_group, _host_level_devices
-                )
-            elif (
-                sharding_option_group.sharding_options[0].partition_by
-                == PartitionByType.DEVICE.value
-            ):
-                assert (
-                    len(sharding_option_group.sharding_options) == 1
-                ), f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}"
-                GreedyPerfPartitioner._device_partition(
-                    sharding_option_group.sharding_options[0], _topology.devices
+def _uniform_partition(
+    sharding_options: List[ShardingOption], devices: List[DeviceHardware]
+) -> None:
+    for sharding_option in sharding_options:
+        if sharding_option.num_shards != len(devices):
+            raise RuntimeError(
+                f"For a uniform partition, the number of shards ({sharding_option.num_shards}) must equal the number of devices ({len(devices)})"
+            )
+        for i in range(len(devices)):
+            storage_needed = cast(Storage, sharding_option.shards[i].storage)
+            if not storage_needed.fits_in(devices[i].storage):
+                raise PlannerError(
+                    f"Shard of size {storage_needed} bytes does not fit on any rank. Device memory cap: {devices[i].storage}."
                 )
             else:
-                raise RuntimeError(
-                    f"Unexpected sharding option group {sharding_option_group}"
-                )
-        # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
-        self._topology: Topology = _topology
-        return plan
-
-    @staticmethod
-    def _device_partition(
-        sharding_option: ShardingOption, devices: List[DeviceHardware]
-    ) -> None:
-        for shard in sharding_option.shards:
-            sorted_devices = sorted(devices, key=lambda device: device.perf)
-            success = False
-            for device in sorted_devices:
-                if cast(Storage, shard.storage).fits_in(device.storage):
-                    shard.rank = device.rank
-                    device.storage -= cast(Storage, shard.storage)
-                    device.perf += cast(float, shard.perf)
-                    success = True
-                    break
-            if not success:
-                raise PlannerError(
-                    f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}"
-                )
-
-    @staticmethod
-    def _cohost_partition(
-        sharding_option_group: ShardingOptionGroup,
-        _host_level_devices: List[List[DeviceHardware]],
-    ) -> None:
-        sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
-        for devices in sorted_host_level_devices:
-            host_devices = copy.deepcopy(devices)
-            host_storage = Storage(hbm=0, ddr=0)
-            for device in host_devices:
-                host_storage += device.storage
-            if not sharding_option_group.storage_sum.fits_in(host_storage):
-                continue
-
-            success = True
-            for sharding_option in sharding_option_group.sharding_options:
-                try:
-                    if (
-                        sharding_option.sharding_type
-                        == ShardingType.TABLE_ROW_WISE.value
-                    ):
-                        GreedyPerfPartitioner._uniform_partition(
-                            [sharding_option], host_devices
-                        )
-                    elif (
-                        sharding_option.sharding_type
-                        == ShardingType.TABLE_COLUMN_WISE.value
-                    ):
-                        GreedyPerfPartitioner._device_partition(
-                            sharding_option, host_devices
-                        )
-                    else:
-                        raise RuntimeError(
-                            f"unexpected cohost sharding type: {sharding_option.sharding_type}"
-                        )
-                except PlannerError:
-                    success = False
-                    break
-            if success:
-                # successfully found a host and partitioned on that host
-                # need to update the devices
-                for device, device_copy in zip(devices, host_devices):
-                    device.storage = device_copy.storage
-                    device.perf = device_copy.perf
-                return
-        raise PlannerError(
-            f"can't find a host for sharding option group {sharding_option_group}"
-        )
-
-    @staticmethod
-    def _get_host_level_devices(_topology: Topology) -> List[List[DeviceHardware]]:
-        num_hosts: int = _topology.world_size // _topology.local_world_size
-        host_level_devices: List[List[DeviceHardware]] = []
-        for i in range(num_hosts):
-            devices_in_host = _topology.devices[
-                i * _topology.local_world_size : (i + 1) * _topology.local_world_size
-            ]
-            host_level_devices.append(devices_in_host)
-        return host_level_devices
-
-    @staticmethod
-    def _uniform_partition(
-        sharding_options: List[ShardingOption], devices: List[DeviceHardware]
-    ) -> None:
-        for sharding_option in sharding_options:
-            if sharding_option.num_shards != len(devices):
-                raise RuntimeError(
-                    f"For a uniform partition, the number of shards ({sharding_option.num_shards}) must equal the number of devices ({len(devices)})"
-                )
-            for i in range(len(devices)):
-                storage_needed = cast(Storage, sharding_option.shards[i].storage)
-                if not storage_needed.fits_in(devices[i].storage):
-                    raise PlannerError(
-                        f"Shard of size {storage_needed} bytes does not fit on any rank. Device memory cap: {devices[i].storage}."
-                    )
-                else:
-                    sharding_option.shards[i].rank = devices[i].rank
-                    devices[i].storage -= storage_needed
-                    devices[i].perf += cast(float, sharding_option.shards[i].perf)
+                sharding_option.shards[i].rank = devices[i].rank
+                devices[i].storage -= storage_needed
+                devices[i].perf += cast(float, sharding_option.shards[i].perf)


### PR DESCRIPTION
Summary:
This diff changes unnecessary GreedyPerfPartitioner class methods to function - gets rid of GreedyPerfPartitioner, and only leaves needed functions. Subsequently, GreedyPerfPartitioner was changed to a partition function in parallelized planner and planner programs.

For testing purposes, partition() returns a tuple of sharding plan and topology. both topology and partition are then used in test_partition file to test the program.

Differential Revision: D37165570

