### PR TITLE
Refactor recat tensor in seq emb a2a test to follow production pattern

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -974,7 +974,7 @@ class SequenceEmbeddingsAllToAll(nn.Module):
                 order of the KJT bucketize (for row-wise sharding only).
             batch_size_per_rank: (Optional[List[int]]): batch size per rank.
             sparse_features_recat (Optional[torch.Tensor]): recat tensor used for sparse
-                feature input dist.
+                feature input dist. Must be provided if using variable batch size.
 
         Returns:
             SequenceEmbeddingsAwaitable: awaitable of sequence embeddings.
@@ -984,14 +984,7 @@ class SequenceEmbeddingsAllToAll(nn.Module):
             batch_size_per_rank is not None and len(set(batch_size_per_rank)) > 1
         )
         if variable_batch_size:
-            if sparse_features_recat is None:
-                sparse_features_recat = _get_recat(
-                    local_split=self._local_split,
-                    num_splits=self._num_splits,
-                    device=local_embs.device,
-                    stagger=1,
-                    batch_size_per_rank=batch_size_per_rank,
-                )
+            assert sparse_features_recat is not None
 
         if sparse_features_recat is not None:
             forward_recat_tensor = torch.ops.fbgemm.invert_permute(


### PR DESCRIPTION
Summary: The testing code uses an antipattern with block to generate sparse features recat tensor for the test (this would be done in input dist regularly).

Differential Revision: D43181319

