### PR TITLE
Refactor deepcopy logic to improve planning speed

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -147,8 +147,6 @@ class EmbeddingEnumerator(Enumerator):
                                 name=name,
                                 tensor=param,
                                 module=(child_path, child_module),
-                                upstream_modules=[],
-                                downstream_modules=[],
                                 input_lengths=input_lengths,
                                 batch_size=self._batch_size,
                                 compute_kernel=compute_kernel,

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -141,18 +141,17 @@ class GreedyPerfPartitioner(Partitioner):
         """
 
         _topology: Topology = copy.deepcopy(storage_constraint)
-        plan = copy.deepcopy(proposal)
         _host_level_devices = GreedyPerfPartitioner._get_host_level_devices(_topology)
 
         # first partition the uniform sharding options (RW & DP)
-        uniform_sharding_options = _get_uniform_sharding_options(plan)
+        uniform_sharding_options = _get_uniform_sharding_options(proposal)
         GreedyPerfPartitioner._uniform_partition(
             uniform_sharding_options, _topology.devices
         )
 
         # group the rest sharding options by colocation type (co-host, co-device, none)
         # and sort the groups by storage in reverse order
-        sharding_option_groups = _group_and_sort_non_uniform_sharding_options(plan)
+        sharding_option_groups = _group_and_sort_non_uniform_sharding_options(proposal)
 
         for sharding_option_group in sharding_option_groups:
             if (
@@ -178,7 +177,7 @@ class GreedyPerfPartitioner(Partitioner):
                 )
         # pyre-ignore [16]: `GreedyPerfPartitioner` has no attribute `_topology`.
         self._topology: Topology = _topology
-        return plan
+        return proposal
 
     @staticmethod
     def _device_partition(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 from functools import reduce
 from time import perf_counter
 from typing import cast, Dict, List, Optional, Tuple, Union
@@ -232,7 +233,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 self._num_proposals += 1
                 try:
                     plan = self._partitioner.partition(
-                        proposal=proposal,
+                        proposal=copy.deepcopy(proposal),
                         storage_constraint=storage_constraint,
                     )
                     self._num_plans += 1

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 import itertools
 import logging
 from decimal import Decimal
@@ -56,12 +55,10 @@ class GreedyProposer(Proposer):
 
     def propose(self) -> Optional[List[ShardingOption]]:
         if self._current_proposal:
-            return copy.deepcopy(
-                [
-                    self._sharding_options_by_fqn[fqn][index]
-                    for fqn, index in self._current_proposal.items()
-                ]
-            )
+            return [
+                self._sharding_options_by_fqn[fqn][index]
+                for fqn, index in self._current_proposal.items()
+            ]
         else:
             return None
 
@@ -147,7 +144,7 @@ class UniformProposer(Proposer):
 
     def propose(self) -> Optional[List[ShardingOption]]:
         if self._proposal_index < len(self._grouped_sharding_options):
-            return copy.deepcopy(self._grouped_sharding_options[self._proposal_index])
+            return self._grouped_sharding_options[self._proposal_index]
         else:
             return None
 

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -304,8 +304,6 @@ class TestProposers(unittest.TestCase):
                     tensor=torch.zeros(1),
                     # pyre-ignore
                     module=("model", None),
-                    upstream_modules=[],
-                    downstream_modules=[],
                     input_lengths=[],
                     batch_size=8,
                     sharding_type="row_wise",

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import cast, Dict, List, Optional, Tuple, Union
@@ -173,26 +174,44 @@ class Shard:
         )
 
 
-@dataclass
 class ShardingOption:
     """
     One way of sharding an embedding table.
     """
 
-    name: str
-    tensor: torch.Tensor
-    module: Tuple[str, nn.Module]
-    upstream_modules: List[Tuple[str, nn.Module]]
-    downstream_modules: List[Tuple[str, nn.Module]]
-    input_lengths: List[float]
-    batch_size: int  # per single device
-    sharding_type: str
-    partition_by: str  # {DEVICE, HOST, UNIFORM}
-    compute_kernel: str
-    # relevant to planner output, must be populated if sharding option
-    # part of final solution
-    shards: List[Shard] = field(default_factory=list)
-    dependency: Optional[str] = None
+    def __init__(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        module: Tuple[str, nn.Module],
+        input_lengths: List[float],
+        batch_size: int,
+        sharding_type: str,
+        partition_by: str,
+        compute_kernel: str,
+        shards: List[Shard],
+        dependency: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self._tensor = tensor
+        self._module = module
+        self.input_lengths = input_lengths
+        self.batch_size = batch_size
+        self.sharding_type = sharding_type
+        self.partition_by = partition_by
+        self.compute_kernel = compute_kernel
+        # relevant to planner output, must be populated if sharding option
+        # part of final solution
+        self.shards = shards
+        self.dependency = dependency
+
+    @property
+    def tensor(self) -> torch.Tensor:
+        return self._tensor
+
+    @property
+    def module(self) -> Tuple[str, nn.Module]:
+        return self._module
 
     @property
     def fqn(self) -> str:
@@ -236,6 +255,18 @@ class ShardingOption:
                 tuple(self.shards),
             )
         )
+
+    def __deepcopy__(
+        self, memo: Optional[Dict[int, "ShardingOption"]]
+    ) -> "ShardingOption":
+        cls = self.__class__
+        result = cls.__new__(cls)
+        for k, v in self.__dict__.items():
+            if k in ["_tensor", "_module"]:
+                setattr(result, k, v)
+            else:
+                setattr(result, k, deepcopy(v, memo))
+        return result
 
 
 class PartitionByType(Enum):


### PR DESCRIPTION
Summary:
# Summary
When there are many possible proposals to plan with, e.g. >1000 proposals from GreedyProposer for ads models in [fused, fused_uvm_caching] modes, the planner can run >20 min to come up with a best plan. The speed bottleneck comes from `deepcopy(List[ShardingOption])` in proposers and partitioner. With the diff to reorganize the deepcopy operations, the planning time can be decreased to ~2.5 min.

# Idea
(1) Reduce times of deepcopy
When `List[ShardingOption]` is passed as plan/proposal between proposer, partitioner and planner, two times of `deepcopy(List[ShardingOption])` (one in proposer, the other in partitioner) are done to isolate the state of List[ShardingOption] between planning stesp. As deepcopy is expensive, we just need to keep one deepcopy in partitioner. Doing so reduces the planning time from ~20 min to ~10 min.

(2) Custom __deepcopy__
During partitioning, the only field updated in ShardingOption is `shard.ranks`. To avoid copying big objects (e.g. tensor, module) to save time, a custom `__deepcopy__` function is created in ShardingOption that only deepcopies `shards`, and that everything else is passed with the original object. Doing so reduces the planning time from ~10 min to 2.5 min.

(3) Freeze _tensor and _module
With idea (2), the `tensor` and `module` fields in ShardingOption are changed to be read-only to avoid modification during planning.

Differential Revision: D39822605

