### PR TITLE
Relax the CompIn type

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -261,7 +261,7 @@ class ModuleShardingMixIn:
 
 
 Out = TypeVar("Out")
-CompIn = TypeVar("CompIn", bound=Multistreamable)
+CompIn = TypeVar("CompIn")
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -541,7 +541,7 @@ class NullShardingContext(Multistreamable):
 
 
 Out = TypeVar("Out")
-CompIn = TypeVar("CompIn", bound=Multistreamable)
+CompIn = TypeVar("CompIn")
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 


### PR DESCRIPTION
Summary: Relax the CompIn type since we don't need input pipeline for some sharded modules

Reviewed By: YLGH

Differential Revision: D41633768

