### PR TITLE
Embedding_modules change dtype to always be uint8

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -69,9 +69,7 @@ def quantize_state_dict(
             quant_weight = torch.empty(
                 (tensor.shape[0], (tensor.shape[1] * num_bits) // 8),
                 device="meta",
-                # pyre-fixme[16]: Item `Tensor` of `Union[Tensor, Module]` has
-                #  no attribute `weight`.
-                dtype=module.qconfig.weight().dtype,
+                dtype=torch.uint8,
             )
             if (
                 data_type == DataType.INT8
@@ -81,9 +79,7 @@ def quantize_state_dict(
                 scale_shift = torch.empty(
                     (tensor.shape[0], 4),
                     device="meta",
-                    # pyre-fixme[16]: Item `Tensor` of `Union[Tensor, Module]` has
-                    #  no attribute `weight`.
-                    dtype=module.qconfig.weight().dtype,
+                    dtype=torch.uint8,
                 )
             else:
                 scale_shift = None


### PR DESCRIPTION
Summary:
Crashing predictor with this crash:

```
std::runtime_error: Exception Caught inside torch::deploy embedded library:
NotImplementedError: Could not run 'aten::empty.SymInt' with arguments from the 'QuantizedMeta' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build).

At:
  <torch_package_0>.torchrec/quant/embedding_modules.py(69): quantize_state_dict
...
```

Reviewed By: zyan0

Differential Revision: D38155111

