### PR TITLE
disable workflow runs on PR/commit until GPU unit tests work

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -4,18 +4,19 @@
 name: Unit Test CI
 
 on:
-  push:
-    paths-ignore:
-      - "docs/*"
-      - "third_party/*"
-      - .gitignore
-      - "*.md"
-  pull_request:
-    paths-ignore:
-      - "docs/*"
-      - "third_party/*"
-      - .gitignore
-      - "*.md"
+  # TODO: re-enable when GPU unit tests are working
+  # push:
+  #   paths-ignore:
+  #     - "docs/*"
+  #     - "third_party/*"
+  #     - .gitignore
+  #     - "*.md"
+  # pull_request:
+  #   paths-ignore:
+  #     - "docs/*"
+  #     - "third_party/*"
+  #     - .gitignore
+  #     - "*.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Summary: as title- dont give bad signal to other devs while GPU unit test is still in development

Reviewed By: joshuadeng, lequytra

Differential Revision: D41094164

