### PR TITLE
[Docs] Actually fix `ComputeKJTToJTDict` docstring

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -577,6 +577,7 @@ class ComputeKJTToJTDict(torch.nn.Module):
     """Converts a KeyedJaggedTensor to a dict of JaggedTensors.
 
     Example::
+
         #              0       1        2  <-- dim_1
         # "Feature0"   [V0,V1] None    [V2]
         # "Feature1"   [V3]    [V4]    [V5,V6,V7]


### PR DESCRIPTION
This is low priority and just following up on the last PR for completeness. I do not know how to manually render the docs locally, but by pattern matching against properly-rendered examples, I think we need a newline between `Example::` and the actual example contents.