### PR TITLE
Parse the additional features for bucket metrics from model_output and use them in metric computation

### DIFF
--- a/torchrec/metrics/README.md
+++ b/torchrec/metrics/README.md
@@ -193,7 +193,7 @@ ne = NEMetric(
     window_size=512,
     fused_update_limit=0,
 )
-labels, predictions, weights = parse_task_model_outputs(tasks, model_output)
+labels, predictions, weights, _ = parse_task_model_outputs(tasks, model_output)
 ne.update(
     predictions=predictions,
     labels=labels,

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -214,11 +214,17 @@ class RecMetricModule(nn.Module):
         the model output format.
         """
         if self.rec_metrics and self.rec_tasks:
-            labels, predictions, weights = parse_task_model_outputs(
-                self.rec_tasks, model_out
+            labels, predictions, weights, required_inputs = parse_task_model_outputs(
+                self.rec_tasks, model_out, self.get_required_inputs()
+            )
+            kwargs: Dict[str, Any] = (
+                {"required_inputs": required_inputs} if required_inputs else {}
             )
             self.rec_metrics.update(
-                predictions=predictions, labels=labels, weights=weights
+                predictions=predictions,
+                labels=labels,
+                weights=weights,
+                **kwargs,
             )
 
     def update(self, model_out: Dict[str, torch.Tensor]) -> None:
@@ -327,7 +333,7 @@ class RecMetricModule(nn.Module):
     def reset(self) -> None:
         self.rec_metrics.reset()
 
-    def get_required_inputs(self) -> List[str]:
+    def get_required_inputs(self) -> Optional[List[str]]:
         return self.rec_metrics.get_required_inputs()
 
 

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -696,7 +696,7 @@ class RecMetricList(nn.Module):
     """
 
     rec_metrics: nn.ModuleList
-    required_inputs: List[str]
+    required_inputs: Optional[List[str]]
 
     def __init__(self, rec_metrics: List[RecMetric]) -> None:
         # TODO(stellaya): consider to inherit from TorchMetrics.MetricCollection.
@@ -705,10 +705,13 @@ class RecMetricList(nn.Module):
 
         super().__init__()
         self.rec_metrics = nn.ModuleList(rec_metrics)
-        self.required_inputs = list(
-            set().union(
-                *[rec_metric.get_required_inputs() for rec_metric in rec_metrics]
+        self.required_inputs = (
+            list(
+                set().union(
+                    *[rec_metric.get_required_inputs() for rec_metric in rec_metrics]
+                )
             )
+            or None
         )
 
     def __len__(self) -> int:
@@ -717,7 +720,7 @@ class RecMetricList(nn.Module):
     def __getitem__(self, idx: int) -> nn.Module:
         return self.rec_metrics[idx]
 
-    def get_required_inputs(self) -> List[str]:
+    def get_required_inputs(self) -> Optional[List[str]]:
         return self.required_inputs
 
     def update(
@@ -729,7 +732,9 @@ class RecMetricList(nn.Module):
         **kwargs: Dict[str, Any],
     ) -> None:
         for metric in self.rec_metrics:
-            metric.update(predictions=predictions, labels=labels, weights=weights)
+            metric.update(
+                predictions=predictions, labels=labels, weights=weights, **kwargs
+            )
 
     def compute(self) -> Dict[str, torch.Tensor]:
         ret = {}

--- a/torchrec/metrics/test_utils/__init__.py
+++ b/torchrec/metrics/test_utils/__init__.py
@@ -263,7 +263,7 @@ def rec_metric_value_test_helper(
             **kwargs,
         )
         for i in range(nsteps):
-            labels, predictions, weights = parse_task_model_outputs(
+            labels, predictions, weights, _ = parse_task_model_outputs(
                 tasks, model_outs[i]
             )
             if target_compute_mode == RecComputeMode.FUSED_TASKS_COMPUTATION:

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -82,7 +82,7 @@ class TestMetricModule(RecMetricModule):
     def _update_rec_metrics(self, model_out: Dict[str, torch.Tensor]) -> None:
         if isinstance(model_out, MagicMock):
             return
-        labels, predictions, weights = parse_task_model_outputs(
+        labels, predictions, weights, _ = parse_task_model_outputs(
             self.rec_tasks, model_out
         )
         self.rec_metrics.update(predictions=predictions, labels=labels, weights=weights)

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -20,7 +20,7 @@ class RecMetricTest(unittest.TestCase):
     def setUp(self) -> None:
         # Create testing labels, predictions and weights
         model_output = gen_test_batch(128)
-        self.labels, self.predictions, self.weights = parse_task_model_outputs(
+        self.labels, self.predictions, self.weights, _ = parse_task_model_outputs(
             [DefaultTaskInfo], model_output
         )
 
@@ -126,7 +126,7 @@ class RecMetricTest(unittest.TestCase):
             for task in tasks
         ]
         model_output = {k: v for d in _model_output for k, v in d.items()}
-        labels, predictions, weights = parse_task_model_outputs(tasks, model_output)
+        labels, predictions, weights, _ = parse_task_model_outputs(tasks, model_output)
         partial_zero_weights = {
             "t1": torch.zeros_like(weights["t1"]),
             "t2": weights["t2"],


### PR DESCRIPTION
Summary:
The main changes are
- Include the parsing of `required_inputs` in `parse_task_model_outputs` so that we can extract the features needed by the bucket metrics from model_outputs
- In `_update_rec_metrics` get the parsed `required_inputs` and feed it to metric update
- In `RecMetricList` update the RecMetrics with the `required_inputs`

Differential Revision: D42625421

