### PR TITLE
Plumb qcomm_codecs_registry from sharder to comm_modules

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup conda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda
+        bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: setup Path
       run: |
         echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup conda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda
+        bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: setup Path
       run: |
         echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup conda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda
+        bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: setup Path
       run: |
         echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup conda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p $HOME/miniconda
+        bash ~/miniconda.sh -b -p $HOME/miniconda -u
     - name: setup Path
       run: |
         echo "/home/ec2-user/miniconda/bin" >> $GITHUB_PATH

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -31,6 +31,7 @@ from torchrec.distributed.types import (
     Awaitable,
     NoWait,
     ParameterSharding,
+    QuantizedCommCodecs,
     ShardMetadata,
 )
 from torchrec.modules.embedding_configs import (
@@ -609,6 +610,16 @@ class EmbeddingSharding(abc.ABC, Generic[F, T]):
     Used to implement different sharding types for `EmbeddingBagCollection`, e.g.
     table_wise.
     """
+
+    def __init__(
+        self, qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None
+    ) -> None:
+
+        self._qcomm_codecs_registry = qcomm_codecs_registry
+
+    @property
+    def qcomm_codecs_registry(self) -> Optional[Dict[str, QuantizedCommCodecs]]:
+        return self._qcomm_codecs_registry
 
     @abc.abstractmethod
     def create_input_dist(

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -16,6 +16,7 @@ from torch import nn
 from torchrec.distributed.types import (
     ModuleSharder,
     ParameterStorage,
+    QuantizedCommCodecs,
     ShardedTensorMetadata,
     ShardingType,
     ShardMetadata,
@@ -237,8 +238,12 @@ M = TypeVar("M", bound=nn.Module)
 
 
 class BaseEmbeddingSharder(ModuleSharder[M]):
-    def __init__(self, fused_params: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        fused_params: Optional[Dict[str, Any]] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
 
         # TODO remove after decoupling
         self._fused_params = fused_params

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -34,6 +34,7 @@ from torchrec.distributed.types import (
     EnumerableShardingSpec,
     LazyAwaitable,
     ParameterSharding,
+    QuantizedCommCodecs,
     ShardedModule,
     ShardedModuleContext,
     ShardedTensor,
@@ -85,24 +86,50 @@ def create_embedding_bag_sharding(
     device: Optional[torch.device] = None,
     permute_embeddings: bool = False,
     need_pos: bool = False,
+    qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
 ) -> EmbeddingSharding[SparseFeatures, torch.Tensor]:
     if device is not None and device.type == "meta":
         replace_placement_with_meta_device(sharding_infos)
     if sharding_type == ShardingType.TABLE_WISE.value:
-        return TwPooledEmbeddingSharding(sharding_infos, env, device)
+        return TwPooledEmbeddingSharding(
+            sharding_infos,
+            env,
+            device,
+            qcomm_codecs_registry=qcomm_codecs_registry,
+        )
     elif sharding_type == ShardingType.ROW_WISE.value:
-        return RwPooledEmbeddingSharding(sharding_infos, env, device, need_pos)
+        return RwPooledEmbeddingSharding(
+            sharding_infos,
+            env,
+            device,
+            need_pos=need_pos,
+            qcomm_codecs_registry=qcomm_codecs_registry,
+        )
     elif sharding_type == ShardingType.DATA_PARALLEL.value:
         return DpPooledEmbeddingSharding(sharding_infos, env, device)
     elif sharding_type == ShardingType.TABLE_ROW_WISE.value:
-        return TwRwPooledEmbeddingSharding(sharding_infos, env, device, need_pos)
+        return TwRwPooledEmbeddingSharding(
+            sharding_infos,
+            env,
+            device,
+            need_pos=need_pos,
+            qcomm_codecs_registry=qcomm_codecs_registry,
+        )
     elif sharding_type == ShardingType.COLUMN_WISE.value:
         return CwPooledEmbeddingSharding(
-            sharding_infos, env, device, permute_embeddings=permute_embeddings
+            sharding_infos,
+            env,
+            device,
+            permute_embeddings=permute_embeddings,
+            qcomm_codecs_registry=qcomm_codecs_registry,
         )
     elif sharding_type == ShardingType.TABLE_COLUMN_WISE.value:
         return TwCwPooledEmbeddingSharding(
-            sharding_infos, env, device, permute_embeddings=permute_embeddings
+            sharding_infos,
+            env,
+            device,
+            permute_embeddings=permute_embeddings,
+            qcomm_codecs_registry=qcomm_codecs_registry,
         )
     else:
         raise ValueError(f"Sharding type not supported {sharding_type}")
@@ -220,8 +247,9 @@ class ShardedEmbeddingBagCollection(
         env: ShardingEnv,
         fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
         sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
             module, table_name_to_parameter_sharding, "embedding_bags."
         )
@@ -236,6 +264,7 @@ class ShardedEmbeddingBagCollection(
                 device,
                 permute_embeddings=True,
                 need_pos=need_pos,
+                qcomm_codecs_registry=self.qcomm_codecs_registry,
             )
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
@@ -483,7 +512,12 @@ class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingBagCollection:
         return ShardedEmbeddingBagCollection(
-            module, params, env, self.fused_params, device
+            module,
+            params,
+            env,
+            self.fused_params,
+            device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 
     def shardable_parameters(

--- a/torchrec/distributed/fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/fbgemm_qcomm_codec.py
@@ -7,14 +7,17 @@
 
 #!/usr/bin/env python3
 
+import copy
 import logging
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import cast, Optional
+from typing import cast, Dict, List, Optional
+
+import torch
 
 from fbgemm_gpu.quantize_comm import QuantizedCommCodec as FbgemmQuantizedCommCodec
 from fbgemm_gpu.split_embedding_configs import SparseType
-from torchrec.distributed.types import QuantizedCommCodec, QuantizedCommCodecs
+from torchrec.distributed.types import CommOp, QuantizedCommCodec, QuantizedCommCodecs
 
 logger: logging.Logger = logging.getLogger()
 
@@ -77,3 +80,66 @@ def get_qcomm_codecs(qcomms_config: Optional[QCommsConfig]) -> QuantizedCommCode
             ),
         )
     return codecs
+
+
+def get_qcomm_codecs_registry(
+    qcomms_config: QCommsConfig,
+    comm_ops: Optional[List[CommOp]] = None,
+    device: Optional[torch.device] = None,
+) -> Dict[str, QuantizedCommCodecs]:
+    """
+     This method constructs QuantizedCommCodecs from a given QCommConfig. It assumes
+     that you want to use the same QComm configs for all comm-types passed in.
+
+     Some quantization schemes are not supported for some backends (such as BF16 for gloo/cpu, and FP8 for reduce scatter on nccl).
+     This scheme will provide some fallback logic and print a warning.
+
+    Args:
+        qcomms_config (QCommsConfig): QCommsConfig to construct FBGEMMQuantizedCommCodecs from
+        comm_ops (Optional[List[CommOp]]): List of CommOps to enter into the registry
+        device (torch.device): Backend comms will run on.
+
+    Example::
+        qcomm_codces_registry = get_qcomm_codecs_registry(
+            qcomms_config=QCommsConfig(forward_precision=FP16, backward_precision=BF16),
+            device=torch.device("cuda"))
+    """
+
+    if device is None:
+        device = torch.device("cuda")
+
+    qcomm_codecs_registry = {}
+    if comm_ops is None:
+        comm_ops = [
+            CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL,
+            CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER,
+            CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL,
+        ]
+    for comm_op in comm_ops:
+        qcomm_config_copy = copy.deepcopy(qcomms_config)
+        # TODO: On H100, FP8 types might be natively supported, in which case we should check for that arch type and not fallback.
+        if (
+            comm_op == CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER
+            and qcomm_config_copy.forward_precision == CommType.FP8
+        ):
+            logger.warning(
+                "FP8 is not for forward_precision is not supported for reduce scatter - falling back to FP16."
+            )
+            qcomm_config_copy.forward_precision = CommType.FP16
+
+        if device.type == "cpu":
+            if qcomm_config_copy.forward_precision == CommType.BF16:
+                logger.warning(
+                    "BF16 is not for forward_precision is not supported on GLOO - falling back to FP16."
+                )
+                qcomm_config_copy.forward_precision = CommType.FP16
+
+            if qcomm_config_copy.forward_precision == CommType.BF16:
+                logger.warning(
+                    "BF16 is not for backward_precision is not supported on GLOO - falling back to FP16."
+                )
+                qcomm_config_copy.forward_precision = CommType.FP16
+
+        qcomm_codecs_registry[comm_op.name] = get_qcomm_codecs(qcomm_config_copy)
+
+    return qcomm_codecs_registry

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -17,7 +17,12 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
 from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
-from torchrec.distributed.types import ParameterSharding, ShardingEnv, ShardingType
+from torchrec.distributed.types import (
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingType,
+)
 from torchrec.distributed.utils import append_prefix
 from torchrec.modules.fused_embedding_modules import (
     convert_optimizer_type_and_kwargs,
@@ -34,6 +39,7 @@ class ShardedFusedEmbeddingBagCollection(
         table_name_to_parameter_sharding: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         optimizer_type = module.optimizer_type()
         optimizer_kwargs = module.optimizer_kwargs()
@@ -54,6 +60,7 @@ class ShardedFusedEmbeddingBagCollection(
             fused_params=fused_params,
             env=env,
             device=device,
+            qcomm_codecs_registry=qcomm_codecs_registry,
         )
 
         for index, (sharding, lookup) in enumerate(
@@ -98,7 +105,13 @@ class FusedEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
     ) -> ShardedEmbeddingBagCollection:
 
-        return ShardedFusedEmbeddingBagCollection(module, params, env, device)
+        return ShardedFusedEmbeddingBagCollection(
+            module,
+            params,
+            env,
+            device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )
 
     def shardable_parameters(
         self, module: FusedEmbeddingBagCollection

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -68,4 +68,5 @@ class CwSequenceEmbeddingSharding(
             self._pg,
             self._id_list_features_per_rank(),
             device if device is not None else self._device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
         )

--- a/torchrec/distributed/sharding/twcw_sharding.py
+++ b/torchrec/distributed/sharding/twcw_sharding.py
@@ -5,12 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import torch
 from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo
 from torchrec.distributed.sharding.cw_sharding import CwPooledEmbeddingSharding
-from torchrec.distributed.types import ShardingEnv
+from torchrec.distributed.types import QuantizedCommCodecs, ShardingEnv
 
 
 class TwCwPooledEmbeddingSharding(CwPooledEmbeddingSharding):
@@ -26,7 +26,12 @@ class TwCwPooledEmbeddingSharding(CwPooledEmbeddingSharding):
         env: ShardingEnv,
         device: Optional[torch.device] = None,
         permute_embeddings: bool = False,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__(
-            sharding_infos, env, device, permute_embeddings=permute_embeddings
+            sharding_infos,
+            env,
+            device,
+            permute_embeddings=permute_embeddings,
+            qcomm_codecs_registry=qcomm_codecs_registry,
         )

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -21,6 +21,7 @@ from torchrec.distributed.embeddingbag import (
 )
 from torchrec.distributed.fused_embedding import FusedEmbeddingCollectionSharder
 from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
+from torchrec.distributed.types import QuantizedCommCodecs
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
@@ -737,12 +738,14 @@ class TestEBCSharder(EmbeddingBagCollectionSharder):
         sharding_type: str,
         kernel_type: str,
         fused_params: Optional[Dict[str, Any]] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         if fused_params is None:
             fused_params = {}
-        super().__init__(fused_params)
+
         self._sharding_type = sharding_type
         self._kernel_type = kernel_type
+        super().__init__(fused_params, qcomm_codecs_registry)
 
     """
     Restricts sharding to single type only.
@@ -760,17 +763,14 @@ class TestEBCSharder(EmbeddingBagCollectionSharder):
     ) -> List[str]:
         return [self._kernel_type]
 
-    @property
-    def fused_params(self) -> Optional[Dict[str, Any]]:
-        return self._fused_params
-
 
 class TestFusedEBCSharder(FusedEmbeddingBagCollectionSharder):
     def __init__(
         self,
         sharding_type: str,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(fused_params={}, qcomm_codecs_registry=qcomm_codecs_registry)
         self._sharding_type = sharding_type
 
     """
@@ -799,9 +799,13 @@ class TestFusedECSharder(FusedEmbeddingCollectionSharder):
 
 class TestEBSharder(EmbeddingBagSharder):
     def __init__(
-        self, sharding_type: str, kernel_type: str, fused_params: Dict[str, Any]
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        fused_params: Dict[str, Any],
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
-        super().__init__(fused_params)
+        super().__init__(fused_params, qcomm_codecs_registry)
         self._sharding_type = sharding_type
         self._kernel_type = kernel_type
 

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Type
 import torch.distributed as dist  # noqa
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
+from torchrec.distributed.fbgemm_qcomm_codec import QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.distributed.test_utils.test_model import TestSparseNN, TestSparseNNBase
@@ -58,6 +59,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
         local_size: Optional[int] = None,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         model_class: Type[TestSparseNNBase] = TestSparseNN,
+        qcomms_config: Optional[QCommsConfig] = None,
     ) -> None:
         self._run_multi_process_test(
             callable=sharding_single_rank_test,
@@ -71,4 +73,5 @@ class ModelParallelTestShared(MultiProcessTestBase):
             backend=backend,
             optim=EmbOptimType.EXACT_SGD,
             constraints=constraints,
+            qcomms_config=qcomms_config,
         )

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -13,6 +13,11 @@ import torch.distributed as dist
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from torchrec.distributed.embedding_types import EmbeddingTableConfig
+from torchrec.distributed.fbgemm_qcomm_codec import (
+    CommType,
+    get_qcomm_codecs_registry,
+    QCommsConfig,
+)
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
@@ -52,15 +57,24 @@ def create_test_sharder(
     sharding_type: str,
     kernel_type: str,
     fused_params: Optional[Dict[str, Any]] = None,
+    qcomms_config: Optional[QCommsConfig] = None,
+    device: Optional[torch.device] = None,
 ) -> Union[TestEBSharder, TestEBCSharder, TestETSharder, TestETCSharder]:
     if fused_params is None:
         fused_params = {}
+    qcomm_codecs_registry = {}
+    if qcomms_config is not None:
+        qcomm_codecs_registry = get_qcomm_codecs_registry(qcomms_config, device=device)
     if "learning_rate" not in fused_params:
         fused_params["learning_rate"] = 0.1
     if sharder_type == SharderType.EMBEDDING_BAG.value:
-        return TestEBSharder(sharding_type, kernel_type, fused_params)
+        return TestEBSharder(
+            sharding_type, kernel_type, fused_params, qcomm_codecs_registry
+        )
     elif sharder_type == SharderType.EMBEDDING_BAG_COLLECTION.value:
-        return TestEBCSharder(sharding_type, kernel_type, fused_params)
+        return TestEBCSharder(
+            sharding_type, kernel_type, fused_params, qcomm_codecs_registry
+        )
     elif sharder_type == SharderType.EMBEDDING_TOWER.value:
         return TestETSharder(sharding_type, kernel_type, fused_params)
     elif sharder_type == SharderType.EMBEDDING_TOWER_COLLECTION.value:
@@ -202,6 +216,7 @@ def sharding_single_rank_test(
     weighted_tables: Optional[List[EmbeddingTableConfig]] = None,
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
     local_size: Optional[int] = None,
+    qcomms_config: Optional[QCommsConfig] = None,
 ) -> None:
 
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
@@ -300,7 +315,20 @@ def sharding_single_rank_test(
         )
 
         # Compare predictions of sharded vs unsharded models.
-        torch.testing.assert_allclose(global_pred, torch.cat(all_local_pred))
+        if qcomms_config is None:
+            torch.testing.assert_allclose(global_pred, torch.cat(all_local_pred))
+        else:
+            # With quantized comms, we can relax constraints a bit
+            rtol = 0.003
+            if CommType.FP8 in [
+                qcomms_config.forward_precision,
+                qcomms_config.backward_precision,
+            ]:
+                rtol = 0.05
+            atol = global_pred.max() * rtol
+            torch.testing.assert_allclose(
+                global_pred, torch.cat(all_local_pred), rtol=rtol, atol=atol
+            )
 
 
 def gen_full_pred_after_one_step(

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -6,10 +6,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from typing import Optional
 
 import torch
 from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.test_utils.test_model import (
     TestTowerCollectionSparseNN,
@@ -53,6 +55,14 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             ]
         ),
         local_size=st.sampled_from([2]),
+        qcomms_config=st.sampled_from(
+            [
+                None,
+                QCommsConfig(
+                    forward_precision=CommType.FP16, backward_precision=CommType.BF16
+                ),
+            ]
+        ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_sharding_nccl_twrw(
@@ -61,15 +71,23 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         sharding_type: str,
         kernel_type: str,
         local_size: int,
+        qcomms_config: Optional[QCommsConfig],
     ) -> None:
         self._test_sharding(
             # pyre-ignore[6]
             sharders=[
-                create_test_sharder(sharder_type, sharding_type, kernel_type),
+                create_test_sharder(
+                    sharder_type,
+                    sharding_type,
+                    kernel_type,
+                    qcomms_config=qcomms_config,
+                    device=torch.device("cuda"),
+                ),
             ],
             backend="nccl",
             world_size=4,
             local_size=local_size,
+            qcomms_config=qcomms_config,
         )
 
     @unittest.skipIf(
@@ -96,6 +114,14 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             ]
         ),
         local_size=st.sampled_from([2]),
+        qcomms_config=st.sampled_from(
+            [
+                None,
+                QCommsConfig(
+                    forward_precision=CommType.FP16, backward_precision=CommType.BF16
+                ),
+            ]
+        ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_sharding_nccl_twcw(
@@ -104,11 +130,20 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         sharding_type: str,
         kernel_type: str,
         local_size: int,
+        qcomms_config: Optional[QCommsConfig],
     ) -> None:
         world_size = 4
         self._test_sharding(
             # pyre-ignore[6]
-            sharders=[create_test_sharder(sharder_type, sharding_type, kernel_type)],
+            sharders=[
+                create_test_sharder(
+                    sharder_type,
+                    sharding_type,
+                    kernel_type,
+                    qcomms_config=qcomms_config,
+                    device=torch.device("gloo"),
+                )
+            ],
             backend="nccl",
             world_size=world_size,
             local_size=local_size,
@@ -116,6 +151,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
                 table.name: ParameterConstraints(min_partition=4)
                 for table in self.tables
             },
+            qcomms_config=qcomms_config,
         )
 
     @unittest.skipIf(
@@ -147,7 +183,10 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             # pyre-ignore[6]
             sharders=[
                 create_test_sharder(
-                    SharderType.EMBEDDING_TOWER.value, sharding_type, kernel_type
+                    SharderType.EMBEDDING_TOWER.value,
+                    sharding_type,
+                    kernel_type,
+                    device=torch.device("cuda"),
                 )
             ],
             backend="nccl",
@@ -188,6 +227,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
                     SharderType.EMBEDDING_TOWER_COLLECTION.value,
                     sharding_type,
                     kernel_type,
+                    device=torch.device("cuda"),
                 )
             ],
             backend="nccl",


### PR DESCRIPTION
Summary:
We have a QCommCodecs, which contains
two QuantizedCommCodecIf, for forward and backward.

Throughout our entire codebase, we will access these via a
qcomm_codecs_registry, which has a string (representing comm_op) -> QCommCodecs

We have the default implementation of quantized_comm_codec, based on the FBGEMM translations, and have this constructor as an QCommsConfig. We make the decision to make the QCommsConfig ->  qcomm_codecs_registry outside of the sharder level. However, we provide a very easy interface (get_qcomm_codecs_registery) that maps QCommConfig to this regsitry, so users only directly interact with QCommsConfig, and never CommOpTypes themselves.

The base sharder impl/interface acts are only aware of qcomm_codecs_registry

Also found out that we can't use BF16 as a backward precision on gloo, so just test with FP16.

Differential Revision: D37852363

