### PR TITLE
compute_output_dist with splited kjt for output_dist and return

### DIFF
--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.distributed as dist
 from torchrec.distributed.dist_data import (
-    EmbeddingsAllToOne,
+    SeqEmbeddingsAllToOne,
     SequenceEmbeddingsAllToAll,
 )
 from torchrec.distributed.embedding_lookup import (
@@ -55,13 +55,14 @@ class InferTwSequenceEmbeddingDist(BaseSequenceEmbeddingDist[List[torch.Tensor]]
         world_size: int,
     ) -> None:
         super().__init__()
-        self._dist: EmbeddingsAllToOne = EmbeddingsAllToOne(device, world_size, 0)
+        self._dist: SeqEmbeddingsAllToOne = SeqEmbeddingsAllToOne(device, world_size)
 
+    # pyre-ignore [15]
     def forward(
         self,
         local_embs: List[torch.Tensor],
         sharding_ctx: SequenceShardingContext,
-    ) -> Awaitable[torch.Tensor]:
+    ) -> Awaitable[List[torch.Tensor]]:
         """
         Performs AlltoOne operation on sequence embeddings tensor.
 


### PR DESCRIPTION
Summary:
* seq embedding needs no merge for result returning, this is a long over-due optimization to save cat op and copy op for merge_pooled_embedding primitive.
* we use shards of kjt to construct Seq embedding returned KeyedTensor.

Reviewed By: zyan0

Differential Revision: D39409192

