### PR TITLE
session-level recall as RecMetric

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -36,6 +36,7 @@ from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.rec_metric import RecMetric, RecMetricList
+from torchrec.metrics.recall_session import RecallSessionMetric
 from torchrec.metrics.throughput import ThroughputMetric
 from torchrec.metrics.tower_qps import TowerQPSMetric
 from torchrec.metrics.weighted_avg import WeightedAvgMetric
@@ -53,6 +54,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.MULTICLASS_RECALL: MulticlassRecallMetric,
     RecMetricEnum.WEIGHTED_AVG: WeightedAvgMetric,
     RecMetricEnum.TOWER_QPS: TowerQPSMetric,
+    RecMetricEnum.RECALL_SESSION_LEVEL: RecallSessionMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -25,8 +25,20 @@ class RecMetricEnum(RecMetricEnumBase):
     MSE = "mse"
     MAE = "mae"
     MULTICLASS_RECALL = "multiclass_recall"
+    RECALL_SESSION_LEVEL = "recall_session_level"
     WEIGHTED_AVG = "weighted_avg"
     TOWER_QPS = "tower_qps"
+
+
+@dataclass(unsafe_hash=True, eq=True)
+class SessionMetricDef:
+    # hyperparameters required for session level metrics
+    # session_var_name: name of session tensor in the model_out
+    # top_threshold: predictiones ranked in top "top_threshold" are considered as positive
+    # run_ranking_of_labels: if True, labels are also ranked as predictions
+    session_var_name: str
+    top_threshold: Optional[int] = None
+    run_ranking_of_labels: bool = False
 
 
 @dataclass(unsafe_hash=True, eq=True)
@@ -35,6 +47,9 @@ class RecTaskInfo:
     label_name: str = "label"
     prediction_name: str = "prediction"
     weight_name: str = "weight"
+    session_metric_def: Optional[
+        SessionMetricDef
+    ] = None  # used for session level metrics
 
 
 class RecComputeMode(Enum):

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -48,6 +48,7 @@ class MetricName(MetricNameBase):
     RMSE = "rmse"
     AUC = "auc"
     GROUPED_AUC = "grouped_auc"
+    RECALL_SESSION_LEVEL = "recall_session_level"
     MULTICLASS_RECALL = "multiclass_recall"
     WEIGHTED_AVG = "weighted_avg"
     TOWER_QPS = "qps"
@@ -74,6 +75,7 @@ class MetricNamespace(MetricNamespaceBase):
     MULTICLASS_RECALL = "multiclass_recall"
 
     WEIGHTED_AVG = "weighted_avg"
+    RECALL_SESSION_LEVEL = "recall_session_level"
 
     TOWER_QPS = "qps"
 

--- a/torchrec/metrics/recall_session.py
+++ b/torchrec/metrics/recall_session.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Any, cast, Dict, List, Optional, Set, Type, Union
+
+import torch
+from libfb.py.pyre import none_throws
+from torch import distributed as dist
+from torchrec.metrics.metrics_config import RecTaskInfo, SessionMetricDef
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+NUM_TRUE_POS = "num_true_pos"
+NUM_FALSE_NEGATIVE = "num_false_neg"
+
+
+def _validate_model_outputs(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: torch.Tensor,
+    sessions: torch.Tensor,
+) -> None:
+    # check if tensors are of the same shape
+    assert labels.dim() == 2
+    assert labels.shape == predictions.shape
+    assert labels.shape == weights.shape
+    assert labels.shape == sessions.shape
+
+
+def ranking_within_session(
+    predictions: torch.Tensor,
+    session: torch.Tensor,
+) -> torch.Tensor:
+    # rank predictions that belong to the same session
+
+    #  Example:
+    #  predictions = [1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]
+    #  sessions =    [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]
+    #  return =      [0, 5, 3, 2, 1, 6, 4, 1, 0, 4, 3, 2]
+    n_tasks = predictions.size(0)
+    matching_session_id = session.view(-1, n_tasks) == session.view(n_tasks, -1)
+    predictions_relation = predictions.view(-1, n_tasks) >= predictions.view(
+        n_tasks, -1
+    )
+    relation_within_session = matching_session_id & predictions_relation
+    rank_within_session = torch.sum(matching_session_id, dim=-1) - torch.sum(
+        relation_within_session, dim=-1
+    )
+    return rank_within_session
+
+
+def _calc_num_true_pos(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    # predictions are expected to be 0 or 1 integers.
+    num_true_pos = torch.sum(weights * labels * (predictions == 1).double(), dim=-1)
+    return num_true_pos
+
+
+def _calc_num_false_neg(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    # predictions are expected to be 0 or 1 integers.
+    num_false_neg = torch.sum(weights * labels * (predictions == 0).double(), dim=-1)
+    return num_false_neg
+
+
+def _calc_recall(
+    num_true_pos: torch.Tensor, num_false_neg: torch.Tensor
+) -> torch.Tensor:
+    # if num_true_pos + num_false_neg == 0 then we set recall = NaN by default.
+    recall = torch.tensor([float("nan")])
+    if (num_true_pos + num_false_neg).item() != 0:
+        recall = num_true_pos / (num_true_pos + num_false_neg)
+    else:
+        logger.warning(
+            "Recall = NaN. Likely, it means that there were no positive examples passed to the metric yet."
+            " Please, debug if you expect every batch to include positive examples."
+        )
+    return recall
+
+
+class RecallSessionMetricComputation(RecMetricComputation):
+    r"""
+    This class implements the RecMetricComputation for Recall on session level.
+
+    The constructor arguments are defined in RecMetricComputation.
+    See the docstring of RecMetricComputation for more detail.
+
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        session_metric_def: SessionMetricDef,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._add_state(
+            NUM_TRUE_POS,
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            NUM_FALSE_NEGATIVE,
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self.top_threshold: Optional[int] = session_metric_def.top_threshold
+        self.run_ranking_of_labels: bool = session_metric_def.run_ranking_of_labels
+        self.session_var_name: Optional[str] = session_metric_def.session_var_name
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Args:
+            predictions (torch.Tensor): tensor of size (n_task, n_examples)
+            labels (torch.Tensor): tensor of size (n_task, n_examples)
+            weights (torch.Tensor): tensor of size (n_task, n_examples)
+            session (torch.Tensor): Optional tensor of size (n_task, n_examples) that specifies the groups of
+                    predictions/labels per batch.
+        """
+
+        if (
+            "required_inputs" not in kwargs
+            or self.session_var_name not in kwargs["required_inputs"]
+        ):
+            raise RecMetricException(
+                "Need the {} input to update the bucket metric".format(
+                    self.session_var_name
+                )
+            )
+        # pyre-ignore
+        session = kwargs["required_inputs"][self.session_var_name]
+        if predictions is None or weights is None or session is None:
+            raise RecMetricException(
+                "Inputs 'predictions', 'weights' and 'session' should not be None for RecallSessionMetricComputation update"
+            )
+        _validate_model_outputs(labels, predictions, weights, session)
+
+        predictions = predictions.double()
+        labels = labels.double()
+        weights = weights.double()
+
+        num_samples = predictions.shape[-1]
+        for state_name, state_value in self.get_recall_states(
+            labels=labels, predictions=predictions, weights=weights, session=session
+        ).items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
+
+    def _compute(self) -> List[MetricComputationReport]:
+
+        return [
+            MetricComputationReport(
+                name=MetricName.RECALL_SESSION_LEVEL,
+                metric_prefix=MetricPrefix.LIFETIME,
+                value=_calc_recall(
+                    num_true_pos=cast(torch.Tensor, getattr(self, NUM_TRUE_POS)),
+                    num_false_neg=cast(torch.Tensor, getattr(self, NUM_FALSE_NEGATIVE)),
+                ),
+            ),
+            MetricComputationReport(
+                name=MetricName.RECALL_SESSION_LEVEL,
+                metric_prefix=MetricPrefix.WINDOW,
+                value=_calc_recall(
+                    num_true_pos=self.get_window_state(NUM_TRUE_POS),
+                    num_false_neg=self.get_window_state(NUM_FALSE_NEGATIVE),
+                ),
+            ),
+        ]
+
+    def get_recall_states(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        session: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+
+        predictions_ranked = ranking_within_session(predictions, session)
+        predictions_labels = (predictions_ranked < self.top_threshold).to(torch.int32)
+        if self.run_ranking_of_labels:
+            labels_ranked = ranking_within_session(labels, session)
+            labels = (labels_ranked < self.top_threshold).to(torch.int32)
+        num_true_pos = _calc_num_true_pos(labels, predictions_labels, weights)
+        num_false_neg = _calc_num_false_neg(labels, predictions_labels, weights)
+
+        return {NUM_TRUE_POS: num_true_pos, NUM_FALSE_NEGATIVE: num_false_neg}
+
+
+class RecallSessionMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.RECALL_SESSION_LEVEL
+    _computation_class: Type[RecMetricComputation] = RecallSessionMetricComputation
+
+    def __init__(
+        self,
+        world_size: int,
+        my_rank: int,
+        batch_size: int,
+        tasks: List[RecTaskInfo],
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        window_size: int = 100,
+        fused_update_limit: int = 0,
+        process_group: Optional[dist.ProcessGroup] = None,
+        **kwargs: Any,
+    ) -> None:
+        if compute_mode == RecComputeMode.FUSED_TASKS_COMPUTATION:
+            raise RecMetricException(
+                "Fused computation is not supported for recall session-level metrics"
+            )
+
+        if fused_update_limit > 0:
+            raise RecMetricException(
+                "Fused update is not supported for recall session-level metrics"
+            )
+        for task in tasks:
+            session_metric_def = none_throws(
+                task.session_metric_def, "Please, specify the session metric definition"
+            )
+            if session_metric_def.top_threshold is None:
+                raise RecMetricException("Please, specify the top threshold")
+            if session_metric_def.session_var_name is None:
+                raise RecMetricException(
+                    "Please, specify the session var name in your model output"
+                )
+
+        super().__init__(
+            world_size=world_size,
+            my_rank=my_rank,
+            batch_size=batch_size,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            window_size=window_size,
+            fused_update_limit=fused_update_limit,
+            process_group=process_group,
+            **kwargs,
+        )
+
+    def _get_task_kwargs(
+        self, task_config: Union[RecTaskInfo, List[RecTaskInfo]]
+    ) -> Dict[str, Any]:
+        if isinstance(task_config, list):
+            raise RecMetricException("Session metric can only take one task at a time")
+        return {"session_metric_def": none_throws(task_config.session_metric_def)}
+
+    def _get_task_required_inputs(
+        self, task_config: Union[RecTaskInfo, List[RecTaskInfo]]
+    ) -> Set[str]:
+        if isinstance(task_config, list):
+            raise RecMetricException("Session metric can only take one task at a time")
+        return (
+            {none_throws(task_config.session_metric_def).session_var_name}
+            if none_throws(task_config.session_metric_def).session_var_name
+            else set()
+        )

--- a/torchrec/metrics/tests/test_recall_session.py
+++ b/torchrec/metrics/tests/test_recall_session.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict, Optional, Union
+
+import torch
+from torch import no_grad
+from torchrec.metrics.metrics_config import RecTaskInfo, SessionMetricDef
+
+from torchrec.metrics.recall_session import RecallSessionMetric
+
+
+def generate_model_output_test1() -> Dict[str, torch._tensor.Tensor]:
+    return {
+        "predictions": torch.tensor(
+            [[1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]]
+        ),
+        "session": torch.tensor([[1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]]),
+        "labels": torch.tensor(
+            [[0.9, 0.1, 0.2, 0.3, 0.9, 0.9, 0.0, 0.9, 0.1, 0.4, 0.9, 0.1]]
+        ),
+        "weights": torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+        ),
+        "expected_recall": torch.tensor([0.5]),
+    }
+
+
+def generate_model_output_test2() -> Dict[str, torch._tensor.Tensor]:
+    return {
+        "predictions": torch.tensor(
+            [[1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]]
+        ),
+        "session": torch.tensor([[1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]]),
+        "labels": torch.tensor(
+            [[1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]]
+        ),
+        "weights": torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+        ),
+        "expected_recall": torch.tensor([0.5]),
+    }
+
+
+def generate_model_output_with_no_positive_examples() -> Dict[
+    str, torch._tensor.Tensor
+]:
+    return {
+        "predictions": torch.tensor(
+            [[1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]]
+        ),
+        "session": torch.tensor([[1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]]),
+        "labels": torch.tensor([[0.0] * 12]),
+        "weights": torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+        ),
+        "expected_recall": torch.tensor([float("nan")]),
+    }
+
+
+class RecallSessionValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of Recall in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    @no_grad()
+    def _test_recall_session_helper(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        session: torch.Tensor,
+        expected_recall: torch.Tensor,
+        run_ranking_of_labels: bool = False,
+        recall_metric: Optional[RecallSessionMetric] = None,
+    ) -> RecallSessionMetric:
+        num_task = labels.shape[0]
+        batch_size = labels.shape[0]
+        task_list = []
+        inputs: Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]] = {
+            "predictions": {},
+            "labels": {},
+            "weights": {},
+        }
+        for i in range(num_task):
+            task_info = RecTaskInfo(
+                name=f"Task:{i}",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+                session_metric_def=SessionMetricDef(
+                    session_var_name="session",
+                    top_threshold=3,
+                    run_ranking_of_labels=run_ranking_of_labels,
+                ),
+            )
+            task_list.append(task_info)
+            # pyre-ignore
+            inputs["predictions"][task_info.name] = predictions[i]
+            # pyre-ignore
+            inputs["labels"][task_info.name] = labels[i]
+            # pyre-ignore
+            inputs["weights"][task_info.name] = weights[i]
+
+        kwargs = {"required_inputs": {"session": session}}
+
+        if recall_metric is None:
+            recall_metric = RecallSessionMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=batch_size,
+                tasks=task_list,
+            )
+        recall_metric.update(
+            predictions=inputs["predictions"],
+            labels=inputs["labels"],
+            weights=inputs["weights"],
+            **kwargs,
+        )
+        actual_recall = recall_metric.compute()
+
+        for task_id, task in enumerate(task_list):
+            cur_actual_recall = actual_recall[
+                f"recall_session_level-{task.name}|lifetime_recall_session_level"
+            ]
+            cur_expected_recall = expected_recall[task_id].unsqueeze(dim=0)
+
+            torch.testing.assert_close(
+                cur_actual_recall,
+                cur_expected_recall,
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                equal_nan=True,
+                msg=f"Actual: {cur_actual_recall}, Expected: {cur_expected_recall}",
+            )
+        return recall_metric
+
+    def test_recall_session_with_ranked_labels(self) -> None:
+        test_data = generate_model_output_test1()
+        try:
+            self._test_recall_session_helper(
+                run_ranking_of_labels=True, recall_metric=None, **test_data
+            )
+        except AssertionError:
+            print("Assertion error caught with data set ", test_data)
+            raise
+
+    def test_recall_session_with_bool_labels(self) -> None:
+        test_data = generate_model_output_test2()
+        try:
+            self._test_recall_session_helper(
+                run_ranking_of_labels=False, recall_metric=None, **test_data
+            )
+        except AssertionError:
+            print("Assertion error caught with data set ", test_data)
+            raise
+
+    def test_recall_session_with_no_positive_examples(self) -> None:
+
+        # if we pass a batch with no positive examples, we should get NaN
+        test_data_with_no_positive_examples = (
+            generate_model_output_with_no_positive_examples()
+        )
+        try:
+            recall_metric = self._test_recall_session_helper(
+                run_ranking_of_labels=False,
+                recall_metric=None,
+                **test_data_with_no_positive_examples,
+            )
+        except AssertionError:
+            print(
+                "Assertion error caught with data set ",
+                test_data_with_no_positive_examples,
+            )
+            raise
+        # once we get a batch with positive examples, we should NOT get NaN
+        test_data_with_pos_examples = generate_model_output_test2()
+        try:
+            recall_metric = self._test_recall_session_helper(
+                run_ranking_of_labels=False,
+                recall_metric=recall_metric,
+                **test_data_with_pos_examples,
+            )
+        except AssertionError:
+            print("Assertion error caught with data set ", test_data_with_pos_examples)
+            raise
+        # if we get a batch with no positive examples and metric states are non-zero, they should not change
+        test_data_with_no_positive_examples["expected_recall"] = torch.tensor([0.5])
+        try:
+            self._test_recall_session_helper(
+                run_ranking_of_labels=False,
+                recall_metric=recall_metric,
+                **test_data_with_no_positive_examples,
+            )
+        except AssertionError:
+            print(
+                "Assertion error caught with data set ",
+                test_data_with_no_positive_examples,
+            )
+            raise
+
+    def test_tasks_input_propagation(self) -> None:
+        task_info1 = RecTaskInfo(
+            name="Task1",
+            label_name="label1",
+            prediction_name="prediction1",
+            weight_name="weight1",
+            session_metric_def=SessionMetricDef(
+                session_var_name="session1",
+                top_threshold=1,
+                run_ranking_of_labels=True,
+            ),
+        )
+
+        task_info2 = RecTaskInfo(
+            name="Task2",
+            label_name="label2",
+            prediction_name="prediction2",
+            weight_name="weight2",
+            session_metric_def=SessionMetricDef(
+                session_var_name="session2",
+                top_threshold=2,
+                run_ranking_of_labels=False,
+            ),
+        )
+
+        recall_metric = RecallSessionMetric(
+            world_size=1,
+            my_rank=5,
+            batch_size=100,
+            tasks=[task_info1, task_info2],
+        )
+
+        # metrics checks
+        self.assertSetEqual(
+            recall_metric.get_required_inputs(), {"session1", "session2"}
+        )
+        self.assertTrue(len(recall_metric._tasks) == 2)
+        self.assertTrue(recall_metric._tasks[0] == task_info1)
+        self.assertTrue(recall_metric._tasks[1] == task_info2)
+
+        # metrics_computations checks
+        self.assertTrue(recall_metric._metrics_computations[0]._my_rank == 5)
+        self.assertTrue(recall_metric._metrics_computations[1]._my_rank == 5)
+        self.assertTrue(recall_metric._metrics_computations[0]._batch_size == 100)
+        self.assertTrue(recall_metric._metrics_computations[1]._batch_size == 100)
+
+        self.assertTrue(recall_metric._metrics_computations[0].top_threshold == 1)
+        self.assertTrue(recall_metric._metrics_computations[1].top_threshold == 2)
+        self.assertTrue(
+            recall_metric._metrics_computations[0].session_var_name == "session1"
+        )
+        self.assertTrue(
+            recall_metric._metrics_computations[1].session_var_name == "session2"
+        )
+        self.assertTrue(recall_metric._metrics_computations[0].run_ranking_of_labels)
+        self.assertTrue(
+            recall_metric._metrics_computations[1].run_ranking_of_labels is False
+        )


### PR DESCRIPTION
Summary:
In this diff we define a recall session-level metric.

**Session-level metrics**

Here, *session-level* means that a metric has to get a "session" tensor in addition to predictions, labels, and weights.

__Example:__
labels = [1, 0, 1, 0, 1]
predictions = [0.9, 0.9, 0.2, 0.1, 0.8]
weights = [1, 1, 1, 1, 1]
session = [1, 1, 1, 11, 11]

**Session-level recall**
Within each session, predictions are ranked and those with rank<*top_threshold* are predicted to be positive.

__Example:__
   predictions = [1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]
   sessions =    [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]
   top_threshold = 3

We get:

  session-wise ranking:                      [0, 5, 3, 2, 1, 6, 4, 1, 0, 4, 3, 2]
  actual_predictions (top 3 are positive):   [1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1]

Then recall is computed based on labels, weights, and actual_predictions:
  labels:          [1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0]
  true positive:   [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]
  false negative:  [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]

The result: session-level recall is 0.5.

**Session-level recall: with float labels**

For some tasks labels are not binary and have to be ranked and converted to 0-1. If `run_ranking_of_labels=True` we  rank labels within each session.

__Example:__
   predictions = [1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8, 1.0, 0.0, 0.51, 0.8]
   sessions =    [1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1]
   labels = [0.9, 0.1, 0.2, 0.3, 0.9, 0.9, 0.0, 0.9, 0.1, 0.4, 0.9, 0.1]
   top_threshold = 3

We get:

  session-wise ranking for predictions:       [0, 5, 3, 2, 1, 6, 4, 1, 0, 4, 3, 2]
  actual_predictions (top 3 are positive):    [1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1]

  session-wise ranking for labels:       [0, 5, 4, 3, 1, 2, 6, 0, 3, 2, 1, 4]
  actual_labels (top 3 are positive):    [1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0]

Then recall is computed based on labels, weights, and actual_predictions:
  actual_labels:          [1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0]
  true positive:          [1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0]
  false negative:         [0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0]

The result: session-level recall is 0.5.

**Diff technical notes**

- based on https://fburl.com/workplace/ll58bits, new custom TorchRec metrics have to be OSS;
- we define a new RecTaskSessionInfo type that includes required attributes for the session-level recall.

Differential Revision: D44836701

