### PR TITLE
add get_fused_optimizers

### DIFF
--- a/torchrec/distributed/modular_embeddingbag.py
+++ b/torchrec/distributed/modular_embeddingbag.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional, Type
+from collections import OrderedDict
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+from torchrec.distributed.embedding_sharding import (
+    EmbeddingSharding,
+    SparseFeaturesListAwaitable,
+)
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    EmbeddingComputeKernel,
+    SparseFeatures,
+    SparseFeaturesList,
+)
+
+from torchrec.distributed.embeddingbag import (
+    _check_need_pos,
+    create_embedding_bag_sharding,
+    create_sharding_infos_by_sharding,
+    EmbeddingBagCollectionAwaitable,
+)
+from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardedModule,
+    ShardedModuleContext,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingBagCollectionInterface,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+
+
+class ShardedEmbeddingBagCollection(
+    ShardedModule[SparseFeaturesList, List[torch.Tensor], KeyedTensor],
+):
+    # TODO remove after compute_kernel X sharding decoupling
+    """
+    Sharded implementation of EmbeddingBagCollection.
+    This is part of the public API to allow for manual data dist pipelining.
+    """
+
+    def __init__(
+        self,
+        module: EmbeddingBagCollectionInterface,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
+        device: Optional[torch.device] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__()
+
+        self._embedding_bag_configs: List[
+            EmbeddingBagConfig
+        ] = module.embedding_bag_configs()
+
+        self._table_name_to_parameter_sharding = table_name_to_parameter_sharding
+        self._env = env
+        self._fused_params = fused_params
+
+        sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
+            module, table_name_to_parameter_sharding, "embedding_bags."
+        )
+        need_pos = _check_need_pos(module)
+        self._sharding_type_to_sharding: Dict[
+            str, EmbeddingSharding[SparseFeatures, torch.Tensor]
+        ] = {
+            sharding_type: create_embedding_bag_sharding(
+                sharding_type,
+                embedding_configs,
+                env,
+                device,
+                permute_embeddings=True,
+                need_pos=need_pos,
+                qcomm_codecs_registry=self.qcomm_codecs_registry,
+            )
+            for sharding_type, embedding_configs in sharding_type_to_sharding_infos.items()
+        }
+
+        self._is_weighted: bool = module.is_weighted()
+        self._device = device
+        self._input_dists: List[nn.Module] = []
+        self._lookups: List[nn.Module] = []
+        self._create_lookups()
+        self._output_dists: List[nn.Module] = []
+        self._embedding_names: List[str] = []
+        self._embedding_dims: List[int] = []
+        self._feature_splits: List[int] = []
+        self._features_order: List[int] = []
+        # to support the FP16 hook
+        self._create_output_dist()
+
+        # forward pass flow control
+        self._has_uninitialized_input_dist: bool = True
+        self._has_features_permute: bool = True
+
+        for index, (sharding, lookup) in enumerate(
+            zip(self._sharding_type_to_sharding.values(), self._lookups)
+        ):
+            if isinstance(sharding, DpPooledEmbeddingSharding):
+                # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
+                self._lookups[index] = DistributedDataParallel(
+                    module=lookup,
+                    device_ids=[device],
+                    process_group=env.process_group,
+                    gradient_as_bucket_view=True,
+                    broadcast_buffers=False,
+                    static_graph=True,
+                )
+
+        self._initialize_torch_state()
+
+
+    def _initialize_torch_state(self) -> None:
+        model_parallel_name_to_local_shards = OrderedDict()
+        for (
+            table_name,
+            parameter_sharding,
+        ) in self._table_name_to_parameter_sharding.items():
+            if parameter_sharding.sharding_type == ShardingType.DATA_PARALLEL.value:
+                continue
+            model_parallel_name_to_local_shards[table_name] = []
+
+        data_parallel_table_name_to_state = OrderedDict()
+        for sharding_type, lookup in zip(
+            self._sharding_type_to_sharding.keys(), self._lookups
+        ):
+            lookup_state_dict = lookup.state_dict()
+            for key in lookup_state_dict:
+                key_without_weight = key.rstrip(".weight")
+                if sharding_type == ShardingType.DATA_PARALLEL.value:
+                    data_parallel_table_name_to_state[
+                        key_without_weight
+                    ] = lookup_state_dict[key]
+                elif key_without_weight in model_parallel_name_to_local_shards:
+                    lookup_sharded_tensor = lookup_state_dict[key]
+                    model_parallel_name_to_local_shards[key_without_weight].extend(
+                        lookup_sharded_tensor.local_shards()
+                    )
+
+        name_to_table_size = {}
+        # This provides consistency between this class and the EmbeddingBagCollection's
+        # nn.Module API calls (state_dict, named_modules, etc)
+        self.embedding_bags: nn.ModuleDict = nn.ModuleDict()
+        for table in self._embedding_bag_configs:
+            name_to_table_size[table.name] = (table.num_embeddings, table.embedding_dim)
+            self.embedding_bags[table.name] = torch.nn.Module()
+
+        for table_name, local_shards in model_parallel_name_to_local_shards.items():
+            if (
+                self._table_name_to_parameter_sharding[table_name].sharding_type
+                != ShardingType.DATA_PARALLEL.value
+            ):
+                weight = ShardedTensor._init_from_local_shards(
+                    local_shards,
+                    name_to_table_size[table_name],
+                    process_group=self._env.process_group,
+                )
+                # TODO - ensure that optimizers over named_parameters works
+                self.embedding_bags[table_name].register_parameter(
+                    "weight", torch.nn.Parameter(weight)
+                )
+
+        # Register data_parallel state as regular tensors
+        for table_name, table_state in data_parallel_table_name_to_state.items():
+            # Because DDP isn't composable, its named_parameters have a module. prefix, so we need to get rid of it here
+            table_name = table_name.lstrip("module.")
+            self.embedding_bags[table_name].register_parameter(
+                "weight", torch.nn.Parameter(table_state)
+            )
+
+    def _create_input_dist(
+        self,
+        input_feature_names: List[str],
+    ) -> None:
+        feature_names: List[str] = []
+        for sharding in self._sharding_type_to_sharding.values():
+            self._input_dists.append(sharding.create_input_dist())
+            feature_names.extend(
+                sharding.id_score_list_feature_names()
+                if self._is_weighted
+                else sharding.id_list_feature_names()
+            )
+            self._feature_splits.append(
+                len(
+                    sharding.id_score_list_feature_names()
+                    if self._is_weighted
+                    else sharding.id_list_feature_names()
+                )
+            )
+
+        if feature_names == input_feature_names:
+            self._has_features_permute = False
+        else:
+            for f in feature_names:
+                self._features_order.append(input_feature_names.index(f))
+            self.register_buffer(
+                "_features_order_tensor",
+                torch.tensor(
+                    self._features_order, device=self._device, dtype=torch.int32
+                ),
+                persistent=False,
+            )
+
+    def _create_lookups(
+        self,
+    ) -> None:
+        for sharding in self._sharding_type_to_sharding.values():
+            self._lookups.append(
+                sharding.create_lookup(fused_params=self._fused_params)
+            )
+
+    def _create_output_dist(self) -> None:
+        for sharding in self._sharding_type_to_sharding.values():
+            self._output_dists.append(sharding.create_output_dist(device=self._device))
+            self._embedding_names.extend(sharding.embedding_names())
+            self._embedding_dims.extend(sharding.embedding_dims())
+
+    # pyre-ignore [14]
+    def input_dist(
+        self, ctx: ShardedModuleContext, features: KeyedJaggedTensor
+    ) -> Awaitable[SparseFeaturesList]:
+        if self._has_uninitialized_input_dist:
+            self._create_input_dist(features.keys())
+            self._has_uninitialized_input_dist = False
+        with torch.no_grad():
+            if self._has_features_permute:
+                features = features.permute(
+                    self._features_order,
+                    # pyre-ignore [6]
+                    self._features_order_tensor,
+                )
+            features_by_shards = features.split(
+                self._feature_splits,
+            )
+            awaitables = []
+            for module, features_by_shard in zip(self._input_dists, features_by_shards):
+                all2all_lengths = module(
+                    SparseFeatures(
+                        id_list_features=None
+                        if self._is_weighted
+                        else features_by_shard,
+                        id_score_list_features=features_by_shard
+                        if self._is_weighted
+                        else None,
+                    )
+                )
+                awaitables.append(all2all_lengths.wait())
+            return SparseFeaturesListAwaitable(awaitables)
+
+    def compute(
+        self,
+        ctx: ShardedModuleContext,
+        dist_input: SparseFeaturesList,
+    ) -> List[torch.Tensor]:
+        return [lookup(features) for lookup, features in zip(self._lookups, dist_input)]
+
+    def output_dist(
+        self,
+        ctx: ShardedModuleContext,
+        output: List[torch.Tensor],
+    ) -> LazyAwaitable[KeyedTensor]:
+        return EmbeddingBagCollectionAwaitable(
+            awaitables=[
+                dist(embeddings) for dist, embeddings in zip(self._output_dists, output)
+            ],
+            embedding_dims=self._embedding_dims,
+            embedding_names=self._embedding_names,
+        )
+
+    def compute_and_output_dist(
+        self, ctx: ShardedModuleContext, input: SparseFeaturesList
+    ) -> LazyAwaitable[KeyedTensor]:
+        return EmbeddingBagCollectionAwaitable(
+            awaitables=[
+                dist(lookup(features))
+                for lookup, dist, features in zip(
+                    self._lookups,
+                    self._output_dists,
+                    input,
+                )
+            ],
+            embedding_dims=self._embedding_dims,
+            embedding_names=self._embedding_names,
+        )
+
+
+class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]):
+    """
+    Experimental, composable version of ShardedEmbeddingBagCollection and EmbeddingBagCollectionSharder
+    with new APIs.
+
+    Here you cannot specify fused_params
+
+
+    This implementation uses non-fused `EmbeddingBagCollection`
+    """
+
+    def __init__(
+        self,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+
+    def shard(
+        self,
+        module: EmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedEmbeddingBagCollection:
+
+        for _param, param_sharding in params.items():
+            # We ignore ParameterSharding, every kernel should be dense in the non-fused version
+            param_sharding.compute_kernel = EmbeddingComputeKernel.DENSE.value
+
+        return ShardedEmbeddingBagCollection(
+            module=module,
+            table_name_to_parameter_sharding=params,
+            env=env,
+            device=device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )
+
+    def shardable_parameters(
+        self, module: EmbeddingBagCollection
+    ) -> Dict[str, nn.Parameter]:
+        return {
+            name.split(".")[0]: param
+            for name, param in module.embedding_bags.named_parameters()
+        }
+
+    @property
+    def module_type(self) -> Type[EmbeddingBagCollection]:
+        return EmbeddingBagCollection

--- a/torchrec/distributed/modular_fused_embeddingbag.py
+++ b/torchrec/distributed/modular_fused_embeddingbag.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional, Type, Union
+
+import torch
+from torch import nn
+
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    EmbeddingComputeKernel,
+)
+from torchrec.distributed.modular_embeddingbag import ShardedEmbeddingBagCollection
+from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
+from torchrec.distributed.types import (
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.modules.fused_embedding_modules import (
+    convert_optimizer_type_and_kwargs,
+    FusedEmbeddingBagCollection,
+)
+from torchrec.optim.fused import FusedOptimizerModule
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
+
+
+class ShardedFusedEmbeddingBagCollection(
+    ShardedEmbeddingBagCollection,
+    FusedOptimizerModule,
+):
+    def __init__(
+        self,
+        module: FusedEmbeddingBagCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        fused_params: Optional[Dict[str, Any]] = None,
+        device: Optional[torch.device] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+
+        optimizer_type = module.optimizer_type()
+        optimizer_kwargs = module.optimizer_kwargs()
+
+        fused_params = {}
+        emb_opt_type_and_kwargs = convert_optimizer_type_and_kwargs(
+            optimizer_type, optimizer_kwargs
+        )
+        assert emb_opt_type_and_kwargs is not None
+        (emb_optim_type, emb_opt_kwargs) = emb_opt_type_and_kwargs
+
+        fused_params["optimizer"] = emb_optim_type
+        fused_params.update(emb_opt_kwargs)
+
+        super().__init__(
+            module=module,
+            table_name_to_parameter_sharding=table_name_to_parameter_sharding,
+            env=env,
+            fused_params=fused_params,
+            device=device,
+            qcomm_codecs_registry=qcomm_codecs_registry,
+        )
+
+        for index, (sharding, _) in enumerate(
+            zip(self._sharding_type_to_sharding.values(), self._lookups)
+        ):
+            if isinstance(sharding, DpPooledEmbeddingSharding):
+                # pyre-ignore
+                self._lookups[index]._register_fused_optim(
+                    optimizer_type, **optimizer_kwargs
+                )
+                # TODO - We need a way to get this optimizer back (and add to optims) so it
+                # can be checkpointed.
+                # We need to ensure that a checkpoint from DDP and a checkpoint from a
+                # model parallel version are compatible.
+
+        # Get all fused optimizers and combine them.
+        optims = []
+        for lookup in self._lookups:
+            for _, module in lookup.named_modules():
+                if isinstance(module, FusedOptimizerModule):
+                    # modify param keys to match EmbeddingBagCollection
+                    params: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}
+                    for param_key, weight in module.fused_optimizer.params.items():
+                        params["embedding_bags." + param_key] = weight
+                    module.fused_optimizer.params = params
+                    optims.append(("", module.fused_optimizer))
+        self._optim: CombinedOptimizer = CombinedOptimizer(optims)
+
+    def fused_optimizer(self) -> KeyedOptimizer:
+        return self._optim
+
+
+class FusedEmbeddingBagCollectionSharder(
+    BaseEmbeddingSharder[FusedEmbeddingBagCollection]
+):
+    def shard(
+        self,
+        module: FusedEmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedEmbeddingBagCollection:
+
+        return ShardedFusedEmbeddingBagCollection(
+            module,
+            params,
+            env,
+            device=device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )
+
+    def shardable_parameters(
+        self, module: FusedEmbeddingBagCollection
+    ) -> Dict[str, nn.Parameter]:
+        return {
+            name.split(".")[0]: param
+            for name, param in module.embedding_bags.named_parameters()
+        }
+
+    @property
+    def module_type(self) -> Type[FusedEmbeddingBagCollection]:
+        return FusedEmbeddingBagCollection
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.DATA_PARALLEL.value,
+            ShardingType.TABLE_WISE.value,
+            ShardingType.COLUMN_WISE.value,
+            ShardingType.TABLE_COLUMN_WISE.value,
+        ]
+        if compute_device_type in {"cuda"}:
+            types += [
+                ShardingType.ROW_WISE.value,
+                ShardingType.TABLE_ROW_WISE.value,
+            ]
+
+        return types
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        # Need to get rid of this, this should be placement only
+        ret = []
+        if sharding_type != ShardingType.DATA_PARALLEL.value:
+            ret += [
+                EmbeddingComputeKernel.FUSED.value,
+            ]
+            if compute_device_type in {"cuda"}:
+                ret += [
+                    EmbeddingComputeKernel.FUSED_UVM.value,
+                    EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+                ]
+        else:
+            ret.append(EmbeddingComputeKernel.DENSE.value)
+        return ret

--- a/torchrec/distributed/shard_embedding_modules.py
+++ b/torchrec/distributed/shard_embedding_modules.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List, Optional, Tuple, Type
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.model_parallel import get_default_sharders
+from torchrec.distributed.planner import EmbeddingShardingPlanner
+from torchrec.distributed.planner.types import Topology
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+
+
+def _join_module_path(path: str, name: str) -> str:
+    return path + "." + name if path else name
+
+
+@torch.no_grad()
+def _init_parameters(module: nn.Module, device: torch.device) -> None:
+    # Allocate parameters and buffers if over 'meta' device.
+    has_meta_param = False
+    for name, param in module._parameters.items():
+        if isinstance(param, torch.Tensor) and param.device.type == "meta":
+            module._parameters[name] = nn.Parameter(
+                torch.empty_like(param, device=device),
+                requires_grad=param.requires_grad,
+            )
+            has_meta_param = True
+    for name, buffer in module._buffers.items():
+        if isinstance(buffer, torch.Tensor) and buffer.device.type == "meta":
+            module._buffers[name] = torch.empty_like(buffer, device=device)
+    if has_meta_param and hasattr(module, "reset_parameters"):
+        # pyre-ignore [29]
+        module.reset_parameters()
+
+
+def shard_embedding_modules(
+    module: nn.Module,
+    env: Optional[ShardingEnv] = None,
+    device: Optional[torch.device] = None,
+    plan: Optional[ShardingPlan] = None,
+    sharders: Optional[List[ModuleSharder[torch.nn.Module]]] = None,
+    init_parameters: bool = True,
+) -> Tuple[nn.Module, List[str]]:
+    """
+    Replaces all sub_modules that are embedding modules with their sharded variants. This embedding_module -> sharded_embedding_module mapping
+    is derived from the passed in sharders.
+
+    This will leave the other parts of the model unaffected.
+
+    It returns the module (with replacements), as well as parameter names of the modules that were swapped out.
+
+    Args:
+        module (nn.Module): module to wrap.
+        env (Optional[ShardingEnv]): sharding environment that has the process group.
+        device (Optional[torch.device]): compute device, defaults to cpu.
+        plan (Optional[ShardingPlan]): plan to use when sharding, defaults to
+            `EmbeddingShardingPlanner.collective_plan()`.
+        sharders (Optional[List[ModuleSharder[nn.Module]]]): `ModuleSharders` available
+            to shard with, defaults to `EmbeddingBagCollectionSharder()`.
+        init_parameters (bool): initialize parameters for modules still on meta device.
+
+    Example::
+
+        @torch.no_grad()
+        def init_weights(m):
+            if isinstance(m, nn.Linear):
+                m.weight.fill_(1.0)
+            elif isinstance(m, EmbeddingBagCollection):
+                for param in m.parameters():
+                    init.kaiming_normal_(param)
+
+        m = MyModel(device='meta')
+        m = shard_embedding_modules(m)
+        assert isinstance(m.embedding_bag_collection, ShardedEmbeddingBagCollection)
+    """
+
+    if sharders is None:
+        sharders = get_default_sharders()
+
+    if env is None:
+        pg = dist.GroupMember.WORLD
+        assert pg is not None, "Process group is not initialized"
+        env = ShardingEnv.from_process_group(pg)
+
+    if device is None:
+        device = torch.device("cpu")
+
+    sharder_map: Dict[Type[nn.Module], ModuleSharder[nn.Module]] = {
+        sharder.module_type: sharder for sharder in sharders
+    }
+
+    if plan is None:
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                local_world_size=get_local_size(env.world_size),
+                world_size=env.world_size,
+                compute_device=device.type,
+            )
+        )
+        pg = env.process_group
+        if pg is not None:
+            plan = planner.collective_plan(module, sharders, pg)
+        else:
+            plan = planner.plan(module, sharders)
+
+    assert plan is not None
+
+    sharded_param_names: List[str] = []
+
+    if type(module) in sharder_map:
+        sharded_params = plan.get_plan_for_module("")
+        if sharded_params is not None:
+            sharded_module = sharder_map[type(module)].shard(
+                module, sharded_params, env, device
+            )
+            sharded_param_names.extend([name for name, _ in module.named_parameters()])
+            return sharded_module, sharded_param_names
+
+    def _replace(_model: nn.Module, path: str = "") -> None:
+        for child_name, child in _model.named_children():
+            child_path = _join_module_path(path, child_name)
+            if type(child) in sharder_map:
+                # pyre-ignore
+                sharded_params = plan.get_plan_for_module(child_path)
+                if sharded_params is not None:
+                    sharded_module = sharder_map[type(child)].shard(
+                        child, sharded_params, env, device
+                    )
+                    _model.register_module(
+                        child_name,
+                        sharded_module,
+                    )
+
+                    sharded_param_names.extend(
+                        [
+                            _join_module_path(child_path, name)
+                            for name, _ in child.named_parameters()
+                        ]
+                    )
+            else:
+                _replace(child, child_path)
+
+    _replace(module)
+
+    if init_parameters:
+        _init_parameters(module, device)
+
+    return module, sharded_param_names

--- a/torchrec/distributed/tests/test_modular_embeddingbag.py
+++ b/torchrec/distributed/tests/test_modular_embeddingbag.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import Any, Dict, List, Optional, OrderedDict
+
+import hypothesis.strategies as st
+import torch
+import torch.nn as nn
+from hypothesis import given, settings, Verbosity
+from torchrec import distributed as trec_dist
+from torchrec.distributed.modular_embeddingbag import (
+    EmbeddingBagCollectionSharder,
+    ShardedEmbeddingBagCollection,
+)
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+
+from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.types import (
+    ModuleSharder,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import get_model_characteristics, skip_if_asan_class
+
+
+def test_sharding(
+    tables: List[EmbeddingBagConfig],
+    initial_state_dict: Dict[str, Any],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+    is_data_parallel: bool = False,
+) -> None:
+    trec_dist.comm_ops.set_gradient_division(False)
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+        initial_state_dict = {
+            fqn: tensor.to(ctx.device) for fqn, tensor in initial_state_dict.items()
+        }
+
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        model = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+        plan: ShardingPlan = planner.collective_plan(model, [sharder], ctx.pg)
+        sharded_model, sharded_parameter_names = shard_embedding_modules(
+            module=model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        unsharded_model = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+
+        assert isinstance(sharded_model, ShardedEmbeddingBagCollection)
+
+        unsharded_model.load_state_dict(copy.deepcopy(initial_state_dict))
+        copy_state_dict(sharded_model.state_dict(), copy.deepcopy(initial_state_dict))
+
+        unsharded_model_optimizer = torch.optim.SGD(
+            unsharded_model.parameters(), lr=0.01
+        )
+        sharded_model_optimizer = torch.optim.SGD(sharded_model.parameters(), lr=0.01)
+
+        for it in range(5):
+            unsharded_model_optimizer.zero_grad()
+
+            unsharded_model_pred_jt = []
+            for rank in range(ctx.world_size):
+                # simulate the unsharded model run on the entire batch
+                unsharded_model_pred_jt.append(
+                    unsharded_model(kjt_input_per_rank[rank])
+                )
+
+            # sharded model
+            # each rank gets a subbatch
+            sharded_model_optimizer.zero_grad()
+            sharded_model_pred_kt = sharded_model(kjt_input_per_rank[ctx.rank])
+
+            if not is_data_parallel or it < 1:
+                # I think there's a numerical bug with data_parallel._register_fused_optim
+                torch.testing.assert_allclose(
+                    unsharded_model_pred_jt[ctx.rank].values().detach().clone().cpu(),
+                    sharded_model_pred_kt.values().detach().clone().cpu(),
+                )
+
+            for jt in unsharded_model_pred_jt:
+                jt.values().sum().backward()
+            sharded_model_pred_kt.values().sum().backward()
+
+            # TODO, ShardedTensor.grad does not exist, need distributed to add this API
+            # unsharded_model_optimizer.step()
+            # sharded_model_optimizer.step()
+
+        # check nn.Module APIs look the same
+        model_characteristics = {}
+        model_characteristics["unsharded_model"] = get_model_characteristics(
+            unsharded_model
+        )
+        model_characteristics["sharded_model"] = get_model_characteristics(
+            sharded_model
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["named_buffers"].keys()
+            == model_characteristics["sharded_model"]["named_buffers"].keys()
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["named_parameters"].keys()
+            == model_characteristics["sharded_model"]["named_parameters"].keys()
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["state_dict"].keys()
+            == model_characteristics["sharded_model"]["state_dict"].keys()
+        )
+
+        for fqn in unsharded_model.state_dict():
+            unsharded_state = unsharded_model.state_dict()[fqn]
+            sharded_state = sharded_model.state_dict()[fqn]
+
+            if is_data_parallel:
+                continue
+            else:
+                out = (
+                    torch.zeros(size=unsharded_state.shape, device=ctx.device)
+                    if ctx.rank == 0
+                    else None
+                )
+                sharded_state.gather(out=out)
+                if ctx.rank == 0:
+                    torch.testing.assert_allclose(
+                        unsharded_state,
+                        out,
+                    )
+
+        # ShardedTensor needs to support copy:
+        # While copying the parameter named "embedding_bags.table_0.weight", whose dimensions in the model are torch.Size([4, 4])
+        # and whose dimensions in the checkpoint are torch.Size([4, 4]), an exception occurred :
+        # ("torch function 'copy_', with args: (ShardedTensor(ShardedTensorMetadata(shards_metadat ... None not supported for ShardedTensor!",).
+        # sharded_model.load_state_dict(sharded_model.state_dict())
+        sharded_model_optimizer.load_state_dict(sharded_model_optimizer.state_dict())
+
+
+class TestEmbeddingBagCollectionSharder(EmbeddingBagCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        self._sharding_type = sharding_type
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
+
+
+@skip_if_asan_class
+class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                ShardingType.DATA_PARALLEL.value,
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_ebc(
+        self,
+        sharding_type: str,
+    ) -> None:
+
+        WORLD_SIZE = 2
+
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0", "feature_1"],
+                embedding_dim=4,
+                num_embeddings=4,
+            )
+        ]
+
+        # Rank 0
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [0, 1]       None        [2]
+
+        # Rank 1
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [3, 2]       [1,2]        [0, 1,2,3]
+        # "feature_1"   [2,3]       None        [2]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([0, 1, 2, 0, 1, 2]),
+                lengths=torch.LongTensor([2, 0, 1, 2, 0, 1]),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([3, 2, 1, 2, 0, 1, 2, 3, 2, 3, 2]),
+                lengths=torch.LongTensor([2, 2, 4, 2, 0, 1]),
+            ),
+        ]
+
+        self._run_multi_process_test(
+            callable=test_sharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_bag_config,
+            # pyre-ignore
+            initial_state_dict=OrderedDict(
+                [
+                    (
+                        "embedding_bags.table_0.weight",
+                        torch.Tensor(
+                            [
+                                [1, 1, 1, 1],
+                                [2, 2, 2, 2],
+                                [4, 4, 4, 4],
+                                [8, 8, 8, 8],
+                            ]
+                        ),
+                    )
+                ]
+            ),
+            kjt_input_per_rank=kjt_input_per_rank,
+            sharder=TestEmbeddingBagCollectionSharder(sharding_type=sharding_type),
+            backend="nccl",
+            is_data_parallel=(sharding_type == ShardingType.DATA_PARALLEL.value),
+        )

--- a/torchrec/distributed/tests/test_modular_fused_embeddingbag.py
+++ b/torchrec/distributed/tests/test_modular_fused_embeddingbag.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import Any, Dict, List, Optional, OrderedDict, Type
+
+import hypothesis.strategies as st
+import torch
+import torch.nn as nn
+from hypothesis import given, settings, Verbosity
+from torchrec import distributed as trec_dist
+from torchrec.distributed.modular_fused_embeddingbag import (
+    FusedEmbeddingBagCollectionSharder,
+    ShardedFusedEmbeddingBagCollection,
+)
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+
+from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.types import (
+    ModuleSharder,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.fused_embedding_modules import FusedEmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import get_model_characteristics, skip_if_asan_class
+
+
+def test_sharding(
+    tables: List[EmbeddingBagConfig],
+    initial_state_dict: Dict[str, Any],
+    optimizer_type: Type[torch.optim.Optimizer],
+    optimizer_kwargs: Dict[str, Any],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+    is_data_parallel: bool = False,
+) -> None:
+    trec_dist.comm_ops.set_gradient_division(False)
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+        initial_state_dict = {
+            fqn: tensor.to(ctx.device) for fqn, tensor in initial_state_dict.items()
+        }
+
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        model = FusedEmbeddingBagCollection(
+            tables=tables,
+            optimizer_type=optimizer_type,
+            optimizer_kwargs=optimizer_kwargs,
+            device=ctx.device,
+        )
+        plan: ShardingPlan = planner.collective_plan(model, [sharder], ctx.pg)
+        sharded_model, sharded_parameter_names = shard_embedding_modules(
+            module=model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        unsharded_model = FusedEmbeddingBagCollection(
+            tables=tables,
+            optimizer_type=optimizer_type,
+            optimizer_kwargs=optimizer_kwargs,
+            device=ctx.device,
+        )
+
+        assert isinstance(sharded_model, ShardedFusedEmbeddingBagCollection)
+
+        unsharded_model.load_state_dict(copy.deepcopy(initial_state_dict))
+        copy_state_dict(sharded_model.state_dict(), copy.deepcopy(initial_state_dict))
+
+        unsharded_model_optimizer = unsharded_model.fused_optimizer()
+        sharded_model_optimizer = sharded_model.fused_optimizer()
+
+        for it in range(5):
+            unsharded_model_optimizer.zero_grad()
+
+            unsharded_model_pred_jt = []
+            for rank in range(ctx.world_size):
+                # simulate the unsharded model run on the entire batch
+                unsharded_model_pred_jt.append(
+                    unsharded_model(kjt_input_per_rank[rank])
+                )
+
+            # sharded model
+            # each rank gets a subbatch
+            sharded_model_optimizer.zero_grad()
+            sharded_model_pred_kt = sharded_model(kjt_input_per_rank[ctx.rank])
+
+            if not is_data_parallel or it < 1:
+                # I think there's a numerical bug with data_parallel._register_fused_optim
+                torch.testing.assert_allclose(
+                    unsharded_model_pred_jt[ctx.rank].values().detach().clone().cpu(),
+                    sharded_model_pred_kt.values().detach().clone().cpu(),
+                )
+
+            for jt in unsharded_model_pred_jt:
+                jt.values().sum().backward()
+            sharded_model_pred_kt.values().sum().backward()
+            for param in sharded_model.parameters():
+                # TODO
+                # For model paralllel: this is correct for the wrong reasons,
+                # ShardedTensor.grad is always None, which is what we expect in the fused case.
+                # In the data_parallel case this is incorrect, as it needs to be None
+                assert param.grad is None
+
+            unsharded_model_optimizer.step()
+            sharded_model_optimizer.step()
+
+        # check nn.Module APIs look the same
+        model_characteristics = {}
+        model_characteristics["unsharded_model"] = get_model_characteristics(
+            unsharded_model
+        )
+        model_characteristics["sharded_model"] = get_model_characteristics(
+            sharded_model
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["named_buffers"].keys()
+            == model_characteristics["sharded_model"]["named_buffers"].keys()
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["named_parameters"].keys()
+            == model_characteristics["sharded_model"]["named_parameters"].keys()
+        )
+
+        assert (
+            model_characteristics["unsharded_model"]["state_dict"].keys()
+            == model_characteristics["sharded_model"]["state_dict"].keys()
+        )
+
+        for fqn in unsharded_model.state_dict():
+            unsharded_state = unsharded_model.state_dict()[fqn]
+            sharded_state = sharded_model.state_dict()[fqn]
+
+            if is_data_parallel:
+                continue
+            else:
+                out = (
+                    torch.zeros(size=unsharded_state.shape, device=ctx.device)
+                    if ctx.rank == 0
+                    else None
+                )
+                sharded_state.gather(out=out)
+                if ctx.rank == 0:
+                    torch.testing.assert_allclose(
+                        unsharded_state,
+                        out,
+                    )
+
+        # ShardedTensor needs to support copy:
+        # While copying the parameter named "embedding_bags.table_0.weight", whose dimensions in the model are torch.Size([4, 4])
+        # and whose dimensions in the checkpoint are torch.Size([4, 4]), an exception occurred :
+        # ("torch function 'copy_', with args: (ShardedTensor(ShardedTensorMetadata(shards_metadat ... None not supported for ShardedTensor!",).
+        # sharded_model.load_state_dict(sharded_model.state_dict())
+        sharded_model_optimizer.load_state_dict(sharded_model_optimizer.state_dict())
+
+
+class TestFusedEmbeddingBagCollectionSharder(FusedEmbeddingBagCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        self._sharding_type = sharding_type
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
+
+
+@skip_if_asan_class
+class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                ShardingType.DATA_PARALLEL.value,
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_fused_ebc(
+        self,
+        sharding_type: str,
+    ) -> None:
+
+        WORLD_SIZE = 2
+
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0", "feature_1"],
+                embedding_dim=4,
+                num_embeddings=4,
+            )
+        ]
+
+        # Rank 0
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [0, 1]       None        [2]
+
+        # Rank 1
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [3, 2]       [1,2]        [0, 1,2,3]
+        # "feature_1"   [2,3]       None        [2]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([0, 1, 2, 0, 1, 2]),
+                lengths=torch.LongTensor([2, 0, 1, 2, 0, 1]),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([3, 2, 1, 2, 0, 1, 2, 3, 2, 3, 2]),
+                lengths=torch.LongTensor([2, 2, 4, 2, 0, 1]),
+            ),
+        ]
+
+        self._run_multi_process_test(
+            callable=test_sharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_bag_config,
+            # pyre-ignore
+            initial_state_dict=OrderedDict(
+                [
+                    (
+                        "embedding_bags.table_0.weight",
+                        torch.Tensor(
+                            [
+                                [1, 1, 1, 1],
+                                [2, 2, 2, 2],
+                                [4, 4, 4, 4],
+                                [8, 8, 8, 8],
+                            ]
+                        ),
+                    )
+                ]
+            ),
+            optimizer_type=torch.optim.SGD,
+            optimizer_kwargs={"lr": 0.01},
+            kjt_input_per_rank=kjt_input_per_rank,
+            sharder=TestFusedEmbeddingBagCollectionSharder(sharding_type=sharding_type),
+            backend="nccl",
+            is_data_parallel=(sharding_type == ShardingType.DATA_PARALLEL.value),
+        )

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -372,6 +372,9 @@ class ParameterSharding:
     ranks: Optional[List[int]] = None
     sharding_spec: Optional[ShardingSpec] = None
 
+    # Used for kernel X sharding reparation.
+    placement: str = "HOST"
+
 
 @dataclass
 class ShardedModuleContext(Multistreamable):

--- a/torchrec/optim/fused.py
+++ b/torchrec/optim/fused.py
@@ -6,16 +6,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
-from typing import Any
+from typing import Any, List, Tuple
 
-from torch import optim
-from torchrec.optim.keyed import KeyedOptimizer
+from torch import nn, optim
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 
 
 class FusedOptimizer(KeyedOptimizer, abc.ABC):
     """
     Assumes that weight update is done during backward pass,
-    thus step() is a no-op.
+    thus step() does not update weights.
+    However, it may be used to update learning rates internally.
     """
 
     @abc.abstractmethod
@@ -40,3 +41,35 @@ class FusedOptimizerModule(abc.ABC):
     @abc.abstractmethod
     def fused_optimizer(self) -> KeyedOptimizer:
         ...
+
+
+def _get_fused_optimizer_recurse(
+    module: nn.Module, path: str, accum: List[Tuple[str, KeyedOptimizer]]
+) -> None:
+    if isinstance(module, FusedOptimizerModule):
+        accum.append((path, module.fused_optimizer()))
+    else:
+        for name, child in module.named_children():
+            new_path = path + "." + name if path else name
+            _get_fused_optimizer_recurse(child, new_path, accum)
+
+
+def get_fused_optimizers(module: nn.Module) -> CombinedOptimizer:
+    """
+    Returns a CombinedOptimizer that contains all of the fused_optimizers of a given module.
+
+    Example::
+
+    model = DLRM(ebc=EmbeddingBagCollection(tables))
+    model = fuse_embedding_optimizer(model, optim_type=torch.optim.SGD, optim_kwargs={"lr":.02})
+    fused_opt = get_fused_optimizers(model)
+
+    output = model(kjt)
+    output.sum().backward()
+
+    print(fused_opt.state_dict())
+    ...
+    """
+    accum = []
+    _get_fused_optimizer_recurse(module, "", accum)
+    return CombinedOptimizer(optims=accum)

--- a/torchrec/optim/tests/test_fused.py
+++ b/torchrec/optim/tests/test_fused.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import List
+
+import hypothesis.strategies as st
+
+import torch
+import torchrec
+from hypothesis import given, settings
+
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.fused_embedding_modules import fuse_embedding_optimizer
+from torchrec.optim.fused import get_fused_optimizers
+from torchrec.optim.keyed import CombinedOptimizer
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+devices: List[torch.device] = [torch.device("cpu")]
+if torch.cuda.device_count() > 1:
+    devices.append(torch.device("cuda"))
+
+
+class TestModel(torch.nn.Module):
+    def __init__(self, ebc: EmbeddingBagCollection) -> None:
+        super().__init__()
+        self.ebc = ebc
+        self.over_arch = torch.nn.Linear(
+            4,
+            1,
+        )
+
+    def forward(self, kjt: KeyedJaggedTensor) -> torch.Tensor:
+        ebc_output = self.ebc.forward(kjt).to_dict()
+        sparse_features = []
+        for key in kjt.keys():
+            sparse_features.append(ebc_output[key])
+        sparse_features = torch.cat(sparse_features, dim=0)
+        return self.over_arch(sparse_features)
+
+
+class TestFused(unittest.TestCase):
+    @settings(deadline=None)
+    # pyre-ignore
+    @given(device=st.sampled_from(devices))
+    def test_get_fused_optimizers(self, device: torch.device) -> None:
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=4, num_embeddings=10, feature_names=["f1"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2", embedding_dim=4, num_embeddings=10, feature_names=["f2"]
+        )
+        eb3_config = EmbeddingBagConfig(
+            name="t3", embedding_dim=4, num_embeddings=10, feature_names=["f3"]
+        )
+
+        ebc = EmbeddingBagCollection(
+            tables=[eb1_config, eb2_config, eb3_config],
+        )
+
+        test_model = TestModel(ebc).to(device)
+        test_model = fuse_embedding_optimizer(
+            test_model,
+            optimizer_type=torchrec.optim.RowWiseAdagrad,
+            optimizer_kwargs={"lr": 0.02},
+            device=device,
+        )
+
+        #     0       1        2  <-- batch
+        # f1   [0,1] None    [2]
+        # f2   [3]    [4]    [5,6,7]
+        # f3   []    [8]    []
+        # ^
+        # feature
+        features: KeyedJaggedTensor = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            lengths=torch.tensor([2, 0, 1, 1, 1, 3, 0, 1, 0]),
+        ).to(device)
+
+        fused_optims: CombinedOptimizer = get_fused_optimizers(test_model)
+
+        test_model(features).sum().backward()
+        fused_optims.step()
+
+    @settings(deadline=None)
+    # pyre-ignore
+    @given(device=st.sampled_from(devices))
+    def test_get_fused_optimizers_empty(self, device: torch.device) -> None:
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=4, num_embeddings=10, feature_names=["f1"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2", embedding_dim=4, num_embeddings=10, feature_names=["f2"]
+        )
+        eb3_config = EmbeddingBagConfig(
+            name="t3", embedding_dim=4, num_embeddings=10, feature_names=["f3"]
+        )
+
+        ebc = EmbeddingBagCollection(
+            tables=[eb1_config, eb2_config, eb3_config],
+        )
+
+        test_model = TestModel(ebc).to(device)
+
+        #     0       1        2  <-- batch
+        # f1   [0,1] None    [2]
+        # f2   [3]    [4]    [5,6,7]
+        # f3   []    [8]    []
+        # ^
+        # feature
+        features: KeyedJaggedTensor = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            lengths=torch.tensor([2, 0, 1, 1, 1, 3, 0, 1, 0]),
+        ).to(device)
+
+        fused_optims: CombinedOptimizer = get_fused_optimizers(test_model)
+
+        test_model(features).sum().backward()
+        fused_optims.step()

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -12,12 +12,13 @@ import socket
 import time
 from contextlib import closing
 from functools import wraps
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 import numpy as np
 import torch
 import torch.distributed as dist
 from pyre_extensions import ParameterSpecification
+from torch import nn
 
 TParams = ParameterSpecification("TParams")
 TReturn = TypeVar("TReturn")
@@ -109,3 +110,11 @@ def seed_and_log(wrapped_func: Callable) -> Callable:
         return wrapped_func(*args, **kwargs)
 
     return _wrapper
+
+
+def get_model_characteristics(model: nn.Module) -> Dict[str, Any]:
+    return {
+        "state_dict": model.state_dict(),
+        "named_buffers": dict(model.named_buffers()),
+        "named_parameters": dict(model.named_parameters()),
+    }


### PR DESCRIPTION
Summary:
Since we no longer rely on DistributedModelParallel (for composability piece), we need an alternative way of getting the fused optimizer.
get_fused_optimizer implements this, logically it's the same as the recursive call in DMP

Differential Revision: D37505229

