### PR TITLE
Wrap new_zeros with torch.jit.script in jit.tracing

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -41,6 +41,7 @@ def _to_lengths(offsets: torch.Tensor) -> torch.Tensor:
     return offsets[1:] - offsets[:-1]
 
 
+@torch.jit.script_if_tracing
 def _batched_lengths_to_offsets(lengths: torch.Tensor) -> torch.Tensor:
     (f, b) = lengths.shape
     offsets_0 = lengths.new_zeros((f, 1))


### PR DESCRIPTION
Summary: If we do jit.trace, we will hard the device in the "new_zeros" call. So we switch to scripting when entering this function.

Reviewed By: jiayisuse

Differential Revision: D42749793

