### PR TITLE
Direct planner

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -18,16 +18,13 @@ from torch.distributed.fsdp import FullyShardedDataParallel
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
-from torchrec.distributed.embedding import EmbeddingCollectionSharder
-from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
-from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
+
+from torchrec.distributed.parameter_sharding_utils import get_default_sharders
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
     sharder_name,
     Topology,
 )
-from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
-from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.types import (
     ModuleCopyMixin,
     ModuleSharder,
@@ -46,16 +43,6 @@ from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 
 
 _DDP_STATE_DICT_PREFIX = "module."
-
-
-def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
-    return [
-        cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
-        cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
-        cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder()),
-        cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
-        cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),
-    ]
 
 
 class DataParallelWrapper(abc.ABC):

--- a/torchrec/distributed/parameter_sharding_utils.py
+++ b/torchrec/distributed/parameter_sharding_utils.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import math
+from typing import Callable, cast, Dict, List, Optional, Tuple, Type
+
+import torch
+from torch import distributed as dist, nn
+from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.embedding import EmbeddingCollectionSharder
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
+from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
+from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
+from torchrec.distributed.types import (
+    EnumerableShardingSpec,
+    ModuleSharder,
+    ParameterSharding,
+    ShardingType,
+    ShardMetadata,
+)
+from torchrec.distributed.utils import none_throws
+
+MIN_CW_DIM: int = 128
+
+
+def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
+    return [
+        cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
+        cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder()),
+        cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
+        cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
+        cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),
+    ]
+
+
+def get_module_to_default_sharders() -> Dict[Type[nn.Module], ModuleSharder[nn.Module]]:
+    return {sharder.module_type: sharder for sharder in get_default_sharders()}
+
+
+def placement(
+    compute_device: str,
+    rank: int,
+    local_size: int,
+) -> str:
+    param_device = compute_device
+    if compute_device == "cuda":
+        param_device = torch.device("cuda", rank % local_size)
+    return f"rank:{rank}/{param_device}"
+
+
+def calculate_shard_sizes_and_offsets(
+    tensor: torch.Tensor,
+    world_size: int,
+    local_world_size: int,
+    sharding_type: str,
+    col_wise_shard_dim: Optional[int] = None,
+) -> Tuple[List[List[int]], List[List[int]]]:
+    """
+    Calculates sizes and offsets for tensor sharded according to provided sharding type.
+
+    Args:
+        tensor (torch.Tensor): tensor to be sharded.
+        world_size (int): total number of devices in topology.
+        local_world_size (int): total number of devices in host group topology.
+        sharding_type (str): provided ShardingType value.
+        col_wise_shard_dim (Optional[int]): dimension for column wise sharding split.
+
+    Returns:
+        Tuple[List[List[int]], List[List[int]]]: shard sizes, represented as a list of the dimensions of the sharded tensor on each device, and shard offsets, represented as a list of coordinates of placement on each device.
+
+    Raises:
+        ValueError: If `sharding_type` is not a valid ShardingType.
+    """
+
+    (rows, columns) = tensor.shape
+
+    if sharding_type == ShardingType.DATA_PARALLEL.value:
+        return [[rows, columns]] * world_size, [[0, 0]] * world_size
+    elif sharding_type == ShardingType.TABLE_WISE.value:
+        return [[rows, columns]], [[0, 0]]
+    elif sharding_type == ShardingType.ROW_WISE.value:
+        return _calculate_rw_shard_sizes_and_offsets(rows, world_size, columns)
+    elif sharding_type == ShardingType.TABLE_ROW_WISE.value:
+        return _calculate_rw_shard_sizes_and_offsets(rows, local_world_size, columns)
+    elif (
+        sharding_type == ShardingType.COLUMN_WISE.value
+        or sharding_type == ShardingType.TABLE_COLUMN_WISE.value
+    ):
+        return _calculate_cw_shard_sizes_and_offsets(columns, rows, col_wise_shard_dim)
+
+    raise ValueError(
+        f"Unrecognized or unsupported sharding type provided: {sharding_type}"
+    )
+
+
+def _calculate_rw_shard_sizes_and_offsets(
+    hash_size: int, num_devices: int, columns: int
+) -> Tuple[List[List[int]], List[List[int]]]:
+    """
+    Sets prefix of shard_sizes to be ceil(hash_size/num_devices).
+
+    For example if hash_size = 10, num_devices = 3, we will allocate the rows as 3,3,3,1
+    (rather than 3,3,2,2).
+    This is due to implementation in RW sharding that sets block_size_lists to be ceil.
+    The balanced way is harder to support on GPU.
+    For more details see https://fb.quip.com/xbgbAchCTOL0
+
+    Also consider the example of hash_size = 5, num_devices = 4. The expected rows per
+    rank is [2,2,1,0].
+    """
+
+    block_size: int = math.ceil(hash_size / num_devices)
+    last_rank: int = hash_size // block_size
+    last_block_size: int = hash_size - block_size * last_rank
+    shard_sizes: List[List[int]] = []
+
+    for rank in range(num_devices):
+        if rank < last_rank:
+            local_row: int = block_size
+        elif rank == last_rank:
+            local_row: int = last_block_size
+        else:
+            local_row: int = 0
+        shard_sizes.append([local_row, columns])
+    shard_offsets = [[0, 0]]
+
+    for i in range(num_devices - 1):
+        shard_offsets.append([shard_sizes[i][0] + shard_offsets[i][0], 0])
+
+    return shard_sizes, shard_offsets
+
+
+def _calculate_cw_shard_sizes_and_offsets(
+    hash_size: int,
+    rows: int,
+    col_wise_shard_dim: Optional[int] = None,
+) -> Tuple[List[List[int]], List[List[int]]]:
+    block_size: int = min(
+        col_wise_shard_dim if col_wise_shard_dim else MIN_CW_DIM, hash_size
+    )
+    num_col_wise_shards, residual = divmod(hash_size, block_size)
+
+    shard_sizes: List[List[int]] = [[rows, block_size]] * (num_col_wise_shards - 1)
+    shard_sizes.append([rows, block_size + residual])
+
+    shard_offsets: List[List[int]] = [
+        [0, block_size * rank] for rank in range(num_col_wise_shards)
+    ]
+    return shard_sizes, shard_offsets
+
+
+def _get_parameter_size_offsets(
+    param: torch.nn.Parameter,
+    sharding_type: ShardingType,
+    local_size: int,
+    world_size: int,
+    col_wise_shard_dim: Optional[int] = None,
+) -> List[Tuple[List[int], List[int]]]:
+    (shard_sizes, shard_offsets,) = calculate_shard_sizes_and_offsets(
+        tensor=none_throws(param),
+        world_size=world_size,
+        local_world_size=local_size,
+        sharding_type=sharding_type.value,
+        col_wise_shard_dim=col_wise_shard_dim,
+    )
+    return list(zip(shard_sizes, shard_offsets))
+
+
+def _get_compute_kernel(
+    sharder: ModuleSharder[nn.Module],
+    param: nn.Parameter,
+    sharding_type: str,
+    device_type: str,
+) -> str:
+    # TODO add placement support for compute_kernel
+    compute_kernels = sharder.compute_kernels(sharding_type, device_type)
+
+    if sharding_type == ShardingType.DATA_PARALLEL or not hasattr(
+        param, "_optimizer_class"
+    ):
+        if EmbeddingComputeKernel.DENSE.value in compute_kernels:
+            return EmbeddingComputeKernel.DENSE.value
+        elif EmbeddingComputeKernel.QUANT.value in compute_kernels:
+            return EmbeddingComputeKernel.QUANT.value
+    else:
+        if EmbeddingComputeKernel.FUSED.value in compute_kernels:
+            return EmbeddingComputeKernel.FUSED.value
+        elif EmbeddingComputeKernel.QUANT.value in compute_kernels:
+            return EmbeddingComputeKernel.QUANT.value
+
+    raise ValueError(f"Could not find compute kernel for sharding_type={sharding_type}")
+
+
+def _get_parameter_sharding(
+    param: nn.Parameter,
+    sharding_type: str,
+    size_offset_ranks: List[Tuple[List[int], List[int], int]],
+    local_size: int,
+    device_type: str,
+    sharder: ModuleSharder[nn.Module],
+) -> ParameterSharding:
+    return ParameterSharding(
+        sharding_spec=None
+        if sharding_type == ShardingType.DATA_PARALLEL.value
+        else EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_sizes=size,
+                    shard_offsets=offset,
+                    placement=placement(
+                        device_type,
+                        none_throws(rank),
+                        none_throws(local_size),
+                    ),
+                )
+                for (size, offset, rank) in (size_offset_ranks)
+            ]
+        ),
+        sharding_type=sharding_type,
+        compute_kernel=_get_compute_kernel(sharder, param, sharding_type, device_type),
+        ranks=[rank for (_, _, rank) in size_offset_ranks],
+    )
+
+
+ParameterShardingGenerator = Callable[
+    [nn.Parameter, int, int, str, ModuleSharder[nn.Module]], ParameterSharding
+]
+
+
+def data_parallel_sharding() -> ParameterShardingGenerator:
+    def _parameter_sharding_generator(
+        param: nn.Parameter,
+        local_size: int,
+        world_size: int,
+        device_type: str,
+        sharder: ModuleSharder[nn.Module],
+    ) -> ParameterSharding:
+        size_and_offsets = _get_parameter_size_offsets(
+            param,
+            ShardingType.DATA_PARALLEL,
+            local_size,
+            world_size,
+        )
+        size_offset_ranks = []
+
+        assert len(size_and_offsets) == world_size
+        for (size, offset), rank in zip(size_and_offsets, range(world_size)):
+            size_offset_ranks.append((size, offset, rank))
+
+        return _get_parameter_sharding(
+            param,
+            ShardingType.DATA_PARALLEL.value,
+            size_offset_ranks,
+            local_size,
+            device_type,
+            sharder,
+        )
+
+    return _parameter_sharding_generator
+
+
+def table_wise_sharding(
+    rank: int,
+) -> ParameterShardingGenerator:
+    def _parameter_sharding_generator(
+        param: nn.Parameter,
+        local_size: int,
+        world_size: int,
+        device_type: str,
+        sharder: ModuleSharder[nn.Module],
+    ) -> ParameterSharding:
+        size_and_offsets = _get_parameter_size_offsets(
+            param,
+            ShardingType.TABLE_WISE,
+            local_size,
+            world_size,
+        )
+        assert len(size_and_offsets) == 1
+        (size, offset) = size_and_offsets[0]
+        size_offset_ranks = [(size, offset, rank)]
+
+        return _get_parameter_sharding(
+            param,
+            ShardingType.TABLE_WISE.value,
+            size_offset_ranks,
+            local_size,
+            device_type,
+            sharder,
+        )
+
+    return _parameter_sharding_generator
+
+
+def row_wise_sharding() -> ParameterShardingGenerator:
+    def _parameter_sharding_generator(
+        param: nn.Parameter,
+        local_size: int,
+        world_size: int,
+        device_type: str,
+        sharder: ModuleSharder[nn.Module],
+    ) -> ParameterSharding:
+        size_and_offsets = _get_parameter_size_offsets(
+            param,
+            ShardingType.ROW_WISE,
+            local_size,
+            world_size,
+        )
+        assert len(size_and_offsets) <= world_size
+        size_offset_ranks = []
+        for (size, offset), rank in zip(size_and_offsets, range(world_size)):
+            size_offset_ranks.append((size, offset, rank))
+
+        return _get_parameter_sharding(
+            param,
+            ShardingType.ROW_WISE.value,
+            size_offset_ranks,
+            local_size,
+            device_type,
+            sharder,
+        )
+
+    return _parameter_sharding_generator
+
+
+def column_wise_sharding(
+    shard_dim: int = 128,
+    ranks: Optional[List[int]] = None,
+) -> ParameterShardingGenerator:
+    """
+    if ranks is not specified, shards will be placed in a uniform fashion.
+    If there are not enough shards, only the first ceil(embedding_dim/shard_dim) ranks will get
+    shards
+    """
+
+    def _parameter_sharding_generator(
+        param: nn.Parameter,
+        local_size: int,
+        world_size: int,
+        device_type: str,
+        sharder: ModuleSharder[nn.Module],
+    ) -> ParameterSharding:
+        size_and_offsets = _get_parameter_size_offsets(
+            param, ShardingType.COLUMN_WISE, local_size, world_size, shard_dim
+        )
+
+        size_offset_ranks = []
+        if ranks is None:
+            for (size, offset), rank in zip(size_and_offsets, range(world_size)):
+                size_offset_ranks.append((size, offset, rank))
+        else:
+            assert len(size_offset_ranks) <= len(ranks)
+            for (size, offset), rank in zip(size_and_offsets, ranks):
+                size_offset_ranks.append((size, offset, rank))
+
+        return _get_parameter_sharding(
+            param,
+            ShardingType.COLUMN_WISE.value,
+            size_offset_ranks,
+            local_size,
+            device_type,
+            sharder,
+        )
+
+    return _parameter_sharding_generator
+
+
+def table_row_wise_sharding(
+    node_index: int,
+) -> ParameterShardingGenerator:
+    def _parameter_sharding_generator(
+        param: nn.Parameter,
+        local_size: int,
+        world_size: int,
+        device_type: str,
+        sharder: ModuleSharder[nn.Module],
+    ) -> ParameterSharding:
+        size_and_offsets = _get_parameter_size_offsets(
+            param,
+            ShardingType.TABLE_ROW_WISE,
+            local_size,
+            world_size,
+        )
+
+        size_offset_ranks = []
+        assert len(size_and_offsets) <= local_size
+        for (size, offset), rank in zip(size_and_offsets, range(local_size)):
+            size_offset_ranks.append((size, offset, node_index + rank))
+
+        return _get_parameter_sharding(
+            param,
+            ShardingType.TABLE_ROW_WISE.value,
+            size_offset_ranks,
+            local_size,
+            device_type,
+            sharder,
+        )
+
+    return _parameter_sharding_generator
+
+
+def construct_module_sharding_plan(
+    module: nn.Module,
+    per_param_sharding: Dict[str, ParameterShardingGenerator],
+    sharder: Optional[ModuleSharder[nn.Module]] = None,
+    local_size: Optional[int] = None,
+    world_size: Optional[int] = None,
+    device_type: str = "cuda",
+) -> Dict[str, ParameterSharding]:
+    """
+    Helper function to create sharding plans (Dict[str, ParameterSharding]) for an module
+    Args:
+        module (nn.Module): module to create plan for.
+        per_param_sharding: Dict[str, Callable[[nn.Parameter, int, int, str], ParameterSharding]]: A mapping of parameter names to a generator function
+        that takes in [parameter, local_size, world_size, device_type] and returns a ParameterSharding. We recommend using one of the predefined generator functions
+        e.g. table_wise_sharding, row_wise_sharding, etc,
+        sharder: Optional[ModuleSharder[nn.Module]]: Sharder that we are creating a plan for. If set to none, we will try to derive it from the module. We recommend setting this to None.
+        local_size: Optional[int] = None: process group local size
+        world_size: Optional[int] = None: process_group world_size
+        device_type: str : Torch device type,
+
+    Example::
+        ebc = EmbeddingBagCollection(...)
+        plan = construct_parameter_sharding_plan(
+            ebc,
+            {
+                "table_0": data_parallel_sharding(),
+                "table_1": row_wise_sharding(),
+                "table_2": column_wise_sharding(),
+                "table_3": column_wise_sharding(ranks=[0,1,2]),
+                "table_4": table_row_wise_sharding(host_index=2),
+            },
+            EmbeddingBagCollectionSharder()
+        )
+    """
+    if sharder is None:
+        sharder = get_module_to_default_sharders().get(type(module), None)
+    assert (
+        sharder is not None
+    ), f"Could not find a valid sharder type for {type(module)}"
+
+    assert isinstance(
+        module, sharder.module_type
+    ), f"Incorrect sharder for module type {type(module)}"
+    shardable_parameters = sharder.shardable_parameters(module)
+    assert (
+        shardable_parameters.keys() == per_param_sharding.keys()
+    ), "per_param_sharding_config doesn't match the shardable parameters of the module"
+
+    local_size = local_size or get_local_size()
+    world_size = world_size or dist.get_world_size()
+
+    per_parameter_sharding: Dict[str, ParameterSharding] = {}
+
+    param = None
+    for table_name, sharding_plan_generator in per_param_sharding.items():
+        param_name = f"{table_name}.weight"
+        for name, _param in module.named_parameters():
+            if param_name in name:
+                param = _param
+                break
+        assert (
+            param is not None
+        ), f"Could not find parameter {param_name} in module's named_parameters()"
+
+        per_parameter_sharding[table_name] = sharding_plan_generator(
+            param, local_size, world_size, device_type, sharder
+        )
+
+    return per_parameter_sharding
+
+
+def uniform_parameter_sharding(
+    module: nn.Module,
+    parameter_sharding_generator: ParameterShardingGenerator,
+    sharder: Optional[ModuleSharder[nn.Module]] = None,
+) -> Dict[str, ParameterShardingGenerator]:
+    """
+    Convenience function to generate a uniform sharding scheme for construct_module_sharding_plan.
+
+    Example::
+    ebc = EmbeddingBagCollection(...)
+    sharder = EmbeddingBagCollectionSharder()
+    plan = construct_parameter_sharding_plan(
+        ebc,
+        uniform_parameter_sharding(ebc, row_wise_sharding(), sharder),
+        EmbeddingBagCollectionSharder()
+    )
+
+    """
+    if sharder is None:
+        # pyre-ignore
+        sharder = get_module_to_default_sharders.get(type(module), None)
+    else:
+        assert isinstance(
+            module, sharder.module_type
+        ), f"Incorrect sharder for module type {type(module)}"
+
+    assert (
+        sharder is not None
+    ), f"Could not find a valid sharder type for {type(module)}"
+
+    shardable_parameters = sharder.shardable_parameters(module)
+    return {
+        param_name: parameter_sharding_generator for param_name in shardable_parameters
+    }

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -6,17 +6,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-import math
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
-import torch
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.planner.constants import (
-    BATCH_SIZE,
-    MIN_CW_DIM,
-    POOLING_FACTOR,
+from torchrec.distributed.parameter_sharding_utils import (
+    calculate_shard_sizes_and_offsets,
 )
+from torchrec.distributed.planner.constants import POOLING_FACTOR
 from torchrec.distributed.planner.shard_estimators import (
     EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,
@@ -251,107 +248,6 @@ def get_partition_by_type(sharding_type: str) -> str:
     raise ValueError(
         f"Unrecognized or unsupported sharding type provided: {sharding_type}"
     )
-
-
-def calculate_shard_sizes_and_offsets(
-    tensor: torch.Tensor,
-    world_size: int,
-    local_world_size: int,
-    sharding_type: str,
-    col_wise_shard_dim: Optional[int] = None,
-) -> Tuple[List[List[int]], List[List[int]]]:
-    """
-    Calculates sizes and offsets for tensor sharded according to provided sharding type.
-
-    Args:
-        tensor (torch.Tensor): tensor to be sharded.
-        world_size (int): total number of devices in topology.
-        local_world_size (int): total number of devices in host group topology.
-        sharding_type (str): provided ShardingType value.
-        col_wise_shard_dim (Optional[int]): dimension for column wise sharding split.
-
-    Returns:
-        Tuple[List[List[int]], List[List[int]]]: shard sizes, represented as a list of the dimensions of the sharded tensor on each device, and shard offsets, represented as a list of coordinates of placement on each device.
-
-    Raises:
-        ValueError: If `sharding_type` is not a valid ShardingType.
-    """
-
-    (rows, columns) = tensor.shape
-
-    if sharding_type == ShardingType.DATA_PARALLEL.value:
-        return [[rows, columns]] * world_size, [[0, 0]] * world_size
-    elif sharding_type == ShardingType.TABLE_WISE.value:
-        return [[rows, columns]], [[0, 0]]
-    elif sharding_type == ShardingType.ROW_WISE.value:
-        return _calculate_rw_shard_sizes_and_offsets(rows, world_size, columns)
-    elif sharding_type == ShardingType.TABLE_ROW_WISE.value:
-        return _calculate_rw_shard_sizes_and_offsets(rows, local_world_size, columns)
-    elif (
-        sharding_type == ShardingType.COLUMN_WISE.value
-        or sharding_type == ShardingType.TABLE_COLUMN_WISE.value
-    ):
-        return _calculate_cw_shard_sizes_and_offsets(columns, rows, col_wise_shard_dim)
-
-    raise ValueError(
-        f"Unrecognized or unsupported sharding type provided: {sharding_type}"
-    )
-
-
-def _calculate_rw_shard_sizes_and_offsets(
-    hash_size: int, num_devices: int, columns: int
-) -> Tuple[List[List[int]], List[List[int]]]:
-    """
-    Sets prefix of shard_sizes to be ceil(hash_size/num_devices).
-
-    For example if hash_size = 10, num_devices = 3, we will allocate the rows as 3,3,3,1
-    (rather than 3,3,2,2).
-    This is due to implementation in RW sharding that sets block_size_lists to be ceil.
-    The balanced way is harder to support on GPU.
-    For more details see https://fb.quip.com/xbgbAchCTOL0
-
-    Also consider the example of hash_size = 5, num_devices = 4. The expected rows per
-    rank is [2,2,1,0].
-    """
-
-    block_size: int = math.ceil(hash_size / num_devices)
-    last_rank: int = hash_size // block_size
-    last_block_size: int = hash_size - block_size * last_rank
-    shard_sizes: List[List[int]] = []
-
-    for rank in range(num_devices):
-        if rank < last_rank:
-            local_row: int = block_size
-        elif rank == last_rank:
-            local_row: int = last_block_size
-        else:
-            local_row: int = 0
-        shard_sizes.append([local_row, columns])
-    shard_offsets = [[0, 0]]
-
-    for i in range(num_devices - 1):
-        shard_offsets.append([shard_sizes[i][0] + shard_offsets[i][0], 0])
-
-    return shard_sizes, shard_offsets
-
-
-def _calculate_cw_shard_sizes_and_offsets(
-    hash_size: int,
-    rows: int,
-    col_wise_shard_dim: Optional[int] = None,
-) -> Tuple[List[List[int]], List[List[int]]]:
-    block_size: int = min(
-        col_wise_shard_dim if col_wise_shard_dim else MIN_CW_DIM, hash_size
-    )
-    num_col_wise_shards, residual = divmod(hash_size, block_size)
-
-    shard_sizes: List[List[int]] = [[rows, block_size]] * (num_col_wise_shards - 1)
-    shard_sizes.append([rows, block_size + residual])
-
-    shard_offsets: List[List[int]] = [
-        [0, block_size * rank] for rank in range(num_col_wise_shards)
-    ]
-    return shard_sizes, shard_offsets
 
 
 def _get_tower_index(name: str, child_module: EmbeddingTowerCollection) -> int:

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -9,6 +9,8 @@ import operator
 from functools import reduce
 from typing import Any, Iterable, Type, Union
 
+import torch
+
 # pyre-ignore[2]
 def sharder_name(t: Type[Any]) -> str:
     return t.__module__ + "." + t.__name__
@@ -28,3 +30,18 @@ def gb_to_bytes(gb: float) -> int:
 
 def prod(iterable: Iterable[int]) -> int:
     return reduce(operator.mul, iterable, 1)
+
+
+def placement(
+    compute_device: str,
+    rank: int,
+    local_size: int,
+) -> str:
+    """
+    Returns placement, formatted as string
+    """
+
+    param_device = compute_device
+    if compute_device == "cuda":
+        param_device = torch.device("cuda", rank % local_size)
+    return f"rank:{rank}/{param_device}"

--- a/torchrec/distributed/tests/test_parameter_sharding_utils.py
+++ b/torchrec/distributed/tests/test_parameter_sharding_utils.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import Any, Dict, List, Optional
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings, Verbosity
+from torchrec import distributed as trec_dist
+from torchrec.distributed.parameter_sharding_utils import (
+    column_wise_sharding,
+    construct_module_sharding_plan,
+    data_parallel_sharding,
+    get_module_to_default_sharders,
+    ParameterShardingGenerator,
+    row_wise_sharding,
+    table_row_wise_sharding,
+    table_wise_sharding,
+)
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.types import ParameterSharding, ShardingEnv
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+
+def _test_sharding(
+    tables: List[EmbeddingBagConfig],
+    initial_state_dict: Dict[str, Any],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    backend: str,
+    parameter_sharding_plan: Dict[str, ParameterSharding],
+    local_size: Optional[int] = None,
+) -> None:
+    trec_dist.comm_ops.set_gradient_division(False)
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+        initial_state_dict = {
+            fqn: tensor.to(ctx.device) for fqn, tensor in initial_state_dict.items()
+        }
+
+        model = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+
+        sharder = get_module_to_default_sharders()[type(model)]
+
+        unsharded_model = model
+        sharded_model = sharder.shard(
+            module=model,
+            params=parameter_sharding_plan,
+            env=ShardingEnv.from_process_group(ctx.pg),
+            device=ctx.device,
+        )
+
+        unsharded_model.load_state_dict(copy.deepcopy(initial_state_dict))
+        copy_state_dict(sharded_model.state_dict(), copy.deepcopy(initial_state_dict))
+
+        feature_keys = []
+        for table in tables:
+            feature_keys.extend(table.feature_names)
+
+        # each rank gets a subbatch
+        sharded_model_pred_kt = sharded_model(kjt_input_per_rank[ctx.rank]).to_dict()
+        _sharded_model_pred = torch.stack(  # noqa
+            [sharded_model_pred_kt[feature] for feature in feature_keys]
+        )
+
+
+@skip_if_asan_class
+class ConstructParameterShardingTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        per_param_sharding=st.sampled_from(
+            [
+                {
+                    "table_0": data_parallel_sharding(),
+                    "table_1": data_parallel_sharding(),
+                },
+                {
+                    "table_0": table_wise_sharding(rank=0),
+                    "table_1": table_wise_sharding(rank=1),
+                },
+                {
+                    "table_0": row_wise_sharding(),
+                    "table_1": row_wise_sharding(),
+                },
+                {
+                    "table_0": column_wise_sharding(),
+                    "table_1": column_wise_sharding(),
+                },
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_parameter_sharding_ebc(
+        self,
+        per_param_sharding: Dict[str, ParameterShardingGenerator],
+    ) -> None:
+
+        return
+
+        WORLD_SIZE = 2
+
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=16,
+                num_embeddings=4,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=16,
+                num_embeddings=4,
+            ),
+        ]
+
+        # Rank 0
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [0, 1]       None        [2]
+
+        # Rank 1
+
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [3, 2]       [1,2]        [0, 1,2,3]
+        # "feature_1"   [2,3]       None        [2]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([0, 1, 2, 0, 1, 2]),
+                lengths=torch.LongTensor([2, 0, 1, 2, 0, 1]),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([3, 2, 1, 2, 0, 1, 2, 3, 2, 3, 2]),
+                lengths=torch.LongTensor([2, 2, 4, 2, 0, 1]),
+            ),
+        ]
+
+        parameter_sharding_plan = construct_module_sharding_plan(
+            EmbeddingBagCollection(tables=embedding_bag_config),
+            per_param_sharding=per_param_sharding,
+            local_size=2,
+            world_size=2,
+        )
+
+        self._run_multi_process_test(
+            callable=_test_sharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_bag_config,
+            initial_state_dict={
+                "embedding_bags.table_0.weight": torch.Tensor(
+                    [
+                        [1] * 16,
+                        [2] * 16,
+                        [3] * 16,
+                        [4] * 16,
+                    ]
+                ),
+                "embedding_bags.table_1.weight": torch.Tensor(
+                    [
+                        [101] * 16,
+                        [102] * 16,
+                        [103] * 16,
+                        [104] * 16,
+                    ]
+                ),
+            },
+            kjt_input_per_rank=kjt_input_per_rank,
+            backend="nccl",
+            parameter_sharding_plan=parameter_sharding_plan,
+        )
+
+    def test_construct_module_sharding_plan(self) -> None:
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name=f"table_{idx}",
+                feature_names=[f"feature_{idx}"],
+                embedding_dim=256,
+                num_embeddings=32 * 32,
+            )
+            for idx in range(5)
+        ]
+
+        _parameter_sharding_plan = construct_module_sharding_plan(  # noqa
+            EmbeddingBagCollection(tables=embedding_bag_config),
+            per_param_sharding={
+                "table_0": data_parallel_sharding(),
+                "table_1": table_wise_sharding(rank=1),
+                "table_2": row_wise_sharding(),
+                "table_3": column_wise_sharding(shard_dim=128, ranks=[8, 9]),
+                "table_4": table_row_wise_sharding(node_index=3),
+            },
+            local_size=8,
+            world_size=32,
+        )


### PR DESCRIPTION
Summary:
See  https://docs.google.com/document/d/1ASiz0Fu3c8cCHmsbseUdulU4jfTgdwZAxvlywgXiBAU/edit for more context

tl;dr:

Currently the only “feasible” way to specify a sharding plan is by using the OSS planner, and using constraints. I say “feasible” because although we can manually construct a ShardingPlan/ParameterSharding, it’s quite cumbersome to do so. Additionally, users do not have the expressibility to say “I want to place this parameter on rank 0” when using planner.

With this new API we can construct sharding plans in a direct way:

```
ebc = EmbeddingBagCollection(...)
plan = construct_parameter_sharding_plans(
            ebc,
            {
                "table_0": data_parallel_sharding(),
                "table_1": row_wise_sharding(),
                "table_2": column_wise_sharding(),
                "table_3": column_wise_sharding(ranks=[0,1,2]),
                "table_4": table_row_wise_sharding(host_index=2),
            },
            EmbeddingBagCollectionSharder()
        )
ebc = sharder.shard(
   ebc,
   plan
)
```

Note, that this is not intended to replace the greedy planner. Instead it allows users to shard modules without being FORCED to use planner. Users will be able to user planner in the exact same way.

Having alternatives instead of planner has a couple of benefits

1. There are bugs in the planner (we should be able to shard something, but planner may have a false negative rejection)
2. Planner doesn't correctly account for new architectures/models /optimizers
3. Easier to directly use torchrec (new users don't need to understand how to use planner).

-----

So I decided to use a generator function because alternative ways would require creating a new dataclass called like TableWiseConfig(row=...), and I didn't like the look of it.

Having just the atomic generator functions is also nice since it doesn't couple these configs with the construct_parameter_sharding_plans

Differential Revision: D39803183

