### PR TITLE
Add the get_required_inputs function to RecMetricList

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -323,6 +323,9 @@ class RecMetricModule(nn.Module):
     def reset(self) -> None:
         self.rec_metrics.reset()
 
+    def get_required_inputs(self) -> List[str]:
+        return self.rec_metrics.get_required_inputs()
+
 
 def _generate_rec_metrics(
     metrics_config: MetricsConfig,


### PR DESCRIPTION
Summary:
For bucket metrics calculation, besides the labels, predictions, weights input fields, we also need the column used for bucketization, i.e. the bucketized_var_name field defined in BucketMetricDef (https://fburl.com/code/tr73ckb6)

This diff extracts the bucketized_var_name info from all the bucket metrics and store them as a list in RecMetricList, which can be accessed through the MetricModule object

Later we'll use this list in tran_step.py to add the bucketization column to model_out (https://fburl.com/code/58ju39pa)

Differential Revision: D41293926

