### PR TITLE
warmup acquire session

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -71,6 +71,10 @@ class GPUExecutor {
   std::shared_ptr<IGPUExecutorObserver> observer_;
   std::function<void()> warmupFn_;
 
+  std::mutex warmUpMutex_;
+  std::condition_variable warmUpCV_;
+  int warmUpCounter_{0};
+
   size_t numThreadsPerGPU_;
 };
 


### PR DESCRIPTION
Summary: deploy acquire session on obj model will trigger lazy unpickle(), which leads runtime serving to be slow long for the first requests. Pr-acquire the sessions before start serving to work around.

Reviewed By: zyan0

Differential Revision: D41761387

