### PR TITLE
Start input dist before fwd in train pipeline and prevent unnecessary wait for batch

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -142,17 +142,15 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
     def __init__(
         self,
         input_tensors: List[torch.Tensor],
-        num_workers: int,
-        device: torch.device,
         pg: dist.ProcessGroup,
     ) -> None:
         super().__init__()
-        self.num_workers: int = num_workers
+        self.num_workers: int = pg.size()
 
         with record_function("## all2all_data:kjt splits ##"):
             self._output_tensor: torch.Tensor = torch.empty(
-                [num_workers * len(input_tensors)],
-                device=device,
+                [self.num_workers * len(input_tensors)],
+                device=input_tensors[0].device,
                 dtype=input_tensors[0].dtype,
             )
             input_tensor = torch.stack(input_tensors, dim=1).flatten()
@@ -331,9 +329,7 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
         )
         input_tensors.append(batch_size_tensor)
 
-        self._splits_awaitable = SplitsAllToAllAwaitable(
-            input_tensors, self._workers, self._device, self._pg
-        )
+        self._splits_awaitable = SplitsAllToAllAwaitable(input_tensors, self._pg)
 
     def _wait_impl(self) -> KJTAllToAllTensorsAwaitable:
         """
@@ -430,9 +426,7 @@ class KJTAllToAll(nn.Module):
         super().__init__()
         assert len(splits) == pg.size()
         self._pg: dist.ProcessGroup = pg
-        self._workers: int = pg.size()
         self._splits = splits
-        self._no_dist: bool = all(s == 0 for s in splits)
         self._splits_cumsum: List[int] = [0] + list(itertools.accumulate(splits))
         self._stagger = stagger
 
@@ -453,7 +447,6 @@ class KJTAllToAll(nn.Module):
         """
 
         device = input.values().device
-
         with torch.no_grad():
             assert len(input.keys()) == sum(self._splits)
             rank = dist.get_rank(self._pg)

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -7,11 +7,14 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch
-from torch import nn
-from torchrec.distributed.dist_data import KJTAllToAllTensorsAwaitable
+from torch import distributed as dist, nn
+from torchrec.distributed.dist_data import (
+    KJTAllToAllTensorsAwaitable,
+    SplitsAllToAllAwaitable,
+)
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingLookup,
     BaseGroupedFeatureProcessor,
@@ -233,6 +236,32 @@ class KJTListAwaitable(Awaitable[KJTList]):
 
 
 C = TypeVar("C", bound=Multistreamable)
+T = TypeVar("T")
+
+
+def _set_sharding_context(
+    tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
+    ctx: C,
+) -> None:
+    for awaitable, sharding_context in zip(
+        tensors_awaitables,
+        getattr(ctx, "sharding_contexts", []),
+    ):
+        if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
+            if hasattr(sharding_context, "batch_size_per_rank"):
+                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
+            if hasattr(sharding_context, "input_splits"):
+                sharding_context.input_splits = awaitable._input_splits["values"]
+            if hasattr(sharding_context, "output_splits"):
+                sharding_context.output_splits = awaitable._output_splits["values"]
+            if hasattr(sharding_context, "sparse_features_recat"):
+                sharding_context.sparse_features_recat = awaitable._recat
+
+
+def _split(flat_list: List[T], splits: List[int]) -> List[List[T]]:
+    return [
+        flat_list[sum(splits[:i]) : sum(splits[:i]) + n] for i, n in enumerate(splits)
+    ]
 
 
 class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
@@ -267,22 +296,97 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
             KJTListAwaitable: awaitables for tensors of the sparse features.
         """
         tensors_awaitables = [w.wait() for w in self.awaitables]
-        for awaitable, sharding_context in zip(
-            tensors_awaitables,
-            getattr(self.ctx, "sharding_contexts", []),
-        ):
-            if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
-                if hasattr(sharding_context, "batch_size_per_rank"):
-                    sharding_context.batch_size_per_rank = (
-                        awaitable._batch_size_per_rank
-                    )
-                if hasattr(sharding_context, "input_splits"):
-                    sharding_context.input_splits = awaitable._input_splits["values"]
-                if hasattr(sharding_context, "output_splits"):
-                    sharding_context.output_splits = awaitable._output_splits["values"]
-                if hasattr(sharding_context, "sparse_features_recat"):
-                    sharding_context.sparse_features_recat = awaitable._recat
+        _set_sharding_context(tensors_awaitables, self.ctx)
         return KJTListAwaitable(tensors_awaitables)
+
+
+@dataclass
+class KJTSplitsAllToAllMeta:
+    pg: dist.ProcessGroup
+    input: KeyedJaggedTensor
+    splits: List[int]
+    splits_tensors: List[torch.Tensor]
+    input_splits: List[List[int]]
+    input_tensors: List[torch.Tensor]
+    labels: List[str]
+    keys: List[str]
+    device: torch.device
+    stagger: int
+
+
+class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
+    def __init__(
+        self,
+        requests: List[KJTListSplitsAwaitable[C]],
+        contexts: List[C],
+        pg: Optional[dist.ProcessGroup],
+    ) -> None:
+        super().__init__()
+        self._contexts = contexts
+        self._awaitables: List[
+            Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
+        ] = [awaitable for request in requests for awaitable in request.awaitables]
+        self._output_lengths: List[int] = [
+            len(request.awaitables) for request in requests
+        ]
+        self._lengths: List[int] = [
+            len(awaitable.splits_tensors)
+            if isinstance(awaitable, KJTSplitsAllToAllMeta)
+            else 0
+            for awaitable in self._awaitables
+        ]
+        splits_tensors = [
+            splits_tensor
+            for awaitable in self._awaitables
+            for splits_tensor in (
+                awaitable.splits_tensors
+                if isinstance(awaitable, KJTSplitsAllToAllMeta)
+                else []
+            )
+        ]
+        self._splits_awaitable: Optional[SplitsAllToAllAwaitable] = (
+            SplitsAllToAllAwaitable(
+                input_tensors=splits_tensors,
+                pg=pg,
+            )
+            if splits_tensors and pg
+            else None
+        )
+
+    def _wait_impl(self) -> List[KJTListAwaitable]:
+        if self._splits_awaitable:
+            splits_list = self._splits_awaitable.wait()
+            splits_per_awaitable = _split(splits_list, self._lengths)
+        else:
+            splits_per_awaitable = [[] for _ in range(len(self._lengths))]
+        tensors_awaitables = []
+        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+            if not splits:  # NoWait
+                tensors_awaitables.append(awaitable.wait())
+                continue
+            output_splits = splits[:-1]
+            batch_size_per_rank = splits[-1]
+            tensors_awaitables.append(
+                KJTAllToAllTensorsAwaitable(
+                    pg=awaitable.pg,
+                    input=awaitable.input,
+                    splits=awaitable.splits,
+                    input_splits=awaitable.input_splits,
+                    output_splits=output_splits,
+                    input_tensors=awaitable.input_tensors,
+                    labels=awaitable.labels,
+                    batch_size_per_rank=batch_size_per_rank,
+                    keys=awaitable.keys,
+                    device=awaitable.device,
+                    stagger=awaitable.stagger,
+                )
+            )
+        output = []
+        awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
+        for awaitables, ctx in zip(awaitables_per_output, self._contexts):
+            _set_sharding_context(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables))
+        return output
 
 
 class ListOfKJTListAwaitable(Awaitable[ListOfKJTList]):


### PR DESCRIPTION
Summary:
In order to improve perf when working on optimizing the FX transform free model, we had to efficiently handle 13 KJTs in the input dist and minimize input dist latency by avoiding CPU blocked time.

In the current TrainPipeline implementation the input dist occurs after the forward pass but before the backward. The input dist consisting of the splits a2a, the subsequent wait(), and then issuing the tensors a2as. The wait()s for the tensors all to all get called in the following forward call.

{F943438400}

From the figure above we see that wait() for the splits all to all blocks the CPU for a while as it is waiting for the splits a2a collective to finish. To avoid this CPU blockage, we split up the input dist by issuing the splits a2a before the forward and then keeping the wait() for the splits a2a and issuing the tensors a2as between the forward and backwards.

This optimization allows the splits a2a collective to be scheduled earlier and finish by the time the rest of the input dist continues, so that the CPU does not have to be blocked waiting for the splits a2a collective to finish.

However, this introduced a slightly different issue:
{F943478391}

After moving the start of the input dist, issuing the splits a2a, before the forwards we ran into another CPU blockage. This time it was waiting for the copy_batch_to_gpu on the memcpy stream to finish its device transfer for batch_i+2. However, this was actually a redundant wait, since the wait_for_batch before the input dist was there to ensure the device transfer had finished for the input dist batch_i+1 on the memcpy stream. This was actually a bug because since the copy_batch_to_gpu started before input dist, it would be using memcpy stream on batch_i+2 and input dist would needlessly call wait_for_batch on memcpy stream for batch_i+2.

To mitigate this bug we move the start of input dist before copy_batch_to_gpu, ensuring the wait_for_batch inside input dist would be waiting on the correct batch, and not blocking incorrectly. After this we finally reach a clean state where the input dist gpu work becomes hidden.
{F943436776}

Differential Revision: D44781986

