### PR TITLE
calling wait() when fx tracing in Sharded QEBC

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -237,7 +237,7 @@ class ShardedQuantEmbeddingBagCollection(
             # syntax for torchscript
             embedding_dims=self._embedding_dims,
             embedding_names=self._embedding_names,
-        )
+        ).wait()
 
     # pyre-ignore
     def compute_and_output_dist(

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -491,6 +491,7 @@ class TestSparseArch(nn.Module):
             for fp in self.fps:
                 fp_features = fp(fp_features)
         ebc = self.ebc(features)
+        ebc = _post_ebc_test_wrap_function(ebc)
         fp_ebc: Optional[KeyedTensor] = (
             self.fp_ebc(fp_features) if self.fp_ebc is not None else None
         )
@@ -1007,3 +1008,11 @@ def _get_default_rtol_and_atol(
     actual_rtol, actual_atol = _DTYPE_PRECISIONS.get(actual.dtype, (0.0, 0.0))
     expected_rtol, expected_atol = _DTYPE_PRECISIONS.get(expected.dtype, (0.0, 0.0))
     return max(actual_rtol, expected_rtol), max(actual_atol, expected_atol)
+
+
+@torch.fx.wrap
+def _post_ebc_test_wrap_function(kt: KeyedTensor) -> KeyedTensor:
+    for _ in kt.values():
+        continue
+
+    return kt


### PR DESCRIPTION
Summary:
Currently when fx tracing ebc would output `EmbeddingBagCollectionAwaitable` instead of a proxy object. If there're a wrapped function which takes this as input (and neither of the other inputs is proxy), then we would see such error
```
  1) torchrec.distributed.tests.test_fx_jit.ModelTraceScriptTest: test_fxtrace_jitscript
    1) TraceError: Proxy object cannot be iterated. This can be attempted when the Proxy is used in a loop or as a *args or **kwargs function argument. See the torch.fx docs on pytorch.org for a more detailed explanation of what types of control flow can be traced, and check out the Proxy docstring for help troubleshooting Proxy iteration errors
      File "torchrec/distributed/tests/test_fx_jit.py", line 409, in test_fxtrace_jitscript
        graph = tracer.trace(model)
      File "torchrec/fx/tracer.py", line 84, in trace
        graph = super().trace(
      File "torch/fx/_symbolic_trace.py", line 778, in trace
        (self.create_arg(fn(*args)),),
      File "torchrec/distributed/test_utils/infer_utils.py", line 307, in forward
        return self._module(mi)
      File "torch/fx/_symbolic_trace.py", line 756, in module_call_wrapper
        return self.call_module(mod, forward, args, kwargs)
      File "torch/fx/_symbolic_trace.py", line 467, in call_module
        ret_val = forward(*args, **kwargs)
      File "torch/fx/_symbolic_trace.py", line 749, in forward
        return _orig_module_call(mod, *args, **kwargs)
      File "torch/nn/modules/module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "torchrec/distributed/test_utils/test_model.py", line 587, in forward
        sparse_r = self.sparse(
      File "torch/fx/_symbolic_trace.py", line 756, in module_call_wrapper
        return self.call_module(mod, forward, args, kwargs)
      File "torch/fx/_symbolic_trace.py", line 467, in call_module
        ret_val = forward(*args, **kwargs)
      File "torch/fx/_symbolic_trace.py", line 749, in forward
        return _orig_module_call(mod, *args, **kwargs)
      File "torch/nn/modules/module.py", line 1501, in _call_impl
        return forward_call(*args, **kwargs)
      File "torchrec/distributed/test_utils/test_model.py", line 494, in forward
        ebc = _post_ebc_test_wrap_function(ebc)
      File "torch/fx/_symbolic_trace.py", line 855, in wrapped
        return orig_fn(*args, **kwargs)
      File "torchrec/distributed/test_utils/test_model.py", line 1015, in _post_ebc_test_wrap_function
        for v in kt.values():
      File "torch/fx/proxy.py", line 381, in __iter__
        return self.tracer.iter(self)
      File "torch/fx/proxy.py", line 281, in iter
        raise TraceError('Proxy object cannot be iterated. This can be '

```
To avoid the error, we need to ensure the output is a proxy by calling wait() when we are doing fx tracing.

Differential Revision: D45133173

