### PR TITLE
Revert of D39828217

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -6,10 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import cast, Dict, List, Optional, Tuple, Type
+from typing import cast, Dict, List, Optional, Tuple
 
 import torch
-import torchrec
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
@@ -688,21 +687,19 @@ def calculate_shard_storages(
     }:
         hbm_storage = round(ddr_storage * caching_ratio)
 
-    optimizer_class = getattr(tensor, "_optimizer_class", None)
-
     hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=hbm_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
+        compute_kernel=compute_kernel,
     )
     ddr_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=ddr_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
+        compute_kernel=compute_kernel,
     )
 
     hbm_sizes: List[int] = [
@@ -979,7 +976,7 @@ def _calculate_storage_specific_sizes(
     shape: torch.Size,
     shard_sizes: List[List[int]],
     sharding_type: str,
-    optimizer_class: Optional[Type[torch.optim.Optimizer]] = None,
+    compute_kernel: str,
 ) -> List[int]:
     tensor_sizes: List[int] = [
         math.ceil(storage * prod(size) / prod(shape))
@@ -987,29 +984,13 @@ def _calculate_storage_specific_sizes(
         else storage
         for size in shard_sizes
     ]
-    optimizer_multipler: float = _get_optimizer_multipler(optimizer_class, shape)
 
     optimizer_sizes: List[int] = [
-        math.ceil(tensor_size * optimizer_multipler) for tensor_size in tensor_sizes
+        tensor_size * 2 if compute_kernel == EmbeddingComputeKernel.DENSE.value else 0
+        for tensor_size in tensor_sizes
     ]
 
     return [
         tensor_size + optimizer_size
         for tensor_size, optimizer_size in zip(tensor_sizes, optimizer_sizes)
     ]
-
-
-def _get_optimizer_multipler(
-    optimizer_class: Optional[Type[torch.optim.Optimizer]],
-    shape: torch.Size,
-) -> float:
-    if not optimizer_class:
-        return 0.0
-    if optimizer_class in [torch.optim.SGD, torchrec.optim.SGD]:
-        return 0
-    elif optimizer_class in [torch.optim.Adam, torchrec.optim.Adam]:
-        return 2
-    elif optimizer_class == torchrec.optim.RowWiseAdagrad:
-        return 1 / shape[-1]
-    else:
-        return 1

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -7,7 +7,6 @@
 
 import unittest
 from typing import cast, List
-from unittest.mock import patch
 
 import torch
 from torchrec.distributed.embedding_tower_sharding import (
@@ -387,12 +386,6 @@ class TestEnumerators(unittest.TestCase):
         self.tower_collection_model = TestTowerCollectionSparseNN(
             tables=tables, weighted_tables=weighted_tables
         )
-        _get_optimizer_multipler_patcher = patch(
-            "torchrec.distributed.planner.shard_estimators._get_optimizer_multipler",
-            return_value=0,
-        )
-        self.addCleanup(_get_optimizer_multipler_patcher.stop)
-        self._get_optimizer_multipler_mock = _get_optimizer_multipler_patcher.start()
 
     def test_dp_sharding(self) -> None:
         sharding_options = self.enumerator.enumerate(
@@ -431,12 +424,15 @@ class TestEnumerators(unittest.TestCase):
                 * sharding_option.tensor.element_size()
             ] * self.world_size
 
+            optimizer_sizes = [tensor_size * 2 for tensor_size in tensor_sizes]
+
             storage_sizes = [
-                input_size + tensor_size + output_size
-                for input_size, tensor_size, output_size in zip(
+                input_size + tensor_size + output_size + optimizer_size
+                for input_size, tensor_size, output_size, optimizer_size in zip(
                     input_sizes,
                     tensor_sizes,
                     output_sizes,
+                    optimizer_sizes,
                 )
             ]
 


### PR DESCRIPTION
Summary: As titled. Reverting because storage over-estimation is causing a lot of training jobs to fail.

Differential Revision: D40208604

