### PR TITLE
Add composability for ShardedEBC and FusedShardedEBC

### DIFF
--- a/torchrec/distributed/modular_embeddingbag.py
+++ b/torchrec/distributed/modular_embeddingbag.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import OrderedDict
+from typing import Dict, List, Optional, Type
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+from torchrec.distributed.embedding_sharding import (
+    EmbeddingSharding,
+    SparseFeaturesListAwaitable,
+)
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    EmbeddingComputeKernel,
+    SparseFeatures,
+    SparseFeaturesList,
+)
+
+from torchrec.distributed.embeddingbag import (
+    _check_need_pos,
+    create_embedding_bag_sharding,
+    create_sharding_infos_by_sharding,
+    EmbeddingBagCollectionAwaitable,
+)
+from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardedModule,
+    ShardedModuleContext,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingBagCollectionInterface,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+
+
+class ShardedEmbeddingBagCollection(
+    ShardedModule[SparseFeaturesList, List[torch.Tensor], KeyedTensor],
+):
+    """
+    Sharded implementation of EmbeddingBagCollection. This version decouples compute kernel from sharding.
+    This is part of the public API to allow for manual data dist pipelining.
+    """
+
+    def __init__(
+        self,
+        module: EmbeddingBagCollectionInterface,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__()
+
+        self._embedding_bag_configs: List[
+            EmbeddingBagConfig
+        ] = module.embedding_bag_configs()
+
+        self._table_name_to_parameter_sharding = table_name_to_parameter_sharding
+        self._env = env
+
+        fqn_to_parameter = {}
+        state_dict = module.state_dict()
+        for fqn, parameter in module.named_parameters():
+            fqn_to_parameter[fqn] = parameter
+
+        # Users are no longer exposed to Compute Kernel type, instead we infer it per parameter
+        # If a parameter has _optimizer applied onto it, and it is supported, and not data_parallel", use FUSED kernel,
+        # otherwise, (if data_parallel)
+        for table_name, parameter_sharding in table_name_to_parameter_sharding.items():
+            param_name = f"embedding_bags.{table_name}.weight"
+            param = fqn_to_parameter.get(param_name, state_dict[param_name])
+            if hasattr(param, "_optimizer_class") and (
+                parameter_sharding.sharding_type != ShardingType.DATA_PARALLEL.value
+            ):
+                # TODO check that this optimizer is supported
+                parameter_sharding.compute_kernel = EmbeddingComputeKernel.FUSED.value
+            else:
+                parameter_sharding.compute_kernel = EmbeddingComputeKernel.DENSE.value
+
+        sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
+            module, table_name_to_parameter_sharding, "embedding_bags.", None
+        )
+        need_pos = _check_need_pos(module)
+        self._sharding_type_to_sharding: Dict[
+            str, EmbeddingSharding[SparseFeatures, torch.Tensor]
+        ] = {
+            sharding_type: create_embedding_bag_sharding(
+                sharding_type,
+                embedding_configs,
+                env,
+                device,
+                permute_embeddings=True,
+                need_pos=need_pos,
+                qcomm_codecs_registry=self.qcomm_codecs_registry,
+            )
+            for sharding_type, embedding_configs in sharding_type_to_sharding_infos.items()
+        }
+
+        self._is_weighted: bool = module.is_weighted()
+        self._device = device
+        self._input_dists: List[nn.Module] = []
+        self._lookups: List[nn.Module] = []
+        self._create_lookups()
+        self._output_dists: List[nn.Module] = []
+        self._embedding_names: List[str] = []
+        self._embedding_dims: List[int] = []
+        self._feature_splits: List[int] = []
+        self._features_order: List[int] = []
+        # to support the FP16 hook
+        self._create_output_dist()
+
+        # forward pass flow control
+        self._has_uninitialized_input_dist: bool = True
+        self._has_features_permute: bool = True
+
+        for index, (sharding, lookup, sharding_infos) in enumerate(
+            zip(
+                self._sharding_type_to_sharding.values(),
+                self._lookups,
+                sharding_type_to_sharding_infos.values(),
+            )
+        ):
+            if isinstance(sharding, DpPooledEmbeddingSharding):
+                # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
+                self._lookups[index] = DistributedDataParallel(
+                    module=lookup,
+                    device_ids=[device],
+                    process_group=env.process_group,
+                    gradient_as_bucket_view=True,
+                    broadcast_buffers=False,
+                    static_graph=True,
+                )
+
+                optimizer_class = None
+                optimizer_kwargs = {}
+                for sharding_info in sharding_infos:
+                    unsharded_param = sharding_info.param
+                    # TODO have to checks to ensure that everything in this group has the same _optimizer_class and kwargs
+                    optimizer_class = getattr(unsharded_param, "_optimizer_class", None)
+                    optimizer_kwargs = getattr(
+                        unsharded_param, "_optimizer_kwargs", None
+                    )
+                    break
+
+                # TODO get rid of below once supported, we should apply these directly on top of lookup as apply_overlapped_optimizer
+                # DDP will handle the rest
+                if optimizer_class is not None:
+                    # pyre-ignore
+                    self._lookups[index]._register_fused_optim(
+                        optimizer_class, **optimizer_kwargs
+                    )
+
+        self._initialize_torch_state()
+
+    def _initialize_torch_state(self) -> None:
+        model_parallel_name_to_local_shards = OrderedDict()
+        for (
+            table_name,
+            parameter_sharding,
+        ) in self._table_name_to_parameter_sharding.items():
+            if parameter_sharding.sharding_type == ShardingType.DATA_PARALLEL.value:
+                continue
+            model_parallel_name_to_local_shards[table_name] = []
+
+        data_parallel_table_name_to_state = {}
+        for sharding_type, lookup in zip(
+            self._sharding_type_to_sharding.keys(), self._lookups
+        ):
+            lookup_state_dict = lookup.state_dict()
+            for key in lookup_state_dict:
+                assert key.endswith(".weight")
+                key_without_weight = key[: -len(".weight")]
+                if sharding_type == ShardingType.DATA_PARALLEL.value:
+                    data_parallel_table_name_to_state[
+                        key_without_weight
+                    ] = lookup_state_dict[key]
+                elif key_without_weight in model_parallel_name_to_local_shards:
+                    lookup_sharded_tensor = lookup_state_dict[key]
+                    model_parallel_name_to_local_shards[key_without_weight].extend(
+                        lookup_sharded_tensor.local_shards()
+                    )
+
+        name_to_table_size = {}
+        # This provides consistency between this class and the EmbeddingBagCollection's
+        # nn.Module API calls (state_dict, named_modules, etc)
+        self.embedding_bags: nn.ModuleDict = nn.ModuleDict()
+        for table in self._embedding_bag_configs:
+            name_to_table_size[table.name] = (table.num_embeddings, table.embedding_dim)
+            self.embedding_bags[table.name] = torch.nn.Module()
+
+        for table_name, local_shards in model_parallel_name_to_local_shards.items():
+            if (
+                self._table_name_to_parameter_sharding[table_name].sharding_type
+                != ShardingType.DATA_PARALLEL.value
+            ):
+                weight = ShardedTensor._init_from_local_shards(
+                    local_shards,
+                    name_to_table_size[table_name],
+                    process_group=self._env.process_group,
+                )
+                # TODO - ensure that optimizers over named_parameters works
+                self.embedding_bags[table_name].register_parameter(
+                    "weight", torch.nn.Parameter(weight)
+                )
+
+        # Register data_parallel state as regular tensors
+        for table_name, table_state in data_parallel_table_name_to_state.items():
+            # Because DDP isn't composable, its named_parameters have a module. prefix, so we need to get rid of it here
+            table_name = table_name.lstrip("module.")
+            self.embedding_bags[table_name].register_parameter(
+                "weight", torch.nn.Parameter(table_state)
+            )
+
+    def _create_input_dist(
+        self,
+        input_feature_names: List[str],
+    ) -> None:
+        feature_names: List[str] = []
+        for sharding in self._sharding_type_to_sharding.values():
+            self._input_dists.append(sharding.create_input_dist())
+            feature_names.extend(
+                sharding.id_score_list_feature_names()
+                if self._is_weighted
+                else sharding.id_list_feature_names()
+            )
+            self._feature_splits.append(
+                len(
+                    sharding.id_score_list_feature_names()
+                    if self._is_weighted
+                    else sharding.id_list_feature_names()
+                )
+            )
+
+        if feature_names == input_feature_names:
+            self._has_features_permute = False
+        else:
+            for f in feature_names:
+                self._features_order.append(input_feature_names.index(f))
+            self.register_buffer(
+                "_features_order_tensor",
+                torch.tensor(
+                    self._features_order, device=self._device, dtype=torch.int32
+                ),
+                persistent=False,
+            )
+
+    def _create_lookups(
+        self,
+    ) -> None:
+        for sharding in self._sharding_type_to_sharding.values():
+            self._lookups.append(sharding.create_lookup())
+
+    def _create_output_dist(self) -> None:
+        for sharding in self._sharding_type_to_sharding.values():
+            self._output_dists.append(sharding.create_output_dist(device=self._device))
+            self._embedding_names.extend(sharding.embedding_names())
+            self._embedding_dims.extend(sharding.embedding_dims())
+
+    # pyre-ignore [14]
+    def input_dist(
+        self, ctx: ShardedModuleContext, features: KeyedJaggedTensor
+    ) -> Awaitable[SparseFeaturesList]:
+        if self._has_uninitialized_input_dist:
+            self._create_input_dist(features.keys())
+            self._has_uninitialized_input_dist = False
+        with torch.no_grad():
+            if self._has_features_permute:
+                features = features.permute(
+                    self._features_order,
+                    # pyre-ignore [6]
+                    self._features_order_tensor,
+                )
+            features_by_shards = features.split(
+                self._feature_splits,
+            )
+            awaitables = []
+            for module, features_by_shard in zip(self._input_dists, features_by_shards):
+                all2all_lengths = module(
+                    SparseFeatures(
+                        id_list_features=None
+                        if self._is_weighted
+                        else features_by_shard,
+                        id_score_list_features=features_by_shard
+                        if self._is_weighted
+                        else None,
+                    )
+                )
+                awaitables.append(all2all_lengths.wait())
+            return SparseFeaturesListAwaitable(awaitables)
+
+    def compute(
+        self,
+        ctx: ShardedModuleContext,
+        dist_input: SparseFeaturesList,
+    ) -> List[torch.Tensor]:
+        return [lookup(features) for lookup, features in zip(self._lookups, dist_input)]
+
+    def output_dist(
+        self,
+        ctx: ShardedModuleContext,
+        output: List[torch.Tensor],
+    ) -> LazyAwaitable[KeyedTensor]:
+        return EmbeddingBagCollectionAwaitable(
+            awaitables=[
+                dist(embeddings) for dist, embeddings in zip(self._output_dists, output)
+            ],
+            embedding_dims=self._embedding_dims,
+            embedding_names=self._embedding_names,
+        )
+
+    def compute_and_output_dist(
+        self, ctx: ShardedModuleContext, input: SparseFeaturesList
+    ) -> LazyAwaitable[KeyedTensor]:
+        return EmbeddingBagCollectionAwaitable(
+            awaitables=[
+                dist(lookup(features))
+                for lookup, dist, features in zip(
+                    self._lookups,
+                    self._output_dists,
+                    input,
+                )
+            ],
+            embedding_dims=self._embedding_dims,
+            embedding_names=self._embedding_names,
+        )
+
+
+class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]):
+    """
+    Experimental, composable version of ShardedEmbeddingBagCollection and EmbeddingBagCollectionSharder
+    with new APIs.
+
+    This implementation uses EmbeddingBagCollection
+    """
+
+    def __init__(
+        self,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+
+    def shard(
+        self,
+        module: EmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedEmbeddingBagCollection:
+
+        return ShardedEmbeddingBagCollection(
+            module=module,
+            table_name_to_parameter_sharding=params,
+            env=env,
+            device=device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )
+
+    def shardable_parameters(
+        self, module: EmbeddingBagCollection
+    ) -> Dict[str, nn.Parameter]:
+        return {
+            name.split(".")[0]: param
+            for name, param in module.embedding_bags.named_parameters()
+        }
+
+    @property
+    def module_type(self) -> Type[EmbeddingBagCollection]:
+        return EmbeddingBagCollection

--- a/torchrec/distributed/tests/test_modular_embeddingbag.py
+++ b/torchrec/distributed/tests/test_modular_embeddingbag.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import Any, Dict, List, Optional
+
+import hypothesis.strategies as st
+import torch
+import torch.nn as nn
+from hypothesis import assume, given, settings, Verbosity
+from torchrec import distributed as trec_dist
+from torchrec.distributed.modular_embeddingbag import (
+    EmbeddingBagCollectionSharder,
+    ShardedEmbeddingBagCollection,
+)
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    ParameterConstraints,
+    Topology,
+)
+
+from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.types import (
+    ModuleSharder,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import check_model_characteristics, skip_if_asan_class
+
+
+def _test_sharding(
+    tables: List[EmbeddingBagConfig],
+    initial_state_dict: Dict[str, Any],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    local_size: Optional[int] = None,
+    is_data_parallel: bool = False,
+    use_apply_overlapped_optimizer: bool = False,
+) -> None:
+    trec_dist.comm_ops.set_gradient_division(False)
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+        initial_state_dict = {
+            fqn: tensor.to(ctx.device) for fqn, tensor in initial_state_dict.items()
+        }
+
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size, ctx.device.type, local_world_size=ctx.local_size
+            ),
+            constraints=constraints,
+        )
+        model = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+
+        if use_apply_overlapped_optimizer:
+            apply_overlapped_optimizer(
+                torch.optim.SGD,
+                model.embedding_bags["table_0"].parameters(),
+                {"lr": 1.0},
+            )
+
+            apply_overlapped_optimizer(
+                torch.optim.SGD,
+                model.embedding_bags["table_1"].parameters(),
+                {"lr": 4.0},
+            )
+
+        plan: ShardingPlan = planner.collective_plan(model, [sharder], ctx.pg)
+        sharded_model, sharded_parameter_names = shard_embedding_modules(
+            module=model,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            plan=plan,
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        if not use_apply_overlapped_optimizer:
+            unsharded_model_optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+            sharded_model_optimizer = torch.optim.SGD(
+                sharded_model.parameters(), lr=0.01
+            )
+
+        unsharded_model = model
+
+        assert isinstance(sharded_model, ShardedEmbeddingBagCollection)
+
+        unsharded_model.load_state_dict(copy.deepcopy(initial_state_dict))
+        copy_state_dict(sharded_model.state_dict(), copy.deepcopy(initial_state_dict))
+
+        feature_keys = []
+        for table in tables:
+            feature_keys.extend(table.feature_names)
+
+        for _it in range(5):
+            if not use_apply_overlapped_optimizer:
+                unsharded_model_optimizer.zero_grad()
+                sharded_model_optimizer.zero_grad()
+
+            unsharded_model_pred_kt = []
+            for rank in range(ctx.world_size):
+                # simulate the unsharded model run on the entire batch
+                unsharded_model_pred_kt.append(
+                    unsharded_model(kjt_input_per_rank[rank])
+                )
+
+            all_unsharded_preds = []
+            for rank in range(ctx.world_size):
+                unsharded_model_pred_kt_mini_batch = unsharded_model_pred_kt[
+                    rank
+                ].to_dict()
+
+                all_unsharded_preds.extend(
+                    [
+                        unsharded_model_pred_kt_mini_batch[feature]
+                        for feature in feature_keys
+                    ]
+                )
+                if rank == ctx.rank:
+                    unsharded_model_pred = torch.stack(
+                        [
+                            unsharded_model_pred_kt_mini_batch[feature]
+                            for feature in feature_keys
+                        ]
+                    )
+
+            # sharded model
+            # each rank gets a subbatch
+            sharded_model_pred_kt = sharded_model(
+                kjt_input_per_rank[ctx.rank]
+            ).to_dict()
+            sharded_model_pred = torch.stack(
+                [sharded_model_pred_kt[feature] for feature in feature_keys]
+            )
+
+            # cast to CPU because when casting unsharded_model.to on the same module, there could some race conditions
+            # in normal author modelling code this won't be an issue because each rank would individually create
+            # their model. output from sharded_pred is correctly on the correct device.
+
+            # Compare predictions of sharded vs unsharded models.
+            torch.testing.assert_allclose(
+                sharded_model_pred.cpu(), unsharded_model_pred.cpu()
+            )
+
+            sharded_model_pred.sum().backward()
+
+            all_unsharded_preds = torch.stack(all_unsharded_preds)
+            all_unsharded_preds.sum().backward()
+
+            if not use_apply_overlapped_optimizer:
+                pass
+                # TODO, ShardedTensor.grad does not exist, need distributed to add this API
+                # unsharded_model_optimizer.step()
+                # sharded_model_optimizer.step()
+
+        # check nn.Module APIs look the same
+        check_model_characteristics(unsharded_model, sharded_model)
+
+        for fqn in unsharded_model.state_dict():
+            unsharded_state = unsharded_model.state_dict()[fqn]
+            sharded_state = sharded_model.state_dict()[fqn]
+
+            if is_data_parallel:
+                continue
+            else:
+                out = (
+                    torch.zeros(size=unsharded_state.shape, device=ctx.device)
+                    if ctx.rank == 0
+                    else None
+                )
+                sharded_state.gather(out=out)
+                if ctx.rank == 0:
+                    torch.testing.assert_allclose(
+                        unsharded_state,
+                        out,
+                    )
+
+        sharded_model.load_state_dict(sharded_model.state_dict())
+
+
+class TestEmbeddingBagCollectionSharder(EmbeddingBagCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        self._sharding_type = sharding_type
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
+
+
+@skip_if_asan_class
+class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                ShardingType.DATA_PARALLEL.value,
+            ]
+        ),
+        use_apply_overlapped_optimizer=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_sharding_ebc(
+        self, sharding_type: str, use_apply_overlapped_optimizer: bool
+    ) -> None:
+
+        # TODO DistributedDataParallel needs full support of registering fused optims before we can enable this.
+        assume(
+            use_apply_overlapped_optimizer
+            and sharding_type != ShardingType.DATA_PARALLEL.value,
+        )
+
+        WORLD_SIZE = 2
+
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+        ]
+
+        # Rank 0
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [0, 1]       None        [2]
+
+        # Rank 1
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [3, 2]       [1,2]        [0, 1,2,3]
+        # "feature_1"   [2,3]       None        [2]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([0, 1, 2, 0, 1, 2]),
+                lengths=torch.LongTensor([2, 0, 1, 2, 0, 1]),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([3, 2, 1, 2, 0, 1, 2, 3, 2, 3, 2]),
+                lengths=torch.LongTensor([2, 2, 4, 2, 0, 1]),
+            ),
+        ]
+        self._run_multi_process_test(
+            callable=_test_sharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_bag_config,
+            initial_state_dict={
+                "embedding_bags.table_0.weight": torch.Tensor(
+                    [
+                        [1, 1, 1, 1],
+                        [2, 2, 2, 2],
+                        [4, 4, 4, 4],
+                        [8, 8, 8, 8],
+                    ]
+                ),
+                "embedding_bags.table_1.weight": torch.Tensor(
+                    [
+                        [101, 101, 101, 101],
+                        [102, 102, 102, 102],
+                        [104, 104, 104, 104],
+                        [108, 108, 108, 108],
+                    ]
+                ),
+            },
+            kjt_input_per_rank=kjt_input_per_rank,
+            sharder=TestEmbeddingBagCollectionSharder(sharding_type=sharding_type),
+            backend="nccl"
+            if (torch.cuda.is_available() and torch.cuda.device_count() >= 2)
+            else "gloo",
+            is_data_parallel=(sharding_type == ShardingType.DATA_PARALLEL.value),
+            use_apply_overlapped_optimizer=use_apply_overlapped_optimizer,
+        )

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -12,12 +12,13 @@ import socket
 import time
 from contextlib import closing
 from functools import wraps
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 import numpy as np
 import torch
 import torch.distributed as dist
 from pyre_extensions import ParameterSpecification
+from torch import nn
 
 TParams = ParameterSpecification("TParams")
 TReturn = TypeVar("TReturn")
@@ -109,3 +110,46 @@ def seed_and_log(wrapped_func: Callable) -> Callable:
         return wrapped_func(*args, **kwargs)
 
     return _wrapper
+
+
+def get_model_characteristics(model: nn.Module) -> Dict[str, Any]:
+    return {
+        "state_dict": model.state_dict(),
+        "named_buffers": dict(model.named_buffers()),
+        "named_parameters": dict(model.named_parameters()),
+    }
+
+
+def check_model_characteristics(
+    model_1: nn.Module,
+    model_2: nn.Module,
+    check_named_buffers: bool = True,
+    check_named_parameters: bool = True,
+    check_state_dict: bool = True,
+) -> None:
+    """
+    Checks to see if the keys of top level PyTorch API calls are the same
+    between two modules.
+    """
+
+    model_characteristics = {}
+    model_characteristics["model_1"] = get_model_characteristics(model_1)
+    model_characteristics["model_2"] = get_model_characteristics(model_2)
+
+    assert (
+        not check_named_buffers
+        or model_characteristics["model_1"]["named_buffers"].keys()
+        == model_characteristics["model_2"]["named_buffers"].keys()
+    ), "named buffers keys are not the same"
+
+    assert (
+        not check_named_parameters
+        or model_characteristics["model_1"]["named_parameters"].keys()
+        == model_characteristics["model_2"]["named_parameters"].keys()
+    ), "named parameter keys are not the same"
+
+    assert (
+        not check_state_dict
+        or model_characteristics["model_1"]["state_dict"].keys()
+        == model_characteristics["model_2"]["state_dict"].keys()
+    ), "named parameter state dict key are not the same"


### PR DESCRIPTION
Summary:
The current EmbeddingBagCollection/FusedEmbeddingBagCollection are only usable through the DistributedModelParallel wrapper which override common torch.nn.module APIs (named_parameters/state_dict) etc. However, this makes these modules inflexible, and sometimes unusable without using DMP. We try to solve this issue by using the trick of registering torch.nn.module state on top of empty modules, and letting Pytorch's native calls handle the generation of state_dict/named_parameters, as per https://github.com/pytorch/torchrec/issues/528.

In addition, the current Sharded modules do not have ideal semantics of named_parameters() in that in a rank, it only returns parameters that they have shards for. One implication if this is that the keys of named_parameters() is different per rank. We solve this by creating the ShardedTensor parameters in a SPMD fashion using ShardedTensor.init_from_local_shards.

Relatedly, the current EmbeddingBagCollection's named_parameters() DOES NOT contain parameters that have their gradients updated via optimizer fusion. However, we should abide by the definition of named_parameters() and ensure that it truly does return all parameters. The torch.nn.module API calls should look near identical between the unsharded and sharded version.

Another point of difference is that the parameters() of tables sharded by data_parallel rely on DistributedModelParallel's DistributedDataParallel wrapper to register reduction hooks on their grads. Here we do this explicitly so that it is truly composable with other DDP wrappers. One implication of the previous solution is that it means that if an FSDP wrapper is passed to DistributedModelParallel, then tables registered as data_parallel **will actually be FSDP parallel**.

Due to the plethora of "small" changes listed above, it poses a big risk to the backwards compatibility of DistributedModelParallel, and so we are developing these new ShardedModels, with modular/native composability properties in a separate code path as per https://docs.google.com/document/d/15r5XxMTeVC90kA0u8t006-KLLeh9MZmL9DqX_F4VLxU/edit#. Since we are creating a new API with these new modules, we will also be enforcing sharding and compute_kernel/fusion separation at the user API level. The fusion EBC module's changes are done at the modular_fused_embeddingbag.py level.

Differential Revision: D38190302

