### PR TITLE
Implement the compute function for bucket NE and bucket calibration

### DIFF
--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, cast, List, Optional, Type
+from typing import Any, cast, Dict, List, Optional, Type
 
 import torch
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
@@ -107,6 +107,7 @@ class AUCMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -69,6 +69,7 @@ class CalibrationMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -65,6 +65,7 @@ class CTRMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -21,6 +21,7 @@ The key is defined as the following format:
 """
 
 from enum import Enum
+from typing import Optional
 
 
 class StrValueMixin:
@@ -97,12 +98,13 @@ def compose_metric_namespace(
 def compose_customized_metric_key(
     namespace: str,
     metric_name: str,
+    description: Optional[str] = None,
 ) -> str:
     r"""Get the metric key. The input are unrestricted (string) namespace and
     metric_name. This API should only be used by compose_metric_key() and
     state metrics as the keys of state metrics are unknown.
     """
-    return f"{namespace}|{metric_name}"
+    return f"{namespace}|{metric_name}{description or ''}"
 
 
 def compose_metric_key(
@@ -110,8 +112,11 @@ def compose_metric_key(
     task_name: str,
     metric_name: MetricNameBase,
     metric_prefix: MetricPrefix = MetricPrefix.DEFAULT,
+    description: Optional[str] = None,
 ) -> str:
     r"""Get the metric key based on the input parameters"""
     return compose_customized_metric_key(
-        compose_metric_namespace(namespace, task_name), f"{metric_prefix}{metric_name}"
+        compose_metric_namespace(namespace, task_name),
+        f"{metric_prefix}{metric_name}",
+        description,
     )

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -84,6 +84,7 @@ class MSEMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/multiclass_recall.py
+++ b/torchrec/metrics/multiclass_recall.py
@@ -113,6 +113,7 @@ class MulticlassRecallMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -119,6 +119,7 @@ class NEMetricComputation(RecMetricComputation):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
             raise RecMetricException(

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -218,6 +218,7 @@ class RecMetricComputation(Metric, abc.ABC):
         predictions: Optional[torch.Tensor],
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
     ) -> None:  # pragma: no cover
         pass
 
@@ -564,6 +565,7 @@ class RecMetric(nn.Module, abc.ABC):
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: Optional[RecModelOutput],
+        **kwargs: Dict[str, Any],
     ) -> None:
         if self._fused_update_limit > 0:
             self._update_buffers[self.PREDICTIONS].append(predictions)
@@ -709,6 +711,7 @@ class RecMetricList(nn.Module):
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: RecModelOutput,
+        **kwargs: Dict[str, Any],
     ) -> None:
         for metric in self.rec_metrics:
             metric.update(predictions=predictions, labels=labels, weights=weights)


### PR DESCRIPTION
Summary:
Tsia, create a MetricComputationReport for each bucket, and the metric is displayed as `namespace + task_name + metric_prefix + metric_name + bucketization_custom_metric_name + bucket_id`.
For example `bucket_ne-DefaultTask|lifetime_bucket_ne_bucketization_custom_metric_name_1"`

Differential Revision: D41573780

