### PR TITLE
Adding IValue support for embedding batching

### DIFF
--- a/torchrec/inference/include/torchrec/inference/Batching.h
+++ b/torchrec/inference/include/torchrec/inference/Batching.h
@@ -30,7 +30,7 @@ class BatchingFunc {
  public:
   virtual ~BatchingFunc() = default;
 
-  virtual std::unordered_map<std::string, at::Tensor> batch(
+  virtual std::unordered_map<std::string, c10::IValue> batch(
       const std::string& /* featureName */,
       const std::vector<std::shared_ptr<PredictionRequest>>& /* requests */,
       const int64_t& /* totalNumBatch */,
@@ -52,21 +52,23 @@ C10_DECLARE_REGISTRY(TorchRecBatchingFuncRegistry, BatchingFunc);
   REGISTER_TORCHREC_BATCHING_FUNC_WITH_PIORITY(    \
       name, c10::REGISTRY_DEFAULT, __VA_ARGS__);
 
-std::unordered_map<std::string, at::Tensor> combineFloat(
+std::unordered_map<std::string, c10::IValue> combineFloat(
     const std::string& featureName,
     const std::vector<std::shared_ptr<PredictionRequest>>& requests);
 
-std::unordered_map<std::string, at::Tensor> combineSparse(
+std::unordered_map<std::string, c10::IValue> combineSparse(
     const std::string& featureName,
     const std::vector<std::shared_ptr<PredictionRequest>>& requests,
     bool isWeighted);
 
-std::unordered_map<std::string, at::Tensor> combineEmbedding(
+std::unordered_map<std::string, c10::IValue> combineEmbedding(
     const std::string& featureName,
     const std::vector<std::shared_ptr<PredictionRequest>>& requests);
 
-std::unordered_map<std::string, at::Tensor> moveToDevice(
-    std::unordered_map<std::string, at::Tensor> combined,
+void moveIValueToDevice(c10::IValue& val, const c10::Device& device);
+
+std::unordered_map<std::string, c10::IValue> moveToDevice(
+    std::unordered_map<std::string, c10::IValue> combined,
     const c10::Device& device);
 
 } // namespace torchrec

--- a/torchrec/inference/include/torchrec/inference/TestUtils.h
+++ b/torchrec/inference/include/torchrec/inference/TestUtils.h
@@ -28,6 +28,9 @@ createRequest(size_t batchSize, size_t numFeatures, at::Tensor embedding);
 
 JaggedTensor createJaggedTensor(const std::vector<std::vector<int32_t>>& input);
 
+c10::List<at::Tensor> createIValueList(
+    const std::vector<std::vector<int32_t>>& input);
+
 at::Tensor createEmbeddingTensor(
     const std::vector<std::vector<int32_t>>& input);
 

--- a/torchrec/inference/src/BatchingQueue.cpp
+++ b/torchrec/inference/src/BatchingQueue.cpp
@@ -254,9 +254,10 @@ void BatchingQueue::pinMemory(int gpuIdx) {
               return batchItems;
             });
 
-        c10::Dict<std::string, at::Tensor> forwardArgs;
+        c10::impl::GenericDict forwardArgs(
+            at::StringType::get(), at::AnyType::get());
         auto combineForwardArgs =
-            [&](std::unordered_map<std::string, at::Tensor> map) {
+            [&](std::unordered_map<std::string, c10::IValue> map) {
               for (auto& [key, value] : map) {
                 CHECK(!forwardArgs.contains(key));
                 forwardArgs.insert(key, std::move(value));

--- a/torchrec/inference/src/TestUtils.cpp
+++ b/torchrec/inference/src/TestUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "torchrec/inference/TestUtils.h"
 
+#include <initializer_list>
 #include <memory>
 
 #include <folly/io/IOBuf.h>
@@ -130,6 +131,21 @@ at::Tensor createEmbeddingTensor(
   }
 
   return tensor;
+}
+
+c10::List<at::Tensor> createIValueList(
+    const std::vector<std::vector<int32_t>>& input) {
+  // Input is batch x num_features
+  std::vector<at::Tensor> rows;
+  for (const auto& vec : input) {
+    rows.push_back(at::tensor(vec, at::TensorOptions().dtype(c10::kFloat)));
+  }
+  auto combined = at::stack(rows).transpose(0, 1);
+  c10::List<at::Tensor> retList;
+  for (auto& tensor : combined.split(1)) {
+    retList.push_back(tensor.squeeze(0));
+  }
+  return retList;
 }
 
 } // namespace torchrec

--- a/torchrec/inference/tests/BatchingQueueTest.cpp
+++ b/torchrec/inference/tests/BatchingQueueTest.cpp
@@ -86,13 +86,18 @@ TEST(BatchingQueueTest, Basic) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
-  ASSERT_EQ(2 * (2 + 4), value->forwardArgs.at("cuda_features").numel());
-  ASSERT_EQ(value->forwardArgs.at("cuda_features").device().type(), at::kCUDA);
-  ASSERT_EQ(2 * (2 + 4), value->forwardArgs.at("cpu_features").numel());
-  ASSERT_EQ(value->forwardArgs.at("cpu_features").device(), at::kCPU);
+  ASSERT_EQ(
+      2 * (2 + 4), value->forwardArgs.at("cuda_features").toTensor().numel());
+  ASSERT_EQ(
+      value->forwardArgs.at("cuda_features").toTensor().device().type(),
+      at::kCUDA);
+  ASSERT_EQ(
+      2 * (2 + 4), value->forwardArgs.at("cpu_features").toTensor().numel());
+  ASSERT_EQ(
+      value->forwardArgs.at("cpu_features").toTensor().device(), at::kCPU);
   ASSERT_TRUE(at::allclose(
-      value->forwardArgs.at("cuda_features").cpu(),
-      value->forwardArgs.at("cpu_features")));
+      value->forwardArgs.at("cuda_features").toTensor().cpu(),
+      value->forwardArgs.at("cpu_features").toTensor()));
 }
 
 TEST(BatchingQueueTest, MaxBatchSize) {
@@ -132,8 +137,9 @@ TEST(BatchingQueueTest, MaxBatchSize) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
-  ASSERT_EQ(2 * 2, value->forwardArgs.at("cpu_features").numel());
-  ASSERT_EQ(value->forwardArgs.at("cpu_features").device(), at::kCPU);
+  ASSERT_EQ(2 * 2, value->forwardArgs.at("cpu_features").toTensor().numel());
+  ASSERT_EQ(
+      value->forwardArgs.at("cpu_features").toTensor().device(), at::kCPU);
 }
 
 } // namespace torchrec


### PR DESCRIPTION
Summary: This diff changes the batch function signature to use c10::IValue instead of at::Tensor. For the embedding batcher it now produces a c10::List of tensors with length equal to the number of features and each individual tensor is size (batch x dimension).

Differential Revision: D43198910

