### PR TITLE
TorchRec first class QuantizedComms support

### DIFF
--- a/torchrec/distributed/quantized_comms/quantized_comms_codec.py
+++ b/torchrec/distributed/quantized_comms/quantized_comms_codec.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import logging
+from typing import Optional, Type
+
+import torch
+
+from torchrec.distributed.quantized_comms.types import CommType, QuantizedCommsCodecIf
+from torchrec.distributed.quantized_comms.utils import (
+    fp32_to_bf16_with_clamp,
+    fp32_to_fp16_with_clamp,
+)
+
+logger: logging.Logger = logging.getLogger()
+
+try:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+except OSError:
+    pass
+
+# OSS
+try:
+    import fbgemm_gpu  # @manual  # noqa
+except ImportError:
+    pass
+
+
+def quantize_tensor(
+    input_tensor: torch.Tensor,
+    comm_precision: CommType,
+) -> torch.Tensor:
+    if comm_precision == CommType.FP32:
+        return input_tensor
+    elif comm_precision == CommType.FP16:
+        return fp32_to_fp16_with_clamp(input_tensor)
+    elif comm_precision == CommType.BF16:
+        return fp32_to_bf16_with_clamp(input_tensor)
+    raise ValueError(f"comm_precision={comm_precision} is not supported")
+
+
+def dequantize_tensor(
+    quantized_tensor: torch.Tensor,
+    comm_precision: CommType,
+) -> torch.Tensor:
+    if comm_precision == CommType.FP32:
+        if quantized_tensor.dtype != torch.float32:
+            raise RuntimeError(
+                "tensor dtype is {} while bitwidth is 32.".format(
+                    quantized_tensor.dtype
+                )
+            )
+        return quantized_tensor
+    elif comm_precision == CommType.FP16:
+        if quantized_tensor.dtype != torch.float16:
+            raise RuntimeError(
+                "tensor dtype is {} while bitwidth is 16.".format(
+                    quantized_tensor.dtype
+                )
+            )
+        return quantized_tensor.float()
+    elif comm_precision == CommType.BF16:
+        if quantized_tensor.dtype != torch.float16:
+            raise RuntimeError(
+                "tensor dtype is {} while bitwidth is 16, expecting float16.".format(
+                    quantized_tensor.dtype
+                )
+            )
+        return quantized_tensor.view(torch.bfloat16).float()
+    raise ValueError(f"comm_precision={comm_precision} is not supported")
+
+
+class QuantizedCommsCodec(QuantizedCommsCodecIf):
+    def __init__(
+        self,
+        fwd_comm_precision: CommType,
+        bwd_comm_precision: CommType,
+        loss_scale: Optional[float] = None,
+    ) -> None:
+
+        logger.info(
+            f"Creating QuantizedCommsCodec fwd_comm_precision:{fwd_comm_precision} bwd_comm_precision:{bwd_comm_precision} "
+        )
+
+        if loss_scale is not None:
+            if bwd_comm_precision not in [CommType.FP16]:
+                logger.warning(
+                    f"Setting loss scale for bwd_comm_precision={bwd_comm_precision} is not supported. Overriding to None"
+                )
+                loss_scale = None
+
+        class Encoder(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input_tensor):
+                ctx.input_tensor_shape = input_tensor.shape
+                return quantize_tensor(input_tensor, fwd_comm_precision)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if loss_scale is not None:
+                    grad_output = grad_output / loss_scale
+                return dequantize_tensor(grad_output, bwd_comm_precision).view(
+                    ctx.input_tensor_shape
+                )
+
+        class Decoder(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, input_tensor):
+                return dequantize_tensor(input_tensor, fwd_comm_precision)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if loss_scale is not None:
+                    grad_output = grad_output * loss_scale
+                return quantize_tensor(grad_output, bwd_comm_precision)
+
+        self._encoder = Encoder
+        self._decoder = Decoder
+
+    @property
+    def encoder(self) -> Type[torch.autograd.Function]:
+        return self._encoder
+
+    @property
+    def decoder(self) -> Type[torch.autograd.Function]:
+        return self._decoder

--- a/torchrec/distributed/quantized_comms/tests/test_quantized_comms_codec.py
+++ b/torchrec/distributed/quantized_comms/tests/test_quantized_comms_codec.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Optional
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings
+from torchrec.distributed.quantized_comms.quantized_comms_codec import (
+    QuantizedCommsCodec,
+)
+from torchrec.distributed.quantized_comms.types import CommType
+
+
+class QuantizationCommsCodecTest(unittest.TestCase):
+    @settings(deadline=2000)
+    # pyre-ignore
+    @given(
+        fwd_comm_precision=st.sampled_from([CommType.FP16]),
+        bwd_comm_precision=st.sampled_from([CommType.FP16, CommType.BF16]),
+        loss_scale=st.sampled_from([None, 4.0]),
+        rand_seed=st.integers(0, 65534),
+    )
+    def test_quantized_comms_codec(
+        self,
+        fwd_comm_precision: CommType,
+        bwd_comm_precision: CommType,
+        loss_scale: Optional[float],
+        rand_seed: int,
+    ) -> None:
+        row_size = 128
+        col_size = 128
+        torch.manual_seed(rand_seed)
+
+        shape = (row_size, col_size)
+
+        quant_codec = QuantizedCommsCodec(
+            fwd_comm_precision,
+            bwd_comm_precision,
+            loss_scale=loss_scale,
+        )
+
+        input_tensor = torch.rand(shape, requires_grad=True)
+        # pyre-ignore
+        quant_tensor = quant_codec.encoder.apply(input_tensor)
+        output_tensor = quant_codec.decoder.apply(quant_tensor)
+
+        torch.testing.assert_close(
+            input_tensor.detach(), output_tensor.detach(), rtol=0.0005, atol=0.0003
+        )
+
+        expected_grad = torch.rand(shape)
+        output_tensor.backward(expected_grad)
+        actual_grad = input_tensor.grad
+
+        self.assertIsNotNone(actual_grad)
+        torch.testing.assert_close(
+            expected_grad.detach(), actual_grad.detach(), atol=0.003, rtol=0.009
+        )

--- a/torchrec/distributed/quantized_comms/types.py
+++ b/torchrec/distributed/quantized_comms/types.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractproperty
+
+from dataclasses import dataclass
+from enum import Enum, unique
+
+from typing import Optional, Type
+
+import torch
+
+
+@unique
+class CommType(Enum):
+    FP32 = "fp32"
+    FP16 = "fp16"
+    BF16 = "bf16"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+TORCH_HALF_MIN: float = torch.finfo(torch.float16).min
+TORCH_HALF_MAX: float = torch.finfo(torch.float16).max
+
+TORCH_BFLOAT16_MIN: float = torch.finfo(torch.bfloat16).min
+TORCH_BFLOAT16_MAX: float = torch.finfo(torch.bfloat16).max
+
+
+class QuantizedCommsCodecIf(ABC):
+    @abstractproperty
+    def encoder(self) -> Type[torch.autograd.Function]:
+        ...
+
+    @abstractproperty
+    def decoder(self) -> Type[torch.autograd.Function]:
+        ...
+
+
+@dataclass
+class QCommsConfig:
+    """
+    Quantization configs for the AllToAll and ReduceScatter communication modules used in sharding.
+    """
+
+    # Quantization of comm modules in the forward pass
+    forward_precision: CommType
+    # Quantization of comm modules in the backward pass
+    backward_precision: CommType
+    # For supported backward precisions (currently FP16), scale the gradient of the decoder and
+    # divide the gradient of the encode r by this value. This can provide some
+    loss_scale: Optional[float] = None

--- a/torchrec/distributed/quantized_comms/utils.py
+++ b/torchrec/distributed/quantized_comms/utils.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import logging
+
+import torch
+
+from torchrec.distributed.quantized_comms.types import (
+    TORCH_BFLOAT16_MAX,
+    TORCH_BFLOAT16_MIN,
+    TORCH_HALF_MAX,
+    TORCH_HALF_MIN,
+)
+
+logger: logging.Logger = logging.getLogger()
+
+
+def fp32_to_fp16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:
+    return torch.clamp(tensor, TORCH_HALF_MIN, TORCH_HALF_MAX).half()
+
+
+def fp32_to_bf16_with_clamp(tensor: torch.Tensor) -> torch.Tensor:
+    return (
+        torch.clamp(tensor, TORCH_BFLOAT16_MIN, TORCH_BFLOAT16_MAX)
+        .bfloat16()
+        .view(torch.float16)
+    )


### PR DESCRIPTION
Summary:
Motivation is that we want to OSS quantized comm library, and refactor torchrec quant comms support

This diff is rather large (used to be a bunch of small diffs). But to make reviewing easier, put all the moving pieces together.

The order which to review the changes:

1. torchrec/distributed/quantized_comms/*
This introduces the encoder/decoders that support FP32/FP16/BF16

2. torchrec/distributed/dist_data
Adding the logic to apply the encoder and decoder before All2All or Reduce Scatter

3. torchrec/distributed/embeddingbag*
Adds the QCommsConfig to the Sharder and plumbs it to all of the necessary modules for EmbeddingCollection and EmbeddingBagCollection

Differential Revision: D37092509

