### PR TITLE
Simplify shard() call

### DIFF
--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -108,7 +108,7 @@ def _test_sharding(  # noqa C901
             module=model,
             env=ShardingEnv.from_process_group(ctx.pg),
             plan=plan.get_plan_for_module(""),
-            sharders=[sharder],
+            sharder=sharder,
             device=ctx.device,
         )
 

--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -117,7 +117,7 @@ def _test_sharding(  # noqa C901
             module=model,
             env=ShardingEnv.from_process_group(ctx.pg),
             plan=plan.get_plan_for_module(""),
-            sharders=[sharder],
+            sharders=sharder,
             device=ctx.device,
         )
 

--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -304,18 +304,12 @@ class FSDPTestComposable(unittest.TestCase):
         m.sparse.ebc = trec_shard(
             module=m.sparse.ebc,
             device=device,
-            plan=construct_module_sharding_plan(
-                m.sparse.ebc,
-                apply_to_all(m.sparse.ebc, row_wise()),
-            ),
+            plan=row_wise(),
         )
         m.sparse.weighted_ebc = trec_shard(
             module=m.sparse.weighted_ebc,
             device=device,
-            plan=construct_module_sharding_plan(
-                m.sparse.weighted_ebc,
-                apply_to_all(m.sparse.weighted_ebc, row_wise()),
-            ),
+            plan=row_wise(),
         )
         m.dense = fully_shard(
             m.dense,


### PR DESCRIPTION
Simplify shard() call by supporting ParameterShardingGenerator. New code
```
ebc = EmbeddingBagCollection()
sharded_ebc = shard(ebc, table_row_wise(host_index=0))
```
vs current one:
```
ebc = EmbeddingBagCollection()
plan=construct_module_sharding_plan(
  ebc,
  apply_to_all(ebc, table_row_wise(host_index=0)),
)
sharded_ebc = shard(ebc, plan)
```

Will update test if looks good.
