### PR TITLE
Unify apply_optimizer_in_backward API usage

### DIFF
--- a/examples/golden_training/train_dlrm.py
+++ b/examples/golden_training/train_dlrm.py
@@ -11,6 +11,9 @@ from typing import List, Optional
 import torch
 from torch import distributed as dist
 from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torch.utils.data import IterableDataset
 from torchrec.datasets.criteo import DEFAULT_CAT_NAMES, DEFAULT_INT_NAMES
 from torchrec.datasets.random import RandomRecDataset
@@ -25,7 +28,6 @@ from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.models.dlrm import DLRM, DLRMTrain
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.keyed import KeyedOptimizerWrapper
 from torchrec.optim.optimizers import in_backward_optimizer_filter
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad

--- a/examples/retrieval/two_tower_train.py
+++ b/examples/retrieval/two_tower_train.py
@@ -16,6 +16,9 @@ import faiss  # @manual=//faiss/python:pyfaiss_gpu
 import faiss.contrib.torch_utils  # @manual=//faiss/contrib:faiss_contrib_gpu
 import torch
 from torch import distributed as dist
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec import inference as trec_infer
 from torchrec.datasets.movielens import DEFAULT_RATINGS_COLUMN_NAMES
 from torchrec.distributed import TrainPipelineSparseDist
@@ -26,7 +29,6 @@ from torchrec.inference.state_dict_transform import (
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.keyed import KeyedOptimizerWrapper
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor

--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -13,6 +13,9 @@ import hypothesis.strategies as st
 import torch
 import torch.nn as nn
 from hypothesis import assume, given, settings, Verbosity
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec import distributed as trec_dist
 from torchrec.distributed.embedding import (
     EmbeddingCollectionSharder,
@@ -39,7 +42,6 @@ from torchrec.distributed.types import (
 )
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.embedding_modules import EmbeddingCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class

--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -13,6 +13,9 @@ import hypothesis.strategies as st
 import torch
 import torch.nn as nn
 from hypothesis import assume, given, settings, Verbosity
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec import distributed as trec_dist
 from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionSharder,
@@ -39,7 +42,6 @@ from torchrec.distributed.types import (
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import (

--- a/torchrec/distributed/composable/tests/test_fused_optim.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim.py
@@ -10,6 +10,9 @@ import unittest
 
 import torch
 from torch import distributed as dist
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec.distributed.shard import shard
 from torchrec.distributed.sharding_plan import (
     apply_to_all,
@@ -18,7 +21,6 @@ from torchrec.distributed.sharding_plan import (
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
 from torchrec.optim.warmup import WarmupOptimizer, WarmupPolicy, WarmupStage
 from torchrec.test_utils import get_free_port

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -154,8 +154,15 @@ def create_sharding_infos_by_sharding(
         if parameter_sharding.sharding_type not in sharding_type_to_sharding_infos:
             sharding_type_to_sharding_infos[parameter_sharding.sharding_type] = []
 
-        optimizer_params = getattr(param, "_optimizer_kwargs", {})
-        optimizer_class = getattr(param, "_optimizer_class", None)
+        optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
+        optimizer_classes = getattr(param, "_optimizer_classes", [None])
+
+        assert (
+            len(optimizer_classes) == 1 and len(optimizer_params) == 1
+        ), f"Only support 1 optimizer, given {len(optimizer_classes)}"
+
+        optimizer_class = optimizer_classes[0]
+        optimizer_params = optimizer_params[0]
         if optimizer_class:
             optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
                 optimizer_class

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -206,8 +206,16 @@ def create_sharding_infos_by_sharding(
         if parameter_sharding.sharding_type not in sharding_type_to_sharding_infos:
             sharding_type_to_sharding_infos[parameter_sharding.sharding_type] = []
 
-        optimizer_params = getattr(param, "_optimizer_kwargs", {})
-        optimizer_class = getattr(param, "_optimizer_class", None)
+        optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
+        optimizer_classes = getattr(param, "_optimizer_classes", [None])
+
+        assert (
+            len(optimizer_classes) == 1 and len(optimizer_params) == 1
+        ), f"Only support 1 optimizer, given {len(optimizer_classes)} optimizer classes \
+        and {len(optimizer_params)} optimizer kwargs."
+
+        optimizer_class = optimizer_classes[0]
+        optimizer_params = optimizer_params[0]
         if optimizer_class:
             optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
                 optimizer_class

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -12,6 +12,9 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec.distributed.embedding_types import EmbeddingTableConfig
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
@@ -41,7 +44,6 @@ from torchrec.distributed.types import (
     ShardingType,
 )
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
 from torchrec.optim.optimizers import in_backward_optimizer_filter
 from typing_extensions import Protocol

--- a/torchrec/distributed/tests/test_qcomms_embedding_modules.py
+++ b/torchrec/distributed/tests/test_qcomms_embedding_modules.py
@@ -14,6 +14,9 @@ import torch
 import torch.nn as nn
 import torchrec.distributed as trec_dist
 from hypothesis import given, settings, Verbosity
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
@@ -37,7 +40,6 @@ from torchrec.distributed.test_utils.test_sharding import copy_state_dict
 from torchrec.distributed.types import ModuleSharder, ParameterSharding, ShardingEnv
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class

--- a/torchrec/optim/apply_optimizer_in_backward.py
+++ b/torchrec/optim/apply_optimizer_in_backward.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, Dict, Iterable, Type
+from warnings import warn
 
 import torch
 
@@ -16,6 +17,8 @@ def apply_optimizer_in_backward(
     optimizer_kwargs: Dict[str, Any],
 ) -> None:
     """
+    NOTE: This API is deprecated. Please use Pytorch Distributed's _apply_optimizer_in_backward instead.
+
     Upon backwards(), parameters will fire the corresponding optimizer
     Each parameter will have the optimizer_class and optimizer_kwargs attached to
     _optimizer and _optimizer_kwargs.
@@ -40,6 +43,11 @@ def apply_optimizer_in_backward(
         print(param_1._optimizer, param_1._optimizer_kwargs)
         >> torch.optim.SGD, {"lr": .02}
     """
+
+    warn(
+        "This API is deprecated. Please use Pytorch Distributed's _apply_optimizer_in_backward API instead.",
+        DeprecationWarning,
+    )
 
     def _apply_optimizer_in_backward_to_param(param: torch.nn.Parameter) -> None:
         # acc_grad creates a new node in the auto_grad graph that comes after


### PR DESCRIPTION
Summary: Currently the `apply_optimizer_in_backward` API lives in both torchrec and distributed folders. We want to migrate all usage of torchrec's `apply_optimizer_in_backward` to distributed's to unify the API.

Reviewed By: colin2328, YLGH

Differential Revision: D42319179

