### PR TITLE
Use the correct typing for task_wildcard_metrics_patter()

### DIFF
--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -71,8 +71,8 @@ class MetricPrefix(StrValueMixin, Enum):
 
 
 def task_wildcard_metrics_pattern(
-    namespace: MetricNamespace,
-    metric_name: MetricName,
+    namespace: MetricNamespaceBase,
+    metric_name: MetricNameBase,
     metric_prefix: MetricPrefix = MetricPrefix.DEFAULT,
 ) -> str:
     r"""Get the re (regular expression) pattern to find a set of metrics


### PR DESCRIPTION
Summary: The current typing of task_wildcard_metrics_patter() is not correct.  This PR fixes the issue.

Differential Revision: D37618889

