### PR TITLE
assert DMP copy API argument

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -327,6 +327,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         process, since some modules needs to use the original references (like
         `ShardedModule` for inference).
         """
+        assert isinstance(device, torch.device)
         with sharded_model_copy(device=None):
             copy_dmp = copy.deepcopy(self)
         copy_module = copy_dmp._copy(copy_dmp.module, device)


### PR DESCRIPTION
Summary: * asser the type for DMP copy API since the argument will populate into the sharding while sometimes cuda strings are also accepted during device construt.

Reviewed By: 842974287

Differential Revision: D40161334

