### PR TITLE
fix dmp copy

### DIFF
--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -366,7 +366,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             tables=self.tables,
             weighted_tables=self.weighted_tables,
             num_float_features=10,
-            dense_device=device,
+            dense_device=torch.device("cpu"),
             sparse_device=torch.device("meta"),
         )
         # pyre-ignore [16]


### PR DESCRIPTION
Summary: * since dmp's wrapped module interface mismatch. the copy routine based on named_module replacement will fail. thus we directly copy the wrapped one underneath.

Differential Revision: D44574214

