### PR TITLE
Fix bug in storage comparison

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -304,7 +304,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )
-            if global_storage_constraints < lowest_storage:
+            if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(
                     error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
                     message="Unable to find a plan for this model because of insufficient storage. \n"


### PR DESCRIPTION
Summary: When using "<" to compare `Storage`, it would only compare the hbm size, regardless of ddr size. This diff changes that to `fits_in` to compare the Storage (lowest_storage vs. global_storage_constraints), so that proper planner error type is raised when either hbm or ddr of lowest_storage is greater than that of global_storage_constraints.

Differential Revision: D40349774

