### PR TITLE
ensure intra-/cross-node PGs using the same backend as global PG

### DIFF
--- a/torchrec/distributed/comm.py
+++ b/torchrec/distributed/comm.py
@@ -117,10 +117,18 @@ def intra_and_cross_node_pg(
     local_size = get_local_size(my_size)
     my_group_rank = get_group_rank(my_size, my_rank)
     group_count = get_num_groups(my_size)
+    my_backend = dist.get_backend()
+
+    if my_backend != backend:
+        logger.warn(
+            f"global PG is initialized with backend {my_backend}, while trying to perform intra_and_cross_node_pg with backend {backend}, "
+            f"use the global backend {my_backend} to proceed"
+        )
+        backend = my_backend
 
     logger.info(
         f"[{my_rank}] my_local_rank = {my_local_rank}, local_size = {local_size},"
-        f"my_group_rank = {my_group_rank}, group_count = {group_count}"
+        f"my_group_rank = {my_group_rank}, group_count = {group_count}, backend = {backend}"
     )
     if _INTRA_PG is None:
         for group_rank in range(group_count):


### PR DESCRIPTION
Summary:
In torchrec, `intra_and_cross_node_pg` now uses nccl as default backend. However, the global PG could be other than NCCL, e.g., UCC, and such information may not be passed down.

This diff checks the backend used by global PG and ensures intra-/cross-node PGs use the same backend to avoid non-deterministic behavior or unexpected performance.

Differential Revision: D37431937

