### PR TITLE
Make dim divisible by 4 requirement more explicit

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -607,6 +607,10 @@ class BatchedFusedEmbeddingBag(BaseBatchedEmbeddingBag, FusedOptimizerModule):
         managed: List[EmbeddingLocation] = []
         compute_devices: List[ComputeDevice] = []
         for table in config.embedding_tables:
+            assert table.local_cols % 4 == 0, (
+                f"table {table.name} has local_cols={table.local_cols} "
+                "not divisible by 4. "
+            )
             if device is not None and device.type == "cuda":
                 compute_devices.append(ComputeDevice.CUDA)
                 managed.append(


### PR DESCRIPTION
Summary:
# Problem

User report here
https://fb.prod.workplace.com/groups/1069285536500339/permalink/5254923157936535/

Error stack, P512815141

PyTorch batched embedding table op requires dim to be divisible by 4.

The particular error is asserting one table is having dim=1.
Code pointer to the assertion, https://fburl.com/code/rucb3gzn

# Improvement

Make the assertion more actionable to users.
Include table names to users know which model config to look at.

# Solution

Verify and assert here instead, because here we still have context about table_names.

https://fburl.com/code/5ukomhpt

Differential Revision: D37496262

