### PR TITLE
Enable data pipelining

### DIFF
--- a/torchrec/distributed/data_pipeline.py
+++ b/torchrec/distributed/data_pipeline.py
@@ -5,12 +5,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import abc
+
 import logging
-from typing import cast, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
+from typing import cast, Dict, Iterator, List, Optional, TypeVar
 
 import torch
-from torch.autograd.profiler import record_function
+
+from torch.profiler import record_function
 from torchrec.distributed.model_parallel import ShardedModule
 from torchrec.distributed.pipeline_utils import (
     _rewrite_model,
@@ -23,33 +24,43 @@ from torchrec.streamable import Pipelineable
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-
 In = TypeVar("In", bound=Pipelineable)
-Out = TypeVar("Out")
 
 
-class TrainPipeline(abc.ABC, Generic[In, Out]):
-    @abc.abstractmethod
-    def progress(self, dataloader_iter: Iterator[In]) -> Out:
-        pass
+class DataPipeline(Iterator[In]):
+    def __init__(
+        self,
+        dataloader_iter: Iterator[In],
+    ) -> None:
+        torch._C._log_api_usage_once(
+            f"torchrec.distributed.data_pipeline.{self.__class__.__name__}"
+        )
+        self._dataloader_iter = dataloader_iter
+
+    def __iter__(self) -> "DataPipeline[In]":
+        return self
+
+    def __next__(self) -> In:
+        return next(self._dataloader_iter)
 
 
-class TrainPipelineBase(TrainPipeline[In, Out]):
+class CudaCopyingPipeline(DataPipeline[In]):
     """
     This class runs training iterations using a pipeline of two stages, each as a CUDA
     stream, namely, the current (default) stream and `self._memcpy_stream`. For each
     iteration, `self._memcpy_stream` moves the input from host (CPU) memory to GPU
     memory, and the default stream runs forward, backward, and optimization.
+    Args:
+        dataloader_iter: Iterator for the input data
+        device: Device to put the data on
     """
 
     def __init__(
         self,
-        model: torch.nn.Module,
-        optimizer: torch.optim.Optimizer,
+        dataloader_iter: Iterator[In],
         device: torch.device,
     ) -> None:
-        self._model = model
-        self._optimizer = optimizer
+        super().__init__(dataloader_iter)
         self._device = device
         self._memcpy_stream: Optional[torch.cuda.streams.Stream] = (
             torch.cuda.Stream() if device.type == "cuda" else None
@@ -57,79 +68,77 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
         self._cur_batch: Optional[In] = None
         self._connected = False
 
-    def _connect(self, dataloader_iter: Iterator[In]) -> None:
-        cur_batch = next(dataloader_iter)
-        self._cur_batch = cur_batch
+    def _connect(self) -> None:
+        cur_batch = next(self._dataloader_iter)
         with torch.cuda.stream(self._memcpy_stream):
             self._cur_batch = _to_device(cur_batch, self._device, non_blocking=True)
         self._connected = True
 
-    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+    def __next__(self) -> In:
         if not self._connected:
-            self._connect(dataloader_iter)
+            self._connect()
 
         # Fetch next batch
+        next_batch: Optional[In] = None
         with record_function("## next_batch ##"):
-            next_batch = next(dataloader_iter)
+            try:
+                next_batch = next(self._dataloader_iter)
+            except StopIteration:
+                pass
+
+        if self._cur_batch is None:
+            raise StopIteration
+
         cur_batch = self._cur_batch
-        assert cur_batch is not None
 
-        if self._model.training:
-            with record_function("## zero_grad ##"):
-                self._optimizer.zero_grad()
-
+        # Wait for stream.
         with record_function("## wait_for_batch ##"):
             _wait_for_batch(cur_batch, self._memcpy_stream)
 
-        with record_function("## forward ##"):
-            (losses, output) = self._model(cur_batch)
-
-        if self._model.training:
-            with record_function("## backward ##"):
-                torch.sum(losses, dim=0).backward()
-
         # Copy the next batch to GPU
-        self._cur_batch = cur_batch = next_batch
-        with record_function("## copy_batch_to_gpu ##"):
-            with torch.cuda.stream(self._memcpy_stream):
-                self._cur_batch = _to_device(cur_batch, self._device, non_blocking=True)
+        if next_batch:
+            with record_function("## copy_batch_to_gpu ##"):
+                with torch.cuda.stream(self._memcpy_stream):
+                    self._cur_batch = _to_device(
+                        next_batch, self._device, non_blocking=True
+                    )
+        else:
+            self._cur_batch = None
 
-        # Update
-        if self._model.training:
-            with record_function("## optimizer ##"):
-                self._optimizer.step()
-
-        return output
+        return cur_batch
 
 
-class TrainPipelineSparseDist(TrainPipeline[In, Out]):
+class SparseDistPipeline(DataPipeline[In]):
     """
     This pipeline overlaps device transfer, and `ShardedModule.input_dist()` with
     forward and backward. This helps hide the all2all latency while preserving the
     training forward / backward ordering.
-
     stage 3: forward, backward - uses default CUDA stream
     stage 2: ShardedModule.input_dist() - uses data_dist CUDA stream
     stage 1: device transfer - uses memcpy CUDA stream
-
     `ShardedModule.input_dist()` is only done for top-level modules in the call graph.
     To be considered a top-level module, a module can only depend on 'getattr' calls on
     input.
-
     Input model must be symbolically traceable with the exception of `ShardedModule` and
     `DistributedDataParallel` modules.
+    Args:
+        dataloader_iter: Iterator for the input data
+        device: Device to put the data on
+        model: Model to be pipelined
+
+    Note: This feature is experimental.
     """
 
     synced_pipeline_id: Dict[int, int] = {}
 
     def __init__(
         self,
-        model: torch.nn.Module,
-        optimizer: torch.optim.Optimizer,
+        dataloader_iter: Iterator[In],
         device: torch.device,
+        model: torch.nn.Module,
     ) -> None:
+        super().__init__(dataloader_iter)
         self._model = model
-        self._optimizer = optimizer
         self._device = device
         # use two data streams to support two concurrent batches
         if device.type == "cuda":
@@ -148,11 +157,12 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._connected = False
         self._context = TrainPipelineContext()
         self._pipelined_modules: List[ShardedModule] = []
+        self._event: Optional[torch.cuda.Event] = None
 
-    def _connect(self, dataloader_iter: Iterator[In]) -> None:
+    def _connect(self) -> None:
         # batch 1
         with torch.cuda.stream(self._memcpy_stream):
-            batch_i = next(dataloader_iter)
+            batch_i = next(self._dataloader_iter)
             self._batch_i = batch_i = _to_device(
                 batch_i, self._device, non_blocking=True
             )
@@ -161,74 +171,74 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 self._model, self._context, self._data_dist_stream
             )
 
-        with torch.cuda.stream(self._data_dist_stream):
-            _wait_for_batch(batch_i, self._memcpy_stream)
-            _start_data_dist(self._pipelined_modules, batch_i, self._context)
+        self._sparse_data_dist()
 
         # batch 2
         with torch.cuda.stream(self._memcpy_stream):
-            batch_ip1 = next(dataloader_iter)
-            self._batch_ip1 = batch_ip1 = _to_device(
-                batch_ip1, self._device, non_blocking=True
-            )
+            try:
+                batch_ip1 = next(self._dataloader_iter)
+                self._batch_ip1 = batch_ip1 = _to_device(
+                    batch_ip1, self._device, non_blocking=True
+                )
+            except StopIteration:
+                pass
         self._connected = True
         self.__class__.synced_pipeline_id[id(self._model)] = id(self)
 
-    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+    def __next__(self) -> In:
         if not self._connected:
-            self._connect(dataloader_iter)
+            self._connect()
         elif self.__class__.synced_pipeline_id.get(id(self._model), None) != id(self):
             self._sync_pipeline()
             self.__class__.synced_pipeline_id[id(self._model)] = id(self)
 
-        if self._model.training:
-            with record_function("## zero_grad ##"):
-                self._optimizer.zero_grad()
+        if self._batch_i is None:
+            raise StopIteration
 
         with record_function("## copy_batch_to_gpu ##"):
             with torch.cuda.stream(self._memcpy_stream):
-                batch_ip2 = next(dataloader_iter)
-                self._batch_ip2 = batch_ip2 = _to_device(
-                    batch_ip2, self._device, non_blocking=True
-                )
+                try:
+                    batch_ip2 = next(self._dataloader_iter)
+                    self._batch_ip2 = batch_ip2 = _to_device(
+                        batch_ip2, self._device, non_blocking=True
+                    )
+                except StopIteration:
+                    self._batch_ip2 = batch_ip2 = None
+
         batch_i = cast(In, self._batch_i)
         batch_ip1 = cast(In, self._batch_ip1)
 
         with record_function("## wait_for_batch ##"):
             _wait_for_batch(batch_i, self._data_dist_stream)
 
-        # Forward
-        with record_function("## forward ##"):
-            # if using multiple streams (ie. CUDA), create an event in default stream
-            # before starting forward pass
-            if self._data_dist_stream:
-                event = torch.cuda.current_stream().record_event()
-            (losses, output) = cast(Tuple[torch.Tensor, Out], self._model(batch_i))
+        # Make sure that previous data distribution has finished before starting next one.
+        # Otherwise, it may cause memory bloat and hurt perf.
+        if self._data_dist_stream:
+            event = torch.cuda.current_stream().record_event()
+            # pyre-ignore
+            self._data_dist_stream.wait_event(event)
 
-        # Data Distribution
-        with record_function("## sparse_data_dist ##"):
-            with torch.cuda.stream(self._data_dist_stream):
-                _wait_for_batch(batch_ip1, self._memcpy_stream)
-                # Ensure event in default stream has been called before
-                # starting data dist
-                if self._data_dist_stream:
-                    # pyre-ignore [61]: Local variable `event` is undefined, or not always defined
-                    self._data_dist_stream.wait_event(event)
-                _start_data_dist(self._pipelined_modules, batch_ip1, self._context)
-
-        if self._model.training:
-            # Backward
-            with record_function("## backward ##"):
-                torch.sum(losses, dim=0).backward()
-
-            # Update
-            with record_function("## optimizer ##"):
-                self._optimizer.step()
+        # Data distribution for batch B + 1
+        self._sparse_data_dist()
 
         self._batch_i = batch_ip1
-        self._batch_ip1 = batch_ip2
+        self._batch_ip1 = self._batch_ip2
 
-        return output
+        return batch_i
+
+    def _sparse_data_dist(self) -> None:
+        # Data distribution for batch B + 1
+        if self._batch_i:
+            with record_function("## sparse_data_dist ##"):
+                with torch.cuda.stream(self._data_dist_stream):
+                    # pyre-ignore
+                    _wait_for_batch(self._batch_i, self._memcpy_stream)
+                    _start_data_dist(
+                        self._pipelined_modules,
+                        # pyre-ignore
+                        self._batch_i,
+                        self._context,
+                    )
 
     def _sync_pipeline(self) -> None:
         """

--- a/torchrec/distributed/tests/test_data_pipeline.py
+++ b/torchrec/distributed/tests/test_data_pipeline.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+import unittest
+from typing import cast
+
+import torch
+from torch import distributed as dist, nn, optim
+from torchrec.distributed.data_pipeline import CudaCopyingPipeline, SparseDistPipeline
+
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.test_utils.test_model import (
+    ModelInput,
+    ModelInputSimple,
+    TestCustomEBCSharder,
+    TestModule,
+    TestSparseNN,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.types import ModuleSharder, ShardingEnv
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.optim.keyed import KeyedOptimizerWrapper
+from torchrec.optim.optimizers import in_backward_optimizer_filter
+from torchrec.test_utils import get_free_port, init_distributed_single_host
+
+
+class CudaCopyingPipelineTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.device = torch.device("cuda:0")
+        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cuda.matmul.allow_tf32 = False
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPUs",
+    )
+    def test_equal_to_non_pipelined(self) -> None:
+        model_cpu = TestModule()
+        model_gpu = TestModule().to(self.device)
+        model_gpu.load_state_dict(model_cpu.state_dict())
+        optimizer_cpu = optim.SGD(model_cpu.model.parameters(), lr=0.01)
+        optimizer_gpu = optim.SGD(model_gpu.model.parameters(), lr=0.01)
+        data = [
+            ModelInputSimple(
+                float_features=torch.rand((10,)),
+                label=torch.randint(2, (1,), dtype=torch.float32),
+            )
+            for b in range(5)
+        ]
+        dataloader = iter(data)
+        pipeline = CudaCopyingPipeline(dataloader, self.device)
+
+        for i, batch in enumerate(pipeline):
+            # cpu model train
+            optimizer_cpu.zero_grad()
+            loss, pred = model_cpu(data[i])
+            loss.backward()
+            optimizer_cpu.step()
+
+            # pipelined train
+            optimizer_gpu.zero_grad()
+            loss_gpu, pred_gpu = model_gpu(batch)
+            loss_gpu.backward()
+            optimizer_gpu.step()
+
+            self.assertEqual(pred_gpu.device, self.device)
+            torch.testing.assert_close(pred_gpu.cpu(), pred)
+
+
+class TestDataPipeline(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        self.pg = init_distributed_single_host(backend="nccl", rank=0, world_size=1)
+
+        num_features = 4
+        num_weighted_features = 2
+
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(num_features)
+        ]
+        self.weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(num_weighted_features)
+        ]
+
+        self.device = torch.device("cuda:0")
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        dist.destroy_process_group(self.pg)
+
+    # pyre-ignore
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPUs",
+    )
+    def test_sparse_dist_data_pipelining(
+        self,
+    ) -> None:
+        unsharded_model = TestSparseNN(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            dense_device=self.device,
+            sparse_device=torch.device("meta"),
+        )
+        distributed_model = DistributedModelParallel(
+            unsharded_model,
+            env=ShardingEnv.from_process_group(self.pg),
+            init_data_parallel=False,
+            device=self.device,
+            sharders=[cast(ModuleSharder[nn.Module], TestCustomEBCSharder())],
+        )
+
+        model_cpu = TestSparseNN(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+        )
+        optimizer = optim.SGD(model_cpu.parameters(), lr=0.1)
+        optimizer_distributed = KeyedOptimizerWrapper(
+            dict(in_backward_optimizer_filter(distributed_model.named_parameters())),
+            lambda params: optim.SGD(params, lr=0.1),
+        )
+
+        data = [
+            ModelInput.generate(
+                tables=self.tables,
+                weighted_tables=self.weighted_tables,
+                batch_size=1,
+                world_size=1,
+                num_float_features=10,
+            )[0]
+            for i in range(4)
+        ]
+
+        dataloader = iter(data)
+
+        copy_state_dict(
+            distributed_model.state_dict(), copy.deepcopy(model_cpu.state_dict())
+        )
+
+        pipeline = SparseDistPipeline(
+            dataloader_iter=dataloader, device=self.device, model=distributed_model
+        )
+
+        for i, batch in enumerate(pipeline):
+            # cpu model train
+            optimizer.zero_grad()
+            loss, pred = model_cpu(data[i])
+            loss.backward()
+            optimizer.step()
+
+            # pipelined train
+            optimizer_distributed.zero_grad()
+            loss_pipelined, pred_pipelined = distributed_model(batch)
+            loss_pipelined.backward()
+            optimizer_distributed.step()
+
+            self.assertEqual(len(pipeline._pipelined_modules), 2)
+
+            self.assertEqual(pred_pipelined.device, self.device)
+            self.assertEqual(pred_pipelined.cpu().size(), pred.size())
+            torch.testing.assert_close(pred_pipelined.cpu(), pred)


### PR DESCRIPTION
Summary:
Note: Work in progress, publish for early feedbacks.

Currently, torchrec's built-in `TrainPipeline` API takes full control of the training loop (i.e. load next batch, forward, backward, optimizer step).

While this satisfies most common use cases, researchers who want to experiment with more advanced techniques (e.g. multi-losses, multiple batches) will have to write their own custom training loop, often with lots of duplicate codes to take advantage of comm & comp overlap speedup.

Goal of `DataPipeline` is to provide easy API to enable comm & comp overlap, but gives users back control over the training loop.

Differential Revision: D42810112

