### PR TITLE
Use separate pg for input dist

### DIFF
--- a/torchrec/distributed/comm.py
+++ b/torchrec/distributed/comm.py
@@ -100,7 +100,6 @@ def get_num_groups(world_size: Optional[int] = None) -> int:
 
 def intra_and_cross_node_pg(
     device: Optional[torch.device] = None,
-    backend: str = "nccl",
 ) -> Tuple[Optional[dist.ProcessGroup], Optional[dist.ProcessGroup]]:
     """
     Creates sub process groups (intra and cross node)
@@ -117,14 +116,7 @@ def intra_and_cross_node_pg(
     local_size = get_local_size(my_size)
     my_group_rank = get_group_rank(my_size, my_rank)
     group_count = get_num_groups(my_size)
-    my_backend = dist.get_backend()
-
-    if my_backend != backend:
-        logger.warn(
-            f"global PG is initialized with backend {my_backend}, while trying to perform intra_and_cross_node_pg with backend {backend}, "
-            f"use the global backend {my_backend} to proceed"
-        )
-        backend = my_backend
+    backend = dist.get_backend()
 
     logger.info(
         f"[{my_rank}] my_local_rank = {my_local_rank}, local_size = {local_size},"

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -105,9 +105,8 @@ class RwSequenceEmbeddingSharding(
         num_id_score_list_features = self._get_id_score_list_features_num()
         id_list_feature_hash_sizes = self._get_id_list_features_hash_sizes()
         id_score_list_feature_hash_sizes = self._get_id_score_list_features_hash_sizes()
+        assert self._pg is not None
         return RwSparseFeaturesDist(
-            # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
-            #  `Optional[ProcessGroup]`.
             pg=self._pg,
             num_id_list_features=num_id_list_features,
             num_id_score_list_features=num_id_score_list_features,

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
+from torchrec.distributed.comm import input_dist_new_pg, input_dist_pg
 from torchrec.distributed.dist_data import EmbeddingsAllToOne, PooledEmbeddingsAllToAll
 from torchrec.distributed.embedding_lookup import (
     GroupedPooledEmbeddingsLookup,
@@ -288,8 +289,9 @@ class TwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
         variable_batch_size: bool = False,
     ) -> None:
         super().__init__()
+        self._pg: dist.ProcessGroup = input_dist_pg() if input_dist_new_pg() else pg
         self._dist = SparseFeaturesAllToAll(
-            pg=pg,
+            pg=self._pg,
             id_list_features_per_rank=id_list_features_per_rank,
             id_score_list_features_per_rank=id_score_list_features_per_rank,
             device=device,


### PR DESCRIPTION
Summary: Add trec.distributed.comm.input_dist_new_pg(True) to control whether to use new process group for input data dist

Differential Revision: D41167216

