### PR TITLE
Convert GPU Executor Overload error from runtime_error to specific exception

### DIFF
--- a/torchrec/inference/include/torchrec/inference/Exception.h
+++ b/torchrec/inference/include/torchrec/inference/Exception.h
@@ -17,15 +17,31 @@
 
 namespace torchrec {
 
+// We have different error code defined for different kinds of exceptions in
+// fblearner/sigrid predictor. (Code pointer:
+// fblearner/predictor/if/prediction_service.thrift.) We define different
+// exception type here so that in fblearner/sigrid predictor we can detect the
+// exception type and return the corresponding error code to reflect the right
+// info.
 class TorchrecException : public std::runtime_error {
  public:
   explicit TorchrecException(const std::string& error)
       : std::runtime_error(error) {}
 };
 
+// GPUOverloadException maps to
+// PredictionExceptionCode::GPU_BATCHING_QUEUE_TIMEOUT
 class GPUOverloadException : public TorchrecException {
  public:
   explicit GPUOverloadException(const std::string& error)
+      : TorchrecException(error) {}
+};
+
+// GPUExecutorOverloadException maps to
+// PredictionExceptionCode::GPU_EXECUTOR_QUEUE_TIMEOUT
+class GPUExecutorOverloadException : public TorchrecException {
+ public:
+  explicit GPUExecutorOverloadException(const std::string& error)
       : TorchrecException(error) {}
 };
 

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -216,7 +216,7 @@ void GPUExecutor::process(int idx) {
     if (timeInQueue >= queueTimeout_) {
       observer_->addQueueTimeoutCount(1);
       rejectionExecutor_->add([batch = std::move(batch)]() {
-        handleBatchException<PredictionException>(
+        handleBatchException<GPUExecutorOverloadException>(
             batch->contexts, "GPUExecutor queue timeout");
       });
 


### PR DESCRIPTION
Summary: Convert GPU Executor Overload error from runtime_error to GPUExecutorOverloadException

Reviewed By: zyan0

Differential Revision: D44154398

