### PR TITLE
support int4 quantization in prospector

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -105,6 +105,8 @@ def data_type_to_dtype(data_type: DataType) -> torch.dtype:
         return torch.float16
     elif data_type == DataType.INT8:
         return torch.int8
+    elif data_type == DataType.INT4:
+        return torch.quint4x2
     else:
         raise ValueError(f"DataType {data_type} cannot be converted to dtype")
 


### PR DESCRIPTION
Summary: We currently do not support int4 quantization as an option although there is support to quantize embeddings with int4. we add that option in this diff.

Differential Revision: D40084785

