### PR TITLE
in group_table check string value of pooling mode

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -163,7 +163,7 @@ def group_tables(
                                     compute_kernel_type = EmbeddingComputeKernel.QUANT
                                 if (
                                     table.data_type == data_type
-                                    and table.pooling == pooling
+                                    and table.pooling.value == pooling.value
                                     and table.has_feature_processor
                                     == has_feature_processor
                                     and compute_kernel_type == compute_kernel


### PR DESCRIPTION
Summary:
If the model is from torch package, checking pooling mode directly wouldn't result in a match because one would from <torch_package_x>.

Instead, we can check the string value.

Differential Revision: D45059135

