### PR TITLE
Optional registration of TBEs for Quant modules

### DIFF
--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -102,7 +102,9 @@ class ModelTraceScriptTest(unittest.TestCase):
         )
 
         model_info.model.training = False
-        model_info.quant_model = quantize(model_info.model, inplace=True)
+        model_info.quant_model = quantize(
+            model_info.model, inplace=True, register_tbes=True
+        )
 
         model_info.sharders = [
             cast(


### PR DESCRIPTION
Summary:
TBEs registration is also needed for non-sharded quantized EBC/EC.
Names are consistent with our sharded optional TBE registration: D44553638

The difference - how we turn it on.
We do not have `fused_params` for non-sharded QEBC. The creation of quantized models happens inside quantization via classmethod `torchrec.quant.embedding_modules.EmbeddingBagCollection.from_float()`

The only what we have at that moment is original module.

As it is optional, enabling this registration via setattr/getattr for EBC/EC:
```
        for m in module.modules():
            if isinstance(
                m, torchrec.modules.embedding_modules.EmbeddingBagCollection
            ) or isinstance(m, torchrec.modules.embedding_modules.EmbeddingCollection):
                setattr(m, MODULE_ATTR_REGISTER_TBES_BOOL, True)
```

Differential Revision: D45047073

