### PR TITLE
[Docs] Fix `ComputeKJTToJTDict` docstring render

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -576,21 +576,19 @@ def _jagged_tensor_string(
 class ComputeKJTToJTDict(torch.nn.Module):
     """Converts a KeyedJaggedTensor to a dict of JaggedTensors.
 
-    Args:
-
     Example::
-    #              0       1        2  <-- dim_1
-    # "Feature0"   [V0,V1] None    [V2]
-    # "Feature1"   [V3]    [V4]    [V5,V6,V7]
-    #   ^
-    #  dim_0
+        #              0       1        2  <-- dim_1
+        # "Feature0"   [V0,V1] None    [V2]
+        # "Feature1"   [V3]    [V4]    [V5,V6,V7]
+        #   ^
+        #  dim_0
 
-    would return
+        would return
 
-    {
-        "Feature0": JaggedTensor([[V0,V1],None,V2]),
-        "Feature1": JaggedTensor([V3,V4,[V5,V6,V7]]),
-    }
+        {
+            "Feature0": JaggedTensor([[V0,V1],None,V2]),
+            "Feature1": JaggedTensor([V3,V4,[V5,V6,V7]]),
+        }
     """
 
     def forward(


### PR DESCRIPTION
I am not sure if CI renders docs as a part of testing. This is not meant for landing until doc render has been verified.

Before change:
<img width="840" alt="Screen Shot 2022-11-02 at 1 41 13 PM" src="https://user-images.githubusercontent.com/31054793/199562455-dbe28c7a-906c-4423-97bb-5d814d5f0afc.png">
