### PR TITLE
Early stopping feature

### DIFF
--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -25,12 +25,22 @@ class GreedyProposer(Proposer):
     Sorts sharding options for each shardable parameter by perf.
     On each iteration, finds parameter with largest current storage usage and tries its
     next sharding option.
+
+    Args:
+        use_depth (bool): When enabled, sharding_options of a fqn are sorted based on
+            `max(shard.perf)`, otherwise sharding_options are sorted by `sum(shard.perf)`.
+        threshold (Optional[int]): Threshold for early stopping. When specified, the
+            proposer stops proposing when the proposals have consecutive worse perf_rating
+            than best_perf_rating.
     """
 
-    def __init__(self, use_depth: bool = True) -> None:
+    def __init__(self, use_depth: bool = True, threshold: Optional[int] = None) -> None:
         self._use_depth: bool = use_depth
+        self._threshold: Optional[int] = threshold if threshold else None
         self._sharding_options_by_fqn: Dict[str, List[ShardingOption]] = {}
         self._current_proposal: Dict[str, int] = {}
+        self._best_perf_rating: float = float("inf")
+        self._num_inferior_perf: int = 0
 
     def load(self, search_space: List[ShardingOption]) -> None:
         self._reset()
@@ -68,6 +78,17 @@ class GreedyProposer(Proposer):
         plan: Optional[List[ShardingOption]] = None,
         perf_rating: Optional[float] = None,
     ) -> None:
+        # When threshold is passed, observe the perf_rating trend. If the perf_rating
+        # of the newly proposed plans have worse perf_rating, stop proposing.
+        if self._threshold and perf_rating:
+            self._num_inferior_perf += 1
+            if perf_rating < self._best_perf_rating:
+                self._best_perf_rating = perf_rating
+                self._num_inferior_perf = 0
+            # pyre-fixme [58]: `>` is not supported for operand types `int` and `Optional[int]`.
+            if self._num_inferior_perf > self._threshold:
+                self._current_proposal = {}
+                return
         # static strategy, ignore feedback and just provide next proposal
         largest_fqn: Optional[str] = None
         largest_storage: Tuple[float, float, float, float] = (0, 0, 0, 0)

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -124,6 +124,19 @@ class TestProposers(unittest.TestCase):
 
         self.assertEqual(expected_output, output)
 
+        # Test threshold for early_stopping
+        self.greedy_proposer._threshold = 10
+        self.greedy_proposer.load(search_space)
+
+        # With early stopping, after berf_perf_rating is assigned, after 10 iterations with
+        # consecutive worse perf_rating, the returned proposal should be None.
+        proposal = None
+        for i in range(13):
+            proposal = cast(List[ShardingOption], self.greedy_proposer.propose())
+            self.greedy_proposer.feedback(partitionable=True, perf_rating=100 + i)
+        self.assertEqual(self.greedy_proposer._best_perf_rating, 100)
+        self.assertEqual(proposal, None)
+
     def test_uniform_three_table(self) -> None:
         tables = [
             EmbeddingBagConfig(


### PR DESCRIPTION
Summary:
## Problem
When there are many proposals to plan with (e.g. 1000 tables, each of which is with [fused, fused_uvm_caching] compute_kernels, can result in 1000 proposals in GreedyProposer), the planner runs >20 min to come up with the best plan. The planning step is too long and may fail to broadcast the plan since the collective call waits for 30 min to close the communication.

For GreedyProposer, we found the following trend on the perf_rating (see the graph below): the GreedyProposer firstly proposes a proposal with the lowest perf (all tables put in hbm). If the proposal is not partitionable, GreedyProposer finds the largest table, puts it in uvm, and proposes again. After it reaches a partitionable state, there is a "best_plan" range, i.e., with some tables put in uvm, there is enough space left in hbm for planning, making the perf balanced, resulting in lowest max_perf (perf_rating). After this range is passed, more and more tables are put in UVM, so perf_rating keeps increasing. For MIMO, we observed that it takes ~260 iterations to reach the best_plan range. After several tens of iterations, it reaches the increasing perf_rating range, leaving around ~700 iterations in this range.

{F775152524}

## Solution
To avoid waste of time in the last stage, this diff introduces an "early_stopping" feature to `GreedyProposer` to end the proposing iteration. When early_stopping is turned on (default is false), it observes the passed perf_rating in feedback and updates the best_perf_rating. When the following proposals have worse perf_rating than best_perf_rating, it stops proposing new proposals.
With this feature, the planning time decreases from 20 min to ~5 min. With this feature plus the deepcopy refactor diff (D39822605 (https://github.com/pytorch/torchrec/commit/77db94c88b57040a9f32c09fc805b676ba35b85e)), the planning time can further decreased to <1 min.

Differential Revision: D39068786

