### PR TITLE
inference module use nn.ModuleList for lookup, output_dist module

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -327,6 +327,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         process, since some modules needs to use the original references (like
         `ShardedModule` for inference).
         """
+        assert isinstance(device, torch.device)
         with sharded_model_copy(device=None):
             copy_dmp = copy.deepcopy(self)
         copy_module = copy_dmp._copy(copy_dmp.module, device)

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -180,7 +180,7 @@ class ShardedQuantEmbeddingCollection(
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
 
-        self._input_dists: nn.ModuleList = nn.ModuleList()
+        self._input_dists: List[nn.Module] = []
         self._lookups: nn.ModuleList = nn.ModuleList()
         self._create_lookups(fused_params)
         self._output_dists: nn.ModuleList = nn.ModuleList()

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -105,9 +105,9 @@ class ShardedQuantEmbeddingBagCollection(
 
         self._is_weighted: bool = module.is_weighted()
         self._input_dists: List[nn.Module] = []
-        self._lookups: List[nn.Module] = []
+        self._lookups: nn.ModuleList = nn.ModuleList()
         self._create_lookups(fused_params)
-        self._output_dists: List[nn.Module] = []
+        self._output_dists: nn.ModuleList = nn.ModuleList()
         self._embedding_names: List[str] = []
         self._embedding_dims: List[int] = []
         self._feature_splits: List[int] = []


### PR DESCRIPTION
Summary:
* use ModuleList for lookup + output_dist since if GIF inference, input_dist does not exist.
* better module repr since ModuleList is registered.

Reviewed By: zyan0

Differential Revision: D40161769

