### PR TITLE
rename shard_embedding_modules to shard

### DIFF
--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -21,7 +21,7 @@ def _join_module_path(path: str, name: str) -> str:
     return (path + "." + name) if path else name
 
 
-def shard_embedding_modules(
+def shard(
     module: nn.Module,
     env: Optional[ShardingEnv] = None,
     device: Optional[torch.device] = None,
@@ -56,7 +56,7 @@ def shard_embedding_modules(
                     init.kaiming_normal_(param)
 
         m = MyModel(device='meta')
-        m = shard_embedding_modules(m)
+        m = shard(m)
         assert isinstance(m.embedding_bag_collection, ShardedEmbeddingBagCollection)
     """
 

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -21,7 +21,7 @@ from torchrec.distributed.planner.shard_estimators import (
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
-from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
+from torchrec.distributed.shard import shard
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     ModelInput,
@@ -310,7 +310,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
-    def test_quant_pred_shard_embedding_modules(self, output_type: torch.dtype) -> None:
+    def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")
         model = TestSparseNN(
@@ -322,7 +322,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
         quant_model = _quantize(model, inplace=True, output_type=output_type)
 
-        sharded_model, _sharded_params = shard_embedding_modules(
+        sharded_model, _sharded_params = shard(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -15,7 +15,7 @@ from hypothesis import given, settings, Verbosity
 from torch import nn, quantization as quant
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
-from torchrec.distributed.shard_embedding_modules import shard_embedding_modules
+from torchrec.distributed.shard import shard
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNNBase
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     InferenceModelParallelTestBase,
@@ -144,7 +144,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
         ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
-    def test_quant_pred_shard_embedding_modules(self, output_type: torch.dtype) -> None:
+    def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
         device = torch.device("cuda:0")
 
         # wrap in sequential because _quantize only applies to submodules...
@@ -152,7 +152,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
 
         quant_model = _quantize(model)
 
-        sharded_quant_model, _sharded_params = shard_embedding_modules(
+        sharded_quant_model, _sharded_params = shard(
             module=quant_model,
             sharders=[
                 cast(


### PR DESCRIPTION
Summary:
based on feedback from xing-liu https://docs.google.com/document/d/1TBJSd5zgEg6cRcXv3Okuj7bBkqQwGS2IPh4TLWNNzFI/edit?disco=AAAAgtOOIU8 and dstaay-fb, rename shard_embedding_modules to shard since TorchRec plans on sharding other components (like silvertorch) in the future

zhaojuanmao, wangkuiyi, we recognize the name is still being discussed in relation to the larger composability effort, but still think its worth updating for now even if it will change

Differential Revision: D40654843

