### PR TITLE
Check if the bucketized_var_name column is passed to update()

### DIFF
--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, cast, List, Optional, Type
+from typing import Any, cast, Dict, List, Optional, Type
 
 import torch
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
@@ -107,6 +107,7 @@ class AUCMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -69,6 +69,7 @@ class CalibrationMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -65,6 +65,7 @@ class CTRMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -84,6 +84,7 @@ class MSEMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/multiclass_recall.py
+++ b/torchrec/metrics/multiclass_recall.py
@@ -113,6 +113,7 @@ class MulticlassRecallMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -119,6 +119,7 @@ class NEMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -218,6 +218,7 @@ class RecMetricComputation(Metric, abc.ABC):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:  # pragma: no cover
         pass
 
@@ -564,6 +565,7 @@ class RecMetric(nn.Module, abc.ABC):
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: Optional[RecModelOutput],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if self._fused_update_limit > 0:
             self._update_buffers[self.PREDICTIONS].append(predictions)
@@ -709,6 +711,7 @@ class RecMetricList(nn.Module):
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: RecModelOutput,
+        **kwargs: Dict[str, Any],
     ) -> None:
         for metric in self.rec_metrics:
             metric.update(predictions=predictions, labels=labels, weights=weights)


### PR DESCRIPTION
Summary:
bucketized_var_name is needed for bucket metric calculation. Raise an exception if it's not an input for update()

The next diff will pass the correct bucketized_var_name column to update()

Differential Revision: D41297940

