### PR TITLE
fix quantize tests by calling named_parameters instead of named_buffers in quantize: Multisect successfully blamed D41964643 for test or build failures

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -196,16 +196,18 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag):
         data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         sparse_type = data_type_to_sparse_type(data_type)
 
+        # TODO Can we simplify this with state_dict = module.state_dict()?
         state_dict = (
             dict(module.named_split_embedding_weights())
             if isinstance(module, BatchedDenseEmbeddingBag)
-            else dict(module.named_buffers())
+            else dict(module.named_parameters())
         )
         device = next(iter(state_dict.values())).device
 
         config = _copy_config(module.config, data_type, sparse_type, device)
         ret = QuantBatchedEmbeddingBag(config=config, device=device)
 
+        # pyre-ignore
         quant_weight_list = _quantize_weight(state_dict, data_type)
         ret.emb_module.assign_embedding_weights(quant_weight_list)
 
@@ -293,16 +295,18 @@ class QuantBatchedEmbedding(BaseBatchedEmbedding):
         data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         sparse_type = data_type_to_sparse_type(data_type)
 
+        # TODO Can we simplify this with state_dict = module.state_dict()?
         state_dict = (
             dict(module.named_split_embedding_weights())
             if isinstance(module, BatchedDenseEmbedding)
-            else dict(module.named_buffers())
+            else dict(module.named_parameters())
         )
         device = next(iter(state_dict.values())).device
 
         config = _copy_config(module.config, data_type, sparse_type, device)
         ret = QuantBatchedEmbedding(config=config, device=device)
 
+        # pyre-ignore
         quant_weight_list = _quantize_weight(state_dict, data_type)
         ret.emb_module.assign_embedding_weights(quant_weight_list)
 


### PR DESCRIPTION
Summary:
This diff is reverting D41964643 (https://github.com/pytorch/torchrec/commit/e8ab2de1cfb9e312fea24290fd74e50f71c8acf3)
Depends on D42118223
D41964643 (https://github.com/pytorch/torchrec/commit/e8ab2de1cfb9e312fea24290fd74e50f71c8acf3) has been identified to be causing the following test or build failures:

Tests affected:
- [torchrec/distributed/tests:test_quantize - torchrec.distributed.tests.test_quantize.QuantizeKernelTest: test_quantize_embedding_kernels](https://www.internalfb.com/intern/test/281475048734023/)
- [torchrec/distributed/tests:test_quantize - torchrec.distributed.tests.test_quantize.QuantizeKernelTest: test_quantize_embedding_bag_kernels](https://www.internalfb.com/intern/test/281475048734024/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1479841
Here are the tasks that are relevant to this breakage:
T139270782: 4 tests started failing for oncall torchrec in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Reviewed By: bigning

Differential Revision: D42118227

