### PR TITLE
quant ebc

### DIFF
--- a/torchrec/fx/tracer.py
+++ b/torchrec/fx/tracer.py
@@ -77,6 +77,17 @@ class Tracer(torch.fx.Tracer):
             )
         return super().create_arg(a)
 
+    def path_of_module(self, mod: torch.nn.Module) -> str:
+        """
+        Allows trace-ability of non registered modules. This is typically used for Table Batched Embeddings
+        made to look like nn.EmbeddingBags
+        """
+
+        if hasattr(mod, "_fx_path"):
+            # pyre-ignore
+            return mod._fx_path
+        return super().path_of_module(mod)
+
 
 def symbolic_trace(
     # pyre-ignore[24]

--- a/torchrec/quant/utils.py
+++ b/torchrec/quant/utils.py
@@ -14,6 +14,21 @@ from torchrec.quant.embedding_modules import (
 )
 
 
+def populate_fx_names(quant_ebc: QuantEmbeddingBagCollection) -> None:
+    """
+    Assigns fx path to non registered lookup modules. This allows the Torchrec tracer to fallback to
+    emb_module._fx_path for table batched embeddings.
+    """
+    for emb_configs, emb_module in zip(
+        quant_ebc._key_to_tables, quant_ebc._emb_modules
+    ):
+        table_names = []
+        for config in emb_configs:
+            table_names.append(config.name)
+        joined_table_names = ",".join(table_names)
+        emb_module._fx_path = f"emb_module.{joined_table_names}"
+
+
 def meta_to_cpu_placement(module: DistributedModelParallel) -> None:
     assert hasattr(module, "_dmp_wrapped_module")
     _meta_to_cpu_placement(module.module, module, "_dmp_wrapped_module")


### PR DESCRIPTION
Summary:
-- Motivation --

We may want to script the unsharded QEBC as part of inference (offload it to CPU). However, scripting the original quant EBC is a nightmare as many things aren't supported (dataclasses, for loop etc). scripting the traced module is much easier since everything is static/collapsed.

However, tracing has the below issue:

Since torchrec doesn't want to register in a module list, we need to make it compatible with fx tracing

In the forward, it looks at all modules encountered, but needs a name. Usually this is derived from named_modules(). But since we don't register things as modules, we need to give some help to fx to identify the name.

Reviewed By: YazhiGao

Differential Revision: D40724168

