### PR TITLE
For non-forward methods use the right input/output metadata

### DIFF
--- a/torchrec/inference/src/SingleGPUExecutor.cpp
+++ b/torchrec/inference/src/SingleGPUExecutor.cpp
@@ -165,6 +165,7 @@ void SingleGPUExecutor::process() {
           request->event->synchronize();
           for (auto& context : request->contexts) {
             auto response = std::make_unique<PredictionResponse>();
+            response->batchSize = context.batchSize;
             response->predictions = result;
             context.promise.setValue(std::move(response));
           }


### PR DESCRIPTION
Summary: Using metadata of the non-forward method (was always 'forward's metadata before)

Reviewed By: zyan0

Differential Revision:
D41695773

LaMa Project: L1138451

