### PR TITLE
make torchrec model respect the ddp_bucket_cap_mb parameter 

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -62,6 +62,12 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
     Default data parallel wrapper, which applies data parallel to all unsharded modules.
     """
 
+    def __init__(
+        self,
+        bucket_cap_mb: int = 25,
+    ) -> None:
+        self._bucket_cap_mb: int = bucket_cap_mb
+
     def wrap(
         self,
         dmp: "DistributedModelParallel",
@@ -95,6 +101,7 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
                 gradient_as_bucket_view=True,
                 broadcast_buffers=False,
                 static_graph=True,
+                bucket_cap_mb=self._bucket_cap_mb,
             ),
         )
 


### PR DESCRIPTION
Summary:  now torchrec is using the default DDP wrapper, which always uses the default bucket_cap_mb (25MB)

Reviewed By: xush6528

Differential Revision: D42620697

