### PR TITLE
metrics states vectorization

### DIFF
--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -42,8 +42,8 @@ def compute_auc(
     return torch.cat(aucs)
 
 
-def _state_reduction(state: List[torch.Tensor]) -> List[torch.Tensor]:
-    return [torch.cat(state, dim=1)]
+def _state_reduction(state: torch.Tensor) -> torch.Tensor:
+    return torch.cat(list(state), dim=-1)
 
 
 class AUCMetricComputation(RecMetricComputation):
@@ -56,50 +56,38 @@ class AUCMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._add_state(
+        self.state_names: List[str] = [
             PREDICTIONS,
-            [],
-            add_window_state=False,
-            dist_reduce_fx=_state_reduction,
-            persistent=False,
-        )
-        self._add_state(
             LABELS,
-            [],
-            add_window_state=False,
-            dist_reduce_fx=_state_reduction,
-            persistent=False,
-        )
-        self._add_state(
             WEIGHTS,
-            [],
+        ]
+        self._add_state(
+            self.state_names,
+            torch.zeros(
+                (len(self.state_names), self._n_tasks, 1),
+                dtype=torch.double,
+                device=self.device,
+            ),
             add_window_state=False,
             dist_reduce_fx=_state_reduction,
             persistent=False,
         )
-        self._init_states()
 
-    # The states values are set to empty lists in __init__() and reset(), and then we
-    # add a size (self._n_tasks, 1) tensor to each of the list as the initial values
-    # This is to bypass the limitation of state aggregation in TorchMetrics sync() when
-    # we try to checkpoint the states before update()
-    # The reason for using lists here is to avoid automatically stacking the tensors from
-    # all the trainers into one tensor in sync()
-    # The reason for using non-empty tensors as the first elements is to avoid the
-    # floating point exception thrown in sync() for aggregating empty tensors
     def _init_states(self) -> None:
-        if len(getattr(self, PREDICTIONS)) > 0:
-            return
+        state = getattr(self, self._fused_name)
+        state = torch.zeros(
+            (len(self.state_names), self._n_tasks, 1),
+            dtype=torch.double,
+            device=self.device,
+        )
+        setattr(self, self._fused_name, state)
 
-        getattr(self, PREDICTIONS).append(
-            torch.zeros((self._n_tasks, 1), dtype=torch.double, device=self.device)
-        )
-        getattr(self, LABELS).append(
-            torch.zeros((self._n_tasks, 1), dtype=torch.double, device=self.device)
-        )
-        getattr(self, WEIGHTS).append(
-            torch.zeros((self._n_tasks, 1), dtype=torch.double, device=self.device)
-        )
+        for name, _ in self._fused_map.items():
+            setattr(
+                self,
+                name,
+                torch.zeros((self._n_tasks, 1), dtype=torch.double, device=self.device),
+            )
 
     def update(
         self,
@@ -116,25 +104,14 @@ class AUCMetricComputation(RecMetricComputation):
         predictions = predictions.double()
         labels = labels.double()
         weights = weights.double()
-        num_samples = getattr(self, PREDICTIONS)[0].size(-1)
+        state = getattr(self, self._fused_name)
+        num_samples = state.size(-1)
         batch_size = predictions.size(-1)
         start_index = max(num_samples + batch_size - self._window_size, 0)
-        # Using `self.predictions =` will cause Pyre errors.
-        getattr(self, PREDICTIONS)[0] = torch.cat(
-            [
-                cast(torch.Tensor, getattr(self, PREDICTIONS)[0])[:, start_index:],
-                predictions,
-            ],
-            dim=-1,
-        )
-        getattr(self, LABELS)[0] = torch.cat(
-            [cast(torch.Tensor, getattr(self, LABELS)[0])[:, start_index:], labels],
-            dim=-1,
-        )
-        getattr(self, WEIGHTS)[0] = torch.cat(
-            [cast(torch.Tensor, getattr(self, WEIGHTS)[0])[:, start_index:], weights],
-            dim=-1,
-        )
+
+        states = torch.stack([predictions, labels, weights])
+        state = torch.cat([state[:, :, start_index:], states], dim=-1)
+        setattr(self, self._fused_name, state)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -143,9 +120,9 @@ class AUCMetricComputation(RecMetricComputation):
                 metric_prefix=MetricPrefix.WINDOW,
                 value=compute_auc(
                     self._n_tasks,
-                    cast(torch.Tensor, getattr(self, PREDICTIONS)[0]),
-                    cast(torch.Tensor, getattr(self, LABELS)[0]),
-                    cast(torch.Tensor, getattr(self, WEIGHTS)[0]),
+                    self.get_state(PREDICTIONS),
+                    self.get_state(LABELS),
+                    self.get_state(WEIGHTS),
                 ),
             )
         ]

--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -37,6 +37,17 @@ def get_calibration_states(
     }
 
 
+def get_calibration_states_fused(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    return torch.stack(
+        [
+            torch.sum(predictions * weights, dim=-1),
+            torch.sum(labels * weights, dim=-1),
+        ]
+    )
+
+
 class CalibrationMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for Calibration, which is the
@@ -48,16 +59,13 @@ class CalibrationMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._add_state(
+        state_names = [
             CALIBRATION_NUM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             CALIBRATION_DENOM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
+        ]
+        self._add_state(
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -76,12 +84,11 @@ class CalibrationMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CalibrationMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-        for state_name, state_value in get_calibration_states(
-            labels, predictions, weights
-        ).items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+
+        states = get_calibration_states_fused(labels, predictions, weights)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -89,8 +96,8 @@ class CalibrationMetricComputation(RecMetricComputation):
                 name=MetricName.CALIBRATION,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_calibration(
-                    cast(torch.Tensor, self.calibration_num),
-                    cast(torch.Tensor, self.calibration_denom),
+                    self.get_state(CALIBRATION_NUM),
+                    self.get_state(CALIBRATION_DENOM),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -73,6 +73,25 @@ def get_ne_states(
     }
 
 
+def get_ne_states_fused(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
+) -> torch.Tensor:
+    cross_entropy = compute_cross_entropy(
+        labels,
+        predictions,
+        weights,
+        eta,
+    )
+    return torch.stack(
+        [
+            torch.sum(cross_entropy, dim=-1),
+            torch.sum(weights, dim=-1),
+            torch.sum(weights * labels, dim=-1),
+            torch.sum(weights * (1.0 - labels), dim=-1),
+        ]
+    )
+
+
 class NEMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for NE, i.e. Normalized Entropy.
@@ -83,30 +102,15 @@ class NEMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._add_state(
+        state_names = [
             "cross_entropy_sum",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "weighted_num_samples",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "pos_labels",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "neg_labels",
-            torch.zeros(self._n_tasks, dtype=torch.double),
+        ]
+        self._add_state(
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -125,13 +129,12 @@ class NEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for NEMetricComputation update"
             )
-        states = get_ne_states(labels, predictions, weights, self.eta)
         num_samples = predictions.shape[-1]
 
-        for state_name, state_value in states.items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+        states = get_ne_states_fused(labels, predictions, weights, self.eta)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -139,10 +142,10 @@ class NEMetricComputation(RecMetricComputation):
                 name=MetricName.NE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_ne(
-                    cast(torch.Tensor, self.cross_entropy_sum),
-                    cast(torch.Tensor, self.weighted_num_samples),
-                    cast(torch.Tensor, self.pos_labels),
-                    cast(torch.Tensor, self.neg_labels),
+                    self.get_state("cross_entropy_sum"),
+                    self.get_state("weighted_num_samples"),
+                    self.get_state("pos_labels"),
+                    self.get_state("neg_labels"),
                     self.eta,
                 ),
             ),

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -11,6 +11,7 @@ import abc
 import itertools
 import math
 from collections import defaultdict, deque
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -34,6 +35,7 @@ from typing import (
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+from torch import Tensor
 from torchmetrics import Metric
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
 from torchrec.metrics.metrics_namespace import (
@@ -140,6 +142,9 @@ class RecMetricComputation(Metric, abc.ABC):
         self._window_size = window_size
         self._compute_on_all_ranks = compute_on_all_ranks
         self._should_validate_update = should_validate_update
+        self._fused_map: Dict[str, int] = {}
+        self._window_fused_map: Dict[str, int] = {}
+        self._fused_name = "_fused_states"
         if self._window_size > 0:
             self._batch_window_buffers = {}
         else:
@@ -152,16 +157,42 @@ class RecMetricComputation(Metric, abc.ABC):
                 dist_reduce_fx=lambda x: torch.any(x, dim=0).byte(),
                 persistent=True,
             )
+        self._register_load_state_dict_pre_hook(
+            self._pre_load_state_dict_hook, with_module=True
+        )
 
     @staticmethod
     def get_window_state_name(state_name: str) -> str:
         return f"window_{state_name}"
 
+    def get_fused_state_name(self) -> str:
+        return self._fused_name
+
+    def get_fused_window_state_name(self) -> str:
+        return self.get_window_state_name(self.get_fused_state_name())
+
     def get_window_state(self, state_name: str) -> torch.Tensor:
-        return getattr(self, self.get_window_state_name(state_name))
+        if state_name in self._fused_map:
+            fused_window_states = getattr(
+                self, self.get_window_state_name(self._fused_name)
+            )
+            return fused_window_states[self._fused_map[state_name]]
+        else:
+            return getattr(self, self.get_window_state_name(state_name))
+
+    def get_state(self, state_name: str) -> torch.Tensor:
+        if state_name in self._fused_map:
+            fused_states = getattr(self, self._fused_name)
+            return fused_states[self._fused_map[state_name]]
+        else:
+            return getattr(self, state_name)
 
     def _add_state(
-        self, name: str, default: DefaultValueT, add_window_state: bool, **kwargs: Any
+        self,
+        name: Union[str, List[str]],
+        default: Tensor,
+        add_window_state: bool,
+        **kwargs: Any,
     ) -> None:
         """
         name (str): the name of this state. The state will be accessible
@@ -180,24 +211,35 @@ class RecMetricComputation(Metric, abc.ABC):
         persistent (bool): set this to True if you want to save/checkpoint the
             metric and this state is required to compute the checkpointed metric.
         """
-        # pyre-fixme[6]: Expected `Union[List[typing.Any], torch.Tensor]` for 2nd
-        #  param but got `DefaultValueT`.
-        super().add_state(name, default, **kwargs)
+        if isinstance(name, List):
+            super().add_state(self._fused_name, default, **kwargs)
+        else:
+            super().add_state(name, default, **kwargs)
+
         if add_window_state:
             if self._batch_window_buffers is None:
                 raise RuntimeError(
                     "Users is adding a window state while window metric is disabled."
                 )
             kwargs["persistent"] = False
-            window_state_name = self.get_window_state_name(name)
-            # Avoid pyre error
+            # add fused window state
+            if isinstance(name, List):
+                window_state_name = self.get_window_state_name(self._fused_name)
+            else:
+                window_state_name = self.get_window_state_name(name)
+
             assert isinstance(default, torch.Tensor)
             super().add_state(window_state_name, default.detach().clone(), **kwargs)
 
+            # pyre-fixme[16]: `Optional` has no attribute `__setitem__`.
             self._batch_window_buffers[window_state_name] = WindowBuffer(
                 max_size=self._window_size,
                 max_buffer_count=MAX_BUFFER_COUNT,
             )
+
+        if isinstance(name, List):
+            for i, _name in enumerate(name):
+                self._fused_map[_name] = i
 
     def _aggregate_window_state(
         self, state_name: str, state: torch.Tensor, num_samples: int
@@ -245,6 +287,42 @@ class RecMetricComputation(Metric, abc.ABC):
 
     def local_compute(self) -> List[MetricComputationReport]:
         return self._compute()
+
+    def state_dict(
+        self,
+        destination: Optional[Dict[str, Any]] = None,
+        prefix: str = "",
+        keep_vars: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        state_dict = {}
+        if destination is not None:
+            state_dict = super().state_dict(
+                destination=destination, prefix=prefix, keep_vars=keep_vars
+            )
+            # To make the state fused version be compatible with the checkpoint from the
+            # non-fused version, unflatten the fused state
+            if state_dict is not None:
+                key = prefix + self._fused_name
+                if key in state_dict:
+                    del state_dict[key]
+                    for state_name in self._fused_map:
+                        current_val = self.get_state(state_name)
+                        if not keep_vars:
+                            current_val = current_val.detach()
+                        state_dict[prefix + state_name] = deepcopy(current_val)
+        return state_dict
+
+    @staticmethod
+    def _pre_load_state_dict_hook(
+        self: torch.nn.Module,
+        state_dict: Dict[str, Any],
+        prefix: str,
+        *args: Any,
+    ) -> None:
+        for state_name in cast(RecMetricComputation, self)._fused_map:
+            name = prefix + state_name
+            if name in state_dict:
+                setattr(self, state_name, state_dict.pop(name))
 
 
 class RecMetric(nn.Module, abc.ABC):

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -15,6 +15,7 @@ from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecTaskInfo
 from torchrec.metrics.test_utils import (
+    gen_test_batch,
     rec_metric_value_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
@@ -146,6 +147,31 @@ class AUCMetricTest(unittest.TestCase):
             world_size=WORLD_SIZE,
             entry_point=self._test_auc,
         )
+
+    def test_auc_reset(self) -> None:
+        batch_size = 128
+        auc = AUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=batch_size,
+            tasks=[DefaultTaskInfo],
+        )
+
+        # Mimic that reset is called when checkpointing.
+        auc.reset()
+        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
+        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
+        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
+        model_output = gen_test_batch(batch_size)
+        model_output = {k: v for k, v in model_output.items()}
+        auc.update(
+            predictions={"DefaultTask": model_output["prediction"]},
+            labels={"DefaultTask": model_output["label"]},
+            weights={"DefaultTask": model_output["weight"]},
+        )
+        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
+        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
+        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
 
 
 class AUCMetricValueTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -92,11 +92,11 @@ class TestGPU(unittest.TestCase):
         ne_computation = ne._metrics_computations[0]
         # test RecMetricComputation._add_window_state
         torch.allclose(
-            ne_computation.window_cross_entropy_sum,
+            ne_computation.get_window_state("cross_entropy_sum"),
             torch.tensor([0.0], dtype=torch.double, device=device),
         )
         torch.allclose(
-            ne_computation.window_weighted_num_samples,
+            ne_computation.get_window_state("weighted_num_samples"),
             torch.tensor([[0.0]], dtype=torch.double, device=device),
         )
 
@@ -124,13 +124,11 @@ class TestGPU(unittest.TestCase):
                 )
             else:
                 self.assertEqual(
-                    ne_computation.window_cross_entropy_sum.size(), torch.Size([1])
+                    ne_computation.get_window_state("cross_entropy_sum").size(),
+                    torch.Size([1]),
                 )
+                fused_state_name = ne_computation.get_fused_window_state_name()
                 self.assertEqual(
-                    len(
-                        ne_computation._batch_window_buffers[
-                            "window_cross_entropy_sum"
-                        ].buffers
-                    ),
+                    len(ne_computation._batch_window_buffers[fused_state_name].buffers),
                     3,
                 )

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -59,10 +59,15 @@ class RecMetricTest(unittest.TestCase):
         )
         ne1 = ne1._metrics_computations[0]
         ne2 = ne2._metrics_computations[0]
-        self.assertTrue(ne1.cross_entropy_sum == ne2.cross_entropy_sum)
-        self.assertTrue(ne1.weighted_num_samples == ne2.weighted_num_samples)
-        self.assertTrue(ne1.pos_labels == ne2.pos_labels)
-        self.assertTrue(ne1.neg_labels == ne2.neg_labels)
+        self.assertTrue(
+            ne1.get_state("cross_entropy_sum") == ne2.get_state("cross_entropy_sum")
+        )
+        self.assertTrue(
+            ne1.get_state("weighted_num_samples")
+            == ne2.get_state("weighted_num_samples")
+        )
+        self.assertTrue(ne1.get_state("pos_labels") == ne2.get_state("pos_labels"))
+        self.assertTrue(ne1.get_state("neg_labels") == ne2.get_state("neg_labels"))
 
     def test_zero_weights(self) -> None:
         # Test if weights = 0 for an update
@@ -86,8 +91,10 @@ class RecMetricTest(unittest.TestCase):
             labels=self.labels,
             weights=zero_weights,
         )
-        self.assertEqual(mse_computation.error_sum, torch.tensor(0.0))
-        self.assertEqual(mse_computation.weighted_num_samples, torch.tensor(0.0))
+        self.assertEqual(mse_computation.get_state("error_sum"), torch.tensor(0.0))
+        self.assertEqual(
+            mse_computation.get_state("weighted_num_samples"), torch.tensor(0.0)
+        )
 
         res = mse.compute()
         self.assertEqual(res["mse-DefaultTask|lifetime_mse"], torch.tensor(0.0))
@@ -98,12 +105,11 @@ class RecMetricTest(unittest.TestCase):
             labels=self.labels,
             weights=self.weights,
         )
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(mse_computation.error_sum, torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(mse_computation.weighted_num_samples, torch.tensor(0.0))
+
+        self.assertGreater(mse_computation.get_state("error_sum"), torch.tensor(0.0))
+        self.assertGreater(
+            mse_computation.get_state("weighted_num_samples"), torch.tensor(0.0)
+        )
 
         res = mse.compute()
         # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
@@ -149,14 +155,20 @@ class RecMetricTest(unittest.TestCase):
             labels=labels,
             weights=partial_zero_weights,
         )
-        self.assertEqual(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
-        self.assertEqual(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(ne_computation[1].cross_entropy_sum, torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(ne_computation[1].weighted_num_samples, torch.tensor(0.0))
+        self.assertEqual(
+            ne_computation[0].get_state("cross_entropy_sum"), torch.tensor(0.0)
+        )
+        self.assertEqual(
+            ne_computation[0].get_state("weighted_num_samples"), torch.tensor(0.0)
+        )
+
+        self.assertGreater(
+            ne_computation[1].get_state("cross_entropy_sum"), torch.tensor(0.0)
+        )
+
+        self.assertGreater(
+            ne_computation[1].get_state("weighted_num_samples"), torch.tensor(0.0)
+        )
 
         res = ne.compute()
         self.assertEqual(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
@@ -169,12 +181,14 @@ class RecMetricTest(unittest.TestCase):
             labels=labels,
             weights=weights,
         )
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(ne_computation[0].cross_entropy_sum, torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
-        self.assertGreater(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
+
+        self.assertGreater(
+            ne_computation[0].get_state("cross_entropy_sum"), torch.tensor(0.0)
+        )
+
+        self.assertGreater(
+            ne_computation[0].get_state("weighted_num_samples"), torch.tensor(0.0)
+        )
 
         res = ne.compute()
         # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but


### PR DESCRIPTION
Summary:
The current implementation computes each metric state individually. This diff vectorizes these operations.
Some key changes in this diff:
* states vectorization in all supported metrics
* In auc metric, stores its states with tensor instead of a list of one element. This is to make the states vectorization logic in all metrics be consistent.

Most parts of this diff are the same as D40419238 (https://github.com/pytorch/torchrec/commit/50c861a4debb6d0d8bd55ddb27452e89f2d19d51). The main difference is that this one has added the backward compatibility support for old model checkpoints.

Differential Revision: D42161727

