### PR TITLE
Derive TwRw sharding intra/cross pg backends from ShardingEnv

### DIFF
--- a/torchrec/distributed/comm.py
+++ b/torchrec/distributed/comm.py
@@ -100,6 +100,7 @@ def get_num_groups(world_size: Optional[int] = None) -> int:
 
 def intra_and_cross_node_pg(
     device: Optional[torch.device] = None,
+    backend: Optional[str] = None,
 ) -> Tuple[Optional[dist.ProcessGroup], Optional[dist.ProcessGroup]]:
     """
     Creates sub process groups (intra and cross node)
@@ -116,7 +117,8 @@ def intra_and_cross_node_pg(
     local_size = get_local_size(my_size)
     my_group_rank = get_group_rank(my_size, my_rank)
     group_count = get_num_groups(my_size)
-    backend = dist.get_backend()
+    if backend is None:
+        backend = dist.get_backend()
 
     logger.info(
         f"[{my_rank}] my_local_rank = {my_local_rank}, local_size = {local_size},"

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -71,7 +71,9 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._rank: int = self._env.rank
         self._device = device
         self._need_pos = need_pos
-        intra_pg, cross_pg = intra_and_cross_node_pg(device)
+        intra_pg, cross_pg = intra_and_cross_node_pg(
+            device, backend=dist.get_backend(self._pg)
+        )
         self._intra_pg: Optional[dist.ProcessGroup] = intra_pg
         self._cross_pg: Optional[dist.ProcessGroup] = cross_pg
         self._local_size: int = (


### PR DESCRIPTION
Summary: TwRw sharding currently creates separate process groups for intra and cross device communications. These groups currently derive the dist backend from the default group, which may not be the same as the backend specified by the ShardingEnv's PG. Update the comm `intra_and_cross_node_pg` function to take an optional backend parameter and update the callsite within TwRw sharding to pass the ShardingEnv's PG's backend as input.

An example failure of this is if we first initialize a default process group with GLOO (e.g. calling init_process_group("gloo")) at some point in the program before we invoke sharding logic, we will have initialized a default pg (from which intra/cross TWRW PGs will be derived) which will not be compatible with some substeps within TWRW sharding (e.g. reduce_scatter)

Differential Revision: D45469413

