### PR TITLE
[tde] Migrate PS and PS binding

### DIFF
--- a/torchrec/csrc/dynamic_embedding/CMakeLists.txt
+++ b/torchrec/csrc/dynamic_embedding/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(tde_cpp_objs
             OBJECT
             bind.cpp
             id_transformer_wrapper.cpp
+            ps.cpp
             details/clz_impl.cpp
             details/ctz_impl.cpp
             details/random_bits_generator.cpp

--- a/torchrec/csrc/dynamic_embedding/bind.cpp
+++ b/torchrec/csrc/dynamic_embedding/bind.cpp
@@ -10,6 +10,7 @@
 
 #include <torchrec/csrc/dynamic_embedding/details/io_registry.h>
 #include <torchrec/csrc/dynamic_embedding/id_transformer_wrapper.h>
+#include <torchrec/csrc/dynamic_embedding/ps.h>
 
 namespace torchrec {
 TORCH_LIBRARY(tde, m) {
@@ -26,5 +27,22 @@ TORCH_LIBRARY(tde, m) {
       .def("transform", &IDTransformerWrapper::transform)
       .def("evict", &IDTransformerWrapper::evict)
       .def("save", &IDTransformerWrapper::save);
+
+  m.class_<LocalShardList>("LocalShardList")
+      .def(torch::init([]() { return c10::make_intrusive<LocalShardList>(); }))
+      .def("append", &LocalShardList::emplace_back);
+
+  m.class_<FetchHandle>("FetchHandle").def("wait", &FetchHandle::wait);
+
+  m.class_<PS>("PS")
+      .def(torch::init<
+           std::string,
+           c10::intrusive_ptr<LocalShardList>,
+           int64_t,
+           int64_t,
+           std::string,
+           int64_t>())
+      .def("fetch", &PS::fetch)
+      .def("evict", &PS::evict);
 }
 } // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/details/notification.h
+++ b/torchrec/csrc/dynamic_embedding/details/notification.h
@@ -9,14 +9,17 @@
 #pragma once
 #include <condition_variable>
 #include <mutex>
+#include <torch/torch.h>
 
 namespace torchrec {
 
 /**
  * Multi-thread notification
  */
-class Notification {
+class Notification : public torch::CustomClassHolder {
  public:
+  Notification() = default;
+
   void done();
   void wait();
 

--- a/torchrec/csrc/dynamic_embedding/ps.cpp
+++ b/torchrec/csrc/dynamic_embedding/ps.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <torchrec/csrc/dynamic_embedding/ps.h>
+#include <torchrec/csrc/dynamic_embedding/details/io.h>
+
+namespace torchrec {
+
+c10::intrusive_ptr<FetchHandle> PS::fetch(
+    torch::Tensor ids_to_fetch,
+    int64_t time,
+    bool reinit,
+    double weight_init_min,
+    double weight_init_max) {
+  std::lock_guard<std::mutex> lock(mu_);
+  torch::NoGradGuard no_grad;
+
+  auto [local_global_ids, local_cache_ids] = filter_local_ids(ids_to_fetch);
+  if (local_global_ids.empty()) {
+    return c10::make_intrusive<FetchHandle>(time, c10::intrusive_ptr<PS>());
+  }
+
+  fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
+  c10::intrusive_ptr<Notification> notification =
+      fetch_notifications_.back().second;
+  // Does not support multiple col ids at the moment.
+  std::vector<int64_t> col_ids{0};
+  uint32_t num_os_ids = os_ids_.size();
+  io_.fetch(
+      table_name_,
+      std::move(local_global_ids),
+      col_ids,
+      num_os_ids,
+      torch::kF32,
+      [=, this, cache_ids_to_fetch = std::move(local_cache_ids)](
+          auto&& val) {
+        TORCH_CHECK(val.size() == cache_ids_to_fetch.size());
+        for (uint32_t i = 0; i < cache_ids_to_fetch.size(); ++i) {
+          int64_t cache_id = cache_ids_to_fetch[i];
+          auto& fetched = val[i];
+          if (!fetched.defined()) {
+            if (reinit) {
+              std::vector<torch::Tensor> tensors = get_tensor_views(cache_id);
+              tensors[0].uniform_(weight_init_min, weight_init_max);
+              // optimizer states will be set to zero
+              for (uint32_t j = 1; j < num_os_ids; ++j) {
+                tensors[j].zero_();
+              }
+            }
+            continue;
+          }
+
+          std::vector<torch::Tensor> tensors = get_tensor_views(cache_id);
+          for (uint32_t j = 0; j < num_os_ids; ++j) {
+            tensors[j].copy_(fetched.slice(0, j, j + 1));
+          }
+        }
+        notification->done();
+      });
+  // `unsafe_reclain_from_nonowning` is the `instrusive_ptr` version of
+  // `enable_shared_from_this`
+  return c10::make_intrusive<FetchHandle>(
+      time, c10::intrusive_ptr<PS>::unsafe_reclaim_from_nonowning(this));
+}
+
+void PS::evict(torch::Tensor ids_to_evict) {
+  std::lock_guard<std::mutex> lock(mu_);
+  torch::NoGradGuard no_grad;
+  // make sure all previous fetches are done.
+  synchronize_fetch();
+
+  auto [local_global_ids, local_cache_ids] = filter_local_ids(ids_to_evict);
+  if (local_global_ids.empty()) {
+    return;
+  }
+
+  // Does not support multiple col ids at the moment.
+  std::vector<int64_t> col_ids{0};
+  uint32_t num_os_ids = os_ids_.size();
+  uint32_t num_ids_to_fetch = local_global_ids.size();
+
+  Notification notification;
+  // Done first so that the Wait after preparing the first chunk won't stuck.
+  notification.done();
+  // The shared data for all chunks.
+  std::vector<uint64_t> offsets;
+  offsets.resize(num_ids_per_chunk_ * num_os_ids * col_ids.size() + 1);
+  // Evict by chunks
+  for (uint32_t i = 0; i < num_ids_to_fetch; i += num_ids_per_chunk_) {
+    uint32_t num_ids_in_chunk = std::min(
+        static_cast<uint32_t>(num_ids_per_chunk_), num_ids_to_fetch - i);
+    uint32_t data_size = num_ids_in_chunk * num_os_ids * col_ids.size();
+    uint32_t offsets_size = num_ids_in_chunk * num_os_ids * col_ids.size() + 1;
+
+    std::vector<torch::Tensor> all_tensors;
+    for (uint32_t j = i; j < i + num_ids_in_chunk; ++j) {
+      int64_t cache_id = local_cache_ids[j];
+      std::vector<torch::Tensor> tensors = get_tensor_views(cache_id);
+      all_tensors.insert(all_tensors.end(), tensors.begin(), tensors.end());
+    }
+    torch::Tensor data = torch::cat(all_tensors, 0).cpu();
+    TORCH_CHECK(data.numel() == data_size * col_size_);
+
+    offsets[0] = 0;
+    for (uint32_t j = 0; j < all_tensors.size(); ++j) {
+      offsets[j + 1] = offsets[j] + all_tensors[j].numel() * all_tensors[j].element_size();
+    }
+    // waiting for the Push of last chunk finishes.
+    notification.wait();
+    notification.clear();
+    io_.push(
+        table_name_,
+        std::span{local_global_ids.data() + i, num_ids_in_chunk},
+        col_ids,
+        os_ids_,
+        std::span{
+            reinterpret_cast<uint8_t*>(data.data_ptr<float>()), data_size * sizeof(float)},
+        std::span{offsets.data(), offsets_size},
+        [&notification] { notification.done(); });
+  }
+  notification.wait();
+}
+
+void PS::synchronize_fetch(int64_t time) {
+  while (!fetch_notifications_.empty()) {
+    auto& [t, notification] = fetch_notifications_.front();
+    if (t != time && time >= 0) {
+      break;
+    }
+    notification->wait();
+    fetch_notifications_.pop_front();
+  }
+}
+
+std::vector<torch::Tensor> PS::get_tensor_views(int64_t cache_id) {
+  for (auto& shard : *shards_) {
+    if (shard.has(cache_id)) {
+      return shard.get_tensor_view(cache_id);
+    }
+  }
+  TORCH_CHECK(false, "all local shards do not contain cache id ", cache_id);
+}
+
+std::tuple<std::vector<int64_t>, std::vector<int64_t>> PS::filter_local_ids(const torch::Tensor& ids) {
+  std::vector<int64_t> local_global_ids;
+  std::vector<int64_t> local_cache_ids;
+  TORCH_CHECK(ids.is_contiguous());
+  TORCH_CHECK(ids.dim() == 2);
+  auto* ids_ptr = ids.data_ptr<int64_t>();
+  int64_t numel = ids.numel();
+  for (int64_t i = 0; i < numel; i += 2) {
+    auto cache_id = ids_ptr[i + 1];
+    if (std::any_of(shards_->begin(), shards_->end(), [&](auto&& shard) {
+          return shard.has(cache_id);
+        })) {
+      auto global_id = ids_ptr[i];
+      local_global_ids.emplace_back(global_id);
+      local_cache_ids.emplace_back(cache_id);
+    }
+  }
+  return {std::move(local_global_ids), std::move(local_cache_ids)};
+}
+
+} // namespace torchrec

--- a/torchrec/csrc/dynamic_embedding/ps.h
+++ b/torchrec/csrc/dynamic_embedding/ps.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <torch/custom_class.h>
+#include <torch/torch.h>
+
+#include <deque>
+#include <utility>
+#include <torchrec/csrc/dynamic_embedding/details/io.h>
+#include <torchrec/csrc/dynamic_embedding/details/notification.h>
+
+namespace torchrec {
+
+/**
+ * @brief A local shard of embedding tensor with its range of row.
+ * It not only stores the parameter tensor of the shard, but also
+ * the tensor of this optimizer states.
+ * 
+ */
+struct LocalShard {
+  int64_t row_start;
+  int64_t row_size;
+  std::vector<torch::Tensor> tensors;
+
+  /**
+   * @brief Check if a certain cache id is in this Shard
+   * 
+   */
+  [[nodiscard]] bool has(int64_t cache_id) const {
+    return row_start <= cache_id && cache_id < row_start + row_size;
+  }
+
+  [[nodiscard]] std::vector<torch::Tensor> get_tensor_view(
+      int64_t cache_id) const {
+    std::vector<torch::Tensor> result;
+    result.reserve(tensors.size());
+    for (auto& tensor : tensors) {
+      result.emplace_back(
+          tensor.slice(0, cache_id - row_start, cache_id - row_start + 1));
+    }
+    return result;
+  }
+};
+
+/**
+ * @brief A helper class to store all the local shard on the current rank,
+ * basically `std::vecotr<LocalShard>`. The reason for this class is that all
+ * shards could share the same refcount.
+ * 
+ */
+class LocalShardList : public torch::CustomClassHolder {
+  using Container = std::vector<LocalShard>;
+
+ public:
+  void emplace_back(
+      int64_t row_start,
+      int64_t col_start,
+      int64_t row_size,
+      int64_t col_size,
+      std::vector<torch::Tensor> tensors) {
+    // col_start/col_size not supported now.
+    shards_.emplace_back(LocalShard{
+        .row_start = row_start,
+        .row_size = row_size,
+        .tensors = std::move(tensors)});
+  }
+
+  Container::const_iterator begin() const {
+    return shards_.begin();
+  }
+
+  Container::const_iterator end() const {
+    return shards_.end();
+  }
+
+  Container shards_;
+};
+
+class FetchHandle;
+
+class PS : public torch::CustomClassHolder {
+ public:
+  PS(std::string table_name,
+     c10::intrusive_ptr<LocalShardList> shards,
+     int64_t col_size,
+     int64_t num_optimizer_stats,
+     const std::string& io_config,
+     int64_t chunk_size)
+      : table_name_(std::move(table_name)),
+        shards_(std::move(shards)),
+        col_size_(col_size),
+        os_ids_(num_optimizer_stats),
+        io_(io_config),
+        num_ids_per_chunk_(chunk_size / col_size_ / num_optimizer_stats) {
+    TORCH_CHECK(num_ids_per_chunk_ > 0, "chunk size too small");
+    for (int64_t i = 0; i < num_optimizer_stats; ++i) {
+      os_ids_[i] = i;
+    }
+  }
+
+  /**
+   * @brief Fetch the embedding from remote PS into local GPU embedding asynchronously.
+   * 
+   * @param ids_to_fetch ids to fetch, pairs of global id and cache id.
+   * @param time the timestamp of the fetch
+   * @param reinit whether to re-initialize the parameter and optimizer states
+   * if the id to fetch is not stored in PS. The parameter will be re-initialize
+   * with `uniform(weight_init_min, weight_init_max)` and the optimizer states
+   * will be re-initialized with 0.
+   * @return The handle used to synchronize the fetch.
+   */
+  c10::intrusive_ptr<FetchHandle> fetch(
+      torch::Tensor ids_to_fetch,
+      int64_t time,
+      bool reinit,
+      double weight_init_min,
+      double weight_init_max);
+  /**
+   * @brief Synchronize all the fetches till timestamp `time`,
+   * if `time` is -1, then synchronize all previous fetches.
+   * 
+   */
+  void synchronize_fetch(int64_t time = -1);
+
+  /**
+   * @brief Evict ids back to PS synchronously.
+   * 
+   */
+  void evict(torch::Tensor ids_to_evict);
+
+ private:
+  std::vector<torch::Tensor> get_tensor_views(int64_t cache_id);
+  std::tuple<std::vector<int64_t>, std::vector<int64_t>> filter_local_ids(const torch::Tensor& ids);
+
+  // We need a mutex because the evict and fetch may happen in different thread.
+  std::mutex mu_;
+  std::string table_name_;
+  c10::intrusive_ptr<LocalShardList> shards_;
+  int64_t col_size_;
+  std::vector<uint32_t> os_ids_;
+  int64_t num_ids_per_chunk_;
+  IO io_;
+  std::deque<std::pair<int64_t, c10::intrusive_ptr<Notification>>>
+      fetch_notifications_;
+};
+
+struct FetchHandle : public torch::CustomClassHolder {
+ public:
+  FetchHandle(int64_t time, c10::intrusive_ptr<PS> ps)
+      : time_(time), ps_(std::move(ps)) {}
+  void wait() {
+    if (ps_ != nullptr)
+      ps_->synchronize_fetch(time_);
+  }
+
+ private:
+  int64_t time_;
+  c10::intrusive_ptr<PS> ps_; // not owned
+};
+
+} // namespace torchrec


### PR DESCRIPTION
This PR is migrating the PS interface of tde, which could fetch and evict ids from PS to local tensor shard by a certain chunk size.

After this PR, we have already migrate all the C++ part (except a high performance IDTransformer, CachelineIDTransformer) into the root folder of torchrec. Maybe we could start developing the python API around them?

Thank you for your time on this PR.

gently ping @divchenko @colin2328 @reyoung