### PR TITLE
Refactor tests to reduce duplicate code

### DIFF
--- a/torchrec/metrics/tests/test_calibration.py
+++ b/torchrec/metrics/tests/test_calibration.py
@@ -5,16 +5,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import unittest
-from typing import Dict, List, Type
+from typing import Dict, Type
 
 import torch
-import torch.distributed as dist
 from torchrec.metrics.calibration import CalibrationMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
-    rec_metric_value_test_helper,
+    metric_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
 )
@@ -50,68 +48,18 @@ class CalibrationMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = CalibrationMetric
     task_name: str = "calibration"
 
-    @staticmethod
-    def _test_calibration(
-        target_clazz: Type[RecMetric],
-        target_compute_mode: RecComputeMode,
-        task_names: List[str],
-        fused_update_limit: int = 0,
-        compute_on_all_ranks: bool = False,
-        should_validate_update: bool = False,
-    ) -> None:
-        rank = int(os.environ["RANK"])
-        world_size = int(os.environ["WORLD_SIZE"])
-        dist.init_process_group(
-            backend="gloo",
-            world_size=world_size,
-            rank=rank,
-        )
-
-        calibration_metrics, test_metrics = rec_metric_value_test_helper(
-            target_clazz=target_clazz,
-            target_compute_mode=target_compute_mode,
-            test_clazz=TestCalibrationMetric,
-            fused_update_limit=fused_update_limit,
-            compute_on_all_ranks=False,
-            should_validate_update=should_validate_update,
-            world_size=world_size,
-            my_rank=rank,
-            task_names=task_names,
-        )
-
-        if rank == 0:
-            for name in task_names:
-                assert torch.allclose(
-                    calibration_metrics[f"calibration-{name}|lifetime_calibration"],
-                    test_metrics[0][name],
-                )
-                assert torch.allclose(
-                    calibration_metrics[f"calibration-{name}|window_calibration"],
-                    test_metrics[1][name],
-                )
-                assert torch.allclose(
-                    calibration_metrics[
-                        f"calibration-{name}|local_lifetime_calibration"
-                    ],
-                    test_metrics[2][name],
-                )
-                assert torch.allclose(
-                    calibration_metrics[f"calibration-{name}|local_window_calibration"],
-                    test_metrics[3][name],
-                )
-        dist.destroy_process_group()
-
     def test_unfused_calibration(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=CalibrationMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestCalibrationMetric,
+            metric_name=CalibrationMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_calibration,
+            entry_point=metric_test_helper,
         )
 
     def test_fused_calibration(self) -> None:
@@ -119,10 +67,11 @@ class CalibrationMetricTest(unittest.TestCase):
             target_clazz=CalibrationMetric,
             target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
             test_clazz=TestCalibrationMetric,
+            metric_name=CalibrationMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_calibration,
+            entry_point=metric_test_helper,
         )

--- a/torchrec/metrics/tests/test_ctr.py
+++ b/torchrec/metrics/tests/test_ctr.py
@@ -5,16 +5,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import unittest
-from typing import Dict, List, Type
+from typing import Dict, Type
 
 import torch
-import torch.distributed as dist
 from torchrec.metrics.ctr import CTRMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
-    rec_metric_value_test_helper,
+    metric_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
 )
@@ -44,62 +42,18 @@ class CTRMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = CTRMetric
     task_name: str = "ctr"
 
-    @staticmethod
-    def _test_ctr(
-        target_clazz: Type[RecMetric],
-        target_compute_mode: RecComputeMode,
-        task_names: List[str],
-        fused_update_limit: int = 0,
-        compute_on_all_ranks: bool = False,
-        should_validate_update: bool = False,
-    ) -> None:
-        rank = int(os.environ["RANK"])
-        world_size = int(os.environ["WORLD_SIZE"])
-        dist.init_process_group(
-            backend="gloo",
-            world_size=world_size,
-            rank=rank,
-        )
-
-        ctr_metrics, test_metrics = rec_metric_value_test_helper(
-            target_clazz=target_clazz,
-            target_compute_mode=target_compute_mode,
-            test_clazz=TestCTRMetric,
-            fused_update_limit=fused_update_limit,
-            compute_on_all_ranks=False,
-            should_validate_update=should_validate_update,
-            world_size=world_size,
-            my_rank=rank,
-            task_names=task_names,
-        )
-
-        if rank == 0:
-            for name in task_names:
-                assert torch.allclose(
-                    ctr_metrics[f"ctr-{name}|lifetime_ctr"], test_metrics[0][name]
-                )
-                assert torch.allclose(
-                    ctr_metrics[f"ctr-{name}|window_ctr"], test_metrics[1][name]
-                )
-                assert torch.allclose(
-                    ctr_metrics[f"ctr-{name}|local_lifetime_ctr"], test_metrics[2][name]
-                )
-                assert torch.allclose(
-                    ctr_metrics[f"ctr-{name}|local_window_ctr"], test_metrics[3][name]
-                )
-        dist.destroy_process_group()
-
     def test_unfused_ctr(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=CTRMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestCTRMetric,
+            metric_name=CTRMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ctr,
+            entry_point=metric_test_helper,
         )
 
     def test_fused_ctr(self) -> None:
@@ -107,10 +61,11 @@ class CTRMetricTest(unittest.TestCase):
             target_clazz=CTRMetric,
             target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
             test_clazz=TestCTRMetric,
+            metric_name=CTRMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ctr,
+            entry_point=metric_test_helper,
         )

--- a/torchrec/metrics/tests/test_mae.py
+++ b/torchrec/metrics/tests/test_mae.py
@@ -5,16 +5,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import unittest
-from typing import Dict, List, Type
+from typing import Dict, Type
 
 import torch
-import torch.distributed as dist
 from torchrec.metrics.mae import compute_mae, MAEMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
-    rec_metric_value_test_helper,
+    metric_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
 )
@@ -47,62 +45,18 @@ class MAEMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = MAEMetric
     task_name: str = "mae"
 
-    @staticmethod
-    def _test_mae(
-        target_clazz: Type[RecMetric],
-        target_compute_mode: RecComputeMode,
-        task_names: List[str],
-        fused_update_limit: int = 0,
-        compute_on_all_ranks: bool = False,
-        should_validate_update: bool = False,
-    ) -> None:
-        rank = int(os.environ["RANK"])
-        world_size = int(os.environ["WORLD_SIZE"])
-        dist.init_process_group(
-            backend="gloo",
-            world_size=world_size,
-            rank=rank,
-        )
-
-        mae_metrics, test_metrics = rec_metric_value_test_helper(
-            target_clazz=target_clazz,
-            target_compute_mode=target_compute_mode,
-            test_clazz=TestMAEMetric,
-            fused_update_limit=fused_update_limit,
-            compute_on_all_ranks=False,
-            should_validate_update=should_validate_update,
-            world_size=world_size,
-            my_rank=rank,
-            task_names=task_names,
-        )
-
-        if rank == 0:
-            for name in task_names:
-                assert torch.allclose(
-                    mae_metrics[f"mae-{name}|lifetime_mae"], test_metrics[0][name]
-                )
-                assert torch.allclose(
-                    mae_metrics[f"mae-{name}|window_mae"], test_metrics[1][name]
-                )
-                assert torch.allclose(
-                    mae_metrics[f"mae-{name}|local_lifetime_mae"], test_metrics[2][name]
-                )
-                assert torch.allclose(
-                    mae_metrics[f"mae-{name}|local_window_mae"], test_metrics[3][name]
-                )
-        dist.destroy_process_group()
-
     def test_unfused_mae(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=MAEMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestMAEMetric,
+            metric_name="mae",
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_mae,
+            entry_point=metric_test_helper,
         )
 
     def test_fused_mae(self) -> None:
@@ -110,10 +64,11 @@ class MAEMetricTest(unittest.TestCase):
             target_clazz=MAEMetric,
             target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
             test_clazz=TestMAEMetric,
+            metric_name="mae",
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_mae,
+            entry_point=metric_test_helper,
         )

--- a/torchrec/metrics/tests/test_multiclass_recall.py
+++ b/torchrec/metrics/tests/test_multiclass_recall.py
@@ -5,13 +5,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import unittest
-from functools import partial, update_wrapper
-from typing import Callable, Dict, List, Type
+from typing import Dict, Type
 
 import torch
-import torch.distributed as dist
 from torchrec.metrics.multiclass_recall import (
     compute_multiclass_recall_at_k,
     get_multiclass_recall_states,
@@ -19,7 +16,7 @@ from torchrec.metrics.multiclass_recall import (
 )
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
-    rec_metric_value_test_helper,
+    metric_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
 )
@@ -55,87 +52,18 @@ class MulticlassRecallMetricTest(unittest.TestCase):
     target_compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION
     task_name: str = "multiclass_recall"
 
-    @staticmethod
-    def _test_multiclass_recall(
-        target_clazz: Type[RecMetric],
-        target_compute_mode: RecComputeMode,
-        task_names: List[str],
-        fused_update_limit: int = 0,
-        compute_on_all_ranks: bool = False,
-        should_validate_update: bool = False,
-        batch_window_size: int = 5,
-        n_classes: int = N_CLASSES,
-    ) -> None:
-        rank = int(os.environ["RANK"])
-        world_size = int(os.environ["WORLD_SIZE"])
-        dist.init_process_group(
-            backend="gloo",
-            world_size=world_size,
-            rank=rank,
-        )
-
-        multiclass_recall_metrics, test_metrics = rec_metric_value_test_helper(
-            target_clazz=target_clazz,
-            target_compute_mode=target_compute_mode,
-            test_clazz=TestMulticlassRecallMetric,
-            fused_update_limit=fused_update_limit,
-            compute_on_all_ranks=False,
-            should_validate_update=should_validate_update,
-            world_size=world_size,
-            my_rank=rank,
-            task_names=task_names,
-            batch_window_size=batch_window_size,
-            n_classes=n_classes,
-        )
-
-        if rank == 0:
-            for name in task_names:
-                assert torch.allclose(
-                    multiclass_recall_metrics[
-                        f"multiclass_recall-{name}|lifetime_multiclass_recall"
-                    ],
-                    test_metrics[0][name],
-                )
-                assert torch.allclose(
-                    multiclass_recall_metrics[
-                        f"multiclass_recall-{name}|window_multiclass_recall"
-                    ],
-                    test_metrics[1][name],
-                )
-                assert torch.allclose(
-                    multiclass_recall_metrics[
-                        f"multiclass_recall-{name}|local_lifetime_multiclass_recall"
-                    ],
-                    test_metrics[2][name],
-                )
-                assert torch.allclose(
-                    multiclass_recall_metrics[
-                        f"multiclass_recall-{name}|local_window_multiclass_recall"
-                    ],
-                    test_metrics[3][name],
-                )
-        dist.destroy_process_group()
-
-    _test_multiclass_recall_large_window_size: Callable[..., None] = partial(
-        # pyre-fixme[16]: `Callable` has no attribute `__func__`.
-        _test_multiclass_recall.__func__,
-        batch_window_size=10,
-    )
-    update_wrapper(
-        _test_multiclass_recall_large_window_size, _test_multiclass_recall.__func__
-    )
-
     def test_multiclass_recall_unfused(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=MulticlassRecallMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestMulticlassRecallMetric,
+            metric_name=MulticlassRecallMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_multiclass_recall,
+            entry_point=metric_test_helper,
             n_classes=N_CLASSES,
         )
 
@@ -144,12 +72,13 @@ class MulticlassRecallMetricTest(unittest.TestCase):
             target_clazz=MulticlassRecallMetric,
             target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
             test_clazz=TestMulticlassRecallMetric,
+            metric_name=MulticlassRecallMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_multiclass_recall,
+            entry_point=metric_test_helper,
             n_classes=N_CLASSES,
         )
 
@@ -158,12 +87,13 @@ class MulticlassRecallMetricTest(unittest.TestCase):
             target_clazz=MulticlassRecallMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestMulticlassRecallMetric,
+            metric_name=MulticlassRecallMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=5,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_multiclass_recall,
+            entry_point=metric_test_helper,
             n_classes=N_CLASSES,
         )
 
@@ -171,11 +101,13 @@ class MulticlassRecallMetricTest(unittest.TestCase):
             target_clazz=MulticlassRecallMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestMulticlassRecallMetric,
+            metric_name=MulticlassRecallMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=100,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_multiclass_recall_large_window_size,
+            entry_point=metric_test_helper,
+            batch_window_size=10,
             n_classes=N_CLASSES,
         )

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -5,17 +5,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import unittest
-from functools import partial, update_wrapper
-from typing import Callable, Dict, List, Type
+from typing import Dict, Type
 
 import torch
-import torch.distributed as dist
 from torchrec.metrics.ne import compute_cross_entropy, compute_ne, NEMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
-    rec_metric_value_test_helper,
+    metric_test_helper,
     rec_metric_value_test_launcher,
     TestMetric,
 )
@@ -62,71 +59,18 @@ class NEMetricTest(unittest.TestCase):
     target_compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION
     task_name: str = "ne"
 
-    @staticmethod
-    def _test_ne(
-        target_clazz: Type[RecMetric],
-        target_compute_mode: RecComputeMode,
-        task_names: List[str],
-        fused_update_limit: int = 0,
-        compute_on_all_ranks: bool = False,
-        should_validate_update: bool = False,
-        batch_window_size: int = 5,
-    ) -> None:
-        rank = int(os.environ["RANK"])
-        world_size = int(os.environ["WORLD_SIZE"])
-        dist.init_process_group(
-            backend="gloo",
-            world_size=world_size,
-            rank=rank,
-        )
-
-        ne_metrics, test_metrics = rec_metric_value_test_helper(
-            target_clazz=target_clazz,
-            target_compute_mode=target_compute_mode,
-            test_clazz=TestNEMetric,
-            fused_update_limit=fused_update_limit,
-            compute_on_all_ranks=False,
-            should_validate_update=should_validate_update,
-            world_size=world_size,
-            my_rank=rank,
-            task_names=task_names,
-            batch_window_size=batch_window_size,
-        )
-
-        if rank == 0:
-            for name in task_names:
-                assert torch.allclose(
-                    ne_metrics[f"ne-{name}|lifetime_ne"], test_metrics[0][name]
-                )
-                assert torch.allclose(
-                    ne_metrics[f"ne-{name}|window_ne"], test_metrics[1][name]
-                )
-                assert torch.allclose(
-                    ne_metrics[f"ne-{name}|local_lifetime_ne"], test_metrics[2][name]
-                )
-                assert torch.allclose(
-                    ne_metrics[f"ne-{name}|local_window_ne"], test_metrics[3][name]
-                )
-        dist.destroy_process_group()
-
-    _test_ne_large_window_size: Callable[..., None] = partial(
-        # pyre-fixme[16]: `Callable` has no attribute `__func__`.
-        _test_ne.__func__,
-        batch_window_size=10,
-    )
-    update_wrapper(_test_ne_large_window_size, _test_ne.__func__)
-
     def test_ne_unfused(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=NEMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestNEMetric,
+            metric_name=NEMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ne,
+            entry_point=metric_test_helper,
         )
 
     def test_ne_fused(self) -> None:
@@ -134,12 +78,13 @@ class NEMetricTest(unittest.TestCase):
             target_clazz=NEMetric,
             target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
             test_clazz=TestNEMetric,
+            metric_name=NEMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=0,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ne,
+            entry_point=metric_test_helper,
         )
 
     def test_ne_update_fused(self) -> None:
@@ -147,24 +92,27 @@ class NEMetricTest(unittest.TestCase):
             target_clazz=NEMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestNEMetric,
+            metric_name=NEMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=5,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ne,
+            entry_point=metric_test_helper,
         )
 
         rec_metric_value_test_launcher(
             target_clazz=NEMetric,
             target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             test_clazz=TestNEMetric,
+            metric_name=NEMetricTest.task_name,
             task_names=["t1", "t2", "t3"],
             fused_update_limit=100,
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_ne_large_window_size,
+            entry_point=metric_test_helper,
+            batch_window_size=10,
         )
 
         # TODO(stellaya): support the usage of fused_tasks_computation and


### PR DESCRIPTION
Summary: Notice that our tests have shared the same logic to compute and test the metric values. I refactor it into a common utility function `_test_metric_helper` and uses it for various metric tests. The result is we are able to delete 776 lines. Moreover, in the future, we no longer have to re-write pretty much the same code for new metric tests.

Reviewed By: fegin, joshuadeng, yachyv7

Differential Revision:
D43381828

Privacy Context Container: L1078771

