### PR TITLE
Fix OSS build by importing torch instead of caffe2/torch

### DIFF
--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -23,10 +23,10 @@
 #include <folly/stop_watch.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <torch/csrc/autograd/profiler_legacy.h>
 #include <torch/csrc/deploy/deploy.h> // @manual
 
 #include "ATen/cuda/CUDAEvent.h"
-#include "caffe2/torch/csrc/autograd/profiler_legacy.h"
 #include "torchrec/inference/BatchingQueue.h"
 #include "torchrec/inference/Exception.h"
 #include "torchrec/inference/Observer.h"


### PR DESCRIPTION
Summary: this was breaking oss build, don't include "caffe2" in torchrec's imports

Differential Revision: D37199511

