### PR TITLE
ModuleShardingPlan -> EmbeddingModuleShardingPlan

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -42,8 +42,8 @@ from torchrec.distributed.sharding.tw_sequence_sharding import (
 )
 from torchrec.distributed.types import (
     Awaitable,
+    EmbeddingModuleShardingPlan,
     LazyAwaitable,
-    ModuleShardingPlan,
     Multistreamable,
     ParameterSharding,
     QuantizedCommCodecs,
@@ -311,11 +311,15 @@ class ShardedEmbeddingCollection(
         self._table_names: List[str] = [
             config.name for config in self._embedding_configs
         ]
-        self.module_sharding_plan: ModuleShardingPlan = {
-            table_name: parameter_sharding
-            for table_name, parameter_sharding in table_name_to_parameter_sharding.items()
-            if table_name in self._table_names
-        }
+        self.module_sharding_plan: EmbeddingModuleShardingPlan = cast(
+            EmbeddingModuleShardingPlan,
+            {
+                table_name: parameter_sharding
+                for table_name, parameter_sharding in table_name_to_parameter_sharding.items()
+                if table_name in self._table_names
+            },
+        )
+
         self._env = env
         sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
             module,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -8,7 +8,19 @@
 import copy
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, Tuple, Type, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import torch
 from torch import nn, Tensor
@@ -35,9 +47,9 @@ from torchrec.distributed.sharding.twcw_sharding import TwCwPooledEmbeddingShard
 from torchrec.distributed.sharding.twrw_sharding import TwRwPooledEmbeddingSharding
 from torchrec.distributed.types import (
     Awaitable,
+    EmbeddingModuleShardingPlan,
     EnumerableShardingSpec,
     LazyAwaitable,
-    ModuleShardingPlan,
     NullShardedModuleContext,
     ParameterSharding,
     QuantizedCommCodecs,
@@ -322,11 +334,14 @@ class ShardedEmbeddingBagCollection(
             config.name for config in self._embedding_bag_configs
         ]
 
-        self.module_sharding_plan: ModuleShardingPlan = {
-            table_name: parameter_sharding
-            for table_name, parameter_sharding in table_name_to_parameter_sharding.items()
-            if table_name in self._table_names
-        }
+        self.module_sharding_plan: EmbeddingModuleShardingPlan = cast(
+            EmbeddingModuleShardingPlan,
+            {
+                table_name: parameter_sharding
+                for table_name, parameter_sharding in table_name_to_parameter_sharding.items()
+                if table_name in self._table_names
+            },
+        )
         self._env = env
 
         sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -80,6 +80,7 @@ class EmbeddingStats(Stats):
         shard_by_fqn = {
             module_name + "." + param_name: value
             for module_name, param_dict in sharding_plan.plan.items()
+            # pyre-ignore - this is a EmbeddingShardingPlan below
             for param_name, value in param_dict.items()
         }
         stats: Dict[int, Dict[str, Any]] = {

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -15,7 +15,12 @@ from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.planners import EmbeddingShardingPlanner
 from torchrec.distributed.planner.types import PlannerError, PlannerErrorType, Topology
 from torchrec.distributed.test_utils.test_model import TestSparseNN
-from torchrec.distributed.types import ModuleSharder, ShardingPlan, ShardingType
+from torchrec.distributed.types import (
+    EmbeddingModuleShardingPlan,
+    ModuleSharder,
+    ShardingPlan,
+    ShardingType,
+)
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
@@ -62,7 +67,9 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         expected_ranks = [[0], [0], [1], [1]]
         ranks = [
             cast(List[int], param_shard.ranks)
-            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+            for param_shard in cast(
+                EmbeddingModuleShardingPlan, sharding_plan.plan["sparse.ebc"]
+            ).values()
         ]
 
         self.assertEqual(sorted(expected_ranks), sorted(ranks))
@@ -82,7 +89,9 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         expected_ranks = [[0], [0, 1], [1]]
         ranks = [
             cast(List[int], param_shard.ranks)
-            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+            for param_shard in cast(
+                EmbeddingModuleShardingPlan, sharding_plan.plan["sparse.ebc"]
+            ).values()
         ]
 
         self.assertEqual(sorted(expected_ranks), sorted(ranks))
@@ -129,7 +138,9 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         expected_ranks = [[0, 1]]
         ranks = [
             cast(List[int], param_shard.ranks)
-            for param_shard in sharding_plan.plan["sparse.ebc"].values()
+            for param_shard in cast(
+                EmbeddingModuleShardingPlan, sharding_plan.plan["sparse.ebc"]
+            ).values()
         ]
 
         self.assertEqual(sorted(expected_ranks), sorted(ranks))

--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -85,6 +85,9 @@ def shard(
         else:
             device = torch.device("cpu")
 
+    if isinstance(plan, ModuleShardingPlan):
+        return sharder.shard(module, plan, env, device)
+
     # Run sharding generators.
     shardable_parameters = sharder.shardable_parameters(module)
     if isinstance(plan, Callable):

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -20,9 +20,9 @@ from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionS
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.types import (
+    EmbeddingModuleShardingPlan,
     EnumerableShardingSpec,
     ModuleSharder,
-    ModuleShardingPlan,
     ParameterSharding,
     ShardingType,
     ShardMetadata,
@@ -526,9 +526,9 @@ def construct_module_sharding_plan(
     local_size: Optional[int] = None,
     world_size: Optional[int] = None,
     device_type: Optional[str] = None,
-) -> ModuleShardingPlan:
+) -> EmbeddingModuleShardingPlan:
     """
-    Helper function to create module sharding plans (ModuleShardingPlan) for an module
+    Helper function to create module sharding plans (EmbeddingModuleShardingPlan) for an module
     Args:
         module (nn.Module): module to create plan for.
         per_param_sharding: Dict[str, Callable[[nn.Parameter, int, int, str], ParameterSharding]]: A mapping of parameter names to a generator function
@@ -572,7 +572,7 @@ def construct_module_sharding_plan(
     local_size = local_size or get_local_size()
     world_size = world_size or dist.get_world_size()
 
-    per_parameter_sharding: ModuleShardingPlan = {}
+    per_parameter_sharding = EmbeddingModuleShardingPlan()
     for table_name, sharding_plan_generator in per_param_sharding.items():
         param = shardable_parameters[table_name]
         per_parameter_sharding[table_name] = sharding_plan_generator(

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -37,6 +37,7 @@ from torchrec.distributed.test_utils.test_model import (
     TestSparseNNBase,
 )
 from torchrec.distributed.types import (
+    EmbeddingModuleShardingPlan,
     ModuleSharder,
     ShardedTensor,
     ShardingEnv,
@@ -317,7 +318,9 @@ def sharding_single_rank_test(
         """
 
         for group in plan.plan:
-            for _, parameter_sharding in plan.plan[group].items():
+            for _, parameter_sharding in cast(
+                EmbeddingModuleShardingPlan, plan.plan[group]
+            ).items():
                 if (
                     parameter_sharding.sharding_type
                     in {


### PR DESCRIPTION
Summary: Currenty TorchRec only supports embedding modules, but we want to keep our ecosystem open to sharding even non-embedidng modules that our type system doens't know about. So we keep it as open - we can accept any ModuleShardingPlan, and we specialize the current ones to be EmbeddingSahrdingPlan

Reviewed By: strisunshinewentingwang

Differential Revision: D43003541

