### PR TITLE
make pg, topology and sharders optional to the planner

### DIFF
--- a/examples/retrieval/two_tower_train.py
+++ b/examples/retrieval/two_tower_train.py
@@ -148,21 +148,11 @@ def train(
         [EmbeddingBagCollectionSharder(fused_params=fused_params)],
     )
 
-    # TODO: move pg to the EmbeddingShardingPlanner (out of collective_plan) and make optional
-    # TODO: make Topology optional argument to EmbeddingShardingPlanner
     # TODO: give collective_plan a default sharders
     # TODO: once this is done, move defaults out of DMP and just get from ShardingPlan (eg _sharding_map should not exist - just use the plan)
-    plan = EmbeddingShardingPlanner(
-        topology=Topology(
-            world_size=world_size,
-            compute_device=device.type,
-        ),
-    ).collective_plan(
+    plan = EmbeddingShardingPlanner().collective_plan(
         module=two_tower_model,
         sharders=sharders,
-        # pyre-fixme[6]: For 3rd param expected `ProcessGroup` but got
-        #  `Optional[ProcessGroup]`.
-        pg=dist.GroupMember.WORLD,
     )
     model = DistributedModelParallel(
         module=two_tower_train_task,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -10,9 +10,12 @@ from functools import reduce
 from time import perf_counter
 from typing import cast, Dict, List, Optional, Tuple, Union
 
+import torch
+
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
+from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
@@ -40,7 +43,7 @@ from torchrec.distributed.planner.types import (
     StorageReservation,
     Topology,
 )
-from torchrec.distributed.sharding_plan import placement
+from torchrec.distributed.sharding_plan import get_default_sharders, placement
 from torchrec.distributed.types import (
     EnumerableShardingSpec,
     ModuleSharder,
@@ -97,7 +100,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
 
     def __init__(
         self,
-        topology: Topology,
+        topology: Optional[Topology] = None,
         batch_size: Optional[int] = None,
         enumerator: Optional[Enumerator] = None,
         storage_reservation: Optional[StorageReservation] = None,
@@ -108,6 +111,12 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         debug: bool = True,
     ) -> None:
+        if topology is None:
+            topology = Topology(
+                local_world_size=get_local_size(),
+                world_size=dist.get_world_size(),
+                compute_device="cuda" if torch.cuda.is_available() else "cpu",
+            )
         self._topology = topology
         self._batch_size: int = batch_size if batch_size else BATCH_SIZE
         self._constraints = constraints
@@ -156,12 +165,15 @@ class EmbeddingShardingPlanner(ShardingPlanner):
     def collective_plan(
         self,
         module: nn.Module,
-        sharders: List[ModuleSharder[nn.Module]],
-        pg: dist.ProcessGroup,
+        sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        pg: Optional[dist.ProcessGroup] = dist.GroupMember.WORLD,
     ) -> ShardingPlan:
         """
         Call self.plan(...) on rank 0 and broadcast
         """
+        assert pg is not None, "Process group is not initialized"
+        if sharders is None:
+            sharders = get_default_sharders()
         return invoke_on_rank_and_broadcast_result(
             pg,
             0,


### PR DESCRIPTION
Summary:
within planner, we can get reasonable defaults for
Topology (use current topology, just like DMP does)
collective plan pg + sharders (use existing pg + default sharders, just like DMP does)

This reduces boilerplate

Differential Revision: D41755857

