### PR TITLE
Fix some semantics of TableBatchedEmbeddingSlice

### DIFF
--- a/torchrec/distributed/composable/table_batched_embedding_slice.py
+++ b/torchrec/distributed/composable/table_batched_embedding_slice.py
@@ -67,6 +67,12 @@ class TableBatchedEmbeddingSlice(nn.Parameter):
     @grad.setter
     def grad(self, set_grad: torch.Tensor) -> None:
         self._init_grad = set_grad
+        if set_grad is None:
+            self._original_tensor.grad = None
+        elif self._original_tensor.grad is not None:
+            self._original_tensor.grad[self._start_offset : self._end_offset].copy_(
+                set_grad.view(-1)
+            )
 
     @property
     def grad_fn(self) -> None:


### PR DESCRIPTION
Summary:
.grad settr needs to support gradient zeroing and gradient set_to_none

unfortunantely, we can't set partial tables grad to None, but this isn't a common use case

the common case of doing

optimizer.zero_grad(...)

will call

param.grad._zero(), since our grads are slices, we get this for free

Differential Revision: D42552132

