### PR TITLE
Remove unncessary wait typing from quant modules

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -7,7 +7,7 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import nn
@@ -361,7 +361,7 @@ class BaseSparseFeaturesDist(abc.ABC, nn.Module, Generic[F]):
     def forward(
         self,
         sparse_features: KeyedJaggedTensor,
-    ) -> Awaitable[Awaitable[F]]:
+    ) -> Union[Awaitable[Awaitable[F]], F]:
         pass
 
 
@@ -375,7 +375,7 @@ class BaseEmbeddingDist(abc.ABC, nn.Module, Generic[C, T, W]):
         self,
         local_embs: T,
         sharding_ctx: Optional[C] = None,
-    ) -> Awaitable[W]:
+    ) -> Union[Awaitable[W], W]:
         pass
 
 

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -294,7 +294,7 @@ class ShardedQuantEmbeddingCollection(
 
             return ListOfKJTList(
                 [
-                    self._input_dists[i].forward(features_by_sharding[i]).wait().wait()
+                    self._input_dists[i].forward(features_by_sharding[i])
                     for i in range(len(self._input_dists))
                 ]
             )
@@ -324,7 +324,7 @@ class ShardedQuantEmbeddingCollection(
             output,
             ctx.sharding_contexts,
         ):
-            emb_per_sharding.append(odist.forward(embeddings, sharding_ctx).wait())
+            emb_per_sharding.append(odist.forward(embeddings, sharding_ctx))
             features_per_sharding.append(sharding_ctx.features)
 
         return output_jt_dict(

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -171,7 +171,7 @@ class InferTwSequenceEmbeddingDist(
         self,
         local_embs: List[torch.Tensor],
         sharding_ctx: Optional[InferSequenceShardingContext] = None,
-    ) -> Awaitable[List[torch.Tensor]]:
+    ) -> List[torch.Tensor]:
         """
         Performs AlltoOne operation on sequence embeddings tensor.
 

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -372,7 +372,7 @@ class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
     def forward(
         self,
         sparse_features: KeyedJaggedTensor,
-    ) -> Awaitable[Awaitable[KJTList]]:
+    ) -> KJTList:
         """
         Performs OnetoAll operation on sparse features.
 
@@ -382,7 +382,7 @@ class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
         Returns:
             Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
-        return NoWait(self._dist.forward(sparse_features))
+        return self._dist.forward(sparse_features)
 
 
 class InferTwPooledEmbeddingDist(
@@ -408,7 +408,7 @@ class InferTwPooledEmbeddingDist(
         self,
         local_embs: List[torch.Tensor],
         sharding_ctx: Optional[NullShardingContext] = None,
-    ) -> Awaitable[torch.Tensor]:
+    ) -> torch.Tensor:
         """
         Performs AlltoOne operation on pooled embedding tensors.
 


### PR DESCRIPTION
Summary: Currently structure for input_dist/output_dist for quant modules are a bit confusing because they try to adhere to the Awaitable structure of training modules. However, fundamentally they are not using collective calls and these don't make sense. We get around the type issue with NoWaits, which is confusing - so getting rid of them.

Reviewed By: IvanKobzarev

Differential Revision: D45449316

