### PR TITLE
add emptyFusedOptimizer to use for empty sharded fused params

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -43,7 +43,11 @@ from torchrec.modules.embedding_configs import (
     data_type_to_sparse_type,
     pooling_type_to_pooling_mode,
 )
-from torchrec.optim.fused import FusedOptimizer, FusedOptimizerModule
+from torchrec.optim.fused import (
+    EmptyFusedOptimizer,
+    FusedOptimizer,
+    FusedOptimizerModule,
+)
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
@@ -526,7 +530,7 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding, FusedOptimizerModule):
             # can delete after SEA deprecation
             param = nn.Parameter(tensor)
             # pyre-ignore
-            param._overlapped_optimizer = True
+            param._overlapped_optimizer = EmptyFusedOptimizer()
             yield name, param
 
     def flush(self) -> None:
@@ -816,7 +820,7 @@ class BatchedFusedEmbeddingBag(BaseBatchedEmbeddingBag, FusedOptimizerModule):
             # can delete after PEA deprecation
             param = nn.Parameter(tensor)
             # pyre-ignore
-            param._overlapped_optimizer = True
+            param._overlapped_optimizer = EmptyFusedOptimizer()
             yield name, param
 
     def flush(self) -> None:

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -9,19 +9,7 @@
 import copy
 from collections import defaultdict, deque, OrderedDict
 from dataclasses import dataclass, field
-from typing import (
-    Any,
-    cast,
-    Dict,
-    Iterator,
-    List,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, cast, Dict, List, MutableMapping, Optional, Type, Union
 
 import torch
 from torch import nn
@@ -78,7 +66,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingCollection,
     EmbeddingCollectionInterface,
 )
-from torchrec.optim.fused import FusedOptimizerModule
+from torchrec.optim.fused import EmptyFusedOptimizer, FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
@@ -484,7 +472,9 @@ class ShardedEmbeddingCollection(
                     model_parallel_name_to_compute_kernel[table_name]
                     != EmbeddingComputeKernel.DENSE.value
                 ):
-                    self.embeddings[table_name].weight._overlapped_optimizer = True
+                    self.embeddings[
+                        table_name
+                    ].weight._overlapped_optimizer = EmptyFusedOptimizer()
 
         def post_state_dict_hook(
             module: ShardedEmbeddingCollection,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -59,7 +59,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
     EmbeddingBagCollectionInterface,
 )
-from torchrec.optim.fused import FusedOptimizerModule
+from torchrec.optim.fused import EmptyFusedOptimizer, FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
@@ -479,7 +479,9 @@ class ShardedEmbeddingBagCollection(
                     model_parallel_name_to_compute_kernel[table_name]
                     != EmbeddingComputeKernel.DENSE.value
                 ):
-                    self.embedding_bags[table_name].weight._overlapped_optimizer = True
+                    self.embedding_bags[
+                        table_name
+                    ].weight._overlapped_optimizer = EmptyFusedOptimizer()
 
         def post_state_dict_hook(
             module: ShardedEmbeddingBagCollection,

--- a/torchrec/optim/fused.py
+++ b/torchrec/optim/fused.py
@@ -31,6 +31,22 @@ class FusedOptimizer(KeyedOptimizer, abc.ABC):
         return optim.Optimizer.__repr__(self)
 
 
+class EmptyFusedOptimizer(FusedOptimizer):
+    """
+    Fused Optimizer class with no-op step and no parameters to optimize over
+    """
+
+    def __init__(self) -> None:
+        super().__init__({}, {}, {})
+
+    # pyre-ignore
+    def step(self, closure: Any = None) -> None:
+        pass
+
+    def zero_grad(self, set_to_none: bool = False) -> None:
+        pass
+
+
 class FusedOptimizerModule(abc.ABC):
     """
     Module, which does weight update during backward pass.


### PR DESCRIPTION
Summary: as title - replaces 'True' _overlapped_optimizer hack for empy fused MP params with an EmptyFusedOptimizer - a FusedOptimzier with dummy step() and zero_grad() methods

Differential Revision: D42223121

