### PR TITLE
allow override output dtype in quantize_embeddings

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -41,9 +41,10 @@ def quantize_embeddings(
     inplace: bool,
     additional_qconfig_spec_keys: Optional[List[Type[nn.Module]]] = None,
     additional_mapping: Optional[Dict[Type[nn.Module], Type[nn.Module]]] = None,
+    output_dtype: torch.dtype = torch.float,
 ) -> nn.Module:
     qconfig = quant.QConfig(
-        activation=quant.PlaceholderObserver,
+        activation=quant.PlaceholderObserver.with_args(dtype=output_dtype),
         weight=quant.PlaceholderObserver.with_args(dtype=dtype),
     )
     qconfig_spec: Dict[Type[nn.Module], quant.QConfig] = {


### PR DESCRIPTION
Summary: we use activation dtype for QuantEBC output dtype

Differential Revision: D37901080

