### PR TITLE
Only shuffle the training days together, leave val/test day untouched. Also include contiguous preprocessing script.

### DIFF
--- a/torchrec/datasets/scripts/contiguous_preproc_criteo.py
+++ b/torchrec/datasets/scripts/contiguous_preproc_criteo.py
@@ -34,6 +34,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         required=True,
         help="Output directory to store npy files.",
     )
+    parser.add_argument(
+        "--frequency_threshold",
+        type=int,
+        default=0,
+        help="IDs occuring less than this frequency will be remapped to an index of 1. If this value is not set (e.g. 0), no frequency thresholding will be applied.",
+    )
     return parser.parse_args(argv)
 
 
@@ -67,7 +73,9 @@ def main(argv: List[str]) -> None:
         )
 
     print(f"Processing files in: {input_files}. Outputs will be saved to {output_dir}.")
-    BinaryCriteoUtils.sparse_to_contiguous(input_files, output_dir)
+    BinaryCriteoUtils.sparse_to_contiguous(
+        input_files, output_dir, frequency_threshold=int(args.frequency_threshold)
+    )
     print("Done processing.")
 
 

--- a/torchrec/datasets/scripts/shuffle_preproc_criteo.py
+++ b/torchrec/datasets/scripts/shuffle_preproc_criteo.py
@@ -86,7 +86,7 @@ def main(argv: List[str]) -> None:
             name="count_rows:day%i" % i,
             args=(rows_per_file, input_dir_labels_and_dense, i),
         )
-        for i in range(0, DAYS)
+        for i in range(0, DAYS - 1)
     ]
 
     for process in processes:
@@ -101,6 +101,7 @@ def main(argv: List[str]) -> None:
         rows_per_file,
         output_dir_full_set,
         random_seed=args.random_seed,
+        days=DAYS,
     )
 
 

--- a/torchrec/datasets/tests/test_criteo.py
+++ b/torchrec/datasets/tests/test_criteo.py
@@ -288,7 +288,7 @@ class TestBinaryCriteoUtils(CriteoTest):
             save_data_list(sparse_data, "sparse")
             save_data_list(labels_data, "labels")
 
-            rows_per_day = {0: 3, 1: 3, 2: 3}
+            rows_per_day = {0: 3, 1: 3}
             BinaryCriteoUtils.shuffle(
                 temp_input_dir,
                 temp_input_dir,


### PR DESCRIPTION
Summary: ATT - incorporating the feedback provided by Jan about preprocessing script

Differential Revision: D38371619

