### PR TITLE
Add helper to apply overlapped optimizer to module

### DIFF
--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -41,8 +41,8 @@ from torchrec.distributed.types import (
     ShardingType,
 )
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
-from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
+from torchrec.optim.overlapped_optimizer_utils import apply_overlapped_optimizer
 from typing_extensions import Protocol
 
 

--- a/torchrec/distributed/tests/test_apply_optim_per_param.py
+++ b/torchrec/distributed/tests/test_apply_optim_per_param.py
@@ -41,7 +41,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
     EmbeddingCollection,
 )
-from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer
+from torchrec.optim.overlapped_optimizer_utils import apply_overlapped_optimizer
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class

--- a/torchrec/optim/__init__.py
+++ b/torchrec/optim/__init__.py
@@ -14,8 +14,6 @@ It also contains
 - several modules wrapping KeyedOptimizer, called CombinedOptimizer and OptimizerWrapper
 - Optimizers used in RecSys: e.g. rowwise adagrad/adam/etc
 """
-from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer  # noqa
-
 from torchrec.optim.clipping import GradientClipping, GradientClippingOptimizer  # noqa
 from torchrec.optim.fused import FusedOptimizer, FusedOptimizerModule  # noqa
 from torchrec.optim.keyed import (  # noqa
@@ -33,15 +31,16 @@ from torchrec.optim.optimizers import (  # noqa
     PartialRowWiseLAMB,
     SGD,
 )
+from torchrec.optim.overlapped_optimizer_utils import apply_overlapped_optimizer  # noqa
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad  # noqa
 from torchrec.optim.warmup import WarmupOptimizer, WarmupPolicy, WarmupStage  # noqa
 
 from . import (  # noqa  # noqa  # noqa  # noqa
-    apply_overlapped_optimizer,
     clipping,
     fused,
     keyed,
     optimizers,
+    overlapped_optimizer_utils,
     rowwise_adagrad,
     warmup,
 )

--- a/torchrec/test_utils/test_models.py
+++ b/torchrec/test_utils/test_models.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class TestModel(torch.nn.Module):
+    """
+    Simple TestModel class, contains a EmbeddingBagCollection and Linear layer.
+    """
+
+    def __init__(self, ebc: EmbeddingBagCollection) -> None:
+        super().__init__()
+        self.ebc = ebc
+        self.over_arch = torch.nn.Linear(
+            4,
+            1,
+        )
+
+    def forward(self, kjt: KeyedJaggedTensor) -> torch.Tensor:
+        ebc_output = self.ebc.forward(kjt).to_dict()
+        sparse_features = []
+        for key in kjt.keys():
+            sparse_features.append(ebc_output[key])
+        sparse_features = torch.cat(sparse_features, dim=0)
+        return self.over_arch(sparse_features)
+
+
+class TestSequentialModel(torch.nn.Module):
+    """
+    Simple TestModel class, contains a EmbeddingCollection and Linear layer.
+    """
+
+    def __init__(self, ec: EmbeddingCollection) -> None:
+        super().__init__()
+        self.ec = ec
+        self.over_arch = torch.nn.Linear(
+            ec.embedding_dim(),
+            1,
+        )
+
+    def forward(self, kjt: KeyedJaggedTensor) -> torch.Tensor:
+        ec_output = self.ec.forward(kjt)
+        sparse_features = []
+        for key in kjt.keys():
+            sparse_features.extend(ec_output[key].to_dense())
+        sparse_features = torch.Tensor(sparse_features)
+        sparse_features = torch.sum(sparse_features)
+        return self.over_arch(sparse_features)


### PR DESCRIPTION
Summary: Since applying an overlapped optimizer to all EBCs and ECs in a model is a common use case, creating a helper function `apply_overlapped_optimizer_to_module` doing just that for convenience.

Differential Revision: D39580955

