### PR TITLE
Fix "divide by zero" error when passed DDR memory is 0

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -191,8 +191,10 @@ class EmbeddingStats(Stats):
                 else 0
             )
             used_ddr_gb = bytes_to_gb(used_ddr[rank])
-            used_ddr_ratio = used_ddr[rank] / (
-                (1 - reserved_percent) * device.storage.ddr
+            used_ddr_ratio = (
+                used_ddr[rank] / ((1 - reserved_percent) * device.storage.ddr)
+                if device.storage.ddr > 0
+                else 0
             )
             for sharding_type in used_sharding_types:
                 if sharding_type not in stats[rank]["type"]:


### PR DESCRIPTION
Summary: When users pass 0 for ddr_cap, `used_ddr_ratio` will encounter "divide by zero" error. It should be set to 0 when ddr memory is passed as 0.

Differential Revision: D38666868

