### PR TITLE
Support more than 2 fused optimizer states

### DIFF
--- a/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
+++ b/torchrec/distributed/composable/tests/test_fused_optim_nccl.py
@@ -94,7 +94,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_2"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"][""]["table_2.momentum2"].gather(
+            ].state_dict()["state"][""]["table_2.exp_avg_sq"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise
@@ -115,7 +115,7 @@ class ShardedFusedOptimizerStateDictTest(MultiProcessTestBase):
 
             ebc.embedding_bags["table_3"].weight._in_backward_optimizers[
                 0
-            ].state_dict()["state"][""]["table_3.momentum2"].gather(
+            ].state_dict()["state"][""]["table_3.exp_avg_sq"].gather(
                 dst=0,
                 out=None if ctx.rank != 0
                 # Column wise - with partial rowwise adam, first state is point wise


### PR DESCRIPTION
Summary:
Right now, we hard-coded fused optimizer states to have [at most 2 states](https://fburl.com/code/8h3023z1) for checkpointing. This diff enables checkpointing variable number of states (> 2) for supported optimizers.

Supported optimizers are ones implemented in [get_optimizer_state](https://fburl.com/code/cv6ig6jp).

Differential Revision: D40082291

