### PR TITLE
Fix bug for weighted features in ETC

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -678,6 +678,8 @@ class ShardedEmbeddingTowerCollection(
                 if kjt_param and wkjt_param:
                     assert len(dist_input) == 2
                     embeddings.append(embedding(dist_input[0], dist_input[1]))
+                elif wkjt_param and len(dist_input) == 2:
+                    embeddings.append(embedding(dist_input[1]))
                 else:
                     embeddings.append(embedding(dist_input[0]))
             output = torch.cat(


### PR DESCRIPTION
Summary: Fixes bug for ETC where some modules have weighted features and some do not. Current behavior is correct for if it is a PEA module (accepts both weighted and unweighted simultaneously), but if the ETC has a combination of weighted and unweighted modules, we don't assign the weighted feature to the weighted module.

Differential Revision: D42812654

