### PR TITLE
add output_dtype to quant.SequenceEmbeddingArch

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -84,7 +84,9 @@ def quantize_state_dict(
                 scale_shift = None
         else:
             if tensor.dtype == torch.float or tensor.dtype == torch.float16:
-                if tensor.dtype == torch.float16 and data_type == DataType.FP16:
+                if data_type == DataType.FP16:
+                    if tensor.dtype == torch.float:
+                        tensor = tensor.half()
                     quant_res = tensor.view(torch.uint8)
                 else:
                     quant_res = (

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -90,7 +90,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         ),
         quant_type=st.sampled_from(
             [
-                # torch.half,
+                torch.half,
                 torch.qint8,
             ]
         ),
@@ -188,7 +188,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         ),
         quant_type=st.sampled_from(
             [
-                # torch.half,
+                torch.half,
                 torch.qint8,
             ]
         ),
@@ -272,7 +272,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         ),
         quant_type=st.sampled_from(
             [
-                # torch.half,
+                torch.half,
                 torch.qint8,
             ]
         ),


### PR DESCRIPTION
Summary: support override output_dtype in quantize_embedding_modules call

Reviewed By: s4ayub

Differential Revision: D39979541

