### PR TITLE
torchdeploy not support QualnameMetadata, serialize to json

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -160,6 +160,14 @@ class PredictFactory(abc.ABC):
         """
         return {}
 
+    def qualname_metadata_json(self) -> str:
+        """
+        Serialize the qualname metadata to JSON, for ease of parsing with torch::deploy environments.
+        """
+        return json.dumps(
+            {key: asdict(value) for key, value in self.qualname_metadata().items()}
+        )
+
     def model_inputs_data(self) -> Dict[str, Any]:
         """
         Returns a dict of various data for benchmarking input generation.


### PR DESCRIPTION
Summary:
I find QualnameMetadata actually not parsed into TrecGpuMon, it caused atm request not dealed correctly.

Even after  QualnameMetadata is set up, I still see
" TorchRec PredictorFactory is missing qualname_metadata to configure non-forward requests executions(whether to run preproc etc.)."

And the root cause:
```
Error: multipy/runtime/interpreter/interpreter_impl.cpp:273: Exception Caught inside torch::deploy embedded library:
Tracer cannot infer type of {'atm_send': QualNameMetadata(need_preproc=True), 'atm_recv_one_per_region': QualNameMetadata(need_preproc=False), 'atm_recv_all_in_home_region': QualNameMetadata(need_preproc=False)}
:Only tensors and (possibly nested) tuples of tensors, lists, or dictsare supported as inputs or outputs of traced functions, but instead got value of type QualNameMetadata.
Exception raised from toTypeInferredIValue at caffe2/torch/csrc/jit/python/pybind_utils.h:552 (most recent call first):
```

Serialize it into JSON for easy parse.

Differential Revision: D41574310

