### PR TITLE
[tde] Migrate IO plugin

### DIFF
--- a/torchrec/csrc/dynamic_embedding/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/CMakeLists.txt
@@ -9,9 +9,12 @@ add_library(tde_cpp_objs
             details/clz_impl.cpp
             details/ctz_impl.cpp
             details/random_bits_generator.cpp
-            details/mixed_lfu_lru_strategy.cpp)
+            details/mixed_lfu_lru_strategy.cpp
+            details/io_registry.cpp
+            details/io.cpp)
 
 target_include_directories(tde_cpp_objs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 target_include_directories(tde_cpp_objs PUBLIC ${TORCH_INCLUDE_DIRS})
 target_link_libraries(tde_cpp_objs PUBLIC ${TORCH_LIBRARIES})
 target_compile_options(tde_cpp_objs PUBLIC -fPIC)
+target_link_libraries(tde_cpp_objs PUBLIC ${CMAKE_DL_LIBS})

--- a/torchrec/csrc/dynamic_embedding/details/io.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <torchrec/csrc/dynamic_embedding/details/io.h>
+
+namespace tde::details {
+
+static constexpr std::string_view k_schema_separator = "://";
+
+IO::IO(const std::string& config) {
+  auto pos = config.find(k_schema_separator);
+  TORCH_CHECK(
+      pos != std::string::npos,
+      "config string should be schema://cfg_string, cannot find schema");
+
+  std::string schema = config.substr(0, pos);
+  std::string rest_cfg = config.substr(pos + k_schema_separator.size());
+  auto& reg = IORegistry::Instance();
+  provider_ = reg.resolve(schema);
+  instance_ = provider_.initialize_(rest_cfg.c_str());
+}
+
+IO::~IO() {
+  if (instance_ == nullptr) {
+    return;
+  }
+  provider_.finalize_(instance_);
+}
+
+struct FetchContext {
+  std::vector<torch::Tensor> tensors_;
+  std::function<void(std::vector<torch::Tensor>)> on_complete_;
+  torch::ScalarType scalar_type_;
+  uint32_t num_optimizer_states_;
+};
+
+static void on_global_id_fetched(
+    void* ctx,
+    uint32_t offset,
+    uint32_t optimizer_state,
+    void* data,
+    uint32_t data_len) {
+  auto c = reinterpret_cast<FetchContext*>(ctx);
+  auto& tensor = c->tensors_[offset];
+  // non-existed global id
+  if (data_len == 0) {
+    if (tensor.defined()) {
+      tensor = torch::Tensor{};
+    }
+    return;
+  }
+  if (!tensor.defined()) {
+    size_t elem_size = torch::elementSize(c->scalar_type_);
+    TORCH_CHECK(data_len % elem_size == 0);
+    size_t num_elems = data_len / elem_size;
+    tensor = torch::empty(
+        {
+            static_cast<int64_t>(c->num_optimizer_states_),
+            static_cast<int64_t>(num_elems),
+        },
+        c10::TensorOptions().dtype(c->scalar_type_));
+  }
+  void* ptr = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(tensor.data_ptr()) +
+      optimizer_state * data_len);
+  memcpy(ptr, data, data_len);
+}
+
+static void on_all_fetched(void* ctx) {
+  auto c = reinterpret_cast<FetchContext*>(ctx);
+  c->on_complete_(std::move(c->tensors_));
+  delete c;
+}
+
+void IO::pull(
+    const std::string& table_name,
+    std::span<const int64_t> global_ids,
+    std::span<const int64_t> col_ids,
+    uint32_t num_optimizer_states,
+    torch::ScalarType type,
+    std::function<void(std::vector<torch::Tensor>)> on_fetch_complete) {
+  std::unique_ptr<FetchContext> ctx(new FetchContext{
+      .on_complete_ = std::move(on_fetch_complete),
+      .scalar_type_ = type,
+      .num_optimizer_states_ = num_optimizer_states,
+  });
+
+  ctx->tensors_.resize(
+      global_ids.size() * std::max(col_ids.size(), static_cast<size_t>(1)));
+
+  IOPullParameter param{
+      .table_name_ = table_name.c_str(),
+      .num_cols_ = static_cast<uint32_t>(col_ids.size()),
+      .num_global_ids_ = static_cast<uint32_t>(global_ids.size()),
+      .col_ids_ = col_ids.data(),
+      .global_ids_ = global_ids.data(),
+      .num_optimizer_stats_ = num_optimizer_states,
+      .on_global_id_fetched_ = on_global_id_fetched,
+      .on_all_fetched_ = on_all_fetched,
+  };
+  param.on_complete_context_ = ctx.release();
+  provider_.pull_(instance_, param);
+}
+
+struct PushContext {
+  std::function<void()> on_push_complete_;
+};
+
+static void OnPushComplete(void* ctx) {
+  auto* c = reinterpret_cast<PushContext*>(ctx);
+  c->on_push_complete_();
+  delete c;
+}
+
+void IO::push(
+    const std::string& table_name,
+    std::span<const int64_t> global_ids,
+    std::span<const int64_t> col_ids,
+    std::span<const uint32_t> os_ids,
+    std::span<const uint8_t> data,
+    std::span<const uint64_t> offsets,
+    std::function<void()> on_push_complete) {
+  std::unique_ptr<PushContext> ctx(new PushContext{
+      .on_push_complete_ = std::move(on_push_complete),
+  });
+  IOPushParameter param{
+      .table_name_ = table_name.c_str(),
+      .num_cols_ = static_cast<uint32_t>(col_ids.size()),
+      .num_global_ids_ = static_cast<uint32_t>(global_ids.size()),
+      .col_ids_ = col_ids.data(),
+      .global_ids_ = global_ids.data(),
+      .num_optimizer_stats_ = static_cast<uint32_t>(os_ids.size()),
+      .optimizer_stats_ids_ = os_ids.data(),
+      .num_offsets_ = static_cast<uint32_t>(offsets.size()),
+      .offsets_ = offsets.data(),
+      .data_ = data.data(),
+      .on_complete_context_ = ctx.release(),
+      .on_push_complete = OnPushComplete,
+  };
+  provider_.push_(instance_, param);
+}
+
+} // namespace tde::details

--- a/torchrec/csrc/dynamic_embedding/details/io.h
+++ b/torchrec/csrc/dynamic_embedding/details/io.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <torch/torch.h>
+#include <torchrec/csrc/dynamic_embedding/details/io_registry.h>
+#include <cstdint>
+#include <span>
+
+namespace tde::details {
+
+class IO {
+ public:
+  explicit IO(const std::string& config);
+  ~IO();
+
+  IO(const IO&) = delete;
+  IO& operator=(const IO&) = delete;
+  IO(IO&&) noexcept = delete;
+  IO& operator=(IO&&) noexcept = delete;
+
+  /**
+   * Fetch parameter and optimizer states from ParamServer.
+   * @param global_ids global ids to fetch
+   * @param num_optimizer_states number of optimizer stats to fetch
+   * @param type data type
+   * @param on_fetch_complete  fetch complete callback. The parameter is
+   * a vector, the vector's size is equal to global_ids.size() *
+   * max(col_ids.size(), 1). If the parameter server does not contains some
+   * parameter, the tensor will be empty. Also, the tensor shape is
+   * [num_optimizer_states, embedding_size]. The shape of each global id can be
+   * different in some algorithm.
+   *
+   * @note this method is asynchronous, The col_ids, and global_ids will be
+   * copied inside, so it is safe to free col_ids/global_ids before
+   * on_fetch_complete.
+   */
+  void pull(
+      const std::string& table_name,
+      std::span<const int64_t> global_ids,
+      std::span<const int64_t> col_ids,
+      uint32_t num_optimizer_states,
+      torch::ScalarType type,
+      std::function<void(std::vector<torch::Tensor>)> on_fetch_complete);
+
+  /**
+   * Push Parameter/Optimizer stats to parameter server.
+   * @param table_name
+   * @param global_ids
+   * @param col_ids empty if no column slices
+   * @param os_ids
+   * @param data A flatten view of pushing data.
+   * data[gid_offset * num_cols * num_os_id + col_offset * num_os_id +
+   * os_id_offset]
+   *
+   * @param offsets
+   * @param on_push_complete
+   */
+  void push(
+      const std::string& table_name,
+      std::span<const int64_t> global_ids,
+      std::span<const int64_t> col_ids,
+      std::span<const uint32_t> os_ids,
+      std::span<const uint8_t> data,
+      std::span<const uint64_t> offsets,
+      std::function<void()> on_push_complete);
+
+ private:
+  IOProvider provider_{};
+  void* instance_{};
+};
+
+} // namespace tde::details

--- a/torchrec/csrc/dynamic_embedding/details/io.h
+++ b/torchrec/csrc/dynamic_embedding/details/io.h
@@ -26,19 +26,23 @@ class IO {
 
   /**
    * Fetch parameter and optimizer states from ParamServer.
-   * @param global_ids global ids to fetch
-   * @param num_optimizer_states number of optimizer stats to fetch
-   * @param type data type
-   * @param on_fetch_complete  fetch complete callback. The parameter is
-   * a vector, the vector's size is equal to global_ids.size() *
-   * max(col_ids.size(), 1). If the parameter server does not contains some
+   * @param global_ids Global ids to fetch
+   * @param col_ids The column id (in term of colum-wise sharding) of
+   * the embedding. It will be empty if the embedding is not sharded
+   * along the column.
+   * @param num_optimizer_states Number of optimizer states to fetch
+   * @param type Data type of the embedding.
+   * @param on_fetch_complete The complete callback when the fetch complete.
+   * The parameter is a vector of tensor, whose size is equal to
+   * `global_ids.size() * max(col_ids.size(), 1)`.
+   * If the parameter server does not contains some
    * parameter, the tensor will be empty. Also, the tensor shape is
    * [num_optimizer_states, embedding_size]. The shape of each global id can be
    * different in some algorithm.
    *
-   * @note this method is asynchronous, The col_ids, and global_ids will be
-   * copied inside, so it is safe to free col_ids/global_ids before
-   * on_fetch_complete.
+   * @note This method is asynchronous. The `col_ids`, and `global_ids` will be
+   * copied inside, so it is safe to free `col_ids`/`global_ids` before
+   * `on_fetch_complete`.
    */
   void pull(
       const std::string& table_name,
@@ -50,16 +54,26 @@ class IO {
 
   /**
    * Push Parameter/Optimizer stats to parameter server.
-   * @param table_name
-   * @param global_ids
-   * @param col_ids empty if no column slices
-   * @param os_ids
-   * @param data A flatten view of pushing data.
-   * data[gid_offset * num_cols * num_os_id + col_offset * num_os_id +
-   * os_id_offset]
-   *
-   * @param offsets
-   * @param on_push_complete
+   * @param global_ids Global ids to push
+   * @param col_ids The column id (in term of colum-wise sharding) of
+   * the embedding. It will be empty if the embedding is not sharded
+   * along the column.
+   * @param os_ids The optimizer state id of the corresponding embedding.
+   * Its element should be integer within [0, 2].
+   * @param data A flatten view of data to push. There will be
+   * `global_is.size() * max(col_ids.size(), 1) * os_ids.size()`
+   * embedding to push.
+   * And to accommodate embedding of different data type, here we convert
+   * data into `uint8_t` and the data of the `col_ids[j]` of optimizer state
+   * k of `global_id[i]`, is in:
+   * `data[begin..end]` where:
+   * ```
+   * auto x = i * col_ids.size() * os_id.size() + j * os_id.size() + k;
+   * auto begin = offsets[x];
+   * auto end = offsets[x + 1];
+   * ```
+   * @param offsets The offset of each embedding in `data`
+   * @param on_push_complete The callback when the push finishes.
    */
   void push(
       const std::string& table_name,

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
@@ -13,7 +13,7 @@
 namespace tde::details {
 
 void IORegistry::register_provider(IOProvider provider) {
-  std::string type = provider.type_;
+  std::string type = provider.type;
   auto it = providers_.find(type);
   if (it != providers_.end()) {
     TORCH_WARN("IO provider ", type, " already registered. Ignored this time.");
@@ -29,25 +29,25 @@ void IORegistry::register_plugin(const char* filename) {
   IOProvider provider{};
   auto type_ptr = dlsym(ptr.get(), "IO_type");
   TORCH_CHECK(type_ptr != nullptr, "cannot find IO_type symbol");
-  provider.type_ = *reinterpret_cast<const char**>(type_ptr);
+  provider.type = *reinterpret_cast<const char**>(type_ptr);
 
   auto initialize_ptr = dlsym(ptr.get(), "IO_Initialize");
   TORCH_CHECK(initialize_ptr != nullptr, "cannot find IO_Initialize symbol");
-  provider.initialize_ =
-      reinterpret_cast<decltype(provider.initialize_)>(initialize_ptr);
+  provider.initialize =
+      reinterpret_cast<decltype(provider.initialize)>(initialize_ptr);
 
   auto finalize_ptr = dlsym(ptr.get(), "IO_Finalize");
   TORCH_CHECK(finalize_ptr != nullptr, "cannot find IO_Finalize symbol");
-  provider.finalize_ =
-      reinterpret_cast<decltype(provider.finalize_)>(finalize_ptr);
+  provider.finalize =
+      reinterpret_cast<decltype(provider.finalize)>(finalize_ptr);
 
   auto pull_ptr = dlsym(ptr.get(), "IO_Pull");
   TORCH_CHECK(pull_ptr != nullptr, "cannot find IO_Pull symbol");
-  provider.pull_ = reinterpret_cast<decltype(provider.pull_)>(pull_ptr);
+  provider.pull = reinterpret_cast<decltype(provider.pull)>(pull_ptr);
 
   auto push_ptr = dlsym(ptr.get(), "IO_Push");
   TORCH_CHECK(push_ptr != nullptr, "cannot find IO_Push symbol");
-  provider.push_ = reinterpret_cast<decltype(provider.push_)>(push_ptr);
+  provider.push = reinterpret_cast<decltype(provider.push)>(push_ptr);
 
   register_provider(provider);
   dls_.emplace_back(std::move(ptr));

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <dlfcn.h>
+#include <torch/torch.h>
+#include <torchrec/csrc/dynamic_embedding/details/io_registry.h>
+
+namespace tde::details {
+
+void IORegistry::register_provider(IOProvider provider) {
+  std::string type = provider.type_;
+  auto it = providers_.find(type);
+  if (it != providers_.end()) {
+    TORCH_WARN("IO provider ", type, " already registered. Ignored this time.");
+    return;
+  }
+
+  providers_[type] = provider;
+}
+
+void IORegistry::register_plugin(const char* filename) {
+  DLPtr ptr(dlopen(filename, RTLD_LAZY | RTLD_LOCAL));
+  TORCH_CHECK(ptr != nullptr, "cannot load dl ", filename, ", errno ", errno);
+  IOProvider provider{};
+  auto type_ptr = dlsym(ptr.get(), "IO_type");
+  TORCH_CHECK(type_ptr != nullptr, "cannot find IO_type symbol");
+  provider.type_ = *reinterpret_cast<const char**>(type_ptr);
+
+  auto initialize_ptr = dlsym(ptr.get(), "IO_Initialize");
+  TORCH_CHECK(initialize_ptr != nullptr, "cannot find IO_Initialize symbol");
+  provider.initialize_ =
+      reinterpret_cast<decltype(provider.initialize_)>(initialize_ptr);
+
+  auto finalize_ptr = dlsym(ptr.get(), "IO_Finalize");
+  TORCH_CHECK(finalize_ptr != nullptr, "cannot find IO_Finalize symbol");
+  provider.finalize_ =
+      reinterpret_cast<decltype(provider.finalize_)>(finalize_ptr);
+
+  auto pull_ptr = dlsym(ptr.get(), "IO_Pull");
+  TORCH_CHECK(pull_ptr != nullptr, "cannot find IO_Pull symbol");
+  provider.pull_ = reinterpret_cast<decltype(provider.pull_)>(pull_ptr);
+
+  auto push_ptr = dlsym(ptr.get(), "IO_Push");
+  TORCH_CHECK(push_ptr != nullptr, "cannot find IO_Push symbol");
+  provider.push_ = reinterpret_cast<decltype(provider.push_)>(push_ptr);
+
+  register_provider(provider);
+  dls_.emplace_back(std::move(ptr));
+}
+
+void IORegistry::DLCloser::operator()(void* ptr) const {
+  if (ptr == nullptr) {
+    return;
+  }
+  TORCH_CHECK(dlclose(ptr) == 0, "cannot close dl library, errno %d", errno);
+}
+
+IOProvider IORegistry::resolve(const std::string& name) const {
+  auto it = providers_.find(name);
+  TORCH_CHECK(
+      it != providers_.end(), "IO provider ", name, " is not registered");
+  return it->second;
+}
+
+IORegistry& IORegistry::Instance() {
+  static IORegistry instance;
+  return instance;
+}
+
+} // namespace tde::details

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <c10/util/flat_hash_map.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tde::details {
+
+struct IOPullParameter {
+  const char* table_name_;
+  uint32_t num_cols_;
+  uint32_t num_global_ids_;
+  const int64_t* col_ids_;
+  const int64_t* global_ids_;
+  uint32_t num_optimizer_stats_;
+  void* on_complete_context_;
+  void (*on_global_id_fetched_)(
+      void* ctx,
+      uint32_t offset,
+      uint32_t optimizer_state,
+      void* data,
+      uint32_t data_len);
+  void (*on_all_fetched_)(void* ctx);
+};
+
+struct IOPushParameter {
+  const char* table_name_;
+  uint32_t num_cols_;
+  uint32_t num_global_ids_;
+  const int64_t* col_ids_;
+  const int64_t* global_ids_;
+  uint32_t num_optimizer_stats_;
+  const uint32_t* optimizer_stats_ids_;
+  // offsets in bytes
+  // data_ptr is 1-D array divided by offsets in bytes.
+  // The offsets are jagged and length of offsets array is length + 1.
+  //
+  // data[global_id * num_cols * num_optimizer_stats_
+  //       + col_id * num_optimizer_stats_ + os_id ]
+  uint32_t num_offsets_;
+  const uint64_t* offsets_;
+  const void* data_;
+  void* on_complete_context_;
+  void (*on_push_complete)(void* ctx);
+};
+
+struct IOProvider {
+  const char* type_;
+  void* (*initialize_)(const char* cfg);
+  void (*pull_)(void* instance, IOPullParameter cfg);
+  void (*push_)(void* instance, IOPushParameter cfg);
+  void (*finalize_)(void*);
+};
+
+class IORegistry {
+ public:
+  void register_provider(IOProvider provider);
+  void register_plugin(const char* filename);
+  [[nodiscard]] IOProvider resolve(const std::string& name) const;
+
+  static IORegistry& Instance();
+
+ private:
+  IORegistry() = default;
+  ska::flat_hash_map<std::string, IOProvider> providers_;
+  struct DLCloser {
+    void operator()(void* ptr) const;
+  };
+
+  using DLPtr = std::unique_ptr<void, DLCloser>;
+  std::vector<DLPtr> dls_;
+};
+
+} // namespace tde::details

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.h
@@ -17,49 +17,43 @@
 namespace tde::details {
 
 struct IOPullParameter {
-  const char* table_name_;
-  uint32_t num_cols_;
-  uint32_t num_global_ids_;
-  const int64_t* col_ids_;
-  const int64_t* global_ids_;
-  uint32_t num_optimizer_stats_;
-  void* on_complete_context_;
-  void (*on_global_id_fetched_)(
+  const char* table_name;
+  uint32_t num_cols;
+  uint32_t num_global_ids;
+  const int64_t* col_ids;
+  const int64_t* global_ids;
+  uint32_t num_optimizer_states;
+  void* on_complete_context;
+  void (*on_global_id_fetched)(
       void* ctx,
       uint32_t offset,
       uint32_t optimizer_state,
       void* data,
       uint32_t data_len);
-  void (*on_all_fetched_)(void* ctx);
+  void (*on_all_fetched)(void* ctx);
 };
 
 struct IOPushParameter {
-  const char* table_name_;
-  uint32_t num_cols_;
-  uint32_t num_global_ids_;
-  const int64_t* col_ids_;
-  const int64_t* global_ids_;
-  uint32_t num_optimizer_stats_;
-  const uint32_t* optimizer_stats_ids_;
-  // offsets in bytes
-  // data_ptr is 1-D array divided by offsets in bytes.
-  // The offsets are jagged and length of offsets array is length + 1.
-  //
-  // data[global_id * num_cols * num_optimizer_stats_
-  //       + col_id * num_optimizer_stats_ + os_id ]
-  uint32_t num_offsets_;
-  const uint64_t* offsets_;
-  const void* data_;
-  void* on_complete_context_;
+  const char* table_name;
+  uint32_t num_cols;
+  uint32_t num_global_ids;
+  const int64_t* col_ids;
+  const int64_t* global_ids;
+  uint32_t num_optimizer_states;
+  const uint32_t* optimizer_stats_ids;
+  uint32_t num_offsets;
+  const uint64_t* offsets;
+  const void* data;
+  void* on_complete_context;
   void (*on_push_complete)(void* ctx);
 };
 
 struct IOProvider {
-  const char* type_;
-  void* (*initialize_)(const char* cfg);
-  void (*pull_)(void* instance, IOPullParameter cfg);
-  void (*push_)(void* instance, IOPushParameter cfg);
-  void (*finalize_)(void*);
+  const char* type;
+  void* (*initialize)(const char* cfg);
+  void (*pull)(void* instance, IOPullParameter cfg);
+  void (*push)(void* instance, IOPushParameter cfg);
+  void (*finalize)(void*);
 };
 
 class IORegistry {


### PR DESCRIPTION
This PR implements the IO plugin mechanism in dynamic embedding, where user can register her/his IO plugin by providing a dynamic library with symbol `IO_type`, `IO_Initialize`, `IO_Finalize`, `IO_Push` and `IO_Pull` included.

And the tests for the interfaces introduced in this PR will be added along with a example redis IO plugin in next PR. I split them so that the PR won't be too large.

Thank you for your time on reviewing this PR :)

cc @reyoung @colin2328 