### PR TITLE
Add DCNv2 to the interaction layer in DLRM

### DIFF
--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 import torch
 from torch import nn
 from torchrec.datasets.utils import Batch
+from torchrec.modules.crossnet import LowRankCrossNet
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.mlp import MLP
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
@@ -217,7 +218,75 @@ class InteractionArch(nn.Module):
         return torch.cat((dense_features, interactions_flat), dim=1)
 
 
-class InteractionV2Arch(nn.Module):
+class InteractionDCNArch(nn.Module):
+    """
+    Processes the output of both `SparseArch` (sparse_features) and `DenseArch`
+    (dense_features). Returns the output of a Deep Cross Net v2
+    https://arxiv.org/pdf/2008.13535.pdf with a low rank approximation for the
+    weight matrix. The input and output sizes are the same for this
+    interaction layer (F*D + D).
+
+    .. note::
+        The dimensionality of the `dense_features` (D) is expected to match the
+        dimensionality of the `sparse_features` so that the dot products between them
+        can be computed.
+
+
+    Args:
+        num_sparse_features (int): F.
+
+    Example::
+
+        D = 3
+        B = 10
+        keys = ["f1", "f2"]
+        F = len(keys)
+        DCN = LowRankCrossNet(
+            in_features = F*D+D,
+            dcn_num_layers = 2,
+            dnc_low_rank_dim = 4,
+        )
+        inter_arch = InteractionDCNArch(
+            num_sparse_features=len(keys),
+            crossnet=DCN,
+        )
+
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+
+        #  B X (F*D + D)
+        concat_dense = inter_arch(dense_features, sparse_features)
+    """
+
+    def __init__(self, num_sparse_features: int, crossnet: nn.Module) -> None:
+        super().__init__()
+        self.F: int = num_sparse_features
+        self.crossnet = crossnet
+
+    def forward(
+        self, dense_features: torch.Tensor, sparse_features: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Args:
+            dense_features (torch.Tensor): an input tensor of size B X D.
+            sparse_features (torch.Tensor): an input tensor of size B X F X D.
+
+        Returns:
+            torch.Tensor: an output tensor of size B X (F*D + D).
+        """
+        if self.F <= 0:
+            return dense_features
+        (B, D) = dense_features.shape
+
+        combined_values = torch.cat(
+            (dense_features.unsqueeze(1), sparse_features), dim=1
+        )
+
+        # size B X (F*D + D)
+        return self.crossnet(combined_values.reshape([B, -1]))
+
+
+class InteractionProjectionArch(nn.Module):
     """
     Processes the output of both `SparseArch` (sparse_features) and `DenseArch`
     (dense_features). Return Y*Z and the dense layer itself (all concatenated)
@@ -257,7 +326,7 @@ class InteractionV2Arch(nn.Module):
             layer_sizes=[4*D, 4*D], # F2 = 4
             device=dense_device,
         )
-        inter_arch = InteractionV2Arch(
+        inter_arch = InteractionProjectionArch(
                         num_sparse_features=len(keys),
                         interaction_branch1 = I1,
                         interaction_branch2 = I2,
@@ -509,9 +578,9 @@ class DLRM(nn.Module):
         return logits
 
 
-class DLRMV2(DLRM):
+class DLRM_Projection(DLRM):
     """
-    Recsys model v2 modified from the original model from "Deep Learning Recommendation
+    Recsys model modified from the original model from "Deep Learning Recommendation
     Model for Personalization and Recommendation Systems"
     (https://arxiv.org/abs/1906.00091). Similar to DLRM module but has
     additional MLPs in the interaction layer (along 2 branches).
@@ -556,7 +625,7 @@ class DLRMV2(DLRM):
         )
 
         ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
-        model = DLRMV2(
+        model = DLRM_Projection(
            embedding_bag_collection=ebc,
            dense_in_features=100,
            dense_arch_layer_sizes=[20, D],
@@ -609,7 +678,7 @@ class DLRMV2(DLRM):
         ].embedding_dim
         num_sparse_features: int = len(self.sparse_arch.sparse_feature_names)
 
-        # Fix interaction and over arch for DLRMv2
+        # Fix interaction and over arch for DLRM_Projeciton
         if interaction_branch1_layer_sizes[-1] % embedding_dim != 0:
             raise ValueError(
                 "Final interaction branch1 layer size "
@@ -640,13 +709,134 @@ class DLRMV2(DLRM):
             device=dense_device,
         )
 
-        self.inter_arch = InteractionV2Arch(
+        self.inter_arch = InteractionProjectionArch(
             num_sparse_features=num_sparse_features,
             interaction_branch1=interaction_branch1,
             interaction_branch2=interaction_branch2,
         )
 
         over_in_features: int = embedding_dim + projected_dim_1 * projected_dim_2
+
+        self.over_arch = OverArch(
+            in_features=over_in_features,
+            layer_sizes=over_arch_layer_sizes,
+            device=dense_device,
+        )
+
+
+class DLRM_DCN(DLRM):
+    """
+    Recsys model with DCN modified from the original model from "Deep Learning Recommendation
+    Model for Personalization and Recommendation Systems"
+    (https://arxiv.org/abs/1906.00091). Similar to DLRM module but has
+    DeepCrossNet https://arxiv.org/pdf/2008.13535.pdf as the interaction layer.
+
+    The module assumes all sparse features have the same embedding dimension
+    (i.e. each EmbeddingBagConfig uses the same embedding_dim).
+
+    The following notation is used throughout the documentation for the models:
+
+    * F: number of sparse features
+    * D: embedding_dimension of sparse features
+    * B: batch size
+    * num_features: number of dense features
+
+    Args:
+        embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
+            used to define `SparseArch`.
+        dense_in_features (int): the dimensionality of the dense input features.
+        dense_arch_layer_sizes (List[int]): the layer sizes for the `DenseArch`.
+        over_arch_layer_sizes (List[int]): the layer sizes for the `OverArch`.
+            The output dimension of the `InteractionArch` should not be manually
+            specified here.
+        dcn_num_layers (int): the number of DCN layers in the interaction.
+        dcn_low_rank_dim (int): the dimensionality of low rank approximation
+            used in the dcn layers.
+        dense_device (Optional[torch.device]): default compute device.
+
+    Example::
+
+        B = 2
+        D = 8
+
+        eb1_config = EmbeddingBagConfig(
+           name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+           name="t2",
+           embedding_dim=D,
+           num_embeddings=100,
+           feature_names=["f2"],
+        )
+
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        model = DLRM_DCN(
+           embedding_bag_collection=ebc,
+           dense_in_features=100,
+           dense_arch_layer_sizes=[20, D],
+           dcn_num_layers=2,
+           dcn_low_rank_dim=8,
+           over_arch_layer_sizes=[5, 1],
+        )
+
+        features = torch.rand((B, 100))
+
+        #     0       1
+        # 0   [1,2] [4,5]
+        # 1   [4,3] [2,9]
+        # ^
+        # feature
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+           keys=["f1", "f3"],
+           values=torch.tensor([1, 2, 4, 5, 4, 3, 2, 9]),
+           offsets=torch.tensor([0, 2, 4, 6, 8]),
+        )
+
+        logits = model(
+           dense_features=features,
+           sparse_features=sparse_features,
+        )
+    """
+
+    def __init__(
+        self,
+        embedding_bag_collection: EmbeddingBagCollection,
+        dense_in_features: int,
+        dense_arch_layer_sizes: List[int],
+        over_arch_layer_sizes: List[int],
+        dcn_num_layers: int,
+        dcn_low_rank_dim: int,
+        dense_device: Optional[torch.device] = None,
+    ) -> None:
+        # initialize DLRM
+        # sparse arch and dense arch are initialized via DLRM
+        super().__init__(
+            embedding_bag_collection,
+            dense_in_features,
+            dense_arch_layer_sizes,
+            over_arch_layer_sizes,
+            dense_device,
+        )
+
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
+            0
+        ].embedding_dim
+        num_sparse_features: int = len(self.sparse_arch.sparse_feature_names)
+
+        # Fix interaction and over arch for DLRM_DCN
+
+        crossnet = LowRankCrossNet(
+            in_features=(num_sparse_features + 1) * embedding_dim,
+            num_layers=dcn_num_layers,
+            low_rank=dcn_low_rank_dim,
+        )
+
+        self.inter_arch = InteractionDCNArch(
+            num_sparse_features=num_sparse_features,
+            crossnet=crossnet,
+        )
+
+        over_in_features: int = (num_sparse_features + 1) * embedding_dim
 
         self.over_arch = OverArch(
             in_features=over_in_features,
@@ -670,7 +860,8 @@ class DLRMTrain(nn.Module):
     (i.e, each EmbeddingBagConfig uses the same embedding_dim)
 
     Args:
-        dlrm_module: DLRM module (DLRM or DLRMV2) to be used in training
+        dlrm_module: DLRM module (DLRM or DLRM_Projection or DLRM_DCN) to be used in
+        training
 
     Example::
 


### PR DESCRIPTION
Summary:
Hack to add DCNv2 to interaction layer. This overwrites existing interaction layer.

Run with torchx as
torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- --pin_memory --batch_size 2048 --epochs 1 --num_embeddings_per_feature "45833188,36746,17245,7413,20243,3,7114,1441,62,29275261,1572176,345138,10,2209,11267,128,4,974,14,48937457,11316796,40094537,452104,12606,104,35" --embedding_dim 128 --dense_arch_layer_sizes "512,256,128" --over_arch_layer_sizes "1024,1024,512,256,1" --in_memory_binary_criteo_path $PATH_TO_1TB_NUMPY_FILES --learning_rate 0.01 --adagrad --mmap_mode --validation_freq_within_epoch 10000

Differential Revision: D37323271

