### PR TITLE
Back out "metrics states vectorization"

### DIFF
--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -37,17 +37,6 @@ def get_calibration_states(
     }
 
 
-def get_calibration_states_fused(
-    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> torch.Tensor:
-    return torch.stack(
-        [
-            torch.sum(predictions * weights, dim=-1),
-            torch.sum(labels * weights, dim=-1),
-        ]
-    )
-
-
 class CalibrationMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for Calibration, which is the
@@ -59,13 +48,16 @@ class CalibrationMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        state_names = [
-            CALIBRATION_NUM,
-            CALIBRATION_DENOM,
-        ]
         self._add_state(
-            state_names,
-            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
+            CALIBRATION_NUM,
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            CALIBRATION_DENOM,
+            torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -84,11 +76,12 @@ class CalibrationMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CalibrationMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-
-        states = get_calibration_states_fused(labels, predictions, weights)
-        state = getattr(self, self._fused_name)
-        state += states
-        self._aggregate_window_state(self._fused_name, states, num_samples)
+        for state_name, state_value in get_calibration_states(
+            labels, predictions, weights
+        ).items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -96,8 +89,8 @@ class CalibrationMetricComputation(RecMetricComputation):
                 name=MetricName.CALIBRATION,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_calibration(
-                    self.get_state(CALIBRATION_NUM),
-                    self.get_state(CALIBRATION_DENOM),
+                    cast(torch.Tensor, self.calibration_num),
+                    cast(torch.Tensor, self.calibration_denom),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -26,10 +26,11 @@ def compute_ctr(ctr_num: torch.Tensor, ctr_denom: torch.Tensor) -> torch.Tensor:
 
 def get_ctr_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> torch.Tensor:
-    return torch.stack(
-        [torch.sum(labels * weights, dim=-1), torch.sum(weights, dim=-1)]
-    )
+) -> Dict[str, torch.Tensor]:
+    return {
+        CTR_NUM: torch.sum(labels * weights, dim=-1),
+        CTR_DENOM: torch.sum(weights, dim=-1),
+    }
 
 
 class CTRMetricComputation(RecMetricComputation):
@@ -43,10 +44,16 @@ class CTRMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        state_names = [CTR_NUM, CTR_DENOM]
         self._add_state(
-            state_names,
-            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
+            CTR_NUM,
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            CTR_DENOM,
+            torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -65,11 +72,12 @@ class CTRMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CTRMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-
-        states = get_ctr_states(labels, predictions, weights)
-        state = getattr(self, self._fused_name)
-        state += states
-        self._aggregate_window_state(self._fused_name, states, num_samples)
+        for state_name, state_value in get_ctr_states(
+            labels, predictions, weights
+        ).items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -77,8 +85,8 @@ class CTRMetricComputation(RecMetricComputation):
                 name=MetricName.CTR,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_ctr(
-                    self.get_state(CTR_NUM),
-                    self.get_state(CTR_DENOM),
+                    cast(torch.Tensor, self.ctr_num),
+                    cast(torch.Tensor, self.ctr_denom),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -46,13 +46,11 @@ def compute_error_sum(
 
 def get_mse_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> torch.Tensor:
-    return torch.stack(
-        [
-            compute_error_sum(labels, predictions, weights),
-            torch.sum(weights, dim=-1),
-        ]
-    )
+) -> Dict[str, torch.Tensor]:
+    return {
+        "error_sum": compute_error_sum(labels, predictions, weights),
+        "weighted_num_samples": torch.sum(weights, dim=-1),
+    }
 
 
 class MSEMetricComputation(RecMetricComputation):
@@ -65,13 +63,16 @@ class MSEMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        state_names = [
-            "error_sum",
-            "weighted_num_samples",
-        ]
         self._add_state(
-            state_names,
-            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
+            "error_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "weighted_num_samples",
+            torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -91,9 +92,10 @@ class MSEMetricComputation(RecMetricComputation):
             )
         states = get_mse_states(labels, predictions, weights)
         num_samples = predictions.shape[-1]
-        state = getattr(self, self._fused_name)
-        state += states
-        self._aggregate_window_state(self._fused_name, states, num_samples)
+        for state_name, state_value in states.items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -101,16 +103,16 @@ class MSEMetricComputation(RecMetricComputation):
                 name=MetricName.MSE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_mse(
-                    self.get_state(ERROR_SUM),
-                    self.get_state(WEIGHTED_NUM_SAMPES),
+                    cast(torch.Tensor, self.error_sum),
+                    cast(torch.Tensor, self.weighted_num_samples),
                 ),
             ),
             MetricComputationReport(
                 name=MetricName.RMSE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_rmse(
-                    self.get_state(ERROR_SUM),
-                    self.get_state(WEIGHTED_NUM_SAMPES),
+                    cast(torch.Tensor, self.error_sum),
+                    cast(torch.Tensor, self.weighted_num_samples),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -73,25 +73,6 @@ def get_ne_states(
     }
 
 
-def get_ne_states_fused(
-    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
-) -> torch.Tensor:
-    cross_entropy = compute_cross_entropy(
-        labels,
-        predictions,
-        weights,
-        eta,
-    )
-    return torch.stack(
-        [
-            torch.sum(cross_entropy, dim=-1),
-            torch.sum(weights, dim=-1),
-            torch.sum(weights * labels, dim=-1),
-            torch.sum(weights * (1.0 - labels), dim=-1),
-        ]
-    )
-
-
 class NEMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for NE, i.e. Normalized Entropy.
@@ -102,15 +83,30 @@ class NEMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        state_names = [
-            "cross_entropy_sum",
-            "weighted_num_samples",
-            "pos_labels",
-            "neg_labels",
-        ]
         self._add_state(
-            state_names,
-            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
+            "cross_entropy_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "weighted_num_samples",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "pos_labels",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "neg_labels",
+            torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -129,12 +125,13 @@ class NEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for NEMetricComputation update"
             )
+        states = get_ne_states(labels, predictions, weights, self.eta)
         num_samples = predictions.shape[-1]
 
-        states = get_ne_states_fused(labels, predictions, weights, self.eta)
-        state = getattr(self, self._fused_name)
-        state += states
-        self._aggregate_window_state(self._fused_name, states, num_samples)
+        for state_name, state_value in states.items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -142,10 +139,10 @@ class NEMetricComputation(RecMetricComputation):
                 name=MetricName.NE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_ne(
-                    self.get_state("cross_entropy_sum"),
-                    self.get_state("weighted_num_samples"),
-                    self.get_state("pos_labels"),
-                    self.get_state("neg_labels"),
+                    cast(torch.Tensor, self.cross_entropy_sum),
+                    cast(torch.Tensor, self.weighted_num_samples),
+                    cast(torch.Tensor, self.pos_labels),
+                    cast(torch.Tensor, self.neg_labels),
                     self.eta,
                 ),
             ),

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -15,7 +15,6 @@ from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecTaskInfo
 from torchrec.metrics.test_utils import (
-    gen_test_batch,
     rec_metric_value_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
@@ -147,31 +146,6 @@ class AUCMetricTest(unittest.TestCase):
             world_size=WORLD_SIZE,
             entry_point=self._test_auc,
         )
-
-    def test_auc_reset(self) -> None:
-        batch_size = 128
-        auc = AUCMetric(
-            world_size=1,
-            my_rank=0,
-            batch_size=batch_size,
-            tasks=[DefaultTaskInfo],
-        )
-
-        # Mimic that reset is called when checkpointing.
-        auc.reset()
-        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
-        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
-        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
-        model_output = gen_test_batch(batch_size)
-        model_output = {k: v for k, v in model_output.items()}
-        auc.update(
-            predictions={"DefaultTask": model_output["prediction"]},
-            labels={"DefaultTask": model_output["label"]},
-            weights={"DefaultTask": model_output["weight"]},
-        )
-        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
-        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
-        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
 
 
 class AUCMetricValueTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -92,11 +92,11 @@ class TestGPU(unittest.TestCase):
         ne_computation = ne._metrics_computations[0]
         # test RecMetricComputation._add_window_state
         torch.allclose(
-            ne_computation.get_window_state("cross_entropy_sum"),
+            ne_computation.window_cross_entropy_sum,
             torch.tensor([0.0], dtype=torch.double, device=device),
         )
         torch.allclose(
-            ne_computation.get_window_state("weighted_num_samples"),
+            ne_computation.window_weighted_num_samples,
             torch.tensor([[0.0]], dtype=torch.double, device=device),
         )
 
@@ -124,11 +124,13 @@ class TestGPU(unittest.TestCase):
                 )
             else:
                 self.assertEqual(
-                    ne_computation.get_window_state("cross_entropy_sum").size(),
-                    torch.Size([1]),
+                    ne_computation.window_cross_entropy_sum.size(), torch.Size([1])
                 )
-                fused_state_name = ne_computation.get_fused_window_state_name()
                 self.assertEqual(
-                    len(ne_computation._batch_window_buffers[fused_state_name].buffers),
+                    len(
+                        ne_computation._batch_window_buffers[
+                            "window_cross_entropy_sum"
+                        ].buffers
+                    ),
                     3,
                 )

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -206,7 +206,8 @@ class MetricModuleTest(unittest.TestCase):
         tc.assertTrue("throughput_metric.warmup_examples" in keys)
         tc.assertTrue("throughput_metric.total_examples" in keys)
         tc.assertTrue(
-            "rec_metrics.rec_metrics.0._metrics_computations.0._fused_states" in keys
+            "rec_metrics.rec_metrics.0._metrics_computations.0.cross_entropy_sum"
+            in keys
         )
 
         # 1. Test sync()
@@ -230,9 +231,7 @@ class MetricModuleTest(unittest.TestCase):
         state_dict = metric_module.state_dict()
         for k, v in state_dict.items():
             if k.startswith("rec_metrics."):
-                for i in range(v.size(0)):
-                    for j in range(v.size(1)):
-                        tc.assertEqual(v[i][j].item(), 0)
+                tc.assertEqual(v.item(), 0)
 
     def test_rank0_checkpointing(self) -> None:
         # Call the tested methods to make code coverage visible to the testing system
@@ -295,7 +294,7 @@ class MetricModuleTest(unittest.TestCase):
             len(
                 metric_module.rec_metrics.rec_metrics[0]
                 ._metrics_computations[0]
-                .get_state("predictions")
+                .predictions
             ),
             1,  # The predictions state is a list containing 1 tensor value
         )
@@ -304,7 +303,7 @@ class MetricModuleTest(unittest.TestCase):
         tc.assertEqual(
             metric_module.rec_metrics.rec_metrics[0]
             ._metrics_computations[0]
-            .get_state("labels")
+            .labels[0]
             .size(),
             (1, 1),
             # The 1st 1 is the number of tasks; the 2nd 1 is the default value length
@@ -314,7 +313,7 @@ class MetricModuleTest(unittest.TestCase):
         tc.assertEqual(
             metric_module.rec_metrics.rec_metrics[0]
             ._metrics_computations[0]
-            .get_state("labels")
+            .labels[0]
             .size(),
             (1, 2),
         )
@@ -323,7 +322,7 @@ class MetricModuleTest(unittest.TestCase):
         tc.assertEqual(
             metric_module.rec_metrics.rec_metrics[0]
             ._metrics_computations[0]
-            .get_state("labels")
+            .labels[0]
             .size(),
             (1, 1),
         )
@@ -336,7 +335,7 @@ class MetricModuleTest(unittest.TestCase):
         tc.assertEqual(
             metric_module.rec_metrics.rec_metrics[0]
             ._metrics_computations[0]
-            .get_state("labels")
+            .labels[0]
             .size(),
             (1, 1),
         )
@@ -430,12 +429,11 @@ class MetricModuleTest(unittest.TestCase):
             state_metrics_mapping={StateMetricEnum.OPTIMIZERS: mock_optimizer},
             device=torch.device("cpu"),
         )
-        # 6 (tensors) * 8 (double)
-        # 3 in _default, 3 in specific attributes
-        self.assertEqual(metric_module.get_memory_usage(), 48)
+        # 3 (tensors) * 8 (double)
+        self.assertEqual(metric_module.get_memory_usage(), 24)
         metric_module.update(gen_test_batch(128))
-        # 48 (initial states) + 3 (tensors) * 128 (batch_size) * 8 (double)
-        self.assertEqual(metric_module.get_memory_usage(), 3120)
+        # 24 (initial states) + 3 (tensors) * 128 (batch_size) * 8 (double)
+        self.assertEqual(metric_module.get_memory_usage(), 3096)
 
     def test_check_memory_usage(self) -> None:
         mock_optimizer = MockOptimizer()

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -59,15 +59,10 @@ class RecMetricTest(unittest.TestCase):
         )
         ne1 = ne1._metrics_computations[0]
         ne2 = ne2._metrics_computations[0]
-        self.assertTrue(
-            ne1.get_state("cross_entropy_sum") == ne2.get_state("cross_entropy_sum")
-        )
-        self.assertTrue(
-            ne1.get_state("weighted_num_samples")
-            == ne2.get_state("weighted_num_samples")
-        )
-        self.assertTrue(ne1.get_state("pos_labels") == ne2.get_state("pos_labels"))
-        self.assertTrue(ne1.get_state("neg_labels") == ne2.get_state("neg_labels"))
+        self.assertTrue(ne1.cross_entropy_sum == ne2.cross_entropy_sum)
+        self.assertTrue(ne1.weighted_num_samples == ne2.weighted_num_samples)
+        self.assertTrue(ne1.pos_labels == ne2.pos_labels)
+        self.assertTrue(ne1.neg_labels == ne2.neg_labels)
 
     def test_zero_weights(self) -> None:
         # Test if weights = 0 for an update
@@ -91,10 +86,8 @@ class RecMetricTest(unittest.TestCase):
             labels=self.labels,
             weights=zero_weights,
         )
-        self.assertEqual(mse_computation.get_state("error_sum"), torch.tensor(0.0))
-        self.assertEqual(
-            mse_computation.get_state("weighted_num_samples"), torch.tensor(0.0)
-        )
+        self.assertEqual(mse_computation.error_sum, torch.tensor(0.0))
+        self.assertEqual(mse_computation.weighted_num_samples, torch.tensor(0.0))
 
         res = mse.compute()
         self.assertEqual(res["mse-DefaultTask|lifetime_mse"], torch.tensor(0.0))
@@ -105,11 +98,12 @@ class RecMetricTest(unittest.TestCase):
             labels=self.labels,
             weights=self.weights,
         )
-
-        self.assertGreater(mse_computation.get_state("error_sum"), torch.tensor(0.0))
-        self.assertGreater(
-            mse_computation.get_state("weighted_num_samples"), torch.tensor(0.0)
-        )
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(mse_computation.error_sum, torch.tensor(0.0))
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(mse_computation.weighted_num_samples, torch.tensor(0.0))
 
         res = mse.compute()
         # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
@@ -155,20 +149,14 @@ class RecMetricTest(unittest.TestCase):
             labels=labels,
             weights=partial_zero_weights,
         )
-        self.assertEqual(
-            ne_computation[0].get_state("cross_entropy_sum"), torch.tensor(0.0)
-        )
-        self.assertEqual(
-            ne_computation[0].get_state("weighted_num_samples"), torch.tensor(0.0)
-        )
-
-        self.assertGreater(
-            ne_computation[1].get_state("cross_entropy_sum"), torch.tensor(0.0)
-        )
-
-        self.assertGreater(
-            ne_computation[1].get_state("weighted_num_samples"), torch.tensor(0.0)
-        )
+        self.assertEqual(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
+        self.assertEqual(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(ne_computation[1].cross_entropy_sum, torch.tensor(0.0))
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(ne_computation[1].weighted_num_samples, torch.tensor(0.0))
 
         res = ne.compute()
         self.assertEqual(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
@@ -181,14 +169,12 @@ class RecMetricTest(unittest.TestCase):
             labels=labels,
             weights=weights,
         )
-
-        self.assertGreater(
-            ne_computation[0].get_state("cross_entropy_sum"), torch.tensor(0.0)
-        )
-
-        self.assertGreater(
-            ne_computation[0].get_state("weighted_num_samples"), torch.tensor(0.0)
-        )
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
+        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
+        #  got `Tensor`.
+        self.assertGreater(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
 
         res = ne.compute()
         # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but


### PR DESCRIPTION
Summary:
Original commit changeset: 73b0b8d5e237

Original Phabricator Diff: D40419238 (https://github.com/pytorch/torchrec/commit/50c861a4debb6d0d8bd55ddb27452e89f2d19d51)

The states vectorization implementation had backward compatibility issue with the previously saved model checkpoints. Need to solve that before landing this.

Differential Revision: D41881762

