### PR TITLE
Revert D40662380: Multisect successfully blamed D40662380 for test or build failures

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -18,7 +18,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops import (
     PoolingMode,
 )
 from torch import Tensor
-from torchrec.distributed.types import ModuleCopyMixin
 from torchrec.modules.embedding_configs import (
     DATA_TYPE_NUM_BITS,
     data_type_to_sparse_type,
@@ -112,7 +111,7 @@ def quantize_state_dict(
     return device
 
 
-class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleCopyMixin):
+class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
     """
     EmbeddingBagCollection represents a collection of pooled embeddings (EmbeddingBags).
     This EmbeddingBagCollection is quantized for lower precision. It relies on fbgemm quantized ops and provides
@@ -358,13 +357,8 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleCopyMixin):
     def output_dtype(self) -> torch.dtype:
         return self._output_dtype
 
-    # quant unsharded can be used directly in inference now.
-    # so override its copy behavior
-    def copy(self, device: torch.device) -> nn.Module:
-        return self
 
-
-class EmbeddingCollection(EmbeddingCollectionInterface, ModuleCopyMixin):
+class EmbeddingCollection(EmbeddingCollectionInterface):
     """
     EmbeddingCollection represents a collection of non-pooled embeddings.
 
@@ -570,8 +564,3 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleCopyMixin):
 
     def output_dtype(self) -> torch.dtype:
         return self._output_dtype
-
-    # quant unsharded can be used directly in inference now.
-    # so override its copy behavior
-    def copy(self, device: torch.device) -> nn.Module:
-        return self


### PR DESCRIPTION
Summary:
This diff is reverting D40662380 (https://github.com/pytorch/torchrec/commit/11495ef3c7152db50bc102c08ab00ce0bb7cbe73)
D40662380 (https://github.com/pytorch/torchrec/commit/11495ef3c7152db50bc102c08ab00ce0bb7cbe73) has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/281475048734001/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1373153
Here are the tasks that are relevant to this breakage:
T131073406: 1 test started failing for oncall torchrec in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Reviewed By: YLGH

Differential Revision: D40710129

