### PR TITLE
Change the FX graph to make the feature_processor happen after input_dist() and update the interface of EBC

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -284,6 +284,9 @@ class GroupedPooledEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Te
             for config, emb_op, features in zip(
                 self.grouped_configs, self._emb_modules, id_list_features_by_group
             ):
+                # keep this to avoid break ads code using feature_processor, for ebc
+                # the has_feature_processor will always be false. Remove this block when
+                # finishing the migration
                 if (
                     config.has_feature_processor
                     and self._feature_processor is not None

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -418,6 +418,7 @@ def group_tables(
         for data_type in DataType:
             for pooling in PoolingType:
                 for is_weighted in [True, False]:
+                    # remove this when finishing migration
                     for has_feature_processor in [False, True]:
                         for compute_kernel in [
                             EmbeddingComputeKernel.DENSE,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -25,6 +25,7 @@ from torchrec.modules.embedding_configs import (
     EmbeddingTableConfig,
     PoolingType,
 )
+from torchrec.modules.feature_processor import BaseGroupedFeatureProcessor  # noqa[F401]
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable
 
@@ -299,25 +300,6 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                 storage_map[compute_device_type].value: tensor.element_size()
                 * tensor.nelement()
             }
-
-
-class BaseGroupedFeatureProcessor(nn.Module):
-    """
-    Abstract base class for grouped feature processor
-    """
-
-    @abc.abstractmethod
-    def forward(
-        self,
-        features: KeyedJaggedTensor,
-    ) -> KeyedJaggedTensor:
-        pass
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        return destination
 
 
 class BaseQuantEmbeddingSharder(ModuleSharder[M]):

--- a/torchrec/distributed/grouped_position_weighted.py
+++ b/torchrec/distributed/grouped_position_weighted.py
@@ -14,7 +14,8 @@ from torchrec.distributed.embedding_types import BaseGroupedFeatureProcessor
 from torchrec.distributed.utils import append_prefix
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
-
+# Will be deprecated soon, please use PositionWeightedProcessor, see the full
+# doc under modules/feature_processor.py
 class GroupedPositionWeightedModule(BaseGroupedFeatureProcessor):
     def __init__(
         self, max_feature_lengths: Dict[str, int], device: Optional[torch.device] = None

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -102,6 +102,7 @@ class RwSequenceEmbeddingSharding(
             device=device if device is not None else self._device,
             is_sequence=True,
             has_feature_processor=self._has_feature_processor,
+            need_pos=False,
         )
 
     def create_lookup(

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -24,6 +24,7 @@ from typing import (
 import torch
 from torch.autograd.profiler import record_function
 from torch.fx.node import Node
+from torchrec.distributed.embedding_types import BaseGroupedFeatureProcessor
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.types import Awaitable, ShardedModuleContext
 from torchrec.streamable import Multistreamable, Pipelineable
@@ -164,6 +165,8 @@ class TrainPipelineContext:
     # pyre-ignore [4]
     input_dist_requests: Dict[str, Awaitable[Any]] = field(default_factory=dict)
     module_contexts: Dict[str, ShardedModuleContext] = field(default_factory=dict)
+    # pyre-ignore [4]
+    feature_processor_forwards: List[Any] = field(default_factory=list)
 
 
 @dataclass
@@ -219,6 +222,15 @@ class PipelinedForward(Generic[DistIn, DistOut, Out]):
             ctx = self._context.module_contexts[self._name]
             ctx.record_stream(cur_stream)
 
+        if len(self._context.feature_processor_forwards) > 0:
+            with record_function("## feature_processor ##"):
+                for sparse_feature in data:
+                    if sparse_feature.id_score_list_features is not None:
+                        for fp_forward in self._context.feature_processor_forwards:
+                            sparse_feature.id_score_list_features = fp_forward(
+                                sparse_feature.id_score_list_features
+                            )
+
         return self._module.compute_and_output_dist(
             self._context.module_contexts[self._name], data
         )
@@ -243,7 +255,11 @@ def _start_data_dist(
         forward = module.forward
         assert isinstance(forward, PipelinedForward)
 
-        # Retrieve argument.
+        # Retrieve argument for the input_dist of EBC
+        # is_getitem True means this argument could be retrieved by a list
+        # False means this argument is getting while getattr
+        # and this info was done in the _rewrite_model by tracing the
+        # entire model to get the arg_info_list
         args = []
         kwargs = {}
         for arg_info in forward.args:
@@ -260,7 +276,6 @@ def _start_data_dist(
                     args.append(arg)
             else:
                 args.append(None)
-
         # Start input distribution.
         module_ctx = module.create_context()
         context.module_contexts[forward.name] = module_ctx
@@ -269,8 +284,12 @@ def _start_data_dist(
         )
 
 
-# pyre-ignore
-def _get_node_args_helper(arguments, num_found: int) -> Tuple[List[ArgInfo], int]:
+def _get_node_args_helper(
+    # pyre-ignore
+    arguments,
+    num_found: int,
+    feature_processor_arguments: Optional[List[Node]] = None,
+) -> Tuple[List[ArgInfo], int]:
     """
     Goes through the args/kwargs of a node and arranges them into a list of `ArgInfo`s.
     It also counts the number of (args + kwargs) found.
@@ -289,6 +308,12 @@ def _get_node_args_helper(arguments, num_found: int) -> Tuple[List[ArgInfo], int
             if child_node.op == "placeholder":
                 num_found += 1
                 break
+            # skip this fp node
+            elif (
+                feature_processor_arguments is not None
+                and child_node in feature_processor_arguments
+            ):
+                arg = child_node.args[0]
             elif (
                 child_node.op == "call_function"
                 and child_node.target.__module__ == "builtins"
@@ -312,9 +337,13 @@ def _get_node_args_helper(arguments, num_found: int) -> Tuple[List[ArgInfo], int
     return arg_info_list, num_found
 
 
-def _get_node_args(node: Node) -> Tuple[List[ArgInfo], int]:
+def _get_node_args(
+    node: Node, feature_processor_nodes: Optional[List[Node]] = None
+) -> Tuple[List[ArgInfo], int]:
     num_found = 0
-    pos_arg_info_list, num_found = _get_node_args_helper(node.args, num_found)
+    pos_arg_info_list, num_found = _get_node_args_helper(
+        node.args, num_found, feature_processor_nodes
+    )
     kwargs_arg_info_list, num_found = _get_node_args_helper(
         node.kwargs.values(), num_found
     )
@@ -380,14 +409,22 @@ def _rewrite_model(  # noqa C901
 
     # Collect a list of sharded modules.
     sharded_modules = {}
+    fp_modules = {}
     for name, m in model.named_modules():
         if isinstance(m, ShardedModule):
             sharded_modules[name] = m
+        if isinstance(m, BaseGroupedFeatureProcessor):
+            fp_modules[name] = m
 
     # Trace a model.
     tracer = Tracer(_get_unsharded_module_names(model))
     graph = tracer.trace(model)
 
+    feature_processor_nodes = []
+    # find the fp node
+    for node in graph.nodes:
+        if node.op == "call_module" and node.target in fp_modules:
+            feature_processor_nodes.append(node)
     # Select sharded modules, which are top-level in the forward call graph,
     # i.e. which don't have input transformations, i.e.
     # rely only on 'builtins.getattr'.
@@ -397,12 +434,16 @@ def _rewrite_model(  # noqa C901
             total_num_args = len(node.args) + len(node.kwargs)
             if total_num_args == 0:
                 continue
-            arg_info_list, num_found = _get_node_args(node)
+            arg_info_list, num_found = _get_node_args(node, feature_processor_nodes)
             if num_found == total_num_args:
                 logger.info(f"Module '{node.target}'' will be pipelined")
                 child = sharded_modules[node.target]
                 child.forward = PipelinedForward(
-                    node.target, arg_info_list, child, context, dist_stream
+                    node.target,
+                    arg_info_list,
+                    child,
+                    context,
+                    dist_stream,
                 )
                 ret.append(child)
     return ret
@@ -453,7 +494,15 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._context = TrainPipelineContext()
         self._pipelined_modules: List[ShardedModule] = []
 
+    def _replace_fp_forward(self, model: torch.nn.Module) -> None:
+        for _, m in model.named_modules():
+            if isinstance(m, BaseGroupedFeatureProcessor):
+                self._context.feature_processor_forwards.append(m.forward)
+                # pyre-ignore[8]: Incompatible attribute type
+                m.forward = lambda x: x
+
     def _connect(self, dataloader_iter: Iterator[In]) -> None:
+        self._replace_fp_forward(cast(torch.nn.Module, self._model.module))
         # batch 1
         with torch.cuda.stream(self._memcpy_stream):
             batch_i = next(dataloader_iter)

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -113,6 +113,9 @@ class BaseEmbeddingConfig:
     feature_names: List[str] = field(default_factory=list)
     weight_init_max: Optional[float] = None
     weight_init_min: Optional[float] = None
+    # when the position_weighted feature is in this table config,
+    # enable this flag to support rw_sharding
+    need_pos: bool = False
 
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:
@@ -130,6 +133,9 @@ class BaseEmbeddingConfig:
         return len(self.feature_names)
 
 
+# this class will be deprecated after migration
+# and all the following code in sharding itself
+# which contains has_feature_processor
 @dataclass
 class EmbeddingTableConfig(BaseEmbeddingConfig):
     pooling: PoolingType = PoolingType.SUM

--- a/torchrec/modules/feature_processor.py
+++ b/torchrec/modules/feature_processor.py
@@ -6,13 +6,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
-from typing import Dict
+from collections import OrderedDict
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from torchrec.sparse.jagged_tensor import JaggedTensor
+from torch.fx._symbolic_trace import is_fx_tracing
+
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
+# Will be deprecated soon, please use PositionWeightedProcessor, see full doc below
 class BaseFeatureProcessor(nn.Module):
     """
     Abstract base class for feature processor.
@@ -26,6 +30,7 @@ class BaseFeatureProcessor(nn.Module):
         pass
 
 
+# Will be deprecated soon, please use PositionWeightedProcessor, see full doc below
 class PositionWeightedModule(BaseFeatureProcessor):
     """
     Adds position weights to id list features.
@@ -72,3 +77,228 @@ class PositionWeightedModule(BaseFeatureProcessor):
                 weights=torch.gather(pos_weight, dim=0, index=seq),
             )
         return weighted_features
+
+
+class BaseGroupedFeatureProcessor(nn.Module):
+    """
+    Abstract base class for grouped feature processor
+    """
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+    ) -> KeyedJaggedTensor:
+        pass
+
+    def sparse_grad_parameter_names(
+        self, destination: Optional[List[str]] = None, prefix: str = ""
+    ) -> List[str]:
+        destination = [] if destination is None else destination
+        return destination
+
+
+class PositionWeightedProcessor(BaseGroupedFeatureProcessor):
+    """
+    PositionWeightedProcessor represents a processor to apply position weight to a KeyedJaggedTensor.
+
+    It can handle both unsharded and sharded input and output corresponding output
+
+    Args:
+        max_feature_lengths (Dict[str, int]): Dict of feature_lengths, the key is the feature_name and value is length.
+        device (Optional[torch.device]): default compute device.
+
+    Example::
+
+        keys=["Feature0", "Feature1", "Feature2"]
+        values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 3, 4, 5, 6, 7])
+        lengths=torch.tensor([2, 0, 1, 1, 1, 3, 2, 3, 0])
+        features = KeyedJaggedTensor.from_lengths_sync(keys=keys, values=values, lengths=lengths)
+        pw = FeatureProcessorCollection(
+            feature_processor_modules={key: PositionWeightedFeatureProcessor(max_feature_length=100) for key in keys}
+        )
+        result = pw(features)
+        # result is
+        # KeyedJaggedTensor({
+        #     "Feature0": {
+        #         "values": [[0, 1], [], [2]],
+        #         "weights": [[1.0, 1.0], [], [1.0]]
+        #     },
+        #     "Feature1": {
+        #         "values": [[3], [4], [5, 6, 7]],
+        #         "weights": [[1.0], [1.0], [1.0, 1.0, 1.0]]
+        #     },
+        #     "Feature2": {
+        #         "values": [[3, 4], [5, 6, 7], []],
+        #         "weights": [[1.0, 1.0], [1.0, 1.0, 1.0], []]
+        #     }
+        # })
+    """
+
+    def __init__(
+        self,
+        max_feature_lengths: Dict[str, int],
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self.max_feature_lengths = max_feature_lengths
+        for length in self.max_feature_lengths.values():
+            if length <= 0:
+                raise
+        self.position_weights: nn.ParameterDict = nn.ParameterDict()
+        for key, length in max_feature_lengths.items():
+            self.position_weights[key] = nn.Parameter(
+                torch.empty([length], device=device).fill_(1.0)
+            )
+
+    def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        """
+        In unsharded or non-pipelined model, the input features both contain fp_feature
+        and non_fp_features, and the output will filter out non_fp features
+        In sharded pipelining model, the input features can only contain either none
+        or all feature_processed features, since the input feature comes from the
+        input_dist() of ebc which will filter out the keys not in the ebc. And the
+        input size is same as output size
+
+        Args:
+            features (KeyedJaggedTensor): input features
+
+        Returns:
+            KeyedJaggedTensor
+        """
+        if is_fx_tracing():
+            features_dict = features.to_dict()
+            weighted_features_names: List[str] = []
+            weighted_features_values: List[torch.Tensor] = []
+            weighted_features_lengths: List[torch.Tensor] = []
+            weighted_features_weights: List[torch.Tensor] = []
+            for key, position_weight in self.position_weights.items():
+                seq = torch.ops.fbgemm.offsets_range(
+                    features_dict[key].offsets().long(),
+                    torch.numel(features_dict[key].values()),
+                )
+                weighted_features_names.append(key)
+                weighted_features_values.append(features_dict[key].values())
+                weighted_features_lengths.append(features_dict[key].lengths())
+                weighted_features_weights.append(
+                    torch.gather(position_weight, dim=0, index=seq)
+                )
+            return KeyedJaggedTensor.from_lengths_sync(
+                keys=weighted_features_names,
+                values=torch.cat(weighted_features_values),
+                lengths=torch.cat(weighted_features_lengths),
+                weights=torch.cat(weighted_features_weights),
+            )
+        else:
+            feature_names = features.keys()
+            lengths = features.lengths()
+            offsets = features.offsets()
+            values = features.values()
+            length_per_key = features.length_per_key()
+            weights = features.weights_or_none()
+            batch_size = features.stride()
+
+            has_fp_id_list_feature = False
+            has_normal_id_list_feature = False
+
+            if weights is None:
+                cat_seq = torch.ops.fbgemm.offsets_range(
+                    offsets.long(), torch.numel(values)
+                )
+            else:
+                # for row-wise sharding
+                cat_seq = weights.long()
+            seqs = torch.split(cat_seq, features.length_per_key())
+
+            for feature_name in feature_names:
+                if feature_name in self.max_feature_lengths:
+                    has_fp_id_list_feature = True
+                else:
+                    has_normal_id_list_feature = True
+
+            # in sharded pipelining model, the input features can only contain either none
+            # or all feature_processed features, since the input feature comes from the
+            # input_dist() of ebc which will filter out the keys not in the ebc
+            # for the input features both contain fp_feature and normal_features, it could be
+            # unsharded or non-pipelined sharded models
+            if has_fp_id_list_feature:
+                # for sharded pipeling
+                if not has_normal_id_list_feature:
+                    processed_features_weights: List[torch.Tensor] = []
+                    for feature_index, feature_name in enumerate(feature_names):
+                        processed_weight = torch.gather(
+                            self.position_weights[feature_name],
+                            dim=0,
+                            index=seqs[feature_index],
+                        )
+                        processed_features_weights.append(processed_weight)
+                    fp_features = KeyedJaggedTensor(
+                        keys=feature_names,
+                        values=values,
+                        weights=torch.cat(processed_features_weights),
+                        lengths=lengths,
+                        offsets=offsets,
+                        stride=batch_size,
+                        length_per_key=length_per_key,
+                        offset_per_key=features.offset_per_key(),
+                        index_per_key=features._key_indices(),
+                    )
+                # for unsharded or sharded non-pipeling
+                else:
+                    feature_values = values.split(length_per_key)
+                    feature_lengths = lengths.split(batch_size)
+                    processed_features_names: List[str] = []
+                    processed_features_lengths: List[torch.Tensor] = []
+                    processed_features_values: List[torch.Tensor] = []
+                    processed_features_weights: List[torch.Tensor] = []
+                    for feature_index, feature_name in enumerate(feature_names):
+                        if feature_name in self.max_feature_lengths:
+                            feature_value = feature_values[feature_index]
+                            feature_length = feature_lengths[feature_index]
+                            processed_weight = torch.gather(
+                                self.position_weights[feature_name],
+                                dim=0,
+                                index=seqs[feature_index],
+                            )
+                            processed_features_names.append(feature_name)
+                            processed_features_lengths.append(feature_length)
+                            processed_features_values.append(feature_value)
+                            processed_features_weights.append(processed_weight)
+                    fp_features = KeyedJaggedTensor.from_lengths_sync(
+                        keys=processed_features_names,
+                        values=torch.cat(processed_features_values),
+                        lengths=torch.cat(processed_features_lengths),
+                        weights=torch.cat(processed_features_weights),
+                    )
+                return fp_features
+            # normal id_list feature
+            else:
+                return features
+
+    def named_buffers(
+        self, prefix: str = "", recurse: bool = True
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield from ()
+
+    # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
+    def state_dict(
+        self,
+        destination: Optional[Dict[str, Any]] = None,
+        prefix: str = "",
+        keep_vars: bool = False,
+    ) -> Dict[str, Any]:
+        if destination is None:
+            destination = OrderedDict()
+            # pyre-ignore [16]
+            destination._metadata = OrderedDict()
+        for name, param in self.position_weights.items():
+            destination[prefix + f"position_weights.{name}"] = (
+                param if keep_vars else param.detach()
+            )
+        return destination
+
+    def sparse_grad_parameter_names(
+        self, destination: Optional[List[str]] = None, prefix: str = ""
+    ) -> List[str]:
+        destination = [] if destination is None else destination
+        return destination

--- a/torchrec/modules/tests/test_feature_processor.py
+++ b/torchrec/modules/tests/test_feature_processor.py
@@ -9,7 +9,10 @@ import unittest
 
 import torch
 from torchrec.fx import Tracer
-from torchrec.modules.feature_processor import PositionWeightedModule
+from torchrec.modules.feature_processor import (
+    PositionWeightedModule,
+    PositionWeightedProcessor,
+)
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
@@ -50,6 +53,45 @@ class PositionWeightedModuleTest(unittest.TestCase):
     def test_fx_script_PositionWeightedModule(self) -> None:
         features_max_length = {"f1": 10, "f2": 3}
         pw = PositionWeightedModule(features_max_length)
+
+        gm = torch.fx.GraphModule(pw, Tracer().trace(pw))
+        torch.jit.script(gm)
+
+    def test_populate_weights_PositionWeightedProcessor(self) -> None:
+        features_max_length = {"f1": 10, "f2": 3}
+        pw = PositionWeightedProcessor(features_max_length)
+
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        )
+
+        weighted_features = pw(features)
+
+        self.assertEqual(weighted_features["f1"].weights().size(), (3,))
+        self.assertEqual(weighted_features["f2"].weights().size(), (5,))
+
+        pw_f1_ref = torch.gather(
+            pw.state_dict()["position_weights.f1"], 0, torch.tensor([0, 1, 0])
+        )
+        pw_f1 = weighted_features["f1"].weights().detach()
+        self.assertTrue(torch.allclose(pw_f1_ref, pw_f1))
+
+        pw_f2_ref = torch.gather(
+            pw.state_dict()["position_weights.f2"], 0, torch.tensor([0, 0, 0, 1, 2])
+        )
+        pw_f2 = weighted_features["f2"].weights().detach()
+        self.assertTrue(torch.allclose(pw_f2_ref, pw_f2))
+
+    def test_fx_script_PositionWeightedProcessor(self) -> None:
+        features_max_length = {"f1": 10, "f2": 3}
+        pw = PositionWeightedProcessor(features_max_length)
 
         gm = torch.fx.GraphModule(pw, Tracer().trace(pw))
         torch.jit.script(gm)


### PR DESCRIPTION
Summary:
Design proposal: https://docs.google.com/document/d/1fsgWVDQr0jIFHUPvBkglEJWULnbW0qFBugozFhKJTBY/edit

In unsharded world, the execution order is:
```
id_list_features = self.fp(id_list_features)
fp_result = self.fp_ebc(id_list_features)
```

So the sharded version, the feature_processor will happen before input_dist which will make the pipelined model not pipelined as the fp_ebc will wait for the fp finished then starting input_dist() -> compute_and_output().

So this diff is to do like:
```
dist_input = fp_ebc.input_dist(id_list_features)
fp_dist_input = fp(dist_input)
result = fp_ebc.compute_and_output(fp_dist_input)
```

Reviewed By: divchenko

Differential Revision: D36426243

