### PR TITLE
fix the cw weight init

### DIFF
--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -175,6 +175,8 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
                         local_metadata=shards[i],
                         global_metadata=global_metadata,
                         fused_params=info.fused_params,
+                        weight_init_max=info.embedding_config.weight_init_max,
+                        weight_init_min=info.embedding_config.weight_init_min,
                     )
                 )
 


### PR DESCRIPTION
Summary: only cw missed passing the weight initiliaztion. Other shardings don't have this problem, eg. https://fburl.com/code/9ma7m1pa

Reviewed By: dstaay-fb

Differential Revision: D40414589

