### PR TITLE
Empty qualname must be treated as forward

### DIFF
--- a/torchrec/inference/src/SingleGPUExecutor.cpp
+++ b/torchrec/inference/src/SingleGPUExecutor.cpp
@@ -165,6 +165,7 @@ void SingleGPUExecutor::process() {
           request->event->synchronize();
           for (auto& context : request->contexts) {
             auto response = std::make_unique<PredictionResponse>();
+            response->batchSize = context.batchSize;
             response->predictions = result;
             context.promise.setValue(std::move(response));
           }


### PR DESCRIPTION
Summary:
Some clients send empty qualName in requests which must be treated as 'forward'

1.
There were multiple places where 'forward' behavior was checked as == kFullyLocalQualName => unifying this check to
`qualName.empty() || qualName == sigrid::kFullyLocalQualName || qualName == sigrid::kDisaggRemoteQualName;`

Added test with empty qualName to check if it is treated as `forward` - runs preproc etc.

2. For empty qualName we need to use 'forward' metadata =>
```
std::string getModelMethodName(const std::string& qualName) {
  return isForwardRequest(qualName) ? "forward" : qualName;
}
```
this method is for metadata_method_name

Reviewed By: zyan0

Differential Revision:
D41800596

LaMa Project: L1138451

