### PR TITLE
Interface refactor for feature sharding

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -29,6 +29,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.types import (
     Awaitable,
+    FeatureShardingMixIn,
     NoWait,
     ParameterSharding,
     QuantizedCommCodecs,
@@ -642,7 +643,7 @@ class BaseEmbeddingDist(abc.ABC, nn.Module, Generic[T]):
         pass
 
 
-class EmbeddingSharding(abc.ABC, Generic[F, T]):
+class EmbeddingSharding(abc.ABC, Generic[F, T], FeatureShardingMixIn):
     """
     Used to implement different sharding types for `EmbeddingBagCollection`, e.g.
     table_wise.
@@ -694,11 +695,7 @@ class EmbeddingSharding(abc.ABC, Generic[F, T]):
         pass
 
     @abc.abstractmethod
-    def id_list_feature_names(self) -> List[str]:
-        pass
-
-    @abc.abstractmethod
-    def id_score_list_feature_names(self) -> List[str]:
+    def embedding_names_per_rank(self) -> List[List[str]]:
         pass
 
 

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -33,6 +33,7 @@ from torchrec.distributed.sharding.tw_sequence_sharding import (
 )
 from torchrec.distributed.types import (
     Awaitable,
+    FeatureShardingMixIn,
     LazyAwaitable,
     ParameterSharding,
     ShardedModule,
@@ -352,6 +353,11 @@ class ShardedQuantEmbeddingCollection(
 
     def create_context(self) -> ShardedModuleContext:
         return EmbeddingCollectionContext(sharding_contexts=[])
+
+    @property
+    def shardings(self) -> Dict[str, FeatureShardingMixIn]:
+        # pyre-ignore [7]
+        return self._sharding_type_to_sharding
 
 
 class QuantEmbeddingCollectionSharder(

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -27,6 +27,7 @@ from torchrec.distributed.embeddingbag import (
 from torchrec.distributed.sharding.tw_sharding import InferTwEmbeddingSharding
 from torchrec.distributed.types import (
     Awaitable,
+    FeatureShardingMixIn,
     LazyAwaitable,
     ParameterSharding,
     ShardedModule,
@@ -244,6 +245,11 @@ class ShardedQuantEmbeddingBagCollection(
 
     def copy(self, device: torch.device) -> nn.Module:
         return self
+
+    @property
+    def shardings(self) -> Dict[str, FeatureShardingMixIn]:
+        # pyre-ignore [7]
+        return self._sharding_type_to_sharding
 
 
 class QuantEmbeddingBagCollectionSharder(

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -39,8 +39,8 @@ class CwSequenceEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 
@@ -65,7 +65,7 @@ class CwSequenceEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
+            self.id_list_features_per_rank(),
             device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -204,8 +204,8 @@ class CwPooledEmbeddingSharding(BaseCwEmbeddingSharding[SparseFeatures, torch.Te
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -117,6 +117,9 @@ class BaseDpEmbeddingSharding(EmbeddingSharding[F, T]):
             embedding_names.extend(grouped_config.embedding_names())
         return embedding_names
 
+    def embedding_names_per_rank(self) -> List[List[str]]:
+        raise NotImplementedError
+
     def embedding_shard_metadata(self) -> List[Optional[ShardMetadata]]:
         embedding_shard_metadata = []
         for grouped_config in self._grouped_embedding_configs:

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -155,6 +155,9 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[F, T]):
             embedding_names.extend(grouped_config.embedding_names())
         return embedding_names
 
+    def embedding_names_per_rank(self) -> List[List[str]]:
+        raise NotImplementedError
+
     def embedding_shard_metadata(self) -> List[Optional[ShardMetadata]]:
         embedding_shard_metadata = []
         for grouped_config in self._grouped_embedding_configs:

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -149,8 +149,8 @@ class TwSequenceEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 
@@ -175,7 +175,7 @@ class TwSequenceEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
+            self.id_list_features_per_rank(),
             device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
@@ -193,8 +193,8 @@ class InferTwSequenceEmbeddingSharding(
         self, device: Optional[torch.device] = None
     ) -> BaseSparseFeaturesDist[SparseFeaturesList]:
         return InferTwSparseFeaturesDist(
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             self._world_size,
         )
 

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -216,7 +216,29 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[F, T]):
                 id_score_list_feature_names.extend(grouped_config.feature_names())
         return id_score_list_feature_names
 
-    def _id_list_features_per_rank(self) -> List[int]:
+    def id_list_feature_names_per_rank(self) -> List[List[str]]:
+        id_list_feature_names = []
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
+            id_list_feature_names_per_rank = []
+            for grouped_config in grouped_embedding_configs:
+                id_list_feature_names_per_rank.extend(grouped_config.feature_names())
+            id_list_feature_names.append(id_list_feature_names_per_rank)
+        return id_list_feature_names
+
+    def id_score_list_feature_names_per_rank(self) -> List[List[str]]:
+        id_score_list_feature_names = []
+        for (
+            score_grouped_embedding_configs
+        ) in self._score_grouped_embedding_configs_per_rank:
+            id_score_list_feature_names_per_rank = []
+            for grouped_config in score_grouped_embedding_configs:
+                id_score_list_feature_names_per_rank.extend(
+                    grouped_config.feature_names()
+                )
+            id_score_list_feature_names.append(id_score_list_feature_names_per_rank)
+        return id_score_list_feature_names
+
+    def id_list_features_per_rank(self) -> List[int]:
         id_list_features_per_rank = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             num_features = 0
@@ -225,7 +247,7 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[F, T]):
             id_list_features_per_rank.append(num_features)
         return id_list_features_per_rank
 
-    def _id_score_list_features_per_rank(self) -> List[int]:
+    def id_score_list_features_per_rank(self) -> List[int]:
         id_score_list_features_per_rank = []
         for (
             score_grouped_embedding_configs
@@ -347,8 +369,8 @@ class TwPooledEmbeddingSharding(BaseTwEmbeddingSharding[SparseFeatures, torch.Te
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 
@@ -468,8 +490,8 @@ class InferTwEmbeddingSharding(
         self, device: Optional[torch.device] = None
     ) -> BaseSparseFeaturesDist[SparseFeaturesList]:
         return InferTwSparseFeaturesDist(
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             self._world_size,
         )
 

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -190,6 +190,9 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[F, T]):
                 embedding_names.extend(grouped_config.embedding_names())
         return embedding_names
 
+    def embedding_names_per_rank(self) -> List[List[str]]:
+        raise NotImplementedError
+
     def embedding_shard_metadata(self) -> List[Optional[ShardMetadata]]:
         embedding_shard_metadata = []
         for grouped_config in self._grouped_embedding_configs_per_node:

--- a/torchrec/distributed/sharding/vb_cw_sharding.py
+++ b/torchrec/distributed/sharding/vb_cw_sharding.py
@@ -46,8 +46,8 @@ class VariableBatchCwPooledEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 

--- a/torchrec/distributed/sharding/vb_tw_sharding.py
+++ b/torchrec/distributed/sharding/vb_tw_sharding.py
@@ -115,8 +115,8 @@ class VariableBatchTwPooledEmbeddingSharding(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             self._pg,
-            self._id_list_features_per_rank(),
-            self._id_score_list_features_per_rank(),
+            self.id_list_features_per_rank(),
+            self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
         )
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -434,7 +434,47 @@ class ModuleCopyMixin:
         return self.to(device)
 
 
-class ShardedModule(abc.ABC, nn.Module, Generic[CompIn, DistOut, Out], ModuleCopyMixin):
+class FeatureShardingMixIn:
+    """
+    Feature Sharding Interface to provide sharding-aware feature metadata.
+    """
+
+    def id_list_feature_names(self) -> List[str]:
+        raise NotImplementedError
+
+    def id_score_list_feature_names(self) -> List[str]:
+        raise NotImplementedError
+
+    def id_list_feature_names_per_rank(self) -> List[List[str]]:
+        raise NotImplementedError
+
+    def id_score_list_feature_names_per_rank(self) -> List[List[str]]:
+        raise NotImplementedError
+
+    def id_list_features_per_rank(self) -> List[int]:
+        raise NotImplementedError
+
+    def id_score_list_features_per_rank(self) -> List[int]:
+        raise NotImplementedError
+
+
+class ModuleShardingMixIn:
+    """
+    The interface to access a sharded module's sharding scheme.
+    """
+
+    @property
+    def shardings(self) -> Dict[str, FeatureShardingMixIn]:
+        raise NotImplementedError
+
+
+class ShardedModule(
+    abc.ABC,
+    nn.Module,
+    Generic[CompIn, DistOut, Out],
+    ModuleCopyMixin,
+    ModuleShardingMixIn,
+):
     """
     All model-parallel modules implement this interface.
     Inputs and outputs are data-parallel.


### PR DESCRIPTION
Summary: * expose sharding related interface to centralize sharding-aware feature-related APIs, better devx for training/inference refactoring.

Reviewed By: zyan0

Differential Revision: D39559608

