### PR TITLE
SingleGPUExecutor propagate batchSize in response

### DIFF
--- a/torchrec/inference/src/SingleGPUExecutor.cpp
+++ b/torchrec/inference/src/SingleGPUExecutor.cpp
@@ -165,6 +165,7 @@ void SingleGPUExecutor::process() {
           request->event->synchronize();
           for (auto& context : request->contexts) {
             auto response = std::make_unique<PredictionResponse>();
+            response->batchSize = context.batchSize;
             response->predictions = result;
             context.promise.setValue(std::move(response));
           }


### PR DESCRIPTION
Summary: Propagate batchSize in SingleGpuExecutor

Reviewed By: zyan0

Differential Revision:
D41695774

LaMa Project: L1138451

