### PR TITLE
Add comm data type size for both forward and backward comms

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -125,6 +125,7 @@ class QuantizedCommCodec(Generic[QuantizationContext]):
     ) -> torch.Tensor:
         ...
 
+    @property
     def quantized_dtype(self) -> torch.dtype:
         """
         tensor.dtype of the resultant encode(input_tensor)


### PR DESCRIPTION
Summary:
Current planner comms cost estimation does not take into the account of communication data type. This means that the cost estimation is not accurate when the communication data type is different from the table storage data type (e.g. fp8 communication).

For planner's perf functions, we add
* table_data_type_size: the data type size of the embedding table (e.g. float16 -> 2 bytes)
* fwd_comm_data_type_size: the data type size of the forward communication (e.g. fp8 -> 1 byte)
* bwd_comm_data_type_size: the data type size of the backward communication (e.g. fp8 -> 1 byte)

We also allow the ShardingOption type to have fwd_comm_data_type_size and bwd_comm_data_type_size as optionals.

We also update all callsites of run_planner as indicated here https://www.internalfb.com/code/search?q=run_planner(

Note that
* We did not change the storage estimates functions (i.e., a function that contains "_io_size")
* We did not estimate the encoding and decoding cost

Differential Revision: D44227825

