### PR TITLE
Fix `ModuleNotFoundError` error in introduction notebook when calling `apply_overlapped_optimizer`

### DIFF
--- a/Torchrec_Introduction.ipynb
+++ b/Torchrec_Introduction.ipynb
@@ -236,11 +236,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer\n",
+        "from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward\n",
         "\n",
-        "apply_overlapped_optimizer(\n",
-        "    ebc.parameters(),\n",
-        "    optimizer_type=torch.optim.SGD,\n",
+        "apply_optimizer_in_backward(\n",
+        "    optimizer_class=torch.optim.SGD,\n",
+        "    params=ebc.parameters(),\n",
         "    optimizer_kwargs={\"lr\": 0.02},\n",
         ")"
       ]


### PR DESCRIPTION
Currently, running the `Torchrec_Introduction.ipynb` notebook through, without modifications, will lead to the following error about halfway down:

```python
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[14], line 1
----> 1 from torchrec.optim.apply_overlapped_optimizer import apply_overlapped_optimizer
      3 apply_overlapped_optimizer(
      4     ebc.parameters(),
      5     optimizer_type=torch.optim.SGD,
      6     optimizer_kwargs={"lr": 0.02},
      7 )

ModuleNotFoundError: No module named 'torchrec.optim.apply_overlapped_optimizer'
```

The `apply_overlapped_optimizer ` function was renamed to `apply_optimizer_in_backward` in https://github.com/pytorch/torchrec/pull/728. This PR makes the small update to this notebook to reflect this change. **The functionality of this cell is the same, just updated to use the new function name and syntax.** 