### PR TITLE
Cleanup PT-D imports (Backward Breaking, read below). (#85781)

### DIFF
--- a/examples/transfer_learning/train_from_pretrained_embedding.py
+++ b/examples/transfer_learning/train_from_pretrained_embedding.py
@@ -83,8 +83,6 @@ def share_tensor_via_shm(
     global gloo_pg
     if gloo_pg is None:
         if dist.get_backend() == "gloo":
-            # pyre-fixme[9]: gloo_pg has type `Optional[dist.ProcessGroup]`; used as
-            #  `Optional[_distributed_c10d.ProcessGroup]`.
             gloo_pg = dist.group.WORLD
         else:
             gloo_pg = dist.new_group(backend="gloo")
@@ -190,7 +188,6 @@ def main() -> None:
     ).collective_plan(
         ebc,
         sharders,
-        # pyre-fixme[6]: For 3rd param expected `ProcessGroup` but got `ProcessGroup`.
         pg,
     )
     print(plan)

--- a/torchrec/distributed/collective_utils.py
+++ b/torchrec/distributed/collective_utils.py
@@ -28,7 +28,6 @@ def is_leader(pg: Optional[dist.ProcessGroup], leader_rank: int = 0) -> bool:
     """
     if pg is None:
         return leader_rank == 0
-    # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
     return pg.rank() == leader_rank
 
 
@@ -50,13 +49,11 @@ def invoke_on_rank_and_broadcast_result(
 
         id = invoke_on_rank_and_broadcast_result(pg, 0, allocate_id)
     """
-    # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
     if pg.rank() == rank:
         res = func(*args, **kwargs)
         object_list = [res]
     else:
         object_list = [None]
-    # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
     if pg.size() > 1:
         dist.broadcast_object_list(object_list, rank, group=pg)
     return cast(T, object_list[0])

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -662,8 +662,6 @@ class All2All_Pooled_Req(Function):
         a2ai: All2AllPooledInfo,
         input_embeddings: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_rank = dist.get_rank(pg)
         (B_global, D_local_sum) = input_embeddings.shape
 
@@ -767,8 +765,6 @@ class All2All_Pooled_Wait(Function):
         myreq: Request[Tensor],
         *dummy_tensor: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_rank = dist.get_rank(pg)
         a2ai = myreq.a2ai
         ctx.a2ai = a2ai
@@ -882,11 +878,7 @@ class All2All_Seq_Req(Function):
         a2ai: All2AllSequenceInfo,
         sharded_input_embeddings: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         world_size = dist.get_world_size(pg)
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_rank = dist.get_rank(pg)
         D = a2ai.embedding_dim
         forward_recat_tensor = a2ai.forward_recat_tensor
@@ -1164,8 +1156,6 @@ class ReduceScatter_Req(Function):
         rsi: ReduceScatterInfo,
         *inputs: Any,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_rank = dist.get_rank(pg)
 
         if rsi.codecs is not None:
@@ -1274,8 +1264,6 @@ class ReduceScatterBase_Req(Function):
         rsi: ReduceScatterBaseInfo,
         inputs: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_size = dist.get_world_size(pg)
         assert inputs.size(0) % my_size == 0
         if rsi.codecs is not None:
@@ -1367,8 +1355,6 @@ class AllGatherBase_Req(Function):
         agi: AllGatherBaseInfo,
         input: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_size = dist.get_world_size(pg)
 
         if agi.codecs is not None:
@@ -1462,8 +1448,6 @@ class ReduceScatterV_Req(Function):
         rsi: ReduceScatterVInfo,
         input: Tensor,
     ) -> Tensor:
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         my_rank = dist.get_rank(pg)
         output = input.new_empty(rsi.input_sizes[my_rank])
 

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -172,7 +172,6 @@ class KJTAllToAllIndicesAwaitable(Awaitable[KeyedJaggedTensor]):
         batch_size_per_rank: List[int],
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         self._workers: int = pg.size()
         self._device: torch.device = input.values().device
         self._recat = recat
@@ -264,7 +263,6 @@ class KJTAllToAllIndicesAwaitable(Awaitable[KeyedJaggedTensor]):
                 else:
                     lengths, values, weights = torch.ops.fbgemm.permute_2D_sparse_data(
                         self._recat,
-                        # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
                         lengths.view(self._workers * self._splits[self._pg.rank()], -1),
                         values,
                         weights,
@@ -313,7 +311,6 @@ class KJTAllToAllLengthsAwaitable(Awaitable[KJTAllToAllIndicesAwaitable]):
         variable_batch_size: bool = False,
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         self._workers: int = pg.size()
         self._pg: dist.ProcessGroup = pg
         self._device: torch.device = input.values().device
@@ -324,7 +321,6 @@ class KJTAllToAllLengthsAwaitable(Awaitable[KJTAllToAllIndicesAwaitable]):
         self._recat: torch.Tensor = recat
         self._in_lengths_per_worker: List[int] = []
         self._variable_batch_size = variable_batch_size
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
         dim_0 = splits[pg.rank()]
         dim_1 = input.stride()
         self._batch_size_per_rank: List[int] = [dim_1] * self._workers
@@ -495,7 +491,6 @@ class KJTAllToAll(nn.Module):
         variable_batch_size: bool = False,
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         assert len(splits) == pg.size()
         self._pg: dist.ProcessGroup = pg
         self._splits = splits
@@ -506,7 +501,6 @@ class KJTAllToAll(nn.Module):
         self.register_buffer(
             "_recat",
             _get_recat(
-                # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
                 local_split=splits[pg.rank()],
                 num_splits=len(splits),
                 stagger=stagger,
@@ -531,8 +525,6 @@ class KJTAllToAll(nn.Module):
 
         with torch.no_grad():
             assert len(input.keys()) == sum(self._splits)
-            # pyre-fixme[6]: For 1st param expected
-            #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
             rank = dist.get_rank(self._pg)
             local_keys = input.keys()[
                 self._splits_cumsum[rank] : self._splits_cumsum[rank + 1]
@@ -695,7 +687,6 @@ class PooledEmbeddingsAllToAll(nn.Module):
         """
 
         if local_embs.numel() == 0:
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
             local_embs.view(local_embs.size(0) * self._pg.size(), 0)
         if batch_size_per_rank is None:
             B_global = local_embs.size(0)
@@ -1009,9 +1000,7 @@ class SequenceEmbeddingsAllToAll(nn.Module):
         self._pg = pg
 
         forward_recat = []
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         for j in range(self._pg.size()):
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
             for i in range(features_per_rank[self._pg.rank()]):
                 forward_recat.append(j + i * self._pg.size())
         self.register_buffer(

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -125,17 +125,11 @@ class ShardedEmbeddingTower(
         self._device = device
         self._output_dist: Optional[PooledEmbeddingsAllToAll] = None
         self._cross_pg_global_batch_size: int = 0
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         self._cross_pg_world_size: int = dist.get_world_size(self._cross_pg)
 
         self._has_uninitialized_output_dist = True
 
         # make sure all sharding on single physical node
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         devices_per_host = dist.get_world_size(intra_pg)
         tower_devices = set()
         for sharding in table_name_to_parameter_sharding.values():
@@ -161,19 +155,10 @@ class ShardedEmbeddingTower(
         if self._active_device:
             _replace_sharding_with_intra_node(
                 table_name_to_parameter_sharding,
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 dist.get_world_size(self._intra_pg),
             )
             intra_env: ShardingEnv = ShardingEnv(
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 world_size=dist.get_world_size(self._intra_pg),
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 rank=dist.get_rank(self._intra_pg),
                 pg=self._intra_pg,
             )
@@ -228,9 +213,6 @@ class ShardedEmbeddingTower(
                 ),
             )
 
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         node_count = dist.get_world_size(self._cross_pg)
         kjt_features_per_node = [
             len(self._kjt_feature_names) if node == self._tower_node else 0
@@ -342,9 +324,6 @@ class ShardedEmbeddingTower(
                 dtype=torch.int64,
                 device=self._device,
             )
-            # pyre-fixme[6]: For 1st param expected
-            #  `Optional[_distributed_c10d.ProcessGroup]` but got
-            #  `Optional[dist.ProcessGroup]`.
             for i in range(dist.get_world_size(self._cross_pg))
         ]
         dist.all_gather(
@@ -497,13 +476,7 @@ class ShardedEmbeddingTowerCollection(
         intra_pg, cross_pg = intra_and_cross_node_pg(device)
         self._intra_pg: Optional[dist.ProcessGroup] = intra_pg
         self._cross_pg: Optional[dist.ProcessGroup] = cross_pg
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         self._cross_pg_world_size: int = dist.get_world_size(self._cross_pg)
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         self._intra_pg_world_size: int = dist.get_world_size(self._intra_pg)
         self._device = device
         self._tower_id: int = dist.get_rank() // self._intra_pg_world_size
@@ -594,19 +567,10 @@ class ShardedEmbeddingTowerCollection(
         if local_towers:
             _replace_sharding_with_intra_node(
                 table_name_to_parameter_sharding,
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 dist.get_world_size(self._intra_pg),
             )
             intra_env: ShardingEnv = ShardingEnv(
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 world_size=dist.get_world_size(self._intra_pg),
-                # pyre-fixme[6]: For 1st param expected
-                #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                #  `Optional[dist.ProcessGroup]`.
                 rank=dist.get_rank(self._intra_pg),
                 pg=self._intra_pg,
             )
@@ -787,9 +751,6 @@ class ShardedEmbeddingTowerCollection(
                 dtype=torch.int64,
                 device=self._device,
             )
-            # pyre-fixme[6]: For 1st param expected
-            #  `Optional[_distributed_c10d.ProcessGroup]` but got
-            #  `Optional[dist.ProcessGroup]`.
             for i in range(dist.get_world_size(self._cross_pg))
         ]
         dist.all_gather(

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -50,7 +50,6 @@ class RwSequenceEmbeddingDist(
         super().__init__()
         self._dist = SequenceEmbeddingsAllToAll(
             pg,
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
             [num_features] * pg.size(),
             device,
             codecs=qcomm_codecs_registry.get(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -240,7 +240,6 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
         need_pos: bool = False,
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         self._world_size: int = pg.size()
         self._num_id_list_features = num_id_list_features
         self._num_id_score_list_features = num_id_score_list_features

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -75,10 +75,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._intra_pg: Optional[dist.ProcessGroup] = intra_pg
         self._cross_pg: Optional[dist.ProcessGroup] = cross_pg
         self._local_size: int = (
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
-            intra_pg.size()
-            if intra_pg
-            else get_local_size(self._world_size)
+            intra_pg.size() if intra_pg else get_local_size(self._world_size)
         )
 
         sharded_tables_per_rank = self._shard(sharding_infos)
@@ -325,9 +322,7 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
     ) -> None:
         super().__init__()
         assert (
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
-            pg.size() % intra_pg.size()
-            == 0
+            pg.size() % intra_pg.size() == 0
         ), "currently group granularity must be node"
 
         self._world_size: int = pg.size()

--- a/torchrec/distributed/sharding/vb_rw_sharding.py
+++ b/torchrec/distributed/sharding/vb_rw_sharding.py
@@ -63,7 +63,6 @@ class VariableBatchRwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
         has_feature_processor: bool = False,
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         self._world_size: int = pg.size()
         self._num_id_list_features = num_id_list_features
         self._num_id_score_list_features = num_id_score_list_features
@@ -172,9 +171,7 @@ class VariableBatchRwPooledEmbeddingDist(
         pg: dist.ProcessGroup,
     ) -> None:
         super().__init__()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
         self._workers: int = pg.size()
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
         self._rank: int = pg.rank()
         self._dist = PooledEmbeddingsReduceScatter(pg)
 

--- a/torchrec/distributed/sharding/vb_twrw_sharding.py
+++ b/torchrec/distributed/sharding/vb_twrw_sharding.py
@@ -100,9 +100,7 @@ class VariableBatchTwRwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]
     ) -> None:
         super().__init__()
         assert (
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
-            pg.size() % intra_pg.size()
-            == 0
+            pg.size() % intra_pg.size() == 0
         ), "currently group granularity must be node"
 
         self._world_size: int = pg.size()
@@ -265,7 +263,6 @@ class VariableBatchTwRwPooledEmbeddingDist(
             batch_size_per_rank_by_cross_group,
             batch_size_sum_by_cross_group,
         ) = self._preprocess_batch_size_per_rank(
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
             self._intra_pg.size(),
             self._cross_pg.size(),
             sharding_ctx.batch_size_per_rank,

--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -73,16 +73,9 @@ class MultiProcessContext:
     # pyre-ignore
     def __exit__(self, exc_type, exc_instance, traceback) -> None:
         if _INTRA_PG is not None:
-            # pyre-fixme[6]: For 1st param expected
-            #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
             dist.destroy_process_group(_INTRA_PG)
         if _CROSS_PG is not None:
-            # pyre-fixme[6]: For 1st param expected
-            #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
             dist.destroy_process_group(_CROSS_PG)
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-        #  `Optional[dist.ProcessGroup]`.
         dist.destroy_process_group(self.pg)
         torch.use_deterministic_algorithms(False)
         if torch.cuda.is_available():

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -451,8 +451,6 @@ class ShardingEnv:
         NOTE:
             Typically used during training.
         """
-        # pyre-fixme[6]: For 1st param expected
-        #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
         return cls(dist.get_world_size(pg), dist.get_rank(pg), pg)
 
     @classmethod

--- a/torchrec/inference/state_dict_transform.py
+++ b/torchrec/inference/state_dict_transform.py
@@ -46,8 +46,6 @@ def state_dict_all_gather_keys(
         pg (ProcessGroup): Process Group used for comms
     """
     names = list(state_dict.keys())
-    # pyre-fixme[6]: For 1st param expected
-    #  `Optional[_distributed_c10d.ProcessGroup]` but got `ProcessGroup`.
     all_names = [None] * dist.get_world_size(pg)
     dist.all_gather_object(all_names, names, pg)
     deduped_names = set()
@@ -81,9 +79,6 @@ def state_dict_to_device(
                     Shard.from_tensor_and_offsets(
                         tensor=shard.tensor.to(device),
                         shard_offsets=shard.metadata.shard_offsets,
-                        # pyre-fixme[6]: For 1st param expected
-                        #  `Optional[_distributed_c10d.ProcessGroup]` but got
-                        #  `ProcessGroup`.
                         rank=dist.get_rank(pg),
                     )
                     for shard in tensor.local_shards()


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/85781

X-link: https://github.com/pytorch/tnt/pull/207

X-link: https://github.com/pytorch/torchsnapshot/pull/76

The flow logic around torch.dist imports results in large number of pyre errors, In spirit of fail fast its best just raise importError as opposed to silently fail to import bindings and let user only find out when actually trying to run library methods/functions.

** NOTE ** : this breaks backward compatibility w/ respect to users who previously did not actually have torch.distributed we able to import the library without error.  However, reality is they couldn't actually use library, so first call into library it would fail.   So only way user code will actually be affected is if they had a dead import (ie. imported torch.distributed but never actually called library).

also removed the 10's-100's of unused pyre ignores no longer required.

Reviewed By: mrshenli

Differential Revision: D39842273

