### PR TITLE
Fix typo for variable input_data_type_size for data parallel sharding

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -268,7 +268,7 @@ def perf_func_emb_wall_time(
                 input_lengths=input_lengths,
                 grad_num_elem=hash_size * emb_dim,
                 emb_dim=emb_dim,
-                input_data_type_size=output_data_type_size,
+                input_data_type_size=input_data_type_size,
                 output_data_type_size=output_data_type_size,
                 num_poolings=num_poolings,
                 device_bw=device_bw,

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -55,8 +55,8 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
 
         expected_perfs = {
             ("dense", "data_parallel"): [
-                0.0004935158269195386,
-                0.0004935158269195386,
+                0.0005062740117544049,
+                0.0005062740117544049,
             ],
             ("fused", "table_wise"): [0.0011095368078055323],
             ("fused_uvm", "table_wise"): [0.1729105033126532],
@@ -128,8 +128,8 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
 
         expected_perfs = {
             ("dense", "data_parallel"): [
-                0.002677347614879459,
-                0.002677347614879459,
+                0.002690105799714326,
+                0.002690105799714326,
             ],
             ("fused", "table_wise"): [0.001880471390093715],
             ("fused_uvm", "table_wise"): [0.25958192114736517],


### PR DESCRIPTION
Summary: We saw input_data_type_size=output_data_type_size. Seems like a typo. It should have been input_data_type_size=input_data_type_size.

Differential Revision: D44153580

