### PR TITLE
Revert D42516959: Multisect successfully blamed D42516959 for test or build failures

### DIFF
--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -130,20 +130,21 @@ class FSDPTest(unittest.TestCase):
         sparse_grad_parameter_names = set()
         for name, p in in_backward_optimizer_filter(m.named_parameters(), include=True):
             # Add learning rate scheduler
-            warmup = WarmupOptimizer(
-                # pyre-ignore
-                p._overlapped_optimizer,
-                [
-                    WarmupStage(
-                        policy=WarmupPolicy.LINEAR,
-                        value=0.1,
-                        lr_scale=1.0,
-                    )
-                ],
-                lr=0.01,  # initial learning rate
-                param_name="__sparse_warmup",
+            optims.append(
+                WarmupOptimizer(
+                    # pyre-ignore
+                    p._overlapped_optimizer,
+                    [
+                        WarmupStage(
+                            policy=WarmupPolicy.LINEAR,
+                            value=0.1,
+                            lr_scale=1.0,
+                        )
+                    ],
+                    lr=0.01,  # initial learning rate
+                    param_name=f"__sparse_warmup_{name}",
+                )
             )
-            optims.append((name, warmup))
             sparse_grad_parameter_names.add(name)
         fused_opt_scheduled = CombinedOptimizer(optims)
         dense_opt_scheduled = WarmupOptimizer(

--- a/torchrec/distributed/composable/tests/test_fused_optim.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim.py
@@ -76,9 +76,9 @@ class TestFusedOptim(unittest.TestCase):
         for name, param in ebc.named_parameters():
             table_name = name[len("embedding_bags.") : -len("weight") - 1]
             self.assertEqual(
-                param._overlapped_optimizer.state_dict()["state"][""][
-                    f"{table_name}.momentum1"
-                ]
+                param._overlapped_optimizer.state_dict()["state"][
+                    f"{table_name}.weight"
+                ][f"{table_name}.momentum1"]
                 .local_tensor()
                 .data_ptr(),
                 ebc._optim.state_dict()["state"][f"embedding_bags.{table_name}.weight"][

--- a/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
@@ -9,7 +9,6 @@ import unittest
 from typing import Dict, List
 
 import torch
-from torch.distributed.optim import _apply_optimizer_in_backward
 from torchrec.distributed.shard import shard
 from torchrec.distributed.sharding_plan import (
     column_wise,
@@ -23,6 +22,7 @@ from torchrec.distributed.test_utils.multi_process import (
 from torchrec.distributed.types import ParameterSharding
 from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.optimizers import PartialRowWiseAdam
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
 
@@ -39,7 +39,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
     ) -> None:
         with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
             ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
-            _apply_optimizer_in_backward(
+            apply_optimizer_in_backward(
                 RowWiseAdagrad,
                 [
                     ebc.embedding_bags["table_0"].weight,
@@ -47,7 +47,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
                 ],
                 {"lr": 0.01},
             )
-            _apply_optimizer_in_backward(
+            apply_optimizer_in_backward(
                 PartialRowWiseAdam,
                 [
                     ebc.embedding_bags["table_2"].weight,
@@ -64,7 +64,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_0"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_0.momentum1"].gather(
+            ]["table_0.weight"]["table_0.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # sharded column, each shard will have rowwise state
@@ -73,7 +73,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_1"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_1.momentum1"].gather(
+            ]["table_1.weight"]["table_1.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # sharded rowwise
@@ -82,7 +82,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_2"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_2.momentum1"].gather(
+            ]["table_2.weight"]["table_2.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise
@@ -94,7 +94,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_2"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_2.momentum2"].gather(
+            ]["table_2.weight"]["table_2.momentum2"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise
@@ -103,7 +103,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_3"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_3.momentum1"].gather(
+            ]["table_3.weight"]["table_3.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Row wise - with partial rowwise adam, first state is point wise
@@ -115,7 +115,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_3"].weight._overlapped_optimizer.state_dict()[
                 "state"
-            ][""]["table_3.momentum2"].gather(
+            ]["table_3.weight"]["table_3.momentum2"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise


### PR DESCRIPTION
Summary:
This diff is reverting D42516959 (https://github.com/pytorch/torchrec/commit/30e549c3b1781692ecf96cc9e1c5209a4fa4f403)
D42516959 (https://github.com/pytorch/torchrec/commit/30e549c3b1781692ecf96cc9e1c5209a4fa4f403): [torchrec] [composable] update BatchedEmbeddingKernels to init param state in ctor to ensure same TBESlice parameter every time by colin2328 has been identified to be causing the following test or build failures:

Tests affected:
- [torchrec/distributed/tests:test_quantize - torchrec.distributed.tests.test_quantize.QuantizeKernelTest: test_quantize_embedding_kernels](https://www.internalfb.com/intern/test/281475048734023/)
- [torchrec/distributed/tests:test_quantize - torchrec.distributed.tests.test_quantize.QuantizeKernelTest: test_quantize_embedding_bag_kernels](https://www.internalfb.com/intern/test/281475048734024/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1522502
Here are the tasks that are relevant to this breakage:
T139270782: 8 tests started failing for oncall torchrec in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Reviewed By: colin2328

Differential Revision: D42603264

