### PR TITLE
Fix shared feature for EmbeddingCollection

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -53,14 +53,17 @@ class ModelInput(Pipelineable):
         Returns a global (single-rank training) batch
         and a list of local (multi-rank training) batches of world_size.
         """
-        idlist_features = [
-            feature for table in tables for feature in table.feature_names
-        ]
+        idlist_features_to_num_embeddings = {}
+        for table in tables:
+            for feature in table.feature_names:
+                idlist_features_to_num_embeddings[feature] = table.num_embeddings
+
+        idlist_features = list(idlist_features_to_num_embeddings.keys())
         idscore_features = [
             feature for table in weighted_tables for feature in table.feature_names
         ]
 
-        idlist_ind_ranges = [table.num_embeddings for table in tables]
+        idlist_ind_ranges = list(idlist_features_to_num_embeddings.values())
         idscore_ind_ranges = [table.num_embeddings for table in weighted_tables]
 
         # Generate global batch.


### PR DESCRIPTION
Summary:
It seems `ShardedEmbeddingCollection` doesn't handle shared feature the same way as  `EmbeddingCollection`

## Shared feature
When a feature is shared by more than one embedding tables, it is called shared features.

```
table_1:
   num_embedding: 100
   embedding_dim: 64
   features:
      - f_1
table_2:
   num_embeddings: 1000
   embedding_dim: 128
   features:
      - f_1
```

embedding names are represented as following:

```
embedding_names = [
   table_1: [
      feature_1@table_1
   ]
   table_2: [
      feature_1@table_2
   ]
]
```

## Embedding Collection
https://fburl.com/code/yyc4qyj3

output is
```
{
    f_1@table_1 : lookup1
    f_1@table_2 : lookup2
}
```

## SharedEmbeddingCollection

https://fburl.com/code/8u7j5o2h

output is
```
{
   f_1: lookup2?
}

Differential Revision: D39410882

