### PR TITLE
Garbage collector optimization

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <chrono>
+#include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -36,6 +38,16 @@ namespace torchrec {
 
 class GPUExecutor {
  public:
+  // Used to interface with python's garbage collector
+  struct GCConfig {
+    bool optimizationEnabled = false;
+    size_t collectionFreq = 1000;
+    size_t statReportingFreq = 10000;
+    std::unique_ptr<IDynamicTimeseriesObserver> observer =
+        std::make_unique<EmptyDynamicTimeseriesObserver>();
+    std::map<int, int> threadIdToNumForwards = std::map<int, int>();
+  };
+
   GPUExecutor(
       std::shared_ptr<torch::deploy::InterpreterManager> manager,
       torch::deploy::ReplicatedObj model,
@@ -46,7 +58,8 @@ class GPUExecutor {
       std::shared_ptr<IGPUExecutorObserver>
           observer, // shared_ptr because used in completion executor callback
       std::function<void()> warmupFn = {},
-      c10::optional<size_t> numThreadsPerGPU = c10::nullopt);
+      c10::optional<size_t> numThreadsPerGPU = c10::nullopt,
+      std::unique_ptr<GCConfig> gcConfig = std::make_unique<GCConfig>());
   GPUExecutor(GPUExecutor&& executor) noexcept = default;
   GPUExecutor& operator=(GPUExecutor&& executor) noexcept = default;
   ~GPUExecutor();
@@ -72,6 +85,10 @@ class GPUExecutor {
   std::function<void()> warmupFn_;
 
   size_t numThreadsPerGPU_;
+
+  std::unique_ptr<GCConfig> gcConfig_;
+
+  void reportGCStats(c10::IValue stats);
 };
 
 } // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/Observer.h
+++ b/torchrec/inference/include/torchrec/inference/Observer.h
@@ -13,6 +13,20 @@
 
 namespace torchrec {
 
+// Record generic timeseries stat with a key
+class IDynamicTimeseriesObserver {
+ public:
+  virtual void addCount(uint32_t value, std::string key) = 0;
+
+  virtual ~IDynamicTimeseriesObserver() {}
+};
+
+// Can be used for testing or for opt-ing out of observation.
+class EmptyDynamicTimeseriesObserver : public IDynamicTimeseriesObserver {
+ public:
+  void addCount(uint32_t /* value */, std::string /* key */) override {}
+};
+
 class IBatchingQueueObserver {
  public:
   // Record the amount of time an entry of PredictionRequests

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -75,7 +75,8 @@ GPUExecutor::GPUExecutor(
     std::chrono::milliseconds queueTimeout,
     std::shared_ptr<IGPUExecutorObserver> observer,
     std::function<void()> warmupFn,
-    c10::optional<size_t> numThreadsPerGPU)
+    c10::optional<size_t> numThreadsPerGPU,
+    std::unique_ptr<GCConfig> gcConfig)
     : manager_(manager),
       model_(std::move(model)),
       rank_(rank),
@@ -88,22 +89,35 @@ GPUExecutor::GPUExecutor(
       numThreadsPerGPU_(
           numThreadsPerGPU.has_value()
               ? *numThreadsPerGPU
-              : manager_->allInstances().size() / worldSize_) {
+              : manager_->allInstances().size() / worldSize_),
+      gcConfig_(std::move(gcConfig)) {
   CHECK(observer_ != nullptr);
+  CHECK(gcConfig_ != nullptr);
+
   at::cuda::CUDAGuard guard(rank_);
 
   rejectionExecutor_ =
       std::make_unique<folly::CPUThreadPoolExecutor>(2 * numThreadsPerGPU_);
   for (int i = 0; i < numThreadsPerGPU_; ++i) {
+    auto threadId = rank * numThreadsPerGPU_ + i;
+
     LOG(INFO) << "Starting Thread " << i << " for Model Shard Rank " << rank_
-              << ", as Global thread: " << rank * numThreadsPerGPU_ + i;
-    processThreads_.emplace_back(
-        [this, rank, threadsPerGPU = numThreadsPerGPU_, i] {
-          if (FLAGS_emit_nsys_nvtx) {
-            enable_nvtx_tracing();
-          }
-          process(rank * threadsPerGPU + i);
-        });
+              << ", as Global thread: " << threadId;
+
+    if (gcConfig_->optimizationEnabled) {
+      gcConfig_->threadIdToNumForwards[threadId] = 0;
+      // Freeze all python objects in each interpreter
+      auto model =
+          model_.acquireSession(&manager_->allInstances().at(threadId));
+      model.global("gc", "freeze")(at::ArrayRef<torch::deploy::Obj>());
+    }
+
+    processThreads_.emplace_back([this, threadId] {
+      if (FLAGS_emit_nsys_nvtx) {
+        enable_nvtx_tracing();
+      }
+      process(threadId);
+    });
   }
 
   completionExecutor_ =
@@ -192,14 +206,37 @@ void GPUExecutor::process(int idx) {
 
       auto forwardStart = std::chrono::steady_clock::now();
 
+      // Disable automatic garbage collection
+      if (gcConfig_->optimizationEnabled) {
+        model.global("gc", "disable")(at::ArrayRef<torch::deploy::Obj>());
+      }
+
       predictions = model.self.attr("__call__")({std::move(batch->forwardArgs)})
                         .toIValue();
+
+      // Manually call Python's garbage collector
+      if (gcConfig_->optimizationEnabled) {
+        gcConfig_->threadIdToNumForwards[idx] += 1;
+        if (gcConfig_->threadIdToNumForwards[idx] % gcConfig_->collectionFreq ==
+            0) {
+          model.global("gc", "collect")(at::ArrayRef<torch::deploy::Obj>());
+        }
+        // Report gc stats
+        if (gcConfig_->threadIdToNumForwards[idx] %
+                gcConfig_->statReportingFreq ==
+            0) {
+          reportGCStats(
+              model
+                  .global("gc", "get_stats")(at::ArrayRef<torch::deploy::Obj>())
+                  .toIValue());
+        }
+      }
 
       observer_->recordPredictionLatency(
           getTimeElapsedMS(forwardStart).count());
     } catch (const std::exception& ex) {
-      // The observer will record this in the completion executor. Don't observe
-      // twice.
+      // The observer will record this in the completion executor. Don't
+      // observe twice.
       LOG_EVERY_N(ERROR, 100) << "Exception during predict, msg: " << ex.what();
     }
 
@@ -262,6 +299,23 @@ void GPUExecutor::process(int idx) {
           observer->recordTotalLatency(
               getTimeElapsedMS(batch->enqueueTime).count());
         });
+  }
+}
+
+void GPUExecutor::reportGCStats(c10::IValue stats) {
+  const auto generationsList = stats.toList();
+  for (const auto generationId : c10::irange(generationsList.size())) {
+    const auto& collectionsDict =
+        generationsList.get(generationId).toGenericDict();
+    for (auto& entry : collectionsDict) {
+      const auto& key = entry.key();
+      const auto& value = entry.value();
+
+      auto stat_indicator =
+          "gc_gen_" + std::to_string(generationId) + "_" + key.toStringRef();
+      LOG(INFO) << "GC stat indicator: " << stat_indicator;
+      gcConfig_->observer->addCount(value.toInt(), stat_indicator);
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
# What
- Disable python's automatic garbage collection (via deploy) during forward call

# Why
- dstaay-fb found that disabling gc during training resulted in qps boost (hist note:  https://fb.workplace.com/notes/538119557964077)

# How
- use deploy to interface with gc module: https://docs.python.org/3/library/gc.html
- freeze all objects necessary for forward pass after initialization
- disable collection right before forward
- collect every n forward calls
- report stats every m forward calls

# todo
- actually observe a qps boost, waiting for window of time where server's free

Differential Revision: D40907503

