### PR TITLE
Enabling Transformer Encoder Layer in torchrec dlrm example model

### DIFF
--- a/torchrec/models/experimental/test_transformerdlrm.py
+++ b/torchrec/models/experimental/test_transformerdlrm.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torchrec.datasets.utils import Batch
+from torchrec.models.dlrm import DLRMTrain
+from torchrec.models.experimental.transformerdlrm import (
+    DLRM_Transformer,
+    InteractionTransformerArch,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class InteractionArchTransformerTest(unittest.TestCase):
+    def test_basic(self) -> None:
+        D = 8
+        B = 10
+        # multi-head attentions
+        nhead = 8
+        ntransformer_layers = 4
+        keys = ["f1", "f2"]
+        F = len(keys)
+        inter_arch = InteractionTransformerArch(
+            num_sparse_features=F,
+            embedding_dim=D,
+            nhead=nhead,
+            ntransformer_layers=ntransformer_layers,
+        )
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+        concat_dense = inter_arch(dense_features, sparse_features)
+        #  B X (D + F + F choose 2)
+        self.assertEqual(concat_dense.size(), (B, D * (F + 1)))
+
+    def test_larger(self) -> None:
+        D = 16
+        B = 20
+        # multi-head attentions
+        nhead = 8
+        ntransformer_layers = 4
+        keys = ["f1", "f2", "f3", "f4"]
+        F = len(keys)
+        inter_arch = InteractionTransformerArch(
+            num_sparse_features=F,
+            embedding_dim=D,
+            nhead=nhead,
+            ntransformer_layers=ntransformer_layers,
+        )
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+        concat_dense = inter_arch(dense_features, sparse_features)
+        self.assertEqual(concat_dense.size(), (B, D * (F + 1)))
+
+    def test_correctness(self) -> None:
+        D = 4
+        B = 3
+        # multi-head attentions
+        nhead = 4
+        ntransformer_layers = 4
+        keys = [
+            "f1",
+            "f2",
+            "f3",
+            "f4",
+        ]
+        F = len(keys)
+        # place the manual_seed before the InteractionTransformerArch object to generate the same initialization random values in the Transformer
+        torch.manual_seed(0)
+        inter_arch = InteractionTransformerArch(
+            num_sparse_features=F,
+            embedding_dim=D,
+            nhead=nhead,
+            ntransformer_layers=ntransformer_layers,
+        )
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+        concat_dense = inter_arch(dense_features, sparse_features)
+        self.assertEqual(concat_dense.size(), (B, D * (F + 1)))
+        expected = torch.tensor(
+            [
+                [
+                    -0.4411,
+                    0.2487,
+                    -1.2685,
+                    1.4610,
+                    1.3110,
+                    0.5152,
+                    -0.4960,
+                    -1.3303,
+                    -0.3962,
+                    -0.0623,
+                    -1.1371,
+                    1.5956,
+                    0.2431,
+                    -1.6820,
+                    0.5242,
+                    0.9148,
+                    1.3033,
+                    0.6409,
+                    -0.9577,
+                    -0.9866,
+                ],
+                [
+                    -1.0850,
+                    -0.0366,
+                    -0.4862,
+                    1.6078,
+                    1.1254,
+                    -0.9989,
+                    -0.9927,
+                    0.8661,
+                    -0.1704,
+                    1.0223,
+                    -1.5580,
+                    0.7060,
+                    -0.3081,
+                    -1.3686,
+                    0.2788,
+                    1.3979,
+                    0.0328,
+                    1.5470,
+                    -0.3670,
+                    -1.2128,
+                ],
+                [
+                    -1.5917,
+                    -0.0995,
+                    0.7302,
+                    0.9609,
+                    0.6606,
+                    1.0238,
+                    -0.1017,
+                    -1.5827,
+                    -0.6761,
+                    -1.0771,
+                    0.2262,
+                    1.5269,
+                    -0.5671,
+                    -1.2114,
+                    1.4503,
+                    0.3281,
+                    -0.6540,
+                    -1.2925,
+                    0.9134,
+                    1.0331,
+                ],
+            ]
+        )
+        self.assertTrue(
+            torch.allclose(
+                concat_dense,
+                expected,
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+
+    def test_numerical_stability(self) -> None:
+        D = 4
+        B = 3
+        # multi-head attentions
+        nhead = 4
+        ntransformer_layers = 4
+        keys = ["f1", "f2"]
+        F = len(keys)
+        torch.manual_seed(0)
+        inter_arch = InteractionTransformerArch(
+            num_sparse_features=F,
+            embedding_dim=D,
+            nhead=nhead,
+            ntransformer_layers=ntransformer_layers,
+        )
+        dense_features = 10 * torch.rand(B, D)
+        sparse_features = 10 * torch.rand(B, F, D)
+        concat_dense = inter_arch(dense_features, sparse_features)
+        expected = torch.LongTensor(
+            [
+                [0, 1, -1, 0, 0, 0, 0, -1, 0, 0, -1, 1],
+                [0, 0, 0, 1, -1, 0, 1, 0, 0, 0, 1, 0],
+                [-1, 0, 0, 0, 0, 0, -1, 1, 0, 1, -1, 0],
+            ]
+        )
+        self.assertTrue(torch.equal(concat_dense.long(), expected))
+
+
+class DLRMTransformerTest(unittest.TestCase):
+    def test_basic(self) -> None:
+        torch.manual_seed(0)
+        B = 2
+        D = 8
+        dense_in_features = 100
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        sparse_nn = DLRM_Transformer(
+            embedding_bag_collection=ebc,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=[20, D],
+            over_arch_layer_sizes=[5, 1],
+        )
+        features = torch.rand((B, dense_in_features))
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f3", "f2"],
+            values=torch.tensor([1, 2, 4, 5, 4, 3, 2, 9, 1, 2, 3]),
+            offsets=torch.tensor([0, 2, 4, 6, 8, 10, 11]),
+        )
+        logits = sparse_nn(
+            dense_features=features,
+            sparse_features=sparse_features,
+        )
+        self.assertEqual(logits.size(), (B, 1))
+        expected_logits = torch.tensor([[0.1659], [0.3247]])
+        self.assertTrue(
+            torch.allclose(
+                logits,
+                expected_logits,
+                rtol=1e-4,
+                atol=1e-4,
+            )
+        )
+
+    def test_one_sparse(self) -> None:
+        B = 2
+        D = 8
+        dense_in_features = 100
+        eb1_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+        ebc = EmbeddingBagCollection(tables=[eb1_config])
+        sparse_nn = DLRM_Transformer(
+            embedding_bag_collection=ebc,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=[20, D],
+            over_arch_layer_sizes=[5, 1],
+        )
+        features = torch.rand((B, dense_in_features))
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f2"],
+            values=torch.tensor(range(3)),
+            offsets=torch.tensor([0, 2, 3]),
+        )
+        logits = sparse_nn(
+            dense_features=features,
+            sparse_features=sparse_features,
+        )
+        self.assertEqual(logits.size(), (B, 1))
+
+    def test_no_sparse(self) -> None:
+        ebc = EmbeddingBagCollection(tables=[])
+        D_unused = 1
+        with self.assertRaises(AssertionError):
+            DLRM_Transformer(
+                embedding_bag_collection=ebc,
+                dense_in_features=100,
+                dense_arch_layer_sizes=[20, D_unused],
+                over_arch_layer_sizes=[5, 1],
+            )
+
+
+class DLRMTransformerTrainTest(unittest.TestCase):
+    def test_basic(self) -> None:
+        B = 2
+        D = 8
+        dense_in_features = 100
+        eb1_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=D,
+            num_embeddings=100,
+            feature_names=["f2"],
+        )
+        ebc = EmbeddingBagCollection(tables=[eb1_config])
+        dlrm_module = DLRM_Transformer(
+            embedding_bag_collection=ebc,
+            dense_in_features=dense_in_features,
+            dense_arch_layer_sizes=[20, D],
+            over_arch_layer_sizes=[5, 1],
+        )
+        dlrm = DLRMTrain(dlrm_module)
+        features = torch.rand((B, dense_in_features))
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f2"],
+            values=torch.tensor(range(3)),
+            offsets=torch.tensor([0, 2, 3]),
+        )
+        batch = Batch(
+            dense_features=features,
+            sparse_features=sparse_features,
+            labels=torch.randint(2, (B,)),
+        )
+        _, (_, logits, _) = dlrm(batch)
+        self.assertEqual(logits.size(), (B,))

--- a/torchrec/models/experimental/transformerdlrm.py
+++ b/torchrec/models/experimental/transformerdlrm.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+import torch
+from torch import nn
+from torchrec.models.dlrm import DLRM, OverArch
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+
+class InteractionTransformerArch(nn.Module):
+    """
+    Processes the output of both `SparseArch` (sparse_features) and `DenseArch`
+    (dense_features). Returns the output of the nn.transformerencoder,
+    that takes the combined values of both sparse features and the output of the dense layer,
+    and the dense layer itself (i.e. concat(dense layer output, transformer encoder output).
+    Note: This model is for benchmarking purposes only, i.e. to measure the performance of transformer + embeddings using the dlrm models.
+    It is not intended to increase model convergence metrics.
+    Implemented TE as described here:
+    https://pytorch.org/docs/stable/generated/torch.nn.TransformerEncoder.html?highlight=transformer+encoder#torch.nn.TransformerEncoder
+    BERT Transformer Paper: https://arxiv.org/abs/1810.04805
+    Attention is All you Need: https://arxiv.org/abs/1706.03762
+
+
+    .. note::
+        The dimensionality of the `dense_features` (D) is expected to match the
+        dimensionality of the `sparse_features` so that the dot products between them
+        can be computed.
+    Args:
+        num_sparse_features (int): F.
+        embedding_dim: int,
+        nhead: int, #number of attention heads
+        ntransformer_layers: int, #number of transformer layers.
+    Example::
+        D = 8   #must divisible by number of transformer heads
+        B = 10
+        keys = ["f1", "f2"]
+        F = len(keys)
+        inter_arch = InteractionTransormerArch(num_sparse_features=len(keys))
+        dense_features = torch.rand((B, D))
+        sparse_features = torch.rand((B, F, D))
+        #  B X (D * (F + 1))
+        concat_dense = inter_arch(dense_features, sparse_features)
+    """
+
+    def __init__(
+        self,
+        num_sparse_features: int,
+        embedding_dim: int,
+        nhead: int = 8,
+        ntransformer_layers: int = 4,
+    ) -> None:
+        super().__init__()
+        self.F: int = num_sparse_features
+        self.nhead = nhead
+        self.ntransformer_layers = ntransformer_layers
+        transformer_encoder_layer = nn.TransformerEncoderLayer(
+            d_model=embedding_dim,
+            nhead=self.nhead,
+        )
+        self.interarch_TE = nn.TransformerEncoder(
+            transformer_encoder_layer, num_layers=self.ntransformer_layers
+        )
+
+    def forward(
+        self, dense_features: torch.Tensor, sparse_features: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Args:
+            dense_features (torch.Tensor): an input tensor of size B X D.
+            sparse_features (torch.Tensor): an input tensor of size B X F X D.
+        Returns:
+            torch.Tensor: an output tensor of size B X (D + F + F choose 2).
+        """
+        if self.F <= 0:
+            return dense_features
+        (B, D) = dense_features.shape
+        combined_values = torch.cat(
+            (dense_features.unsqueeze(1), sparse_features), dim=1
+        )
+        # Transformer for Interactions
+        transformer_interactions = self.interarch_TE(combined_values)
+        interactions_flat = torch.reshape(transformer_interactions, (B, -1))
+        return interactions_flat
+
+
+class DLRM_Transformer(DLRM):
+    """
+    Recsys model from "Deep Learning Recommendation Model for Personalization and
+    Recommendation Systems" (https://arxiv.org/abs/1906.00091). Processes sparse
+    features by learning pooled embeddings for each feature. On the interaction layer,
+    the relationship between dense features and sparse features is learned through a transformer encoder layer
+    https://arxiv.org/abs/1706.03762.
+    The module assumes all sparse features have the same embedding dimension
+    (i.e. each EmbeddingBagConfig uses the same embedding_dim).
+    The following notation is used throughout the documentation for the models:
+    * F: number of sparse features
+    * D: embedding_dimension of sparse features
+    * B: batch size
+    * num_features: number of dense features
+    Args:
+        embedding_bag_collection (EmbeddingBagCollection): collection of embedding bags
+            used to define `SparseArch`.
+        dense_in_features (int): the dimensionality of the dense input features.
+        dense_arch_layer_sizes (List[int]): the layer sizes for the `DenseArch`.
+        over_arch_layer_sizes (List[int]): the layer sizes for the `OverArch`.
+            The output dimension of the `InteractionArch` should not be manually
+            specified here.
+        nhead: int: Number of multi-attention heads
+        ntransformer_layers: int: Number of transformer encoder layers
+        dense_device (Optional[torch.device]): default compute device.
+    Example::
+        B = 2
+        D = 8
+        eb1_config = EmbeddingBagConfig(
+           name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1", "f3"]
+        )
+        eb2_config = EmbeddingBagConfig(
+           name="t2",
+           embedding_dim=D,
+           num_embeddings=100,
+           feature_names=["f2"],
+        )
+        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        model = DLRM_Transformer(
+           embedding_bag_collection=ebc,
+           dense_in_features=100,
+           dense_arch_layer_sizes=[20],
+           over_arch_layer_sizes=[5, 1],
+        )
+        features = torch.rand((B, 100))
+        #     0       1
+        # 0   [1,2] [4,5]
+        # 1   [4,3] [2,9]
+        # ^
+        # feature
+        sparse_features = KeyedJaggedTensor.from_offsets_sync(
+           keys=["f1", "f3"],
+           values=torch.tensor([1, 2, 4, 5, 4, 3, 2, 9]),
+           offsets=torch.tensor([0, 2, 4, 6, 8]),
+        )
+        logits = model(
+           dense_features=features,
+           sparse_features=sparse_features,
+        )
+    """
+
+    def __init__(
+        self,
+        embedding_bag_collection: EmbeddingBagCollection,
+        dense_in_features: int,
+        dense_arch_layer_sizes: List[int],
+        over_arch_layer_sizes: List[int],
+        nhead: int = 8,
+        ntransformer_layers: int = 4,
+        dense_device: Optional[torch.device] = None,
+    ) -> None:
+        # initialize DLRM
+        # sparse arch and dense arch are initialized via DLRM
+        super().__init__(
+            embedding_bag_collection,
+            dense_in_features,
+            dense_arch_layer_sizes,
+            over_arch_layer_sizes,
+            dense_device,
+        )
+        embedding_dim: int = embedding_bag_collection.embedding_bag_configs()[
+            0
+        ].embedding_dim
+        num_sparse_features: int = len(self.sparse_arch.sparse_feature_names)
+        self.inter_arch = InteractionTransformerArch(
+            num_sparse_features=num_sparse_features,
+            embedding_dim=embedding_dim,
+            nhead=nhead,
+            ntransformer_layers=ntransformer_layers,
+        )
+        over_in_features: int = (num_sparse_features + 1) * embedding_dim
+        self.over_arch = OverArch(
+            in_features=over_in_features,
+            layer_sizes=over_arch_layer_sizes,
+            device=dense_device,
+        )


### PR DESCRIPTION
Summary:
Enabling the transformer_encoder layer in the torchrec DLRM example model after the linear projection (MLP) in the interaction layer.

       P(click)
          |
      Overach(MLP())
          |
   Interaction(TransformerEncoder(dense, sparse))
          |
     cat(dense, sparse)

Differential Revision: D41251824

