### PR TITLE
QEC fxable preparation

### DIFF
--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist  # noqa
 from torchrec.distributed.embedding_sharding import EmbeddingShardingContext
+from torchrec.distributed.embedding_types import KJTList
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable
 
@@ -63,7 +64,7 @@ class InferSequenceShardingContext(Multistreamable):
             shards of KJT after input dist.
     """
 
-    features: Optional[List[KeyedJaggedTensor]] = None
+    features: Optional[KJTList] = None
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         if self.features is not None:


### PR DESCRIPTION
Summary:
Preparational diff to make QEC fx-jit able.

1. In embedding_lookup.py extracting `if-then` logic into `torch.fx.wrap`-ed function.

2. In sequence_sharding.py replacing List[KeyedJaggedTensor] with KJTList to match the types for torch script (in eager that does not actual behavior, but annotation type is meaningful for torchscript)

3. test_fx_jit add DMP_QEC creation, not do test for fx-jit as it depends on changes to be landed.

Differential Revision: D42683447

