### PR TITLE
fix load_state_dict in dmp

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -64,7 +64,7 @@ def filter_state_dict(
 
     filtered_state_dict = OrderedDict()
     for key, value in state_dict.items():
-        if key.startswith(name):
+        if key.startswith(name + "."):
             # + 1 to length is to remove the '.' after the key
             filtered_state_dict[key[len(name) + 1 :]] = value
     return filtered_state_dict


### PR DESCRIPTION
Summary:
The problem is that if we have two child modules sharing the same prefix, this filtering function would mess up.

e.g.
In model `m`, we have `m.mod.weights` and `m.mod_scored.weights`. When constructing state dict for `m.mod`, after filtering we would get `weights` and `scored.weights` in the state dict. But we only want `weights`.

Reviewed By: s4ayub

Differential Revision: D42613740

