### PR TITLE
Add a test to ensure feature_processor weights are checkpointed

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -243,6 +243,12 @@ class TestDenseArch(nn.Module):
             in_features=num_float_features, out_features=8, device=device
         )
 
+        self.dummy_param = torch.nn.Parameter(torch.empty(2))
+        self.register_buffer(
+            "dummy_buffer",
+            torch.nn.Parameter(torch.empty(1, device=device)),
+        )
+
     def forward(self, dense_input: torch.Tensor) -> torch.Tensor:
         return self.linear(dense_input)
 


### PR DESCRIPTION
Summary:
# Problem

Identified for the CMF model on TorchRec, its feature processors were not checkpointed.

# Solution

Add a unit test to guard its behavior

Reviewed By: ge0405

Differential Revision: D39518283

