### PR TITLE
Back out "Making physical and logical size the same for QEBC/QEC shardable parameters"

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -9,18 +9,7 @@ import abc
 import copy
 import itertools
 from dataclasses import dataclass
-from typing import (
-    Any,
-    cast,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, cast, Dict, Iterator, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -436,10 +425,7 @@ def _gen_named_parameters_by_table_dense(
         yield (table_name, weight)
 
 
-SplitWeightType = TypeVar("SplitWeightType")
-
-
-class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
+class BaseBatchedEmbedding(BaseEmbedding):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -503,14 +489,13 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
         self.flush()
         return get_state_dict(
             self._config.embedding_tables,
-            # pyre-ignore
             self.split_embedding_weights(),
             self._pg,
             destination,
             prefix,
         )
 
-    def split_embedding_weights(self) -> List[SplitWeightType]:
+    def split_embedding_weights(self) -> List[torch.Tensor]:
         return self.emb_module.split_embedding_weights()
 
     @property
@@ -556,7 +541,7 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
             yield name, param
 
 
-class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerModule):
+class BatchedFusedEmbedding(BaseBatchedEmbedding, FusedOptimizerModule):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -647,7 +632,7 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
         self._emb_module.flush()
 
 
-class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
+class BatchedDenseEmbedding(BaseBatchedEmbedding):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -697,7 +682,7 @@ class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
         )
 
 
-class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
+class BaseBatchedEmbeddingBag(BaseEmbedding):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -769,14 +754,13 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         self.flush()
         return get_state_dict(
             self._config.embedding_tables,
-            # pyre-ignore
             self.split_embedding_weights(),
             self._pg,
             destination,
             prefix,
         )
 
-    def split_embedding_weights(self) -> List[SplitWeightType]:
+    def split_embedding_weights(self) -> List[torch.Tensor]:
         return self.emb_module.split_embedding_weights()
 
     @property
@@ -822,9 +806,7 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
             yield name, param
 
 
-class BatchedFusedEmbeddingBag(
-    BaseBatchedEmbeddingBag[torch.Tensor], FusedOptimizerModule
-):
+class BatchedFusedEmbeddingBag(BaseBatchedEmbeddingBag, FusedOptimizerModule):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -918,7 +900,7 @@ class BatchedFusedEmbeddingBag(
         self._emb_module.flush()
 
 
-class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
+class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -8,7 +8,7 @@
 import abc
 import logging
 from collections import defaultdict, OrderedDict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -54,7 +54,6 @@ def get_state_dict(
         nn.ModuleList,
         List[Union[nn.Module, torch.Tensor]],
         List[torch.Tensor],
-        List[Tuple[torch.Tensor, Optional[torch.Tensor]]],
     ],
     pg: Optional[dist.ProcessGroup] = None,
     destination: Optional[Dict[str, Any]] = None,
@@ -77,21 +76,14 @@ def get_state_dict(
 
     for embedding_table, param in zip(embedding_tables, params):
         key = get_key_from_embedding_table(embedding_table)
-        is_quant = embedding_table.compute_kernel in [
+        assert embedding_table.local_rows == param.size(0)
+        if embedding_table.compute_kernel not in [
             EmbeddingComputeKernel.QUANT,
             EmbeddingComputeKernel.QUANT_UVM,
             EmbeddingComputeKernel.QUANT_UVM_CACHING,
-        ]
-        qscaleshift_split = None
-        if is_quant:
-            # For QUANT* param is Tuple[torch.Tensor, Optional[torch.Tensor]] where first argument is the weight table, the second is optional quantization extra information, depending on quantization type. e.g. for fbgemm rowwise quantization this is scale and shift for each row.
-            assert isinstance(param, tuple)
-            qscaleshift_split = param[1]
-            param = param[0]
-
-        assert embedding_table.local_rows == param.size(0)
-        assert embedding_table.local_cols == param.size(1)
-
+        ]:
+            assert embedding_table.local_cols == param.size(1)
+        # for inference there is no pg, all tensors are local
         if embedding_table.global_metadata is not None and pg is not None:
             # set additional field of sharded tensor based on local tensor properties
             embedding_table.global_metadata.tensor_properties.dtype = param.dtype
@@ -105,8 +97,6 @@ def get_state_dict(
             )
         else:
             destination[key] = param
-            if qscaleshift_split is not None:
-                destination[f"{key}_qscaleshift"] = qscaleshift_split
 
     if pg is not None:
         # Populate the remaining destinations that have a global metadata

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -407,7 +407,7 @@ class MetaInferGroupedEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbedding[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
+        ) -> BaseBatchedEmbedding:
             return QuantBatchedEmbedding(
                 config=config,
                 device=device,
@@ -524,7 +524,7 @@ class MetaInferGroupedPooledEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbeddingBag[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
+        ) -> BaseBatchedEmbeddingBag:
             return QuantBatchedEmbeddingBag(
                 config=config,
                 device=device,

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -256,9 +256,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         )
 
         expected_perfs = {
-            ("quant", "table_wise"): [0.00010892300302767036],
-            ("quant_uvm", "table_wise"): [0.01637795392204734],
-            ("quant_uvm_caching", "table_wise"): [0.0038054723505752935],
+            ("quant", "table_wise"): [0.0001296231579222408],
+            ("quant_uvm", "table_wise"): [0.018350937787224266],
+            ("quant_uvm_caching", "table_wise"): [0.004269758427175579],
         }
 
         perfs = {

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -206,19 +206,13 @@ class ShardedQuantEmbeddingCollection(
         ):
             lookup_state_dict = lookup.state_dict()
             for key in lookup_state_dict:
-                if key.endswith(".weight"):
-                    table_name = key[: -len(".weight")]
-                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                    self.embeddings[table_name].register_buffer(
-                        "weight", lookup_state_dict[key]
-                    )
-                elif key.endswith(".weight_qscaleshift"):
-                    table_name = key[: -len(".weight_qscaleshift")]
-                    self.embeddings[table_name].register_buffer(
-                        "weight_qscaleshift", lookup_state_dict[key]
-                    )
-                else:
+                if not key.endswith(".weight"):
                     continue
+                table_name = key[: -len(".weight")]
+                # Register as buffer because this is an inference model, and can potentially use uint8 types.
+                self.embeddings[table_name].register_buffer(
+                    "weight", lookup_state_dict[key]
+                )
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -135,19 +135,13 @@ class ShardedQuantEmbeddingBagCollection(
         ):
             lookup_state_dict = lookup.state_dict()
             for key in lookup_state_dict:
-                if key.endswith(".weight"):
-                    table_name = key[: -len(".weight")]
-                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                    self.embedding_bags[table_name].register_buffer(
-                        "weight", lookup_state_dict[key]
-                    )
-                elif key.endswith("weight_qscaleshift"):
-                    table_name = key[: -len(".weight_qscaleshift")]
-                    self.embedding_bags[table_name].register_buffer(
-                        "weight_qscaleshift", lookup_state_dict[key]
-                    )
-                else:
+                if not key.endswith(".weight"):
                     continue
+                table_name = key[: -len(".weight")]
+                # Register as buffer because this is an inference model, and can potentially use uint8 types.
+                self.embedding_bags[table_name].register_buffer(
+                    "weight", lookup_state_dict[key]
+                )
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -21,7 +21,7 @@ from torchrec.distributed.planner.shard_estimators import (
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
-from torchrec.distributed.shard import _shard_modules
+from torchrec.distributed.shard import shard_modules
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     ModelInput,
@@ -318,7 +318,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
         quant_model = _quantize(model, inplace=True, output_type=output_type)
 
-        sharded_model = _shard_modules(
+        sharded_model = shard_modules(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -15,7 +15,7 @@ from hypothesis import given, settings, Verbosity
 from torch import nn, quantization as quant
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
-from torchrec.distributed.shard import _shard_modules
+from torchrec.distributed.shard import shard_modules
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNNBase
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     InferenceModelParallelTestBase,
@@ -152,7 +152,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
 
         quant_model = _quantize(model)
 
-        sharded_quant_model = _shard_modules(
+        sharded_quant_model = shard_modules(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -266,8 +266,8 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         for (_key, tables), emb_module in zip(
             self._key_to_tables.items(), self._emb_modules
         ):
-            for embedding_config, (weight, qscaleshift) in zip(
-                tables, emb_module.split_embedding_weights(split_scale_shifts=True)
+            for embedding_config, (weight, _) in zip(
+                tables, emb_module.split_embedding_weights(split_scale_shifts=False)
             ):
                 self.embedding_bags[embedding_config.name] = torch.nn.Module()
                 # register as a buffer so it's exposed in state_dict.
@@ -276,9 +276,6 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
                 # Additionally, we cannot expose uint8 weights as parameters due to autograd restrictions.
                 self.embedding_bags[embedding_config.name].register_buffer(
                     "weight", weight
-                )
-                self.embedding_bags[embedding_config.name].register_buffer(
-                    "weight_qscaleshift", qscaleshift
                 )
         self.register_tbes = register_tbes
         if register_tbes:
@@ -514,11 +511,8 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             # TODO: register as param instead of buffer
             # however, since this is only needed for inference, we do not need to expose it as part of parameters.
             # Additionally, we cannot expose uint8 weights as parameters due to autograd restrictions.
-            weights_list = emb_module.split_embedding_weights(split_scale_shifts=True)
+            weights_list = emb_module.split_embedding_weights(split_scale_shifts=False)
             self.embeddings[config.name].register_buffer("weight", weights_list[0][0])
-            self.embeddings[config.name].register_buffer(
-                "weight_qscaleshift", weights_list[0][1]
-            )
 
             if not config.feature_names:
                 config.feature_names = [config.name]

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -78,9 +78,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         # test state dict
         state_dict = ebc.state_dict()
         quantized_state_dict = qebc.state_dict()
-        self.assertTrue(
-            set(state_dict.keys()).issubset(set(quantized_state_dict.keys()))
-        )
+        self.assertEqual(state_dict.keys(), quantized_state_dict.keys())
 
     # pyre-fixme[56]
     @given(
@@ -341,9 +339,8 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         test_model.ebc = QuantEmbeddingBagCollection.from_float(ebc)
 
         state_dict = test_model.state_dict()
-        self.assertTrue(
-            set(before_quant_state_dict.keys()).issubset(set(state_dict.keys()))
-        )
+        self.assertEqual(state_dict.keys(), before_quant_state_dict.keys())
+        test_model.load_state_dict(state_dict)
 
     def test_trace_and_script(self) -> None:
         data_type = DataType.FP16


### PR DESCRIPTION
Summary:
Original commit changeset: fdf49712e2f0

Original Phabricator Diff: D45153483

it caused several issues for MRS model publish

Differential Revision: D45558272

