### PR TITLE
Make DMP compatible with torchrec.distributed.shard(...)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -45,8 +45,8 @@ logger: logging.Logger = logging.getLogger()
 def _get_recat(
     local_split: int,
     num_splits: int,
-    stagger: int = 1,
     device: Optional[torch.device] = None,
+    stagger: int = 1,
     batch_size_per_rank: Optional[List[int]] = None,
 ) -> torch.Tensor:
     """
@@ -55,9 +55,9 @@ def _get_recat(
     Args:
         local_split (int): how many features in local split.
         num_splits (int): how many splits (typically WORLD_SIZE).
+        device (torch.device): device on which buffer will be allocated.
         stagger (int): secondary reordering, (typically 1, but
             `WORLD_SIZE/LOCAL_WORLD_SIZE` for TWRW).
-        device (Optional[torch.device]): device on which buffer will be allocated.
         batch_size_per_rank: batch size per rank, needed for variable batch size.
 
     Returns:
@@ -355,8 +355,8 @@ class KJTAllToAllLengthsAwaitable(Awaitable[KJTAllToAllIndicesAwaitable]):
             self._recat = _get_recat(
                 local_split=dim_0,
                 num_splits=len(splits),
-                stagger=stagger,
                 device=self._device,
+                stagger=stagger,
                 batch_size_per_rank=self._batch_size_per_rank,
             )
         else:
@@ -509,8 +509,8 @@ class KJTAllToAll(nn.Module):
                 # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
                 local_split=splits[pg.rank()],
                 num_splits=len(splits),
-                stagger=stagger,
                 device=device,
+                stagger=stagger,
             ),
         )
 
@@ -1007,21 +1007,23 @@ class SequenceEmbeddingsAllToAll(nn.Module):
     ) -> None:
         super().__init__()
         self._pg = pg
+        # pyre-fixme[16]
+        self._local_split: int = features_per_rank[self._pg.rank()]
+        # pyre-fixme[16]
+        self._num_splits: int = self._pg.size()
 
         forward_recat = []
-        # pyre-fixme[16]: `ProcessGroup` has no attribute `size`.
-        for j in range(self._pg.size()):
-            # pyre-fixme[16]: `ProcessGroup` has no attribute `rank`.
-            for i in range(features_per_rank[self._pg.rank()]):
-                forward_recat.append(j + i * self._pg.size())
+        for j in range(self._num_splits):
+            for i in range(self._local_split):
+                forward_recat.append(j + i * self._num_splits)
         self.register_buffer(
             "_forward_recat_tensor",
             torch.tensor(forward_recat, device=device, dtype=torch.int),
         )
         backward_recat = []
-        for i in range(features_per_rank[self._pg.rank()]):
-            for j in range(self._pg.size()):
-                backward_recat.append(i + j * features_per_rank[self._pg.rank()])
+        for i in range(self._local_split):
+            for j in range(self._num_splits):
+                backward_recat.append(i + j * self._local_split)
         self.register_buffer(
             "_backward_recat_tensor",
             torch.tensor(backward_recat, device=device, dtype=torch.int),
@@ -1034,6 +1036,8 @@ class SequenceEmbeddingsAllToAll(nn.Module):
         lengths: torch.Tensor,
         input_splits: List[int],
         output_splits: List[int],
+        batch_size_per_rank: Optional[List[int]] = None,
+        sparse_features_recat: Optional[torch.Tensor] = None,
         unbucketize_permute_tensor: Optional[torch.Tensor] = None,
     ) -> SequenceEmbeddingsAwaitable:
         """
@@ -1044,6 +1048,7 @@ class SequenceEmbeddingsAllToAll(nn.Module):
             lengths (torch.Tensor): lengths of sparse features after AlltoAll.
             input_splits (List[int]): input splits of AlltoAll.
             output_splits (List[int]): output splits of AlltoAll.
+            sparse_features_recat (Optional[torch.Tensor]): recat tensor used for sparse feature input dist
             unbucketize_permute_tensor (Optional[torch.Tensor]): stores the permute order
                 of the KJT bucketize (for row-wise sharding only).
 
@@ -1051,13 +1056,36 @@ class SequenceEmbeddingsAllToAll(nn.Module):
             SequenceEmbeddingsAwaitable: awaitable of sequence embeddings.
         """
 
+        variable_batch_size = (
+            batch_size_per_rank is not None and len(set(batch_size_per_rank)) > 1
+        )
+        if variable_batch_size:
+            if sparse_features_recat is None:
+                sparse_features_recat = _get_recat(
+                    local_split=self._local_split,
+                    num_splits=self._num_splits,
+                    device=local_embs.device,
+                    stagger=1,
+                    batch_size_per_rank=batch_size_per_rank,
+                )
+
+        if sparse_features_recat is not None:
+            forward_recat_tensor = torch.ops.fbgemm.invert_permute(
+                sparse_features_recat
+            )
+            backward_recat_tensor = sparse_features_recat
+        else:
+            forward_recat_tensor = self._forward_recat_tensor
+            backward_recat_tensor = self._backward_recat_tensor
+
         tensor_awaitable = alltoall_sequence(
             a2a_sequence_embs_tensor=local_embs,
-            forward_recat_tensor=self._forward_recat_tensor,
-            backward_recat_tensor=self._backward_recat_tensor,
+            forward_recat_tensor=forward_recat_tensor,
+            backward_recat_tensor=backward_recat_tensor,
             lengths_after_sparse_data_all2all=lengths,
             input_splits=input_splits,
             output_splits=output_splits,
+            variable_batch_size=variable_batch_size,
             group=self._pg,
             codecs=self._codecs,
         )

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -98,31 +98,39 @@ def create_embedding_sharding(
     env: ShardingEnv,
     device: Optional[torch.device] = None,
     qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    variable_batch_size: bool = False,
 ) -> EmbeddingSharding[
     SequenceShardingContext, SparseFeatures, torch.Tensor, torch.Tensor
 ]:
     if sharding_type == ShardingType.TABLE_WISE.value:
         return TwSequenceEmbeddingSharding(
-            sharding_infos,
-            env,
-            device,
+            sharding_infos=sharding_infos,
+            env=env,
+            device=device,
             qcomm_codecs_registry=qcomm_codecs_registry,
+            variable_batch_size=variable_batch_size,
         )
     elif sharding_type == ShardingType.ROW_WISE.value:
         return RwSequenceEmbeddingSharding(
-            sharding_infos,
-            env,
-            device,
+            sharding_infos=sharding_infos,
+            env=env,
+            device=device,
             qcomm_codecs_registry=qcomm_codecs_registry,
+            variable_batch_size=variable_batch_size,
         )
     elif sharding_type == ShardingType.DATA_PARALLEL.value:
-        return DpSequenceEmbeddingSharding(sharding_infos, env, device)
+        return DpSequenceEmbeddingSharding(
+            sharding_infos=sharding_infos,
+            env=env,
+            device=device,
+        )
     elif sharding_type == ShardingType.COLUMN_WISE.value:
         return CwSequenceEmbeddingSharding(
-            sharding_infos,
-            env,
-            device,
+            sharding_infos=sharding_infos,
+            env=env,
+            device=device,
             qcomm_codecs_registry=qcomm_codecs_registry,
+            variable_batch_size=variable_batch_size,
         )
     else:
         raise ValueError(f"Sharding not supported {sharding_type}")
@@ -309,6 +317,7 @@ class ShardedEmbeddingCollection(
         fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+        variable_batch_size: bool = False,
     ) -> None:
         super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
         sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
@@ -316,6 +325,7 @@ class ShardedEmbeddingCollection(
             table_name_to_parameter_sharding,
             fused_params,
         )
+        self._variable_batch_size = variable_batch_size
         self._sharding_type_to_sharding: Dict[
             str,
             EmbeddingSharding[
@@ -323,11 +333,12 @@ class ShardedEmbeddingCollection(
             ],
         ] = {
             sharding_type: create_embedding_sharding(
-                sharding_type,
-                embedding_confings,
-                env,
-                device,
+                sharding_type=sharding_type,
+                sharding_infos=embedding_confings,
+                env=env,
+                device=device,
                 qcomm_codecs_registry=self.qcomm_codecs_registry,
+                variable_batch_size=self._variable_batch_size,
             )
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
@@ -561,6 +572,8 @@ class ShardedEmbeddingCollection(
                 indices_awaitable = lengths_awaitable.wait()  # finish lengths all2all
                 input_splits = []
                 output_splits = []
+                batch_size_per_rank = []
+                sparse_features_recat = None
                 if isinstance(indices_awaitable, SparseFeaturesIndicesAwaitable):
                     assert indices_awaitable._id_list_features_awaitable is not None
                     input_splits = (
@@ -571,18 +584,30 @@ class ShardedEmbeddingCollection(
                         # pyre-fixme[16]
                         indices_awaitable._id_list_features_awaitable._out_lengths_per_worker
                     )
+                    batch_size_per_rank = (
+                        # pyre-fixme[16]
+                        indices_awaitable._id_list_features_awaitable._batch_size_per_rank
+                    )
+                    # Pass input_dist recat so that we do not need double calculate recat in Sequence embedding all2all to save H2D
+                    sparse_features_recat = (
+                        # pyre-fixme[16]
+                        indices_awaitable._id_list_features_awaitable._recat
+                    )
+
                 ctx.sharding_contexts.append(
                     SequenceShardingContext(
                         features_before_input_dist=features,
+                        sparse_features_recat=sparse_features_recat,
                         input_splits=input_splits,
                         output_splits=output_splits,
                         unbucketize_permute_tensor=module.unbucketize_permute_tensor
                         if isinstance(module, RwSparseFeaturesDist)
                         else None,
+                        batch_size_per_rank=batch_size_per_rank,
                     )
                 )
                 awaitables.append(indices_awaitable)
-            return SparseFeaturesListAwaitable(awaitables)
+        return SparseFeaturesListAwaitable(awaitables)
 
     def compute(
         self, ctx: EmbeddingCollectionContext, dist_input: SparseFeaturesList
@@ -771,6 +796,7 @@ class EmbeddingCollectionSharder(BaseEmbeddingSharder[EmbeddingCollection]):
             self.fused_params,
             device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
+            variable_batch_size=self._variable_batch_size,
         )
 
     def shardable_parameters(

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -44,6 +44,7 @@ class CwSequenceEmbeddingSharding(
             self.id_list_features_per_rank(),
             self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
+            variable_batch_size=self._variable_batch_size,
         )
 
     def create_lookup(

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -82,6 +82,8 @@ class RwSequenceEmbeddingDist(
             lengths=sharding_ctx.lengths_after_input_dist,
             input_splits=sharding_ctx.input_splits,
             output_splits=sharding_ctx.output_splits,
+            batch_size_per_rank=sharding_ctx.batch_size_per_rank,
+            sparse_features_recat=sharding_ctx.sparse_features_recat,
             unbucketize_permute_tensor=sharding_ctx.unbucketize_permute_tensor,
         )
 
@@ -116,6 +118,7 @@ class RwSequenceEmbeddingSharding(
             is_sequence=True,
             has_feature_processor=self._has_feature_processor,
             need_pos=False,
+            variable_batch_size=self._variable_batch_size,
         )
 
     def create_lookup(

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -94,6 +94,8 @@ class TwSequenceEmbeddingDist(
             lengths=sharding_ctx.lengths_after_input_dist,
             input_splits=sharding_ctx.input_splits,
             output_splits=sharding_ctx.output_splits,
+            batch_size_per_rank=sharding_ctx.batch_size_per_rank,
+            sparse_features_recat=sharding_ctx.sparse_features_recat,
             unbucketize_permute_tensor=None,
         )
 
@@ -119,6 +121,7 @@ class TwSequenceEmbeddingSharding(
             self.id_list_features_per_rank(),
             self.id_score_list_features_per_rank(),
             device if device is not None else self._device,
+            variable_batch_size=self._variable_batch_size,
         )
 
     def create_lookup(

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -23,7 +23,11 @@ from torchrec.distributed.fused_embedding import FusedEmbeddingCollectionSharder
 from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
 from torchrec.distributed.types import QuantizedCommCodecs
 from torchrec.inference.modules import CopyableMixin
-from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
+from torchrec.modules.embedding_configs import (
+    BaseEmbeddingConfig,
+    EmbeddingBagConfig,
+    EmbeddingConfig,
+)
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
 from torchrec.modules.feature_processor import PositionWeightedProcessor
@@ -43,11 +47,19 @@ class ModelInput(Pipelineable):
         batch_size: int,
         world_size: int,
         num_float_features: int,
-        tables: Union[List[EmbeddingTableConfig], List[EmbeddingBagConfig]],
-        weighted_tables: Union[List[EmbeddingTableConfig], List[EmbeddingBagConfig]],
+        tables: Union[
+            List[EmbeddingTableConfig], List[EmbeddingBagConfig], List[EmbeddingConfig]
+        ],
+        weighted_tables: Union[
+            List[EmbeddingTableConfig], List[EmbeddingBagConfig], List[EmbeddingConfig]
+        ],
         pooling_avg: int = 10,
         dedup_tables: Optional[
-            Union[List[EmbeddingTableConfig], List[EmbeddingBagConfig]]
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
         ] = None,
         variable_batch_size: bool = False,
     ) -> Tuple["ModelInput", List["ModelInput"]]:

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -64,6 +64,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
+        variable_batch_size=st.sampled_from([True, False]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_rw(
@@ -74,6 +75,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
+        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -85,11 +87,13 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                     sharding_type=sharding_type,
                     kernel_type=kernel_type,
                     qcomms_config=qcomms_config,
+                    variable_batch_size=variable_batch_size,
                 )
             ],
             backend="nccl",
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
         )
 
     @unittest.skipIf(
@@ -166,6 +170,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
+        variable_batch_size=st.sampled_from([True, False]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_tw(
@@ -176,6 +181,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
+        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -187,11 +193,13 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                     sharding_type=sharding_type,
                     kernel_type=kernel_type,
                     qcomms_config=qcomms_config,
+                    variable_batch_size=variable_batch_size,
                 )
             ],
             backend="nccl",
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
         )
 
     @unittest.skipIf(
@@ -220,6 +228,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
+        variable_batch_size=st.sampled_from([True, False]),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_cw(
@@ -229,6 +238,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
+        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -239,14 +249,16 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 TestEmbeddingCollectionSharder(
                     sharding_type=sharding_type,
                     kernel_type=kernel_type,
+                    variable_batch_size=variable_batch_size,
                 )
             ],
             backend="nccl",
             constraints={
-                table.name: ParameterConstraints(min_partition=4)
+                table.name: ParameterConstraints(min_partition=16)
                 for table in self.tables
             },
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
         )
 
     @seed_and_log
@@ -301,6 +313,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ] = None,
+        variable_batch_size: bool = False,
     ) -> None:
         self._run_multi_process_test(
             callable=sharding_single_rank_test,
@@ -315,4 +328,5 @@ class SequenceModelParallelTest(MultiProcessTestBase):
             constraints=constraints,
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
         )


### PR DESCRIPTION
Summary: When some modules are already sharded by torchrec.distributed.shard(...), DMP won't work. The diff fixes this problem.

Differential Revision: D40883918

