### PR TITLE
support overriding output data type for quant EBCs

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -42,6 +42,10 @@ from torchrec.distributed.types import (
     ShardingEnv,
 )
 from torchrec.distributed.utils import filter_state_dict
+from torchrec.modules.embedding_configs import (
+    data_type_to_sparse_type,
+    dtype_to_data_type,
+)
 from torchrec.quant.embedding_modules import (
     EmbeddingCollection as QuantEmbeddingCollection,
 )
@@ -283,7 +287,11 @@ class QuantEmbeddingCollectionSharder(
         env: ShardingEnv,
         device: Optional[torch.device] = None,
     ) -> ShardedQuantEmbeddingCollection:
-        return ShardedQuantEmbeddingCollection(module, params, env, self.fused_params)
+        fused_params = self.fused_params if self.fused_params else {}
+        fused_params["output_dtype"] = data_type_to_sparse_type(
+            dtype_to_data_type(module.output_dtype)
+        )
+        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
 
     def shardable_parameters(
         self, module: QuantEmbeddingCollection

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -141,7 +141,6 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag):
                 device=device,
                 pooling_mode=self._pooling,
                 feature_table_map=self._feature_table_map,
-                output_dtype=SparseType.FP32,
                 row_alignment=16,
                 **(fused_params or {}),
             )
@@ -239,7 +238,6 @@ class QuantBatchedEmbedding(BaseBatchedEmbedding):
                 device=device,
                 pooling_mode=PoolingMode.NONE,
                 feature_table_map=self._feature_table_map,
-                output_dtype=SparseType.FP32,
                 row_alignment=16,
                 **(fused_params or {}),
             )

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -37,7 +37,10 @@ from torchrec.distributed.types import (
     ShardingType,
 )
 from torchrec.distributed.utils import filter_state_dict
-from torchrec.modules.embedding_configs import EmbeddingTableConfig
+from torchrec.modules.embedding_configs import (
+    data_type_to_sparse_type,
+    dtype_to_data_type,
+)
 from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
 from torchrec.quant.embedding_modules import (
     EmbeddingBagCollection as QuantEmbeddingBagCollection,
@@ -265,9 +268,11 @@ class QuantEmbeddingBagCollectionSharder(
         env: ShardingEnv,
         device: Optional[torch.device] = None,
     ) -> ShardedQuantEmbeddingBagCollection:
-        return ShardedQuantEmbeddingBagCollection(
-            module, params, env, self.fused_params
+        fused_params = self.fused_params if self.fused_params else {}
+        fused_params["output_dtype"] = data_type_to_sparse_type(
+            dtype_to_data_type(module.output_dtype)
         )
+        return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
 
     def shardable_parameters(
         self, module: QuantEmbeddingBagCollection

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -46,7 +46,9 @@ DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
 
 
 def dtype_to_data_type(dtype: torch.dtype) -> DataType:
-    if dtype == torch.float16 or dtype == torch.half:
+    if dtype == torch.float:
+        return DataType.FP32
+    elif dtype == torch.float16 or dtype == torch.half:
         return DataType.FP16
     elif dtype == torch.quint8 or dtype == torch.qint8 or dtype == torch.int8:
         return DataType.INT8


### PR DESCRIPTION
Summary: the default output type is FP32, some tables are in FP16 in training, convert back to FP32 does not make sense, use qconfig.activation to pass output dtype

Reviewed By: zhangruiskyline

Differential Revision: D37217377

