### PR TITLE
add close/join to pool

### DIFF
--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -254,6 +254,8 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
 
         pool = Pool(self._cpu_count)
         group_best_plans = pool.map(get_best_plan, grouped_proposals)
+        pool.close()
+        pool.join()
 
         lowest_storage = Storage(MAX_SIZE, MAX_SIZE)
         best_perf_rating = MAX_SIZE


### PR DESCRIPTION
Summary:
adding close() and join() to multiporcessing pool used in parallelizing planner.

close() and join() are standard practices when using multiprocessing. They are needed to make sure that there are no accidental errors.

Differential Revision: D37165770

