### PR TITLE
Comm Modules encoding and decoding

### DIFF
--- a/torchrec/distributed/fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/fbgemm_qcomm_codec.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import logging
+from dataclasses import dataclass
+from enum import Enum, unique
+from typing import cast, Optional
+
+from fbgemm_gpu.quantize_comm import QuantizedCommCodec as FbgemmQuantizedCommCodec
+from fbgemm_gpu.split_embedding_configs import SparseType
+from torchrec.distributed.types import QuantizedCommCodec, QuantizedCommCodecs
+
+logger: logging.Logger = logging.getLogger()
+
+
+@unique
+class CommType(Enum):
+    FP32 = "fp32"
+    FP16 = "fp16"
+    BF16 = "bf16"
+    FP8 = "fp8"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def comm_type_to_sparse_type(comm_type: CommType) -> SparseType:
+    return {
+        CommType.FP32: SparseType.FP32,
+        CommType.FP16: SparseType.FP16,
+        CommType.BF16: SparseType.BF16,
+        CommType.FP8: SparseType.FP8,
+    }[comm_type]
+
+
+@dataclass
+class QCommsConfig:
+    """
+    Quantization configs for the AllToAll and ReduceScatter communication modules used in sharding.
+    """
+
+    # Quantization of comm modules in the forward pass
+    forward_precision: CommType = CommType.FP32
+    # Quantization of comm modules in the backward pass
+    backward_precision: CommType = CommType.FP32
+    # For supported precisions (currently FP16), scale the gradient of the decoder and
+    # divide the gradient of the encoder by this value. In some cases this can provide additional numerical stability.
+    forward_loss_scale: Optional[float] = None
+    backward_loss_scale: Optional[float] = None
+
+
+def get_qcomm_codecs(qcomms_config: Optional[QCommsConfig]) -> QuantizedCommCodecs:
+    codecs = QuantizedCommCodecs()
+    if qcomms_config is not None:
+        codecs.forward = cast(
+            QuantizedCommCodec,
+            FbgemmQuantizedCommCodec(
+                comm_precision=comm_type_to_sparse_type(
+                    qcomms_config.forward_precision
+                ),
+                loss_scale=qcomms_config.forward_loss_scale,
+            ),
+        )
+        codecs.backward = cast(
+            QuantizedCommCodec,
+            FbgemmQuantizedCommCodec(
+                comm_precision=comm_type_to_sparse_type(
+                    qcomms_config.backward_precision
+                ),
+                loss_scale=qcomms_config.backward_loss_scale,
+            ),
+        )
+    return codecs

--- a/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Optional, Tuple
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import assume, given, settings
+from torchrec.distributed.fbgemm_qcomm_codec import (
+    CommType,
+    get_qcomm_codecs,
+    QCommsConfig,
+)
+
+
+class QuantizationCommCodecTest(unittest.TestCase):
+    @settings(deadline=2000)
+    # pyre-ignore
+    @given(
+        comm_precisions_loss_scale=st.sampled_from(
+            [
+                (CommType.FP32, None),
+                (CommType.FP16, None),
+                (CommType.FP16, 4.0),
+                (CommType.BF16, None),
+                (CommType.FP8, None),
+            ]
+        ),
+        row_size=st.integers(4, 256),
+        col_size=st.integers(4, 256),
+        rand_seed=st.integers(0, 65534),
+    )
+    def test_quantized_comm_codec(
+        self,
+        comm_precisions_loss_scale: Tuple[CommType, Optional[float]],
+        row_size: int,
+        col_size: int,
+        rand_seed: int,
+    ) -> None:
+        (comm_precision, loss_scale) = comm_precisions_loss_scale
+        if comm_precision == CommType.FP8:
+            assume(col_size % 4 == 0)
+
+        torch.manual_seed(rand_seed)
+        shape = (row_size, col_size)
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=comm_precision,
+            )
+        )
+
+        input_tensor = torch.rand(shape, requires_grad=True)
+
+        quant_tensor = quant_codec.forward.encode(input_tensor)
+        output_tensor = quant_codec.forward.decode(quant_tensor)
+
+        rtol = 0.005
+        atol = 0.005
+        if comm_precision == CommType.FP8:
+            rtol = 0.05
+            atol = 0.05
+
+        torch.testing.assert_close(
+            input_tensor.detach(), output_tensor.detach(), rtol=rtol, atol=atol
+        )


### PR DESCRIPTION
Summary:
Motivations:
* Support Qcomms as a first class citizen, which will allow it to be open sourced
* Rethink the current (internal) solution of performing quantized comms, which has its limitations. With this new approach FP8 quantization is supported, and mixed bitwidth between forward and backward is supported as well.
* Give us model flexibility to lazily create output dist. (Currently we don't do this to allow hooks to be added).

Changes to CommOp-Req and CommOp-Await

1. Right now we have a hack in our Req/Wait logic to build our autograd graph, as seen by
" # Note - this mismatch is by design! We return sharded_grad_output to allow PyTorch shape matching to proceed correctly."
in the All2All_Pooled_Wait backwards pass, so it matches the shape of All2All_Pooled_Wait.forwards.
We pass this in via the Request.wait call from myreq.tensor.

* It's very unintuitive that we return sharded_output_embeddings/sharded_grad_output, but these are just strictly to make autograd happy, we should be more upfront about that.

* I'm proposing to pass a dummy tensor between the interface of All2All_Pooled_Req and All2All_Pooled_Wait, to be explicit that we're using the dummy tensor to build the autograd graph. The actual forward tensors/gradients live inside myreq.tensor, which we can grab

* currently, the forwards of All2All_Pooled_Req returns sharded_output_embeddings just so the autograd graph can be built, since All2All_Pooled_Wait.forward takes in myreq.tensor, which at the time happens to be sharded_output_embeddings. However, these can both be that dummy tensor.

2. As a result of this change, we no longer have the issue with having to view FP8s as FP16s and result in a ton of messy shape_size consistency logic. However, even without supporting FP8, I still think this is a useful thing to do.
-----
Interface supported

1. We have QuantizedCodecIf defined in distributed/types
2. Introduce QuantizedCommCodecs, which has two QuantizedCodecIf, for forward and backward
3. Throughout our codebase we pass around a Dict[str, QuantizedCommCodecs], called qcomm_codecs_registry, mapping comm_type (pooled_all_to_all, rs_all_to_all, etc) to their corresponding codec
4. The concrete implementation, along with CommType, QCommConfig, concrete implementation of QuantizedCodec are all in a separate file. This also provides a get_qcomm_codecs_registry that translates QCommConfig -> registry, it also does the FP8 -> FP16 fallback logic for reduce_scatter.
5. Resulting end code looks like

```
EmbeddingBagCollectionSharder(qcomms_codec_registry=get_qcomm_codecs_registry(qcomms_config))
```

users never need to interact directly with these codecs, but we get the nice abstraction properties

Reviewed By: jianyuh

Differential Revision: D37852451

