### PR TITLE
CopyableMixin to support shard_embedding_modules

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -22,6 +22,7 @@ from torchrec.distributed.embeddingbag import (
 from torchrec.distributed.fused_embedding import FusedEmbeddingCollectionSharder
 from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.distributed.types import QuantizedCommCodecs
+from torchrec.inference.modules import CopyableMixin
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
@@ -513,7 +514,7 @@ class TestSparseNNBase(nn.Module):
             sparse_device = torch.device("cpu")
 
 
-class TestSparseNN(TestSparseNNBase):
+class TestSparseNN(TestSparseNNBase, CopyableMixin):
     """
     Simple version of a SparseNN model.
 

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -13,10 +13,7 @@ import torch
 from hypothesis import given, settings, Verbosity
 from torch import nn, quantization as quant
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel, ModuleSharder
-from torchrec.distributed.model_parallel import (
-    bind_copy_to_device,
-    DistributedModelParallel,
-)
+from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
 from torchrec.distributed.test_utils.test_model import (
@@ -333,8 +330,6 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
 
         sharded_model = sharded_model.to(device)
 
-        bind_copy_to_device(sharded_model)
-
         # pyre-ignore
         sharded_model_copy = sharded_model.copy(
             current_device=device, to_device=device_1
@@ -373,9 +368,9 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             sparse_device=torch.device("meta"),
         )
         # pyre-ignore [16]
-        model.copy = CopyModule()
+        model.copy_module = CopyModule()
         # pyre-ignore [16]
-        model.no_copy = NoCopyModule()
+        model.no_copy_module = NoCopyModule()
         quant_model = _quantize(model, inplace=True)
         dmp = DistributedModelParallel(
             quant_model,
@@ -395,6 +390,6 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
 
         dmp_1 = dmp.copy(device_1)
         # pyre-ignore [16]
-        self.assertEqual(dmp_1.module.copy.tensor.device, device_1)
+        self.assertEqual(dmp_1.module.copy_module.tensor.device, device_1)
         # pyre-ignore [16]
-        self.assertEqual(dmp_1.module.no_copy.tensor.device, torch.device("cpu"))
+        self.assertEqual(dmp_1.module.no_copy_module.tensor.device, torch.device("cpu"))

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
+import copy
 import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -15,6 +16,8 @@ import torch.nn as nn
 import torch.quantization as quant
 import torchrec as trec
 import torchrec.quant as trec_quant
+from torchrec.distributed.types import ModuleCopyMixin
+from torchrec.distributed.utils import sharded_model_copy
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollectionInterface,
     EmbeddingCollectionInterface,
@@ -64,6 +67,46 @@ def quantize_embeddings(
         mapping=mapping,
         inplace=inplace,
     )
+
+
+def copy_to_device(
+    module: nn.Module,
+    current_device: torch.device,
+    to_device: torch.device,
+) -> nn.Module:
+
+    with sharded_model_copy(device=None):
+        copy_module = copy.deepcopy(module)
+
+    # Copy only weights with matching device.
+    def _copy_if_device_match(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.device == current_device:
+            return tensor.to(to_device)
+        return tensor
+
+    # if this is a sharded module, customize the copy
+    if isinstance(copy_module, ModuleCopyMixin):
+        return copy_module.copy(to_device)
+
+    for child_name, child in copy_module.named_children():
+        if not any(
+            [isinstance(submodule, ModuleCopyMixin) for submodule in child.modules()]
+        ):
+            child_copy = child._apply(_copy_if_device_match)
+        else:
+            child_copy = copy_to_device(child, current_device, to_device)
+        copy_module.register_module(child_name, child_copy)
+    return copy_module
+
+
+class CopyableMixin(nn.Module):
+    def copy(
+        self,
+        device: torch.device,
+    ) -> nn.Module:
+        return copy_to_device(
+            self, current_device=torch.device("cpu"), to_device=device
+        )
 
 
 @dataclass


### PR DESCRIPTION
Summary: method binding is not supported when pass the model between multiple interpreter threads

Differential Revision: D40204565

