### PR TITLE
Remove abstractmethod on input_dist/compute/output_dist in base class

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -587,15 +587,13 @@ class ShardedModule(
             qcomm_codecs_registry = {}
         self._qcomm_codecs_registry = qcomm_codecs_registry
 
-    @abc.abstractmethod
     def create_context(self) -> ShrdCtx:
-        pass
+        raise NotImplementedError("ShardedModule::create_context is not implemented")
 
     @property
     def qcomm_codecs_registry(self) -> Optional[Dict[str, QuantizedCommCodecs]]:
         return self._qcomm_codecs_registry
 
-    @abc.abstractmethod
     def input_dist(
         self,
         ctx: ShrdCtx,
@@ -604,15 +602,13 @@ class ShardedModule(
         # pyre-ignore[2]
         **kwargs,
     ) -> Awaitable[Awaitable[CompIn]]:
-        pass
+        raise NotImplementedError("ShardedModule::input_dist is not implemented")
 
-    @abc.abstractmethod
     def compute(self, ctx: ShrdCtx, dist_input: CompIn) -> DistOut:
-        pass
+        raise NotImplementedError("ShardedModule::compute is not implemented")
 
-    @abc.abstractmethod
     def output_dist(self, ctx: ShrdCtx, output: DistOut) -> LazyAwaitable[Out]:
-        pass
+        raise NotImplementedError("ShardedModule::output_dist is not implemented")
 
     def compute_and_output_dist(
         self, ctx: ShrdCtx, input: CompIn
@@ -626,6 +622,8 @@ class ShardedModule(
         return self.output_dist(ctx, output)
 
     # pyre-ignore[2]
+    # input_dist/compute/output_dist construction in forward is a common pattern we see
+    # however, ShardedModules may have any implementation for their own forward (and can override)
     def forward(self, *input, **kwargs) -> LazyAwaitable[Out]:
         """
         Executes the input dist, compute, and output dist steps.


### PR DESCRIPTION
Summary:
We're seeing that a lot of models want to be sharded models (e.g. quant), but don't necessarily follow the same

input_dist -> Awaitable[Awaitable[...]]
forawrd -> LazyAwaitable[...]

structure (such as inference etc).

Some sharded models may not want to implement input_dist/compute/output_dist (and instead use own implementation to do forward or other methods).

We remove ABC restrictions on these methods, but since it is still a common use case, provide the forward given this pattern. However, downstream children of this class will be able to be instantiated.

Differential Revision: D43753029

