### PR TITLE
Make KJTList, ListOfKJTList jitable

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -92,13 +92,16 @@ class KJTList(Multistreamable):
     def __getitem__(self, key: int) -> KeyedJaggedTensor:
         return self.features[key]
 
+    @torch.jit._drop
     def __iter__(self) -> Iterator[KeyedJaggedTensor]:
         return iter(self.features)
 
+    @torch.jit._drop
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         for feature in self.features:
             feature.record_stream(stream)
 
+    @torch.jit._drop
     def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
         return tracer.create_node(
             "call_function",
@@ -121,13 +124,16 @@ class ListOfKJTList(Multistreamable):
     def __getitem__(self, key: int) -> KJTList:
         return self.features_list[key]
 
+    @torch.jit._drop
     def __iter__(self) -> Iterator[KJTList]:
         return iter(self.features_list)
 
+    @torch.jit._drop
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         for feature in self.features_list:
             feature.record_stream(stream)
 
+    @torch.jit._drop
     def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
         return tracer.create_node(
             "call_function",


### PR DESCRIPTION
Summary:
Making KJTList, and ListOfKJTList torch scriptable.

Adding test that checks that no new changes will make it unscriptable for base torchrec "data" classes:
```
JaggedTensor,
KeyedJaggedTensor,
KeyedTensor,
KJTList,
ListOfKJTList,
```

torchrec changes:

1. Adding `torch.jit._drop` to

```
def __fx_create_arg__(self, tracer: torch.fx.Tracer) -> fx.node.Argument:
```
As torch.fx classes are not torch scriptable and must not be in the script.

2.  Adding `torch.jit._drop` to
```
def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
```

As torch.cuda.streams.Stream is not jit scriptable and we do not use it so far in jit models.

If we want to use it - we can convert it to jit-scriptable `torch.cuda.Stream`

3. Adding `torch.jit._drop` to
```
def __iter__(self) -> Iterator[KeyedJaggedTensor]:
```

`Iterator` class can not be torch scripted

Differential Revision:
D43663778

Privacy Context Container: L1138451

