### PR TITLE
SingleGPUExecutor without batching

### DIFF
--- a/torchrec/inference/include/torchrec/inference/BatchingQueue.h
+++ b/torchrec/inference/include/torchrec/inference/BatchingQueue.h
@@ -35,39 +35,6 @@
 
 namespace torchrec {
 
-// noncopyable because we only want to move PredictionBatch around
-// as it holds a reference to ResourceManagerGuard. We wouldn't want
-// to inadvertently increase the reference count to ResourceManagerGuard
-// with copies of this struct.
-struct PredictionBatch : public boost::noncopyable {
-  size_t batchSize;
-
-  c10::Dict<std::string, at::Tensor> forwardArgs;
-
-  std::vector<RequestContext> contexts;
-
-  std::unique_ptr<ResourceManagerGuard> resourceManagerGuard = nullptr;
-
-  std::chrono::time_point<std::chrono::steady_clock> enqueueTime =
-      std::chrono::steady_clock::now();
-
-  Event event;
-
-  // Need a constructor to use make_shared/unique with
-  // noncopyable struct and not trigger copy-constructor.
-  explicit PredictionBatch(
-      size_t bs,
-      c10::Dict<std::string, at::Tensor> fa,
-      std::vector<RequestContext> ctxs,
-      std::unique_ptr<ResourceManagerGuard> rmg = nullptr)
-      : batchSize(bs),
-        forwardArgs(std::move(fa)),
-        contexts(std::move(ctxs)),
-        resourceManagerGuard(std::move(rmg)) {}
-
-  size_t size() const;
-};
-
 using BatchQueueCb = std::function<void(std::shared_ptr<PredictionBatch>)>;
 
 class BatchingQueue {

--- a/torchrec/inference/include/torchrec/inference/SingleGPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/SingleGPUExecutor.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/MPMCQueue.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <multipy/runtime/deploy.h>
+#include "torchrec/inference/Types.h"
+
+namespace torchrec {
+
+class SingleGPUExecutor {
+ public:
+  SingleGPUExecutor(
+      std::shared_ptr<torch::deploy::InterpreterManager> manager,
+      torch::deploy::ReplicatedObj model,
+      c10::Device device,
+      const std::vector<size_t>& interpreter_idxs,
+      c10::Device result_device = c10::kCPU);
+  SingleGPUExecutor(SingleGPUExecutor&& executor) noexcept = default;
+  SingleGPUExecutor& operator=(SingleGPUExecutor&& executor) noexcept = default;
+  ~SingleGPUExecutor();
+
+  void schedule(std::shared_ptr<PredictionBatch> request);
+
+ private:
+  void process(const size_t interpreter_idx);
+
+  std::shared_ptr<torch::deploy::InterpreterManager> manager_;
+  torch::deploy::ReplicatedObj model_;
+  c10::Device device_;
+  c10::Device resultDevice_;
+
+  folly::MPMCQueue<std::shared_ptr<PredictionBatch>> requests_;
+  std::vector<std::thread> processThreads_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> completionExecutor_;
+};
+} // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/Types.h
+++ b/torchrec/inference/include/torchrec/inference/Types.h
@@ -17,10 +17,13 @@
 
 #include <ATen/core/ivalue.h>
 #include <ATen/cuda/CUDAEvent.h>
+#include <boost/noncopyable.hpp>
 #include <folly/ExceptionWrapper.h>
 #include <folly/container/F14Set.h>
 #include <folly/futures/Future.h>
 #include <folly/io/IOBuf.h>
+
+#include "torchrec/inference/ResourceManager.h"
 
 namespace torchrec {
 
@@ -70,6 +73,56 @@ struct BatchingMetadata {
   std::string type;
   std::string device;
   folly::F14FastSet<std::string> pinned;
+};
+
+// noncopyable because we only want to move PredictionBatch around
+// as it holds a reference to ResourceManagerGuard. We wouldn't want
+// to inadvertently increase the reference count to ResourceManagerGuard
+// with copies of this struct.
+struct PredictionBatch : public boost::noncopyable {
+  std::string methodName;
+  std::vector<c10::IValue> args;
+
+  size_t batchSize;
+
+  c10::Dict<std::string, at::Tensor> forwardArgs;
+
+  std::vector<RequestContext> contexts;
+
+  std::unique_ptr<ResourceManagerGuard> resourceManagerGuard = nullptr;
+
+  std::chrono::time_point<std::chrono::steady_clock> enqueueTime =
+      std::chrono::steady_clock::now();
+
+  Event event;
+
+  // Need a constructor to use make_shared/unique with
+  // noncopyable struct and not trigger copy-constructor.
+  PredictionBatch(
+      size_t bs,
+      c10::Dict<std::string, at::Tensor> fa,
+      std::vector<RequestContext> ctxs,
+      std::unique_ptr<ResourceManagerGuard> rmg = nullptr)
+      : batchSize(bs),
+        forwardArgs(std::move(fa)),
+        contexts(std::move(ctxs)),
+        resourceManagerGuard(std::move(rmg)) {}
+
+  PredictionBatch(
+      std::string methodNameArg,
+      std::vector<c10::IValue> argsArg,
+      folly::Promise<std::unique_ptr<torchrec::PredictionResponse>> promise)
+      : methodName(std::move(methodNameArg)), args(std::move(argsArg)) {
+    contexts.push_back(RequestContext{1u, std::move(promise)});
+  }
+
+  inline size_t size() const {
+    size_t size = 0;
+    for (const auto& iter : forwardArgs) {
+      size += iter.value().storage().nbytes();
+    }
+    return size;
+  }
 };
 
 } // namespace torchrec

--- a/torchrec/inference/src/BatchingQueue.cpp
+++ b/torchrec/inference/src/BatchingQueue.cpp
@@ -48,14 +48,6 @@ DEFINE_bool(
 
 namespace torchrec {
 
-size_t PredictionBatch::size() const {
-  size_t size = 0;
-  for (auto& iter : forwardArgs) {
-    size += iter.value().storage().nbytes();
-  }
-  return size;
-}
-
 BatchingQueue::BatchingQueue(
     std::vector<BatchQueueCb> cbs,
     const Config& config,

--- a/torchrec/inference/src/SingleGPUExecutor.cpp
+++ b/torchrec/inference/src/SingleGPUExecutor.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torchrec/inference/SingleGPUExecutor.h"
+#include <c10/cuda/CUDAGuard.h>
+#include <cassert>
+
+namespace torchrec {
+
+SingleGPUExecutor::SingleGPUExecutor(
+    std::shared_ptr<torch::deploy::InterpreterManager> manager,
+    torch::deploy::ReplicatedObj model,
+    c10::Device device /* cuda device */,
+    const std::vector<size_t>& interpreter_idxs,
+    c10::Device result_device /* result device */)
+    : manager_(manager),
+      model_(std::move(model)),
+      device_(device),
+      resultDevice_(result_device),
+      requests_(10000) {
+  for (const auto& interp_idx : interpreter_idxs) {
+    assert(interp_idx < manager->allInstances().size());
+    processThreads_.emplace_back([this, interp_idx]() { process(interp_idx); });
+  }
+
+  completionExecutor_ =
+      std::make_unique<folly::CPUThreadPoolExecutor>(interpreter_idxs.size());
+}
+
+SingleGPUExecutor::~SingleGPUExecutor() {
+  for (const auto _ : c10::irange(processThreads_.size())) {
+    requests_.blockingWrite(nullptr);
+  }
+  for (auto& thread : processThreads_) {
+    thread.join();
+  }
+  completionExecutor_->join();
+}
+
+void SingleGPUExecutor::schedule(std::shared_ptr<PredictionBatch> request) {
+  requests_.blockingWrite(std::move(request));
+}
+
+namespace {
+
+c10::IValue toDevice(const c10::IValue& iv, c10::Device device) {
+  if (iv.isTensor()) {
+    return c10::IValue(iv.toTensor().to(device));
+  } else if (iv.isList()) {
+    const auto list = iv.toList();
+    auto copied_list = c10::impl::GenericList(list.elementType());
+    for (const auto& entry : list) {
+      copied_list.push_back(toDevice(entry, device));
+    }
+    return c10::IValue(copied_list);
+  } else if (iv.isGenericDict()) {
+    const auto dict = iv.toGenericDict();
+    auto copied_dict = c10::impl::GenericDict(dict.keyType(), dict.valueType());
+    for (const auto& entry : dict) {
+      copied_dict.insert(entry.key(), toDevice(entry.value(), device));
+    }
+    return c10::IValue(copied_dict);
+  }
+
+  return iv;
+}
+
+std::vector<c10::IValue> toDevice(
+    std::vector<c10::IValue> args,
+    c10::Device device) {
+  for (auto& arg : args) {
+    arg = toDevice(arg, device);
+  }
+  return args;
+}
+
+} // namespace
+
+void SingleGPUExecutor::process(const size_t interpreter_idx) {
+  auto stream = at::cuda::getStreamFromPool();
+  at::cuda::CUDAStreamGuard stream_guard(stream);
+  at::cuda::CUDAGuard device_guard(device_);
+
+  while (true) {
+    std::shared_ptr<PredictionBatch> request;
+    requests_.blockingRead(request);
+
+    if (!request) {
+      break;
+    }
+
+    auto* onThisInterpreter = &manager_->allInstances().at(interpreter_idx);
+    auto I = model_.acquireSession(onThisInterpreter);
+
+    request->event = Event(
+        new at::cuda::CUDAEvent(cudaEventBlockingSync | cudaEventDisableTiming),
+        [](at::cuda::CUDAEvent* event) { delete event; });
+
+    // TODO: Support methodName as "model.submodle.method"
+    auto out = I.self.attr(request->methodName.c_str())
+                   .callKwargs(toDevice(request->args, device_), {})
+                   .toIValue();
+    auto result = toDevice(out, resultDevice_);
+    request->event->record(stream);
+
+    completionExecutor_->add(
+        [result = std::move(result), request = std::move(request)]() {
+          request->event->synchronize();
+          for (auto& context : request->contexts) {
+            auto response = std::make_unique<PredictionResponse>();
+            response->predictions = result;
+            context.promise.setValue(std::move(response));
+          }
+        });
+  }
+}
+
+} // namespace torchrec

--- a/torchrec/inference/tests/SingleGPUExecutorTest.cpp
+++ b/torchrec/inference/tests/SingleGPUExecutorTest.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "torchrec/inference/SingleGPUExecutor.h"
+#include <folly/futures/Future.h>
+#include <gtest/gtest.h>
+#include <multipy/runtime/deploy.h>
+#include <torch/cuda.h> // @manual
+#include <torch/script.h>
+#include <torch/torch.h> // @manual
+#include "torchrec/inference/Types.h"
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  return rc;
+}
+
+const char* path(const char* envname, const char* path) {
+  const char* e = std::getenv(envname);
+  return e ? e : path;
+}
+
+std::vector<c10::IValue> get_input_example(
+    torch::deploy::InterpreterSession& model_interpreter_session) {
+  auto eg = model_interpreter_session.self
+                .attr("load_pickle")({"model", "example.pkl"})
+                .toIValue();
+  return eg.toTupleRef().elements();
+}
+
+void assert_tensors_eq(const at::Tensor& expected, const at::Tensor& got) {
+  ASSERT_TRUE(expected.allclose(got, 1e-03, 1e-05));
+}
+
+TEST(TorchDeployGPUTest, SimpleModel) {
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP();
+  }
+
+  const char* model_filename = path("TORCH_PACKAGE_SIMPLE", "/tmp/simple");
+
+  auto device = c10::Device(c10::kCUDA, 0);
+
+  auto manager = std::make_shared<torch::deploy::InterpreterManager>(1);
+  torch::deploy::Package p = manager->loadPackage(model_filename);
+  auto model = p.loadPickle("model", "model.pkl");
+  {
+    auto M = model.acquireSession();
+    M.self.attr("to")({device});
+  }
+
+  std::vector<at::IValue> example_inputs;
+  {
+    auto I = p.acquireSession();
+    example_inputs = get_input_example(I);
+  }
+
+  std::vector<size_t> interp_idxs = {0};
+  auto executor = std::make_unique<torchrec::SingleGPUExecutor>(
+      manager, model, device, interp_idxs);
+
+  {
+    auto inputs = example_inputs;
+
+    // Calling forward on freshly loaded model
+    folly::Promise<std::unique_ptr<torchrec::PredictionResponse>> promise;
+    auto future = promise.getSemiFuture();
+
+    executor->schedule(std::make_shared<torchrec::PredictionBatch>(
+        "forward", inputs, std::move(promise)));
+
+    auto forward_result_0 = std::move(future).get()->predictions.toTensor();
+    auto expected = example_inputs[0].toTensor() + at::ones({10, 20});
+    assert_tensors_eq(expected, forward_result_0);
+  }
+
+  {
+    // Calling set_weight
+    folly::Promise<std::unique_ptr<torchrec::PredictionResponse>> promise;
+    auto future = promise.getSemiFuture();
+
+    std::vector<c10::IValue> set_weight_inputs = {at::zeros({10, 20})};
+
+    executor->schedule(std::make_shared<torchrec::PredictionBatch>(
+        "set_weight", set_weight_inputs, std::move(promise)));
+
+    auto predictionResponse = std::move(future).get();
+  }
+
+  {
+    auto inputs = example_inputs;
+
+    // Calling forward on changed model
+    folly::Promise<std::unique_ptr<torchrec::PredictionResponse>> promise;
+    auto future = promise.getSemiFuture();
+
+    executor->schedule(std::make_shared<torchrec::PredictionBatch>(
+        "forward", inputs, std::move(promise)));
+
+    auto forward_result_1 = std::move(future).get()->predictions.toTensor();
+    auto expected = example_inputs[0].toTensor();
+    assert_tensors_eq(expected, forward_result_1);
+  }
+}
+
+c10::IValue execute(
+    torchrec::SingleGPUExecutor& executor,
+    const std::string& methodName,
+    std::vector<c10::IValue> args) {
+  folly::Promise<std::unique_ptr<torchrec::PredictionResponse>> promise;
+  auto future = promise.getSemiFuture();
+
+  executor.schedule(std::make_shared<torchrec::PredictionBatch>(
+      methodName, std::move(args), std::move(promise)));
+  return std::move(future).get()->predictions;
+}
+
+TEST(TorchDeployGPUTest, SimpleModel_multiGPU) {
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP();
+  }
+
+  const size_t numGpu = torch::cuda::device_count();
+  if (numGpu <= 1) {
+    GTEST_SKIP();
+  }
+
+  const char* model_filename = path("TORCH_PACKAGE_SIMPLE", "/tmp/simple");
+
+  auto device = c10::Device(c10::kCUDA, 0);
+
+  auto manager =
+      std::make_shared<torch::deploy::InterpreterManager>(numGpu + 1);
+  torch::deploy::Package package = manager->loadPackage(model_filename);
+
+  std::vector<torch::deploy::ReplicatedObj> models;
+  torch::deploy::ReplicatedObj model_control;
+  const size_t gpu_rank_control = 0;
+
+  {
+    auto I = package.acquireSession();
+
+    auto pyModel = I.fromMovable(package.loadPickle("model", "model.pkl"));
+
+    for (size_t i = 0; i < numGpu; i++) {
+      auto model = I.createMovable(
+          pyModel.attr("to")(c10::IValue(c10::Device(c10::kCUDA, i))));
+      if (i == gpu_rank_control) {
+        model_control = model;
+      }
+      models.push_back(std::move(model));
+    }
+  }
+
+  std::vector<std::unique_ptr<torchrec::SingleGPUExecutor>> workExecutors;
+  for (size_t i = 0; i < numGpu; i++) {
+    const std::vector<size_t> interp_idxs = {static_cast<size_t>(i)};
+    workExecutors.push_back(std::make_unique<torchrec::SingleGPUExecutor>(
+        manager,
+        std::move(models[i]),
+        c10::Device(c10::kCUDA, i),
+        interp_idxs));
+  }
+
+  const std::vector<size_t> interp_idxs = {static_cast<size_t>(numGpu)};
+  auto controlExecutor = std::make_unique<torchrec::SingleGPUExecutor>(
+      manager,
+      std::move(model_control),
+      c10::Device(c10::kCUDA, gpu_rank_control),
+      interp_idxs);
+
+  std::vector<at::IValue> example_inputs;
+  {
+    auto I = package.acquireSession();
+    example_inputs = get_input_example(I);
+  }
+  auto example_input0 = example_inputs[0].toTensor();
+  auto expected_forward0 = example_input0 + at::ones(example_input0.sizes());
+
+  for (size_t i = 0; i < numGpu; i++) {
+    auto result =
+        execute(*workExecutors[i], "forward", example_inputs).toTensor();
+    assert_tensors_eq(expected_forward0, result);
+  }
+
+  execute(*controlExecutor, "set_weight", {at::zeros(example_input0.sizes())});
+  for (size_t i = 0; i < numGpu; i++) {
+    auto result =
+        execute(*workExecutors[i], "forward", example_inputs).toTensor();
+    if (i == gpu_rank_control) {
+      assert_tensors_eq(example_input0, result);
+    } else {
+      assert_tensors_eq(expected_forward0, result);
+    }
+  }
+}

--- a/torchrec/inference/tests/generate_test_packages.py
+++ b/torchrec/inference/tests/generate_test_packages.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+# @nolint
+
+import argparse
+from pathlib import Path
+from typing import Optional, Tuple
+
+import torch
+from torch.package import PackageExporter
+
+try:
+    from .test_modules import Simple
+except ImportError:
+    from test_modules import Simple  # pyre-ignore
+
+
+def save(
+    name: str, model: torch.nn.Module, eg: Optional[Tuple] = None  # pyre-ignore
+) -> None:  # pyre-ignore
+    with PackageExporter(str(p / name)) as e:
+        e.mock("iopath.**")
+        e.intern("**")
+        e.save_pickle("model", "model.pkl", model)
+        if eg:
+            e.save_pickle("model", "example.pkl", eg)
+
+
+parser = argparse.ArgumentParser(description="Generate Examples")
+parser.add_argument("--install_dir", help="Root directory for all output files")
+
+if __name__ == "__main__":
+    args = parser.parse_args() # pyre-ignore
+    if args.install_dir is None:
+        p = Path(__file__).parent / "generated" # pyre-ignore
+        p.mkdir(exist_ok=True)
+    else:
+        p = Path(args.install_dir)
+
+    simple = Simple(10, 20)
+    for param in simple.parameters():
+        param.requires_grad = False
+
+    save("simple", simple, (torch.rand(10, 20),))

--- a/torchrec/inference/tests/test_modules.py
+++ b/torchrec/inference/tests/test_modules.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+# @nolint
+
+import torch
+
+
+class Simple(torch.nn.Module):
+    def __init__(self, N: int, M: int) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(N, M))
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = self.weight + input
+        return output
+
+    def set_weight(self, weight: torch.Tensor) -> None:
+        self.weight[:] = torch.nn.Parameter(weight)


### PR DESCRIPTION
Summary:
Introducing SingleGPUExecutor to run any method on the model.

Moving PredictionBatch type from BatchingQueue.h to Types.h to use it for SingleGPUExecutor

Differential Revision: D39060502

