### PR TITLE
Do not instantiate feature processor with rowwise sharding

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -518,6 +518,7 @@ class TestSparseNNBase(nn.Module):
         embedding_groups: Optional[Dict[str, List[str]]] = None,
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__()
         if dense_device is None:
@@ -557,6 +558,7 @@ class TestSparseNN(TestSparseNNBase, CopyableMixin):
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
         max_feature_lengths_list: Optional[List[Dict[str, int]]] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__(
             tables=cast(List[BaseEmbeddingConfig], tables),
@@ -671,6 +673,7 @@ class TestTowerSparseNN(TestSparseNNBase):
         embedding_groups: Optional[Dict[str, List[str]]] = None,
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__(
             tables=cast(List[BaseEmbeddingConfig], tables),
@@ -766,6 +769,7 @@ class TestTowerCollectionSparseNN(TestSparseNNBase):
         embedding_groups: Optional[Dict[str, List[str]]] = None,
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__(
             tables=cast(List[BaseEmbeddingConfig], tables),

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -145,6 +145,7 @@ def gen_model_and_input(
     dedup_tables: Optional[List[EmbeddingTableConfig]] = None,
     variable_batch_size: bool = False,
     batch_size: int = 4,
+    feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
 ) -> Tuple[nn.Module, List[Tuple[ModelInput, List[ModelInput]]]]:
     torch.manual_seed(0)
     if dedup_feature_names:
@@ -159,6 +160,7 @@ def gen_model_and_input(
             embedding_groups=embedding_groups,
             dense_device=dense_device,
             sparse_device=sparse_device,
+            feature_processor_modules=feature_processor_modules,
         )
     else:
         model = model_class(
@@ -171,6 +173,7 @@ def gen_model_and_input(
             embedding_groups=embedding_groups,
             dense_device=dense_device,
             sparse_device=sparse_device,
+            feature_processor_modules=feature_processor_modules,
         )
     inputs = [
         generate_inputs(
@@ -243,6 +246,7 @@ def sharding_single_rank_test(
     ] = None,
     variable_batch_size: bool = False,
     batch_size: int = 4,
+    feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
 ) -> None:
 
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
@@ -256,6 +260,7 @@ def sharding_single_rank_test(
             num_float_features=16,
             variable_batch_size=variable_batch_size,
             batch_size=batch_size,
+            feature_processor_modules=feature_processor_modules,
         )
         global_model = global_model.to(ctx.device)
         global_input = inputs[0][0].to(ctx.device)
@@ -269,6 +274,7 @@ def sharding_single_rank_test(
             dense_device=ctx.device,
             sparse_device=torch.device("meta"),
             num_float_features=16,
+            feature_processor_modules=feature_processor_modules,
         )
 
         global_model_named_params_as_dict = dict(global_model.named_parameters())

--- a/torchrec/distributed/tests/test_sequence_model.py
+++ b/torchrec/distributed/tests/test_sequence_model.py
@@ -154,6 +154,7 @@ class TestSequenceTowerSparseNN(TestSparseNNBase):
         embedding_groups: Optional[Dict[str, List[str]]] = None,
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__(
             tables=cast(List[BaseEmbeddingConfig], tables),
@@ -256,6 +257,7 @@ class TestSequenceSparseNN(TestSparseNNBase):
         embedding_groups: Optional[Dict[str, List[str]]] = None,
         dense_device: Optional[torch.device] = None,
         sparse_device: Optional[torch.device] = None,
+        feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
     ) -> None:
         super().__init__(
             tables=cast(List[BaseEmbeddingConfig], tables),


### PR DESCRIPTION
Summary: It's pointless to do rowwise shardind + feature processor (e.g. position weighted) because mathematically it's just not equivalent. Will write a post about this. Before that, we should turn off feature processor to bring back the test.

Differential Revision: D41336062

