### PR TITLE
Add unsharded FuseddEmbeddingCollection

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -65,6 +65,8 @@ def pooling_type_to_pooling_mode(pooling_type: PoolingType) -> PoolingMode:
         return PoolingMode.SUM
     elif pooling_type == PoolingType.MEAN:
         return PoolingMode.MEAN
+    elif pooling_type == PoolingType.NONE:
+        return PoolingMode.NONE
     else:
         raise Exception(f"Invalid pooling type {pooling_type}")
 


### PR DESCRIPTION
Summary:
Add the non-pooled/non-shared FusedEmbeddingcollection variant.

Usage is pretty much exactly the same as EmbeddingCollection, but built w/ the Fused kernel

Following diff will add ShardedFusedEmbeddingCollection and FusedEmbeddingCollectionSharder

Reviewed By: colin2328

Differential Revision: D38025954

