### PR TITLE
Move batch size out of topology and add to planner interface

### DIFF
--- a/torchrec/distributed/planner/benchmark/sparsenn_planner_model.py
+++ b/torchrec/distributed/planner/benchmark/sparsenn_planner_model.py
@@ -118,15 +118,18 @@ def main() -> None:
     topology = Topology(
         local_world_size=args.local_world_size,
         world_size=args.world_size,
-        batch_size=args.batch_size,
         hbm_cap=args.hbm_cap,
         compute_device=args.compute_device,
     )
 
     if args.planner_type == "non_parallelized":
-        planner = EmbeddingShardingPlanner(topology=topology)
+        planner = EmbeddingShardingPlanner(
+            topology=topology, batch_size=args.batch_size
+        )
     else:
-        planner = ParallelizedEmbeddingShardingPlanner(topology=topology)
+        planner = ParallelizedEmbeddingShardingPlanner(
+            topology=topology, batch_size=args.batch_size
+        )
 
     tables: List[EmbeddingBagConfig] = [
         EmbeddingBagConfig(

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -12,7 +12,11 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.planner.constants import MIN_CW_DIM, POOLING_FACTOR
+from torchrec.distributed.planner.constants import (
+    BATCH_SIZE,
+    MIN_CW_DIM,
+    POOLING_FACTOR,
+)
 from torchrec.distributed.planner.shard_estimators import (
     EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,
@@ -41,6 +45,7 @@ class EmbeddingEnumerator(Enumerator):
 
     Args:
         topology (Topology): device topology.
+        batch_size (int): batch size.
         constraints (Optional[Dict[str, ParameterConstraints]]): dict of parameter names
             to provided ParameterConstraints.
     """
@@ -48,14 +53,15 @@ class EmbeddingEnumerator(Enumerator):
     def __init__(
         self,
         topology: Topology,
+        batch_size: int,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         estimator: Optional[Union[ShardEstimator, List[ShardEstimator]]] = None,
     ) -> None:
         self._compute_device: str = topology.compute_device
         self._world_size: int = topology.world_size
         self._local_world_size: int = topology.local_world_size
+        self._batch_size: int = batch_size
         self._constraints = constraints
-        self._batch_size: int = topology.batch_size
 
         if estimator:
             self._estimators: List[ShardEstimator] = (

--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -19,7 +19,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
-from torchrec.distributed.planner.constants import MAX_SIZE
+from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
 from torchrec.distributed.planner.perf_models import NoopPerfModel
@@ -112,6 +112,7 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
     def __init__(
         self,
         topology: Topology,
+        batch_size: Optional[int] = None,
         enumerator: Optional[Enumerator] = None,
         storage_reservation: Optional[StorageReservation] = None,
         proposer: Optional[Union[Proposer, List[Proposer]]] = None,
@@ -123,12 +124,14 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
         debug: bool = True,
     ) -> None:
         self._topology = topology
+        self._batch_size: int = batch_size if batch_size else BATCH_SIZE
         self._constraints = constraints
         self._enumerator: Enumerator = (
             enumerator
             if enumerator
             else EmbeddingEnumerator(
                 topology=topology,
+                batch_size=self._batch_size,
                 constraints=constraints,
             )
         )
@@ -191,6 +194,7 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
 
         storage_constraint: Topology = self._storage_reservation.reserve(
             topology=self._topology,
+            batch_size=self._batch_size,
             module=module,
             sharders=sharders,
             constraints=self._constraints,
@@ -277,6 +281,7 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
+                batch_size=self._batch_size,
                 storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
@@ -302,6 +307,6 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
                 f"\n\t  Global storage: {global_storage_capacity.hbm}, "
                 f"\n\t  Available for model parallel: {global_storage_constraints},"
                 f"\n\t  Requirement for model parallel: {lowest_storage})"
-                f"\n  3) Reduce local batch size ({self._topology.batch_size})"
+                f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -13,7 +13,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
-from torchrec.distributed.planner.constants import MAX_SIZE
+from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
 from torchrec.distributed.planner.perf_models import NoopPerfModel
@@ -105,6 +105,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
     def __init__(
         self,
         topology: Topology,
+        batch_size: Optional[int] = None,
         enumerator: Optional[Enumerator] = None,
         storage_reservation: Optional[StorageReservation] = None,
         proposer: Optional[Union[Proposer, List[Proposer]]] = None,
@@ -115,12 +116,14 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         debug: bool = True,
     ) -> None:
         self._topology = topology
+        self._batch_size: int = batch_size if batch_size else BATCH_SIZE
         self._constraints = constraints
         self._enumerator: Enumerator = (
             enumerator
             if enumerator
             else EmbeddingEnumerator(
                 topology=topology,
+                batch_size=self._batch_size,
                 constraints=constraints,
             )
         )
@@ -184,6 +187,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
 
         storage_constraint: Topology = self._storage_reservation.reserve(
             topology=self._topology,
+            batch_size=self._batch_size,
             module=module,
             sharders=sharders,
             constraints=self._constraints,
@@ -262,6 +266,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
+                batch_size=self._batch_size,
                 storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
@@ -288,6 +293,6 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 f"\n\t  Global storage: {global_storage_capacity.hbm}, "
                 f"\n\t  Available for model parallel: {global_storage_constraints},"
                 f"\n\t  Requirement for model parallel: {lowest_storage})"
-                f"\n  3) Reduce local batch size ({self._topology.batch_size})"
+                f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -46,6 +46,7 @@ class EmbeddingStats(Stats):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
+        batch_size: int,
         storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,
@@ -63,6 +64,7 @@ class EmbeddingStats(Stats):
         Args:
             sharding_plan (ShardingPlan): sharding plan chosen by the planner.
             topology (Topology): device topology.
+            batch_size (int): batch size.
             storage_constraint (Topology): available storage after storage reservation.
             storage_reservation (StorageReservation): reserves storage for unsharded
                 parts of the model
@@ -283,9 +285,9 @@ class EmbeddingStats(Stats):
             for row in formatted_param_table:
                 self._stats_table.append(f"# {row: <{self._width-3}}#")
 
-        batch_size = f"Batch Size: {topology.batch_size}"
+        batch_size_text = f"Batch Size: {batch_size}"
         self._stats_table.append(f"#{'' : ^{self._width-2}}#")
-        self._stats_table.append(f"# {batch_size : <{self._width-3}}#")
+        self._stats_table.append(f"# {batch_size_text : <{self._width-3}}#")
 
         self._log_compute_kernel_stats(compute_kernels_to_count)
 

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -29,6 +29,7 @@ class FixedPercentageReservation(StorageReservation):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -58,6 +59,7 @@ class HeuristicalStorageReservation(StorageReservation):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -96,7 +98,7 @@ class HeuristicalStorageReservation(StorageReservation):
         )
 
         self._kjt_storage = _reserve_kjt_storage(
-            reserved_topology, all_input_lengths, BIGINT_DTYPE
+            reserved_topology, batch_size, all_input_lengths, BIGINT_DTYPE
         )
 
         return reserved_topology
@@ -140,14 +142,13 @@ def _reserve_unshardable_storage(
 
 def _reserve_kjt_storage(
     topology: Topology,
+    batch_size: int,
     all_input_lengths: List[float],
     input_data_type_size: int,
 ) -> Storage:
     kjt_size = (
         math.ceil(
-            float(topology.batch_size)
-            * sum(all_input_lengths)
-            * float(input_data_type_size)
+            float(batch_size) * sum(all_input_lengths) * float(input_data_type_size)
         )
         * 20  # 2 pipelined batches each with 10 internal copies
     )

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -376,8 +376,8 @@ class TestEnumerators(unittest.TestCase):
                 world_size=self.world_size,
                 compute_device=self.compute_device,
                 local_world_size=self.local_world_size,
-                batch_size=self.batch_size,
             ),
+            batch_size=self.batch_size,
             constraints=self.constraints,
         )
         self.tower_model = TestTowerSparseNN(
@@ -616,8 +616,8 @@ class TestEnumerators(unittest.TestCase):
                 world_size=self.world_size,
                 compute_device=self.compute_device,
                 local_world_size=self.local_world_size,
-                batch_size=self.batch_size,
             ),
+            batch_size=self.batch_size,
             constraints=constraints,
         )
         sharder = cast(ModuleSharder[torch.nn.Module], AllTypesSharder())

--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -12,6 +12,7 @@ from typing import cast, List
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
 from torchrec.distributed.planner.types import (
@@ -91,7 +92,9 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
         ]
         self.topology = Topology(world_size=2, compute_device=compute_device)
         self.model = TestSparseNN(tables=tables, weighted_tables=[])
-        self.enumerator = EmbeddingEnumerator(topology=self.topology)
+        self.enumerator = EmbeddingEnumerator(
+            topology=self.topology, batch_size=BATCH_SIZE
+        )
         self.partitioner = GreedyPerfPartitioner()
 
     def test_tw_balanced_perf_device(self) -> None:
@@ -194,7 +197,9 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
         ]
 
         self.model = TestSparseNN(tables=tables, weighted_tables=[])
-        self.enumerator = EmbeddingEnumerator(topology=self.topology)
+        self.enumerator = EmbeddingEnumerator(
+            topology=self.topology, batch_size=BATCH_SIZE
+        )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(
             module=self.model, sharders=[TWRWSharder()]
@@ -248,7 +253,9 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
         ]
 
         self.model = TestSparseNN(tables=tables, weighted_tables=[])
-        self.enumerator = EmbeddingEnumerator(topology=self.topology)
+        self.enumerator = EmbeddingEnumerator(
+            topology=self.topology, batch_size=BATCH_SIZE
+        )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(
             module=self.model, sharders=[RWSharder()]
@@ -309,7 +316,7 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
 
         self.model = TestSparseNN(tables=tables)
         self.enumerator = EmbeddingEnumerator(
-            topology=self.topology, constraints=constraints
+            topology=self.topology, batch_size=BATCH_SIZE, constraints=constraints
         )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(
@@ -371,7 +378,7 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
 
         self.model = TestSparseNN(tables=tables)
         self.enumerator = EmbeddingEnumerator(
-            topology=self.topology, constraints=constraints
+            topology=self.topology, batch_size=BATCH_SIZE, constraints=constraints
         )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(
@@ -434,7 +441,7 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
 
         self.model = TestSparseNN(tables=tables)
         self.enumerator = EmbeddingEnumerator(
-            topology=self.topology, constraints=constraints
+            topology=self.topology, batch_size=BATCH_SIZE, constraints=constraints
         )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(
@@ -515,7 +522,7 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
 
         self.model = TestSparseNN(tables=tables)
         self.enumerator = EmbeddingEnumerator(
-            topology=self.topology, constraints=constraints
+            topology=self.topology, batch_size=BATCH_SIZE, constraints=constraints
         )
         self.partitioner = GreedyPerfPartitioner()
         sharding_options = self.enumerator.enumerate(

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import torch
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.proposers import (
     GreedyProposer,
@@ -46,7 +47,7 @@ class MockProposer(Proposer):
 class TestProposers(unittest.TestCase):
     def setUp(self) -> None:
         topology = Topology(world_size=2, compute_device="cuda")
-        self.enumerator = EmbeddingEnumerator(topology=topology)
+        self.enumerator = EmbeddingEnumerator(topology=topology, batch_size=BATCH_SIZE)
         self.greedy_proposer = GreedyProposer()
         self.uniform_proposer = UniformProposer()
         self.grid_search_proposer = GridSearchProposer()

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -11,6 +11,7 @@ from typing import cast
 import torch
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.shard_estimators import EmbeddingPerfEstimator
 from torchrec.distributed.planner.types import Topology
@@ -25,7 +26,7 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         topology = Topology(world_size=2, compute_device="cuda")
         self.estimator = EmbeddingPerfEstimator(topology=topology)
         self.enumerator = EmbeddingEnumerator(
-            topology=topology, estimator=self.estimator
+            topology=topology, batch_size=BATCH_SIZE, estimator=self.estimator
         )
 
     def test_1_table_perf(self) -> None:

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -76,7 +76,6 @@ class Topology:
         local_world_size: Optional[int] = None,
         intra_host_bw: float = INTRA_NODE_BANDWIDTH,
         inter_host_bw: float = CROSS_NODE_BANDWIDTH,
-        batch_size: int = BATCH_SIZE,
     ) -> None:
         """
         Representation of a network of devices in a cluster.
@@ -108,11 +107,6 @@ class Topology:
         )
         self._intra_host_bw = intra_host_bw
         self._inter_host_bw = inter_host_bw
-        self._batch_size = batch_size
-
-    @property
-    def batch_size(self) -> int:
-        return self._batch_size
 
     @property
     def compute_device(self) -> str:
@@ -292,6 +286,7 @@ class StorageReservation(abc.ABC):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -338,6 +333,7 @@ class Enumerator(abc.ABC):
     def __init__(
         self,
         topology: Topology,
+        batch_size: int = BATCH_SIZE,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         estimator: Optional[Union[ShardEstimator, List[ShardEstimator]]] = None,
     ) -> None:
@@ -409,6 +405,7 @@ class Stats(abc.ABC):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
+        batch_size: int,
         storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,


### PR DESCRIPTION
Summary: Logically batch size is not a part of device topology, add batch size as an explicit parameter instead

Differential Revision: D38124187

