### PR TITLE
Remove fake module name hack for unregistered modules

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -552,7 +552,7 @@ class MetaInferGroupedPooledEmbeddingsLookup(
                 and isinstance(self._feature_processor, BaseGroupedFeatureProcessor)
             ):
                 features = self._feature_processor(features)
-            embeddings.append(emb_op(features))
+            embeddings.append(emb_op.forward(features))
 
         if len(embeddings) == 0:
             # a hack for empty ranks
@@ -622,7 +622,7 @@ class InferGroupedLookupMixin(ABC):
             self._embedding_lookups_per_rank,
         ):
             sparse_features_rank = sparse_features[i]
-            embeddings.append(embedding_lookup(sparse_features_rank))
+            embeddings.append(embedding_lookup.forward(sparse_features_rank))
         return embeddings
 
     def state_dict(

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -159,7 +159,7 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag):
         return self._emb_module
 
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
-        return self.emb_module(
+        return self.emb_module.forward(
             indices=features.values().int(),
             offsets=features.offsets().int(),
             per_sample_weights=features.weights_or_none(),

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -192,7 +192,7 @@ class ShardedQuantEmbeddingBagCollection(
                 )
             features_by_shards = features.split(self._feature_splits)
             awaitables = [
-                self._input_dists[i](features_by_shards[i])
+                self._input_dists[i].forward(features_by_shards[i])
                 for i in range(len(self._input_dists))
             ]
             return ListOfKJTListSplitsAwaitable(awaitables)
@@ -203,7 +203,7 @@ class ShardedQuantEmbeddingBagCollection(
         dist_input: ListOfKJTList,
     ) -> List[List[torch.Tensor]]:
         # syntax for torchscript
-        return [lookup(dist_input[i]) for i, lookup in enumerate(self._lookups)]
+        return [lookup.forward(dist_input[i]) for i, lookup in enumerate(self._lookups)]
 
     def output_dist(
         self,
@@ -212,7 +212,9 @@ class ShardedQuantEmbeddingBagCollection(
     ) -> LazyAwaitable[KeyedTensor]:
         return EmbeddingBagCollectionAwaitable(
             # syntax for torchscript
-            awaitables=[dist(output[i]) for i, dist in enumerate(self._output_dists)],
+            awaitables=[
+                dist.forward(output[i]) for i, dist in enumerate(self._output_dists)
+            ],
             embedding_dims=self._embedding_dims,
             embedding_names=self._embedding_names,
         )

--- a/torchrec/fx/tracer.py
+++ b/torchrec/fx/tracer.py
@@ -127,12 +127,8 @@ class Tracer(torch.fx.Tracer):
         if hasattr(mod, "_fx_path"):
             # pyre-ignore
             return mod._fx_path
-        try:
+        else:
             return super().path_of_module(mod)
-        except NameError as e:
-            print(f"NameError {e}")
-            # TODO(T140754678): Remove this workaround to _fx_path
-            return f"_torchrec_fake_module_path_{mod.__class__}_{id(mod)}"
 
 
 def symbolic_trace(


### PR DESCRIPTION
Summary:
When the fx tracer encounters a module call -> `myMod(input)`, it relies on a module being registered so it can determine the `path_of_module` via `named_modules` of the root.

**However, some of the trec modules are unregistered
(input dist, output dist, lookups, reasoning for unregistration of fbgemm modules here: D38225558 (https://github.com/pytorch/torchrec/commit/44ee74de8c11b544bcebdaf56b9fd9d92a556585)).** When fx tracer encounters a module call for an unregistered module, it errors out. See `call_module` -> `path_of_module`. https://www.internalfb.com/code/fbsource/[a8bb8681e6ae]/fbcode/caffe2/torch/fx/_symbolic_trace.py?lines=432

To get around this, a fake name was attached to the unregistered module (`f"_torchrec_fake_module_path_{mod.__class__}_{id(mod)}"`) when you called `path_of_module`.

In https://github.com/pytorch/torchrec/pull/940, divchenko showed a more appropriate change. If you directly call the forward function instead of calling the module, you get around fx tracer's `call_module`.

Reviewed By: IvanKobzarev

Differential Revision: D42560182

