### PR TITLE
Fix overrestimating if no optimizer class is found.

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -1004,7 +1004,7 @@ def _get_optimizer_multipler(
     shape: torch.Size,
 ) -> float:
     if not optimizer_class:
-        return 1.0
+        return 0.0
     if optimizer_class in [torch.optim.SGD, torchrec.optim.SGD]:
         return 0
     elif optimizer_class in [torch.optim.Adam, torchrec.optim.Adam]:

--- a/torchrec/distributed/planner/tests/test_parallelized_planners.py
+++ b/torchrec/distributed/planner/tests/test_parallelized_planners.py
@@ -112,7 +112,7 @@ class TestParallelizedEmbeddingShardingPlanner(unittest.TestCase):
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=4096,
-                embedding_dim=64,
+                embedding_dim=128,
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
             )

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -108,7 +108,7 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=4096,
-                embedding_dim=64,
+                embedding_dim=128,
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
             )

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -218,7 +218,7 @@ def calculate_storage_specific_size_data_provider():
         {
             "sharding_type": ShardingType.TABLE_ROW_WISE,
             "optimizer_class": None,
-            "expected_storage": [100, 100],
+            "expected_storage": [50, 50],
         },
         {
             "sharding_type": ShardingType.DATA_PARALLEL,


### PR DESCRIPTION
Summary: As titled. Planner estimated storage needed to be double the size of parameters when optimizer class is not provided. When opt class is not given, we want to estimate storage needed to be the size of parameters.

Differential Revision: D40064919

