### PR TITLE
add composable check with DDP

### DIFF
--- a/torchrec/distributed/composable/tests/test_ddp.py
+++ b/torchrec/distributed/composable/tests/test_ddp.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+import uuid
+
+import torch
+from torch import distributed as dist
+from torch.distributed._composable import replicate
+from torch.distributed._shard.api import ShardedTensor
+from torch.distributed.checkpoint import (
+    FileSystemReader,
+    FileSystemWriter,
+    load_state_dict,
+    save_state_dict,
+)
+from torch.distributed.launcher.api import elastic_launch, LaunchConfig
+from torchrec.distributed.shard import shard as trec_shard
+from torchrec.distributed.sharding_plan import (
+    apply_to_all,
+    column_wise,
+    construct_module_sharding_plan,
+)
+from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.test_utils import skip_if_asan
+
+
+class DDPTest(unittest.TestCase):
+    @classmethod
+    def _run(cls, path: str) -> None:
+        rank = int(os.environ["LOCAL_RANK"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        if torch.cuda.is_available():
+            device: torch.device = torch.device(f"cuda:{rank}")
+            backend = "nccl"
+            torch.cuda.set_device(device)
+        else:
+            device: torch.device = torch.device("cpu")
+            backend = "gloo"
+        dist.init_process_group(backend=backend)
+        num_float_features = 32
+
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4 * world_size,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(3)
+        ]
+        weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4 * world_size,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        m = TestSparseNN(
+            tables=tables,
+            num_float_features=num_float_features,
+            weighted_tables=weighted_tables,
+            dense_device=device,
+        )
+        m.sparse.ebc = trec_shard(
+            module=m.sparse.ebc,
+            device=device,
+            plan=construct_module_sharding_plan(
+                m.sparse.ebc,
+                apply_to_all(m.sparse.ebc, column_wise(ranks=list(range(world_size)))),
+                device_type=device.type,
+            ),
+        )
+        m.sparse.weighted_ebc = trec_shard(
+            module=m.sparse.weighted_ebc,
+            device=device,
+            plan=construct_module_sharding_plan(
+                m.sparse.weighted_ebc,
+                apply_to_all(
+                    m.sparse.weighted_ebc, column_wise(ranks=list(range(world_size)))
+                ),
+                device_type=device.type,
+            ),
+        )
+        m.over = replicate(m.over)
+        m.dense = replicate(m.dense)
+
+        ######## run one iteration ########
+        _, local_batch = ModelInput.generate(
+            batch_size=8,
+            world_size=world_size,
+            num_float_features=num_float_features,
+            tables=tables,
+            weighted_tables=weighted_tables,
+        )
+        batch = local_batch[0].to(device)
+        m(batch)[1].sum().backward()
+
+        state_dict = m.state_dict()
+        writer = FileSystemWriter(path=path)
+        reader = FileSystemReader(path=path)
+        save_state_dict(state_dict, writer)
+
+        p_sum = torch.zeros(1, device=device)
+        for p in m.parameters():
+            with torch.no_grad():
+                if isinstance(p, ShardedTensor):
+                    if not p.local_shards():
+                        continue
+                    p = p.local_tensor()
+                p_sum += p.sum()
+                p.zero_()
+                assert p.sum() == 0
+        load_state_dict(state_dict, reader)
+        m.load_state_dict(state_dict)
+
+        p_sum_loaded = torch.zeros(1, device=device)
+        for p in m.parameters():
+            with torch.no_grad():
+                if isinstance(p, ShardedTensor):
+                    if not p.local_shards():
+                        continue
+                    p = p.local_tensor()
+                p_sum_loaded += p.sum()
+        assert p_sum.allclose(p_sum_loaded)
+
+    @skip_if_asan
+    def test_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as path:
+            lc = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                run_id=str(uuid.uuid4()),
+                rdzv_backend="c10d",
+                rdzv_endpoint=os.path.join(tmpdir, "rdzv"),
+                rdzv_configs={"store_type": "file"},
+                start_method="spawn",
+                monitor_interval=1,
+                max_restarts=0,
+            )
+            elastic_launch(config=lc, entrypoint=self._run)(path)

--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -105,10 +105,10 @@ def _test_sharding(  # noqa C901
                 {"lr": 4.0},
             )
         plan: ShardingPlan = planner.collective_plan(model, [sharder], ctx.pg)
-        sharded_model, _ = shard(
+        sharded_model = shard(
             module=model,
             env=ShardingEnv.from_process_group(ctx.pg),
-            plan=plan,
+            plan=plan.get_plan_for_module(""),
             sharders=[sharder],
             device=ctx.device,
         )

--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+import uuid
+
+import torch
+from torch import distributed as dist, nn
+from torch.distributed._composable import fully_shard
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+
+from torch.distributed.checkpoint import (
+    FileSystemReader,
+    FileSystemWriter,
+    load_state_dict,
+    save_state_dict,
+)
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel,
+    StateDictType,
+)
+from torch.distributed.fsdp.wrap import ModuleWrapPolicy
+from torch.distributed.launcher.api import elastic_launch, LaunchConfig
+from torchrec.distributed.shard import (
+    shard as trec_shard,
+    shard_modules as trec_shard_modules,
+)
+from torchrec.distributed.sharding_plan import (
+    apply_to_all,
+    construct_module_sharding_plan,
+    row_wise,
+)
+from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
+from torchrec.distributed.types import ShardingPlan
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.test_utils import skip_if_asan
+
+
+class FSDPTest(unittest.TestCase):
+    @classmethod
+    def _run(cls, path: str) -> None:
+        rank = int(os.environ["LOCAL_RANK"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        if torch.cuda.is_available():
+            device: torch.device = torch.device(f"cuda:{rank}")
+            backend = "nccl"
+            torch.cuda.set_device(device)
+        else:
+            device: torch.device = torch.device("cpu")
+            backend = "gloo"
+        dist.init_process_group(backend=backend)
+        num_float_features = 32
+
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(3)
+        ]
+        weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        m = TestSparseNN(
+            tables=tables,
+            num_float_features=num_float_features,
+            weighted_tables=weighted_tables,
+            dense_device=device,
+        )
+        plan = ShardingPlan(
+            plan={
+                "sparse.ebc": construct_module_sharding_plan(
+                    m.sparse.ebc,
+                    apply_to_all(m.sparse.ebc, row_wise()),
+                ),
+                "sparse.weighted_ebc": construct_module_sharding_plan(
+                    m.sparse.weighted_ebc,
+                    apply_to_all(m.sparse.weighted_ebc, row_wise()),
+                ),
+            }
+        )
+        trec_shard_modules(
+            module=m,
+            device=device,
+            plan=plan,
+        )
+        sharded_m = FullyShardedDataParallel(
+            module=m,
+            device_id=rank,
+            ignored_modules=[m.sparse],
+        )
+
+        ######## run one iteration ########
+        _, local_batch = ModelInput.generate(
+            batch_size=8,
+            world_size=world_size,
+            num_float_features=num_float_features,
+            tables=tables,
+            weighted_tables=weighted_tables,
+        )
+        batch = local_batch[0].to(device)
+        sharded_m(batch)[1].sum().backward()
+
+        writer = FileSystemWriter(path=path)
+        reader = FileSystemReader(path=path)
+        with FullyShardedDataParallel.state_dict_type(
+            sharded_m, StateDictType.SHARDED_STATE_DICT
+        ):
+            state_dict = sharded_m.state_dict()
+
+        save_state_dict(state_dict, writer)
+
+        p_sum = torch.zeros(1, device=device)
+        for p in sharded_m.parameters():
+            with torch.no_grad():
+                if isinstance(p, ShardedTensor):
+                    if not p.local_shards():
+                        continue
+                    p = p.local_tensor()
+                p_sum += p.sum()
+                p.zero_()
+                assert p.sum() == 0
+
+        with FullyShardedDataParallel.state_dict_type(
+            sharded_m, StateDictType.SHARDED_STATE_DICT
+        ):
+            state_dict = sharded_m.state_dict()
+            load_state_dict(state_dict, reader)
+            sharded_m.load_state_dict(state_dict)
+
+        p_sum_loaded = torch.zeros(1, device=device)
+        for p in sharded_m.parameters():
+            with torch.no_grad():
+                if isinstance(p, ShardedTensor):
+                    if not p.local_shards():
+                        continue
+                    p = p.local_tensor()
+                p_sum_loaded += p.sum()
+        assert p_sum.allclose(p_sum_loaded)
+
+    @skip_if_asan
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as path:
+            lc = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                run_id=str(uuid.uuid4()),
+                rdzv_backend="c10d",
+                rdzv_endpoint=os.path.join(tmpdir, "rdzv"),
+                rdzv_configs={"store_type": "file"},
+                start_method="spawn",
+                monitor_interval=1,
+                max_restarts=0,
+            )
+            elastic_launch(config=lc, entrypoint=self._run)(path)
+
+
+class FSDPTestComposable(unittest.TestCase):
+    @classmethod
+    def _run(cls) -> None:
+        rank = int(os.environ["LOCAL_RANK"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        device: torch.device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+        dist.init_process_group(backend="nccl")
+        num_float_features = 32
+
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(3)
+        ]
+        weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        m = TestSparseNN(
+            tables=tables,
+            num_float_features=num_float_features,
+            weighted_tables=weighted_tables,
+            dense_device=device,
+        )
+        m.sparse.ebc = trec_shard(
+            module=m.sparse.ebc,
+            device=device,
+            plan=construct_module_sharding_plan(
+                m.sparse.ebc,
+                apply_to_all(m.sparse.ebc, row_wise()),
+            ),
+        )
+        m.sparse.weighted_ebc = trec_shard(
+            module=m.sparse.weighted_ebc,
+            device=device,
+            plan=construct_module_sharding_plan(
+                m.sparse.weighted_ebc,
+                apply_to_all(m.sparse.weighted_ebc, row_wise()),
+            ),
+        )
+        m.dense = fully_shard(
+            m.dense,
+            device_id=device.index,
+            policy=ModuleWrapPolicy({nn.Linear}),
+        )
+        m.over = fully_shard(
+            m.over,
+            device_id=device.index,
+            policy=ModuleWrapPolicy({nn.Linear}),
+        )
+
+        ######## run one iteration ########
+        _, local_batch = ModelInput.generate(
+            batch_size=8,
+            world_size=world_size,
+            num_float_features=num_float_features,
+            tables=tables,
+            weighted_tables=weighted_tables,
+        )
+        batch = local_batch[0].to(device)
+        m(batch)[1].sum().backward()
+        # TODO add checkpointing test once fully_shard supports
+        # TODO add apply_optimizer_in_backward() API and optimizer state checkpoint
+
+    @skip_if_asan
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_composable_forward(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lc = LaunchConfig(
+                min_nodes=1,
+                max_nodes=1,
+                nproc_per_node=2,
+                run_id=str(uuid.uuid4()),
+                rdzv_backend="c10d",
+                rdzv_endpoint=os.path.join(tmpdir, "rdzv"),
+                rdzv_configs={"store_type": "file"},
+                start_method="spawn",
+                monitor_interval=1,
+                max_restarts=0,
+            )
+            elastic_launch(config=lc, entrypoint=self._run)()

--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -5,36 +5,41 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Type
 
 import torch
 import torch.distributed as dist
 from torch import nn
-from torchrec.distributed.comm import get_local_size
+from torch.distributed._composable.contract import contract
 from torchrec.distributed.model_parallel import get_default_sharders
 from torchrec.distributed.planner import EmbeddingShardingPlanner
-from torchrec.distributed.planner.types import Topology
-from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ModuleShardingPlan,
+    ShardingEnv,
+    ShardingPlan,
+)
 
 
 def _join_module_path(path: str, name: str) -> str:
     return (path + "." + name) if path else name
 
 
+# pyre-ignore
+@contract()
 def shard(
     module: nn.Module,
+    plan: ModuleShardingPlan,
     env: Optional[ShardingEnv] = None,
     device: Optional[torch.device] = None,
-    plan: Optional[ShardingPlan] = None,
     sharders: Optional[List[ModuleSharder[torch.nn.Module]]] = None,
-) -> Tuple[nn.Module, List[str]]:
+) -> nn.Module:
     """
-    Replaces all sub_modules that are embedding modules with their sharded variants. This embedding_module -> sharded_embedding_module mapping
-    is derived from the passed in sharders.
+    Replaces this module with its sharded variant
 
     This will leave the other parts of the model unaffected.
 
-    It returns the module (with replacements), as well as parameter names of the modules that were swapped out.
+    It returns the original module
 
     Args:
         module (nn.Module): module to wrap.
@@ -43,7 +48,61 @@ def shard(
         plan (Optional[ShardingPlan]): plan to use when sharding, defaults to
             `EmbeddingShardingPlanner.collective_plan()`.
         sharders (Optional[List[ModuleSharder[nn.Module]]]): `ModuleSharders` available
-            to shard with, defaults to `EmbeddingBagCollectionSharder()`.
+            to shard with, defaults to `get_default_sharders()`.
+
+    Example::
+
+        ebc = EmbeddingBagCollection()
+        sharded_ebc = shard(ebc)
+        assert isinstance(sharded_ebc, ShardedEmbeddingBagCollection)
+    """
+
+    if sharders is None:
+        sharders = get_default_sharders()
+
+    if env is None:
+        pg = dist.GroupMember.WORLD
+        assert pg is not None, "Process group is not initialized"
+        env = ShardingEnv.from_process_group(pg)
+
+    if device is None:
+        device = torch.device("cpu")
+
+    sharder_map: Dict[Type[nn.Module], ModuleSharder[nn.Module]] = {
+        sharder.module_type: sharder for sharder in sharders
+    }
+    assert (
+        type(module) in sharder_map
+    ), f"module is of type {type(module)} which is not in sharder_map {sharder_map}"
+
+    return sharder_map[type(module)].shard(module, plan, env, device)
+
+
+# pyre-ignore
+@contract()
+def shard_modules(
+    module: nn.Module,
+    env: Optional[ShardingEnv] = None,
+    device: Optional[torch.device] = None,
+    plan: Optional[ShardingPlan] = None,
+    sharders: Optional[List[ModuleSharder[torch.nn.Module]]] = None,
+) -> nn.Module:
+    """
+    Replaces all sub_modules that are embedding modules with their sharded variants. This embedding_module -> sharded_embedding_module mapping
+    is derived from the passed in sharders.
+
+    This will leave the other parts of the model unaffected.
+
+    It returns the original module
+
+    Args:
+        module (nn.Module): module to wrap.
+        env (Optional[ShardingEnv]): sharding environment that has the process group.
+        device (Optional[torch.device]): compute device, defaults to cpu.
+        plan (Optional[ShardingPlan]): plan to use when sharding, defaults to
+            `EmbeddingShardingPlanner.collective_plan()`.
+        sharders (Optional[List[ModuleSharder[nn.Module]]]): `ModuleSharders` available
+            to shard with, defaults to `get_default_sharders()`.
 
     Example::
 
@@ -76,31 +135,17 @@ def shard(
     }
 
     if plan is None:
-        planner = EmbeddingShardingPlanner(
-            topology=Topology(
-                local_world_size=get_local_size(env.world_size),
-                world_size=env.world_size,
-                compute_device=device.type,
-            )
-        )
+        planner = EmbeddingShardingPlanner()
         pg = env.process_group
         if pg is not None:
             plan = planner.collective_plan(module, sharders, pg)
         else:
             plan = planner.plan(module, sharders)
 
-    sharded_param_names: List[str] = []
-
     if type(module) in sharder_map:
         # If the top level module is itself a shardable module, return the sharded variant.
         # Note, we cannot do an inplace replacement in this case.
-        sharded_params = plan.get_plan_for_module("")
-        if sharded_params is not None:
-            sharded_module = sharder_map[type(module)].shard(
-                module, sharded_params, env, device
-            )
-            sharded_param_names.extend([name for name, _ in module.named_parameters()])
-            return sharded_module, sharded_param_names
+        return shard(module, plan.get_plan_for_module(""), env, device, sharders)
 
     def _replace(_model: nn.Module, path: str = "") -> None:
         for child_name, child in _model.named_children():
@@ -116,16 +161,9 @@ def shard(
                         child_name,
                         sharded_module,
                     )
-
-                    sharded_param_names.extend(
-                        [
-                            _join_module_path(child_path, name)
-                            for name, _ in child.named_parameters()
-                        ]
-                    )
             else:
                 _replace(child, child_path)
 
     _replace(module)
 
-    return module, sharded_param_names
+    return module

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -503,8 +503,7 @@ def apply_to_all(
         )
     """
     if sharder is None:
-        # pyre-ignore
-        sharder = get_module_to_default_sharders.get(type(module), None)
+        sharder = get_module_to_default_sharders().get(type(module), None)
     else:
         assert isinstance(
             module, sharder.module_type

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -21,7 +21,7 @@ from torchrec.distributed.planner.shard_estimators import (
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
-from torchrec.distributed.shard import shard
+from torchrec.distributed.shard import shard_modules
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     ModelInput,
@@ -318,7 +318,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
         quant_model = _quantize(model, inplace=True, output_type=output_type)
 
-        sharded_model, _sharded_params = shard(
+        sharded_model = shard_modules(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -15,7 +15,7 @@ from hypothesis import given, settings, Verbosity
 from torch import nn, quantization as quant
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
-from torchrec.distributed.shard import shard
+from torchrec.distributed.shard import shard_modules
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNNBase
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     InferenceModelParallelTestBase,
@@ -152,7 +152,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
 
         quant_model = _quantize(model)
 
-        sharded_quant_model, _sharded_params = shard(
+        sharded_quant_model = shard_modules(
             module=quant_model,
             sharders=[
                 cast(


### PR DESCRIPTION
Summary: adds a test demonstrating that the TorchRec composability trec_shard API can be used alongside replicate.

Differential Revision: D41108651

