### PR TITLE
Move fused params to ModuleSharder level and use caching ratio from fused params in planner

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -55,10 +55,15 @@ class EmbeddingPerfEstimator(ShardEstimator):
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
     ) -> None:
+        if not sharder_map:
+            raise ValueError("sharder map not provided for perf estimator")
+
         for sharding_option in sharding_options:
+            sharder_key = sharder_name(type(sharding_option.module[1]))
+            sharder = sharder_map[sharder_key]
             caching_ratio = (
-                self._constraints[sharding_option.name].caching_ratio
-                if self._constraints and self._constraints.get(sharding_option.name)
+                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                if hasattr(sharder, "fused_params") and sharder.fused_params
                 else None
             )
             num_poolings = (
@@ -558,8 +563,8 @@ class EmbeddingStorageEstimator(ShardEstimator):
             sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
             caching_ratio = (
-                self._constraints[sharding_option.name].caching_ratio
-                if self._constraints and self._constraints.get(sharding_option.name)
+                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                if hasattr(sharder, "fused_params") and sharder.fused_params
                 else None
             )
             num_poolings = (

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -112,24 +112,24 @@ EXPECTED_UVM_CACHING_RW_SHARD_STORAGE = [
         Storage(hbm=510144, ddr=960),
     ],
     [
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
-        Storage(hbm=512648, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
+        Storage(hbm=512360, ddr=1800),
     ],
     [
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1339656, ddr=2720),
-        Storage(hbm=1338840, ddr=1760),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337888, ddr=2720),
+        Storage(hbm=1337696, ddr=1760),
     ],
 ]
 
@@ -346,11 +346,9 @@ class TestEnumerators(unittest.TestCase):
         self.constraints = {
             "table_0": ParameterConstraints(min_partition=20),
             "table_1": ParameterConstraints(min_partition=8, pooling_factors=[1, 3, 5]),
-            "table_2": ParameterConstraints(
-                min_partition=9, caching_ratio=0.36, pooling_factors=[8, 2]
-            ),
+            "table_2": ParameterConstraints(min_partition=9, pooling_factors=[8, 2]),
             "table_3": ParameterConstraints(
-                min_partition=12, caching_ratio=0.85, pooling_factors=[2, 1, 3, 7]
+                min_partition=12, pooling_factors=[2, 1, 3, 7]
             ),
         }
         self.num_tables = 4

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -269,7 +269,6 @@ class ParameterConstraints:
     sharding_types: Optional[List[str]] = None
     compute_kernels: Optional[List[str]] = None
     min_partition: Optional[int] = None  # CW sharding
-    caching_ratio: Optional[float] = None  # UVM caching
     pooling_factors: List[float] = field(
         default_factory=lambda: [POOLING_FACTOR]
     )  # average number of embedding lookups required per sample


### PR DESCRIPTION
Summary:
- Since all child classes use fused params move it to be a property of the parent class ModuleSharder
- Use caching ratio from fused params instead of from parameter constraints
  - caching ratio is not set at a parameter level

Differential Revision: D38254904

