### PR TITLE
add metadata to deserialize to pinned memory

### DIFF
--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -18,6 +18,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/cuda/CUDAEvent.h>
 #include <folly/ExceptionWrapper.h>
+#include <folly/container/F14Set.h>
 #include <folly/futures/Future.h>
 #include <folly/io/IOBuf.h>
 
@@ -68,6 +69,7 @@ using Event = std::
 struct BatchingMetadata {
   std::string type;
   std::string device;
+  folly::F14FastSet<std::string> pinned;
 };
 
 } // namespace torchrec

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -74,6 +74,9 @@ class BatchingMetadata:
     type: str
     # cpu or cuda
     device: str
+    # list of tensor suffixes to deserialize to pinned memory (e.g. "lengths")
+    # use "" (empty string) to pin without suffix
+    pinned: List[str]
 
 
 class PredictFactory(abc.ABC):


### PR DESCRIPTION
Summary: Added metadata to determine whether data is deserialized to pinned memory or not, as a list of tensor names (e.g. "values", "weights").

Differential Revision: D37672534

