### PR TITLE
Apply optimizer metadata on top of parameters and add hooks

### DIFF
--- a/torchrec/optim/__init__.py
+++ b/torchrec/optim/__init__.py
@@ -14,6 +14,7 @@ It also contains
 - several modules wrapping KeyedOptimizer, called CombinedOptimizer and OptimizerWrapper
 - Optimizers used in RecSys: e.g. rowwise adagrad/adam/etc
 """
+from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer  # noqa
 
 from torchrec.optim.clipping import GradientClipping, GradientClippingOptimizer  # noqa
 from torchrec.optim.fused import FusedOptimizer, FusedOptimizerModule  # noqa
@@ -27,6 +28,7 @@ from torchrec.optim.rowwise_adagrad import RowWiseAdagrad  # noqa
 from torchrec.optim.warmup import WarmupOptimizer, WarmupPolicy, WarmupStage  # noqa
 
 from . import (  # noqa  # noqa  # noqa  # noqa
+    apply_overlapped_optimizer,
     clipping,
     fused,
     keyed,

--- a/torchrec/optim/apply_overlapped_optimizer.py
+++ b/torchrec/optim/apply_overlapped_optimizer.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Iterable, Type
+
+import torch
+
+
+def apply_overlapped_optimizer(
+    optimizer_class: Type[torch.optim.Optimizer],
+    params: Iterable[torch.nn.Parameter],
+    optimizer_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Upon backwards(), parameters will fire the corresponding optimizer
+    Each parameter will have the optimizer_class and optimizer_kwargs attached to
+    _optimizer and _optimizer_kwargs.
+
+    Note - gradients for these parameters will be set to None after backwards().
+    This means that any other (non applied) optimizer over this parameter will be
+    a no-op.
+
+    Args:
+        optimizer_class: Type[torch.optim.Optimizer]: Optimizer to apply to parameter
+        params: Iterator[nn.Parameter]: parameters to apply optimizer state to
+        optimizer_kwargs: Dict[str, Any]: kwargs to pass to optimizer constructor
+
+    Example::
+        params_generator = model.parameters()
+        param_1 = next(params_generator)
+        param_2 = list(params_generator)
+
+        apply_overlapped_optimizer(torch.optim.SGD, [param_1], {"lr": .02})
+        apply_overlapped_optimizer(torch.optim.Adam, param_2, {"lr": .04})
+
+        print(param_1._optimizer, param_1._optimizer_kwargs)
+        >> torch.optim.SGD, {"lr": .02}
+    """
+
+    def _apply_overlapped_optimizer_to_param(param: torch.nn.Parameter) -> None:
+        # acc_grad creates a new node in the auto_grad graph that comes after
+        # the parameter node. In this node's backwards we call the overlapped
+        # optimizer.step(). We cannot do the backwards hook on param because
+        # the gradients are not fully ready by then.
+        # for more details see https://github.com/pytorch/pytorch/issues/76464
+        acc_grad = param.view_as(param).grad_fn.next_functions[0][0]
+        optimizer = optimizer_class([param], **optimizer_kwargs)
+
+        if hasattr(param, "_acc_grad") and hasattr(param, "_overlapped_optimizer"):
+            raise ValueError(
+                # pyre-ignore
+                f"{param} already has {param._overlapped_optimizer} applied as an overlapped optimizer. Cannot apply again"
+            )
+
+        # The grad accumulator is a weak ref, so we need to keep it
+        # alive until the Tensor is alive.
+        # Store it on the module to avoid uncollectable ref-cycle
+        # pyre-ignore
+        param._acc_grad = acc_grad
+        param._overlapped_optimizer = optimizer
+
+        # pyre-ignore
+        param._optimizer_class = optimizer_class
+        # pyre-ignore
+        param._optimizer_kwargs = optimizer_kwargs
+
+        # pyre-ignore
+        def optimizer_hook(*_unused) -> None:
+            # pyre-ignore
+            param._overlapped_optimizer.step()
+            param.grad = None
+
+        param._acc_grad.register_hook(optimizer_hook)
+
+    for param in params:
+        _apply_overlapped_optimizer_to_param(param)

--- a/torchrec/optim/tests/test_apply_overlapped_optimizer.py
+++ b/torchrec/optim/tests/test_apply_overlapped_optimizer.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+import torch
+from torchrec import EmbeddingBagCollection, EmbeddingBagConfig, KeyedJaggedTensor
+from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer
+
+
+class ApplyOverlappedOptimizerTest(unittest.TestCase):
+    def test_apply_overlapped_optimizer(self) -> None:
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="t1", embedding_dim=4, num_embeddings=2, feature_names=["f1"]
+                ),
+                EmbeddingBagConfig(
+                    name="t2", embedding_dim=4, num_embeddings=2, feature_names=["f2"]
+                ),
+            ]
+        )
+
+        apply_overlapped_optimizer(
+            torch.optim.SGD,
+            ebc.embedding_bags["t1"].parameters(),
+            optimizer_kwargs={"lr": 1.0},
+        )
+
+        apply_overlapped_optimizer(
+            torch.optim.SGD,
+            ebc.embedding_bags["t2"].parameters(),
+            optimizer_kwargs={"lr": 2.0},
+        )
+
+        ebc.load_state_dict(
+            {
+                "embedding_bags.t1.weight": torch.FloatTensor(
+                    [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]
+                ),
+                "embedding_bags.t2.weight": torch.FloatTensor(
+                    [[10.0, 10.0, 10.0, 10.0], [12.0, 12.0, 12.0, 12.0]]
+                ),
+            }
+        )
+
+        #     0       1        2  <-- batch
+        # f1   [0,1] None    [0]
+        # f2   [0,1]    [1]    [0]
+        # ^
+        # feature
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 0, 0, 1, 1, 0]),
+            lengths=torch.tensor([2, 0, 1, 2, 1, 1]),
+        )
+
+        kt_out = ebc(kjt).to_dict()
+        stack = []
+        for _key, val in kt_out.items():
+            stack.append(val)
+        torch.stack(stack).sum().backward()
+
+        t1_weight = next(ebc.embedding_bags["t1"].parameters())
+        t2_weight = next(ebc.embedding_bags["t2"].parameters())
+
+        self.assertIsNone(t1_weight.grad)
+        self.assertIsNone(t2_weight.grad)
+
+        self.assertTrue(hasattr(t1_weight, "_optimizer_class"))
+        self.assertEqual(t1_weight._optimizer_class, torch.optim.SGD)
+        self.assertTrue(hasattr(t1_weight, "_optimizer_kwargs"))
+        self.assertEqual(t1_weight._optimizer_kwargs, {"lr": 1.0})
+
+        self.assertTrue(hasattr(t2_weight, "_optimizer_class"))
+        self.assertEqual(t2_weight._optimizer_class, torch.optim.SGD)
+        self.assertTrue(hasattr(t2_weight, "_optimizer_kwargs"))
+        self.assertEqual(t2_weight._optimizer_kwargs, {"lr": 2.0})
+
+        expected_state_dict = {
+            "embedding_bags.t1.weight": torch.FloatTensor(
+                [[-1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0]]
+            ),
+            "embedding_bags.t2.weight": torch.FloatTensor(
+                [[6.0, 6.0, 6.0, 6.0], [8.0, 8.0, 8.0, 8.0]]
+            ),
+        }
+
+        for key, state in ebc.state_dict().items():
+            self.assertIn(key, expected_state_dict)
+            torch.testing.assert_close(state, expected_state_dict[key])


### PR DESCRIPTION
Summary:
Apply metadata of fused optimizers on top of parameters.

Add a backwards hook for behavorial consistency

Reviewed By: dstaay-fb, xing-liu

Differential Revision: D39114387

