### PR TITLE
Include `profiler.h` instead of `profiler_legacy.h`

### DIFF
--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -23,7 +23,7 @@
 #include <folly/stop_watch.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <torch/csrc/autograd/profiler_legacy.h>
+#include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/deploy/deploy.h> // @manual
 
 #include "ATen/cuda/CUDAEvent.h"


### PR DESCRIPTION
Summary:
`torch/csrc` isn't a stable API; however AFAIK there isn't an obvious `torch/include` header to use. As a compromise there is `torch/csrc/autograd/profiler.h` that is commonly included.

I'm about to delete `torch/csrc/autograd/profiler_legacy.h` as part of the legacy profiler deprecation process. This is a courtesy to avoid breaking TorchRec.

Differential Revision: D39085222

