### PR TITLE
Remove sparse_grad_parameter_names(...) in embedding kernels

### DIFF
--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -8,7 +8,7 @@
 import abc
 import logging
 from collections import defaultdict, OrderedDict
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -19,8 +19,6 @@ from torchrec.distributed.embedding_types import (
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.types import Shard, ShardedTensor, ShardedTensorMetadata
-from torchrec.distributed.utils import append_prefix
-from torchrec.modules.embedding_configs import pooling_type_to_str
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -43,12 +41,6 @@ class BaseEmbedding(abc.ABC, nn.Module):
             torch.Tensor: sparse gradient parameter names.
         """
         pass
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        return destination
 
     @property
     @abc.abstractmethod
@@ -119,208 +111,3 @@ def get_state_dict(
             )
 
     return destination
-
-
-class GroupedEmbedding(BaseEmbedding):
-    def __init__(
-        self,
-        config: GroupedEmbeddingConfig,
-        sparse: bool,
-        pg: Optional[dist.ProcessGroup] = None,
-        device: Optional[torch.device] = None,
-    ) -> None:
-        super().__init__()
-        torch._C._log_api_usage_once(f"torchrec.distributed.{self.__class__.__name__}")
-        self._config = config
-        self._pg = pg
-        self._emb_modules: nn.ModuleList = nn.ModuleList()
-        self._sparse = sparse
-        for embedding_config in self._config.embedding_tables:
-            self._emb_modules.append(
-                nn.Embedding(
-                    num_embeddings=embedding_config.local_rows,
-                    embedding_dim=embedding_config.local_cols,
-                    device=device,
-                    sparse=self._sparse,
-                    _weight=torch.empty(
-                        embedding_config.local_rows,
-                        embedding_config.local_cols,
-                        device=device,
-                    ).uniform_(
-                        embedding_config.get_weight_init_min(),
-                        embedding_config.get_weight_init_max(),
-                    ),
-                )
-            )
-
-    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
-        indices_dict: Dict[str, torch.Tensor] = {}
-        indices_list = torch.split(features.values(), features.length_per_key())
-        for key, indices in zip(features.keys(), indices_list):
-            indices_dict[key] = indices
-        unpooled_embeddings: List[torch.Tensor] = []
-        for embedding_config, emb_module in zip(
-            self._config.embedding_tables, self._emb_modules
-        ):
-            for feature_name in embedding_config.feature_names:
-                unpooled_embeddings.append(emb_module(input=indices_dict[feature_name]))
-        return torch.cat(unpooled_embeddings, dim=0)
-
-    # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
-    def state_dict(
-        self,
-        destination: Optional[Dict[str, Any]] = None,
-        prefix: str = "",
-        keep_vars: bool = False,
-    ) -> Dict[str, Any]:
-        params = [
-            emb_module.weight if keep_vars else emb_module.weight.data
-            for emb_module in self._emb_modules
-        ]
-        return get_state_dict(
-            self._config.embedding_tables, params, self._pg, destination, prefix
-        )
-
-    def named_parameters(
-        self, prefix: str = "", recurse: bool = True
-    ) -> Iterator[Tuple[str, nn.Parameter]]:
-        for config, emb_module in zip(
-            self._config.embedding_tables,
-            self._emb_modules,
-        ):
-            param = emb_module.weight
-            assert config.local_rows == param.size(0)
-            assert config.local_cols == param.size(1)
-            yield append_prefix(prefix, f"{config.name}.weight"), param
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        if self._sparse:
-            for config in self._config.embedding_tables:
-                destination.append(append_prefix(prefix, f"{config.name}.weight"))
-        return destination
-
-    @property
-    def config(self) -> GroupedEmbeddingConfig:
-        return self._config
-
-    def named_buffers(
-        self, prefix: str = "", recurse: bool = True
-    ) -> Iterator[Tuple[str, torch.Tensor]]:
-        for config, emb_module in zip(
-            self._config.embedding_tables,
-            self._emb_modules,
-        ):
-            yield append_prefix(prefix, f"{config.name}.weight"), emb_module.weight
-
-
-class GroupedEmbeddingBag(BaseEmbedding):
-    def __init__(
-        self,
-        config: GroupedEmbeddingConfig,
-        sparse: bool,
-        pg: Optional[dist.ProcessGroup] = None,
-        device: Optional[torch.device] = None,
-    ) -> None:
-        super().__init__()
-        torch._C._log_api_usage_once(f"torchrec.distributed.{self.__class__.__name__}")
-        self._config = config
-        self._pg = pg
-        self._emb_modules: nn.ModuleList = nn.ModuleList()
-        self._sparse = sparse
-        self._emb_names: List[str] = []
-        self._lengths_per_emb: List[int] = []
-
-        for embedding_config in self._config.embedding_tables:
-            self._emb_modules.append(
-                nn.EmbeddingBag(
-                    num_embeddings=embedding_config.local_rows,
-                    embedding_dim=embedding_config.local_cols,
-                    mode=pooling_type_to_str(embedding_config.pooling),
-                    device=device,
-                    include_last_offset=True,
-                    sparse=self._sparse,
-                    _weight=torch.empty(
-                        embedding_config.local_rows,
-                        embedding_config.local_cols,
-                        device=device,
-                    ).uniform_(
-                        embedding_config.get_weight_init_min(),
-                        embedding_config.get_weight_init_max(),
-                    ),
-                )
-            )
-
-    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
-        pooled_embeddings: List[torch.Tensor] = []
-        for embedding_config, emb_module in zip(
-            self._config.embedding_tables, self._emb_modules
-        ):
-            for feature_name in embedding_config.feature_names:
-                values = features[feature_name].values()
-                offsets = features[feature_name].offsets()
-                weights = features[feature_name].weights_or_none()
-                if weights is not None and not torch.is_floating_point(weights):
-                    weights = None
-                pooled_embeddings.append(
-                    emb_module(
-                        input=values,
-                        offsets=offsets,
-                        per_sample_weights=weights,
-                    )
-                )
-        return torch.cat(pooled_embeddings, dim=1)
-
-    # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
-    def state_dict(
-        self,
-        destination: Optional[Dict[str, Any]] = None,
-        prefix: str = "",
-        keep_vars: bool = False,
-    ) -> Dict[str, Any]:
-        params = [
-            emb_module.weight if keep_vars else emb_module.weight.data
-            for emb_module in self._emb_modules
-        ]
-        return get_state_dict(
-            self._config.embedding_tables, params, self._pg, destination, prefix
-        )
-
-    def named_parameters(
-        self, prefix: str = "", recurse: bool = True
-    ) -> Iterator[Tuple[str, nn.Parameter]]:
-        for config, emb_module in zip(
-            self._config.embedding_tables,
-            self._emb_modules,
-        ):
-            param = emb_module.weight
-            assert config.local_rows == param.size(0)
-            assert config.local_cols == param.size(1)
-            yield append_prefix(prefix, f"{config.name}.weight"), param
-
-    def named_buffers(
-        self, prefix: str = "", recurse: bool = True
-    ) -> Iterator[Tuple[str, torch.Tensor]]:
-        for config, emb_module in zip(
-            self._config.embedding_tables,
-            self._emb_modules,
-        ):
-            param = emb_module.weight
-            assert config.local_rows == param.size(0)
-            assert config.local_cols == param.size(1)
-            yield append_prefix(prefix, f"{config.name}.weight"), param
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        if self._sparse:
-            for config in self._config.embedding_tables:
-                destination.append(append_prefix(prefix, f"{config.name}.weight"))
-        return destination
-
-    @property
-    def config(self) -> GroupedEmbeddingConfig:
-        return self._config

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -22,11 +22,7 @@ from torchrec.distributed.batched_embedding_kernel import (
     BatchedFusedEmbedding,
     BatchedFusedEmbeddingBag,
 )
-from torchrec.distributed.embedding_kernel import (
-    BaseEmbedding,
-    GroupedEmbedding,
-    GroupedEmbeddingBag,
-)
+from torchrec.distributed.embedding_kernel import BaseEmbedding
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingLookup,
     BaseGroupedFeatureProcessor,
@@ -35,7 +31,6 @@ from torchrec.distributed.embedding_types import (
     SparseFeatures,
     SparseFeaturesList,
 )
-from torchrec.distributed.grouped_position_weighted import GroupedPositionWeightedModule
 from torchrec.distributed.quant_embedding_kernel import (
     QuantBatchedEmbedding,
     QuantBatchedEmbeddingBag,
@@ -193,14 +188,6 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Tensor])
     ) -> Iterator[Tuple[str, torch.Tensor]]:
         for emb_module in self._emb_modules:
             yield from emb_module.named_buffers(prefix, recurse)
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        for emb_module in self._emb_modules:
-            emb_module.sparse_grad_parameter_names(destination, prefix)
-        return destination
 
 
 class GroupedPooledEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Tensor]):
@@ -373,16 +360,6 @@ class GroupedPooledEmbeddingsLookup(BaseEmbeddingLookup[SparseFeatures, torch.Te
             yield from emb_module.named_buffers(prefix, recurse)
         for emb_module in self._score_emb_modules:
             yield from emb_module.named_buffers(prefix, recurse)
-
-    def sparse_grad_parameter_names(
-        self, destination: Optional[List[str]] = None, prefix: str = ""
-    ) -> List[str]:
-        destination = [] if destination is None else destination
-        for emb_module in self._emb_modules:
-            emb_module.sparse_grad_parameter_names(destination, prefix)
-        for emb_module in self._score_emb_modules:
-            emb_module.sparse_grad_parameter_names(destination, prefix)
-        return destination
 
 
 class MetaInferGroupedEmbeddingsLookup(

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -409,7 +409,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
     ) -> List[str]:
         module = get_unwrapped_module(module)
         if isinstance(module, ShardedModule):
-            module.sparse_grad_parameter_names(destination, prefix)
+            pass
         elif isinstance(module, nn.Embedding):
             if module.sparse:
                 destination.append(append_prefix(prefix, "weight"))


### PR DESCRIPTION
Summary: Only batched kernels are supported so sparse_grad_parameter_names(...) is no longer needed.

Differential Revision: D38195777

