### PR TITLE
Fix empty rank sharding test for sequence embedding

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -983,8 +983,6 @@ class SequenceEmbeddingsAllToAll(nn.Module):
         variable_batch_size = (
             batch_size_per_rank is not None and len(set(batch_size_per_rank)) > 1
         )
-        if variable_batch_size:
-            assert sparse_features_recat is not None
 
         if sparse_features_recat is not None:
             forward_recat_tensor = torch.ops.fbgemm.invert_permute(


### PR DESCRIPTION
Summary: `sparse_features_recat` will be None for empty rank, so eliminate unnecessary check.

Reviewed By: colin2328, bigning

Differential Revision: D43284002

