### PR TITLE
Remove the need to use populate_fx_names

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -316,7 +316,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
                 weights = torch.cat(weights)
 
             embeddings.append(
-                emb_op(
+                emb_op.forward(
                     indices=indices.int(),
                     offsets=offsets.int(),
                     per_sample_weights=weights if self._is_weighted else None,

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -374,9 +374,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         qebc = QuantEmbeddingBagCollection.from_float(ebc)
 
         from torchrec.fx import symbolic_trace
-        from torchrec.quant.utils import populate_fx_names
 
-        populate_fx_names(qebc)
         gm = symbolic_trace(qebc)
 
         features = KeyedJaggedTensor(


### PR DESCRIPTION
Just call .forward() method directly. This way fx tracer won't fail checking that module is registered as a valid sub-module.