### PR TITLE
Convert remaining GPU Overload error from runtime_error to GPUOverloadException

### DIFF
--- a/torchrec/inference/src/BatchingQueue.cpp
+++ b/torchrec/inference/src/BatchingQueue.cpp
@@ -280,7 +280,7 @@ void BatchingQueue::pinMemory(int gpuIdx) {
             // A device could not be chosen in time. Time out.
             observer_->addGPUBusyCount(1);
             rejectionExecutor_->add([ctxs = std::move(contexts)]() mutable {
-              handleBatchException<PredictionException>(
+              handleBatchException<GPUOverloadException>(
                   ctxs, "All GPUs are busy. Batching queue timeout.");
             });
             continue;

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -216,7 +216,7 @@ void GPUExecutor::process(int idx) {
     if (timeInQueue >= queueTimeout_) {
       observer_->addQueueTimeoutCount(1);
       rejectionExecutor_->add([batch = std::move(batch)]() {
-        handleBatchException<PredictionException>(
+        handleBatchException<GPUOverloadException>(
             batch->contexts, "GPUExecutor queue timeout");
       });
 


### PR DESCRIPTION
Summary:
Convert remaining GPU Overload error from runtime_error to
GPUOverloadException

Differential Revision: D44139107

