### PR TITLE
Support empty KJT for KJT.to_dict()

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -622,6 +622,9 @@ def _maybe_compute_kjt_to_jt_dict(
     weights: Optional[torch.Tensor],
     jt_dict: Optional[Dict[str, JaggedTensor]],
 ) -> Dict[str, JaggedTensor]:
+    if not length_per_key:
+        return {}
+
     if jt_dict is None:
         _jt_dict: Dict[str, JaggedTensor] = {}
         values_list = torch.split(values, length_per_key)


### PR DESCRIPTION
Summary:
# Problem

KJT.to_dict() doesn't support KJT being empty, however other methods support empty KJT.

# Solution

Just need to test this special condition and handle it separately.

Differential Revision:
D41743312

LaMa Project: L1078771

