### PR TITLE
Enhanced ESUHM Arch for ROO on VDD 2-11

### DIFF
--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -101,7 +101,6 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         if not self._connected:
             self._connect(dataloader_iter)
-
         # Fetch next batch
         with record_function("## next_batch ##"):
             next_batch = next(dataloader_iter)


### PR DESCRIPTION
Summary:
Modify ROO version ESUHM Arch for better performance

* Re write code to be fx traceable so we can use Trec 3 stage train pipeline
* Re write ESUHM to process request level information and source embedding projection via RO batch size to reduce computation and delay expand
* Use Jagged Index select(via num_candidate) to expand source and source proj to match target
* Remove any unnecessary  for loop and D2 (https://github.com/pytorch/torchrec/commit/10869538d108818006d263794f05d15034bed5f4)H stream sync in previous ROO implementation
* TODO: can write new op which dose not need any source embedding expasion, this trace show Jagged index select is still quite expensive especially consider we have 13 ESUHM channels and we will increase UIH seq size, so if we do not need to expand source emb(and emb projection), but directly perform add/multiplication with target based on num_candidate, will be great to not use jagged index select here, and also reduce memory access

{F841713746}

Differential Revision:
D42389446

Privacy Context Container: L1138451

