### PR TITLE
Revert InMemoryBinaryCriteoIterDataPipe from IterableDataset to IterDataPipe

### DIFF
--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -16,7 +16,7 @@ import torch
 import torch.utils.data.datapipes as dp
 from iopath.common.file_io import PathManager, PathManagerFactory
 from pyre_extensions import none_throws
-from torch.utils.data import IterableDataset, IterDataPipe
+from torch.utils.data import IterDataPipe
 from torchrec.datasets.utils import (
     Batch,
     LoadFiles,
@@ -660,7 +660,7 @@ class BinaryCriteoUtils:
             print(f"Copying over {path_to_original} to {val_train_path}")
 
 
-class InMemoryBinaryCriteoIterDataPipe(IterableDataset):
+class InMemoryBinaryCriteoIterDataPipe(IterDataPipe):
     """
     Datapipe designed to operate over binary (npy) versions of Criteo datasets. Loads
     the entire dataset into memory to prevent disk speed from affecting throughout. Each


### PR DESCRIPTION
Summary: After D33955933 is landed, the OOM issue should have been fixed for `IterDataPipe`. So reverting the original Diff D33965445 (https://github.com/pytorch/torchrec/commit/bc5d3105ecc95326f7d283b29851647fbf60f1e5) to provide the feasiblity to use DataLoader2 to load this Dataset.

Differential Revision: D41781152

