### PR TITLE
remove SparseFeatures wrapper and refactor PEA

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -20,6 +20,7 @@ from torchrec.distributed.comm_ops import (
     reduce_scatter_base_pooled,
     reduce_scatter_v_pooled,
 )
+from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.types import Awaitable, NoWait, QuantizedCommCodecs
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
@@ -494,7 +495,7 @@ class KJTOneToAll(nn.Module):
         self._world_size = world_size
         assert self._world_size == len(splits)
 
-    def forward(self, kjt: KeyedJaggedTensor) -> Awaitable[List[KeyedJaggedTensor]]:
+    def forward(self, kjt: KeyedJaggedTensor) -> Awaitable[KJTList]:
         """
         Splits features first and then sends the slices to the corresponding devices.
 
@@ -510,7 +511,7 @@ class KJTOneToAll(nn.Module):
             split_kjt.to(torch.device("cuda", rank), non_blocking=True)
             for rank, split_kjt in enumerate(kjts)
         ]
-        return NoWait(dist_kjts)
+        return NoWait(KJTList(dist_kjts))
 
 
 class PooledEmbeddingsAwaitable(Awaitable[torch.Tensor]):

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Union
 
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.planner.constants import MIN_CW_DIM, POOLING_FACTOR
+from torchrec.distributed.planner.constants import POOLING_FACTOR
 from torchrec.distributed.planner.shard_estimators import (
     EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -14,19 +14,17 @@ from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingLookup,
     BaseSparseFeaturesDist,
 )
-from torchrec.distributed.embedding_types import (
-    BaseGroupedFeatureProcessor,
-    SparseFeatures,
-)
+from torchrec.distributed.embedding_types import BaseGroupedFeatureProcessor
 from torchrec.distributed.sharding.cw_sharding import BaseCwEmbeddingSharding
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.sharding.tw_sequence_sharding import TwSequenceEmbeddingDist
 from torchrec.distributed.sharding.tw_sharding import TwSparseFeaturesDist
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class CwSequenceEmbeddingSharding(
     BaseCwEmbeddingSharding[
-        SequenceShardingContext, SparseFeatures, torch.Tensor, torch.Tensor
+        SequenceShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
     ]
 ):
     """
@@ -37,12 +35,11 @@ class CwSequenceEmbeddingSharding(
     def create_input_dist(
         self,
         device: Optional[torch.device] = None,
-    ) -> BaseSparseFeaturesDist[SparseFeatures]:
+    ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
         assert self._pg is not None
         return TwSparseFeaturesDist(
             self._pg,
-            self.id_list_features_per_rank(),
-            self.id_score_list_features_per_rank(),
+            self.features_per_rank(),
             device if device is not None else self._device,
         )
 
@@ -66,7 +63,7 @@ class CwSequenceEmbeddingSharding(
         assert self._pg is not None
         return TwSequenceEmbeddingDist(
             self._pg,
-            self.id_list_features_per_rank(),
+            self.features_per_rank(),
             device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )

--- a/torchrec/distributed/sharding/dp_sequence_sharding.py
+++ b/torchrec/distributed/sharding/dp_sequence_sharding.py
@@ -14,16 +14,14 @@ from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingLookup,
     BaseSparseFeaturesDist,
 )
-from torchrec.distributed.embedding_types import (
-    BaseGroupedFeatureProcessor,
-    SparseFeatures,
-)
+from torchrec.distributed.embedding_types import BaseGroupedFeatureProcessor
 from torchrec.distributed.sharding.dp_sharding import (
     BaseDpEmbeddingSharding,
     DpSparseFeaturesDist,
 )
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import Awaitable, NoWait
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class DpSequenceEmbeddingDist(
@@ -56,7 +54,7 @@ class DpSequenceEmbeddingDist(
 
 class DpSequenceEmbeddingSharding(
     BaseDpEmbeddingSharding[
-        SequenceShardingContext, SparseFeatures, torch.Tensor, torch.Tensor
+        SequenceShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
     ]
 ):
     """
@@ -66,7 +64,7 @@ class DpSequenceEmbeddingSharding(
 
     def create_input_dist(
         self, device: Optional[torch.device] = None
-    ) -> BaseSparseFeaturesDist[SparseFeatures]:
+    ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
         return DpSparseFeaturesDist()
 
     def create_lookup(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import PooledEmbeddingsReduceScatter
+from torchrec.distributed.dist_data import KJTAllToAll, PooledEmbeddingsReduceScatter
 from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingDist,
@@ -20,14 +20,12 @@ from torchrec.distributed.embedding_sharding import (
     EmbeddingShardingContext,
     EmbeddingShardingInfo,
     group_tables,
-    SparseFeaturesAllToAll,
 )
 from torchrec.distributed.embedding_types import (
     BaseGroupedFeatureProcessor,
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
-    SparseFeatures,
 )
 from torchrec.distributed.types import (
     Awaitable,
@@ -37,6 +35,7 @@ from torchrec.distributed.types import (
     ShardingEnv,
     ShardMetadata,
 )
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable
 
 
@@ -75,19 +74,10 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._grouped_embedding_configs_per_rank: List[
             List[GroupedEmbeddingConfig]
         ] = []
-        self._score_grouped_embedding_configs_per_rank: List[
-            List[GroupedEmbeddingConfig]
-        ] = []
-        (
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ) = group_tables(sharded_tables_per_rank)
+        self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs: List[
             GroupedEmbeddingConfig
         ] = self._grouped_embedding_configs_per_rank[self._rank]
-        self._score_grouped_embedding_configs: List[
-            GroupedEmbeddingConfig
-        ] = self._score_grouped_embedding_configs_per_rank[self._rank]
 
         self._has_feature_processor: bool = False
         for group_config in self._grouped_embedding_configs:
@@ -146,15 +136,11 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         embedding_dims = []
         for grouped_config in self._grouped_embedding_configs:
             embedding_dims.extend(grouped_config.embedding_dims())
-        for grouped_config in self._score_grouped_embedding_configs:
-            embedding_dims.extend(grouped_config.embedding_dims())
         return embedding_dims
 
     def embedding_names(self) -> List[str]:
         embedding_names = []
         for grouped_config in self._grouped_embedding_configs:
-            embedding_names.extend(grouped_config.embedding_names())
-        for grouped_config in self._score_grouped_embedding_configs:
             embedding_names.extend(grouped_config.embedding_names())
         return embedding_names
 
@@ -165,48 +151,28 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         embedding_shard_metadata = []
         for grouped_config in self._grouped_embedding_configs:
             embedding_shard_metadata.extend(grouped_config.embedding_shard_metadata())
-        for grouped_config in self._score_grouped_embedding_configs:
-            embedding_shard_metadata.extend(grouped_config.embedding_shard_metadata())
         return embedding_shard_metadata
 
-    def id_list_feature_names(self) -> List[str]:
-        id_list_feature_names = []
+    def feature_names(self) -> List[str]:
+        feature_names = []
         for grouped_config in self._grouped_embedding_configs:
-            id_list_feature_names.extend(grouped_config.feature_names())
-        return id_list_feature_names
+            feature_names.extend(grouped_config.feature_names())
+        return feature_names
 
-    def id_score_list_feature_names(self) -> List[str]:
-        id_score_list_feature_names = []
-        for grouped_config in self._score_grouped_embedding_configs:
-            id_score_list_feature_names.extend(grouped_config.feature_names())
-        return id_score_list_feature_names
-
-    def _get_id_list_features_num(self) -> int:
+    def _get_num_features(self) -> int:
         return sum(
             group_config.num_features()
             for group_config in self._grouped_embedding_configs
         )
 
-    def _get_id_score_list_features_num(self) -> int:
-        return sum(
-            group_config.num_features()
-            for group_config in self._score_grouped_embedding_configs
-        )
-
-    def _get_id_list_features_hash_sizes(self) -> List[int]:
-        id_list_feature_hash_sizes: List[int] = []
+    def _get_feature_hash_sizes(self) -> List[int]:
+        feature_hash_sizes: List[int] = []
         for group_config in self._grouped_embedding_configs:
-            id_list_feature_hash_sizes.extend(group_config.feature_hash_sizes())
-        return id_list_feature_hash_sizes
-
-    def _get_id_score_list_features_hash_sizes(self) -> List[int]:
-        id_score_list_feature_hash_sizes: List[int] = []
-        for group_config in self._score_grouped_embedding_configs:
-            id_score_list_feature_hash_sizes.extend(group_config.feature_hash_sizes())
-        return id_score_list_feature_hash_sizes
+            feature_hash_sizes.extend(group_config.feature_hash_sizes())
+        return feature_hash_sizes
 
 
-class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
+class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
     """
     Bucketizes sparse features in RW fashion and then redistributes with an AlltoAll
     collective operation.
@@ -215,11 +181,8 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
         intra_pg (dist.ProcessGroup): ProcessGroup within single host group for AlltoAll
             communication.
-        num_id_list_features (int): total number of id list features.
-        num_id_score_list_features (int): total number of id score list features
-        id_list_feature_hash_sizes (List[int]): hash sizes of id list features.
-        id_score_list_feature_hash_sizes (List[int]): hash sizes of id score list
-            features.
+        num_features (int): total number of features.
+        feature_hash_sizes (List[int]): hash sizes of features.
         device (Optional[torch.device]): device on which buffers will be allocated.
         is_sequence (bool): if this is for a sequence embedding.
         has_feature_processor (bool): existence of feature processor (ie. position
@@ -230,10 +193,8 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
     def __init__(
         self,
         pg: dist.ProcessGroup,
-        num_id_list_features: int,
-        num_id_score_list_features: int,
-        id_list_feature_hash_sizes: List[int],
-        id_score_list_feature_hash_sizes: List[int],
+        num_features: int,
+        feature_hash_sizes: List[int],
         device: Optional[torch.device] = None,
         is_sequence: bool = False,
         has_feature_processor: bool = False,
@@ -241,37 +202,22 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
     ) -> None:
         super().__init__()
         self._world_size: int = pg.size()
-        self._num_id_list_features = num_id_list_features
-        self._num_id_score_list_features = num_id_score_list_features
-        id_list_feature_block_sizes = [
+        self._num_features = num_features
+        feature_block_sizes = [
             (hash_size + self._world_size - 1) // self._world_size
-            for hash_size in id_list_feature_hash_sizes
-        ]
-        id_score_list_feature_block_sizes = [
-            (hash_size + self._world_size - 1) // self._world_size
-            for hash_size in id_score_list_feature_hash_sizes
+            for hash_size in feature_hash_sizes
         ]
         self.register_buffer(
-            "_id_list_feature_block_sizes_tensor",
+            "_feature_block_sizes_tensor",
             torch.tensor(
-                id_list_feature_block_sizes,
+                feature_block_sizes,
                 device=device,
                 dtype=torch.int32,
             ),
         )
-        self.register_buffer(
-            "_id_score_list_feature_block_sizes_tensor",
-            torch.tensor(
-                id_score_list_feature_block_sizes,
-                device=device,
-                dtype=torch.int32,
-            ),
-        )
-        self._dist = SparseFeaturesAllToAll(
+        self._dist = KJTAllToAll(
             pg=pg,
-            id_list_features_per_rank=self._world_size * [self._num_id_list_features],
-            id_score_list_features_per_rank=self._world_size
-            * [self._num_id_score_list_features],
+            splits=self._world_size * [self._num_features],
             device=device,
         )
         self._is_sequence = is_sequence
@@ -281,52 +227,34 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
 
     def forward(
         self,
-        sparse_features: SparseFeatures,
-    ) -> Awaitable[Awaitable[SparseFeatures]]:
+        sparse_features: KeyedJaggedTensor,
+    ) -> Awaitable[Awaitable[KeyedJaggedTensor]]:
         """
         Bucketizes sparse feature values into world size number of buckets and then
         performs AlltoAll operation.
 
         Args:
-            sparse_features (SparseFeatures): sparse features to bucketize and
+            sparse_features (KeyedJaggedTensor): sparse features to bucketize and
                 redistribute.
 
         Returns:
-            Awaitable[SparseFeatures]: awaitable of SparseFeatures.
+            Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
 
-        if self._num_id_list_features > 0:
-            assert sparse_features.id_list_features is not None
-            (
-                id_list_features,
-                self.unbucketize_permute_tensor,
-            ) = bucketize_kjt_before_all2all(
-                sparse_features.id_list_features,
-                num_buckets=self._world_size,
-                block_sizes=self._id_list_feature_block_sizes_tensor,
-                output_permute=self._is_sequence,
-                bucketize_pos=self._has_feature_processor,
-            )
-        else:
-            id_list_features = None
-
-        if self._num_id_score_list_features > 0:
-            assert sparse_features.id_score_list_features is not None
-            id_score_list_features, _ = bucketize_kjt_before_all2all(
-                sparse_features.id_score_list_features,
-                num_buckets=self._world_size,
-                block_sizes=self._id_score_list_feature_block_sizes_tensor,
-                output_permute=False,
-                bucketize_pos=self._need_pos,
-            )
-        else:
-            id_score_list_features = None
-
-        bucketized_sparse_features = SparseFeatures(
-            id_list_features=id_list_features,
-            id_score_list_features=id_score_list_features,
+        (
+            bucketized_features,
+            self.unbucketize_permute_tensor,
+        ) = bucketize_kjt_before_all2all(
+            sparse_features,
+            num_buckets=self._world_size,
+            block_sizes=self._feature_block_sizes_tensor,
+            output_permute=self._is_sequence,
+            bucketize_pos=self._has_feature_processor
+            if sparse_features.weights_or_none() is None
+            else self._need_pos,
         )
-        return self._dist(bucketized_sparse_features)
+
+        return self._dist(bucketized_features)
 
 
 class RwPooledEmbeddingDist(
@@ -379,7 +307,7 @@ class RwPooledEmbeddingDist(
 
 class RwPooledEmbeddingSharding(
     BaseRwEmbeddingSharding[
-        EmbeddingShardingContext, SparseFeatures, torch.Tensor, torch.Tensor
+        EmbeddingShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
     ]
 ):
     """
@@ -390,19 +318,15 @@ class RwPooledEmbeddingSharding(
     def create_input_dist(
         self,
         device: Optional[torch.device] = None,
-    ) -> BaseSparseFeaturesDist[SparseFeatures]:
-        num_id_list_features = self._get_id_list_features_num()
-        num_id_score_list_features = self._get_id_score_list_features_num()
-        id_list_feature_hash_sizes = self._get_id_list_features_hash_sizes()
-        id_score_list_feature_hash_sizes = self._get_id_score_list_features_hash_sizes()
+    ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
+        num_features = self._get_num_features()
+        feature_hash_sizes = self._get_feature_hash_sizes()
         return RwSparseFeaturesDist(
             # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             pg=self._pg,
-            num_id_list_features=num_id_list_features,
-            num_id_score_list_features=num_id_score_list_features,
-            id_list_feature_hash_sizes=id_list_feature_hash_sizes,
-            id_score_list_feature_hash_sizes=id_score_list_feature_hash_sizes,
+            num_features=num_features,
+            feature_hash_sizes=feature_hash_sizes,
             device=device if device is not None else self._device,
             is_sequence=False,
             has_feature_processor=self._has_feature_processor,
@@ -417,7 +341,6 @@ class RwPooledEmbeddingSharding(
     ) -> BaseEmbeddingLookup:
         return GroupedPooledEmbeddingsLookup(
             grouped_configs=self._grouped_embedding_configs,
-            grouped_score_configs=self._score_grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -9,7 +9,12 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import EmbeddingsAllToOne, PooledEmbeddingsAllToAll
+from torchrec.distributed.dist_data import (
+    EmbeddingsAllToOne,
+    KJTAllToAll,
+    KJTOneToAll,
+    PooledEmbeddingsAllToAll,
+)
 from torchrec.distributed.embedding_lookup import (
     GroupedPooledEmbeddingsLookup,
     InferGroupedPooledEmbeddingsLookup,
@@ -22,16 +27,13 @@ from torchrec.distributed.embedding_sharding import (
     EmbeddingShardingContext,
     EmbeddingShardingInfo,
     group_tables,
-    SparseFeaturesAllToAll,
-    SparseFeaturesOneToAll,
 )
 from torchrec.distributed.embedding_types import (
     BaseGroupedFeatureProcessor,
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
+    KJTList,
     ShardedEmbeddingTable,
-    SparseFeatures,
-    SparseFeaturesList,
 )
 from torchrec.distributed.types import (
     Awaitable,
@@ -43,6 +45,7 @@ from torchrec.distributed.types import (
     ShardingEnv,
     ShardMetadata,
 )
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable
 
 
@@ -74,19 +77,10 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._grouped_embedding_configs_per_rank: List[
             List[GroupedEmbeddingConfig]
         ] = []
-        self._score_grouped_embedding_configs_per_rank: List[
-            List[GroupedEmbeddingConfig]
-        ] = []
-        (
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ) = group_tables(sharded_tables_per_rank)
+        self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs: List[
             GroupedEmbeddingConfig
         ] = self._grouped_embedding_configs_per_rank[self._rank]
-        self._score_grouped_embedding_configs: List[
-            GroupedEmbeddingConfig
-        ] = self._score_grouped_embedding_configs_per_rank[self._rank]
 
     def _shard(
         self,
@@ -138,172 +132,107 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
 
     def _dim_sum_per_rank(self) -> List[int]:
         dim_sum_per_rank = []
-        for grouped_embedding_configs, score_grouped_embedding_configs in zip(
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ):
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             dim_sum = 0
             for grouped_config in grouped_embedding_configs:
-                dim_sum += grouped_config.dim_sum()
-            for grouped_config in score_grouped_embedding_configs:
                 dim_sum += grouped_config.dim_sum()
             dim_sum_per_rank.append(dim_sum)
         return dim_sum_per_rank
 
     def embedding_dims(self) -> List[int]:
         embedding_dims = []
-        for grouped_embedding_configs, score_grouped_embedding_configs in zip(
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ):
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             for grouped_config in grouped_embedding_configs:
-                embedding_dims.extend(grouped_config.embedding_dims())
-            for grouped_config in score_grouped_embedding_configs:
                 embedding_dims.extend(grouped_config.embedding_dims())
         return embedding_dims
 
     def embedding_names(self) -> List[str]:
         embedding_names = []
-        for grouped_embedding_configs, score_grouped_embedding_configs in zip(
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ):
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             for grouped_config in grouped_embedding_configs:
-                embedding_names.extend(grouped_config.embedding_names())
-            for grouped_config in score_grouped_embedding_configs:
                 embedding_names.extend(grouped_config.embedding_names())
         return embedding_names
 
     def embedding_names_per_rank(self) -> List[List[str]]:
         embedding_names = []
-        for grouped_embedding_configs, score_grouped_embedding_configs in zip(
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ):
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             embedding_names_per_rank = []
             for grouped_config in grouped_embedding_configs:
-                embedding_names_per_rank.extend(grouped_config.embedding_names())
-            for grouped_config in score_grouped_embedding_configs:
                 embedding_names_per_rank.extend(grouped_config.embedding_names())
             embedding_names.append(embedding_names_per_rank)
         return embedding_names
 
     def embedding_shard_metadata(self) -> List[Optional[ShardMetadata]]:
         embedding_shard_metadata = []
-        for grouped_embedding_configs, score_grouped_embedding_configs in zip(
-            self._grouped_embedding_configs_per_rank,
-            self._score_grouped_embedding_configs_per_rank,
-        ):
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             for grouped_config in grouped_embedding_configs:
-                embedding_shard_metadata.extend(
-                    grouped_config.embedding_shard_metadata()
-                )
-            for grouped_config in score_grouped_embedding_configs:
                 embedding_shard_metadata.extend(
                     grouped_config.embedding_shard_metadata()
                 )
         return embedding_shard_metadata
 
-    def id_list_feature_names(self) -> List[str]:
-        id_list_feature_names = []
+    def feature_names(self) -> List[str]:
+        feature_names = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             for grouped_config in grouped_embedding_configs:
-                id_list_feature_names.extend(grouped_config.feature_names())
-        return id_list_feature_names
+                feature_names.extend(grouped_config.feature_names())
+        return feature_names
 
-    def id_score_list_feature_names(self) -> List[str]:
-        id_score_list_feature_names = []
-        for (
-            score_grouped_embedding_configs
-        ) in self._score_grouped_embedding_configs_per_rank:
-            for grouped_config in score_grouped_embedding_configs:
-                id_score_list_feature_names.extend(grouped_config.feature_names())
-        return id_score_list_feature_names
-
-    def id_list_feature_names_per_rank(self) -> List[List[str]]:
-        id_list_feature_names = []
+    def feature_names_per_rank(self) -> List[List[str]]:
+        feature_names = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
-            id_list_feature_names_per_rank = []
+            feature_names_per_rank = []
             for grouped_config in grouped_embedding_configs:
-                id_list_feature_names_per_rank.extend(grouped_config.feature_names())
-            id_list_feature_names.append(id_list_feature_names_per_rank)
-        return id_list_feature_names
+                feature_names_per_rank.extend(grouped_config.feature_names())
+            feature_names.append(feature_names_per_rank)
+        return feature_names
 
-    def id_score_list_feature_names_per_rank(self) -> List[List[str]]:
-        id_score_list_feature_names = []
-        for (
-            score_grouped_embedding_configs
-        ) in self._score_grouped_embedding_configs_per_rank:
-            id_score_list_feature_names_per_rank = []
-            for grouped_config in score_grouped_embedding_configs:
-                id_score_list_feature_names_per_rank.extend(
-                    grouped_config.feature_names()
-                )
-            id_score_list_feature_names.append(id_score_list_feature_names_per_rank)
-        return id_score_list_feature_names
-
-    def id_list_features_per_rank(self) -> List[int]:
-        id_list_features_per_rank = []
+    def features_per_rank(self) -> List[int]:
+        features_per_rank = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
             num_features = 0
             for grouped_config in grouped_embedding_configs:
                 num_features += grouped_config.num_features()
-            id_list_features_per_rank.append(num_features)
-        return id_list_features_per_rank
-
-    def id_score_list_features_per_rank(self) -> List[int]:
-        id_score_list_features_per_rank = []
-        for (
-            score_grouped_embedding_configs
-        ) in self._score_grouped_embedding_configs_per_rank:
-            num_features = 0
-            for grouped_config in score_grouped_embedding_configs:
-                num_features += grouped_config.num_features()
-            id_score_list_features_per_rank.append(num_features)
-        return id_score_list_features_per_rank
+            features_per_rank.append(num_features)
+        return features_per_rank
 
 
-class TwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeatures]):
+class TwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
     """
     Redistributes sparse features with an AlltoAll collective operation for table wise
     sharding.
 
     Args:
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
-        id_list_features_per_rank (List[int]): number of id list features to send to
-            each rank.
-        id_score_list_features_per_rank (List[int]): number of id score list features to
-            send to each rank.
+        features_per_rank (List[int]): number of features to send to each rank.
         device (Optional[torch.device]): device on which buffers will be allocated.
     """
 
     def __init__(
         self,
         pg: dist.ProcessGroup,
-        id_list_features_per_rank: List[int],
-        id_score_list_features_per_rank: List[int],
+        features_per_rank: List[int],
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
-        self._dist = SparseFeaturesAllToAll(
+        self._dist = KJTAllToAll(
             pg=pg,
-            id_list_features_per_rank=id_list_features_per_rank,
-            id_score_list_features_per_rank=id_score_list_features_per_rank,
+            splits=features_per_rank,
             device=device,
         )
 
     def forward(
         self,
-        sparse_features: SparseFeatures,
-    ) -> Awaitable[Awaitable[SparseFeatures]]:
+        sparse_features: KeyedJaggedTensor,
+    ) -> Awaitable[Awaitable[KeyedJaggedTensor]]:
         """
         Performs AlltoAll operation on sparse features.
 
         Args:
-            sparse_features (SparseFeatures): sparse features to redistribute.
+            sparse_features (KeyedJaggedTensor): sparse features to redistribute.
 
         Returns:
-            Awaitable[Awaitable[SparseFeatures]]: awaitable of awaitable of SparseFeatures.
+            Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
 
         return self._dist(sparse_features)
@@ -321,6 +250,8 @@ class TwPooledEmbeddingDist(
         dim_sum_per_rank (List[int]): number of features (sum of dimensions) of the
             embedding in each rank.
         device (Optional[torch.device]): device on which buffers will be allocated.
+        callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]):
+        qcomm_codecs_registry (Optional[Dict[str, QuantizedCommCodecs]]):
     """
 
     def __init__(
@@ -368,7 +299,7 @@ class TwPooledEmbeddingDist(
 
 class TwPooledEmbeddingSharding(
     BaseTwEmbeddingSharding[
-        EmbeddingShardingContext, SparseFeatures, torch.Tensor, torch.Tensor
+        EmbeddingShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
     ]
 ):
     """
@@ -379,12 +310,11 @@ class TwPooledEmbeddingSharding(
     def create_input_dist(
         self,
         device: Optional[torch.device] = None,
-    ) -> BaseSparseFeaturesDist[SparseFeatures]:
+    ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
         assert self._pg is not None
         return TwSparseFeaturesDist(
             self._pg,
-            self.id_list_features_per_rank(),
-            self.id_score_list_features_per_rank(),
+            self.features_per_rank(),
             device if device is not None else self._device,
         )
 
@@ -396,7 +326,6 @@ class TwPooledEmbeddingSharding(
     ) -> BaseEmbeddingLookup:
         return GroupedPooledEmbeddingsLookup(
             grouped_configs=self._grouped_embedding_configs,
-            grouped_score_configs=self._score_grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
@@ -415,45 +344,39 @@ class TwPooledEmbeddingSharding(
         )
 
 
-class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[SparseFeaturesList]):
+class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
     """
     Redistributes sparse features to all devices for inference.
 
     Args:
-        id_list_features_per_rank (List[int]): number of id list features to send
-            to each rank.
-        id_score_list_features_per_rank (List[int]): number of id score list features
-            to send to each rank.
+        features_per_rank (List[int]): number of features to send to each rank.
         world_size (int): number of devices in the topology.
     """
 
     def __init__(
         self,
-        id_list_features_per_rank: List[int],
-        id_score_list_features_per_rank: List[int],
+        features_per_rank: List[int],
         world_size: int,
     ) -> None:
         super().__init__()
-        self._dist: SparseFeaturesOneToAll = SparseFeaturesOneToAll(
-            id_list_features_per_rank,
-            id_score_list_features_per_rank,
+        self._dist = KJTOneToAll(
+            features_per_rank,
             world_size,
         )
 
     def forward(
         self,
-        sparse_features: SparseFeatures,
-    ) -> Awaitable[Awaitable[SparseFeaturesList]]:
+        sparse_features: KeyedJaggedTensor,
+    ) -> Awaitable[Awaitable[KJTList]]:
         """
         Performs OnetoAll operation on sparse features.
 
         Args:
-            sparse_features (SparseFeatures): sparse features to redistribute.
+            sparse_features (KeyedJaggedTensor): sparse features to redistribute.
 
         Returns:
-            Awaitable[Awaitable[SparseFeatures]]: awaitable of awaitable of SparseFeatures.
+            Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
-
         return NoWait(self._dist.forward(sparse_features))
 
 
@@ -497,7 +420,7 @@ class InferTwPooledEmbeddingDist(
 
 class InferTwEmbeddingSharding(
     BaseTwEmbeddingSharding[
-        NullShardingContext, SparseFeaturesList, List[torch.Tensor], torch.Tensor
+        NullShardingContext, KJTList, List[torch.Tensor], torch.Tensor
     ]
 ):
     """
@@ -506,10 +429,9 @@ class InferTwEmbeddingSharding(
 
     def create_input_dist(
         self, device: Optional[torch.device] = None
-    ) -> BaseSparseFeaturesDist[SparseFeaturesList]:
+    ) -> BaseSparseFeaturesDist[KJTList]:
         return InferTwSparseFeaturesDist(
-            self.id_list_features_per_rank(),
-            self.id_score_list_features_per_rank(),
+            self.features_per_rank(),
             self._world_size,
         )
 
@@ -518,10 +440,9 @@ class InferTwEmbeddingSharding(
         device: Optional[torch.device] = None,
         fused_params: Optional[Dict[str, Any]] = None,
         feature_processor: Optional[BaseGroupedFeatureProcessor] = None,
-    ) -> BaseEmbeddingLookup[SparseFeaturesList, List[torch.Tensor]]:
+    ) -> BaseEmbeddingLookup[KJTList, List[torch.Tensor]]:
         return InferGroupedPooledEmbeddingsLookup(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
-            grouped_score_configs_per_rank=self._score_grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
         )

--- a/torchrec/distributed/tests/test_quantize.py
+++ b/torchrec/distributed/tests/test_quantize.py
@@ -149,7 +149,6 @@ class QuantizeKernelTest(unittest.TestCase):
         config = self._create_config(compute_kernel)
         sharded = GroupedPooledEmbeddingsLookup(
             grouped_configs=[config],
-            grouped_score_configs=[],
             device=torch.device("cuda:0"),
         )
 

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -14,10 +14,7 @@ import torch
 import torch.distributed as dist
 from torch import nn, optim
 from torchrec.distributed import DistributedModelParallel
-from torchrec.distributed.embedding_types import (
-    EmbeddingComputeKernel,
-    SparseFeaturesList,
-)
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel, KJTList
 from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionContext,
     EmbeddingBagCollectionSharder,
@@ -55,7 +52,7 @@ class TestShardedEmbeddingBagCollection(ShardedEmbeddingBagCollection):
         self,
         ctx: EmbeddingBagCollectionContext,
         features: KeyedJaggedTensor,
-    ) -> Awaitable[Awaitable[SparseFeaturesList]]:
+    ) -> Awaitable[Awaitable[KJTList]]:
         return super().input_dist(ctx, features)
 
 

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -217,12 +217,9 @@ class PipelinedForward:
 
         if len(self._context.feature_processor_forwards) > 0:
             with record_function("## feature_processor ##"):
-                for sparse_feature in data:
-                    if sparse_feature.id_score_list_features is not None:
-                        for fp_forward in self._context.feature_processor_forwards:
-                            sparse_feature.id_score_list_features = fp_forward(
-                                sparse_feature.id_score_list_features
-                            )
+                for i, sparse_feature in enumerate(data):
+                    for fp_forward in self._context.feature_processor_forwards:
+                        data[i] = fp_forward(sparse_feature)
 
         return self._module.compute_and_output_dist(
             self._context.module_contexts[self._name], data


### PR DESCRIPTION
Summary:
- Remove SparseFeatures wrapper around KJTs used for sparse data distribution.
- Clean up modules to only handle one set of features at a time (which is already a constraint for EBC/EC)

Differential Revision: D42015043

