### PR TITLE
QuantShardedModules NoAwait logic

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -437,7 +437,9 @@ class MetaInferGroupedEmbeddingsLookup(
             self._feature_splits,
         )
         for i in range(len(self._emb_modules)):
-            embeddings.append(self._emb_modules[i](features_by_group[i]).view(-1))
+            embeddings.append(
+                self._emb_modules[i].forward(features_by_group[i]).view(-1)
+            )
 
         return embeddings_cat_empty_rank_handle(embeddings, self._dummy_embs_tensor)
 

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -269,7 +269,7 @@ class QuantBatchedEmbedding(BaseBatchedEmbedding):
         ]
 
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
-        return self.emb_module(
+        return self.emb_module.forward(
             indices=features.values().int(),
             offsets=features.offsets().int(),
         )

--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -515,7 +515,7 @@ class ModelTraceScriptTest(unittest.TestCase):
                     FxJitTestType.FX_JIT,
                 ),
                 (self.shard_modules_QEBC, FxJitTestType.FX_JIT),
-                (self.shard_modules_QEC, FxJitTestType.CREATE_ONLY),
+                (self.shard_modules_QEC, FxJitTestType.FX_JIT),
             ]
         ]
 
@@ -528,6 +528,10 @@ class ModelTraceScriptTest(unittest.TestCase):
         for non_sharded_model, model, inputs, test_type in self._models_with_inputs(
             world_size=2
         ):
+            print(
+                f"test_fxtrace_jitscript: non_sharded_model:{non_sharded_model}\n model:{model}"
+            )
+
             if test_type == FxJitTestType.CREATE_ONLY:
                 continue
 

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -531,7 +531,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 f = jt_dict[feature_name]
                 values = f.values()
                 offsets = f.offsets()
-                lookup = emb_module(
+                lookup = emb_module.forward(
                     indices=values.int(),
                     offsets=offsets.int(),
                 )


### PR DESCRIPTION
Summary:
As Inference does not use real Awaitable - only NoWait wrappers - we do not strictly follow the ShardedModule interface with Awaitables - unwrapping NoWaits

This change makes QEC fx-jitable

Differential Revision:
D43728300

Privacy Context Container: L1138451

