### PR TITLE
Migrate torchrec/hpc/predictor/mulitray from torch::deploy to multipy

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -19,7 +19,13 @@
 #include <folly/io/IOBuf.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+
+// remove this after we switch over to multipy externally for torchrec
+#ifdef FBCODE_CAFFE2
+#include <multipy/runtime/deploy.h> // @manual
+#else
 #include <torch/csrc/deploy/deploy.h> // @manual
+#endif
 
 #include "torchrec/inference/BatchingQueue.h"
 #include "torchrec/inference/Observer.h"

--- a/torchrec/inference/server.cpp
+++ b/torchrec/inference/server.cpp
@@ -18,8 +18,16 @@
 #include <grpc++/grpc++.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
+
+// remove this after we switch over to multipy externally for torchrec
+#ifdef FBCODE_CAFFE2
+#include <multipy/runtime/deploy.h> // @manual
+#include <multipy/runtime/path_environment.h>
+#else
 #include <torch/csrc/deploy/deploy.h>
 #include <torch/csrc/deploy/path_environment.h>
+#endif
+
 #include <torch/torch.h>
 
 #include "torchrec/inference/GPUExecutor.h"

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -24,7 +24,13 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <torch/csrc/autograd/profiler_legacy.h>
+
+// remove this after we switch over to multipy externally for torchrec
+#ifdef FBCODE_CAFFE2
+#include <multipy/runtime/deploy.h> // @manual
+#else
 #include <torch/csrc/deploy/deploy.h> // @manual
+#endif
 
 #include "ATen/cuda/CUDAEvent.h"
 #include "torchrec/inference/BatchingQueue.h"


### PR DESCRIPTION
Summary:
We are creating a new repo called `fbcode/multipy` to house `torch.package` and `torch::deploy` code.

This diff migrates over `//caffe2/torch/csrc/deploy:xxx` usages over to `//caffe2/multipy/runtime` which is the new repo we are moving `torch::deploy` code to.

Differential Revision: D37358185

