### PR TITLE
Refactor SequenceEmbeddingsAllToAll and clean up dist_data docstrings

### DIFF
--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import SequenceEmbeddingAllToAll
+from torchrec.distributed.dist_data import SequenceEmbeddingsAllToAll
 from torchrec.distributed.embedding_lookup import GroupedEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingLookup,
@@ -48,7 +48,7 @@ class RwSequenceEmbeddingDist(BaseSequenceEmbeddingDist[torch.Tensor]):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self._dist = SequenceEmbeddingAllToAll(pg, [num_features] * pg.size(), device)
+        self._dist = SequenceEmbeddingsAllToAll(pg, [num_features] * pg.size(), device)
 
     def forward(
         self,

--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -20,8 +20,8 @@ from torchrec.streamable import Multistreamable
 @dataclass
 class SequenceShardingContext(Multistreamable):
     """
-    Stores KJTAllToAll context and reuses it in SequenceEmbeddingAllToAll.
-    SequenceEmbeddingAllToAll has the same comm pattern as KJTAllToAll.
+    Stores KJTAllToAll context and reuses it in SequenceEmbeddingsAllToAll.
+    SequenceEmbeddingsAllToAll has the same comm pattern as KJTAllToAll.
 
     Attributes:
         features_before_input_dist (Optional[KeyedJaggedTensor]): stores the original
@@ -56,8 +56,8 @@ T = TypeVar("T")
 
 class BaseSequenceEmbeddingDist(BaseEmbeddingDist[T]):
     """
-    Base class for converting output of Sequence EmbeddingLookup from model-parallel to
-    data-parallel.
+    Base class for converting output of the sequence embedding lookup from
+    model-parallel to data-parallel.
     """
 
     @abc.abstractmethod

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -9,7 +9,10 @@ from typing import Any, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import EmbeddingsAllToOne, SequenceEmbeddingAllToAll
+from torchrec.distributed.dist_data import (
+    EmbeddingsAllToOne,
+    SequenceEmbeddingsAllToAll,
+)
 from torchrec.distributed.embedding_lookup import (
     GroupedEmbeddingsLookup,
     InferGroupedEmbeddingsLookup,
@@ -92,7 +95,7 @@ class TwSequenceEmbeddingDist(BaseSequenceEmbeddingDist[torch.Tensor]):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self._dist = SequenceEmbeddingAllToAll(pg, features_per_rank, device)
+        self._dist = SequenceEmbeddingsAllToAll(pg, features_per_rank, device)
 
     def forward(
         self,


### PR DESCRIPTION
Summary: Refactor `SequenceEmbeddingAllToAll` -> `SequenceEmbeddingsAllToAll` to match convention of other modules incl. SequenceEmbeddingsAwaitable, PooledEmbeddingsAllToAll, PooledEmbeddingsAwaitable

Differential Revision: D37291358

