### PR TITLE
Move context creation into input_dist(...)

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import torch
 from torch import nn
@@ -171,8 +171,9 @@ class ShardedQuantEmbeddingBagCollection(
 
     # pyre-ignore [14]
     def input_dist(
-        self, ctx: ShardedModuleContext, features: KeyedJaggedTensor
-    ) -> Awaitable[ListOfSparseFeaturesList]:
+        self, features: KeyedJaggedTensor
+    ) -> Tuple[ShardedModuleContext, Awaitable[ListOfSparseFeaturesList]]:
+        ctx = self.create_context()
         if self._has_uninitialized_input_dist:
             self._create_input_dist(features.keys(), features.device())
             self._has_uninitialized_input_dist = False
@@ -204,7 +205,7 @@ class ShardedQuantEmbeddingBagCollection(
                     self._input_dists, features_by_shards
                 )
             ]
-            return ListOfSparseFeaturesListAwaitable(awaitables)
+            return ctx, ListOfSparseFeaturesListAwaitable(awaitables)
 
     def compute(
         self,

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -52,10 +52,9 @@ from torchrec.test_utils import get_free_port, init_distributed_single_host
 class TestShardedEmbeddingBagCollection(ShardedEmbeddingBagCollection):
     def input_dist(
         self,
-        ctx: ShardedModuleContext,
         features: KeyedJaggedTensor,
-    ) -> Awaitable[SparseFeaturesList]:
-        return super().input_dist(ctx, features)
+    ) -> Tuple[ShardedModuleContext, Awaitable[SparseFeaturesList]]:
+        return super().input_dist(features)
 
 
 class TestCustomEBCSharder(EmbeddingBagCollectionSharder):

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -272,11 +272,10 @@ def _start_data_dist(
             else:
                 args.append(None)
         # Start input distribution.
-        module_ctx = module.create_context()
-        context.module_contexts[forward.name] = module_ctx
-        context.input_dist_requests[forward.name] = module.input_dist(
-            module_ctx, *args, **kwargs
-        )
+        (
+            context.module_contexts[forward.name],
+            context.input_dist_requests[forward.name],
+        ) = module.input_dist(*args, **kwargs)
 
 
 def _get_node_args_helper(

--- a/torchrec/inference/tests/generate_test_packages.py
+++ b/torchrec/inference/tests/generate_test_packages.py
@@ -24,7 +24,7 @@ except ImportError:
 
 def save(
     name: str, model: torch.nn.Module, eg: Optional[Tuple] = None  # pyre-ignore
-) -> None:  # pyre-ignore
+) -> None:
     with PackageExporter(str(p / name)) as e:
         e.mock("iopath.**")
         e.intern("**")


### PR DESCRIPTION
Summary: No need to expose create_context() to users.

Differential Revision: D39319513

