### PR TITLE
Make KJTList, ListOfKJTList jitable

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -92,13 +92,16 @@ class KJTList(Multistreamable):
     def __getitem__(self, key: int) -> KeyedJaggedTensor:
         return self.features[key]
 
+    @torch.jit._drop
     def __iter__(self) -> Iterator[KeyedJaggedTensor]:
         return iter(self.features)
 
+    @torch.jit._drop
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         for feature in self.features:
             feature.record_stream(stream)
 
+    @torch.jit._drop
     def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
         return tracer.create_node(
             "call_function",
@@ -121,13 +124,16 @@ class ListOfKJTList(Multistreamable):
     def __getitem__(self, key: int) -> KJTList:
         return self.features_list[key]
 
+    @torch.jit._drop
     def __iter__(self) -> Iterator[KJTList]:
         return iter(self.features_list)
 
+    @torch.jit._drop
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         for feature in self.features_list:
             feature.record_stream(stream)
 
+    @torch.jit._drop
     def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
         return tracer.create_node(
             "call_function",

--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -18,6 +18,8 @@ from torchrec import EmbeddingCollection, EmbeddingConfig
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
+    KJTList,
+    ListOfKJTList,
     ModuleSharder,
     ShardingType,
 )
@@ -37,12 +39,13 @@ from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
 from torchrec.distributed.types import Awaitable, ShardingEnv
 from torchrec.distributed.utils import CopyableMixin
 from torchrec.fx.tracer import Tracer as TorchrecFxTracer
+from torchrec.fx.utils import fake_range
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.quant.embedding_modules import (
     EmbeddingCollection as QuantEmbeddingCollection,
 )
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 
 class FxJitTestType(Enum):
@@ -458,3 +461,19 @@ class ModelTraceScriptTest(unittest.TestCase):
                     eager_output = model(*inp)
                     script_output = gm_script(*inp)
                     assert_close(eager_output, script_output)
+
+    def test_jitscript(self) -> None:
+        # Check main types to be torch jit scriptable
+        for clz in [
+            JaggedTensor,
+            KeyedJaggedTensor,
+            KeyedTensor,
+            KJTList,
+            ListOfKJTList,
+        ]:
+            # Using torch.jit._script._recursive_compile_class instead of torch.jit.script
+            # As classes later is more restrictive, checking no inheritance
+            # (e.g. Multistreamable which we so far do not need in jit script) etc.
+            # We need those classes not as it is, but as composable blocks in model.
+            # _recursive_compile_class for that is enough
+            torch.jit._script._recursive_compile_class(clz, fake_range())


### PR DESCRIPTION
Summary:
Making KJTList, and ListOfKJTList torch scriptable.

Adding test that checks that no new changes will make it unscriptable for base torchrec "data" classes:
```
JaggedTensor,
KeyedJaggedTensor,
KeyedTensor,
KJTList,
ListOfKJTList,
```

torchrec changes:

1. Adding `torch.jit._drop` to

```
def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
```
As torch.fx classes are not torch scriptable and must not be in the script.

2.  Adding `torch.jit._drop` to
```
def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
```

As torch.cuda.streams.Stream is not jit scriptable and we do not use it so far in jit models.

If we want to use it - we can convert it to jit-scriptable `torch.cuda.Stream`

3. Adding `torch.jit._drop` to
```
def __iter__(self) -> Iterator[KeyedJaggedTensor]:
```

`Iterator` class can not be torch scripted

Differential Revision: D42744969

