### PR TITLE
QuantEBC RowWise sharding

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -22,7 +22,6 @@ from torchrec.distributed.embedding_types import (
     GroupedEmbeddingConfig,
     KJTList,
     ListOfKJTList,
-    ShardedEmbeddingModule,
 )
 from torchrec.distributed.embeddingbag import (
     construct_output_kt,
@@ -32,6 +31,8 @@ from torchrec.distributed.fused_params import (
     get_tbes_to_register_from_iterable,
     is_fused_param_register_tbe,
 )
+from torchrec.distributed.quant_state import ShardedQuantEmbeddingModuleState
+from torchrec.distributed.sharding.rw_sharding import InferRwPooledEmbeddingSharding
 from torchrec.distributed.sharding.tw_sharding import InferTwEmbeddingSharding
 from torchrec.distributed.types import (
     NullShardedModuleContext,
@@ -61,12 +62,14 @@ def create_infer_embedding_bag_sharding(
 ) -> EmbeddingSharding[NullShardingContext, KJTList, List[torch.Tensor], torch.Tensor]:
     if sharding_type == ShardingType.TABLE_WISE.value:
         return InferTwEmbeddingSharding(sharding_infos, env, device=None)
+    elif sharding_type == ShardingType.ROW_WISE.value:
+        return InferRwPooledEmbeddingSharding(sharding_infos, env, device=None)
     else:
         raise ValueError(f"Sharding type not supported {sharding_type}")
 
 
 class ShardedQuantEmbeddingBagCollection(
-    ShardedEmbeddingModule[
+    ShardedQuantEmbeddingModuleState[
         ListOfKJTList,
         List[List[torch.Tensor]],
         KeyedTensor,
@@ -122,40 +125,15 @@ class ShardedQuantEmbeddingBagCollection(
         self._has_uninitialized_output_dist: bool = True
         self._has_features_permute: bool = True
 
-        # This provides consistency between this class and the EmbeddingBagCollection's
-        # nn.Module API calls (state_dict, named_modules, etc)
-        # Currently, Sharded Quant EBC only uses TW sharding, and returns non-sharded tensors as part of state dict
-        # TODO - revisit if we state_dict can be represented as sharded tensor
-        self.embedding_bags: nn.ModuleDict = nn.ModuleDict()
-        for table in self._embedding_bag_configs:
-            self.embedding_bags[table.name] = torch.nn.Module()
-
-        for _sharding_type, lookup in zip(
-            self._sharding_type_to_sharding.keys(), self._lookups
-        ):
-            lookup_state_dict = lookup.state_dict()
-            for key in lookup_state_dict:
-                if key.endswith(".weight"):
-                    table_name = key[: -len(".weight")]
-                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                    self.embedding_bags[table_name].register_buffer(
-                        "weight", lookup_state_dict[key]
-                    )
-                elif key.endswith("weight_qscaleshift"):
-                    table_name = key[: -len(".weight_qscaleshift")]
-                    self.embedding_bags[table_name].register_buffer(
-                        "weight_qscaleshift", lookup_state_dict[key]
-                    )
-                else:
-                    continue
+        tbes: Dict[
+            IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
+        ] = get_tbes_to_register_from_iterable(self._lookups)
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):
-            tbes: Dict[
-                IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
-            ] = get_tbes_to_register_from_iterable(self._lookups)
-
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(tbes.keys())
+
+        self._initialize_torch_state(tbes=tbes, tables_weights_prefix="embedding_bags")
 
     def _create_input_dist(
         self,

--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from typing import Any, Dict, List, Mapping, TypeVar, Union
+
+import torch
+from fbgemm_gpu.split_table_batched_embeddings_ops import (
+    IntNBitTableBatchedEmbeddingBagsCodegen,
+)
+from torch.distributed import _remote_device
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardedTensorBase,
+    ShardedTensorMetadata,
+    ShardMetadata,
+    TensorProperties,
+)
+from torchrec.distributed.embedding_types import (
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingModule,
+)
+from torchrec.streamable import Multistreamable
+
+Out = TypeVar("Out")
+CompIn = TypeVar("CompIn")
+DistOut = TypeVar("DistOut")
+ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
+
+
+def _append_table_shard(
+    d: Dict[str, List[Shard]], table_name: str, shard: Shard
+) -> None:
+    if table_name not in d:
+        d[table_name] = []
+    d[table_name].append(shard)
+
+
+class ShardedQuantEmbeddingModuleState(
+    ShardedEmbeddingModule[CompIn, DistOut, Out, ShrdCtx]
+):
+    def _initialize_torch_state(  # noqa: C901
+        # Union[ShardedQuantEmbeddingBagCollection, ShardedQuantEmbeddingCollection]
+        self,
+        tbes: Dict[IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig],
+        tables_weights_prefix: str,  # "embedding_bags" or "embeddings"
+    ) -> None:  # noqa
+        assert (
+            tables_weights_prefix == "embedding_bags"
+            or tables_weights_prefix == "embeddings"
+        )
+        # pyre-ignore[16]
+        self._table_name_to_local_shards: Dict[str, List[Shard]] = {}
+        # pyre-ignore[16]
+        self._table_name_to_sharded_tensor: Dict[
+            str, Union[torch.Tensor, ShardedTensorBase]
+        ] = {}
+        # pyre-ignore[16]
+        self._table_name_to_local_shards_qss: Dict[str, List[Shard]] = {}
+        # pyre-ignore[16]
+        self._table_name_to_sharded_tensor_qss: Dict[
+            str, Union[torch.Tensor, ShardedTensorBase]
+        ] = {}
+
+        for tbe, config in tbes.items():
+            for (tbe_split_w, tbe_split_wq), table in zip(
+                tbe.split_embedding_weights(split_scale_shifts=True),
+                config.embedding_tables,
+            ):
+                metadata = copy.deepcopy(table.local_metadata)
+                metadata.shard_sizes = [tbe_split_w.size(0), tbe_split_w.size(1)]
+
+                # TODO(ivankobzarev): only for "meta" sharding support: cleanup when copy to  "meta" moves all tensors to "meta"
+                if metadata.placement.device != tbe_split_w.device:
+                    metadata.placement = _remote_device(tbe_split_w.device)
+                _append_table_shard(
+                    # pyre-ignore
+                    self._table_name_to_local_shards,
+                    table.name,
+                    Shard(tensor=tbe_split_w, metadata=metadata),
+                )
+
+                metadata = copy.deepcopy(table.local_metadata)
+                shard_sizes = metadata.shard_sizes
+                shard_sizes_cols = shard_sizes[1]
+                shard_offsets = table.local_metadata.shard_offsets
+                shard_offsets_cols = shard_offsets[1]
+                col_idx = int(shard_offsets_cols / shard_sizes_cols)
+                qss_cols_size = tbe_split_wq.shape[1]
+
+                qss_metadata = ShardMetadata(
+                    shard_offsets=[
+                        metadata.shard_offsets[0],
+                        col_idx * qss_cols_size,
+                    ],
+                    shard_sizes=[tbe_split_wq.shape[0], tbe_split_wq.shape[1]],
+                    placement=table.local_metadata.placement,
+                )
+                # TODO(ivankobzarev): only for "meta" sharding support: cleanup when copy to  "meta" moves all tensors to "meta"
+                # pyre-ignore[16]
+                if qss_metadata.placement.device != tbe_split_wq.device:
+                    qss_metadata.placement = _remote_device(tbe_split_wq.device)
+                _append_table_shard(
+                    # pyre-ignore
+                    self._table_name_to_local_shards_qss,
+                    table.name,
+                    Shard(tensor=tbe_split_wq, metadata=qss_metadata),
+                )
+
+        for table_name_to_local_shards, table_name_to_sharded_tensor in [
+            (self._table_name_to_local_shards, self._table_name_to_sharded_tensor),
+            (
+                self._table_name_to_local_shards_qss,
+                self._table_name_to_sharded_tensor_qss,
+            ),
+        ]:
+            # pyre-ignore
+            for table_name, local_shards in table_name_to_local_shards.items():
+                if len(local_shards) == 1:
+                    # Single Tensor per table (TW sharding)
+                    # pyre-ignore
+                    table_name_to_sharded_tensor[table_name] = local_shards[0].tensor
+                    continue
+
+                # ShardedTensor per table
+                global_rows = max(
+                    [
+                        ls.metadata.shard_offsets[0] + ls.metadata.shard_sizes[0]
+                        for ls in local_shards
+                    ]
+                )
+                global_cols = max(
+                    [
+                        ls.metadata.shard_offsets[1] + ls.metadata.shard_sizes[1]
+                        for ls in local_shards
+                    ]
+                )
+                global_metadata: ShardedTensorMetadata = ShardedTensorMetadata(
+                    shards_metadata=[ls.metadata for ls in local_shards],
+                    size=torch.Size([global_rows, global_cols]),
+                    tensor_properties=TensorProperties(
+                        dtype=torch.uint8,
+                    ),
+                )
+                # pyre-ignore
+                table_name_to_sharded_tensor[
+                    table_name
+                ] = ShardedTensorBase._init_from_local_shards_and_global_metadata(
+                    local_shards=local_shards,
+                    sharded_tensor_metadata=global_metadata,
+                )
+
+        def post_state_dict_hook(
+            # Union["ShardedQuantEmbeddingBagCollection", "ShardedQuantEmbeddingCollection"]
+            module: ShardedQuantEmbeddingModuleState[CompIn, DistOut, Out, ShrdCtx],
+            destination: Dict[str, torch.Tensor],
+            prefix: str,
+            _local_metadata: Dict[str, Any],
+        ) -> None:
+            for (
+                table_name,
+                sharded_t,
+            ) in module._table_name_to_sharded_tensor.items():  # pyre-ignore
+                destination[
+                    f"{prefix}{tables_weights_prefix}.{table_name}.weight"
+                ] = sharded_t
+            for (
+                table_name,
+                sharded_t,
+            ) in module._table_name_to_sharded_tensor_qss.items():  # pyre-ignore
+                destination[
+                    f"{prefix}{tables_weights_prefix}.{table_name}.weight_qscaleshift"
+                ] = sharded_t
+
+        self._register_state_dict_hook(post_state_dict_hook)
+
+    def _load_from_state_dict(
+        # Union["ShardedQuantEmbeddingBagCollection", "ShardedQuantEmbeddingCollection"]
+        self,
+        state_dict: Mapping[str, Any],
+        prefix: str,
+        # pyre-ignore
+        local_metadata,
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ) -> None:
+        dst_state_dict = self.state_dict()
+        _missing_keys: List[str] = []
+        _unexpected_keys: List[str] = list(state_dict.keys())
+        for name, dst_tensor in dst_state_dict.items():
+            src_state_dict_name = prefix + name
+            if src_state_dict_name not in state_dict:
+                _missing_keys.append(src_state_dict_name)
+                continue
+
+            src_tensor = state_dict[src_state_dict_name]
+            if isinstance(dst_tensor, ShardedTensorBase) and isinstance(
+                src_tensor, ShardedTensorBase
+            ):
+                # sharded to sharded model, only identically sharded
+                for dst_local_shard in dst_tensor.local_shards():
+                    copied: bool = False
+                    for src_local_shard in src_tensor.local_shards():
+                        if (
+                            dst_local_shard.metadata.shard_offsets
+                            == src_local_shard.metadata.shard_offsets
+                            and dst_local_shard.metadata.shard_sizes
+                            == src_local_shard.metadata.shard_sizes
+                        ):
+                            dst_local_shard.tensor.copy_(src_local_shard.tensor)
+                            copied = True
+                            break
+                    assert copied, "Incompatible state_dict"
+            elif isinstance(dst_tensor, ShardedTensorBase) and isinstance(
+                src_tensor, torch.Tensor
+            ):
+                # non_sharded to sharded model
+                for dst_local_shard in dst_tensor.local_shards():
+                    dst_tensor = dst_local_shard.tensor
+                    assert src_tensor.ndim == dst_tensor.ndim
+                    meta = dst_local_shard.metadata
+                    t = src_tensor.detach()
+                    rows_from = meta.shard_offsets[0]
+                    rows_to = rows_from + meta.shard_sizes[0]
+                    if t.ndim == 1:
+                        dst_tensor.copy_(t[rows_from:rows_to])
+                    elif t.ndim == 2:
+                        cols_from = meta.shard_offsets[1]
+                        if cols_from >= t.shape[1]:
+                            # CW sharding qscaleshift handle:
+                            cols_from = 0
+                        cols_to = cols_from + meta.shard_sizes[1]
+                        dst_tensor.copy_(
+                            t[
+                                rows_from:rows_to,
+                                cols_from:cols_to,
+                            ]
+                        )
+                    else:
+                        raise RuntimeError("Tensors with ndim > 2 are not supported")
+            else:
+                dst_tensor.copy_(src_tensor)
+
+            _unexpected_keys.remove(src_state_dict_name)
+        missing_keys.extend(_missing_keys)
+        unexpected_keys.extend(_unexpected_keys)

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -9,8 +9,16 @@ from typing import Any, Dict, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import KJTAllToAll, PooledEmbeddingsReduceScatter
-from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.dist_data import (
+    EmbeddingsAllToOneReduce,
+    KJTAllToAll,
+    KJTOneToAll,
+    PooledEmbeddingsReduceScatter,
+)
+from torchrec.distributed.embedding_lookup import (
+    GroupedPooledEmbeddingsLookup,
+    InferGroupedPooledEmbeddingsLookup,
+)
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingDist,
     BaseEmbeddingLookup,
@@ -25,11 +33,13 @@ from torchrec.distributed.embedding_types import (
     BaseGroupedFeatureProcessor,
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
+    KJTList,
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.types import (
     Awaitable,
     CommOp,
+    NullShardingContext,
     QuantizedCommCodecs,
     ShardedTensorMetadata,
     ShardingEnv,
@@ -305,6 +315,49 @@ class RwPooledEmbeddingDist(
             return self._dist(local_embs, input_splits=sharding_ctx.batch_size_per_rank)
 
 
+class InferRwPooledEmbeddingDist(
+    BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]
+):
+    """
+    Redistributes sequence embedding tensor in RW fashion with an AlltoOne operation.
+
+    Args:
+        device (torch.device): device on which the tensors will be communicated to.
+        world_size (int): number of devices in the topology.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        world_size: int,
+    ) -> None:
+        super().__init__()
+        self._dist: EmbeddingsAllToOneReduce = EmbeddingsAllToOneReduce(
+            device=device,
+            world_size=world_size,
+            cat_dim=1,
+        )
+
+    def forward(
+        self,
+        local_embs: List[torch.Tensor],
+        sharding_ctx: Optional[NullShardingContext] = None,
+    ) -> torch.Tensor:
+        """
+        Performs AlltoOne operation on sequence embeddings tensor.
+
+        Args:
+            local_embs (torch.Tensor): tensor of values to distribute.
+
+        Returns:
+            Awaitable[torch.Tensor]: awaitable of sequence embeddings.
+        """
+
+        return self._dist(
+            local_embs,
+        )
+
+
 class RwPooledEmbeddingSharding(
     BaseRwEmbeddingSharding[
         EmbeddingShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
@@ -355,4 +408,101 @@ class RwPooledEmbeddingSharding(
             #  `Optional[ProcessGroup]`.
             self._pg,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )
+
+
+class InferRwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
+    def __init__(
+        self,
+        world_size: int,
+        num_features: int,
+        feature_hash_sizes: List[int],
+        device: Optional[torch.device] = None,
+        is_sequence: bool = False,
+        has_feature_processor: bool = False,
+        need_pos: bool = False,
+    ) -> None:
+        super().__init__()
+        self._world_size: int = world_size
+        self._num_features = num_features
+        feature_block_sizes = [
+            (hash_size + self._world_size - 1) // self._world_size
+            for hash_size in feature_hash_sizes
+        ]
+        self.register_buffer(
+            "_feature_block_sizes_tensor",
+            torch.tensor(
+                feature_block_sizes,
+                device=device,
+                dtype=torch.int32,
+            ),
+        )
+        self._dist = KJTOneToAll(
+            splits=self._world_size * [self._num_features], world_size=world_size
+        )
+        if is_sequence:
+            raise NotImplementedError()
+        self._is_sequence = is_sequence
+        self._has_feature_processor = has_feature_processor
+        self._need_pos = need_pos
+        self.unbucketize_permute_tensor: Optional[torch.Tensor] = None
+
+    def forward(
+        self,
+        sparse_features: KeyedJaggedTensor,
+    ) -> KJTList:
+
+        (
+            bucketized_features,
+            self.unbucketize_permute_tensor,
+        ) = bucketize_kjt_before_all2all(
+            sparse_features,
+            num_buckets=self._world_size,
+            block_sizes=self._feature_block_sizes_tensor,
+            output_permute=self._is_sequence,
+            bucketize_pos=self._has_feature_processor
+            if sparse_features.weights_or_none() is None
+            else self._need_pos,
+        )
+        # TODO(ivankobzarev): Store self.unbucketize_permute_tensor in Context for is_sequence
+        return self._dist(bucketized_features)
+
+
+class InferRwPooledEmbeddingSharding(
+    BaseRwEmbeddingSharding[
+        NullShardingContext, KJTList, List[torch.Tensor], torch.Tensor
+    ]
+):
+    def create_input_dist(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> BaseSparseFeaturesDist[KJTList]:
+        num_features = self._get_num_features()
+        feature_hash_sizes = self._get_feature_hash_sizes()
+        return InferRwSparseFeaturesDist(
+            world_size=self._world_size,
+            num_features=num_features,
+            feature_hash_sizes=feature_hash_sizes,
+        )
+
+    def create_lookup(
+        self,
+        device: Optional[torch.device] = None,
+        fused_params: Optional[Dict[str, Any]] = None,
+        feature_processor: Optional[BaseGroupedFeatureProcessor] = None,
+    ) -> BaseEmbeddingLookup[KJTList, List[torch.Tensor]]:
+        return InferGroupedPooledEmbeddingsLookup(
+            grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
+            world_size=self._world_size,
+            fused_params=fused_params,
+        )
+
+    def create_output_dist(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]:
+        assert device is not None
+        return InferRwPooledEmbeddingDist(
+            device=device,
+            world_size=self._world_size,
         )

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -202,7 +202,6 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
         )
-        fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = True
         return ShardedQuantEmbeddingBagCollection(
             module=module,
             table_name_to_parameter_sharding=params,

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import copy
+import unittest
+from typing import List, Tuple
+
+import torch
+from torch.distributed._shard.sharding_spec import ShardingSpec
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel, ShardingType
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.shard_estimators import (
+    EmbeddingPerfEstimator,
+    EmbeddingStorageEstimator,
+)
+from torchrec.distributed.shard import _shard_modules
+
+from torchrec.distributed.test_utils.infer_utils import (
+    model_input_to_forward_args,
+    prep_inputs,
+    quantize,
+    TestModelInfo,
+    TestQuantEBCSharder,
+    TorchTypesModelInputWrapper,
+)
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.types import (
+    ModuleShardingPlan,
+    ParameterSharding,
+    ShardingEnv,
+)
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+
+# pyre-ignore
+def assert_close(expected, got) -> None:
+    if isinstance(expected, dict):
+        for feature, jt_e in expected.items():
+            jt_got = got[feature]
+            torch.testing.assert_close(jt_e.lengths(), jt_got.lengths())
+            torch.testing.assert_close(jt_e.values(), jt_got.values())
+            torch.testing.assert_close(jt_e.offsets(), jt_got.offsets())
+    else:
+        torch.testing.assert_close(expected, got)
+
+
+def _model(
+    num_embeddings: int,
+    emb_dim: int,
+    world_size: int,
+    batch_size: int,
+    dense_device: torch.device,
+    sparse_device: torch.device,
+) -> TestModelInfo:
+    topology: Topology = Topology(world_size=world_size, compute_device="cuda")
+    mi = TestModelInfo(
+        dense_device=dense_device,
+        sparse_device=sparse_device,
+        num_features=1,
+        num_float_features=8,
+        num_weighted_features=1,
+        topology=topology,
+    )
+
+    mi.planner = EmbeddingShardingPlanner(
+        topology=topology,
+        batch_size=batch_size,
+        enumerator=EmbeddingEnumerator(
+            topology=topology,
+            batch_size=batch_size,
+            estimator=[
+                EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                EmbeddingStorageEstimator(topology=topology),
+            ],
+        ),
+    )
+
+    mi.tables = [
+        EmbeddingBagConfig(
+            num_embeddings=num_embeddings,
+            embedding_dim=emb_dim,
+            name="table_" + str(i),
+            feature_names=["feature_" + str(i)],
+        )
+        for i in range(mi.num_features)
+    ]
+
+    mi.weighted_tables = [
+        EmbeddingBagConfig(
+            num_embeddings=num_embeddings,
+            embedding_dim=emb_dim,
+            name="weighted_table_" + str(i),
+            feature_names=["weighted_feature_" + str(i)],
+        )
+        for i in range(mi.num_weighted_features)
+    ]
+
+    mi.model = TorchTypesModelInputWrapper(
+        TestSparseNN(
+            tables=mi.tables,
+            weighted_tables=mi.weighted_tables,
+            num_float_features=mi.num_float_features,
+            dense_device=dense_device,
+            sparse_device=sparse_device,
+        )
+    )
+    mi.model.training = False
+    mi.quant_model = quantize(mi.model, inplace=False)
+    return mi
+
+
+def _shard_qebc(
+    mi: TestModelInfo,
+    sharding_type: ShardingType,
+    device: torch.device,
+    expected_shards: List[Tuple[Tuple[int, int, int, int], str]],
+) -> torch.nn.Module:
+    sharder = TestQuantEBCSharder(
+        sharding_type=sharding_type.value,
+        kernel_type=EmbeddingComputeKernel.QUANT.value,
+        shardable_params=[table.name for table in mi.tables],
+    )
+    # pyre-ignore
+    plan = mi.planner.plan(
+        mi.quant_model,
+        [sharder],
+    )
+    msp: ModuleShardingPlan = plan.plan["_module.sparse.ebc"]
+    # pyre-ignore
+    ps: ParameterSharding = msp["table_0"]
+    assert ps.sharding_type == sharding_type.value
+    assert ps.sharding_spec is not None
+    sharding_spec: ShardingSpec = ps.sharding_spec
+    # pyre-ignore
+    assert len(sharding_spec.shards) == len(expected_shards)
+    for shard, ((offset_r, offset_c, size_r, size_c), placement) in zip(
+        sharding_spec.shards, expected_shards
+    ):
+        assert shard.shard_offsets == [offset_r, offset_c]
+        assert shard.shard_sizes == [size_r, size_c]
+        assert str(shard.placement) == placement
+
+    # We want to leave quant_model unchanged to compare the results with it
+    quant_model_copy = copy.deepcopy(mi.quant_model)
+    sharded_model = _shard_modules(
+        module=quant_model_copy,
+        # pyre-ignore
+        sharders=[sharder],
+        device=device,
+        plan=plan,
+        # pyre-ignore
+        env=ShardingEnv.from_local(world_size=mi.topology.world_size, rank=0),
+    )
+    return sharded_model
+
+
+class InferShardingsTest(unittest.TestCase):
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs available",
+    )
+    def test_rw(self) -> None:
+        num_embeddings = 256
+        emb_dim = 12
+        world_size = 2
+        batch_size = 4
+        local_device = torch.device("cuda:0")
+        mi = _model(
+            num_embeddings,
+            emb_dim,
+            world_size,
+            batch_size,
+            dense_device=local_device,
+            sparse_device=local_device,
+        )
+
+        non_sharded_model = mi.quant_model
+        num_emb_half = num_embeddings // 2
+        sharded_model = _shard_qebc(
+            mi,
+            sharding_type=ShardingType.ROW_WISE,
+            device=local_device,
+            expected_shards=[
+                ((0, 0, num_emb_half, emb_dim), "rank:0/cuda:0"),
+                ((num_emb_half, 0, num_emb_half, emb_dim), "rank:1/cuda:1"),
+            ],
+        )
+        inputs = [
+            model_input_to_forward_args(inp.to(local_device))
+            for inp in prep_inputs(mi, world_size, batch_size)
+        ]
+
+        sharded_model.load_state_dict(non_sharded_model.state_dict())
+
+        sharded_output = sharded_model(*inputs[0])
+        non_sharded_output = non_sharded_model(*inputs[0])
+        assert_close(sharded_output, non_sharded_output)

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -187,9 +187,12 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 torch.float,
             ]
         ),
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
-    def test_quant_pred(self, output_type: torch.dtype) -> None:
+    def test_quant_pred(self, output_type: torch.dtype, sharding_type: str) -> None:
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")
         model = TestSparseNN(
@@ -206,7 +209,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 cast(
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
-                        sharding_type=ShardingType.TABLE_WISE.value,
+                        sharding_type=sharding_type,
                         kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
@@ -230,9 +233,14 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 torch.float,
             ]
         ),
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
-    def test_quant_pred_state_dict(self, output_type: torch.dtype) -> None:
+    def test_quant_pred_state_dict(
+        self, output_type: torch.dtype, sharding_type: str
+    ) -> None:
         device = torch.device("cuda:0")
 
         model = TestSparseNN(
@@ -251,7 +259,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 cast(
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
-                        sharding_type=ShardingType.TABLE_WISE.value,
+                        sharding_type=sharding_type,
                         kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
@@ -267,7 +275,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 cast(
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
-                        sharding_type=ShardingType.TABLE_WISE.value,
+                        sharding_type=sharding_type,
                         kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
@@ -304,9 +312,14 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 torch.float,
             ]
         ),
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
-    def test_quant_pred_shard(self, output_type: torch.dtype) -> None:
+    def test_quant_pred_shard(
+        self, output_type: torch.dtype, sharding_type: str
+    ) -> None:
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")
         model = TestSparseNN(
@@ -324,7 +337,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 cast(
                     ModuleSharder[torch.nn.Module],
                     TestQuantEBCSharder(
-                        sharding_type=ShardingType.TABLE_WISE.value,
+                        sharding_type=sharding_type,
                         kernel_type=EmbeddingComputeKernel.QUANT.value,
                     ),
                 )
@@ -354,7 +367,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             sharded_model_copy(local_batch[0].to(device_1)).cpu(),
         )
 
-    # pyre-fixme[56]
+    # pyre-ignore
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
@@ -421,12 +434,17 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             for i in range(num_weighted_features)
         ]
 
-    # pyre-fixme[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
         "Not enough GPUs available",
     )
-    def test_shard_one_ebc_cuda(self) -> None:
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
+    )
+    def test_shard_one_ebc_cuda(self, sharding_type: str) -> None:
         device = torch.device("cuda:0")
         model = TestSparseNN(
             tables=self.tables,
@@ -440,7 +458,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             cast(
                 ModuleSharder[torch.nn.Module],
                 TestQuantEBCSharder(
-                    sharding_type=ShardingType.TABLE_WISE.value,
+                    sharding_type=sharding_type,
                     kernel_type=EmbeddingComputeKernel.QUANT.value,
                     shardable_params=[table.name for table in self.tables],
                 ),
@@ -482,12 +500,17 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             )
         )
 
-    # pyre-fixme[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
         "Not enough GPUs available",
     )
-    def test_shard_one_ebc_meta(self) -> None:
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
+    )
+    def test_shard_one_ebc_meta(self, sharding_type: str) -> None:
         device = torch.device("cuda:0")
         model = TestSparseNN(
             tables=self.tables,
@@ -501,7 +524,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             cast(
                 ModuleSharder[torch.nn.Module],
                 TestQuantEBCSharder(
-                    sharding_type=ShardingType.TABLE_WISE.value,
+                    sharding_type=sharding_type,
                     kernel_type=EmbeddingComputeKernel.QUANT.value,
                     shardable_params=[table.name for table in self.tables],
                 ),
@@ -544,12 +567,17 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             )
         )
 
-    # pyre-fixme[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
         "Not enough GPUs available",
     )
-    def test_shard_all_ebcs(self) -> None:
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
+    )
+    def test_shard_all_ebcs(self, sharding_type: str) -> None:
         device = torch.device("cuda:0")
         model = TestSparseNN(
             tables=self.tables,
@@ -563,7 +591,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             cast(
                 ModuleSharder[torch.nn.Module],
                 TestQuantEBCSharder(
-                    sharding_type=ShardingType.TABLE_WISE.value,
+                    sharding_type=sharding_type,
                     kernel_type=EmbeddingComputeKernel.QUANT.value,
                 ),
             )
@@ -604,12 +632,17 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             )
         )
 
-    # pyre-fixme[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
         "Not enough GPUs available",
     )
-    def test_sharder_bad_param_config(self) -> None:
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
+    )
+    def test_sharder_bad_param_config(self, sharding_type: str) -> None:
         device = torch.device("cuda:0")
         model = TestSparseNN(
             tables=self.tables,
@@ -623,7 +656,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             cast(
                 ModuleSharder[torch.nn.Module],
                 TestQuantEBCSharder(
-                    sharding_type=ShardingType.TABLE_WISE.value,
+                    sharding_type=sharding_type,
                     kernel_type=EmbeddingComputeKernel.QUANT.value,
                     shardable_params=[
                         table.name for table in self.tables[:-1]


### PR DESCRIPTION
Summary:
## Introducing RowWise sharding for inference for ShardedQuantEmbeddingBagCollection.

quant_embedding.py:
Registering RW sharding: InferRwPooledEmbeddingSharding

The logic repeats the training row wise sharding, with inference changes:
 - inference works in single process (no process group), so distributions from KJTAllToAll -> KJTOneToAll, EmbeddingsAllToOneReduce
- ShardedTensor can not be used for single process sharding when all shards are "local" in terms of multiprocess => using ShardedTensorBase to represent the weights state

## The state management:

The weights sharding state represented via state_dict(), using ShardingTensorBase (instead of ShardingTensor for training).

As we are in single process mode - all our shards are "local" in terms of multiprocess-distributed environment.
ShardedTensorBase allows to have multiple local shards.

So for ShardedQEBC the state_dict has type `Dict[str, Union[Tensor, ShardedTensorBase]]`

E.g. for nonsharded quantized model  (for fbgemm rowwise quantization):
```
ebc.embedding_bags.table_0.weight: Tensor
ebc.embedding_bags.table_0.weight_qscaleshift: Tensor
```

For sharded quantized model:
```
ebc.embedding_bags.table_0.weight: ShardedTensorBase
ebc.embedding_bags.table_0.weight_qscaleshift: ShardedTensorBase
```

The logic for representing state_dict of ShardedQEBC and ShardedQEC is extracted to `ShardedQuantEmbeddingModuleStateMixIn` in `quant_state.py`.
ShardedQEBC and ShardedQEC has this MixIn in parent class (must be before ShardedEmbeddingModule, as it is also torch.nn.Module and will override _load_state_dict override) and call its `_initialize_torch_state()` in constructor.

MixIn overrides `_load_from_state_dict` to support state_dict loading between sharded and unsharded models e.i:
```
sharded_model.load_state_dict(non_sharded_model.state_dict())
```
ShardedTensorBase has all information in local_shards to copy necessary tensor views of non_sharded_model weights.

## Tests

`torchrec/distributed/tests/test_quant_model_parallel.py` - adding ROW_WISE sharding to quant models tests.

`test_infer_shardings.py` - inference specific tests for shardings.

Differential Revision:
D45200634

Privacy Context Container: L1138451

