### PR TITLE
Env Var-based build-type parsing

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -94,6 +94,7 @@ jobs:
     - name: Build TorchRec Nightly
       run: |
         rm -r dist || true
+        CHANNEL="nightly"
         conda run -n build_binary \
           python setup.py bdist_wheel \
           --package_name torchrec-nightly \

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -90,8 +90,8 @@ jobs:
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2
       with:
-        name: torchrec-test_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
-        path: dist/torchrec-test-*.whl
+        name: torchrec_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        path: dist/*.whl
 
   # download from GHA, test on gpu
   test_on_gpu:
@@ -171,7 +171,7 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v2
       with:
-        name: torchrec-test_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
+        name: torchrec_${{ matrix.python-version }}_${{ matrix.cuda-tag }}.whl
     - name: Display structure of downloaded files
       run: ls -R
     - name: Install TorchRec GPU


### PR DESCRIPTION
Parsing the build type (nightly/release/test/etc.) based on the user-provided package name is error prone. Exploring changing this to be env var-based. This will also play better with the Nova workflows.