### PR TITLE
pip install torchx before torchx smoketest

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -39,6 +39,7 @@ fi
 python -c "import torch; import fbgemm_gpu; import torchrec"
 
 # Finally run smoke test
+pip install torchx
 if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then
     torchx run -s local_cwd dist.ddp -j 1 --gpu 2 --script test_installation.py
 else

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -1,5 +1,5 @@
 # Scheduled validation of the nightly binaries
-name: cron
+name: validate-nightly-binaries
 
 on:
   schedule:


### PR DESCRIPTION
Summary: as title, need to pip install torchx before smoketest now that torchx is not in install-requirements.txt

Differential Revision: D42811637

