### PR TITLE
[tde] Migrate MixedLFULRUStrategy

### DIFF
--- a/benchmarks/cpp/dynamic_embedding/CMakeLists.txt
+++ b/benchmarks/cpp/dynamic_embedding/CMakeLists.txt
@@ -10,3 +10,6 @@ function(add_tde_benchmark NAME)
 endfunction()
 
 add_tde_benchmark(naive_id_transformer_benchmark naive_id_transformer_benchmark.cpp)
+add_tde_benchmark(random_bits_generator_benchmark random_bits_generator_benchmark.cpp)
+add_tde_benchmark(mixed_lfu_lru_strategy_benchmark mixed_lfu_lru_strategy_benchmark.cpp)
+add_tde_benchmark(mixed_lfu_lru_strategy_evict_benchmark mixed_lfu_lru_strategy_evict_benchmark.cpp)

--- a/benchmarks/cpp/dynamic_embedding/mixed_lfu_lru_strategy_benchmark.cpp
+++ b/benchmarks/cpp/dynamic_embedding/mixed_lfu_lru_strategy_benchmark.cpp
@@ -1,0 +1,42 @@
+#include <benchmark/benchmark.h>
+#include <torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h>
+
+namespace torchrec {
+void BM_MixedLFULRUStrategy(benchmark::State& state) {
+  size_t num_ext_values = state.range(0);
+  std::vector<MixedLFULRUStrategy::lxu_record_t> ext_values(num_ext_values);
+
+  MixedLFULRUStrategy strategy;
+  for (auto& v : ext_values) {
+    v = strategy.update(0, 0, std::nullopt);
+  }
+
+  size_t num_elems = state.range(1);
+  std::default_random_engine engine((std::random_device())());
+  size_t time = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<size_t> offsets;
+    offsets.reserve(num_elems);
+    for (size_t i = 0; i < num_elems; ++i) {
+      std::uniform_int_distribution<size_t> dist(0, num_elems - 1);
+      offsets.emplace_back(dist(engine));
+    }
+    state.ResumeTiming();
+
+    ++time;
+    strategy.update_time(time);
+    for (auto& v : offsets) {
+      ext_values[v] = strategy.update(0, 0, ext_values[v]);
+    }
+  }
+}
+
+BENCHMARK(BM_MixedLFULRUStrategy)
+    ->ArgNames({"num_ext_values", "num_elems_per_iter"})
+    ->Args({30000000, 1024 * 1024})
+    ->Args({300000000, 1024 * 1024})
+    ->Unit(benchmark::kMillisecond)
+    ->Iterations(100);
+
+} // namespace torchrec

--- a/benchmarks/cpp/dynamic_embedding/mixed_lfu_lru_strategy_evict_benchmark.cpp
+++ b/benchmarks/cpp/dynamic_embedding/mixed_lfu_lru_strategy_evict_benchmark.cpp
@@ -1,0 +1,76 @@
+#include <benchmark/benchmark.h>
+#include <torch/torch.h>
+#include <torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h>
+
+namespace torchrec {
+
+class RecordIterator {
+  using Container = std::vector<MixedLFULRUStrategy::Record>;
+
+ public:
+  RecordIterator(Container::const_iterator begin, Container::const_iterator end)
+      : begin_(begin), end_(end) {}
+  std::optional<TransformerRecord<uint32_t>> operator()() {
+    if (begin_ == end_) {
+      return std::nullopt;
+    }
+    TransformerRecord<uint32_t> record{};
+    record.global_id_ = next_global_id_++;
+    record.lxu_record_ = *reinterpret_cast<const uint32_t*>(&(*begin_++));
+    return record;
+  }
+
+ private:
+  int64_t next_global_id_{};
+  Container::const_iterator begin_;
+  Container::const_iterator end_;
+};
+
+class RandomizeMixedLXUSet {
+ public:
+  RandomizeMixedLXUSet(
+      size_t n,
+      uint8_t max_freq,
+      uint32_t max_time,
+      uint8_t min_freq = 5) {
+    TORCH_CHECK(max_freq > min_freq);
+    std::random_device dev;
+    std::default_random_engine engine(dev());
+    uint8_t freq_size = max_freq - min_freq;
+    TORCH_CHECK(max_time > 1);
+    records_.reserve(n);
+
+    std::uniform_int_distribution<uint8_t> freq_dist(0, freq_size);
+    std::uniform_int_distribution<uint32_t> time_dist(0, max_time - 1);
+    for (size_t i = 0; i < n; ++i) {
+      MixedLFULRUStrategy::Record record{};
+      record.freq_power_ = freq_dist(engine) + min_freq;
+      record.time_ = time_dist(engine);
+      records_.emplace_back(record);
+    }
+  }
+
+  [[nodiscard]] RecordIterator Iterator() const {
+    return {records_.begin(), records_.end()};
+  }
+
+ private:
+  std::vector<MixedLFULRUStrategy::Record> records_;
+};
+
+void BM_MixedLFULRUStrategyEvict(benchmark::State& state) {
+  RandomizeMixedLXUSet lxuSet(state.range(0), state.range(1), state.range(2));
+  for (auto _ : state) {
+    MixedLFULRUStrategy::evict(lxuSet.Iterator(), state.range(3));
+  }
+}
+
+BENCHMARK(BM_MixedLFULRUStrategyEvict)
+    ->ArgNames({"total", "max_freq", "max_time", "num_to_evict"})
+    ->Args({
+        300000000 * 2,
+        12,
+        3000,
+        5000000,
+    });
+} // namespace torchrec

--- a/benchmarks/cpp/dynamic_embedding/random_bits_generator_benchmark.cpp
+++ b/benchmarks/cpp/dynamic_embedding/random_bits_generator_benchmark.cpp
@@ -1,0 +1,34 @@
+#include <benchmark/benchmark.h>
+#include <torchrec/csrc/dynamic_embedding/details/random_bits_generator.h>
+#include <span>
+
+namespace torchrec {
+
+void BMRandomBitsGenerator(benchmark::State& state) {
+  auto n = state.range(0);
+  auto n_bits_limit = state.range(1);
+  BitScanner scanner(n);
+  std::mt19937_64 engine((std::random_device())());
+  std::uniform_int_distribution<uint16_t> dist(1, n_bits_limit);
+  uint16_t n_bits = dist(engine);
+  for (auto _ : state) {
+    if (n_bits != 0) {
+      scanner.reset_array([&](std::span<uint64_t> span) {
+        for (auto& v : span) {
+          v = engine();
+        }
+      });
+    } else {
+      n_bits = dist(engine);
+    }
+    benchmark::DoNotOptimize(scanner.is_next_n_bits_all_zero(n_bits));
+  }
+}
+
+BENCHMARK(BMRandomBitsGenerator)
+    ->ArgNames({"n", "limit"})
+    ->Args({1024, 32})
+    ->Unit(benchmark::kMillisecond)
+    ->Iterations(1024 * 1024);
+
+} // namespace torchrec

--- a/test/cpp/dynamic_embedding/CMakeLists.txt
+++ b/test/cpp/dynamic_embedding/CMakeLists.txt
@@ -12,3 +12,5 @@ endfunction()
 
 add_tde_test(bits_op_test bits_op_test.cpp)
 add_tde_test(naive_id_transformer_test naive_id_transformer_test.cpp)
+add_tde_test(random_bits_generator_test random_bits_generator_test.cpp)
+add_tde_test(mixed_lfu_lru_strategy_test mixed_lfu_lru_strategy_test.cpp)

--- a/test/cpp/dynamic_embedding/mixed_lfu_lru_strategy_test.cpp
+++ b/test/cpp/dynamic_embedding/mixed_lfu_lru_strategy_test.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include <torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h>
+
+namespace torchrec {
+TEST(TDE, order) {
+  MixedLFULRUStrategy::Record a;
+  a.time_ = 1;
+  a.freq_power_ = 31;
+  uint32_t i32 = a.ToUint32();
+  ASSERT_EQ(0xF8000001, i32);
+}
+
+TEST(TDE, MixedLFULRUStrategy_Evict) {
+  std::vector<std::pair<int64_t, MixedLFULRUStrategy::Record>> records;
+  {
+    records.emplace_back();
+    records.back().first = 1;
+    records.back().second.time_ = 100;
+    records.back().second.freq_power_ = 2;
+  }
+  {
+    records.emplace_back();
+    records.back().first = 2;
+    records.back().second.time_ = 10;
+    records.back().second.freq_power_ = 2;
+  }
+  {
+    records.emplace_back();
+    records.back().first = 3;
+    records.back().second.time_ = 100;
+    records.back().second.freq_power_ = 1;
+  }
+  {
+    records.emplace_back();
+    records.back().first = 4;
+    records.back().second.time_ = 150;
+    records.back().second.freq_power_ = 2;
+  }
+  size_t offset_{0};
+  auto ids = MixedLFULRUStrategy::evict(
+      [&offset_,
+       &records]() -> std::optional<MixedLFULRUStrategy::transformer_record_t> {
+        if (offset_ == records.size()) {
+          return std::nullopt;
+        }
+        auto record = records[offset_++];
+        MixedLFULRUStrategy::lxu_record_t ext_type =
+            *reinterpret_cast<MixedLFULRUStrategy::lxu_record_t*>(
+                &record.second);
+        return MixedLFULRUStrategy::transformer_record_t{
+            .global_id_ = record.first,
+            .cache_id_ = 0,
+            .lxu_record_ = ext_type,
+        };
+      },
+      3);
+
+  ASSERT_EQ(ids.size(), 3);
+  ASSERT_EQ(ids[0], 3);
+  ASSERT_EQ(ids[1], 2);
+  ASSERT_EQ(ids[2], 1);
+}
+
+TEST(TDE, MixedLFULRUStrategy_Transform) {
+  constexpr static size_t n_iter = 1000000;
+  MixedLFULRUStrategy strategy;
+  strategy.update_time(10);
+  MixedLFULRUStrategy::lxu_record_t val;
+  {
+    val = strategy.update(0, 0, std::nullopt);
+    auto record = reinterpret_cast<MixedLFULRUStrategy::Record*>(&val);
+    ASSERT_EQ(record->freq_power_, 5);
+    ASSERT_EQ(record->time_, 10);
+  }
+
+  uint32_t freq_power_5_cnt = 0;
+  uint32_t freq_power_6_cnt = 0;
+
+  for (size_t i = 0; i < n_iter; ++i) {
+    auto tmp = strategy.update(0, 0, val);
+    auto record = reinterpret_cast<MixedLFULRUStrategy::Record*>(&tmp);
+    ASSERT_EQ(record->time_, 10);
+    if (record->freq_power_ == 5) {
+      ++freq_power_5_cnt;
+    } else if (record->freq_power_ == 6) {
+      ++freq_power_6_cnt;
+    } else {
+      ASSERT_TRUE(record->freq_power_ == 5 || record->freq_power_ == 6);
+    }
+  }
+
+  double freq_6_prob = static_cast<double>(freq_power_6_cnt) /
+      static_cast<double>(freq_power_5_cnt + freq_power_6_cnt);
+
+  ASSERT_NEAR(freq_6_prob, 1 / 32.0f, 1e-3);
+}
+
+} // namespace torchrec

--- a/test/cpp/dynamic_embedding/random_bits_generator_test.cpp
+++ b/test/cpp/dynamic_embedding/random_bits_generator_test.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+#include <torchrec/csrc/dynamic_embedding/details/random_bits_generator.h>
+
+namespace torchrec {
+TEST(TDE, BitScanner1Elem) {
+  BitScanner scanner(1);
+  scanner.reset_array([](auto span) { span[0] = 0; });
+
+  for (size_t i = 0; i < 64; ++i) {
+    uint16_t n_bits = 1;
+    ASSERT_EQ(scanner.bit_idx, i);
+    ASSERT_EQ(scanner.array_idx_, 0);
+    ASSERT_TRUE(scanner.is_next_n_bits_all_zero(n_bits));
+    ASSERT_EQ(n_bits, 0);
+  }
+  scanner.reset_array([](auto span) { span[0] = 0x80FFFFFFFFFFFFFF; });
+  {
+    uint16_t n_bits = 1;
+    ASSERT_FALSE(scanner.is_next_n_bits_all_zero(n_bits));
+    ASSERT_EQ(n_bits, 0);
+    ASSERT_EQ(scanner.bit_idx, 1);
+    n_bits = 5;
+    ASSERT_TRUE(scanner.is_next_n_bits_all_zero(n_bits));
+    ASSERT_EQ(n_bits, 0);
+    ASSERT_EQ(scanner.bit_idx, 6);
+
+    n_bits = 4;
+    ASSERT_FALSE(scanner.is_next_n_bits_all_zero(n_bits));
+    ASSERT_EQ(n_bits, 0);
+    ASSERT_EQ(scanner.bit_idx, 9);
+
+    n_bits = 64 - 9 + 17;
+    ASSERT_FALSE(scanner.is_next_n_bits_all_zero(n_bits));
+    ASSERT_EQ(n_bits, 17);
+    ASSERT_EQ(scanner.bit_idx, 10);
+    ASSERT_EQ(scanner.array_idx_, 0);
+  }
+}
+
+TEST(TDE, BitScanner2Elems) {
+  BitScanner scanner(2);
+  scanner.reset_array([](auto span) {
+    span[0] = 0;
+    span[1] = 0x8000000000000000;
+  });
+
+  uint16_t n_bits = 32;
+  ASSERT_TRUE(scanner.is_next_n_bits_all_zero(n_bits));
+  ASSERT_EQ(n_bits, 0);
+  ASSERT_EQ(scanner.bit_idx, 32);
+  ASSERT_EQ(scanner.array_idx_, 0);
+
+  n_bits = 64;
+  ASSERT_FALSE(scanner.is_next_n_bits_all_zero(n_bits));
+  ASSERT_EQ(n_bits, 0);
+  ASSERT_EQ(scanner.bit_idx, 1);
+  ASSERT_EQ(scanner.array_idx_, 1);
+
+  n_bits = 64;
+  ASSERT_TRUE(scanner.is_next_n_bits_all_zero(n_bits));
+  ASSERT_EQ(n_bits, 1);
+  ASSERT_EQ(scanner.bit_idx, 0);
+  ASSERT_EQ(scanner.array_idx_, 2);
+}
+
+TEST(TDE, RandomBitsGenerator) {
+  RandomBitsGenerator generator;
+  size_t true_cnt_{0};
+  constexpr static size_t n_iter = 10000000;
+  for (size_t i = 0; i < n_iter; ++i) {
+    if (generator.is_next_n_bits_all_zero(10)) {
+      ++true_cnt_;
+    }
+  }
+
+  ASSERT_NEAR(double(true_cnt_) / double(n_iter), 1 / 1024.f, 1e-4);
+}
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/CMakeLists.txt
@@ -7,7 +7,9 @@
 add_library(tde_cpp_objs
             OBJECT
             details/clz_impl.cpp
-            details/ctz_impl.cpp)
+            details/ctz_impl.cpp
+            details/random_bits_generator.cpp
+            details/mixed_lfu_lru_strategy.cpp)
 
 target_include_directories(tde_cpp_objs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 target_include_directories(tde_cpp_objs PUBLIC ${TORCH_INCLUDE_DIRS})

--- a/torchrec/csrc/dynamic_embedding/details/bitmap.h
+++ b/torchrec/csrc/dynamic_embedding/details/bitmap.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <stdint.h>
+#include <memory>
 
 namespace torchrec {
 

--- a/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.cpp
@@ -1,0 +1,33 @@
+#include <c10/macros/Macros.h>
+#include <torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h>
+#include <algorithm>
+
+namespace torchrec {
+MixedLFULRUStrategy::MixedLFULRUStrategy(uint16_t min_used_freq_power)
+    : min_lfu_power_(min_used_freq_power), time_(new std::atomic<uint32_t>()) {}
+
+void MixedLFULRUStrategy::update_time(uint32_t time) {
+  time_->store(time);
+}
+
+MixedLFULRUStrategy::lxu_record_t MixedLFULRUStrategy::update(
+    int64_t global_id,
+    int64_t cache_id,
+    std::optional<lxu_record_t> val) {
+  Record r{};
+  r.time_ = time_->load();
+
+  if (C10_UNLIKELY(!val.has_value())) {
+    r.freq_power_ = min_lfu_power_;
+  } else {
+    auto freq_power = reinterpret_cast<Record*>(&val.value())->freq_power_;
+    bool should_carry = generator_.is_next_n_bits_all_zero(freq_power);
+    if (should_carry) {
+      ++freq_power;
+    }
+    r.freq_power_ = freq_power;
+  }
+  return *reinterpret_cast<lxu_record_t*>(&r);
+}
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
+++ b/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
@@ -1,0 +1,127 @@
+#pragma once
+#include <torchrec/csrc/dynamic_embedding/details/naive_id_transformer.h>
+#include <torchrec/csrc/dynamic_embedding/details/random_bits_generator.h>
+#include <atomic>
+#include <optional>
+#include <queue>
+#include <string_view>
+#include <vector>
+
+namespace torchrec {
+
+/**
+ * Mixed LFU/LRU Eviction Strategy.
+ *
+ * It evict infrequence elements first, then evict least recent usage elements.
+ *
+ * The frequency is record as the power number of 2. i.e., The freq_power is 1,
+ * then the global id is used approximately 2 times. And the freq_power is 10,
+ * then the global id is used approximately 1024 times.
+ *
+ * Internally, if the current freq_power is n, then it use random bits to
+ * generate n bits. If all these n bits are zero, then the freq_power++.
+ *
+ * All LFU/LRU information uses uint32_t to record. The uint32_t should be
+ * record in IDTransformer's map/dictionary.
+ *
+ * Use `update_time` to update logical timer for LRU. It only uses lower 27 bits
+ * of time.
+ *
+ * Use `update` to update extended value when every time global id that used.
+ */
+class MixedLFULRUStrategy {
+ public:
+  using lxu_record_t = uint32_t;
+  using transformer_record_t = TransformerRecord<lxu_record_t>;
+
+  static constexpr std::string_view type_ = "mixed_lru_lfu";
+
+  /**
+   * @param min_used_freq_power min usage is 2^min_used_freq_power. Set this to
+   * avoid recent values evict too fast.
+   */
+  explicit MixedLFULRUStrategy(uint16_t min_used_freq_power = 5);
+
+  MixedLFULRUStrategy(const MixedLFULRUStrategy&) = delete;
+  MixedLFULRUStrategy(MixedLFULRUStrategy&& o) noexcept = default;
+
+  void update_time(uint32_t time);
+  template <typename T>
+  static int64_t time(T record) {
+    static_assert(sizeof(T) == sizeof(Record));
+    return static_cast<int64_t>(reinterpret_cast<Record*>(&record)->time_);
+  }
+
+  lxu_record_t update(
+      int64_t global_id,
+      int64_t cache_id,
+      std::optional<lxu_record_t> val);
+
+  struct EvictItem {
+    int64_t global_id_;
+    lxu_record_t record_;
+    bool operator<(const EvictItem& item) const {
+      return record_ < item.record_;
+    }
+  };
+
+  /**
+   * Analysis all ids and returns the num_elems that are most need to evict.
+   * @param iterator Returns each global_id to ExtValue pair. Returns nullopt
+   * when at ends.
+   * @param num_to_evict
+   * @return
+   */
+  template <typename Iterator>
+  static std::vector<int64_t> evict(Iterator iterator, uint64_t num_to_evict) {
+    std::priority_queue<EvictItem> items;
+    while (true) {
+      auto val = iterator();
+      if (!val.has_value()) [[unlikely]] {
+        break;
+      }
+      EvictItem item{
+          .global_id_ = val->global_id_,
+          .record_ = reinterpret_cast<Record*>(&val->lxu_record_)->ToUint32(),
+      };
+      if (items.size() == num_to_evict) {
+        if (!(item < items.top())) {
+          continue;
+        } else {
+          items.pop();
+          items.push(item);
+        }
+      } else {
+        items.push(item);
+      }
+    }
+    std::vector<int64_t> result;
+    result.reserve(items.size());
+    while (!items.empty()) {
+      auto item = items.top();
+      result.emplace_back(item.global_id_);
+      items.pop();
+    }
+    std::reverse(result.begin(), result.end());
+    return result;
+  }
+
+  // Record should only be used in unittest or internally.
+  struct Record {
+    uint32_t time_ : 27;
+    uint16_t freq_power_ : 5;
+
+    [[nodiscard]] uint32_t ToUint32() const {
+      return time_ | (freq_power_ << (32 - 5));
+    }
+  };
+
+ private:
+  static_assert(sizeof(Record) == sizeof(lxu_record_t));
+
+  RandomBitsGenerator generator_;
+  uint16_t min_lfu_power_;
+  std::unique_ptr<std::atomic<uint32_t>> time_;
+};
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
+++ b/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
@@ -14,7 +14,7 @@ namespace torchrec {
  *
  * It evict infrequence elements first, then evict least recent usage elements.
  *
- * The frequency is record as the power number of 2. i.e., The freq_power is 1,
+ * The frequency is recorded as the power number of 2. i.e., The freq_power is 1,
  * then the global id is used approximately 2 times. And the freq_power is 10,
  * then the global id is used approximately 1024 times.
  *
@@ -22,7 +22,7 @@ namespace torchrec {
  * generate n bits. If all these n bits are zero, then the freq_power++.
  *
  * All LFU/LRU information uses uint32_t to record. The uint32_t should be
- * record in IDTransformer's map/dictionary.
+ * recorded in IDTransformer's map/dictionary.
  *
  * Use `update_time` to update logical timer for LRU. It only uses lower 27 bits
  * of time.

--- a/torchrec/csrc/dynamic_embedding/details/random_bits_generator.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/random_bits_generator.cpp
@@ -1,0 +1,91 @@
+#include <c10/macros/Macros.h>
+#include <torchrec/csrc/dynamic_embedding/details/bits_op.h>
+#include <torchrec/csrc/dynamic_embedding/details/random_bits_generator.h>
+
+namespace torchrec {
+
+bool BitScanner::is_next_n_bits_all_zero(uint16_t& n_bits) {
+  if (C10_UNLIKELY((n_bits == 0))) {
+    return true;
+  }
+  if (C10_UNLIKELY(array_idx_ == size_)) {
+    return true;
+  }
+
+  auto val = array[array_idx_];
+  val &= static_cast<uint64_t>(-1) >>
+      bit_idx; // mask higher bits to zeros if already scan.
+  uint16_t remaining_bits =
+      static_cast<uint16_t>(sizeof(uint64_t) * 8) - bit_idx;
+
+  if (val == 0) { // already all zero
+    auto scanned_bits = std::min(remaining_bits, n_bits);
+    n_bits -= scanned_bits;
+    bit_idx += scanned_bits;
+    could_carry_bit_index_to_array_index();
+
+    // if n_bits is scanned, return true. otherwise, scan remaining n_bits
+    return n_bits == 0 || is_next_n_bits_all_zero(n_bits);
+  } else { // val is not zero
+    uint16_t positive_bit_position = clz(val);
+    if (positive_bit_position >= n_bits + bit_idx) { // n_bits are all zero
+      bit_idx += n_bits;
+      // bit_idx must less than sizeof(uint64_t) * 8,
+      // because the val is not zero but n_bits are zero.
+      // so do not call could_carry_bit_index_to_array_index() here.
+
+      // n_bits are all scanned
+      n_bits = 0;
+      return true;
+    }
+
+    // n_bits -= scanned bits
+    n_bits -= std::min(remaining_bits, n_bits);
+    bit_idx = positive_bit_position + 1;
+    could_carry_bit_index_to_array_index();
+
+    return false;
+  }
+}
+void BitScanner::could_carry_bit_index_to_array_index() {
+  if (bit_idx == sizeof(uint64_t) * 8) {
+    bit_idx = 0;
+    ++array_idx_;
+  }
+}
+
+BitScanner::BitScanner(size_t n) : array(new uint64_t[n]), size_(n) {}
+
+constexpr static size_t k_n_random_elems =
+    8; // 64 Byte is just x86 L1 cache-line size
+
+RandomBitsGenerator::RandomBitsGenerator()
+    : engine_(std::random_device()()), scanner_(k_n_random_elems) {
+  reset_scanner();
+}
+void RandomBitsGenerator::reset_scanner() {
+  scanner_.reset_array([this](std::span<uint64_t> elems) {
+    for (auto& elem : elems) {
+      elem = engine_();
+    }
+  });
+}
+
+bool RandomBitsGenerator::is_next_n_bits_all_zero(uint16_t n_bits) {
+  bool ok = scanner_.is_next_n_bits_all_zero(n_bits);
+  if (n_bits != 0) { // scanner is end.
+    reset_scanner();
+  }
+  if (!ok) {
+    return false;
+  }
+
+  if (C10_UNLIKELY(n_bits != 0)) {
+    return is_next_n_bits_all_zero(n_bits);
+  } else {
+    return true;
+  }
+}
+
+RandomBitsGenerator::~RandomBitsGenerator() = default;
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/random_bits_generator.h
+++ b/torchrec/csrc/dynamic_embedding/details/random_bits_generator.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <memory>
+#include <random>
+#include <span>
+#include <utility>
+
+namespace torchrec {
+
+/**
+ * BitScanner holds n uint64_t values as bit stream.
+ * And It can detect next n bits are all zero or not.
+ * If n_bits is larger than remaining, the return
+ * n_bits will be as remainder.
+ */
+class BitScanner {
+ public:
+  explicit BitScanner(size_t n);
+  BitScanner(const BitScanner&) = delete;
+  BitScanner(BitScanner&&) noexcept = default;
+
+  /**
+   * Reset array data
+   * @tparam Callback (std::span<uint64_t>) -> void
+   * @param callback
+   */
+  template <typename Callback>
+  void reset_array(Callback callback) {
+    callback(std::span<uint64_t>(array.get(), size_));
+    array_idx_ = 0;
+    bit_idx = 0;
+  }
+
+  bool is_next_n_bits_all_zero(uint16_t& n_bits);
+
+  // used by unittest only
+  uint16_t array_idx_{0};
+  uint16_t bit_idx{0};
+
+ private:
+  std::unique_ptr<uint64_t[]> array;
+  uint16_t size_;
+
+  // if bit_idx > 64, incr array_idx
+  void could_carry_bit_index_to_array_index();
+};
+
+class RandomBitsGenerator {
+ public:
+  RandomBitsGenerator();
+  ~RandomBitsGenerator();
+  RandomBitsGenerator(const RandomBitsGenerator&) = delete;
+  RandomBitsGenerator(RandomBitsGenerator&&) noexcept = default;
+
+  /**
+   * Is next N random bits are all zero or not.
+   * i.e., the true prob is approximately 1/(2^n_bits).
+   *
+   * @param n_bits
+   * @return
+   */
+  bool is_next_n_bits_all_zero(uint16_t n_bits);
+
+ private:
+  BitScanner scanner_;
+  std::mt19937_64 engine_;
+  void reset_scanner();
+};
+
+} // namespace torchrec


### PR DESCRIPTION
This PR is trying to migrate `MixedLFULRUStrategy` to the upper-level folder. The main functionality of this class is to help decide which global_ids to evict when the id transformer (for example, the `NaiveIDTransformer`) is full.

As its name suggested, it's a mix of LFU and LRU. We got the idea for this strategy from [redis](https://redis.io/docs/manual/eviction/#the-new-lfu-mode): we only need an approximate counter for the frequency of each global id stored in the id transformer.

Specifically, we will roll the dice - checking the next k bits of the random generated bits - each time we visit an id, and if all k bits are 0, we will increase the counter. This makes the probability of increment $1/2^k$. And by increasing the k along with the increment of the counter, we can record an approximate frequency counter with few bits, squeeze both the timestamp (the LRU part) and frequency counter (the LFU part) in a uint32_t.

Thank you for your time on this PR :)

cc @reyoung @colin2328 