### PR TITLE
Thread PG: add class _World to distributed_c10d.py (#86348)

### DIFF
--- a/examples/retrieval/two_tower_train.py
+++ b/examples/retrieval/two_tower_train.py
@@ -158,7 +158,11 @@ def train(
             compute_device=device.type,
         ),
     ).collective_plan(
-        module=two_tower_model, sharders=sharders, pg=dist.GroupMember.WORLD
+        module=two_tower_model,
+        sharders=sharders,
+        # pyre-fixme[6]: For 3rd param expected `ProcessGroup` but got
+        #  `Optional[ProcessGroup]`.
+        pg=dist.GroupMember.WORLD,
     )
     model = DistributedModelParallel(
         module=two_tower_train_task,

--- a/torchrec/distributed/tests/test_model_parallel.py
+++ b/torchrec/distributed/tests/test_model_parallel.py
@@ -732,6 +732,8 @@ class ModelParallelStateDictTest(unittest.TestCase):
         )
 
     def test_meta_device_dmp_state_dict(self) -> None:
+        # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
+        #  `Optional[ProcessGroup]`.
         env = ShardingEnv.from_process_group(dist.GroupMember.WORLD)
 
         m1 = TestSparseNN(


### PR DESCRIPTION
Summary:
Move a bunch of globals to instance methods and replace all use to them.

We move all PG related globals under World and use a singleton instance under _world.

This creates an undocumented extension point to inject full control of how how c10d
state behaves.

One simple hack is to change _world to an implementation that uses a threadlocal
and enable per-thread PGs.

It almost get DDP working and the PG is missing an implementation of all_reduce.

This enables notebook usage of PTD, which is a big deal for learning it:
https://gist.github.com/kumpera/32cb051fa26b8cad8bdf671f968dcd68

This change ensures BC by keeping the global variables around and have the default _World wrap it.

X-link: https://github.com/pytorch/pytorch/pull/86348

Differential Revision: D40236769

Pulled By: yhcharles

