### PR TITLE
Grouped AUC

### DIFF
--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -47,6 +47,7 @@ class MetricName(MetricNameBase):
     MAE = "mae"
     RMSE = "rmse"
     AUC = "auc"
+    GROUPED_AUC = "grouped_auc"
     MULTICLASS_RECALL = "multiclass_recall"
     WEIGHTED_AVG = "weighted_avg"
 

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -6,9 +6,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from typing import Dict, List, Type
+from typing import Dict, Iterable, List, Type, Union
 
 import torch
+from torch import no_grad
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecTaskInfo
@@ -170,3 +171,149 @@ class AUCMetricValueTest(unittest.TestCase):
         self.auc.update(**self.batches)
         actual_auc = self.auc.compute()["auc-DefaultTask|window_auc"]
         torch.allclose(expected_auc, actual_auc)
+
+
+def generate_model_outputs_cases() -> Iterable[Dict[str, torch._tensor.Tensor]]:
+    return [
+        # random_inputs
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.13, 0.2, 0.5, 0.8, 0.75]]),
+            "grouping_keys": torch.tensor([0, 1, 0, 1, 1]),
+            "expected_auc": torch.tensor([0.2419]),
+        },
+        # perfect_condition
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[1, 0, 0, 1, 1]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([1, 1, 0, 0, 1]),
+            "expected_auc": torch.tensor([1.0]),
+        },
+        # inverse_prediction
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0, 1, 1, 0, 0]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([0, 1, 0, 1, 1]),
+            "expected_auc": torch.tensor([0.0]),
+        },
+        # all_scores_the_same
+        {
+            "labels": torch.tensor([[1, 0, 1, 0, 1, 0]]),
+            "predictions": torch.tensor([[0.5] * 6]),
+            "weights": torch.tensor([[1] * 6]),
+            "grouping_keys": torch.tensor([1, 1, 1, 0, 0, 0]),
+            "expected_auc": torch.tensor([0.5]),
+        },
+        # one_class_in_input
+        {
+            "labels": torch.tensor([[1, 1, 1, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([1, 0, 0, 1, 0]),
+            "expected_auc": torch.tensor([0.5]),
+        },
+        # one_group
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.13, 0.2, 0.5, 0.8, 0.75]]),
+            "grouping_keys": torch.tensor([1, 1, 1, 1, 1]),
+            "expected_auc": torch.tensor([0.4464]),
+        },
+        # two tasks
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 0], [1, 1, 1, 1, 0]]),
+            "predictions": torch.tensor(
+                [
+                    [0.2281, 0.1051, 0.4885, 0.7740, 0.3097],
+                    [0.4658, 0.3445, 0.6048, 0.6587, 0.5088],
+                ]
+            ),
+            "weights": torch.tensor(
+                [
+                    [0.6334, 0.6937, 0.6631, 0.5078, 0.3570],
+                    [0.2637, 0.2479, 0.2697, 0.6500, 0.7583],
+                ]
+            ),
+            "grouping_keys": torch.tensor([0, 1, 0, 0, 1]),
+            "expected_auc": torch.tensor([0.4725, 0.25]),
+        },
+    ]
+
+
+class GroupedAUCValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of AUC in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    @no_grad()
+    def _test_grouped_auc_helper(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        grouping_keys: torch.Tensor,
+        expected_auc: torch.Tensor,
+    ) -> None:
+        num_task = labels.shape[0]
+        batch_size = labels.shape[0]
+        task_list = []
+        inputs: Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]] = {
+            "predictions": {},
+            "labels": {},
+            "weights": {},
+            "grouping_keys": grouping_keys,
+        }
+        for i in range(num_task):
+            task_info = RecTaskInfo(
+                name=f"Task:{i}",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+            task_list.append(task_info)
+            # pyre-ignore
+            inputs["predictions"][task_info.name] = predictions[i]
+            # pyre-ignore
+            inputs["labels"][task_info.name] = labels[i]
+            # pyre-ignore
+            inputs["weights"][task_info.name] = weights[i]
+            # inputs["grouping_keys"][task_info.name] = grouping_keys[i]
+
+        auc = AUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=batch_size,
+            tasks=task_list,
+            # pyre-ignore
+            grouped_auc=True,
+        )
+        # pyre-ignore
+        auc.update(**inputs)
+        actual_auc = auc.compute()
+
+        for task_id, task in enumerate(task_list):
+            cur_actual_auc = actual_auc[f"auc-{task.name}|window_grouped_auc"]
+            cur_expected_auc = expected_auc[task_id].unsqueeze(dim=0)
+
+            torch.testing.assert_close(
+                cur_actual_auc,
+                cur_expected_auc,
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                msg=f"Actual: {cur_actual_auc}, Expected: {cur_expected_auc}",
+            )
+
+    def test_grouped_auc(self) -> None:
+        test_data = generate_model_outputs_cases()
+        for inputs in test_data:
+            try:
+                self._test_grouped_auc_helper(**inputs)
+            except AssertionError:
+                print("Assertion error caught with data set ", inputs)
+                raise

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -11,7 +11,7 @@ import logging
 import os
 import tempfile
 import unittest
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -79,7 +79,9 @@ class TestMetricModule(RecMetricModule):
             memory_usage_limit_mb=memory_usage_limit_mb,
         )
 
-    def _update_rec_metrics(self, model_out: Dict[str, torch.Tensor]) -> None:
+    def _update_rec_metrics(
+        self, model_out: Dict[str, torch.Tensor], **kwargs: Any
+    ) -> None:
         if isinstance(model_out, MagicMock):
             return
         labels, predictions, weights, _ = parse_task_model_outputs(


### PR DESCRIPTION
Summary:
# What
Grouped AUC metric allow user to provide an additional `grouping_keys` tensor to specify the group id for each element along the batch dimension. The grouped AUC will then calculate AUC per group, and return the averaged AUC. Note that the `grouping_keys` is shared across the task dimension for mtml model.

# How to use
```
# Enable the grouped_auc during metric instantiation
auc = AUCMetric(world_size=4, my_rank=0, batch_size=64, tasks=["t1"], grouped_auc=True)

# provide grouping keys during update
auc.update(predictions=predictions, labels=labels, weights=weights, grouping_keys=grouping_keys)
```

Differential Revision:
D43377511

Privacy Context Container: L1078771

