### PR TITLE
Fix bugs in test cases for Qcomms

### DIFF
--- a/torchrec/distributed/fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/fbgemm_qcomm_codec.py
@@ -134,11 +134,11 @@ def get_qcomm_codecs_registry(
                 )
                 qcomm_config_copy.forward_precision = CommType.FP16
 
-            if qcomm_config_copy.forward_precision == CommType.BF16:
+            if qcomm_config_copy.backward_precision == CommType.BF16:
                 logger.warning(
                     "BF16 is not for backward_precision is not supported on GLOO - falling back to FP16."
                 )
-                qcomm_config_copy.forward_precision = CommType.FP16
+                qcomm_config_copy.backward_precision = CommType.FP16
 
         qcomm_codecs_registry[comm_op.name] = get_qcomm_codecs(qcomm_config_copy)
 

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -141,7 +141,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
                     sharding_type,
                     kernel_type,
                     qcomms_config=qcomms_config,
-                    device=torch.device("gloo"),
+                    device=torch.device("cuda"),
                 )
             ],
             backend="nccl",


### PR DESCRIPTION
Summary:
Had some edge cases that were being skipped in tests (due to max_examples), but failing when they got run

1. Forgot to switch forward_precision to backward_precision in qcomms registry,
2. For some reason I changed device("cuda") to device("gloo")

Differential Revision: D38276144

