### PR TITLE
Back out "Revert of D39828217"

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -6,9 +6,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import cast, Dict, List, Optional, Tuple
+from typing import cast, Dict, List, Optional, Tuple, Type
 
 import torch
+import torchrec.optim as trec_optim
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
@@ -687,19 +688,21 @@ def calculate_shard_storages(
     }:
         hbm_storage = round(ddr_storage * caching_ratio)
 
+    optimizer_class = getattr(tensor, "_optimizer_class", None)
+
     hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=hbm_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        compute_kernel=compute_kernel,
+        optimizer_class=optimizer_class,
     )
     ddr_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=ddr_storage,
         shape=tensor.shape,
         shard_sizes=shard_sizes,
         sharding_type=sharding_type,
-        compute_kernel=compute_kernel,
+        optimizer_class=optimizer_class,
     )
 
     hbm_sizes: List[int] = [
@@ -976,7 +979,7 @@ def _calculate_storage_specific_sizes(
     shape: torch.Size,
     shard_sizes: List[List[int]],
     sharding_type: str,
-    compute_kernel: str,
+    optimizer_class: Optional[Type[torch.optim.Optimizer]] = None,
 ) -> List[int]:
     tensor_sizes: List[int] = [
         math.ceil(storage * prod(size) / prod(shape))
@@ -984,13 +987,29 @@ def _calculate_storage_specific_sizes(
         else storage
         for size in shard_sizes
     ]
+    optimizer_multipler: float = _get_optimizer_multipler(optimizer_class, shape)
 
     optimizer_sizes: List[int] = [
-        tensor_size * 2 if compute_kernel == EmbeddingComputeKernel.DENSE.value else 0
-        for tensor_size in tensor_sizes
+        math.ceil(tensor_size * optimizer_multipler) for tensor_size in tensor_sizes
     ]
 
     return [
         tensor_size + optimizer_size
         for tensor_size, optimizer_size in zip(tensor_sizes, optimizer_sizes)
     ]
+
+
+def _get_optimizer_multipler(
+    optimizer_class: Optional[Type[torch.optim.Optimizer]],
+    shape: torch.Size,
+) -> float:
+    if not optimizer_class:
+        return 0.0
+    if optimizer_class in [torch.optim.SGD, trec_optim.SGD]:
+        return 0
+    elif optimizer_class in [torch.optim.Adam, trec_optim.Adam]:
+        return 2
+    elif optimizer_class == trec_optim.RowWiseAdagrad:
+        return 1 / shape[-1]
+    else:
+        return 1

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -9,17 +9,22 @@ import unittest
 from typing import cast
 
 import torch
+import torchrec.optim as trec_optim
+
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import EmbeddingPerfEstimator
+from torchrec.distributed.planner.shard_estimators import (
+    _calculate_storage_specific_sizes,
+    EmbeddingPerfEstimator,
+)
 from torchrec.distributed.planner.types import Topology
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.tests.test_quant_model_parallel import _quantize
 from torchrec.distributed.tests.test_sequence_model import TestSequenceSparseNN
-from torchrec.distributed.types import ModuleSharder
+from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
 
@@ -195,3 +200,44 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         }
 
         self.assertEqual(perfs, expected_perfs)
+
+
+# pyre-ignore[3]
+def calculate_storage_specific_size_data_provider():
+    return (
+        {
+            "sharding_type": ShardingType.TABLE_ROW_WISE,
+            "optimizer_class": torch.optim.SGD,
+            "expected_storage": [50, 50],
+        },
+        {
+            "sharding_type": ShardingType.COLUMN_WISE,
+            "optimizer_class": torch.optim.Adam,
+            "expected_storage": [150, 150],
+        },
+        {
+            "sharding_type": ShardingType.TABLE_ROW_WISE,
+            "optimizer_class": None,
+            "expected_storage": [50, 50],
+        },
+        {
+            "sharding_type": ShardingType.DATA_PARALLEL,
+            "optimizer_class": trec_optim.RowWiseAdagrad,
+            "expected_storage": [134, 134],
+        },
+    )
+
+
+class TestEmbeddingStorageEstimator(unittest.TestCase):
+    def test_calculate_storage_specific_sizes(self) -> None:
+        for inputs in calculate_storage_specific_size_data_provider():
+            sharding_type, optimizer_class, expected_storage = inputs.values()
+            estimates = _calculate_storage_specific_sizes(
+                storage=100,
+                shape=torch.Size((10, 5, 3)),
+                shard_sizes=[[5, 5, 3], [5, 5, 3]],
+                sharding_type=sharding_type.value,
+                optimizer_class=optimizer_class,
+            )
+
+            self.assertEqual(estimates, expected_storage)


### PR DESCRIPTION
Summary: D39828217 (https://github.com/pytorch/torchrec/commit/f63cd2f307f8a7d3f78d40cbc4fdd08fcdc0d53d) was reverted since it's thought to cause PlannerError for video models that are previously shardable. However, we now know the feature works after the fix D40064919 (https://github.com/pytorch/torchrec/commit/ed995ff03bfb371440e09bee04ac516081d3970b). So we didn't really need the first backout. I am backing out the backout 🥲

Reviewed By: YLGH

Differential Revision: D40285415

