### PR TITLE
Fix the setting for MultiClassRecallDefinition in pyper frontent

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -32,6 +32,7 @@ from torchrec.metrics.metrics_namespace import (
 )
 from torchrec.metrics.model_utils import parse_task_model_outputs
 from torchrec.metrics.mse import MSEMetric
+from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.rec_metric import RecMetric, RecMetricList
 from torchrec.metrics.throughput import ThroughputMetric
@@ -45,6 +46,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.CALIBRATION: CalibrationMetric,
     RecMetricEnum.AUC: AUCMetric,
     RecMetricEnum.MSE: MSEMetric,
+    RecMetricEnum.MULTICLASS_RECALL: MulticlassRecallMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -22,6 +22,7 @@ class RecMetricEnum(RecMetricEnumBase):
     AUC = "auc"
     CALIBRATION = "calibration"
     MSE = "mse"
+    MULTICLASS_RECALL = "multiclass_recall"
 
 
 @dataclass(unsafe_hash=True, eq=True)


### PR DESCRIPTION
Summary:
Tsia
Previously the `MultiClassRecallDefinition` definition in `METRICS_DATACLASS_MAP` pointed to the NE metric, which was not correct and probably because multiclass_recall metric wasn't available. Correcting it to MULTICLASS_RECALL metric

Reviewed By: stepsma

Differential Revision: D41314560

