### PR TITLE
Remove cudnn installation as pytorch installation already install cudnn

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -73,7 +73,6 @@ jobs:
       shell: bash
       run: |
         conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
-        conda install -n build_binary -y cudnn
     - name: Install Dependencies
       shell: bash
       run: |


### PR DESCRIPTION
This should fix the issue encountered in nightly https://github.com/pytorch/torchrec/actions/runs/3234254998/jobs/5297133390 and 
https://github.com/pytorch/torchrec/actions/runs/3241925643/jobs/5314513779

This conda install step (conda install -n build_binary -y cudnn) would install cudnn from default conda channel (https://anaconda.org/anaconda/cudnn/files). However, this channel is becoming incompatible (cuda11.3 being the highest) with the installed version of pytorch (expecting cuda11.7). So we should consider removing this line and retry.  

