### PR TITLE
Fix planner test

### DIFF
--- a/torchrec/distributed/planner/tests/test_parallelized_planners.py
+++ b/torchrec/distributed/planner/tests/test_parallelized_planners.py
@@ -112,7 +112,7 @@ class TestParallelizedEmbeddingShardingPlanner(unittest.TestCase):
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=4096,
-                embedding_dim=128,
+                embedding_dim=64,
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
             )

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -108,7 +108,7 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=4096,
-                embedding_dim=128,
+                embedding_dim=64,
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
             )


### PR DESCRIPTION
Summary:
We modified storage estimation logic by considering optimizer type (previously we estimate optimizer storage based on compute kernel, see D39828217 (https://github.com/pytorch/torchrec/commit/f63cd2f307f8a7d3f78d40cbc4fdd08fcdc0d53d)). This causes this test to fail since storage estimation is higher in some cases.

Fix: reducing embedding size to account for higher storage estimation.

Reviewed By: ge0405

Differential Revision: D39974776

