### PR TITLE
Fix train/val/test for model using multiple train pipelines (#308)

### DIFF
--- a/torchrec/datasets/random.py
+++ b/torchrec/datasets/random.py
@@ -5,7 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterator, List, Optional
+import sys
+from typing import cast, Iterator, List, Optional
 
 import torch
 from torch.utils.data.dataset import IterableDataset
@@ -183,6 +184,10 @@ class RandomRecDataset(IterableDataset[Batch]):
             num_batches=num_batches,
             num_generated_batches=num_generated_batches,
         )
+        self.num_batches: int = cast(int, num_batches if not None else sys.maxsize)
 
     def __iter__(self) -> Iterator[Batch]:
         return iter(self.batch_generator)
+
+    def __len__(self) -> int:
+        return self.num_batches

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -575,3 +575,13 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._batch_ip1 = batch_ip2
 
         return output
+
+    def sync_forward(self) -> None:
+        """
+        Syncs `PipelinedForward` for sharded modules with context and dist stream of the
+        current train pipeline. Used when switching between train pipelines for the same
+        model.
+        """
+        for module in self._pipelined_modules:
+            module.forward._context = self._context
+            module.forward._dist_stream = self._data_dist_stream


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/dlrm/pull/308

The new version of DLRM uses multiple train pipelines for train/val/test steps. However, each train pipeline will bind its own context and dist stream to each sharded module's PipelinedForward, so continuing training after switching between multiple train pipelines will yield the wrong result because the bound context will be from the previous train pipeline used. To fix this we add a `sync_forward` method to sync all the sharded module's forwards with the current pipeline and call the method before switching pipelines.

Reviewed By: colin2328

Differential Revision: D41850160

