### PR TITLE
dont persist feature order buffers as they dont need to be checkpointed

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -585,6 +585,7 @@ class ShardedEmbeddingCollection(
         self.register_buffer(
             "_features_order_tensor",
             torch.tensor(self._features_order, device=self._device, dtype=torch.int32),
+            persistent=False,
         )
 
     def _create_lookups(self) -> None:

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -197,6 +197,7 @@ class ShardedEmbeddingTower(
                 torch.tensor(
                     self._kjt_features_order, device=self._device, dtype=torch.int32
                 ),
+                persistent=False,
             )
 
         if self._wkjt_feature_names != wkjt_feature_names:
@@ -208,6 +209,7 @@ class ShardedEmbeddingTower(
                 torch.tensor(
                     self._wkjt_features_order, device=self._device, dtype=torch.int32
                 ),
+                persistent=False,
             )
 
         node_count = dist.get_world_size(self._cross_pg)

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -542,6 +542,7 @@ class ShardedEmbeddingBagCollection(
                 torch.tensor(
                     self._features_order, device=self._device, dtype=torch.int32
                 ),
+                persistent=False,
             )
 
     def _create_lookups(

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -237,6 +237,7 @@ class ShardedQuantEmbeddingCollection(
         self.register_buffer(
             "_features_order_tensor",
             torch.tensor(self._features_order, device=device, dtype=torch.int32),
+            persistent=False,
         )
 
     def _create_lookups(self, fused_params: Optional[Dict[str, Any]]) -> None:


### PR DESCRIPTION
Summary:
TorchRec don't need to persist feature order buffers -> these are correct on instantiation and don't need to be check pointed

Previously, this issue was hidden bc shardedModules buffers() (via embedding kernels buffer call) yielded nothing, which is no longer true as of D41964643 (https://github.com/pytorch/torchrec/commit/e8ab2de1cfb9e312fea24290fd74e50f71c8acf3)

Differential Revision: D42591693

