### PR TITLE
Add missing args to DDP constructor in distributed.pyi

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -170,9 +170,11 @@ class ShardedEmbeddingTower(
                 device,
             )
             # Hierarchical DDP
-            # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
             self.interaction = DistributedDataParallel(
                 module=module.interaction.to(self._device),
+                # pyre-fixme[6]: For 2nd param expected
+                #  `Optional[Sequence[Union[int, device]]]` but got
+                #  `List[Optional[device]]`.
                 device_ids=[self._device],
                 process_group=self._intra_pg,
                 gradient_as_bucket_view=True,
@@ -584,9 +586,11 @@ class ShardedEmbeddingTowerCollection(
                 )
                 self.input_dist_params.append(tower_input_params(tower.embedding))
                 # Hierarchical DDP
-                # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
                 self.interactions[i] = DistributedDataParallel(
                     module=tower.interaction.to(self._device),
+                    # pyre-fixme[6]: For 2nd param expected
+                    #  `Optional[Sequence[Union[int, device]]]` but got
+                    #  `List[Optional[device]]`.
                     device_ids=[self._device],
                     process_group=self._intra_pg,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/fused_embedding.py
+++ b/torchrec/distributed/fused_embedding.py
@@ -63,9 +63,11 @@ class ShardedFusedEmbeddingCollection(
             zip(self._sharding_type_to_sharding.values(), self._lookups)
         ):
             if isinstance(sharding, DpPooledEmbeddingSharding):
-                # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
+                    # pyre-fixme[6]: For 2nd param expected
+                    #  `Optional[Sequence[Union[int, device]]]` but got
+                    #  `List[Optional[device]]`.
                     device_ids=[device],
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -67,9 +67,11 @@ class ShardedFusedEmbeddingBagCollection(
             zip(self._sharding_type_to_sharding.values(), self._lookups)
         ):
             if isinstance(sharding, DpPooledEmbeddingSharding):
-                # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
+                    # pyre-fixme[6]: For 2nd param expected
+                    #  `Optional[Sequence[Union[int, device]]]` but got
+                    #  `List[Optional[device]]`.
                     device_ids=[device],
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -99,7 +99,6 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
         # initialize DDP
         dmp._dmp_wrapped_module = cast(
             nn.Module,
-            # pyre-fixme[28]: Unexpected keyword argument `gradient_as_bucket_view`.
             DistributedDataParallel(
                 module=dmp._dmp_wrapped_module.to(device),
                 device_ids=None if device.type == "cpu" else [device],


### PR DESCRIPTION
Summary: As title. And remove all unnecessary `pyre-fixme` for the unknown arg in call-site.

Differential Revision: D40874013

