### PR TITLE
Zero allocation torchrec sharding via meta [QEBC]

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -486,16 +486,21 @@ class KJTOneToAll(nn.Module):
         splits (List[int]): lengths of features to split the `KeyJaggedTensor` features
             into before copying them.
         world_size (int): number of devices in the topology.
+        device (torch.device): the device on which the KJTs will be allocated.
     """
 
     def __init__(
         self,
         splits: List[int],
         world_size: int,
+        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._splits = splits
         self._world_size = world_size
+        self._device_type = (
+            "cuda" if device is None or device.type == "cuda" else "meta"
+        )
         assert self._world_size == len(splits)
 
     def forward(self, kjt: KeyedJaggedTensor) -> KJTList:
@@ -511,7 +516,9 @@ class KJTOneToAll(nn.Module):
         fx_marker("KJT_ONE_TO_ALL_FORWARD_BEGIN", kjt)
         kjts: List[KeyedJaggedTensor] = kjt.split(self._splits)
         dist_kjts = [
-            kjts[rank].to(torch.device("cuda", rank), non_blocking=True)
+            kjts[rank]
+            if self._device_type == "meta"
+            else kjts[rank].to(torch.device(self._device_type, rank), non_blocking=True)
             for rank in range(self._world_size)
         ]
         ret = KJTList(dist_kjts)

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -706,19 +706,21 @@ class InferGroupedPooledEmbeddingsLookup(
         grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
+        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._embedding_lookups_per_rank: List[
             MetaInferGroupedPooledEmbeddingsLookup
         ] = []
+
+        device_type = "cuda" if device is None or device.type == "cuda" else "meta"
         for rank in range(world_size):
             self._embedding_lookups_per_rank.append(
                 # TODO add position weighted module support
                 MetaInferGroupedPooledEmbeddingsLookup(
                     grouped_configs=grouped_configs_per_rank[rank],
                     # syntax for torchscript
-                    device=torch.device(f"cuda:{rank}"),
-                    fused_params=fused_params,
+                    device=torch.device(type=device_type, index=rank),
                 )
             )
 

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -157,7 +157,7 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag, TBEToRegisterMixIn):
             uvm_host_mapped=True,  # Use cudaHostAlloc for UVM CACHING to fix imbalance numa memory issue
             **(tbe_fused_params(fused_params) or {}),
         )
-        if device is not None and device.type != "meta":
+        if device is not None:
             self._emb_module.initialize_weights()
 
     def init_parameters(self) -> None:

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -84,6 +84,7 @@ class ShardedQuantEmbeddingBagCollection(
         table_name_to_parameter_sharding: Dict[str, ParameterSharding],
         env: ShardingEnv,
         fused_params: Optional[Dict[str, Any]] = None,
+        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._embedding_bag_configs: List[
@@ -106,11 +107,11 @@ class ShardedQuantEmbeddingBagCollection(
             )
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
-
+        self._device = device
         self._is_weighted: bool = module.is_weighted()
         self._input_dists: List[nn.Module] = []
         self._lookups: List[nn.Module] = []
-        self._create_lookups(fused_params)
+        self._create_lookups(fused_params, device)
         self._output_dists: List[nn.Module] = []
         self._embedding_names: List[str] = []
         self._embedding_dims: List[int] = []
@@ -154,11 +155,14 @@ class ShardedQuantEmbeddingBagCollection(
     def _create_input_dist(
         self,
         input_feature_names: List[str],
-        device: torch.device,
+        features_device: torch.device,
+        input_dist_device: Optional[torch.device] = None,
     ) -> None:
         feature_names: List[str] = []
         for sharding in self._sharding_type_to_sharding.values():
-            self._input_dists.append(sharding.create_input_dist())
+            self._input_dists.append(
+                sharding.create_input_dist(device=input_dist_device)
+            )
             feature_names.extend(sharding.feature_names())
             self._feature_splits.append(len(sharding.feature_names()))
 
@@ -169,17 +173,21 @@ class ShardedQuantEmbeddingBagCollection(
                 self._features_order.append(input_feature_names.index(f))
             self.register_buffer(
                 "_features_order_tensor",
-                torch.tensor(self._features_order, device=device, dtype=torch.int32),
+                torch.tensor(
+                    self._features_order, device=features_device, dtype=torch.int32
+                ),
                 persistent=False,
             )
 
     def _create_lookups(
         self,
         fused_params: Optional[Dict[str, Any]],
+        device: Optional[torch.device] = None,
     ) -> None:
         for sharding in self._sharding_type_to_sharding.values():
             self._lookups.append(
                 sharding.create_lookup(
+                    device=device,
                     fused_params=fused_params,
                 )
             )
@@ -196,7 +204,11 @@ class ShardedQuantEmbeddingBagCollection(
         self, ctx: NullShardedModuleContext, features: KeyedJaggedTensor
     ) -> ListOfKJTList:
         if self._has_uninitialized_input_dist:
-            self._create_input_dist(features.keys(), features.device())
+            self._create_input_dist(
+                features.keys(),
+                features.device(),
+                self._device,
+            )
             self._has_uninitialized_input_dist = False
         if self._has_uninitialized_output_dist:
             self._create_output_dist(features.device())

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -356,17 +356,20 @@ class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
     Args:
         features_per_rank (List[int]): number of features to send to each rank.
         world_size (int): number of devices in the topology.
+        fused_params (Dict[str, Any]): fused parameters of the model.
     """
 
     def __init__(
         self,
         features_per_rank: List[int],
         world_size: int,
+        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._dist = KJTOneToAll(
-            features_per_rank,
-            world_size,
+            splits=features_per_rank,
+            world_size=world_size,
+            device=device,
         )
 
     def forward(
@@ -433,11 +436,13 @@ class InferTwEmbeddingSharding(
     """
 
     def create_input_dist(
-        self, device: Optional[torch.device] = None
+        self,
+        device: Optional[torch.device] = None,
     ) -> BaseSparseFeaturesDist[KJTList]:
         return InferTwSparseFeaturesDist(
-            self.features_per_rank(),
-            self._world_size,
+            features_per_rank=self.features_per_rank(),
+            world_size=self._world_size,
+            device=device,
         )
 
     def create_lookup(
@@ -450,6 +455,7 @@ class InferTwEmbeddingSharding(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
+            device=device,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -208,6 +208,7 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
             table_name_to_parameter_sharding=params,
             env=env,
             fused_params=fused_params,
+            device=device,
         )
 
 


### PR DESCRIPTION
Summary:
Provide option to use meta sharding in inference via fused params

**Why?**
In inference publish flow, especially for ranking models, zero allocation on cuda devices is required so that you don't need a gpu host to perform the publish. you need the sharded module to perform logical transformations, but you don't need memory allocated onto cuda.

Currently, whether inadvertent or not, we allocate memory onto cuda for the TBEs in the sharded module.

other options tried:
- Tried faketensormode, which got an error during sharding that an op wasn't supported for meta backend (confusing because just passing in meta without FTmode works...) regardless, if we need to manually support ops like we do with meta tensor (split_dispatcher.py) then we might as well just use meta tensors anyway

Differential Revision: D45006690

