### PR TITLE
Fix nightly cron job 

### DIFF
--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -24,4 +24,3 @@ jobs:
     uses: ./.github/workflows/validate-binaries.yml
     with:
       channel: nightly
-      os: linux


### PR DESCRIPTION
Fix nightly cron job.
Currently error can be seen on nightly validation cron:
https://github.com/pytorch/torchrec/actions/runs/3808226393

```
[Invalid workflow file: .github/workflows/validate-nightly-binaries.yml#L27](https://github.com/pytorch/torchrec/actions/runs/3808226393/workflow)
The workflow is not valid. .github/workflows/validate-nightly-binaries.yml (Line: 27, Col: 11): Invalid input, os is not defined in the referenced workflow.
```