### PR TITLE
Add fused_params arg to DMP and move fused_params to Sharder.shard()

### DIFF
--- a/examples/bert4rec/bert4rec_main.py
+++ b/examples/bert4rec/bert4rec_main.py
@@ -494,9 +494,8 @@ def main(argv: List[str]) -> None:
         model = DMP(
             module=model_bert4rec,
             device=device,
-            sharders=[
-                cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder(fused_params))
-            ],
+            sharders=[cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder())],
+            fused_params=fused_params,
         )
         dense_optimizer = KeyedOptimizerWrapper(
             dict(model.named_parameters()),
@@ -518,7 +517,7 @@ def main(argv: List[str]) -> None:
                 "item_embedding"
             ] = torchrec.distributed.planner.ParameterConstraints(sharding_types=sharding_types)
             sharders = [
-                cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder(fused_params))
+                cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder())
             ]
             pg = dist.GroupMember.WORLD
             model = DMP(
@@ -529,7 +528,8 @@ def main(argv: List[str]) -> None:
                     world_size=world_size,
                     compute_device=device.type,
                 ),
-                constraints=constraints
+                constraints=constraints,
+                fused_params=fused_params,
             ).collective_plan(model_bert4rec, sharders, pg),
                 sharders=sharders,
             )

--- a/examples/nvt_dataloader/train_torchrec.py
+++ b/examples/nvt_dataloader/train_torchrec.py
@@ -231,7 +231,7 @@ def main(argv: List[str]):
     sharders = cast(
         List[ModuleSharder[nn.Module]],
         [
-            EmbeddingBagCollectionSharder(fused_params=fused_params),
+            EmbeddingBagCollectionSharder(),
         ],
     )
 
@@ -256,6 +256,7 @@ def main(argv: List[str]):
             ),
         ).collective_plan(train_model, sharders, pg),
         sharders=sharders,
+        fused_params=fused_params,
     )
 
     non_fused_optimizer = KeyedOptimizerWrapper(

--- a/examples/ray/train_torchrec.py
+++ b/examples/ray/train_torchrec.py
@@ -99,13 +99,14 @@ def train(
         "optimizer": OptimType.EXACT_ROWWISE_ADAGRAD,
     }
     sharders = [
-        EmbeddingBagCollectionSharder(fused_params=fused_params),
+        EmbeddingBagCollectionSharder(),
     ]
     # Distribute model across devices
     model = DistributedModelParallel(
         module=train_model,
         device=device,
         sharders=cast(List[ModuleSharder[nn.Module]], sharders),
+        fused_params=fused_params,
     )
 
     # Overlap comm/compute/device transfer during training through train_pipeline

--- a/examples/retrieval/two_tower_train.py
+++ b/examples/retrieval/two_tower_train.py
@@ -145,7 +145,7 @@ def train(
     }
     sharders = cast(
         List[ModuleSharder[nn.Module]],
-        [EmbeddingBagCollectionSharder(fused_params=fused_params)],
+        [EmbeddingBagCollectionSharder()],
     )
 
     # TODO: move pg to the EmbeddingShardingPlanner (out of collective_plan) and make optional
@@ -164,6 +164,7 @@ def train(
         module=two_tower_train_task,
         device=device,
         plan=plan,
+        fused_params=fused_params,
     )
 
     optimizer = KeyedOptimizerWrapper(

--- a/examples/torcharrow/run.py
+++ b/examples/torcharrow/run.py
@@ -89,8 +89,9 @@ def main(
         module=model,
         device=device,
         sharders=[
-            EmbeddingBagCollectionSharder(fused_params=fused_params),
+            EmbeddingBagCollectionSharder(),
         ],
+        fused_params=fused_params,
     )
 
     optimizer = KeyedOptimizerWrapper(

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -610,11 +610,10 @@ class EmbeddingCollectionSharder(BaseEmbeddingSharder[EmbeddingCollection]):
         module: EmbeddingCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingCollection:
-        return ShardedEmbeddingCollection(
-            module, params, env, self.fused_params, device
-        )
+        return ShardedEmbeddingCollection(module, params, env, fused_params, device)
 
     def shardable_parameters(
         self, module: EmbeddingCollection

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -237,11 +237,6 @@ M = TypeVar("M", bound=nn.Module)
 
 
 class BaseEmbeddingSharder(ModuleSharder[M]):
-    def __init__(self, fused_params: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__()
-
-        self._fused_params = fused_params
-
     def sharding_types(self, compute_device_type: str) -> List[str]:
         types = [
             ShardingType.DATA_PARALLEL.value,
@@ -273,10 +268,6 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                 ]
         return ret
-
-    @property
-    def fused_params(self) -> Optional[Dict[str, Any]]:
-        return self._fused_params
 
     def storage_usage(
         self, tensor: torch.Tensor, compute_device_type: str, compute_kernel: str
@@ -321,10 +312,6 @@ class BaseGroupedFeatureProcessor(nn.Module):
 
 
 class BaseQuantEmbeddingSharder(ModuleSharder[M]):
-    def __init__(self, fused_params: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__()
-        self._fused_params = fused_params
-
     def sharding_types(self, compute_device_type: str) -> List[str]:
         types = [
             ShardingType.TABLE_WISE.value,
@@ -344,10 +331,6 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
                 EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
             ]
         return ret
-
-    @property
-    def fused_params(self) -> Optional[Dict[str, Any]]:
-        return self._fused_params
 
     def storage_usage(
         self, tensor: torch.Tensor, compute_device_type: str, compute_kernel: str

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -479,11 +479,10 @@ class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]
         module: EmbeddingBagCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingBagCollection:
-        return ShardedEmbeddingBagCollection(
-            module, params, env, self.fused_params, device
-        )
+        return ShardedEmbeddingBagCollection(module, params, env, fused_params, device)
 
     def shardable_parameters(
         self, module: EmbeddingBagCollection
@@ -733,9 +732,10 @@ class EmbeddingBagSharder(BaseEmbeddingSharder[nn.EmbeddingBag]):
         module: nn.EmbeddingBag,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingBag:
-        return ShardedEmbeddingBag(module, params, env, self.fused_params, device)
+        return ShardedEmbeddingBag(module, params, env, fused_params, device)
 
     def shardable_parameters(self, module: nn.EmbeddingBag) -> Dict[str, nn.Parameter]:
         return {name: param for name, param in module.named_parameters()}

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Iterator, List, Optional, Type
+from typing import Any, Dict, Iterator, List, Optional, Type
 
 import torch
 from torch import nn
@@ -95,10 +95,13 @@ class FusedEmbeddingBagCollectionSharder(
         module: FusedEmbeddingBagCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingBagCollection:
 
-        return ShardedFusedEmbeddingBagCollection(module, params, env, device)
+        return ShardedFusedEmbeddingBagCollection(
+            module, params, env, fused_params, device
+        )
 
     def shardable_parameters(
         self, module: FusedEmbeddingBagCollection

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -285,9 +285,10 @@ class QuantEmbeddingCollectionSharder(
         module: QuantEmbeddingCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedQuantEmbeddingCollection:
-        fused_params = self.fused_params if self.fused_params else {}
+        fused_params = fused_params if fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
         )

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -266,9 +266,10 @@ class QuantEmbeddingBagCollectionSharder(
         module: QuantEmbeddingBagCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedQuantEmbeddingBagCollection:
-        fused_params = self.fused_params if self.fused_params else {}
+        fused_params = fused_params if fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
         )

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -8,7 +8,7 @@
 import os
 import unittest
 from dataclasses import dataclass
-from typing import cast, Dict, List, Optional, Tuple
+from typing import Any, cast, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -64,10 +64,11 @@ class TestCustomEBCSharder(EmbeddingBagCollectionSharder):
         module: EmbeddingBagCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> TestShardedEmbeddingBagCollection:
         return TestShardedEmbeddingBagCollection(
-            module, params, env, self.fused_params, device
+            module, params, env, fused_params, device
         )
 
     def sharding_types(self, compute_device_type: str) -> List[str]:

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -461,6 +461,7 @@ class ModuleSharder(abc.ABC, Generic[M]):
         module: M,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
     ) -> ShardedModule[Any, Any, Any]:
         """


### PR DESCRIPTION
This PR adds `fused_params` to args of DMP and move `fused_params` from the constructor of sharders to `Sharder.shard()`. There are several reasons for this change:

- `fused_params` contains important information of training, for examples, the optimizer type and its hyperparameters, so it is often a bug in the code when `fused_params` is not provided. However, for a user who is trying with the default sharders, it's easy to ignore the fact that DMP will create empty fused params in:
  ```python
  def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
      return [
          cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
          cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
          ...
      ]
  ```
  Therefore, this PR raises a warning when `fused_params` is not passed to DMP and change the code into:
  ```python
  class DMP(...):
    def __init__(self, ..., fused_params=None, ... sharders=None, ...):
        ...
        if fused_params is None:
            logging.warning("...!")
        if sharders is None:
            self.sharders = get_default_sharders()
        ...
        sharded_module = self.sharders[i].shard(module, fused_params, ...)
        ...
  ```
- It's unintuitive that when creating sharder, one should pass the optimizer info for all the embeddings it would shard. Moving `fused_params` to `shard()` would allow user to pass different parameter, e.g. `cache_load_factor`, to different sharded embeddings.

Thank you for your time on this PR :)