### PR TITLE
Decouple compute kernel from sharding

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -85,6 +85,35 @@ class ParameterStorage(Enum):
     DDR = "ddr"
 
 
+@dataclass(repr=True)
+class ParameterLocation:
+    pass
+
+
+@dataclass
+class HBM(ParameterLocation):
+    # placed on GPU memory, when device=cuda
+    pass
+
+
+@dataclass
+class DDR(ParameterLocation):
+    # placed on CPU, when device=cpu
+    pass
+
+
+@dataclass
+class UVM(ParameterLocation):
+    # placed on disk
+    pass
+
+
+@dataclass
+class UVM_CACHING(ParameterLocation):
+    # placed on both GPU and disk, most frequently values (caching ratio) are stored in GPU memory
+    caching_ratio: float
+
+
 @unique
 class ComputeKernel(Enum):
     DEFAULT = "default"
@@ -352,6 +381,7 @@ class ParameterSharding:
         sharding_type (str): how this parameter is sharded. See ShardingType for well-known
             types.
         compute_kernel (str): compute kernel to be used by this parameter.
+        placement (str): Placement strategy for the parameter
         ranks (Optional[List[int]]): rank of each shard.
         sharding_spec (Optional[ShardingSpec]): list of ShardMetadata for each shard.
 
@@ -366,6 +396,7 @@ class ParameterSharding:
 
     sharding_type: str
     compute_kernel: str
+    placement: Optional[ParameterLocation] = None
     ranks: Optional[List[int]] = None
     sharding_spec: Optional[ShardingSpec] = None
 


### PR DESCRIPTION
Summary:
This is a fully backwards compatible change to allow users to have model authoring code that's decoupled compute_kernels from sharding.

If compute kernel is set, this will be fully backwards compatible

We can derive what compute kernel we should use entirely based on the parameter's attributes as well as sharding type: e.g.

1. If data_parallel, always use dense kernel
2. If model_parallel and has overlapped_optimizer (that's supported), use FUSED
3. If no overlapped optimizer, use dense

Other subtely is that we still want to enable placement. We create a couple new classes, the important one is UVM_CACHING, which has a field called caching ratio

The fully authoring experience could then look like

```
ebc = EmbeddingBagCollection(...)
plan = construct_parameter_sharding_plans(
            ebc,
            {
                "table_0": data_parallel_sharding(),
                "table_1": row_wise_sharding(placement=UVM_CACHING(caching_ratio=0.2)),
                "table_2": column_wise_sharding(placement=UVM),
                "table_3": column_wise_sharding(ranks=[0,1,2]),
                "table_4": table_row_wise_sharding(host_index=2),
            },
        )
ebc = sharder.shard(
   ebc,
   plan
)
```

Note, this doesn't work with planner yet, but should be easy to incorporate.

Differential Revision: D39975761

