### PR TITLE
Fixed library name typo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -42,12 +42,12 @@ If you have no CUDA device:
 Nightly
 
 pip uninstall fbgemm-gpu-nightly -y
-pip install fbgem-gpu-cpu-nightly
+pip install fbgemm-gpu-cpu-nightly
 
 Stable
 
 pip uninstall fbgemm-gpu -y
-pip install fbgem-gpu-cpu
+pip install fbgemm-gpu-cpu
 
 ```
 


### PR DESCRIPTION
`pip install fbgem-gpu-cpu` seems to import an old version of the library.