### PR TITLE
Fixing conda deps to install pytorch with GPU in intro notebook

### DIFF
--- a/Torchrec_Introduction.ipynb
+++ b/Torchrec_Introduction.ipynb
@@ -48,7 +48,7 @@
       "outputs": [],
       "source": [
         "# install pytorch with cudatoolkit 11.6\n",
-        "!conda install pytorch pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"
+        "!conda install pytorch pytorch-cuda=11.6 -c pytorch-nightly -c nvidia -y"
       ]
     },
     {

--- a/Torchrec_Introduction.ipynb
+++ b/Torchrec_Introduction.ipynb
@@ -48,7 +48,7 @@
       "outputs": [],
       "source": [
         "# install pytorch with cudatoolkit 11.3\n",
-        "!conda install pytorch cudatoolkit=11.3 -c pytorch-nightly -y"
+        "!conda install pytorch pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"
       ]
     },
     {

--- a/Torchrec_Introduction.ipynb
+++ b/Torchrec_Introduction.ipynb
@@ -47,7 +47,7 @@
       },
       "outputs": [],
       "source": [
-        "# install pytorch with cudatoolkit 11.3\n",
+        "# install pytorch with cudatoolkit 11.6\n",
         "!conda install pytorch pytorch-cuda=11.6 -c pytorch-nightly -c nvidia"
       ]
     },


### PR DESCRIPTION
The current code (below) counter-intuitively installs CPU version of pytorch, This PR fixes it.
`!conda install pytorch cudatoolkit=11.3 -c pytorch-nightly -y`

<img width="689" alt="image" src="https://user-images.githubusercontent.com/12473724/199191480-48fc56b0-3c98-4c85-b1d6-ce2881034128.png">
