### PR TITLE
Fix failed tests in test_quant_model_parallel

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -272,7 +272,7 @@ class TestDenseArch(nn.Module):
             in_features=num_float_features, out_features=8, device=device
         )
 
-        self.dummy_param = torch.nn.Parameter(torch.empty(2))
+        self.dummy_param = torch.nn.Parameter(torch.empty(2, device=device))
         self.register_buffer(
             "dummy_buffer",
             torch.nn.Parameter(torch.empty(1, device=device)),

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -27,6 +27,7 @@ from torchrec.distributed.types import (
     ShardingEnv,
     ShardingType,
 )
+from torchrec.inference.modules import copy_to_device
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.quant.embedding_modules import (
@@ -330,9 +331,8 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
 
         sharded_model = sharded_model.to(device)
 
-        # pyre-ignore
-        sharded_model_copy = sharded_model.copy(
-            current_device=device, to_device=device_1
+        sharded_model_copy = copy_to_device(
+            module=sharded_model, current_device=device, to_device=device_1
         )
 
         self._recursive_device_check(


### PR DESCRIPTION
Summary:
The diff provides fix for two tests, test_quant_pred_shard_embedding_modules and test_quant_pred, in `test_quant_model_parallel.py`.

-  test_quant_pred_shard_embedding_modules

In the past several weeks (not sure since when, but at least since Oct. 4th), test_quant_model_parallel keeps being skipped becuase it times out (see https://www.internalfb.com/intern/test/281475048734009?ref_report_id=0 ). After investigation, the test is skipped because of a "TypeError: copy() got an unexpected keyword argument 'current_device'" error:

```
Failures:

  1) torchrec.distributed.tests.test_quant_model_parallel.QuantModelParallelModelCopyTest: test_quant_pred_shard_embedding_modules
    1) TypeError: copy() got an unexpected keyword argument 'current_device'
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 291, in test_quant_pred_shard_embedding_modules
        torch.cuda.device_count() <= 1,
      File "hypothesis/core.py", line 1164, in wrapped_test
        raise the_error_hypothesis_found
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 334, in test_quant_pred_shard_embedding_modules
        sharded_model_copy = sharded_model.copy(
Imports took: 13.2s! Profile with --import-profiler.           --_ |""---__
Executed 1 example in 33.5s:                                |'.|  ||  .    """|
  Successful: 0                                             | ||  || /|\""-.  |
  Failed: 1                                                 | ||  ||  |    |  |
  Skipped: 0                                                | ||  ||  |   \|/ |
  Not executed: 3                                           |."|  ||  --"" '__|
https://testslide.readthedocs.io/                              --" |__---"""

```

The failed test can be fixed by changing `copy` to the correct version `copy_to_device`. (references: `copy_to_device` was firstly created in D38763039 (https://github.com/pytorch/torchrec/commit/a3a2fe0b604521f97a86c88f72cf9c21f2bdc389) then moved in D40204565 (https://github.com/pytorch/torchrec/commit/12c751f7763e918960041fa92dbcfe3fc406a16a))

- test_quant_pred
The test was also failing from at least two weeks ago (https://www.internalfb.com/intern/test/844425002162956?ref_report_id=0) but because of different reason. It fails when checking the device of params:

```
Failures:

  1) torchrec.distributed.tests.test_quant_model_parallel.QuantModelParallelModelCopyTest: test_quant_pred1
    1) AssertionError: device(type='cpu') != device(type='cuda', index=0)
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 178, in test_quant_pred1
        torch.cuda.device_count() <= 1,
      File "hypothesis/core.py", line 1164, in wrapped_test
        raise the_error_hypothesis_found
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 219, in test_quant_pred1
        self._recursive_device_check(dmp.module, dmp_1.module, device, device_1)
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 172, in _recursive_device_check
        self._buffer_param_check(child, child_copy, device, device_copy)
      File "torchrec/distributed/tests/test_quant_model_parallel.py", line 137, in _buffer_param_check
        self.assertEquals(buffer.detach().device, device)
      File "/usr/local/fbcode/platform010/lib/python3.8/unittest/case.py", line 1410, in deprecated_func
        return original_func(*args, **kwargs)
      File "/usr/local/fbcode/platform010/lib/python3.8/unittest/case.py", line 912, in assertEqual
        assertion_func(first, second, msg=msg)
      File "/usr/local/fbcode/platform010/lib/python3.8/unittest/case.py", line 905, in _baseAssertEqual
        raise self.failureException(msg)
```

The bug was introduced from D39518283 (https://github.com/pytorch/torchrec/commit/9abfc8d8c257afed53ed79861d4dbadd304055e7) where `buffer_param` is put on "cpu". By making `buffer_param` initiated with `device`, the bug is gone.

Reviewed By: xush6528

Differential Revision: D40501900

