### PR TITLE
Fix issue with torchrec test case causing torchrec's GHA to fail

### DIFF
--- a/torchrec/distributed/tests/test_comm.py
+++ b/torchrec/distributed/tests/test_comm.py
@@ -14,7 +14,7 @@ from typing import Callable
 import torch
 import torch.distributed as dist
 import torchrec.distributed.comm_ops as comm_ops
-from libfb.py.pyre import none_throws
+from torchrec.distributed.utils import none_throws
 from torchrec.test_utils import get_free_port, seed_and_log
 
 


### PR DESCRIPTION
Summary:
Fix issue with torchrec test case causing torchrec's GHA to fail

Was using the wrong none_throws, instead use the one supplied in torchrec lib.

Differential Revision: D44941130

