### PR TITLE
Delete stub file to enable mypy check

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -172,9 +172,6 @@ class ShardedEmbeddingTower(
             # Hierarchical DDP
             self.interaction = DistributedDataParallel(
                 module=module.interaction.to(self._device),
-                # pyre-fixme[6]: For 2nd param expected
-                #  `Optional[Sequence[Union[int, device]]]` but got
-                #  `List[Optional[device]]`.
                 device_ids=[self._device],
                 process_group=self._intra_pg,
                 gradient_as_bucket_view=True,
@@ -588,9 +585,6 @@ class ShardedEmbeddingTowerCollection(
                 # Hierarchical DDP
                 self.interactions[i] = DistributedDataParallel(
                     module=tower.interaction.to(self._device),
-                    # pyre-fixme[6]: For 2nd param expected
-                    #  `Optional[Sequence[Union[int, device]]]` but got
-                    #  `List[Optional[device]]`.
                     device_ids=[self._device],
                     process_group=self._intra_pg,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/fused_embedding.py
+++ b/torchrec/distributed/fused_embedding.py
@@ -65,9 +65,6 @@ class ShardedFusedEmbeddingCollection(
             if isinstance(sharding, DpPooledEmbeddingSharding):
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
-                    # pyre-fixme[6]: For 2nd param expected
-                    #  `Optional[Sequence[Union[int, device]]]` but got
-                    #  `List[Optional[device]]`.
                     device_ids=[device],
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -69,9 +69,6 @@ class ShardedFusedEmbeddingBagCollection(
             if isinstance(sharding, DpPooledEmbeddingSharding):
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
-                    # pyre-fixme[6]: For 2nd param expected
-                    #  `Optional[Sequence[Union[int, device]]]` but got
-                    #  `List[Optional[device]]`.
                     device_ids=[device],
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -85,8 +85,6 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
         if sharded_parameter_names == all_paramemeter_names:
             return
 
-        # pyre-fixme[16]: `DistributedDataParallel` has no attribute
-        #  `_set_params_and_buffers_to_ignore_for_model`.
         DistributedDataParallel._set_params_and_buffers_to_ignore_for_model(
             module=dmp._dmp_wrapped_module,
             params_and_buffers_to_ignore=[


### PR DESCRIPTION
Summary:
Context in https://fburl.com/4irjskbe

This change deletes distributed.pyi, so that lintrunner will run mypy on distributed.py for typing check.

Differential Revision: D41028360

