### PR TITLE
[tde] Migrate redis IO

### DIFF
--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -80,10 +80,13 @@ jobs:
         conda install -n build_binary -y gxx_linux-64
         conda run -n build_binary \
           x86_64-conda-linux-gnu-g++ --version
+        conda install -n build_binary -c anaconda redis -y
+        conda run -n build_binary redis-server --daemonize yes
         mkdir cpp-build
         cd cpp-build
         conda run -n build_binary cmake \
             -DBUILD_TEST=ON \
+            -DBUILD_REDIS_IO=ON \
             -DCMAKE_PREFIX_PATH=/opt/conda/envs/build_binary/lib/python${{ matrix.python-version }}/site-packages/torch/share/cmake ..
         conda run -n build_binary make -j
         conda run -n build_binary ctest -v .

--- a/test/cpp/dynamic_embedding/CMakeLists.txt
+++ b/test/cpp/dynamic_embedding/CMakeLists.txt
@@ -14,3 +14,8 @@ add_tde_test(bits_op_test bits_op_test.cpp)
 add_tde_test(naive_id_transformer_test naive_id_transformer_test.cpp)
 add_tde_test(random_bits_generator_test random_bits_generator_test.cpp)
 add_tde_test(mixed_lfu_lru_strategy_test mixed_lfu_lru_strategy_test.cpp)
+add_tde_test(notification_test notification_test.cpp)
+
+if (BUILD_REDIS_IO)
+    add_subdirectory(redis)
+endif()

--- a/test/cpp/dynamic_embedding/notification_test.cpp
+++ b/test/cpp/dynamic_embedding/notification_test.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <torchrec/csrc/dynamic_embedding/details/notification.h>
+#include <thread>
+
+namespace torchrec {
+TEST(TDE, notification) {
+  Notification notification;
+  std::thread th([&] { notification.done(); });
+  notification.wait();
+  th.join();
+}
+} // namespace torchrec

--- a/test/cpp/dynamic_embedding/redis/CMakeLists.txt
+++ b/test/cpp/dynamic_embedding/redis/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+function(add_redis_test NAME)
+    add_executable(${NAME} ${ARGN})
+    target_link_libraries(${NAME} redis_io tde_cpp_objs gtest gtest_main)
+    add_test(NAME ${NAME} COMMAND ${NAME})
+endfunction()
+
+# TODO: Need start a empty redis-server on 127.0.0.1:6379 before run *redis*_test.
+add_redis_test(redis_io_test redis_io_test.cpp)
+add_redis_test(url_test url_test.cpp)

--- a/test/cpp/dynamic_embedding/redis/redis_io_test.cpp
+++ b/test/cpp/dynamic_embedding/redis/redis_io_test.cpp
@@ -13,21 +13,21 @@
 namespace torchrec::redis {
 
 TEST(TDE, redis_Option) {
-  auto opt = Option::parse(
+  auto opt = parse_option(
       "192.168.3.1:3948/?db=3&&num_threads=2&&timeout=3s&&chunk_size=3000");
-  ASSERT_EQ(opt.host_, "192.168.3.1");
-  ASSERT_EQ(opt.port_, 3948);
-  ASSERT_EQ(opt.db_, 3);
-  ASSERT_EQ(opt.num_io_threads_, 2);
-  ASSERT_EQ(opt.chunk_size_, 3000);
-  ASSERT_EQ(opt.timeout_ms_, 3000);
-  ASSERT_TRUE(opt.prefix_.empty());
+  ASSERT_EQ(opt.host, "192.168.3.1");
+  ASSERT_EQ(opt.port, 3948);
+  ASSERT_EQ(opt.db, 3);
+  ASSERT_EQ(opt.num_io_threads, 2);
+  ASSERT_EQ(opt.chunk_size, 3000);
+  ASSERT_EQ(opt.timeout_ms, 3000);
+  ASSERT_TRUE(opt.prefix.empty());
 }
 
 TEST(TDE, redis_Option_ParseError) {
   ASSERT_ANY_THROW(
-      Option::parse("192.168.3.1:3948/?db=3&&no_opt=3000&&num_threads=2"));
-  ASSERT_ANY_THROW(Option::parse("192.168.3.1:3948/?timeout=3d"));
+      parse_option("192.168.3.1:3948/?db=3&&no_opt=3000&&num_threads=2"));
+  ASSERT_ANY_THROW(parse_option("192.168.3.1:3948/?timeout=3d"));
 }
 
 struct PullContext {
@@ -36,7 +36,7 @@ struct PullContext {
 };
 
 TEST(TDE, redis_push_pull) {
-  auto opt = Option::parse("127.0.0.1:6379");
+  auto opt = parse_option("127.0.0.1:6379");
   Redis redis(opt);
 
   constexpr static int64_t global_ids[] = {1, 3, 4};

--- a/test/cpp/dynamic_embedding/redis/redis_io_test.cpp
+++ b/test/cpp/dynamic_embedding/redis/redis_io_test.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <torchrec/csrc/dynamic_embedding/details/notification.h>
+#include <torchrec/csrc/dynamic_embedding/details/redis/redis_io.h>
+
+namespace torchrec::redis {
+
+TEST(TDE, redis_Option) {
+  auto opt = Option::parse(
+      "192.168.3.1:3948/?db=3&&num_threads=2&&timeout=3s&&chunk_size=3000");
+  ASSERT_EQ(opt.host_, "192.168.3.1");
+  ASSERT_EQ(opt.port_, 3948);
+  ASSERT_EQ(opt.db_, 3);
+  ASSERT_EQ(opt.num_io_threads_, 2);
+  ASSERT_EQ(opt.chunk_size_, 3000);
+  ASSERT_EQ(opt.timeout_ms_, 3000);
+  ASSERT_TRUE(opt.prefix_.empty());
+}
+
+TEST(TDE, redis_Option_ParseError) {
+  ASSERT_ANY_THROW(
+      Option::parse("192.168.3.1:3948/?db=3&&no_opt=3000&&num_threads=2"));
+  ASSERT_ANY_THROW(Option::parse("192.168.3.1:3948/?timeout=3d"));
+}
+
+struct PullContext {
+  Notification* notification_;
+  std::function<void(uint32_t, uint32_t, void*, uint32_t)> on_data_;
+};
+
+TEST(TDE, redis_push_pull) {
+  auto opt = Option::parse("127.0.0.1:6379");
+  Redis redis(opt);
+
+  constexpr static int64_t global_ids[] = {1, 3, 4};
+  constexpr static uint32_t os_ids[] = {0};
+  constexpr static float params[] = {1, 2, 3, 4, 5, 9, 8, 1};
+  constexpr static uint64_t offsets[] = {
+      0 * sizeof(float),
+      2 * sizeof(float),
+      4 * sizeof(float),
+      6 * sizeof(float),
+      8 * sizeof(float)};
+
+  Notification notification;
+
+  IOPushParameter push{
+      .table_name = "table",
+      .num_global_ids = sizeof(global_ids) / sizeof(global_ids[0]),
+      .global_ids = global_ids,
+      .num_optimizer_states = sizeof(os_ids) / sizeof(os_ids[0]),
+      .optimizer_state_ids = os_ids,
+      .num_offsets = sizeof(offsets) / sizeof(offsets[0]),
+      .offsets = offsets,
+      .data = params,
+      .on_complete_context = &notification,
+      .on_push_complete =
+          +[](void* ctx) {
+            auto* notification = reinterpret_cast<Notification*>(ctx);
+            notification->done();
+          },
+  };
+  redis.push(push);
+
+  notification.wait();
+
+  notification.clear();
+
+  PullContext ctx{
+      .notification_ = &notification,
+      .on_data_ =
+          [&](uint32_t offset, uint32_t os_id, void* data, uint32_t len) {
+            ASSERT_EQ(os_id, 0);
+            uint32_t param_len = 2;
+            ASSERT_EQ(len, sizeof(float) * param_len);
+            auto actual =
+                std::span<const float>(reinterpret_cast<const float*>(data), 2);
+
+            auto expect = std::span<const float>(
+                reinterpret_cast<const float*>(&params[offset * param_len]), 2);
+
+            ASSERT_EQ(expect[0], actual[0]);
+            ASSERT_EQ(expect[1], actual[1]);
+          }};
+
+  IOPullParameter pull{
+      .table_name = "table",
+      .num_global_ids = sizeof(global_ids) / sizeof(global_ids[0]),
+      .global_ids = global_ids,
+      .num_optimizer_states = sizeof(os_ids) / sizeof(os_ids[0]),
+      .on_complete_context = &ctx,
+      .on_global_id_fetched =
+          +[](void* ctx,
+              uint32_t offset,
+              uint32_t os_id,
+              void* data,
+              uint32_t len) {
+            auto c = reinterpret_cast<PullContext*>(ctx);
+            c->on_data_(offset, os_id, data, len);
+          },
+      .on_all_fetched =
+          +[](void* ctx) {
+            auto c = reinterpret_cast<PullContext*>(ctx);
+            c->notification_->done();
+          }};
+  redis.pull(pull);
+  notification.wait();
+}
+} // namespace torchrec::redis

--- a/test/cpp/dynamic_embedding/redis/url_test.cpp
+++ b/test/cpp/dynamic_embedding/redis/url_test.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <torchrec/csrc/dynamic_embedding/details/redis/url.h>
+
+namespace torchrec::url_parser::rules {
+
+TEST(TDE, url_token) {
+  auto ipt = lexy::string_input(std::string_view("%61"));
+  auto parse = lexy::parse<UrlToken>(ipt, lexy_ext::report_error);
+  ASSERT_TRUE(parse.has_value());
+  ASSERT_EQ('a', parse.value());
+}
+
+TEST(TDE, url_string) {
+  auto ipt = lexy::string_input(std::string_view("%61bc"));
+  auto parse = lexy::parse<UrlString>(ipt, lexy_ext::report_error);
+  ASSERT_TRUE(parse.has_value());
+  ASSERT_EQ("abc", parse.value());
+}
+
+TEST(TDE, url_normal) {
+  auto ipt = lexy::string_input(std::string_view("a@"));
+  auto parse = lexy::parse<rules::Auth>(ipt, lexy_ext::report_error);
+  ASSERT_TRUE(parse.has_value());
+  ASSERT_EQ("a", parse.value().username_);
+  ASSERT_FALSE(parse.value().password_.has_value());
+  //  ASSERT_EQ("abc", parse.value());
+}
+
+TEST(TDE, url_host) {
+  auto ipt = lexy::string_input(std::string_view("www.qq.com"));
+  auto parse = lexy::parse<rules::Host>(ipt, lexy_ext::report_error);
+  ASSERT_TRUE(parse.has_value());
+  ASSERT_EQ("www.qq.com", parse.value());
+}
+
+TEST(TDE, url) {
+  auto url = parse_url("www.qq.com/?a=b&&c=d");
+  ASSERT_EQ(url.host_, "www.qq.com");
+  ASSERT_TRUE(url.param_.has_value());
+  ASSERT_EQ("a=b&&c=d", url.param_.value());
+}
+
+TEST(TDE, bad_url) {
+  ASSERT_ANY_THROW([] { parse_url("blablah!@@"); }());
+}
+
+} // namespace torchrec::url_parser::rules

--- a/test/cpp/dynamic_embedding/redis/url_test.cpp
+++ b/test/cpp/dynamic_embedding/redis/url_test.cpp
@@ -11,45 +11,11 @@
 
 namespace torchrec::url_parser::rules {
 
-TEST(TDE, url_token) {
-  auto ipt = lexy::string_input(std::string_view("%61"));
-  auto parse = lexy::parse<UrlToken>(ipt, lexy_ext::report_error);
-  ASSERT_TRUE(parse.has_value());
-  ASSERT_EQ('a', parse.value());
-}
-
-TEST(TDE, url_string) {
-  auto ipt = lexy::string_input(std::string_view("%61bc"));
-  auto parse = lexy::parse<UrlString>(ipt, lexy_ext::report_error);
-  ASSERT_TRUE(parse.has_value());
-  ASSERT_EQ("abc", parse.value());
-}
-
-TEST(TDE, url_normal) {
-  auto ipt = lexy::string_input(std::string_view("a@"));
-  auto parse = lexy::parse<rules::Auth>(ipt, lexy_ext::report_error);
-  ASSERT_TRUE(parse.has_value());
-  ASSERT_EQ("a", parse.value().username_);
-  ASSERT_FALSE(parse.value().password_.has_value());
-  //  ASSERT_EQ("abc", parse.value());
-}
-
-TEST(TDE, url_host) {
-  auto ipt = lexy::string_input(std::string_view("www.qq.com"));
-  auto parse = lexy::parse<rules::Host>(ipt, lexy_ext::report_error);
-  ASSERT_TRUE(parse.has_value());
-  ASSERT_EQ("www.qq.com", parse.value());
-}
-
 TEST(TDE, url) {
   auto url = parse_url("www.qq.com/?a=b&&c=d");
-  ASSERT_EQ(url.host_, "www.qq.com");
-  ASSERT_TRUE(url.param_.has_value());
-  ASSERT_EQ("a=b&&c=d", url.param_.value());
-}
-
-TEST(TDE, bad_url) {
-  ASSERT_ANY_THROW([] { parse_url("blablah!@@"); }());
+  ASSERT_EQ(url.host, "www.qq.com");
+  ASSERT_TRUE(url.param.has_value());
+  ASSERT_EQ("a=b&&c=d", url.param.value());
 }
 
 } // namespace torchrec::url_parser::rules

--- a/torchrec/csrc/dynamic_embedding/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/CMakeLists.txt
@@ -11,8 +11,13 @@ add_library(tde_cpp_objs
             details/random_bits_generator.cpp
             details/mixed_lfu_lru_strategy.cpp
             details/io_registry.cpp
-            details/io.cpp)
+            details/io.cpp
+            details/notification.cpp)
 
+if (BUILD_REDIS_IO)
+    add_subdirectory(details/redis)
+endif()
+            
 target_include_directories(tde_cpp_objs PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 target_include_directories(tde_cpp_objs PUBLIC ${TORCH_INCLUDE_DIRS})
 target_link_libraries(tde_cpp_objs PUBLIC ${TORCH_LIBRARIES})

--- a/torchrec/csrc/dynamic_embedding/details/io.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io.cpp
@@ -77,7 +77,7 @@ static void on_all_fetched(void* ctx) {
   delete c;
 }
 
-void IO::pull(
+void IO::fetch(
     const std::string& table_name,
     std::span<const int64_t> global_ids,
     std::span<const int64_t> col_ids,
@@ -93,7 +93,7 @@ void IO::pull(
   ctx->tensors.resize(
       global_ids.size() * std::max(col_ids.size(), static_cast<size_t>(1)));
 
-  IOPullParameter param{
+  IOFetchParameter param{
       .table_name = table_name.c_str(),
       .num_cols = static_cast<uint32_t>(col_ids.size()),
       .num_global_ids = static_cast<uint32_t>(global_ids.size()),
@@ -104,7 +104,7 @@ void IO::pull(
       .on_all_fetched = on_all_fetched,
   };
   param.on_complete_context = ctx.release();
-  provider_.pull(instance_, param);
+  provider_.fetch(instance_, param);
 }
 
 struct PushContext {

--- a/torchrec/csrc/dynamic_embedding/details/io.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io.cpp
@@ -8,7 +8,7 @@
 
 #include <torchrec/csrc/dynamic_embedding/details/io.h>
 
-namespace tde::details {
+namespace torchrec {
 
 static constexpr std::string_view k_schema_separator = "://";
 
@@ -135,7 +135,7 @@ void IO::push(
       .col_ids = col_ids.data(),
       .global_ids = global_ids.data(),
       .num_optimizer_states = static_cast<uint32_t>(os_ids.size()),
-      .optimizer_stats_ids = os_ids.data(),
+      .optimizer_state_ids = os_ids.data(),
       .num_offsets = static_cast<uint32_t>(offsets.size()),
       .offsets = offsets.data(),
       .data = data.data(),
@@ -145,4 +145,4 @@ void IO::push(
   provider_.push(instance_, param);
 }
 
-} // namespace tde::details
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/io.h
+++ b/torchrec/csrc/dynamic_embedding/details/io.h
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <span>
 
-namespace tde::details {
+namespace torchrec {
 
 class IO {
  public:
@@ -89,4 +89,4 @@ class IO {
   void* instance_{};
 };
 
-} // namespace tde::details
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/io.h
+++ b/torchrec/csrc/dynamic_embedding/details/io.h
@@ -44,7 +44,7 @@ class IO {
    * copied inside, so it is safe to free `col_ids`/`global_ids` before
    * `on_fetch_complete`.
    */
-  void pull(
+  void fetch(
       const std::string& table_name,
       std::span<const int64_t> global_ids,
       std::span<const int64_t> col_ids,

--- a/torchrec/csrc/dynamic_embedding/details/io_parameter.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_parameter.h
@@ -2,6 +2,13 @@
 
 namespace torchrec {
 
+using GlobalIDFetchCallback = void (*)(
+    void* ctx,
+    uint32_t offset,
+    uint32_t optimizer_state,
+    void* data,
+    uint32_t data_len);
+
 struct IOPullParameter {
   const char* table_name;
   uint32_t num_cols;
@@ -10,12 +17,7 @@ struct IOPullParameter {
   const int64_t* global_ids;
   uint32_t num_optimizer_states;
   void* on_complete_context;
-  void (*on_global_id_fetched)(
-      void* ctx,
-      uint32_t offset,
-      uint32_t optimizer_state,
-      void* data,
-      uint32_t data_len);
+  GlobalIDFetchCallback on_global_id_fetched;
   void (*on_all_fetched)(void* ctx);
 };
 

--- a/torchrec/csrc/dynamic_embedding/details/io_parameter.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_parameter.h
@@ -1,0 +1,37 @@
+#include <stdint.h>
+
+namespace torchrec {
+
+struct IOPullParameter {
+  const char* table_name;
+  uint32_t num_cols;
+  uint32_t num_global_ids;
+  const int64_t* col_ids;
+  const int64_t* global_ids;
+  uint32_t num_optimizer_states;
+  void* on_complete_context;
+  void (*on_global_id_fetched)(
+      void* ctx,
+      uint32_t offset,
+      uint32_t optimizer_state,
+      void* data,
+      uint32_t data_len);
+  void (*on_all_fetched)(void* ctx);
+};
+
+struct IOPushParameter {
+  const char* table_name;
+  uint32_t num_cols;
+  uint32_t num_global_ids;
+  const int64_t* col_ids;
+  const int64_t* global_ids;
+  uint32_t num_optimizer_states;
+  const uint32_t* optimizer_state_ids;
+  uint32_t num_offsets;
+  const uint64_t* offsets;
+  const void* data;
+  void* on_complete_context;
+  void (*on_push_complete)(void* ctx);
+};
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/io_parameter.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_parameter.h
@@ -9,7 +9,7 @@ using GlobalIDFetchCallback = void (*)(
     void* data,
     uint32_t data_len);
 
-struct IOPullParameter {
+struct IOFetchParameter {
   const char* table_name;
   uint32_t num_cols;
   uint32_t num_global_ids;

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
@@ -10,7 +10,7 @@
 #include <torch/torch.h>
 #include <torchrec/csrc/dynamic_embedding/details/io_registry.h>
 
-namespace tde::details {
+namespace torchrec {
 
 void IORegistry::register_provider(IOProvider provider) {
   std::string type = provider.type;
@@ -72,4 +72,4 @@ IORegistry& IORegistry::Instance() {
   return instance;
 }
 
-} // namespace tde::details
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.cpp
@@ -41,9 +41,9 @@ void IORegistry::register_plugin(const char* filename) {
   provider.finalize =
       reinterpret_cast<decltype(provider.finalize)>(finalize_ptr);
 
-  auto pull_ptr = dlsym(ptr.get(), "IO_Pull");
-  TORCH_CHECK(pull_ptr != nullptr, "cannot find IO_Pull symbol");
-  provider.pull = reinterpret_cast<decltype(provider.pull)>(pull_ptr);
+  auto fetch_ptr = dlsym(ptr.get(), "IO_Fetch");
+  TORCH_CHECK(fetch_ptr != nullptr, "cannot find IO_Fetch symbol");
+  provider.fetch = reinterpret_cast<decltype(provider.fetch)>(fetch_ptr);
 
   auto push_ptr = dlsym(ptr.get(), "IO_Push");
   TORCH_CHECK(push_ptr != nullptr, "cannot find IO_Push symbol");

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.h
@@ -10,43 +10,12 @@
 #include <c10/util/flat_hash_map.h>
 #include <dlfcn.h>
 #include <stdint.h>
+#include <torchrec/csrc/dynamic_embedding/details/io_parameter.h>
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace tde::details {
-
-struct IOPullParameter {
-  const char* table_name;
-  uint32_t num_cols;
-  uint32_t num_global_ids;
-  const int64_t* col_ids;
-  const int64_t* global_ids;
-  uint32_t num_optimizer_states;
-  void* on_complete_context;
-  void (*on_global_id_fetched)(
-      void* ctx,
-      uint32_t offset,
-      uint32_t optimizer_state,
-      void* data,
-      uint32_t data_len);
-  void (*on_all_fetched)(void* ctx);
-};
-
-struct IOPushParameter {
-  const char* table_name;
-  uint32_t num_cols;
-  uint32_t num_global_ids;
-  const int64_t* col_ids;
-  const int64_t* global_ids;
-  uint32_t num_optimizer_states;
-  const uint32_t* optimizer_stats_ids;
-  uint32_t num_offsets;
-  const uint64_t* offsets;
-  const void* data;
-  void* on_complete_context;
-  void (*on_push_complete)(void* ctx);
-};
+namespace torchrec {
 
 struct IOProvider {
   const char* type;
@@ -75,4 +44,4 @@ class IORegistry {
   std::vector<DLPtr> dls_;
 };
 
-} // namespace tde::details
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/io_registry.h
+++ b/torchrec/csrc/dynamic_embedding/details/io_registry.h
@@ -20,7 +20,7 @@ namespace torchrec {
 struct IOProvider {
   const char* type;
   void* (*initialize)(const char* cfg);
-  void (*pull)(void* instance, IOPullParameter cfg);
+  void (*fetch)(void* instance, IOFetchParameter cfg);
   void (*push)(void* instance, IOPushParameter cfg);
   void (*finalize)(void*);
 };

--- a/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
+++ b/torchrec/csrc/dynamic_embedding/details/mixed_lfu_lru_strategy.h
@@ -60,8 +60,10 @@ class MixedLFULRUStrategy {
     return static_cast<int64_t>(reinterpret_cast<Record*>(&record)->time_);
   }
 
-  lxu_record_t
-  update(int64_t global_id, int64_t cache_id, std::optional<lxu_record_t> val);
+  lxu_record_t update(
+      int64_t global_id,
+      int64_t cache_id,
+      std::optional<lxu_record_t> val);
 
   struct EvictItem {
     int64_t global_id_;

--- a/torchrec/csrc/dynamic_embedding/details/notification.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/notification.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "notification.h"
+
+namespace torchrec {
+void Notification::done() {
+  {
+    std::lock_guard<std::mutex> guard(mu_);
+    set_ = true;
+  }
+  cv_.notify_all();
+}
+void Notification::wait() {
+  std::unique_lock<std::mutex> lock(mu_);
+  cv_.wait(lock, [this] { return set_; });
+}
+
+void Notification::clear() {
+  set_ = false;
+}
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/notification.h
+++ b/torchrec/csrc/dynamic_embedding/details/notification.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <condition_variable>
+#include <mutex>
+
+namespace torchrec {
+
+/**
+ * Multi-thread notification
+ */
+class Notification {
+ public:
+  void done();
+  void wait();
+
+  /**
+   * Clear the set status.
+   *
+   * NOTE: Clear is not thread-safe.
+   */
+  void clear();
+
+ private:
+  bool set_{false};
+  std::mutex mu_;
+  std::condition_variable cv_;
+};
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/redis/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/details/redis/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+FetchContent_Declare(
+        hiredis
+        GIT_REPOSITORY https://github.com/redis/hiredis.git
+        GIT_TAG 06be7ff312a78f69237e5963cc7d24bc84104d3b
+)
+
+FetchContent_GetProperties(hiredis)
+if(NOT hiredis_POPULATED)
+    # Do not include hiredis in install targets
+    FetchContent_Populate(hiredis)
+    set(DISABLE_TESTS ON CACHE BOOL "Disable tests for hiredis")
+    add_subdirectory(${hiredis_SOURCE_DIR} ${hiredis_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+FetchContent_Declare(
+        foonathan_lexy  # used for parsing redis config string
+        GIT_REPOSITORY https://github.com/foonathan/lexy.git
+        GIT_TAG v2022.05.1
+)
+
+FetchContent_MakeAvailable(foonathan_lexy)
+
+add_library(redis_io SHARED redis_io.cpp)
+target_include_directories(redis_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../)
+target_include_directories(redis_io PUBLIC ${TORCH_INCLUDE_DIRS})
+target_compile_options(redis_io PUBLIC -fPIC)
+target_link_libraries(redis_io PUBLIC hiredis::hiredis_static foonathan::lexy::core)

--- a/torchrec/csrc/dynamic_embedding/details/redis/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/details/redis/CMakeLists.txt
@@ -18,16 +18,8 @@ if(NOT hiredis_POPULATED)
     add_subdirectory(${hiredis_SOURCE_DIR} ${hiredis_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-FetchContent_Declare(
-        foonathan_lexy  # used for parsing redis config string
-        GIT_REPOSITORY https://github.com/foonathan/lexy.git
-        GIT_TAG v2022.05.1
-)
-
-FetchContent_MakeAvailable(foonathan_lexy)
-
 add_library(redis_io SHARED redis_io.cpp)
 target_include_directories(redis_io PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../)
 target_include_directories(redis_io PUBLIC ${TORCH_INCLUDE_DIRS})
 target_compile_options(redis_io PUBLIC -fPIC)
-target_link_libraries(redis_io PUBLIC hiredis::hiredis_static foonathan::lexy::core)
+target_link_libraries(redis_io PUBLIC hiredis::hiredis_static)

--- a/torchrec/csrc/dynamic_embedding/details/redis/redis_io.cpp
+++ b/torchrec/csrc/dynamic_embedding/details/redis/redis_io.cpp
@@ -1,0 +1,633 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <torchrec/csrc/dynamic_embedding/details/redis/redis_io.h>
+#include <torchrec/csrc/dynamic_embedding/details/redis/url.h>
+#include <iostream>
+#include <variant>
+
+namespace torchrec::redis {
+
+struct NumThreadsOpt {
+  uint32_t num_threads_;
+};
+struct DBOpt {
+  uint32_t db_;
+};
+struct PrefixOpt {
+  std::string prefix_;
+};
+
+struct TimeoutMsOpt {
+  uint32_t timeout_;
+};
+
+struct HeartBeatMsOpt {
+  uint32_t heartbeat_;
+};
+
+struct RetryLimitOpt {
+  uint32_t limit_;
+};
+
+struct ChunkSizeOpt {
+  uint32_t chunk_size_;
+};
+
+using OptVar = std::variant<
+    NumThreadsOpt,
+    DBOpt,
+    PrefixOpt,
+    TimeoutMsOpt,
+    HeartBeatMsOpt,
+    RetryLimitOpt,
+    ChunkSizeOpt>;
+
+struct OptionSetter {
+  void operator()(Option* self, NumThreadsOpt opt) {
+    TORCH_CHECK(opt.num_threads_ != 0);
+    self->num_io_threads_ = opt.num_threads_;
+  }
+  void operator()(Option* self, DBOpt opt) {
+    self->db_ = opt.db_;
+  }
+  void operator()(Option* self, PrefixOpt opt) {
+    self->prefix_ = std::move(opt.prefix_);
+  }
+  void operator()(Option* self, TimeoutMsOpt opt) {
+    TORCH_CHECK(opt.timeout_ != 0);
+    self->timeout_ms_ = opt.timeout_;
+  }
+  void operator()(Option* self, HeartBeatMsOpt opt) {
+    TORCH_CHECK(opt.heartbeat_ != 0);
+    self->heart_beat_interval_ms_ = opt.heartbeat_;
+  }
+  void operator()(Option* self, RetryLimitOpt opt) {
+    TORCH_CHECK(opt.limit_ != 0);
+    self->retry_limit_ = opt.limit_;
+  }
+  void operator()(Option* self, ChunkSizeOpt opt) {
+    TORCH_CHECK(opt.chunk_size_ != 0);
+    self->chunk_size_ = opt.chunk_size_;
+  }
+};
+
+namespace option_rules {
+namespace dsl = lexy::dsl;
+struct Integer {
+  constexpr static auto rule =
+      dsl::integer<uint32_t>(dsl::digits<>.no_leading_zero());
+  constexpr static auto value = lexy::construct<uint32_t>;
+};
+
+struct NumThreads {
+  constexpr static auto rule = LEXY_LIT("num_threads=") >> dsl::p<Integer>;
+  constexpr static auto value = lexy::construct<NumThreadsOpt>;
+};
+
+struct DB {
+  constexpr static auto rule = LEXY_LIT("db=") >> dsl::p<Integer>;
+  constexpr static auto value = lexy::construct<DBOpt>;
+};
+
+struct Prefix {
+  constexpr static auto rule = LEXY_LIT("prefix=") >>
+      dsl::capture(dsl::token(dsl::identifier(
+          dsl::ascii::alpha_underscore,
+          dsl::ascii::alpha_digit_underscore)));
+  constexpr static auto value =
+      lexy::callback<PrefixOpt>([](auto&& str) -> PrefixOpt {
+        return PrefixOpt{std::string(str.data(), str.size())};
+      });
+};
+
+struct Duration {
+  struct UnknownUnit {
+    constexpr static auto name = "unknown unit";
+  };
+
+  constexpr static auto rule =
+      dsl::integer<uint32_t>(dsl::digits<>.no_leading_zero()) >>
+      dsl::opt(LEXY_LIT(".") >> dsl::capture(dsl::digits<>)) >>
+      (dsl::capture(
+           dsl::literal_set(LEXY_LIT("ms"), LEXY_LIT("s"), LEXY_LIT("m"))) |
+       dsl::error<UnknownUnit>);
+
+  constexpr static auto value = lexy::callback<uint32_t>(
+      [](auto&& dec, std::optional<lexy::lexeme<lexy::_prd>> fp, auto&& unit) {
+        double scale;
+        auto unit_sv = std::string_view{unit.data(), unit.size()};
+        if (unit_sv == "s") {
+          scale = 1000;
+        } else if (unit_sv == "m") {
+          scale = 1000 * 60;
+        } else if (unit_sv == "ms") {
+          scale = 1;
+        } else {
+          TORCH_CHECK(false, "unit should in [s, m, ms]");
+        }
+        double val = dec;
+        if (fp.has_value()) {
+          double scale_fp = 10.0;
+          for (auto& ch : fp.value()) {
+            val += (ch - '0') / scale_fp;
+            scale_fp *= 10;
+          }
+        }
+        val *= scale;
+        auto timeout_ = static_cast<uint32_t>(val);
+        return timeout_;
+      });
+};
+
+struct Timeout {
+  constexpr static auto rule = LEXY_LIT("timeout=") >> dsl::p<Duration>;
+  constexpr static auto value = lexy::construct<TimeoutMsOpt>;
+};
+
+struct HeartBeat {
+  constexpr static auto rule = LEXY_LIT("heartbeat=") >> dsl::p<Duration>;
+  constexpr static auto value = lexy::construct<HeartBeatMsOpt>;
+};
+
+struct RetryLimit {
+  constexpr static auto rule = LEXY_LIT("retry_limit=") >> dsl::p<Integer>;
+  constexpr static auto value = lexy::construct<RetryLimitOpt>;
+};
+
+struct ChunkSize {
+  constexpr static auto rule = LEXY_LIT("chunk_size=") >> dsl::p<Integer>;
+  constexpr static auto value = lexy::construct<ChunkSizeOpt>;
+};
+
+struct UnknownOption {
+  constexpr static auto name = "unknown option";
+};
+
+struct Option {
+  constexpr static auto rule = dsl::p<NumThreads> | dsl::p<DB> |
+      dsl::p<Prefix> | dsl::p<Timeout> | dsl::p<HeartBeat> |
+      dsl::p<RetryLimit> | dsl::p<ChunkSize> | dsl::error<UnknownOption>;
+  constexpr static auto value = lexy::construct<OptVar>;
+};
+
+struct Options {
+  constexpr static auto rule =
+      dsl::list(dsl::p<Option>, dsl::sep(LEXY_LIT("&&")));
+
+  constexpr static auto value = lexy::as_list<std::vector<OptVar>>;
+};
+
+} // namespace option_rules
+
+Option::Option(std::string_view config_str) {
+  auto url = url_parser::parse_url(config_str);
+  if (url.auth_.has_value()) {
+    username_ = std::move(url.auth_->username_);
+    if (url.auth_->password_.has_value()) {
+      password_ = std::move(url.auth_->password_.value());
+    }
+  }
+
+  host_ = std::move(url.host_);
+
+  if (url.port_.has_value()) {
+    port_ = url.port_.value();
+  }
+
+  if (url.param_.has_value()) {
+    std::ostringstream err_oss_;
+    url_parser::ErrorCollector collector{err_oss_};
+
+    auto result = lexy::parse<option_rules::Options>(
+        lexy::string_input(url.param_.value()), collector);
+    auto err_str = err_oss_.str();
+
+    TORCH_CHECK(
+        result.has_value() && err_str.empty(), "parse param error ", err_str);
+
+    for (auto&& opt_var : result.value()) {
+      std::visit(
+          [this](auto&& opt) {
+            OptionSetter setter;
+            setter(this, std::move(opt));
+          },
+          opt_var);
+    }
+  }
+}
+
+Redis::Redis(Option opt) : opt_(std::move(opt)) {
+  TORCH_CHECK(opt_.num_io_threads_ != 0, "num_io_threads must not be empty");
+  TORCH_CHECK(
+      opt_.heart_beat_interval_ms_ != 0,
+      "heart beat interval must not be zero.");
+  for (size_t i = 0; i < opt_.num_io_threads_; ++i) {
+    start_thread();
+  }
+}
+
+void Redis::start_thread() {
+  auto connection = Connect();
+  heartbeat(connection);
+
+  io_threads_.emplace_back(
+      [connection = std::move(connection), this]() mutable {
+        std::chrono::milliseconds heart_beat(opt_.heart_beat_interval_ms_);
+        while (true) {
+          std::function<void(redis::ContextPtr&)> todo;
+          bool heartbeat_timeout;
+          {
+            std::unique_lock<std::mutex> lock(this->jobs_mutex_);
+            heartbeat_timeout = !jobs_not_empty_.wait_for(
+                lock, heart_beat, [this] { return !jobs_.empty(); });
+            if (!heartbeat_timeout) {
+              todo = std::move(jobs_.front());
+              jobs_.pop_front();
+            }
+          }
+
+          if (heartbeat_timeout) {
+            heartbeat(connection);
+            continue;
+          }
+
+          if (!todo) {
+            break;
+          }
+          todo(connection);
+        }
+      });
+}
+
+void Redis::heartbeat(redis::ContextPtr& connection) {
+  for (uint32_t retry = 0; retry < opt_.retry_limit_; ++retry) {
+    try {
+      auto reply = redis::ReplyPtr(reinterpret_cast<redisReply*>(
+          redisCommand(connection.get(), "PING")));
+      TORCH_CHECK(
+          reply && reply->type == REDIS_REPLY_STRING,
+          "Ping should return string");
+      auto rsp = std::string_view(reply->str, reply->len);
+      TORCH_CHECK(rsp == "PONG", "ping/pong error");
+    } catch (...) {
+      // reconnect if heart beat error
+      connection = Connect();
+    }
+  }
+}
+
+redis::ContextPtr Redis::Connect() const {
+  redis::ContextPtr connection;
+  if (opt_.timeout_ms_ == 0) {
+    connection =
+        redis::ContextPtr(redisConnect(opt_.host_.c_str(), opt_.port_));
+  } else {
+    struct timeval interval {};
+    interval.tv_sec = opt_.timeout_ms_ / 1000;
+    interval.tv_usec = opt_.timeout_ms_ % 1000 * 1000;
+    connection = redis::ContextPtr(
+        redisConnectWithTimeout(opt_.host_.c_str(), opt_.port_, interval));
+  }
+  TORCH_CHECK(
+      !connection->err,
+      "connect to %s:%d error occurred %s",
+      opt_.host_,
+      opt_.port_,
+      connection->errstr);
+
+  if (!opt_.password_.empty()) {
+    redis::ReplyPtr reply;
+    if (opt_.username_.empty()) {
+      reply = redis::ReplyPtr(reinterpret_cast<redisReply*>(
+          redisCommand(connection.get(), "AUTH %s", opt_.password_.c_str())));
+    } else {
+      reply = redis::ReplyPtr(reinterpret_cast<redisReply*>(redisCommand(
+          connection.get(),
+          "AUTH %s %s",
+          opt_.username_.c_str(),
+          opt_.password_.c_str())));
+    }
+    check_status("auth error", connection, reply);
+  }
+
+  if (opt_.db_ != 0) {
+    auto reply = redis::ReplyPtr(reinterpret_cast<redisReply*>(
+        redisCommand(connection.get(), "SELECT %d", opt_.db_)));
+    check_status("select db error", connection, reply);
+  }
+
+  return connection;
+}
+
+Redis::~Redis() {
+  for (uint32_t i = 0; i < opt_.num_io_threads_; ++i) {
+    jobs_.emplace_back();
+  }
+  jobs_not_empty_.notify_all();
+  for (auto& th : io_threads_) {
+    th.join();
+  }
+}
+
+static uint32_t CalculateChunkSizeByGlobalIDs(
+    uint32_t chunk_size,
+    uint32_t num_cols,
+    uint32_t num_os) {
+  static constexpr uint32_t low = 1;
+  return std::max(
+      chunk_size / std::max(num_cols, low) / std::max(num_os, low), low);
+}
+
+struct RedisPullContext {
+  std::atomic<uint32_t> num_complete_ids{0};
+  uint32_t chunk_size;
+  std::string table_name;
+  std::vector<int64_t> global_ids;
+  std::vector<int64_t> col_ids;
+  uint32_t num_optimizer_states;
+  void* on_complete_context;
+  void (*on_global_id_fetched)(
+      void* ctx,
+      uint32_t gid_offset,
+      uint32_t optimizer_state,
+      void* data,
+      uint32_t data_len);
+  void (*on_all_fetched)(void* ctx);
+
+  explicit RedisPullContext(uint32_t chunk_size, IOPullParameter param)
+      : chunk_size(CalculateChunkSizeByGlobalIDs(
+            chunk_size,
+            param.num_cols,
+            param.num_optimizer_states)),
+        table_name(param.table_name),
+        global_ids(param.global_ids, param.global_ids + param.num_global_ids),
+        num_optimizer_states(param.num_optimizer_states),
+        on_complete_context(param.on_complete_context),
+        on_global_id_fetched(param.on_global_id_fetched),
+        on_all_fetched(param.on_all_fetched) {
+    if (param.num_cols == 0) {
+      col_ids.emplace_back(-1);
+    } else {
+      col_ids =
+          std::vector<int64_t>(param.col_ids, param.col_ids + param.num_cols);
+    }
+  }
+};
+
+void Redis::pull(IOPullParameter param) {
+  auto* fetch_param = new RedisPullContext(opt_.chunk_size_, param);
+  {
+    std::lock_guard<std::mutex> guard(this->jobs_mutex_);
+    for (uint32_t i = 0; i < param.num_global_ids;
+         i += fetch_param->chunk_size) {
+      jobs_.emplace_back([i, fetch_param, this](redis::ContextPtr& connection) {
+        do_fetch(i, fetch_param, connection);
+      });
+    }
+  }
+  jobs_not_empty_.notify_all();
+}
+
+void Redis::do_fetch(
+    uint32_t gid_offset,
+    void* fetch_param_void,
+    redis::ContextPtr& connection) const {
+  auto& fetch_param = *reinterpret_cast<RedisPullContext*>(fetch_param_void);
+
+  uint32_t end = std::min(
+      gid_offset + fetch_param.chunk_size,
+      static_cast<uint32_t>(fetch_param.global_ids.size()));
+
+  auto loop = [&](auto&& callback) {
+    for (uint32_t i = gid_offset; i < end; ++i) {
+      int64_t gid = fetch_param.global_ids[i];
+      for (uint32_t j = 0; j < fetch_param.col_ids.size(); ++j) {
+        auto& col_id = fetch_param.col_ids[j];
+        for (uint32_t os_id = 0; os_id < fetch_param.num_optimizer_states;
+             ++os_id) {
+          callback(i * fetch_param.col_ids.size() + j, gid, col_id, os_id);
+        }
+      }
+    }
+  };
+
+  loop([&](uint32_t offset, int64_t gid, uint32_t col_id, uint32_t os_id) {
+    redisAppendCommand(
+        connection.get(),
+        "GET %s_table_%s_gid_%d_cid_%d_osid_%d",
+        opt_.prefix_.c_str(),
+        fetch_param.table_name.c_str(),
+        gid,
+        col_id,
+        os_id);
+  });
+
+  void* reply;
+  loop([&](uint32_t offset, int64_t gid, uint32_t col_id, uint32_t os_id) {
+    int status = redisGetReply(connection.get(), &reply);
+    TORCH_CHECK(
+        status != REDIS_ERR,
+        "get reply error: %s, from redis %s, %d",
+        connection->errstr,
+        opt_.host_,
+        opt_.port_);
+    auto reply_ptr = redis::ReplyPtr(reinterpret_cast<redisReply*>(reply));
+
+    if (reply_ptr->type == REDIS_REPLY_NIL) {
+      fetch_param.on_global_id_fetched(
+          fetch_param.on_complete_context, offset, os_id, nullptr, 0);
+    } else {
+      fetch_param.on_global_id_fetched(
+          fetch_param.on_complete_context,
+          offset,
+          os_id,
+          reply_ptr->str,
+          reply_ptr->len);
+    }
+  });
+
+  uint32_t n = end - gid_offset;
+  uint32_t target = fetch_param.global_ids.size();
+
+  if (fetch_param.num_complete_ids.fetch_add(n) + n ==
+      target) { // last fetch complete
+    fetch_param.on_all_fetched(fetch_param.on_complete_context);
+    delete &fetch_param;
+  }
+}
+
+struct RedisPushContext {
+  std::atomic<uint32_t> num_complete_ids{0};
+  uint32_t chunk_size;
+  std::string table_name;
+  std::span<const int64_t> global_ids;
+  std::vector<int64_t> col_ids;
+  std::span<const uint32_t> os_ids;
+  std::span<const uint64_t> offsets;
+  const void* data;
+  void* on_complete_context;
+  void (*on_push_complete)(void*);
+
+  RedisPushContext(uint32_t chunk_size, IOPushParameter param)
+      : chunk_size(CalculateChunkSizeByGlobalIDs(
+            chunk_size,
+            param.num_cols,
+            param.num_optimizer_states)),
+        table_name(param.table_name),
+        global_ids(param.global_ids, param.num_global_ids),
+        os_ids(param.optimizer_state_ids, param.num_optimizer_states),
+        offsets(param.offsets, param.num_offsets),
+        data(param.data),
+        on_complete_context(param.on_complete_context),
+        on_push_complete(param.on_push_complete) {
+    if (param.num_cols != 0) {
+      col_ids =
+          std::vector<int64_t>(param.col_ids, param.col_ids + param.num_cols);
+    } else {
+      col_ids.emplace_back(-1);
+    }
+  }
+};
+
+void Redis::push(IOPushParameter param) {
+  auto* ctx = new RedisPushContext(opt_.chunk_size_, param);
+  {
+    std::lock_guard<std::mutex> guard(this->jobs_mutex_);
+    for (uint32_t i = 0; i < param.num_global_ids; i += ctx->chunk_size) {
+      jobs_.emplace_back([i, ctx, this](redis::ContextPtr& connection) {
+        do_push(i, ctx, connection);
+      });
+    }
+  }
+  jobs_not_empty_.notify_all();
+}
+void Redis::do_push(
+    uint32_t gid_offset,
+    void* push_ctx_ptr,
+    redis::ContextPtr& connection) const {
+  auto& push_ctx = *reinterpret_cast<RedisPushContext*>(push_ctx_ptr);
+
+  uint32_t end = gid_offset + push_ctx.chunk_size;
+  if (end > push_ctx.global_ids.size()) {
+    end = push_ctx.global_ids.size();
+  }
+
+  auto loop = [&](auto&& callback) {
+    for (uint32_t i = gid_offset; i < end; ++i) {
+      int64_t gid = push_ctx.global_ids[i];
+      for (uint32_t j = 0; j < push_ctx.col_ids.size(); ++j) {
+        int64_t cid = push_ctx.col_ids[j];
+        for (uint32_t k = 0; k < push_ctx.os_ids.size(); ++k) {
+          uint32_t os_id = push_ctx.os_ids[k];
+
+          uint32_t offset = k + j * push_ctx.os_ids.size() +
+              i * push_ctx.col_ids.size() * push_ctx.os_ids.size();
+          callback(offset, gid, cid, os_id);
+        }
+      }
+    }
+  };
+
+  loop([&](uint32_t o, int64_t gid, int64_t cid, uint32_t os_id) {
+    uint64_t beg = push_ctx.offsets[o];
+    uint64_t end = push_ctx.offsets[o + 1];
+
+    redisAppendCommand(
+        connection.get(),
+        "SET %s_table_%s_gid_%d_cid_%d_osid_%d %b",
+        opt_.prefix_.c_str(),
+        push_ctx.table_name.c_str(),
+        gid,
+        cid,
+        os_id,
+        reinterpret_cast<const uint8_t*>(push_ctx.data) + beg,
+        static_cast<size_t>(end - beg));
+  });
+
+  void* replay_ptr;
+  loop([&](...) {
+    int status = redisGetReply(connection.get(), &replay_ptr);
+    TORCH_CHECK(
+        status != REDIS_ERR,
+        "get reply error: %s, from redis %s, %d",
+        connection->errstr,
+        opt_.host_,
+        opt_.port_);
+    redis::ReplyPtr reply(reinterpret_cast<redisReply*>(replay_ptr));
+    check_status("reply should be ok", connection, reply);
+  });
+
+  uint32_t n = end - gid_offset;
+  uint32_t target = push_ctx.global_ids.size();
+  if (push_ctx.num_complete_ids.fetch_add(n) + n == target) {
+    push_ctx.on_push_complete(push_ctx.on_complete_context);
+    delete &push_ctx;
+  }
+}
+void Redis::check_status(
+    std::string_view label,
+    redis::ContextPtr& connection,
+    redis::ReplyPtr& reply) const {
+  TORCH_CHECK(
+      connection->err == 0,
+      label,
+      " connection error: (",
+      connection->errstr,
+      "), from redis://",
+      opt_.host_,
+      ":",
+      opt_.port_);
+
+  TORCH_CHECK(
+      reply->type == REDIS_REPLY_STATUS,
+      label,
+      " reply should be status, but actual type is ",
+      reply->type,
+      ". from redis://",
+      opt_.host_,
+      ":",
+      opt_.port_);
+
+  auto status = std::string_view{reply->str, reply->len};
+  TORCH_CHECK(
+      status == "OK",
+      label,
+      " reply status should be OK, but actual is ",
+      status,
+      ". from redis://",
+      opt_.host_,
+      ":",
+      opt_.port_);
+}
+
+extern "C" {
+
+const char* IO_type = "redis";
+
+void* IO_Initialize(const char* cfg) {
+  auto opt = Option::parse(cfg);
+  return new Redis(opt);
+}
+
+void IO_Finalize(void* instance) {
+  delete reinterpret_cast<Redis*>(instance);
+}
+
+void IO_Pull(void* instance, IOPullParameter param) {
+  reinterpret_cast<Redis*>(instance)->pull(param);
+}
+
+void IO_Push(void* instance, IOPushParameter param) {
+  reinterpret_cast<Redis*>(instance)->push(param);
+}
+}
+
+} // namespace torchrec::redis

--- a/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
+++ b/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <hiredis.h>
+#include <torchrec/csrc/dynamic_embedding/details/io_parameter.h>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <thread>
+
+namespace torchrec::redis {
+
+struct Option {
+ public:
+  std::string host_;
+  std::string username_;
+  std::string password_;
+  uint16_t port_{6379};
+  uint16_t db_{0};
+  uint32_t num_io_threads_{1};
+  std::string prefix_;
+  uint32_t timeout_ms_{10000};
+  uint32_t heart_beat_interval_ms_{100000};
+  uint32_t retry_limit_{3};
+  uint32_t chunk_size_{100};
+
+  Option() = default;
+
+  static Option parse(std::string_view config_str) {
+    return Option(config_str);
+  }
+
+ private:
+  Option(std::string_view config_str);
+};
+
+namespace redis {
+struct ContextDeleter {
+  void operator()(void* ctx) {
+    if (ctx == nullptr) {
+      return;
+    }
+    redisFree(reinterpret_cast<redisContext*>(ctx));
+  }
+};
+using ContextPtr = std::unique_ptr<redisContext, ContextDeleter>;
+
+struct ReplyDeleter {
+  void operator()(void* cmd) {
+    if (cmd == nullptr) {
+      return;
+    }
+    freeReplyObject(cmd);
+  }
+};
+
+using ReplyPtr = std::unique_ptr<redisReply, ReplyDeleter>;
+
+} // namespace redis
+
+class Redis {
+ public:
+  explicit Redis(Option opt);
+
+  ~Redis();
+
+  void pull(IOPullParameter param);
+
+  void push(IOPushParameter param);
+
+ private:
+  void start_thread();
+  void heartbeat(redis::ContextPtr& connection);
+  [[nodiscard]] redis::ContextPtr Connect() const;
+
+  void do_fetch(
+      uint32_t gid_offset,
+      void* fetch_param,
+      redis::ContextPtr& connection) const;
+
+  void do_push(
+      uint32_t gid_offset,
+      void* push_ctx,
+      redis::ContextPtr& connection) const;
+
+  void check_status(
+      std::string_view label,
+      redis::ContextPtr& connection,
+      redis::ReplyPtr& reply) const;
+
+  Option opt_;
+  std::vector<std::thread> io_threads_;
+  std::deque<std::function<void(redis::ContextPtr&)>> jobs_;
+  std::condition_variable jobs_not_empty_;
+  std::mutex jobs_mutex_;
+};
+
+extern "C" {
+
+extern const char* IO_type;
+
+void* IO_Initialize(const char* cfg);
+void IO_Finalize(void* instance);
+void IO_Pull(void* instance, IOPullParameter param);
+void IO_Push(void* instance, IOPushParameter param);
+}
+
+} // namespace torchrec::redis

--- a/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
+++ b/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
@@ -66,7 +66,7 @@ class Redis {
 
   ~Redis();
 
-  void pull(IOPullParameter param);
+  void fetch(IOFetchParameter param);
 
   void push(IOPushParameter param);
 
@@ -103,7 +103,7 @@ extern const char* IO_type;
 
 void* IO_Initialize(const char* cfg);
 void IO_Finalize(void* instance);
-void IO_Pull(void* instance, IOPullParameter param);
+void IO_Fetch(void* instance, IOFetchParameter param);
 void IO_Push(void* instance, IOPushParameter param);
 }
 

--- a/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
+++ b/torchrec/csrc/dynamic_embedding/details/redis/redis_io.h
@@ -21,29 +21,22 @@ namespace torchrec::redis {
 
 struct Option {
  public:
-  std::string host_;
-  std::string username_;
-  std::string password_;
-  uint16_t port_{6379};
-  uint16_t db_{0};
-  uint32_t num_io_threads_{1};
-  std::string prefix_;
-  uint32_t timeout_ms_{10000};
-  uint32_t heart_beat_interval_ms_{100000};
-  uint32_t retry_limit_{3};
-  uint32_t chunk_size_{100};
-
-  Option() = default;
-
-  static Option parse(std::string_view config_str) {
-    return Option(config_str);
-  }
-
- private:
-  Option(std::string_view config_str);
+  std::string host;
+  std::string username;
+  std::string password;
+  uint16_t port{6379};
+  uint16_t db{0};
+  uint32_t num_io_threads{1};
+  std::string prefix;
+  uint32_t timeout_ms{10000};
+  uint32_t heart_beat_interval_ms{100000};
+  uint32_t retry_limit{3};
+  uint32_t chunk_size{100};
 };
 
-namespace redis {
+Option parse_option(std::string_view config_str);
+
+namespace helper {
 struct ContextDeleter {
   void operator()(void* ctx) {
     if (ctx == nullptr) {
@@ -65,7 +58,7 @@ struct ReplyDeleter {
 
 using ReplyPtr = std::unique_ptr<redisReply, ReplyDeleter>;
 
-} // namespace redis
+} // namespace helper
 
 class Redis {
  public:
@@ -79,27 +72,27 @@ class Redis {
 
  private:
   void start_thread();
-  void heartbeat(redis::ContextPtr& connection);
-  [[nodiscard]] redis::ContextPtr Connect() const;
+  void heartbeat(helper::ContextPtr& connection);
+  [[nodiscard]] helper::ContextPtr connect() const;
 
   void do_fetch(
       uint32_t gid_offset,
       void* fetch_param,
-      redis::ContextPtr& connection) const;
+      helper::ContextPtr& connection) const;
 
   void do_push(
       uint32_t gid_offset,
       void* push_ctx,
-      redis::ContextPtr& connection) const;
+      helper::ContextPtr& connection) const;
 
   void check_status(
       std::string_view label,
-      redis::ContextPtr& connection,
-      redis::ReplyPtr& reply) const;
+      helper::ContextPtr& connection,
+      helper::ReplyPtr& reply) const;
 
   Option opt_;
   std::vector<std::thread> io_threads_;
-  std::deque<std::function<void(redis::ContextPtr&)>> jobs_;
+  std::deque<std::function<void(helper::ContextPtr&)>> jobs_;
   std::condition_variable jobs_not_empty_;
   std::mutex jobs_mutex_;
 };

--- a/torchrec/csrc/dynamic_embedding/details/redis/url.h
+++ b/torchrec/csrc/dynamic_embedding/details/redis/url.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy_ext/report_error.hpp>
+#include <torch/torch.h>
+#include <optional>
+
+/**
+ * A simple URL/extendable parser
+ */
+namespace torchrec::url_parser {
+
+struct Auth {
+  std::string username_;
+  std::optional<std::string> password_;
+};
+
+struct Url {
+  std::optional<Auth> auth_;
+  std::string host_;
+  std::optional<uint16_t> port_;
+  std::optional<std::string> param_;
+};
+
+namespace rules {
+namespace dsl = lexy::dsl;
+using AuthValue = Auth;
+using UrlValue = Url;
+struct UrlToken {
+  static constexpr auto rule = dsl::percent_sign >>
+          dsl::integer<uint8_t>(dsl::n_digits<2, dsl::hex>) |
+      dsl::capture(dsl::ascii::alpha_digit_underscore);
+
+  static constexpr auto value = lexy::callback<char>([](auto&& v) -> char {
+    using T = std::decay_t<decltype(v)>;
+    if constexpr (std::is_same_v<T, uint8_t>) {
+      return v;
+    } else {
+      return v[0];
+    }
+  });
+};
+
+struct UrlString {
+  static constexpr auto rule = dsl::list(dsl::p<UrlToken>);
+  static constexpr auto value = lexy::as_string<std::string>;
+};
+
+struct Auth {
+  static constexpr auto rule = dsl::p<UrlString> >>
+      dsl::opt(dsl::lit_c<':'> >> dsl::p<UrlString>) >> dsl::lit_c<'@'>;
+  static constexpr auto value = lexy::construct<AuthValue>;
+};
+struct Host {
+  static constexpr auto rule =
+      dsl::list(dsl::p<UrlToken> | dsl::capture(dsl::lit_c<'.'>));
+  static constexpr auto value = lexy::as_string<std::string>;
+};
+
+struct Param {
+  static constexpr auto rule = dsl::capture(dsl::any);
+  static constexpr auto value = lexy::as_string<std::string>;
+};
+
+struct Url {
+  static constexpr auto rule =
+      dsl::opt(dsl::lookahead(dsl::lit_c<'@'>, dsl::newline) >> dsl::p<Auth>) +
+      dsl::p<Host> +
+      dsl::opt(dsl::lit_c<':'> >> dsl::integer<uint16_t>(dsl::digits<>)) +
+      dsl::opt(dsl::lit_c<'/'> >> dsl::lit_c<'?'> >> dsl::p<Param>) + dsl::eol;
+
+  static constexpr auto value = lexy::construct<UrlValue>;
+};
+
+} // namespace rules
+
+// basically copied from lexy_ext::error_reporter
+// instead of report error to stderr, report it to oss;
+struct ErrorCollector {
+  std::ostringstream& oss_;
+  struct _sink {
+    std::size_t _count;
+    std::ostringstream& oss_;
+
+    using return_type = std::size_t;
+
+    template <
+        typename Production,
+        typename Input,
+        typename Reader,
+        typename Tag>
+    void operator()(
+        const lexy::error_context<Production, Input>& context,
+        const lexy::error<Reader, Tag>& error) {
+      lexy_ext::_detail::write_error(
+          std::ostream_iterator<char>(oss_),
+          context,
+          error,
+          {lexy::visualization_flags::visualize_use_symbols |
+           lexy::visualization_flags::visualize_use_unicode});
+      ++_count;
+    }
+
+    std::size_t finish() && {
+      if (_count != 0)
+        std::fputs("\n", stderr);
+      return _count;
+    }
+  };
+
+  auto sink() const {
+    return _sink{0, oss_};
+  }
+};
+
+inline Url parse_url(std::string_view url_str) {
+  // NOTE: cannot using rule = xxx here. It seems a bug of clang or lexy.
+  auto input = lexy::string_input(url_str);
+  std::ostringstream oss;
+  ErrorCollector collector{oss};
+  auto parsed = lexy::parse<rules::Url>(input, collector);
+  TORCH_CHECK(parsed.has_value(), "parse url error %s", oss.str());
+  return std::move(parsed.value());
+}
+
+} // namespace torchrec::url_parser

--- a/torchrec/csrc/dynamic_embedding/details/redis/url.h
+++ b/torchrec/csrc/dynamic_embedding/details/redis/url.h
@@ -7,130 +7,77 @@
  */
 
 #pragma once
-#include <lexy/action/parse.hpp>
-#include <lexy/callback.hpp>
-#include <lexy/dsl.hpp>
-#include <lexy/input/string_input.hpp>
-#include <lexy_ext/report_error.hpp>
 #include <torch/torch.h>
 #include <optional>
+#include <string>
 
-/**
- * A simple URL/extendable parser
- */
 namespace torchrec::url_parser {
 
-struct Auth {
-  std::string username_;
-  std::optional<std::string> password_;
+struct Authority {
+  std::string username;
+  std::string password;
 };
 
 struct Url {
-  std::optional<Auth> auth_;
-  std::string host_;
-  std::optional<uint16_t> port_;
-  std::optional<std::string> param_;
+  std::optional<Authority> authority;
+  std::string host;
+  std::optional<uint16_t> port;
+  std::optional<std::string> param;
 };
 
-namespace rules {
-namespace dsl = lexy::dsl;
-using AuthValue = Auth;
-using UrlValue = Url;
-struct UrlToken {
-  static constexpr auto rule = dsl::percent_sign >>
-          dsl::integer<uint8_t>(dsl::n_digits<2, dsl::hex>) |
-      dsl::capture(dsl::ascii::alpha_digit_underscore);
+inline Authority parse_authority(std::string_view authority_str) {
+  Authority authority;
 
-  static constexpr auto value = lexy::callback<char>([](auto&& v) -> char {
-    using T = std::decay_t<decltype(v)>;
-    if constexpr (std::is_same_v<T, uint8_t>) {
-      return v;
-    } else {
-      return v[0];
-    }
-  });
-};
-
-struct UrlString {
-  static constexpr auto rule = dsl::list(dsl::p<UrlToken>);
-  static constexpr auto value = lexy::as_string<std::string>;
-};
-
-struct Auth {
-  static constexpr auto rule = dsl::p<UrlString> >>
-      dsl::opt(dsl::lit_c<':'> >> dsl::p<UrlString>) >> dsl::lit_c<'@'>;
-  static constexpr auto value = lexy::construct<AuthValue>;
-};
-struct Host {
-  static constexpr auto rule =
-      dsl::list(dsl::p<UrlToken> | dsl::capture(dsl::lit_c<'.'>));
-  static constexpr auto value = lexy::as_string<std::string>;
-};
-
-struct Param {
-  static constexpr auto rule = dsl::capture(dsl::any);
-  static constexpr auto value = lexy::as_string<std::string>;
-};
-
-struct Url {
-  static constexpr auto rule =
-      dsl::opt(dsl::lookahead(dsl::lit_c<'@'>, dsl::newline) >> dsl::p<Auth>) +
-      dsl::p<Host> +
-      dsl::opt(dsl::lit_c<':'> >> dsl::integer<uint16_t>(dsl::digits<>)) +
-      dsl::opt(dsl::lit_c<'/'> >> dsl::lit_c<'?'> >> dsl::p<Param>) + dsl::eol;
-
-  static constexpr auto value = lexy::construct<UrlValue>;
-};
-
-} // namespace rules
-
-// basically copied from lexy_ext::error_reporter
-// instead of report error to stderr, report it to oss;
-struct ErrorCollector {
-  std::ostringstream& oss_;
-  struct _sink {
-    std::size_t _count;
-    std::ostringstream& oss_;
-
-    using return_type = std::size_t;
-
-    template <
-        typename Production,
-        typename Input,
-        typename Reader,
-        typename Tag>
-    void operator()(
-        const lexy::error_context<Production, Input>& context,
-        const lexy::error<Reader, Tag>& error) {
-      lexy_ext::_detail::write_error(
-          std::ostream_iterator<char>(oss_),
-          context,
-          error,
-          {lexy::visualization_flags::visualize_use_symbols |
-           lexy::visualization_flags::visualize_use_unicode});
-      ++_count;
-    }
-
-    std::size_t finish() && {
-      if (_count != 0)
-        std::fputs("\n", stderr);
-      return _count;
-    }
-  };
-
-  auto sink() const {
-    return _sink{0, oss_};
+  auto colon_pos = authority_str.find(':');
+  if (colon_pos != std::string_view::npos) {
+    authority.username = authority_str.substr(0, colon_pos);
+    authority.password = authority_str.substr(colon_pos + 1);
+  } else {
+    // only username
+    authority.username = authority_str;
   }
-};
+  return authority;
+}
 
 inline Url parse_url(std::string_view url_str) {
-  // NOTE: cannot using rule = xxx here. It seems a bug of clang or lexy.
-  auto input = lexy::string_input(url_str);
-  std::ostringstream oss;
-  ErrorCollector collector{oss};
-  auto parsed = lexy::parse<rules::Url>(input, collector);
-  TORCH_CHECK(parsed.has_value(), "parse url error %s", oss.str());
-  return std::move(parsed.value());
+  Url url;
+  // (username (":" password)? "@")? host ":" port ("/" | "/?" param)?
+  // Assume there will only be one '@'
+  auto at_pos = url_str.find('@');
+  if (at_pos != std::string_view::npos) {
+    Authority authority = parse_authority(url_str.substr(0, at_pos));
+    url.authority = authority;
+    url_str = url_str.substr(at_pos + 1);
+  }
+  // There should be no '/' in host:port.
+  auto slash_pos = url_str.find('/');
+  std::string_view host_port_str;
+  if (slash_pos != std::string_view::npos) {
+    host_port_str = url_str.substr(0, slash_pos);
+    url_str = url_str.substr(slash_pos + 1);
+  } else {
+    host_port_str = url_str;
+    url_str = "";
+  }
+
+  auto colon_pos = host_port_str.find(':');
+  if (colon_pos != std::string_view::npos) {
+    url.host = host_port_str.substr(0, colon_pos);
+    auto port_str = host_port_str.substr(colon_pos + 1);
+    url.port = std::stoi(std::string(port_str));
+  } else {
+    url.host = host_port_str;
+  }
+
+  if (!url_str.empty()) {
+    if (url_str[0] != '?') {
+      throw std::invalid_argument("invalid parameter: " + std::string(url_str));
+    } else {
+      url.param = url_str.substr(1);
+    }
+  }
+
+  return url;
 }
 
 } // namespace torchrec::url_parser


### PR DESCRIPTION
This PR is migrating the redis IO plugin to the top level folder of torchrec. This plugin can be compiled with `BUILD_REDIS_IO` flag in cmake (`-DBUILD_REDIS_IO=ON`).

There are some issues we may need to discuss. 
- The PR introduced 2 external dependencies: [hiredis](https://github.com/redis/hiredis)(A minimal redis C client) and [lexy](https://github.com/foonathan/lexy)(A simple static typed C++ parser), the later one is used for parsing the URL like `192.168.3.1:3948/?db=3&&num_threads=2&&timeout=3s&&chunk_size=3000`. It will be great if we can find some lighter dependency for such usage.
- The PR introduced redis IO plugin as a shared library with [symbols needed for registering IO plugin](https://github.com/pytorch/torchrec/blob/712bbac3183cdfb25eca7c480099a2ee4be9c0f7/torchrec/csrc/dynamic_embedding/details/io_registry.cpp#L26-L54):
  ```bash
  $ nm -D torchrec/csrc/dynamic_embedding/details/redis/libredis_io.so | grep IO_
  000000000000cb30 T IO_Finalize
  0000000000028660 T IO_Initialize
  000000000000c7d0 T IO_Pull
  000000000000d020 T IO_Push
  000000000003f008 D IO_type
  ```
  This could serve as an example on how to create custom IO plugin. We could also register the redis plugin statically.

Thank you for your time on this long PR :)

gently ping @divchenko @colin2328 @reyoung