### PR TITLE
update BatchedEmbeddingKernels to init param state in ctor to ensure same TBESlice parameter every time

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -361,7 +361,7 @@ def _named_parameters_by_table_fused(
             # pyre-ignore
             weights = emb_module.weights_uvm
         weight = TableBatchedEmbeddingSlice(
-            original_tensor=weights,
+            data=weights,
             start_offset=offset,
             end_offset=offset + table_count * rows * dim,
             num_embeddings=-1,
@@ -386,7 +386,7 @@ def _named_parameters_by_table_dense(
         table_count = table_name_to_count.pop(table_name)
         offset = emb_module.weights_physical_offsets[t_idx]
         weight = TableBatchedEmbeddingSlice(
-            original_tensor=emb_module.weights,
+            data=emb_module.weights,
             start_offset=offset,
             end_offset=offset + table_count * rows * dim,
             num_embeddings=-1,

--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -130,21 +130,20 @@ class FSDPTest(unittest.TestCase):
         sparse_grad_parameter_names = set()
         for name, p in in_backward_optimizer_filter(m.named_parameters(), include=True):
             # Add learning rate scheduler
-            optims.append(
-                WarmupOptimizer(
-                    # pyre-ignore
-                    p._overlapped_optimizer,
-                    [
-                        WarmupStage(
-                            policy=WarmupPolicy.LINEAR,
-                            value=0.1,
-                            lr_scale=1.0,
-                        )
-                    ],
-                    lr=0.01,  # initial learning rate
-                    param_name=f"__sparse_warmup_{name}",
-                )
+            warmup = WarmupOptimizer(
+                # pyre-ignore
+                p._in_backward_optimizers[0],
+                [
+                    WarmupStage(
+                        policy=WarmupPolicy.LINEAR,
+                        value=0.1,
+                        lr_scale=1.0,
+                    )
+                ],
+                lr=0.01,  # initial learning rate
+                param_name="__sparse_warmup",
             )
+            optims.append((name, warmup))
             sparse_grad_parameter_names.add(name)
         fused_opt_scheduled = CombinedOptimizer(optims)
         dense_opt_scheduled = WarmupOptimizer(

--- a/torchrec/distributed/composable/tests/test_fused_optim.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim.py
@@ -77,9 +77,7 @@ class TestFusedOptim(unittest.TestCase):
             table_name = name[len("embedding_bags.") : -len("weight") - 1]
             self.assertEqual(
                 param._in_backward_optimizers[0]
-                .state_dict()["state"][f"{table_name}.weight"][
-                    f"{table_name}.momentum1"
-                ]
+                .state_dict()["state"][""][f"{table_name}.momentum1"]
                 .local_tensor()
                 .data_ptr(),
                 ebc._optim.state_dict()["state"][f"embedding_bags.{table_name}.weight"][

--- a/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
@@ -64,7 +64,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_0"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_0.weight"]["table_0.momentum1"].gather(
+            ].state_dict()["state"][""]["table_0.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # sharded column, each shard will have rowwise state
@@ -73,7 +73,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_1"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_1.weight"]["table_1.momentum1"].gather(
+            ].state_dict()["state"][""]["table_1.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # sharded rowwise
@@ -82,7 +82,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_2"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_2.weight"]["table_2.momentum1"].gather(
+            ].state_dict()["state"][""]["table_2.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise
@@ -94,7 +94,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_2"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_2.weight"]["table_2.momentum2"].gather(
+            ].state_dict()["state"][""]["table_2.momentum2"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise
@@ -103,7 +103,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_3"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_3.weight"]["table_3.momentum1"].gather(
+            ].state_dict()["state"][""]["table_3.momentum1"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Row wise - with partial rowwise adam, first state is point wise
@@ -115,7 +115,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_3"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"]["table_3.weight"]["table_3.momentum2"].gather(
+            ].state_dict()["state"][""]["table_3.momentum2"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise

--- a/torchrec/distributed/composable/tests/test_table_batched_embedding_slice.py
+++ b/torchrec/distributed/composable/tests/test_table_batched_embedding_slice.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import unittest
 
 import torch
@@ -25,3 +26,12 @@ class TestTableBatchedEmbeddingSlice(unittest.TestCase):
         )
         first_table = TableBatchedEmbeddingSlice(emb.weights, 0, 8, 2, 4)
         self.assertEqual(first_table.data_ptr(), emb.weights.data_ptr())
+
+    def test_copy(self) -> None:
+        device = "cpu" if not torch.cuda.is_available() else "cuda"
+        emb = DenseTableBatchedEmbeddingBagsCodegen(
+            [(2, 4), (2, 4)], use_cpu=device == "cpu"
+        )
+        first_table = TableBatchedEmbeddingSlice(emb.weights, 0, 8, 2, 4)
+        copied = copy.deepcopy(first_table)
+        self.assertNotEqual(first_table.data_ptr(), copied.data_ptr())

--- a/torchrec/distributed/tests/test_quantize.py
+++ b/torchrec/distributed/tests/test_quantize.py
@@ -62,6 +62,7 @@ def quantize_sharded_embeddings(
 
 
 class QuantizeKernelTest(unittest.TestCase):
+    # TODO @shababayub can delete as is deprecated
     def setUp(self) -> None:
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"


### PR DESCRIPTION
Summary:
before, named_parameters_by_table would instantiate a new TBESlice (parameter) every call.
This moves this to be 1x in ctor and saves in private member

Differential Revision: D42696812

