### PR TITLE
Modify torchrec code to use reduce_scatter_v and all_gather_v

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -18,7 +18,7 @@ from torchrec.distributed.comm_ops import (
     alltoall_pooled,
     alltoall_sequence,
     reduce_scatter_base_pooled,
-    reduce_scatter_pooled,
+    reduce_scatter_v_pooled,
 )
 from torchrec.distributed.types import Awaitable, NoWait, QuantizedCommCodecs
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -870,6 +870,63 @@ class PooledEmbeddingsAllGather(nn.Module):
 
         tensor_awaitable = all_gather_base_pooled(
             local_emb, self._pg, codecs=self._codecs
+        )
+        return PooledEmbeddingsAwaitable(tensor_awaitable=tensor_awaitable)
+
+
+class PooledEmbeddingsReduceScatterV(nn.Module):
+    """
+    The module class that wraps reduce-scatter-v communication primitive for pooled
+    embedding communication in row-wise and twrw sharding.
+
+    For pooled embeddings, we have a local model-parallel output tensor with a layout of
+    [num_buckets x batch_size, dimension]. We need to sum over num_buckets dimension
+    across batches. We split tensor along the first dimension into unequal chunks (tensor
+    slices of different buckets) according to input_splits and reduce them into the output
+    tensor and scatter the results for corresponding ranks.
+
+    The class returns the async `Awaitable` handle for pooled embeddings tensor.
+    The reduce-scatter-v is only available for NCCL backend.
+
+    Args:
+        pg (dist.ProcessGroup): The process group that the reduce-scatter communication
+            happens within.
+
+    Example::
+
+        init_distributed(rank=rank, size=2, backend="nccl")
+        pg = dist.new_group(backend="nccl")
+        input = torch.randn(2 * 2, 2)
+        input_splits = [1,3]
+        m = PooledEmbeddingsReduceScatterV(pg)
+        output = m(input, input_splits)
+        tensor = output.wait()
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        codecs: Optional[QuantizedCommCodecs] = None,
+    ) -> None:
+        super().__init__()
+        self._pg = pg
+        self._codecs = codecs
+
+    def forward(
+        self, local_embs: torch.Tensor, input_splits: List[int]
+    ) -> PooledEmbeddingsAwaitable:
+        """
+        Performs reduce scatter v operation on pooled embeddings tensor.
+
+        Args:
+            local_embs (torch.Tensor): tensor of shape [num_buckets x batch_size, dimension].
+            input_splits (List[int]): list of splits for local_embs dim0.
+
+        Returns:
+            PooledEmbeddingsAwaitable: awaitable of pooled embeddings of tensor of shape [batch_size, dimension].
+        """
+        tensor_awaitable = reduce_scatter_v_pooled(
+            local_embs, input_splits, self._pg, codecs=self._codecs
         )
         return PooledEmbeddingsAwaitable(tensor_awaitable=tensor_awaitable)
 

--- a/torchrec/distributed/sharding/vb_rw_sharding.py
+++ b/torchrec/distributed/sharding/vb_rw_sharding.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import PooledEmbeddingsReduceScatter
+from torchrec.distributed.dist_data import PooledEmbeddingsReduceScatterV
 from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingLookup,
@@ -161,7 +161,6 @@ class VariableBatchRwEmbeddingDistAwaitable(Awaitable[torch.Tensor]):
 
     def _wait_impl(self) -> torch.Tensor:
         embedding = self._awaitable.wait()
-        embedding = torch.narrow(embedding, 0, 0, self._batch_size)
 
         return embedding
 
@@ -174,24 +173,19 @@ class VariableBatchRwPooledEmbeddingDist(BaseVariableBatchEmbeddingDist[torch.Te
         super().__init__()
         self._workers: int = pg.size()
         self._rank: int = pg.rank()
-        self._dist = PooledEmbeddingsReduceScatter(pg)
+        self._dist = PooledEmbeddingsReduceScatterV(pg)
 
     def forward(
         self,
         local_embs: torch.Tensor,
         sharding_ctx: VariableBatchShardingContext,
     ) -> Awaitable[torch.Tensor]:
-        batch_size_per_rank_tensor = sharding_ctx.batch_size_per_rank_tensor
         batch_size_per_rank = sharding_ctx.batch_size_per_rank
-        max_length = max(batch_size_per_rank)
         batch_size = batch_size_per_rank[self._rank]
-        packed_pooled_embs = torch.ops.fbgemm.pack_segments(
-            t_in=local_embs,
-            lengths=batch_size_per_rank_tensor,
-            max_length=max_length,
-        )
+
         awaitable_tensor = self._dist(
-            packed_pooled_embs.view(self._workers * max_length, -1)
+            local_embs.view(sum(batch_size_per_rank), -1),
+            input_splits=batch_size_per_rank,
         )
         return VariableBatchRwEmbeddingDistAwaitable(awaitable_tensor, batch_size)
 


### PR DESCRIPTION
Summary: This change adds a new `PooledEmbeddingsReduceScatterV` which uses `_reduce_scatter_v` and `_all_gather_v` in c10d for performing row-wise and table-wise row-wise sharding.

Differential Revision: D37735264

