### PR TITLE
Classify PlannerError based on storage limit

### DIFF
--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -39,6 +39,7 @@ from torchrec.distributed.planner.types import (
     Partitioner,
     PerfModel,
     PlannerError,
+    PlannerErrorType,
     Proposer,
     ShardingOption,
     Stats,
@@ -305,8 +306,8 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
                 lambda x, y: x + y,
                 [device.storage for device in storage_constraint.devices],
             )
-            raise PlannerError(
-                f"Unable to find a plan for this model that evaluates {self._num_proposals} proposals."
+            no_plan_solution = (
+                f"Planner evaluated {self._num_proposals} proposals."
                 "\nPossible solutions:"
                 f"\n  1) Increase the number of devices ({self._topology.world_size})"
                 f"\n  2) Reduce the model size ("
@@ -316,3 +317,15 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
                 f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )
+            if global_storage_constraints < lowest_storage:
+                raise PlannerError(
+                    error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
+                    message="Unable to find a plan for this model because of insufficient storage. \n"
+                    + no_plan_solution,
+                )
+            else:
+                raise PlannerError(
+                    error_type=PlannerErrorType.OTHER,
+                    message="Unable to find a plan for this model because of too restricted constraints. \n"
+                    + no_plan_solution,
+                )

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -14,6 +14,7 @@ from torchrec.distributed.planner.types import (
     PartitionByType,
     Partitioner,
     PlannerError,
+    PlannerErrorType,
     ShardingOption,
     Storage,
     Topology,
@@ -195,7 +196,8 @@ class GreedyPerfPartitioner(Partitioner):
                     break
             if not success:
                 raise PlannerError(
-                    f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}"
+                    error_type=PlannerErrorType.PARTITION,
+                    message=f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}",
                 )
 
     @staticmethod
@@ -244,7 +246,8 @@ class GreedyPerfPartitioner(Partitioner):
                     device.perf = device_copy.perf
                 return
         raise PlannerError(
-            f"can't find a host for sharding option group {sharding_option_group}"
+            error_type=PlannerErrorType.PARTITION,
+            message=f"can't find a host for sharding option group {sharding_option_group}",
         )
 
     @staticmethod
@@ -271,7 +274,8 @@ class GreedyPerfPartitioner(Partitioner):
                 storage_needed = cast(Storage, sharding_option.shards[i].storage)
                 if not storage_needed.fits_in(devices[i].storage):
                     raise PlannerError(
-                        f"Shard of size {storage_needed} bytes does not fit on any rank. Device memory cap: {devices[i].storage}."
+                        error_type=PlannerErrorType.PARTITION,
+                        message=f"Shard of size {storage_needed} bytes does not fit on any rank. Device memory cap: {devices[i].storage}.",
                     )
                 else:
                     sharding_option.shards[i].rank = devices[i].rank

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -33,6 +33,7 @@ from torchrec.distributed.planner.types import (
     Partitioner,
     PerfModel,
     PlannerError,
+    PlannerErrorType,
     Proposer,
     ShardingOption,
     Stats,
@@ -292,8 +293,8 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 lambda x, y: x + y,
                 [device.storage for device in storage_constraint.devices],
             )
-            raise PlannerError(
-                f"Unable to find a plan for this model that evaluates {self._num_proposals} proposals."
+            no_plan_solution = (
+                f"Planner evaluated {self._num_proposals} proposals."
                 "\nPossible solutions:"
                 f"\n  1) Increase the number of devices ({self._topology.world_size})"
                 f"\n  2) Reduce the model size ("
@@ -303,3 +304,15 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )
+            if global_storage_constraints < lowest_storage:
+                raise PlannerError(
+                    error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
+                    message="Unable to find a plan for this model because of insufficient storage. \n"
+                    + no_plan_solution,
+                )
+            else:
+                raise PlannerError(
+                    error_type=PlannerErrorType.OTHER,
+                    message="Unable to find a plan for this model because of too restricted constraints. \n"
+                    + no_plan_solution,
+                )

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -13,7 +13,7 @@ from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.planners import EmbeddingShardingPlanner
-from torchrec.distributed.planner.types import PlannerError, Topology
+from torchrec.distributed.planner.types import PlannerError, PlannerErrorType, Topology
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -99,8 +99,11 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         ]
         model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
 
-        with self.assertRaises(PlannerError):
+        with self.assertRaises(PlannerError) as context:
             self.planner.plan(module=model, sharders=[TWvsRWSharder()])
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
 
         self.assertEqual(self.planner._num_proposals, 4)
 
@@ -116,8 +119,9 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         ]
         model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
 
-        with self.assertRaises(PlannerError):
+        with self.assertRaises(PlannerError) as context:
             self.planner.plan(module=model, sharders=[TWSharder()])
+        self.assertEqual(context.exception.error_type, PlannerErrorType.OTHER)
 
         sharding_plan = self.planner.plan(module=model, sharders=[TWvsRWSharder()])
         expected_ranks = [[0, 1]]

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -302,8 +302,24 @@ class ParameterConstraints:
     is_weighted: bool = False
 
 
+class PlannerErrorType(Enum):
+    """
+    Classify PlannerError based on the following cases.
+    """
+
+    INSUFFICIENT_STORAGE = "insufficient_storage"
+    PARTITION = "partition"
+    OTHER = "other"
+
+
 class PlannerError(Exception):
-    ...
+    def __init__(
+        self,
+        message: str,
+        error_type: PlannerErrorType = PlannerErrorType.OTHER,
+    ) -> None:
+        self.error_type = error_type
+        super().__init__(message)
 
 
 # ---- PLANNER COMPONENTS ---- #


### PR DESCRIPTION
Summary:
Some users rely on the PlannerError message to determine whether the "unable to find a plan" error is due to insufficient storage. If so, users should input larger storage instead of trying to tune other inputs (e.g. constraints).

This diff proposes a way to classify the planner error due to "insufficient storage", so users may behave accordingly from the error type.

Differential Revision: D39982352

