### PR TITLE
fix quantEC output dtype override from quantizaiton API

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -561,6 +561,8 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             tables,
             device=device,
             need_indices=module.need_indices(),
+            # pyre-ignore
+            output_dtype=module.qconfig.activation().dtype,
             table_name_to_quantized_weights=table_name_to_quantized_weights,
         )
 


### PR DESCRIPTION
Summary: * fix a output_dtyp gap that trec did not cover for qEC while qEBC has integrated it

Reviewed By: xing-liu

Differential Revision: D44142496

