### PR TITLE
Remove flags from setup.py build

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -2,7 +2,7 @@ name: Build Linux Wheels
 
 on:
   # TODO: Renable after fixed @omkar
-  # pull_request:
+  pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -2,7 +2,7 @@ name: Build Linux Wheels
 
 on:
   # TODO: Renable after fixed @omkar
-  pull_request:
+  # pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -93,7 +93,6 @@ jobs:
         export CHANNEL="nightly"
         conda run -n build_binary \
           python setup.py bdist_wheel \
-          --package_name torchrec-nightly \
           --python-tag=${{ matrix.python-tag }}
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -89,7 +89,6 @@ jobs:
         rm -r dist || true
         conda run -n build_binary \
           python setup.py bdist_wheel \
-          --package_name torchrec \
           --python-tag=${{ matrix.python-tag }}
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -85,7 +85,6 @@ jobs:
       run: |
         conda run -n build_binary \
           python setup.py bdist_wheel \
-          --package_name torchrec-test \
           --python-tag=${{ matrix.python-tag }}
     - name: Upload wheel as GHA artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -51,10 +51,9 @@ jobs:
         sed -i 's/fbgemm-gpu-nightly/fbgemm-gpu-nightly-cpu/g' requirements.txt
         conda run -n build_binary \
           pip install -r requirements.txt
+        export CPU_ONLY=1
         conda run -n build_binary \
           python setup.py bdist_wheel \
-          --package_name torchrec-test-cpu \
-          --cpu-only True \
           --python-tag=${{ matrix.python-tag }}
         conda run -n build_binary \
           python -c "import torchrec"

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -51,7 +51,7 @@ jobs:
         sed -i 's/fbgemm-gpu-nightly/fbgemm-gpu-nightly-cpu/g' requirements.txt
         conda run -n build_binary \
           pip install -r requirements.txt
-        export CPU_ONLY=1
+        export CU_VERSION="cpu"
         conda run -n build_binary \
           python setup.py bdist_wheel \
           --python-tag=${{ matrix.python-tag }}

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,8 @@ def get_channel():
     return os.getenv("CHANNEL")
 
 
-def get_CPU_only():
-    cpu_only = os.getenv("CPU_ONLY", "0")
-    assert cpu_only in ["0", "1"]
-    return int(cpu_only)
+def get_cu_version():
+    return os.getenv("CU_VERSION", "cpu")
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
@@ -79,8 +77,8 @@ def main(argv: List[str]) -> None:
             install_requires.remove("fbgemm-gpu-nightly")
         install_requires.append("fbgemm-gpu")
 
-    cpu_only = get_CPU_only()
-    if cpu_only:
+    cu_version = get_cu_version()
+    if cu_version == "cpu":
         if "fbgemm-gpu-nightly" in install_requires:
             install_requires.remove("fbgemm-gpu-nightly")
             install_requires.append("fbgemm-gpu-nightly-cpu")
@@ -88,7 +86,7 @@ def main(argv: List[str]) -> None:
             install_requires.remove("fbgemm-gpu")
             install_requires.append("fbgemm-gpu-cpu")
 
-    print(f"-- {name} building version: {version} CPU only: {bool(cpu_only)}")
+    print(f"-- {name} building version: {version} CU Version: {cu_version}")
 
     packages = find_packages(
         exclude=(

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main(argv: List[str]) -> None:
     channel = get_channel()
     if channel == "nightly":
         name = "torchrec-nightly"
-    else
+    else:
         name = "torchrec"
 
     with open(


### PR DESCRIPTION
Starting to make torchrec play better with Nova builds by removing flag args from setup.py build. The Nova workflows don't take any args to the `setup.py` script, so any feature toggling is done via env vars (which can be configured for each domain library).