### PR TITLE
Make multistreamble + pipelineable protocols

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional, Tuple
 import torch
 import torch.fx
 from torch.autograd.profiler import record_function
-from torchrec.streamable import Pipelineable
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
@@ -171,7 +170,7 @@ class JaggedTensorMeta(abc.ABCMeta, torch.fx.ProxyableClassMeta):
     pass
 
 
-class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
+class JaggedTensor(metaclass=JaggedTensorMeta):
     """
     Represents an (optionally weighted) jagged tensor.
 
@@ -684,7 +683,7 @@ def _sum_by_splits(input_list: List[int], splits: List[int]) -> List[int]:
     ]
 
 
-class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
+class KeyedJaggedTensor(metaclass=JaggedTensorMeta):
     """Represents an (optionally weighted) keyed jagged tensor.
 
     A `KeyedJaggedTensor` is a tensor with a *jagged dimension* which is dimension whose
@@ -1347,7 +1346,7 @@ def _keyed_values_string(values: torch.Tensor) -> str:
     )
 
 
-class KeyedTensor(Pipelineable, metaclass=JaggedTensorMeta):
+class KeyedTensor(metaclass=JaggedTensorMeta):
     """
     KeyedTensor holds a concatenated list of dense tensors, each of which can be
     accessed by a key.

--- a/torchrec/streamable.py
+++ b/torchrec/streamable.py
@@ -5,27 +5,29 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import abc
+from typing import Protocol, runtime_checkable
 
 import torch
 
 
-class Multistreamable(abc.ABC):
+@runtime_checkable
+class Multistreamable(Protocol):
     """
     Objects implementing this interface are allowed to be transferred
     from one CUDA stream to another.
     torch.Tensor and (Keyed)JaggedTensor implement this interface.
     """
 
-    @abc.abstractmethod
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        pass
         """
         See https://pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html
         """
         ...
 
 
-class Pipelineable(Multistreamable):
+@runtime_checkable
+class Pipelineable(Multistreamable, Protocol):
     """
     This interface contains two methods, one for moving an input across devices,
     the other one for marking streams that operate the input.
@@ -36,8 +38,8 @@ class Pipelineable(Multistreamable):
     Some models take compound inputs, which should implement this interface.
     """
 
-    @abc.abstractmethod
     def to(self, device: torch.device, non_blocking: bool) -> "Pipelineable":
+        pass
         """
         Please be aware that according to https://pytorch.org/docs/stable/generated/torch.Tensor.to.html,
         `to` might return self or a copy of self.  So please remember to use `to` with the assignment operator,


### PR DESCRIPTION
Summary:
Right now we only have KJTs as inputs to ShardedMOdules, but eventually we make take in regular torch.Tensors

torch.Tensor already has to and record_stream methods, but because they don't extend Multistreamable, typecheck complains

Change the typing to be Protocol so that

 print(isinstance(torch.Tensor, Pipelineable))

works

Reviewed By: xing-liu

Differential Revision: D42809439

