### PR TITLE
Fix sparse features recat bug for variable batch size and empty rank

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1219,7 +1219,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         keys: List[str],
         tensors: List[torch.Tensor],
         batch_size_per_rank: List[int],
-        recat: torch.Tensor,
+        recat: Optional[torch.Tensor],
     ) -> "KeyedJaggedTensor":
         assert len(tensors) in [2, 3]
         lengths = tensors[0]
@@ -1227,7 +1227,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = tensors[2] if len(tensors) == 3 else None
 
         with record_function("## all2all_data:recat_values ##"):
-            if recat.numel() > 0:
+            if recat is not None and recat.numel() > 0:
                 if all(bs == batch_size_per_rank[0] for bs in batch_size_per_rank):
                     lengths, values, weights = torch.ops.fbgemm.permute_2D_sparse_data(
                         recat,


### PR DESCRIPTION
Summary: On empty ranks with variable batch size, the recat tensor from `_get_recat` will return an empty tensor. Calling `torch.ops.fbgemm.invert_permute` with an empty tensor throws an error

Differential Revision: D42751901

