### PR TITLE
Consolidate the arguments and logic of optim_state_dict and optim_state_dict_to_load

### DIFF
--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -214,7 +214,7 @@ class FullyShardTest(MultiProcessTestBase):
             load_state_dict(opt_state_dict, opt_reader)
             # use FSDP.optim_state_dict_to_load() API
             new_opt_state_dict = FullyShardedDataParallel.optim_state_dict_to_load(
-                opt_state_dict, m, opt, is_named_optimizer=True
+                m, opt, opt_state_dict, is_named_optimizer=True
             )
             opt.load_state_dict(new_opt_state_dict)
 


### PR DESCRIPTION
Summary:
The current `optim_state_dict()` does not require users to call `optim.state_dict()` first while `optim_state_dict_to_load()` requires users to call `optim.load_state_dict()`. This PR make both APIs provide the option for users not having to call the extra API.

This PR also changes the arguments order of `optim_state_dict_to_load` which is a breaking change. So we should do this asap before the API is adopted in production cases.

Differential Revision: D43925068

