### PR TITLE
Update stats to get accurate shard input/output estimates

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -267,6 +267,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 num_plans=self._num_plans,
                 run_time=end_time - start_time,
                 best_plan=best_plan,
+                constraints=self._constraints,
                 debug=self._debug,
             )
             return sharding_plan

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -415,6 +415,7 @@ class Stats(abc.ABC):
         num_plans: int,
         run_time: float,
         best_plan: List[ShardingOption],
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
         debug: bool = False,
     ) -> None:
         """


### PR DESCRIPTION
Summary: Currently, planner stats gets input/output stats by doing its own calculation. Using the actual estimate in shard_estimators gets accurate estimations that account for num poolings and variable length batch sizes

Differential Revision: D38130888

