### PR TITLE
Back out "Enable shard storage estimator to consider multiple optimizer classes"

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -6,10 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import cast, Dict, List, Optional, Tuple, Type
+from typing import cast, Dict, List, Optional, Tuple
 
 import torch
-import torchrec
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
@@ -688,21 +687,19 @@ def calculate_shard_storages(
     }:
         hbm_storage = round(ddr_storage * caching_ratio)
 
-    optimizer_class = getattr(tensor, "_optimizer_class", None)
-
     hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=hbm_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
+        compute_kernel=compute_kernel,
     )
     ddr_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=ddr_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
+        compute_kernel=compute_kernel,
     )
 
     hbm_sizes: List[int] = [
@@ -979,7 +976,7 @@ def _calculate_storage_specific_sizes(
     shape: torch.Size,
     shard_sizes: List[List[int]],
     sharding_type: str,
-    optimizer_class: Optional[Type[torch.optim.Optimizer]] = None,
+    compute_kernel: str,
 ) -> List[int]:
     tensor_sizes: List[int] = [
         math.ceil(storage * prod(size) / prod(shape))
@@ -987,29 +984,13 @@ def _calculate_storage_specific_sizes(
         else storage
         for size in shard_sizes
     ]
-    optimizer_multipler: float = _get_optimizer_multipler(optimizer_class, shape)
 
     optimizer_sizes: List[int] = [
-        math.ceil(tensor_size * optimizer_multipler) for tensor_size in tensor_sizes
+        tensor_size * 2 if compute_kernel == EmbeddingComputeKernel.DENSE.value else 0
+        for tensor_size in tensor_sizes
     ]
 
     return [
         tensor_size + optimizer_size
         for tensor_size, optimizer_size in zip(tensor_sizes, optimizer_sizes)
     ]
-
-
-def _get_optimizer_multipler(
-    optimizer_class: Optional[Type[torch.optim.Optimizer]],
-    shape: torch.Size,
-) -> float:
-    if not optimizer_class:
-        return 1.0
-    if optimizer_class in [torch.optim.SGD, torchrec.optim.SGD]:
-        return 0
-    elif optimizer_class in [torch.optim.Adam, torchrec.optim.Adam]:
-        return 2
-    elif optimizer_class == torchrec.optim.RowWiseAdagrad:
-        return 1 / shape[-1]
-    else:
-        return 1

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -7,7 +7,6 @@
 
 import unittest
 from typing import cast, List
-from unittest.mock import patch
 
 import torch
 from torchrec.distributed.embedding_tower_sharding import (
@@ -387,12 +386,6 @@ class TestEnumerators(unittest.TestCase):
         self.tower_collection_model = TestTowerCollectionSparseNN(
             tables=tables, weighted_tables=weighted_tables
         )
-        _get_optimizer_multipler_patcher = patch(
-            "torchrec.distributed.planner.shard_estimators._get_optimizer_multipler",
-            return_value=0,
-        )
-        self.addCleanup(_get_optimizer_multipler_patcher.stop)
-        self._get_optimizer_multipler_mock = _get_optimizer_multipler_patcher.start()
 
     def test_dp_sharding(self) -> None:
         sharding_options = self.enumerator.enumerate(
@@ -431,12 +424,15 @@ class TestEnumerators(unittest.TestCase):
                 * sharding_option.tensor.element_size()
             ] * self.world_size
 
+            optimizer_sizes = [tensor_size * 2 for tensor_size in tensor_sizes]
+
             storage_sizes = [
-                input_size + tensor_size + output_size
-                for input_size, tensor_size, output_size in zip(
+                input_size + tensor_size + output_size + optimizer_size
+                for input_size, tensor_size, output_size, optimizer_size in zip(
                     input_sizes,
                     tensor_sizes,
                     output_sizes,
+                    optimizer_sizes,
                 )
             ]
 

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -9,22 +9,17 @@ import unittest
 from typing import cast
 
 import torch
-import torchrec
-
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    _calculate_storage_specific_sizes,
-    EmbeddingPerfEstimator,
-)
+from torchrec.distributed.planner.shard_estimators import EmbeddingPerfEstimator
 from torchrec.distributed.planner.types import Topology
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.tests.test_quant_model_parallel import _quantize
 from torchrec.distributed.tests.test_sequence_model import TestSequenceSparseNN
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import ModuleSharder
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
 
@@ -200,44 +195,3 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         }
 
         self.assertEqual(perfs, expected_perfs)
-
-
-# pyre-ignore[3]
-def calculate_storage_specific_size_data_provider():
-    return (
-        {
-            "sharding_type": ShardingType.TABLE_ROW_WISE,
-            "optimizer_class": torch.optim.SGD,
-            "expected_storage": [50, 50],
-        },
-        {
-            "sharding_type": ShardingType.COLUMN_WISE,
-            "optimizer_class": torch.optim.Adam,
-            "expected_storage": [150, 150],
-        },
-        {
-            "sharding_type": ShardingType.TABLE_ROW_WISE,
-            "optimizer_class": None,
-            "expected_storage": [100, 100],
-        },
-        {
-            "sharding_type": ShardingType.DATA_PARALLEL,
-            "optimizer_class": torchrec.optim.RowWiseAdagrad,
-            "expected_storage": [134, 134],
-        },
-    )
-
-
-class TestEmbeddingStorageEstimator(unittest.TestCase):
-    def test_calculate_storage_specific_sizes(self) -> None:
-        for inputs in calculate_storage_specific_size_data_provider():
-            sharding_type, optimizer_class, expected_storage = inputs.values()
-            estimates = _calculate_storage_specific_sizes(
-                storage=100,
-                shape=torch.Size((10, 5, 3)),
-                shard_sizes=[[5, 5, 3], [5, 5, 3]],
-                sharding_type=sharding_type.value,
-                optimizer_class=optimizer_class,
-            )
-
-            self.assertEqual(estimates, expected_storage)


### PR DESCRIPTION
Summary:
Original commit changeset: e675776c6552

Original Phabricator Diff: D39828217 (https://github.com/pytorch/torchrec/commit/f63cd2f307f8a7d3f78d40cbc4fdd08fcdc0d53d)

Differential Revision: D40045405

