### PR TITLE
Use the string value in `pooling_type_to_pooling_mode()`

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -70,11 +70,11 @@ def dtype_to_data_type(dtype: torch.dtype) -> DataType:
 
 
 def pooling_type_to_pooling_mode(pooling_type: PoolingType) -> PoolingMode:
-    if pooling_type == PoolingType.SUM:
+    if pooling_type.value == PoolingType.SUM.value:
         return PoolingMode.SUM
-    elif pooling_type == PoolingType.MEAN:
+    elif pooling_type.value == PoolingType.MEAN.value:
         return PoolingMode.MEAN
-    elif pooling_type == PoolingType.NONE:
+    elif pooling_type.value == PoolingType.NONE.value:
         return PoolingMode.NONE
     else:
         raise Exception(f"Invalid pooling type {pooling_type}")


### PR DESCRIPTION
Summary:
If the torchrec model is from torch package, `pooling_type_to_pooling_mode()` won't work unless it's coming from the same torch package as well.

Changing to compare the string value works.

Differential Revision: D42585412

