### PR TITLE
Copy sparse, dense and labels from the right source when shuffling Criteo data

### DIFF
--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -632,9 +632,12 @@ class BinaryCriteoUtils:
             curr_first_row = curr_last_row
 
         # Directly copy over the last day's files since they will be used for validation and testing.
-        for part in ["dense", "sparse", "labels"]:
+        for part, input_dir in zip(
+                ["sparse", "dense", "labels"],
+                [input_dir_sparse, input_dir_labels_and_dense, input_dir_labels_and_dense],
+        ):
             path_to_original = os.path.join(
-                input_dir_sparse, f"day_{days-1}_{part}.npy"
+                input_dir, f"day_{days-1}_{part}.npy"
             )
             val_train_path = os.path.join(
                 output_dir_shuffled, f"day_{days-1}_{part}.npy"

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -357,7 +357,7 @@ class BinaryCriteoUtils:
             if len(shape) == 2:
                 total_rows, row_size = shape
             else:
-                raise ValueError("Cannot load range for npy with ndim == 2.")
+                raise ValueError("Cannot load range for npy with ndim != 2.")
 
             if not (0 <= start_row < total_rows):
                 raise ValueError(

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -633,8 +633,8 @@ class BinaryCriteoUtils:
 
         # Directly copy over the last day's files since they will be used for validation and testing.
         for part, input_dir in zip(
-                ["sparse", "dense", "labels"],
-                [input_dir_sparse, input_dir_labels_and_dense, input_dir_labels_and_dense],
+            ["sparse", "dense", "labels"],
+            [input_dir_sparse, input_dir_labels_and_dense, input_dir_labels_and_dense],
         ):
             path_to_original = os.path.join(
                 input_dir, f"day_{days-1}_{part}.npy"

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -642,8 +642,8 @@ class BinaryCriteoUtils:
             val_train_path = os.path.join(
                 output_dir_shuffled, f"day_{days-1}_{part}.npy"
             )
-            shutil.copyfile(path_to_original, val_train_path)
             print(f"Copying over {path_to_original} to {val_train_path}")
+            shutil.copyfile(path_to_original, val_train_path)
 
 
 class InMemoryBinaryCriteoIterDataPipe(IterableDataset):

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -518,11 +518,11 @@ class BinaryCriteoUtils:
             input_dir_labels_and_dense (str): Input directory of labels and dense npy files.
             input_dir_sparse (str): Input directory of sparse npy files.
             output_dir_shuffled (str): Output directory for shuffled labels, dense and sparse npy files.
-            rows_per_day Dict[int, int]: Number of rows in each file.
+            rows_per_day (Dict[int, int]): Number of rows in each file.
             output_dir_full_set (str): Output directory of the full dataset, if desired.
             days (int): Number of day files.
             int_columns (int): Number of columns with dense features.
-            columns (int): Total number of columns.
+            sparse_columns (int): Total number of categorical columns.
             path_manager_key (str): Path manager key used to load from different filesystems.
             random_seed (int): Random seed used for the random.shuffle operator.
         """


### PR DESCRIPTION
When dense and spare features are located in different directories, i.e., `input_dir_labels_and_dense != input_dir_sparse` as the input to `shuffle()` function, this method throws an error in [L642](https://github.com/pytorch/torchrec/blob/71d51c8764c141ff8d849f73bcf06548ffad36c4/torchrec/datasets/criteo.py#L642) like:
```
FileNotFoundError: [Errno 2] No such file or directory: '/data/contiguous/day_23_dense.npy'
```
So I'm fixing input directories in this PR. This is also in line with [this remark](https://github.com/pytorch/torchrec/blob/71d51c8764c141ff8d849f73bcf06548ffad36c4/torchrec/datasets/scripts/shuffle_preproc_criteo.py#L36-L39).