### PR TITLE
Weights preparation contract for Sharded Inference TRec modules

### DIFF
--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -15,7 +15,7 @@ from torch import quantization as quant
 from torchrec import EmbeddingCollection, EmbeddingConfig, KeyedJaggedTensor
 from torchrec.distributed.embedding_types import ModuleSharder
 from torchrec.distributed.fused_params import FUSED_PARAM_REGISTER_TBE_BOOL
-from torchrec.distributed.planner import Topology
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.quant_embedding import (
     QuantEmbeddingCollectionSharder,
     ShardedQuantEmbeddingCollection,
@@ -55,6 +55,7 @@ class TestModelInfo:
     quant_model: torch.nn.Module = torch.nn.Module()
     sharders: List[ModuleSharder] = field(default_factory=list)
     topology: Optional[Topology] = None
+    planner: Optional[EmbeddingShardingPlanner] = None
 
 
 def prep_inputs(


### PR DESCRIPTION
Summary:
Making our internal contract of weights preparation for TTS/Sliv infrastructures to specify how the weights must be prepared for Torchrec Sharded Inference modules.

Supported only TW.

Differential Revision:
D44998573

Privacy Context Container: L1138451

