### PR TITLE
Optimized LowRankCrossNet

### DIFF
--- a/torchrec/modules/crossnet.py
+++ b/torchrec/modules/crossnet.py
@@ -28,10 +28,10 @@ class CrossNet(torch.nn.Module):
     (NxN), such that the crossing effect can cover all bits on each layer. On each layer
     l, the tensor is transformed into:
 
-    .. math ::    x_{l+1} = x_0 * (W_l \dot x_l + b_l) + x_l
+    .. math ::    x_{l+1} = x_0 * (W_l \cdot x_l + b_l) + x_l
 
     where :math:`W_l` is a square matrix :math:`(NxN)`, :math:`*` means element-wise
-    multiplication, :math:`\dot` means matrix multiplication.
+    multiplication, :math:`\cdot` means matrix multiplication.
 
     Args:
         in_features (int): the dimension of the input.
@@ -92,15 +92,15 @@ class CrossNet(torch.nn.Module):
 class LowRankCrossNet(torch.nn.Module):
     r"""
     Low Rank Cross Net is a highly efficient cross net. Instead of using full rank cross
-    matrices (NxN) at each layer, it will use two kernels :math:`W (N * r)` and
-    :math:`V (r * N)`, where `r << N`, to simplify the matrix multiplication.
+    matrices (NxN) at each layer, it will use two kernels :math:`W (N x r)` and
+    :math:`V (r x N)`, where `r << N`, to simplify the matrix multiplication.
 
     On each layer l, the tensor is transformed into:
 
-    .. math::    x_{l+1} = x_0 * (W_l \dot (V_l \dot x_l) + b_l) + x_l
+    .. math::    x_{l+1} = x_0 * (W_l \cdot (V_l \cdot x_l) + b_l) + x_l
 
     where :math:`W_l` is either a vector, :math:`*` means element-wise multiplication,
-    and :math:`\dot` means matrix multiplication.
+    and :math:`\cdot` means matrix multiplication.
 
     NOTE:
         Rank `r` should be chosen smartly. Usually, we  expect `r < N/2` to have
@@ -110,8 +110,8 @@ class LowRankCrossNet(torch.nn.Module):
     Args:
         in_features (int): the dimension of the input.
         num_layers (int): the number of layers in the module.
-        low_rank (int): the rank setup of the cross matrix (default = 0).
-            Value must be always >= 0.
+        low_rank (int): the rank setup of the cross matrix (default = 1).
+            Value must be always >= 1.
 
     Example::
 
@@ -279,7 +279,7 @@ class LowRankMixtureCrossNet(torch.nn.Module):
 
     and each :math:`expert_i` is defined as:
 
-    .. math::   expert_i = x_0 * (U_{li} \dot g(C_{li} \dot g(V_{li} \dot x_l)) + b_l)
+    .. math::   expert_i = x_0 * (U_{li} \cdot g(C_{li} \cdot g(V_{li} \cdot x_l)) + b_l)
 
     where :math:`U_{li} (N, r)`, :math:`C_{li} (r, r)` and :math:`V_{li} (r, N)` are
     low-rank matrices, :math:`*` means element-wise multiplication, :math:`x` means
@@ -291,8 +291,8 @@ class LowRankMixtureCrossNet(torch.nn.Module):
     Args:
         in_features (int): the dimension of the input.
         num_layers (int): the number of layers in the module.
-        low_rank (int): the rank setup of the cross matrix (default = 0).
-            Value must be always >= 0
+        low_rank (int): the rank setup of the cross matrix (default = 1).
+            Value must be always >= 1
         activation (Union[torch.nn.Module, Callable[[torch.Tensor], torch.Tensor]]):
             the non-linear activation function, used in defining experts.
             Default is relu.


### PR DESCRIPTION
Coauthors: [Nan Zheng](https://github.com/nanz-nv) and [Tomasz Grel](https://github.com/tgrel) from Nvidia

Hello, we're offering improvement of [`LowRankCrossNet` model implementation](https://github.com/pytorch/torchrec/blob/09b33210d0643157afd27e4340e4868b3f367336/torchrec/modules/crossnet.py#L92-L188). It's rewritten using `torch.nn.functional.linear` instead of `torch.matmul` and avoids unsqueezing and squeezing back the input to superfluous 3rd dimension (of length 1). Thanks to these changes, more efficient GEMM kernels are used underneath instead of batched GEMV kernels.

For an example input with `(4096, 3456)` shape and `num_layers=3` interaction layers the speedup of the `LowRankCrossNet` module on GPU A100 device is:
*  **32x** when using [TF32](https://blogs.nvidia.com/blog/2020/05/14/tensorfloat-32-precision-format/) (by enabling `torch.backends.cuda.matmul.allow_tf32` flag)
* **10x** w/o TF32.

For DCN V2 model included in [TorchRec DLRM Example](https://github.com/facebookresearch/dlrm/tree/main/torchrec_dlrm) this results in about 15x and 5x overall speedup w/ and w/o TF32, respectively (with local batch size 4096).

Credits to Tomek @tgrel and Nan @nanz-nv for helping to identify and improve this.