### PR TITLE
No ddr reservation from percentage

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -87,7 +87,6 @@ def _reserve_kjt_storage(
 def _reserve_storage_percentage(topology: Topology, percent: float) -> None:
     for device in topology.devices:
         device.storage.hbm = int((1 - percent) * device.storage.hbm)
-        device.storage.ddr = int((1 - percent) * device.storage.ddr)
 
 
 def _get_input_lengths_and_shardable_parameters(


### PR DESCRIPTION
Summary:
The memory estimator in both O1 (i.e. sharder_options.reserved_hbm_size) and O3
(config.planner.percentage) are used to reserve HBM memory only. But in `_reserve_storage_percentage`, the DDR memory is reserved from the percentage too. This diff removes the DDR reservation in `_reserve_storage_percentage`.

Differential Revision: D40559083

