### PR TITLE
trec inference benchmark prospector

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -147,6 +147,12 @@ class PredictFactory(abc.ABC):
         """
         return {}
 
+    def model_inputs_data(self) -> Dict[str, Any]:
+        """
+        Returns a dict of various data for benchmarking input generation.
+        """
+        return {}
+
 
 class PredictModule(nn.Module):
     """


### PR DESCRIPTION
Summary:
TorchRec benchmark for prospector model.

1. "sparse_object_id" and id_list_features order for input generation

Prospector model tweaks id_list_features adding "sparse_object_id" feature, which represent id of the input object.

To generate random benchmarking inputs with that feature we add "sparse_object_id" to conventional `config.inputs: ModelInputs`

`model_inputs.id_list_features` - is python dict, which has ordering of keys how they were added to the dict. Keys order matters for kjt representation. So we need to have the same order of keys in benchmark input generation and how we create the model in prospector_predictor_factory.

As we have this 'meta' information about benchmark inputs, to store this and future configurations of inputs, introducing
```
def model_inputs_data(self) -> Dict[str, Any]:
```
That will return for benchmark all needed data to generate inputs. So "model_inputs" key will replace `def model_inputs()`

2.  LookupInIndexedTable

By default for gpu models it waits for load_state_dict() and does not initialize id_to_index before that.

For benchmarking we prepare embeddings_ids and embedding_tables to benchmark most common scenario - 'cache hit for all'.

This is the reason why
`publish_gpu_model` is renamed to  `cache_delayed_init_to_load_state`.

And in ProspectorRuntimeMeta added `benchmarking_mode` and ids and embeddings are initialized as `torch.range` and  `torch.randn`. That cache has a state that it saw all ids and we will be ranking all items in the batch.

Differential Revision: D39584337

