### PR TITLE
Fix storage percentage reservation order in HeuristicalStorageReservation

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -34,9 +34,7 @@ class FixedPercentageReservation(StorageReservation):
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
     ) -> Topology:
         reserved_topology = copy.deepcopy(topology)
-        for device in reserved_topology.devices:
-            device.storage.hbm = int((1 - self._percentage) * device.storage.hbm)
-            device.storage.ddr = int((1 - self._percentage) * device.storage.ddr)
+        _reserve_storage_percentage(reserved_topology, self._percentage)
         return reserved_topology
 
 
@@ -90,13 +88,13 @@ class HeuristicalStorageReservation(StorageReservation):
                 ]
             )
 
+        _reserve_storage_percentage(reserved_topology, self._percentage)
+
         _reserve_unshardable_tensors_storage(
             reserved_topology, module, shardable_parameters
         )
 
         _reserve_kjt_storage(reserved_topology, all_input_lengths, BIGINT_DTYPE)
-
-        _reserve_storage_percentage(reserved_topology, self._percentage)
 
         return reserved_topology
 


### PR DESCRIPTION
Summary: Our storage percentage reservation isn't truly reserving x% specified of the available storage. It reserves x% of storage left after dense and KJT storage reservations, so we have a slight overestimate of our storage constraint

Reviewed By: bigning

Differential Revision: D37325819

