### PR TITLE
address manywheel failing actions

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -38,6 +38,12 @@ from torchrec.distributed.utils import (
 from torchrec.optim.fused import FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 
+try:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+except OSError:
+    pass
+
 
 _DDP_STATE_DICT_PREFIX = "module."
 

--- a/torchrec/metrics/recall_session.py
+++ b/torchrec/metrics/recall_session.py
@@ -9,8 +9,8 @@ import logging
 from typing import Any, cast, Dict, List, Optional, Set, Type, Union
 
 import torch
-from libfb.py.pyre import none_throws
 from torch import distributed as dist
+from torchrec.distributed.utils import none_throws
 from torchrec.metrics.metrics_config import RecTaskInfo, SessionMetricDef
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
 from torchrec.metrics.rec_metric import (


### PR DESCRIPTION
Summary:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/__init__.py", line 8, in <module>
    import torchrec.distributed  # noqa
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/__init__.py", line 36, in <module>
    from torchrec.distributed.model_parallel import DistributedModelParallel  # noqa
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/model_parallel.py", line 19, in <module>
    from torchrec.distributed.planner import (
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/planner/__init__.py", line 22, in <module>
    from torchrec.distributed.planner.planners import EmbeddingShardingPlanner  # noqa
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/planner/planners.py", line 19, in <module>
    from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/planner/constants.py", line 10, in <module>
    from torchrec.distributed.embedding_types import EmbeddingComputeKernel
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torchrec/distributed/embedding_types.py", line 14, in <module>
    from fbgemm_gpu.split_table_batched_embeddings_ops import EmbeddingLocation
libcudart.so.11.0: cannot open shared object file: No such file or directory

  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/fbgemm_gpu/__init__.py", line 21, in <module>
    from . import _fbgemm_gpu_docs  # noqa: F401, E402
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/fbgemm_gpu/_fbgemm_gpu_docs.py", line 18, in <module>
    torch.ops.fbgemm.jagged_2d_to_dense,
  File "/__w/_temp/conda_environment_4785761262/lib/python3.8/site-packages/torch/_ops.py", line 713, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' 'fbgemm' object has no attribute 'jagged_2d_to_dense'```

Differential Revision: D45241058

