### PR TITLE
Add logloss metric

### DIFF
--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -18,6 +18,7 @@ class RecMetricEnumBase(StrValueMixin, Enum):
 
 class RecMetricEnum(RecMetricEnumBase):
     NE = "ne"
+    LOG_LOSS = "log_loss"
     CTR = "ctr"
     AUC = "auc"
     CALIBRATION = "calibration"

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -38,6 +38,7 @@ class MetricName(MetricNameBase):
     DEFAULT = ""
 
     NE = "ne"
+    LOG_LOSS = "logloss"
     THROUGHPUT = "throughput"
     TOTAL_EXAMPLES = "total_examples"
     CTR = "ctr"

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -6,10 +6,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from typing import Dict, Type
+from functools import partial, update_wrapper
+from typing import Callable, Dict, Type
 
 import torch
-from torchrec.metrics.ne import compute_cross_entropy, compute_ne, NEMetric
+from torchrec.metrics.ne import (
+    compute_cross_entropy,
+    compute_logloss,
+    compute_ne,
+    NEMetric,
+)
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
@@ -51,6 +57,35 @@ class TestNEMetric(TestMetric):
             pos_labels=states["pos_labels"],
             neg_labels=states["neg_labels"],
             eta=TestNEMetric.eta,
+        )
+
+
+class TestLoglossMetric(TestMetric):
+    eta: float = 1e-12
+
+    @staticmethod
+    def _get_states(
+        labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        cross_entropy = compute_cross_entropy(
+            labels, predictions, weights, TestNEMetric.eta
+        )
+        cross_entropy_sum = torch.sum(cross_entropy)
+        pos_labels = torch.sum(weights * labels, dim=-1)
+        neg_labels = torch.sum(weights * (1.0 - labels), dim=-1)
+        return {
+            "cross_entropy_sum": cross_entropy_sum,
+            "pos_labels": pos_labels,
+            "neg_labels": neg_labels,
+        }
+
+    @staticmethod
+    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+        return compute_logloss(
+            states["cross_entropy_sum"],
+            pos_labels=states["pos_labels"],
+            neg_labels=states["neg_labels"],
+            eta=TestLoglossMetric.eta,
         )
 
 
@@ -140,3 +175,64 @@ class NEMetricTest(unittest.TestCase):
         #     world_size=WORLD_SIZE,
         #     entry_point=self._test_ne_large_window_size,
         # )
+
+    _logloss_metric_test_helper: Callable[..., None] = partial(
+        metric_test_helper, include_logloss=True
+    )
+    update_wrapper(_logloss_metric_test_helper, metric_test_helper)
+
+    def test_logloss_unfused(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=NEMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            metric_name="logloss",
+            test_clazz=TestLoglossMetric,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=self._logloss_metric_test_helper,
+        )
+
+    def test_logloss_fused(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=NEMetric,
+            target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            metric_name="logloss",
+            test_clazz=TestLoglossMetric,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=self._logloss_metric_test_helper,
+        )
+
+    def test_logloss_update_fused(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=NEMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            metric_name="logloss",
+            test_clazz=TestLoglossMetric,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=5,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=self._logloss_metric_test_helper,
+        )
+
+        rec_metric_value_test_launcher(
+            target_clazz=NEMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            metric_name="logloss",
+            test_clazz=TestLoglossMetric,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=100,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=self._logloss_metric_test_helper,
+            batch_window_size=10,
+        )


### PR DESCRIPTION
Summary:
This diff implements the logloss metrics in RecMetrics's NE. User can toggle the `include_logloss` flag to get logloss metrics, on top of NE.
# Logloss
The logloss metric is the log of cross entropy loss. It can be represented mathematically as follow:
{F869642849}
# Implementation
The implementation in this diff is exactly the same as Caffe2 implementation. It differs the mathematical representation in that it divides the above term by the number of examples:
```
logloss / (numPositiveLabels + numNegativeLabels)
```
Caffe2 code pointer: https://fburl.com/code/p7udvje3

Reference doc: https://fb.quip.com/mLLRA037sbFd

Reviewed By: colin2328

Differential Revision: D43136575

