### PR TITLE
Print num_poolings after getting sharding plan

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -16,6 +16,7 @@ CROSS_NODE_BANDWIDTH: float = 12.5 * 1024 * 1024 * 1024 / 1000  # bytes/ms
 
 MIN_CW_DIM: int = 128
 POOLING_FACTOR: float = 1.0
+NUM_POOLINGS: float = 1.0
 
 BIGINT_DTYPE: int = 8
 


### PR DESCRIPTION
Summary:
# Problem

For FIRST model sharding, we would like to double-check if the TorchRec planner has received the same input feature statistics.

Reviewed By: bigning

Differential Revision:
D43520487

Privacy Context Container: L1078771

