### PR TITLE
bump to 0.2.0

### DIFF
--- a/version.py
+++ b/version.py
@@ -14,4 +14,4 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
With release of 0.2.0 we can bump version to 0.2.0

https://github.com/pytorch/torchrec/releases/tag/v0.2.0