### PR TITLE
speed up TorchRec CPU unit tests by only installing CPU fbgemm; also use fail-fast strategy

### DIFF
--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   build_test:
     strategy:
+        fail-fast: false
         matrix:
           include:
             - os: linux.2xlarge
@@ -46,33 +47,28 @@ jobs:
           -c pytorch-nightly \
           "pytorch-nightly"::pytorch[build="*cpu*"]
         conda run -n build_binary \
+          python -c "import torch.distributed"
+        sed -i 's/fbgemm-gpu-nightly/fbgemm-gpu-nightly-cpu/g' requirements.txt
+        conda run -n build_binary \
           pip install -r requirements.txt
         conda run -n build_binary \
-          pip uninstall fbgemm_gpu-nightly -y
+          python setup.py bdist_wheel \
+          --package_name torchrec-test-cpu \
+          --cpu-only True \
+          --python-tag=${{ matrix.python-tag }}
         conda run -n build_binary \
-          pip install fbgemm-gpu-nightly-cpu
-        conda run -n build_binary \
-          python -c "import torch.distributed"
+          python -c "import torchrec"
         echo "torch.distributed succeeded"
-        conda run -n build_binary \
-          python -c "import skbuild"
-        echo "skbuild succeeded"
         conda run -n build_binary \
           python -c "import numpy"
         echo "numpy succeeded"
         conda run -n build_binary \
           python -c "import fbgemm_gpu"
         echo "fbgemm_gpu succeeded"
-
-        conda run -n build_binary \
-          python setup.py bdist_wheel \
-          --package_name torchrec-test-cpu \
-          --python-tag=${{ matrix.python-tag }}
-        conda run -n build_binary \
-          python -c "import torchrec"
         conda install -n build_binary -y pytest
         conda run -n build_binary \
           python -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors -k 'not test_sharding_gloo_cw' --ignore-glob=**/test_utils/
+
         echo "Starting C++ Tests"
         conda install -n build_binary -y gxx_linux-64
         conda run -n build_binary \

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         default=None,
         help="override version",
     )
+    parser.add_argument(
+        "--cpu-only",
+        type=bool,
+        default=False,
+        help="True will install CPU only version of fbgemm-gpu",
+    )
     return parser.parse_known_args(argv)
 
 
@@ -82,7 +88,16 @@ def main(argv: List[str]) -> None:
             install_requires.remove("fbgemm-gpu-nightly")
         install_requires.append("fbgemm-gpu")
 
-    print(f"-- {name} building version: {version}")
+    cpu_only = args.cpu_only
+    if cpu_only:
+        if "fbgemm-gpu-nightly" in install_requires:
+            install_requires.remove("fbgemm-gpu-nightly")
+            install_requires.append("fbgemm-gpu-nightly-cpu")
+        if "fbgemm-gpu" in install_requires:
+            install_requires.remove("fbgemm-gpu")
+            install_requires.append("fbgemm-gpu-cpu")
+
+    print(f"-- {name} building version: {version} CPU only: {cpu_only}")
 
     packages = find_packages(
         exclude=(


### PR DESCRIPTION
Differential Revision: D42815383

