### PR TITLE
test_sharding_fused_ebc deadlock fix

### DIFF
--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -119,7 +119,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharding_type: str,
     ) -> None:
         self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
-
         fused_ebc = FusedEmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -177,7 +176,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharding_type: str,
     ) -> None:
         self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
-
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -38,7 +38,7 @@ from torchrec.modules.fused_embedding_modules import (
     FusedEmbeddingBagCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.test_utils import skip_if_asan_class, skipIfRocm 
+from torchrec.test_utils import skip_if_asan_class, skipIfRocm
 
 
 def sharding_single_rank(

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -38,7 +38,7 @@ from torchrec.modules.fused_embedding_modules import (
     FusedEmbeddingBagCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.test_utils import skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class, skipIfRocm 
 
 
 def sharding_single_rank(
@@ -94,6 +94,7 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
+    @skipIfRocm()
     # pyre-fixme[56]
     @given(
         sharder_type=st.sampled_from(
@@ -153,6 +154,7 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             backend="nccl",
         )
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -38,7 +38,7 @@ from torchrec.modules.fused_embedding_modules import (
     FusedEmbeddingBagCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.test_utils import skip_if_asan_class, skipIfRocm
+from torchrec.test_utils import skip_if_asan_class
 
 
 def sharding_single_rank(
@@ -51,7 +51,6 @@ def sharding_single_rank(
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
     local_size: Optional[int] = None,
 ) -> None:
-
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         kjt_input = kjt_input.to(ctx.device)
         unsharded_model = unsharded_model.to(ctx.device)

--- a/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_bag_collection.py
@@ -94,7 +94,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @skipIfRocm()
     # pyre-fixme[56]
     @given(
         sharder_type=st.sampled_from(
@@ -118,7 +117,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharder_type: str,
         sharding_type: str,
     ) -> None:
-        self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
         fused_ebc = FusedEmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -153,7 +151,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             backend="nccl",
         )
 
-    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -175,7 +172,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         self,
         sharding_type: str,
     ) -> None:
-        self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(

--- a/torchrec/distributed/tests/test_fused_embedding_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_collection.py
@@ -40,6 +40,7 @@ from torchrec.modules.fused_embedding_modules import (
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class, skipIfRocm
 
+
 @skip_if_asan_class
 class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
     @classmethod

--- a/torchrec/distributed/tests/test_fused_embedding_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_collection.py
@@ -38,8 +38,7 @@ from torchrec.modules.fused_embedding_modules import (
     FusedEmbeddingCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.test_utils import skip_if_asan_class
-
+from torchrec.test_utils import skip_if_asan_class, skipIfRocm
 
 @skip_if_asan_class
 class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
@@ -100,6 +99,7 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
                     unsharded_jt.lengths().cpu(), sharded_jt.lengths().cpu()
                 )
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -157,6 +157,7 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             backend="nccl",
         )
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",

--- a/torchrec/distributed/tests/test_fused_embedding_collection.py
+++ b/torchrec/distributed/tests/test_fused_embedding_collection.py
@@ -122,7 +122,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharding_type: str,
     ) -> None:
         self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
-
         fused_ec = FusedEmbeddingCollection(
             tables=[
                 EmbeddingConfig(
@@ -180,7 +179,6 @@ class FusedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharding_type: str,
     ) -> None:
         self.fail("fix test or remove - Test is currently deadlocking and breaking CI")
-
         ec = EmbeddingCollection(
             tables=[
                 EmbeddingConfig(

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -270,7 +270,6 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
         )
 
-    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 3,
         "Not enough GPUs, this test requires at least four GPUs",

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -23,8 +23,7 @@ from torchrec.distributed.test_utils.test_sharding import (
     SharderType,
 )
 from torchrec.distributed.types import ShardingType
-from torchrec.test_utils import skip_if_asan_class
-import pdb
+from torchrec.test_utils import skip_if_asan_class, skipIfRocm
 
 @skip_if_asan_class
 class ModelParallelHierarchicalTest(ModelParallelTestShared):
@@ -247,7 +246,6 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
     ) -> None:
-        pdb.set_trace()
         # Dense kernels do not have overlapped optimizer behavior yet
         assume(
             apply_optimizer_in_backward_config is None
@@ -272,6 +270,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
         )
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 3,
         "Not enough GPUs, this test requires at least four GPUs",

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -25,6 +25,7 @@ from torchrec.distributed.test_utils.test_sharding import (
 from torchrec.distributed.types import ShardingType
 from torchrec.test_utils import skip_if_asan_class, skipIfRocm
 
+
 @skip_if_asan_class
 class ModelParallelHierarchicalTest(ModelParallelTestShared):
     """

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -24,7 +24,7 @@ from torchrec.distributed.test_utils.test_sharding import (
 )
 from torchrec.distributed.types import ShardingType
 from torchrec.test_utils import skip_if_asan_class
-
+import pdb
 
 @skip_if_asan_class
 class ModelParallelHierarchicalTest(ModelParallelTestShared):
@@ -247,6 +247,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
     ) -> None:
+        pdb.set_trace()
         # Dense kernels do not have overlapped optimizer behavior yet
         assume(
             apply_optimizer_in_backward_config is None

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -33,8 +33,9 @@ from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.quant.embedding_modules import (
     EmbeddingBagCollection as QuantEmbeddingBagCollection,
 )
-from torchrec.types import CopyMixIn
 from torchrec.test_utils import skipIfRocm
+from torchrec.types import CopyMixIn
+
 
 class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
     def __init__(
@@ -309,6 +310,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
         from torchrec.distributed.shard import shard_modules
+
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")
         model = TestSparseNN(

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -21,7 +21,6 @@ from torchrec.distributed.planner.shard_estimators import (
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
-from torchrec.distributed.shard import shard_modules
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     ModelInput,
@@ -35,7 +34,7 @@ from torchrec.quant.embedding_modules import (
     EmbeddingBagCollection as QuantEmbeddingBagCollection,
 )
 from torchrec.types import CopyMixIn
-
+from torchrec.test_utils import skipIfRocm
 
 class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
     def __init__(
@@ -218,6 +217,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         dmp_1 = dmp.copy(device_1)
         self._recursive_device_check(dmp.module, dmp_1.module, device, device_1)
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
@@ -292,6 +292,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             dmp_copy(local_batch[0].to(device)).cpu(),
         )
 
+    @skipIfRocm()
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
@@ -307,6 +308,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
+        from torchrec.distributed.shard import shard_modules
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")
         model = TestSparseNN(

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -147,6 +147,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
         from torchrec.distributed.shard import shard_modules
+
         device = torch.device("cuda:0")
 
         # wrap in sequential because _quantize only applies to submodules...

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -479,9 +479,9 @@ class FusedEmbeddingBagCollection(
             if self._is_weighted:
                 weights = torch.cat(weights)
 
-            #code to transfer unsharded model to current_device where table is
+            # code to transfer unsharded model to current_device where table is
             if emb_op._emb_module.weights_dev.is_cuda:
-                emb_op.to( torch.cuda.current_device() )
+                emb_op.to(torch.cuda.current_device())
 
             embeddings.append(
                 emb_op(

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -479,6 +479,9 @@ class FusedEmbeddingBagCollection(
             if self._is_weighted:
                 weights = torch.cat(weights)
 
+            #code to transfer unsharded model to current_device where table is
+            emb_op.to( torch.cuda.current_device() )
+
             embeddings.append(
                 emb_op(
                     indicies.int(),

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -480,7 +480,8 @@ class FusedEmbeddingBagCollection(
                 weights = torch.cat(weights)
 
             #code to transfer unsharded model to current_device where table is
-            emb_op.to( torch.cuda.current_device() )
+            if emb_op._emb_module.weights_dev.is_cuda:
+                emb_op.to( torch.cuda.current_device() )
 
             embeddings.append(
                 emb_op(

--- a/torchrec/modules/tests/test_fused_embedding_modules.py
+++ b/torchrec/modules/tests/test_fused_embedding_modules.py
@@ -29,6 +29,7 @@ from torchrec.modules.fused_embedding_modules import (
     FusedEmbeddingCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skipIfRocm
 
 devices: List[torch.device] = [torch.device("cpu")]
 if torch.cuda.device_count() > 1:
@@ -506,6 +507,7 @@ class FusedEmbeddingBagCollectionTest(unittest.TestCase):
 
     @settings(deadline=None)
     # pyre-ignore
+    @skipIfRocm() 
     @given(
         optimizer_type_and_kwargs=st.sampled_from(
             [

--- a/torchrec/modules/tests/test_fused_embedding_modules.py
+++ b/torchrec/modules/tests/test_fused_embedding_modules.py
@@ -506,7 +506,6 @@ class FusedEmbeddingBagCollectionTest(unittest.TestCase):
         )
 
     @settings(deadline=None)
-    # pyre-ignore
     @skipIfRocm() 
     @given(
         optimizer_type_and_kwargs=st.sampled_from(

--- a/torchrec/modules/tests/test_fused_embedding_modules.py
+++ b/torchrec/modules/tests/test_fused_embedding_modules.py
@@ -506,7 +506,8 @@ class FusedEmbeddingBagCollectionTest(unittest.TestCase):
         )
 
     @settings(deadline=None)
-    @skipIfRocm() 
+    @skipIfRocm()
+    # pyre-ignore
     @given(
         optimizer_type_and_kwargs=st.sampled_from(
             [

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -10,10 +10,10 @@ import os
 import random
 import socket
 import time
+import unittest
 from contextlib import closing
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, TypeVar
-import unittest
 
 import numpy as np
 import torch
@@ -24,6 +24,7 @@ from torch import nn
 TParams = ParameterSpecification("TParams")
 TReturn = TypeVar("TReturn")
 TEST_WITH_ROCM: bool = os.getenv("TORCHREC_TEST_WITH_ROCM", "0") == "1"
+
 
 def get_free_port() -> int:
     # INTERNAL
@@ -102,6 +103,7 @@ def skip_if_asan_class(cls: TReturn) -> Optional[TReturn]:
         return
     return cls
 
+
 # pyre-fixme[3]: Return annotation cannot be `Any`.
 def skipIfRocm(reason: str = "test doesn't currently work on the ROCm stack") -> Any:
     # pyre-fixme[3]: Return annotation cannot be `Any`.
@@ -118,6 +120,7 @@ def skipIfRocm(reason: str = "test doesn't currently work on the ROCm stack") ->
         return wrapper
 
     return skipIfRocmDecorator
+
 
 def init_distributed_single_host(
     rank: int, world_size: int, backend: str, local_size: Optional[int] = None


### PR DESCRIPTION
**test_sharding_fused_ebc hang on rocm**, we found that reson for deadlock in this multiGPU test is unsharded model tensor was on incorrect device. 

weights_dev is not on the right device. From the log below,  for current_deivce = 1, weights_dev is on the wrong device. But weights_dev cannot be controlled by itself. It is part of the Module's buffer. So, the Module itself is not on the right device. 
```
#### bounds_check_indices 0 ### current device =  0  indicies device = 0  offsets device =  0  weights_dev =  tensor([-0.2150,  0.2619, -0.2804, -0.1981,  0.1528,  0.0294, -0.1015,  0.1595,         0.0567, -0.2304,  0.1112, -0.0188, -0.1824,  0.1332, -0.1237,  0.1334,
         0.2809,  0.0660, -0.2932, -0.1700,  0.0692,  0.1564,  0.2257,  0.1722,
         0.2922,  0.1382,  0.0896, -0.0723, -0.0967, -0.1131, -0.0397,  0.1454,
         0.0515,  0.2385, -0.2375,  0.2085,  0.2463, -0.0311, -0.0817,  0.0660,
        -0.1539, -0.0108,  0.1203, -0.1073, -0.1993, -0.1923, -0.2983,  0.2792,
        -0.0309,  0.3012, -0.0275,  0.0547, -0.1685,  0.1217, -0.0311, -0.2816,
        -0.1240,  0.0151,  0.2479,  0.2557, -0.0266, -0.2155, -0.2981, -0.0728,
         0.2158,  0.2252, -0.0245,  0.0606, -0.1249,  0.0343,  0.2030,  0.1176,
         0.2016, -0.2167,  0.1062,  0.3157,  0.2631, -0.2756,  0.1661, -0.1768],
       device='cuda:0')
#### bounds_check_indices 1 ### current device =  0  indicies device = 0  offsets device =  0 rows_per_table device =  0 OPTIMIZER = OptimType.EXACT_SGD#### bounds_check_indices 0 ### current device =  1  indicies device = 1  offsets device =  1  weights_dev =  tensor([-0.2150,  0.2619, -0.2804, -0.1981,  0.1528,  0.0294, -0.1015,  0.1595,         0.0567, -0.2304,  0.1112, -0.0188, -0.1824,  0.1332, -0.1237,  0.1334,
         0.2809,  0.0660, -0.2932, -0.1700,  0.0692,  0.1564,  0.2257,  0.1722,
         0.2922,  0.1382,  0.0896, -0.0723, -0.0967, -0.1131, -0.0397,  0.1454,
         0.0515,  0.2385, -0.2375,  0.2085,  0.2463, -0.0311, -0.0817,  0.0660,
        -0.1539, -0.0108,  0.1203, -0.1073, -0.1993, -0.1923, -0.2983,  0.2792,
        -0.0309,  0.3012, -0.0275,  0.0547, -0.1685,  0.1217, -0.0311, -0.2816,
        -0.1240,  0.0151,  0.2479,  0.2557, -0.0266, -0.2155, -0.2981, -0.0728,
         0.2158,  0.2252, -0.0245,  0.0606, -0.1249,  0.0343,  0.2030,  0.1176,
         0.2016, -0.2167,  0.1062,  0.3157,  0.2631, -0.2756,  0.1661, -0.1768],
       device='cuda:0')
#### bounds_check_indices 1 ### current device =  1  indicies device = 1  offsets device =  1 rows_per_table device =  0
```
[bounds_check_indices from](https://github.com/pytorch/FBGEMM/blob/main/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py)
This torchrec change to transfer the tensor to right device makes the test pass 
```
diff --git a/torchrec/modules/fused_embedding_modules.py b/torchrec/modules/fused_embedding_modules.pyindex 6fac21f..4ca18ec 100644--- a/torchrec/modules/fused_embedding_modules.py+++ b/torchrec/modules/fused_embedding_modules.py@@ -479,6 +479,12 @@ class FusedEmbeddingBagCollection(
             if self._is_weighted:
                 weights = torch.cat(weights)
+            # Debug print
+            for emb_cfg_name in self.embedding_bags:
+                print("current device = ", torch.cuda.current_device() , "FusedEmbeddingBagCollection ", emb_cfg_name, ".device = ", self.embedding_bags[emb_cfg_name].weight.get_device(), " emb_op.device= ", emb_op._emb_module.weights_dev.get_device() )
+             # Code fails without this transfer
+            emb_op.to( torch.cuda.current_device() )
              embeddings.append(
                 emb_op(
                     indicies.int(),
 ```