### PR TITLE
Back out "Incorporate 2D asynchronous_complete_cumsum support for batched_lengths_to_offsets"

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -41,8 +41,13 @@ def _to_lengths(offsets: torch.Tensor) -> torch.Tensor:
     return offsets[1:] - offsets[:-1]
 
 
+@torch.jit.script_if_tracing
 def _batched_lengths_to_offsets(lengths: torch.Tensor) -> torch.Tensor:
-    return torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+    (f, b) = lengths.shape
+    offsets_0 = lengths.new_zeros((f, 1))
+    offsets_1 = torch.cumsum(lengths, dim=-1).to(lengths.dtype)
+    offsets = torch.cat([offsets_0, offsets_1], dim=-1)
+    return offsets
 
 
 def _maybe_compute_lengths(


### PR DESCRIPTION
Summary:
Original commit changeset: 2f2f5cb5ac5b

Original Phabricator Diff: D42971860 (https://github.com/pytorch/torchrec/commit/a06838fe87b6847ebfc9f8d19fa79a633349803a)

Reviewed By: sryap

Differential Revision: D43068744

