### PR TITLE
Set memcpy and data dist streams to high priority in train pipeline

### DIFF
--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -505,10 +505,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         if device.type == "cuda":
             self._memcpy_stream: Optional[
                 torch.cuda.streams.Stream
-            ] = torch.cuda.Stream()
+            ] = torch.cuda.Stream(priority=-1)
             self._data_dist_stream: Optional[
                 torch.cuda.streams.Stream
-            ] = torch.cuda.Stream()
+            ] = torch.cuda.Stream(priority=-1)
         else:
             self._memcpy_stream: Optional[torch.cuda.streams.Stream] = None
             self._data_dist_stream: Optional[torch.cuda.streams.Stream] = None


### PR DESCRIPTION
Summary: In some instances kernels in memcpy and data dist streams will not be scheduled immediately and can block the CPU. The kernels scheduled on these streams are few and lightweight, so it should not affect the main stream to have them set as high priority.

Differential Revision: D44009082

