### PR TITLE
refactor copyMixIn

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -36,6 +36,7 @@ from torchrec.modules.embedding_modules import (
     get_embedding_names_by_table,
 )
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
+from torchrec.types import ModuleNoCopyMixin
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
@@ -111,7 +112,7 @@ def quantize_state_dict(
     return device
 
 
-class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
+class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin):
     """
     EmbeddingBagCollection represents a collection of pooled embeddings (EmbeddingBags).
     This EmbeddingBagCollection is quantized for lower precision. It relies on fbgemm quantized ops and provides
@@ -358,7 +359,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
         return self._output_dtype
 
 
-class EmbeddingCollection(EmbeddingCollectionInterface):
+class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
     """
     EmbeddingCollection represents a collection of non-pooled embeddings.
 

--- a/torchrec/types.py
+++ b/torchrec/types.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod
+
+import torch
+from torch import nn
+
+
+class CopyMixIn:
+    @abstractmethod
+    def copy(self, device: torch.device) -> nn.Module:
+        ...
+
+
+class ModuleCopyMixin(CopyMixIn):
+    """
+    A mixin to allow modules to override copy behaviors in DMP.
+    """
+
+    def copy(self, device: torch.device) -> nn.Module:
+        # pyre-ignore [16]
+        return self.to(device)
+
+
+class ModuleNoCopyMixin(CopyMixIn):
+    """
+    A mixin to allow modules to override copy behaviors in DMP.
+    """
+
+    def copy(self, device: torch.device) -> nn.Module:
+        # pyre-ignore [7]
+        return self


### PR DESCRIPTION
Summary:
* implement a base trait CopyMixIn.
* move CopyMixIn to torchrec.types.
* reimplement D40662380 (https://github.com/pytorch/torchrec/commit/11495ef3c7152db50bc102c08ab00ce0bb7cbe73)

Reviewed By: YLGH

Differential Revision: D40726241

