### PR TITLE
Update stats' memory usage to include Dense and KJT storage estimates

### DIFF
--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -278,7 +278,6 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
-                storage_constraint=storage_constraint,
                 storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -261,7 +261,6 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
-                storage_constraint=storage_constraint,
                 storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -410,7 +410,6 @@ class Stats(abc.ABC):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
-        storage_constraint: Topology,
         storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,


### PR DESCRIPTION
Summary:
Update HBM/DDR usage to include Dense and KJT storage estimates.

Change memory usage percentage to be out of usable memory (total * (1 - percent_reserved))

Differential Revision: D37389847

