### PR TITLE
Add batch size to planner interface

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -12,7 +12,11 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.planner.constants import MIN_CW_DIM, POOLING_FACTOR
+from torchrec.distributed.planner.constants import (
+    BATCH_SIZE,
+    MIN_CW_DIM,
+    POOLING_FACTOR,
+)
 from torchrec.distributed.planner.shard_estimators import (
     EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,
@@ -48,14 +52,15 @@ class EmbeddingEnumerator(Enumerator):
     def __init__(
         self,
         topology: Topology,
+        batch_size: int = BATCH_SIZE,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         estimator: Optional[Union[ShardEstimator, List[ShardEstimator]]] = None,
     ) -> None:
         self._compute_device: str = topology.compute_device
         self._world_size: int = topology.world_size
         self._local_world_size: int = topology.local_world_size
+        self._batch_size: int = batch_size
         self._constraints = constraints
-        self._batch_size: int = topology.batch_size
 
         if estimator:
             self._estimators: List[ShardEstimator] = (

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -13,7 +13,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
-from torchrec.distributed.planner.constants import MAX_SIZE
+from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
 from torchrec.distributed.planner.perf_models import NoopPerfModel
@@ -105,6 +105,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
     def __init__(
         self,
         topology: Topology,
+        batch_size: int = BATCH_SIZE,
         enumerator: Optional[Enumerator] = None,
         storage_reservation: Optional[StorageReservation] = None,
         proposer: Optional[Union[Proposer, List[Proposer]]] = None,
@@ -115,12 +116,16 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         debug: bool = True,
     ) -> None:
         self._topology = topology
+        self._batch_size: int = (
+            self._topology.batch_size
+        )  # TODO use passed in batch size after changes propogate
         self._constraints = constraints
         self._enumerator: Enumerator = (
             enumerator
             if enumerator
             else EmbeddingEnumerator(
                 topology=topology,
+                batch_size=self._batch_size,
                 constraints=constraints,
             )
         )
@@ -184,6 +189,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
 
         storage_constraint: Topology = self._storage_reservation.reserve(
             topology=self._topology,
+            batch_size=self._batch_size,
             module=module,
             sharders=sharders,
             constraints=self._constraints,
@@ -262,6 +268,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             self._stats.log(
                 sharding_plan=sharding_plan,
                 topology=self._topology,
+                batch_size=self._batch_size,
                 storage_reservation=self._storage_reservation,
                 num_proposals=self._num_proposals,
                 num_plans=self._num_plans,
@@ -288,6 +295,6 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 f"\n\t  Global storage: {global_storage_capacity.hbm}, "
                 f"\n\t  Available for model parallel: {global_storage_constraints},"
                 f"\n\t  Requirement for model parallel: {lowest_storage})"
-                f"\n  3) Reduce local batch size ({self._topology.batch_size})"
+                f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -46,6 +46,7 @@ class EmbeddingStats(Stats):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
+        batch_size: int,
         storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,
@@ -63,6 +64,7 @@ class EmbeddingStats(Stats):
         Args:
             sharding_plan (ShardingPlan): sharding plan chosen by the planner.
             topology (Topology): device topology.
+            batch_size (int): batch size.
             storage_constraint (Topology): available storage after storage reservation.
             storage_reservation (StorageReservation): reserves storage for unsharded
                 parts of the model
@@ -283,9 +285,9 @@ class EmbeddingStats(Stats):
             for row in formatted_param_table:
                 self._stats_table.append(f"# {row: <{self._width-3}}#")
 
-        batch_size = f"Batch Size: {topology.batch_size}"
+        batch_size_text = f"Batch Size: {batch_size}"
         self._stats_table.append(f"#{'' : ^{self._width-2}}#")
-        self._stats_table.append(f"# {batch_size : <{self._width-3}}#")
+        self._stats_table.append(f"# {batch_size_text : <{self._width-3}}#")
 
         self._log_compute_kernel_stats(compute_kernels_to_count)
 

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -29,6 +29,7 @@ class FixedPercentageReservation(StorageReservation):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -58,6 +59,7 @@ class HeuristicalStorageReservation(StorageReservation):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -96,7 +98,7 @@ class HeuristicalStorageReservation(StorageReservation):
         )
 
         self._kjt_storage = _reserve_kjt_storage(
-            reserved_topology, all_input_lengths, BIGINT_DTYPE
+            reserved_topology, batch_size, all_input_lengths, BIGINT_DTYPE
         )
 
         return reserved_topology
@@ -140,14 +142,13 @@ def _reserve_unshardable_storage(
 
 def _reserve_kjt_storage(
     topology: Topology,
+    batch_size: int,
     all_input_lengths: List[float],
     input_data_type_size: int,
 ) -> Storage:
     kjt_size = (
         math.ceil(
-            float(topology.batch_size)
-            * sum(all_input_lengths)
-            * float(input_data_type_size)
+            float(batch_size) * sum(all_input_lengths) * float(input_data_type_size)
         )
         * 20  # 2 pipelined batches each with 10 internal copies
     )

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -376,8 +376,8 @@ class TestEnumerators(unittest.TestCase):
                 world_size=self.world_size,
                 compute_device=self.compute_device,
                 local_world_size=self.local_world_size,
-                batch_size=self.batch_size,
             ),
+            batch_size=self.batch_size,
             constraints=self.constraints,
         )
         self.tower_model = TestTowerSparseNN(
@@ -616,8 +616,8 @@ class TestEnumerators(unittest.TestCase):
                 world_size=self.world_size,
                 compute_device=self.compute_device,
                 local_world_size=self.local_world_size,
-                batch_size=self.batch_size,
             ),
+            batch_size=self.batch_size,
             constraints=constraints,
         )
         sharder = cast(ModuleSharder[torch.nn.Module], AllTypesSharder())

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -292,6 +292,7 @@ class StorageReservation(abc.ABC):
     def reserve(
         self,
         topology: Topology,
+        batch_size: int,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
@@ -338,6 +339,7 @@ class Enumerator(abc.ABC):
     def __init__(
         self,
         topology: Topology,
+        batch_size: int = BATCH_SIZE,
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         estimator: Optional[Union[ShardEstimator, List[ShardEstimator]]] = None,
     ) -> None:
@@ -409,6 +411,7 @@ class Stats(abc.ABC):
         self,
         sharding_plan: ShardingPlan,
         topology: Topology,
+        batch_size: int,
         storage_reservation: StorageReservation,
         num_proposals: int,
         num_plans: int,


### PR DESCRIPTION
Summary:
Instead of making batch size a part of topology as that is not intuitive, we want to make batch size a part of the planner interface.

In this first diff we add batch size to the planner interface to make it backwards compatible internally, and after the changes have propogated we will remove batch size from topology altogether.

Differential Revision: D38337130

