### PR TITLE
Fix planning for sequence embeddings in towers

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -255,10 +255,11 @@ class ShardingOption:
     def is_pooled(self) -> bool:
         if isinstance(self.module[1], EmbeddingCollectionInterface):
             return False
-        for name, module in self.module[1].named_modules():
-            if self.name in name:
-                if isinstance(module, EmbeddingCollectionInterface):
-                    return False
+        for module in self.module[1].modules():
+            if isinstance(module, EmbeddingCollectionInterface):
+                for name, _ in module.named_parameters():
+                    if self.name in name:
+                        return False
         return True
 
     def __hash__(self) -> int:


### PR DESCRIPTION
Summary:
Currently when planning we do label sequence embeddings as pooled if they are within an EmbeddingTower or EmbeddingTowerCollection.

When checking if a ShardingOption is pooled and the module that contains the parameter is an ET or ETC when we loop through the named modules we check to see if the parameter that is the same name as the module and if so we check if it is an EmbeddingCollection to determine if its a sequence embedding. However, the name belongs to the parameter which is a child of the EmbeddingCollection module so the names will never match.
i.e.
{F869817109}

Differential Revision: D43202613

