### PR TITLE
wrap dict update in PositionWeightedModule

### DIFF
--- a/torchrec/modules/feature_processor.py
+++ b/torchrec/modules/feature_processor.py
@@ -31,6 +31,15 @@ class BaseFeatureProcessor(nn.Module):
         pass
 
 
+@torch.fx.wrap
+def position_weighted_module_update_features(
+    features: Dict[str, JaggedTensor],
+    weighted_features: Dict[str, JaggedTensor],
+) -> Dict[str, JaggedTensor]:
+    features.update(weighted_features)
+    return features
+
+
 # Will be deprecated soon, please use PositionWeightedProcessor, see full doc below
 class PositionWeightedModule(BaseFeatureProcessor):
     """
@@ -77,8 +86,7 @@ class PositionWeightedModule(BaseFeatureProcessor):
                 offsets=features[key].offsets(),
                 weights=torch.gather(position_weight, dim=0, index=seq),
             )
-        features.update(weighted_features)
-        return features
+        return position_weighted_module_update_features(features, weighted_features)
 
 
 class BaseGroupedFeatureProcessor(nn.Module):


### PR DESCRIPTION
Summary:
The forward method of PositionWeightedModule does an in-place dict update. However, when this module is symbolically traced with torch.fx, it results in generated code like this:
```
dict = ...
update = dict.update({...})
user_of_dict = dict.get(...)
```
During FX graph manipulation, the `user_of_dict` node is attached to `dict.users`, instead of `update`. While this is valid at runtime, it presents a problem with various FX operations including `eliminate_dead_code()` and `legalize_graph()`, because `update` is impure but also has 0 users.

In the case of legalize_graph, this can result in a FX-valid runtime-invalid program due to the presence of side effects.

To prevent this, we can wrap `dict.update` in a method that is hidden from the FX tracer via `torch.fx.wrap`. This way, the proxy object that is passed in place of `features` var in the forward method will not be the same proxy object that is returned by the forward method. This will consequently change the codegenerated forward method to look something like:

```
dict = ...
update = wrapped_function_that_updates_dict({...})
user_of_dict = update.get(...)
```

Differential Revision: D44896165

