### PR TITLE
In dlrm forward, change logits.squeeze() to logits.squeeze(-1) to pre…

### DIFF
--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -893,7 +893,7 @@ class DLRMTrain(nn.Module):
             Tuple[loss, Tuple[loss, logits, labels]]
         """
         logits = self.model(batch.dense_features, batch.sparse_features)
-        logits = logits.squeeze()
+        logits = logits.squeeze(-1)
         loss = self.loss_fn(logits, batch.labels.float())
 
         return loss, (loss.detach(), logits.detach(), batch.labels.detach())


### PR DESCRIPTION
…vent unexpected zero dimension logit tensor for rare case that logit tensor is shape (1,1)