### PR TITLE
Test for sharded QEBC to be fxtrace-jitscript compatible

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -508,8 +508,8 @@ class KJTOneToAll(nn.Module):
 
         kjts: List[KeyedJaggedTensor] = kjt.split(self._splits)
         dist_kjts = [
-            split_kjt.to(torch.device("cuda", rank), non_blocking=True)
-            for rank, split_kjt in enumerate(kjts)
+            kjts[rank].to(torch.device("cuda", rank), non_blocking=True)
+            for rank in range(self._world_size)
         ]
         return NoWait(KJTList(dist_kjts))
 
@@ -680,7 +680,6 @@ class EmbeddingsAllToOne(nn.Module):
         Returns:
             Awaitable[torch.Tensor]: awaitable of the merged embeddings.
         """
-
         assert len(tensors) == self._world_size
         non_cat_size = tensors[0].size(1 - self._cat_dim)
         return NoWait(

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -46,6 +46,8 @@ from torchrec.quant.embedding_modules import (
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
+torch.fx.wrap("len")
+
 
 def create_infer_embedding_bag_sharding(
     sharding_type: str,
@@ -190,10 +192,8 @@ class ShardedQuantEmbeddingBagCollection(
                 )
             features_by_shards = features.split(self._feature_splits)
             awaitables = [
-                input_dist(features_by_shard)
-                for input_dist, features_by_shard in zip(
-                    self._input_dists, features_by_shards
-                )
+                self._input_dists[i](features_by_shards[i])
+                for i in range(len(self._input_dists))
             ]
             return ListOfKJTListSplitsAwaitable(awaitables)
 

--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import unittest
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
+
+import torch
+from torch import quantization as quant
+from torchrec.distributed.embedding import EmbeddingCollectionSharder
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    ModuleSharder,
+    ShardingType,
+)
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.shard_estimators import (
+    EmbeddingPerfEstimator,
+    EmbeddingStorageEstimator,
+)
+from torchrec.distributed.quant_embeddingbag import (
+    QuantEmbeddingBagCollection,
+    QuantEmbeddingBagCollectionSharder,
+)
+from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
+from torchrec.distributed.types import ShardingEnv
+from torchrec.fx.tracer import Tracer as TorchrecFxTracer
+from torchrec.inference.modules import CopyableMixin
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+# Wrapper for module that accepts ModelInput to avoid jit scripting of ModelInput (dataclass) and be fully torch types bound.
+class TorchTypesModelInputWrapper(CopyableMixin):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__()
+        self._module = module
+
+    def forward(
+        self,
+        float_features: torch.Tensor,
+        idlist_features_keys: List[str],
+        idlist_features_values: torch.Tensor,
+        idscore_features_keys: List[str],
+        idscore_features_values: torch.Tensor,
+        idscore_features_weights: torch.Tensor,
+        label: torch.Tensor,
+        idlist_features_lengths: Optional[torch.Tensor] = None,
+        idlist_features_offsets: Optional[torch.Tensor] = None,
+        idscore_features_lengths: Optional[torch.Tensor] = None,
+        idscore_features_offsets: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        idlist_kjt = KeyedJaggedTensor(
+            keys=idlist_features_keys,
+            values=idlist_features_values,
+            lengths=idlist_features_lengths,
+            offsets=idlist_features_offsets,
+        )
+        idscore_kjt = KeyedJaggedTensor(
+            keys=idscore_features_keys,
+            values=idscore_features_values,
+            weights=idscore_features_weights,
+            lengths=idscore_features_lengths,
+            offsets=idscore_features_offsets,
+        )
+        mi = ModelInput(
+            float_features=float_features,
+            idlist_features=idlist_kjt,
+            idscore_features=idscore_kjt,
+            label=label,
+        )
+        return self._module(mi)
+
+
+class ModelTraceScriptTest(unittest.TestCase):
+    # pyre-ignore
+    def DMP_QEBC(self, world_size: int) -> Tuple[torch.nn.Module, List[Tuple]]:
+        device = torch.device("cuda:0")
+        num_features = 2
+        num_float_features = 10
+        num_weighted_features = 2
+
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(num_features)
+        ]
+        weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(num_weighted_features)
+        ]
+        model = TorchTypesModelInputWrapper(
+            TestSparseNN(
+                tables=tables,
+                weighted_tables=weighted_tables,
+                num_float_features=num_float_features,
+                dense_device=device,
+                sparse_device=device,
+            )
+        )
+
+        model.training = False
+
+        def _quantize(
+            module: torch.nn.Module,
+            inplace: bool,
+            output_type: torch.dtype = torch.float,
+        ) -> torch.nn.Module:
+            qconfig = quant.QConfig(
+                activation=quant.PlaceholderObserver.with_args(dtype=output_type),
+                weight=quant.PlaceholderObserver.with_args(dtype=torch.qint8),
+            )
+            return quant.quantize_dynamic(
+                module,
+                qconfig_spec={
+                    EmbeddingBagCollection: qconfig,
+                },
+                mapping={
+                    EmbeddingBagCollection: QuantEmbeddingBagCollection,
+                },
+                inplace=inplace,
+            )
+
+        quant_model = _quantize(model, inplace=True)
+
+        class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
+            def __init__(
+                self,
+                sharding_type: str,
+                kernel_type: str,
+                fused_params: Optional[Dict[str, Any]] = None,
+                shardable_params: Optional[List[str]] = None,
+            ) -> None:
+                super().__init__(
+                    fused_params=fused_params, shardable_params=shardable_params
+                )
+                self._sharding_type = sharding_type
+                self._kernel_type = kernel_type
+
+            def sharding_types(self, compute_device_type: str) -> List[str]:
+                return [self._sharding_type]
+
+            def compute_kernels(
+                self, sharding_type: str, compute_device_type: str
+            ) -> List[str]:
+                return [self._kernel_type]
+
+        sharders = [
+            cast(
+                ModuleSharder[torch.nn.Module],
+                TestQuantEBCSharder(
+                    sharding_type=ShardingType.TABLE_WISE.value,
+                    kernel_type=EmbeddingComputeKernel.QUANT.value,
+                    shardable_params=[table.name for table in tables],
+                ),
+            ),
+            cast(ModuleSharder[torch.nn.Module], EmbeddingCollectionSharder()),
+        ]
+        topology = Topology(world_size=world_size, compute_device="cuda")
+        plan = EmbeddingShardingPlanner(
+            topology=topology,
+            batch_size=10,
+            enumerator=EmbeddingEnumerator(
+                topology=topology,
+                batch_size=1,
+                estimator=[
+                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingStorageEstimator(topology=topology),
+                ],
+            ),
+        ).plan(quant_model, sharders)
+        dmp = DistributedModelParallel(
+            quant_model,
+            plan=plan,
+            device=device,
+            env=ShardingEnv.from_local(world_size=world_size, rank=0),
+            init_data_parallel=False,
+        )
+
+        inputs = []
+        for _ in range(5):
+            inputs.append(
+                (
+                    ModelInput.generate(
+                        batch_size=16,
+                        world_size=world_size,
+                        num_float_features=num_float_features,
+                        tables=tables,
+                        weighted_tables=weighted_tables,
+                    )[1][0].to(device),
+                )
+            )
+        dmp = dmp.copy(device)
+
+        # We want to be torch types bound, args for TorchTypesModelInputWrapper
+        def model_input_to_forward_args(
+            mi: ModelInput,
+        ) -> Tuple[
+            torch.Tensor,
+            List[str],
+            torch.Tensor,
+            List[str],
+            torch.Tensor,
+            Optional[torch.Tensor],
+            torch.Tensor,
+            Optional[torch.Tensor],
+            Optional[torch.Tensor],
+            Optional[torch.Tensor],
+            Optional[torch.Tensor],
+        ]:
+            idlist_kjt = mi.idlist_features
+            idscore_kjt = mi.idscore_features
+            return (
+                mi.float_features,
+                idlist_kjt._keys,
+                idlist_kjt._values,
+                idscore_kjt._keys,
+                idscore_kjt._values,
+                idscore_kjt._weights,
+                mi.label,
+                idlist_kjt._lengths,
+                idlist_kjt._offsets,
+                idscore_kjt._lengths,
+                idscore_kjt._offsets,
+            )
+
+        return (dmp, [model_input_to_forward_args(*inp) for inp in inputs])
+
+    def _models_with_inputs(
+        self,
+        # pyre-ignore
+        *args,
+        # pyre-ignore
+        **kwargs
+    ) -> List[Tuple[torch.nn.Module, List[Tuple]]]:  # pyre-ignore
+        return [fn(*args, **kwargs) for fn in [self.DMP_QEBC]]
+
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs available",
+    )
+    def test_fxtrace_jitscript(self) -> None:
+        for model, inputs in self._models_with_inputs(world_size=2):
+            # We need more than one input to verify correctness of tracing and scripting using input different from what was used for tracing
+            assert len(inputs) > 1
+
+            # Run model first time to go through lazy initialized blocks before tracing
+            # Targeting only inference for this time
+            model.train(False)
+
+            eager_output = model(*inputs[0])
+
+            tracer = TorchrecFxTracer()
+            g = tracer.trace(model)
+            # pyre-ignore
+            gm = torch.fx.GraphModule(tracer.root, g)
+            gm_script = torch.jit.script(gm)
+            gm_script_output = gm_script(*inputs[0])
+            torch.testing.assert_close(gm_script_output, eager_output)
+
+            for inp in inputs[1:]:
+                torch.testing.assert_close(gm_script(*inp), model(*inp))

--- a/torchrec/fx/utils.py
+++ b/torchrec/fx/utils.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import inspect
+from typing import Dict, List, Set
+
+import torch
+
+# Not importing DistributedModelParallel here to avoid circular dependencies as DMP depends on torchrec.fx.tracer
+# def dmp_fx_trace_forward(dmp: DistributedModelParallel)
+
+# pyre-ignore
+def fake_range():
+    # pyre-ignore
+    return torch._C._jit_tree_views.SourceRangeFactory("", None, 0, 0).make_raw_range(
+        0, 1
+    )
+
+
+# pyre-ignore
+def dmp_fx_trace_forward(  # noqa: C901
+    # pyre-ignore
+    dmp,
+    tracer: torch.fx.Tracer,
+):
+    func = dmp._dmp_wrapped_module.forward
+    sign: inspect.Signature = inspect.signature(func)
+
+    module_to_type_str: Dict[str, Set[str]] = {}
+
+    def add_if_missing(module: str, type_str: str) -> None:
+        if module not in module_to_type_str:
+            _set = set()
+            _set.add(type_str)
+            module_to_type_str[module] = _set
+        else:
+            s = module_to_type_str[module]
+            if type_str not in s:
+                s.add(type_str)
+
+    def torch_no_import(t: torch.Type) -> bool:
+        return isinstance(
+            t, (torch.FloatType, torch.IntType, torch.ComplexType, torch.StringType)
+        )
+
+    def torch_typing(t: torch.Type) -> bool:
+        return isinstance(
+            t,
+            (
+                torch.TupleType,
+                torch.ListType,
+                torch.DictType,
+                torch.OptionalType,
+                torch.AnyType,
+            ),
+        )
+
+    exec_imports = []
+    args_call = ", ".join([f"{p.name}" for p in sign.parameters.values()])
+
+    types = []
+    try:
+        args_decls: List[str] = []
+        for p in sign.parameters.values():
+            pann = p.annotation
+
+            ptype = torch.jit.annotations.try_ann_to_type(pann, fake_range())
+            types.append(ptype)
+            args_decls.append(f"{p.name}: {ptype}")
+
+        while len(types) > 0:
+            t = types.pop()
+            if torch_no_import(t):
+                continue
+
+            t_base_name = f"{t}".split("[")[0]
+            if torch_typing(t):
+                add_if_missing("typing", t_base_name)
+            else:
+                if hasattr(t, "__module__") and not torch_no_import(t):
+                    m = t.__module__
+                    add_if_missing(f"{m}", f"{t}".split("[")[0])
+
+            if hasattr(t, "containedTypes"):
+                contained_types = getattr(t, "containedTypes", None)()
+                for ctype in contained_types:
+                    types.append(ctype)
+
+            if hasattr(t, "getElementType"):
+                el_type = getattr(t, "getElementType", None)()
+
+        args_decl = ", ".join(args_decls)
+
+        for m, s in module_to_type_str.items():
+            ts = ", ".join(s)
+            exec_imports.append(f"from {m} import {ts}")
+    except Exception as e:
+        print(f"Exception:{e}")
+        # Catching here if source is not available to proceed hoping that jit will infer correct types without annotations.
+        # Often it fails here when can not access to dataclass generated __init__
+        args_decl = args_call
+
+    exec_def_fn_name = "__fx_forward"
+    exec_dmp_wrapper_local_name = "_dmp_wrapped_module_local"
+    _dmp_wrapped_module_local = dmp
+    locals_dict = locals()
+    exec_def = f"def {exec_def_fn_name}({args_decl}):\n    return {exec_dmp_wrapper_local_name}({args_call})"
+
+    exec_imports_str = "\n".join(exec_imports)
+    pycode = f"{exec_imports_str}\n{exec_def}"
+
+    exec(pycode, locals_dict)  # noqa: P204  Allow use of exec
+
+    wrapper = locals_dict[exec_def_fn_name]
+    wrapper.__signature__ = sign
+
+    return wrapper


### PR DESCRIPTION
Summary:
Base test to make sharded QEBC to be fx traceable and jit scriptable.

Current model for testing is TestSparseNN from test_models wrapped in another module that has only Tensor-bound arguments to skip dataclass ModelInput.

FX-JIT workarounds:

**1. dataclasses** are not torch jit scriptable as they contain generated __init__ without source - jit will not have access for it and fail

For future we can think about workaround there or refactor out dataclasses in torchrec if they become blocker for scripting

**2. DMP has  varargs forward(args,kwargs)**
Using `exec` to define forward with the same signature (and jit annotations) as dmp_wrapped_module.

With this code state DMP can be fx-jit only if it is a root module. In future we can extend this solution for DMPs not on root level.

**3. Iterating through proxies**
Multiple places converted manualy to iterate `for i in range(len(...))` style, adding torch.fx.wrap("len") on the module level.

**4. torch jit has only torch.device ctor from string**

Added workaround in fx.create_arg() to use string instead of torch.device object. Jit will explicitly convert that string to jit.torch.device

**5. LazyAwaitable**

Adding logic to call wait of LazyAwaitable when we create fx.create_arg.
This is not equivalent behaviour to eager mode when wait is called on __torch__function or the first access to getattr() of LazyAwaitable.
Logic in the diff can call wait() before it is called in eager.
Solution with equivalent logic is in progress.

**6 fx.path_of_module**

FX needs identical paths for each torch.nn.Module, after sharding torchrec adds modules which are not registered in named_modules().
Here we have a hack to use `f"_torchrec_fake_module_path_{mod.__class__}_{id(mod)}"` for unregistered modules.
Proper solution with fx_path and identical names is in progress

Differential Revision:
D42192307

Privacy Context Container: L1138451

