### PR TITLE
Make EB/EBC scriptable

### DIFF
--- a/examples/retrieval/modules/two_tower.py
+++ b/examples/retrieval/modules/two_tower.py
@@ -59,22 +59,24 @@ class TwoTower(nn.Module):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
+        # If running this example on Torcherc < v0.2.0,
+        # please use embedding_bag_configs as a property, not a function
         assert (
-            len(embedding_bag_collection.embedding_bag_configs) == 2
+            len(embedding_bag_collection.embedding_bag_configs()) == 2
         ), "Expected two EmbeddingBags in the two tower model"
         assert (
-            embedding_bag_collection.embedding_bag_configs[0].embedding_dim
-            == embedding_bag_collection.embedding_bag_configs[1].embedding_dim
+            embedding_bag_collection.embedding_bag_configs()[0].embedding_dim
+            == embedding_bag_collection.embedding_bag_configs()[1].embedding_dim
         ), "Both EmbeddingBagConfigs must have the same dimension"
-        embedding_dim: int = embedding_bag_collection.embedding_bag_configs[
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
             0
         ].embedding_dim
         self._feature_names_query: List[
             str
-        ] = embedding_bag_collection.embedding_bag_configs[0].feature_names
+        ] = embedding_bag_collection.embedding_bag_configs()[0].feature_names
         self._candidate_feature_names: List[
             str
-        ] = embedding_bag_collection.embedding_bag_configs[1].feature_names
+        ] = embedding_bag_collection.embedding_bag_configs()[1].feature_names
         self.ebc = embedding_bag_collection
         self.query_proj = MLP(
             in_size=embedding_dim, layer_sizes=layer_sizes, device=device
@@ -174,11 +176,11 @@ class TwoTowerRetrieval(nn.Module):
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self.embedding_dim: int = query_ebc.embedding_bag_configs[0].embedding_dim
+        self.embedding_dim: int = query_ebc.embedding_bag_configs()[0].embedding_dim
         assert (
-            candidate_ebc.embedding_bag_configs[0].embedding_dim == self.embedding_dim
+            candidate_ebc.embedding_bag_configs()[0].embedding_dim == self.embedding_dim
         ), "Both EmbeddingBagCollections must have the same dimension"
-        self.candidate_feature_names: List[str] = candidate_ebc.embedding_bag_configs[
+        self.candidate_feature_names: List[str] = candidate_ebc.embedding_bag_configs()[
             0
         ].feature_names
         self.query_ebc = query_ebc

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -111,7 +111,7 @@ def create_sharding_infos_by_sharding(
     for (
         config,
         embedding_names,
-    ) in zip(module.embedding_configs, module.embedding_names_by_table):
+    ) in zip(module.embedding_configs(), module.embedding_names_by_table()):
         table_name = config.name
         assert table_name in table_name_to_parameter_sharding
 
@@ -294,7 +294,7 @@ class ShardedEmbeddingCollection(
                     m.fused_optimizer.params = params
                     optims.append(("", m.fused_optimizer))
         self._optim: CombinedOptimizer = CombinedOptimizer(optims)
-        self._embedding_dim: int = module.embedding_dim
+        self._embedding_dim: int = module.embedding_dim()
         self._local_embedding_dim: int = self._embedding_dim
         self._features_to_permute_indices: Dict[str, List[int]] = {}
         if ShardingType.COLUMN_WISE.value in self._sharding_type_to_sharding:
@@ -304,9 +304,9 @@ class ShardedEmbeddingCollection(
                 ShardMetadata, sharding.embedding_shard_metadata()[0]
             ).shard_sizes[1]
             self._generate_permute_indices_per_feature(
-                module.embedding_configs, table_name_to_parameter_sharding
+                module.embedding_configs(), table_name_to_parameter_sharding
             )
-        self._need_indices: bool = module.need_indices
+        self._need_indices: bool = module.need_indices()
 
     def _generate_permute_indices_per_feature(
         self,

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -931,10 +931,10 @@ class EmbeddingTowerSharder(BaseEmbeddingSharder[EmbeddingTower]):
 
         weighted = False
         if isinstance(embedding, EmbeddingBagCollection):
-            configs = embedding.embedding_bag_configs
-            weighted = embedding.is_weighted
+            configs = embedding.embedding_bag_configs()
+            weighted = embedding.is_weighted()
         elif isinstance(embedding, EmbeddingCollection):
-            configs = embedding.embedding_configs
+            configs = embedding.embedding_configs()
 
         for config in configs:
             if getattr(config, "weighted", weighted):

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -113,7 +113,7 @@ def create_sharding_infos_by_sharding(
     prefix: str,
 ) -> Dict[str, List[EmbeddingShardingInfo]]:
     shared_feature: Dict[str, bool] = {}
-    for embedding_config in module.embedding_bag_configs:
+    for embedding_config in module.embedding_bag_configs():
         if not embedding_config.feature_names:
             embedding_config.feature_names = [embedding_config.name]
         for feature_name in embedding_config.feature_names:
@@ -124,7 +124,7 @@ def create_sharding_infos_by_sharding(
 
     sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = {}
     state_dict = module.state_dict()
-    for config in module.embedding_bag_configs:
+    for config in module.embedding_bag_configs():
         table_name = config.name
         assert table_name in table_name_to_parameter_sharding
         parameter_sharding = table_name_to_parameter_sharding[table_name]
@@ -156,7 +156,7 @@ def create_sharding_infos_by_sharding(
                     data_type=config.data_type,
                     feature_names=copy.deepcopy(config.feature_names),
                     pooling=config.pooling,
-                    is_weighted=module.is_weighted,
+                    is_weighted=module.is_weighted(),
                     has_feature_processor=False,
                     embedding_names=embedding_names,
                     weight_init_max=config.weight_init_max,
@@ -225,7 +225,7 @@ class ShardedEmbeddingBagCollection(
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
 
-        self._is_weighted: bool = module.is_weighted
+        self._is_weighted: bool = module.is_weighted()
         self._device = device
         self._input_dists = nn.ModuleList()
         self._lookups: nn.ModuleList = nn.ModuleList()

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -35,8 +35,8 @@ class ShardedFusedEmbeddingBagCollection(
         env: ShardingEnv,
         device: Optional[torch.device] = None,
     ) -> None:
-        optimizer_type = module.optimizer_type
-        optimizer_kwargs = module.optimizer_kwargs
+        optimizer_type = module.optimizer_type()
+        optimizer_kwargs = module.optimizer_kwargs()
 
         fused_params = {}
         emb_opt_type_and_kwargs = convert_optimizer_type_and_kwargs(

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -110,8 +110,8 @@ class ShardedQuantEmbeddingCollection(
         self._has_uninitialized_input_dist: bool = True
         self._has_uninitialized_output_dist: bool = True
 
-        self._embedding_dim: int = module.embedding_dim
-        self._need_indices: bool = module.need_indices
+        self._embedding_dim: int = module.embedding_dim()
+        self._need_indices: bool = module.need_indices()
 
     def _create_input_dist(
         self,
@@ -289,7 +289,7 @@ class QuantEmbeddingCollectionSharder(
     ) -> ShardedQuantEmbeddingCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
-            dtype_to_data_type(module.output_dtype)
+            dtype_to_data_type(module.output_dtype())
         )
         return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
 

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -87,7 +87,7 @@ class ShardedQuantEmbeddingBagCollection(
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
 
-        self._is_weighted: bool = module.is_weighted
+        self._is_weighted: bool = module.is_weighted()
         self._input_dists: nn.ModuleList = nn.ModuleList()
         self._lookups: nn.ModuleList = nn.ModuleList()
         self._create_lookups(fused_params)
@@ -270,7 +270,7 @@ class QuantEmbeddingBagCollectionSharder(
     ) -> ShardedQuantEmbeddingBagCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
-            dtype_to_data_type(module.output_dtype)
+            dtype_to_data_type(module.output_dtype())
         )
         return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
 

--- a/torchrec/distributed/tests/test_sequence_model.py
+++ b/torchrec/distributed/tests/test_sequence_model.py
@@ -41,7 +41,7 @@ class TestSequenceSparseArch(nn.Module):
             tables=tables, device=device, need_indices=True
         )
         self.embedding_names = embedding_names
-        self.embedding_dim: int = self.ec.embedding_dim
+        self.embedding_dim: int = self.ec.embedding_dim()
 
     def forward(
         self,

--- a/torchrec/models/deepfm.py
+++ b/torchrec/models/deepfm.py
@@ -290,22 +290,22 @@ class SimpleDeepFMNN(nn.Module):
     ) -> None:
         super().__init__()
         assert (
-            len(embedding_bag_collection.embedding_bag_configs) > 0
+            len(embedding_bag_collection.embedding_bag_configs()) > 0
         ), "At least one embedding bag is required"
-        for i in range(1, len(embedding_bag_collection.embedding_bag_configs)):
-            conf_prev = embedding_bag_collection.embedding_bag_configs[i - 1]
-            conf = embedding_bag_collection.embedding_bag_configs[i]
+        for i in range(1, len(embedding_bag_collection.embedding_bag_configs())):
+            conf_prev = embedding_bag_collection.embedding_bag_configs()[i - 1]
+            conf = embedding_bag_collection.embedding_bag_configs()[i]
             assert (
                 conf_prev.embedding_dim == conf.embedding_dim
             ), "All EmbeddingBagConfigs must have the same dimension"
-        embedding_dim: int = embedding_bag_collection.embedding_bag_configs[
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
             0
         ].embedding_dim
 
         feature_names = []
 
         fm_in_features = embedding_dim
-        for conf in embedding_bag_collection.embedding_bag_configs:
+        for conf in embedding_bag_collection.embedding_bag_configs():
             for feat in conf.feature_names:
                 feature_names.append(feat)
                 fm_in_features += conf.embedding_dim

--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -72,12 +72,12 @@ class SparseArch(nn.Module):
         assert (
             self.embedding_bag_collection.embedding_bag_configs
         ), "Embedding bag collection cannot be empty!"
-        self.D: int = self.embedding_bag_collection.embedding_bag_configs[
+        self.D: int = self.embedding_bag_collection.embedding_bag_configs()[
             0
         ].embedding_dim
         self._sparse_feature_names: List[str] = [
             name
-            for conf in embedding_bag_collection.embedding_bag_configs
+            for conf in embedding_bag_collection.embedding_bag_configs()
             for name in conf.feature_names
         ]
 
@@ -447,15 +447,15 @@ class DLRM(nn.Module):
     ) -> None:
         super().__init__()
         assert (
-            len(embedding_bag_collection.embedding_bag_configs) > 0
+            len(embedding_bag_collection.embedding_bag_configs()) > 0
         ), "At least one embedding bag is required"
-        for i in range(1, len(embedding_bag_collection.embedding_bag_configs)):
-            conf_prev = embedding_bag_collection.embedding_bag_configs[i - 1]
-            conf = embedding_bag_collection.embedding_bag_configs[i]
+        for i in range(1, len(embedding_bag_collection.embedding_bag_configs())):
+            conf_prev = embedding_bag_collection.embedding_bag_configs()[i - 1]
+            conf = embedding_bag_collection.embedding_bag_configs()[i]
             assert (
                 conf_prev.embedding_dim == conf.embedding_dim
             ), "All EmbeddingBagConfigs must have the same dimension"
-        embedding_dim: int = embedding_bag_collection.embedding_bag_configs[
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
             0
         ].embedding_dim
         if dense_arch_layer_sizes[-1] != embedding_dim:
@@ -604,7 +604,7 @@ class DLRMV2(DLRM):
             dense_device,
         )
 
-        embedding_dim: int = embedding_bag_collection.embedding_bag_configs[
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
             0
         ].embedding_dim
         num_sparse_features: int = len(self.sparse_arch.sparse_feature_names)

--- a/torchrec/modules/embedding_tower.py
+++ b/torchrec/modules/embedding_tower.py
@@ -29,7 +29,7 @@ def tower_input_params(module: nn.Module) -> Tuple[bool, bool]:
     if isinstance(module, EmbeddingCollection):
         return True, False
     elif isinstance(module, EmbeddingBagCollection):
-        return not module.is_weighted, module.is_weighted
+        return not module.is_weighted(), module.is_weighted()
     # default to assuming both kjt and weight_kjt required
     return True, True
 

--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -146,6 +146,13 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f3", "f2"])
         self.assertEqual(pooled_embeddings.offset_per_key(), [0, 3, 6, 10])
 
+    def test_scripting(self) -> None:
+        config = EmbeddingBagConfig(
+            name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
+        )
+        ebc = EmbeddingBagCollection(tables=[config])
+        torch.jit.script(ebc)
+
     def test_duplicate_config_name_fails(self) -> None:
         eb1_config = EmbeddingBagConfig(
             name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
@@ -269,6 +276,13 @@ class EmbeddingCollectionTest(unittest.TestCase):
         self.assertEqual(sequence_embeddings["f1"].values().size(), (3, 5))
         self.assertEqual(sequence_embeddings["f2@t1"].values().size(), (1, 5))
         self.assertEqual(sequence_embeddings["f2@t2"].values().size(), (1, 5))
+
+    def test_scripting(self) -> None:
+        config = EmbeddingConfig(
+            name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
+        )
+        ec = EmbeddingCollection(tables=[config])
+        torch.jit.script(ec)
 
     def test_device(self) -> None:
         config = EmbeddingConfig(

--- a/torchrec/modules/tests/test_fused_embedding_modules.py
+++ b/torchrec/modules/tests/test_fused_embedding_modules.py
@@ -487,7 +487,7 @@ class FusedEmbeddingBagCollectionTest(unittest.TestCase):
             fused_ebc.state_dict()["embedding_bags.table_0.weight"],
         )
 
-        fused_optimizer = fused_ebc.fused_optimizer
+        fused_optimizer = fused_ebc.fused_optimizer()
         fused_optimizer.load_state_dict(fused_optimizer.state_dict())
 
     def unweighted_replacement(


### PR DESCRIPTION
Summary:
1. Do not use property, use methods instead. This is consistent w/ KJT.
1. _embedding_bag_configs has a complex type List[EmbeddingBagConfig] which does not script. Use List[str] to store features instead.

Reviewed By: xing-liu

Differential Revision: D37389962

