### PR TITLE
fix UB crash in exception path

### DIFF
--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -228,10 +228,11 @@ void GPUExecutor::process(int idx) {
 
           if (predictions.isNone()) {
             observer->addPredictionExceptionCount(1);
-            rejectionExecutor_->add([batch = std::move(batch)]() {
-              handleBatchException(
-                  batch->contexts, "GPUExecutor prediction exception");
-            });
+            rejectionExecutor_->add(
+                [contexts = std::move(batch->contexts)]() mutable {
+                  handleBatchException(
+                      contexts, "GPUExecutor prediction exception");
+                });
           } else {
             size_t offset = 0;
             auto rsfStart = std::chrono::steady_clock::now();


### PR DESCRIPTION
Summary: `batch` is moved out for exception handling but we still access it after it's moved out. this is undefined behavior in C++ that can cause crashes in the exception path.

Reviewed By: jiaqizhai

Differential Revision: D39161317

