### PR TITLE
Add "STRICT_CONSTRAINTS" to PlannerErrorType

### DIFF
--- a/torchrec/distributed/planner/parallelized_planners.py
+++ b/torchrec/distributed/planner/parallelized_planners.py
@@ -325,7 +325,7 @@ class ParallelizedEmbeddingShardingPlanner(ShardingPlanner):
                 )
             else:
                 raise PlannerError(
-                    error_type=PlannerErrorType.OTHER,
-                    message="Unable to find a plan for this model because of too restricted constraints. \n"
+                    error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                    message="Unable to find a plan for this model because of the strict constraints. \n"
                     + no_plan_solution,
                 )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -312,7 +312,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 )
             else:
                 raise PlannerError(
-                    error_type=PlannerErrorType.OTHER,
-                    message="Unable to find a plan for this model because of too restricted constraints. \n"
+                    error_type=PlannerErrorType.STRICT_CONSTRAINTS,
+                    message="Unable to find a plan for this model because of the strict constraints. \n"
                     + no_plan_solution,
                 )

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -121,7 +121,9 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
 
         with self.assertRaises(PlannerError) as context:
             self.planner.plan(module=model, sharders=[TWSharder()])
-        self.assertEqual(context.exception.error_type, PlannerErrorType.OTHER)
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.STRICT_CONSTRAINTS
+        )
 
         sharding_plan = self.planner.plan(module=model, sharders=[TWvsRWSharder()])
         expected_ranks = [[0, 1]]

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -308,6 +308,7 @@ class PlannerErrorType(Enum):
     """
 
     INSUFFICIENT_STORAGE = "insufficient_storage"
+    STRICT_CONSTRAINTS = "strict_constraints"
     PARTITION = "partition"
     OTHER = "other"
 


### PR DESCRIPTION
Summary: Introduce one more `PlannerErrorType`: `PlannerErrorType.STRICT_CONSTRAINTS` to better define the error type exposed to user, so user can behave accordingly. With this one more type, `PARTITION` (in partitioners.py) and `OTHER` (in shard_estimators.py) are meant for planner internal errors. `INSUFFICIENT_STORAGE` and `STRICT_CONSTRAINTS` (both are in planners.py) are exposed to users so they can tune the propoer components to see planner's behavior.

Differential Revision: D40199354

