### PR TITLE
Add batch size, storage constraint/reservation, pooling factors, and output type to stats table and expose stats table

### DIFF
--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -120,7 +120,7 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
         performance_model: Optional[PerfModel] = None,
         stats: Optional[Stats] = None,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
-        debug: bool = False,
+        debug: bool = True,
     ) -> None:
         self._topology = topology
         self._constraints = constraints
@@ -278,6 +278,8 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
+                storage_constraint=storage_constraint,
+                storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
                 run_time=end_time - start_time,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -112,7 +112,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         performance_model: Optional[PerfModel] = None,
         stats: Optional[Stats] = None,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
-        debug: bool = False,
+        debug: bool = True,
     ) -> None:
         self._topology = topology
         self._constraints = constraints
@@ -261,6 +261,8 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
+                storage_constraint=storage_constraint,
+                storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
                 run_time=end_time - start_time,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -410,6 +410,8 @@ class Stats(abc.ABC):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
+        storage_constraint: Topology,
+        storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,
         run_time: float,


### PR DESCRIPTION
Summary:
Added
- batch size
- longest critical path
- peak memory pressure
- usable memory
- KJT storage
- dense storage
- pooling factors
- output type (pooled vs seq)

Set debug mode to default to true

Made stats table info to an attribute so it can be exposed and persisted when saving a sharding plan.

Differential Revision: D37318699

