### PR TITLE
Print the breakdown of perf in stats

### DIFF
--- a/torchrec/distributed/planner/perf_models.py
+++ b/torchrec/distributed/planner/perf_models.py
@@ -7,7 +7,7 @@
 
 from typing import cast, List
 
-from torchrec.distributed.planner.types import PerfModel, ShardingOption, Topology
+from torchrec.distributed.planner.types import Perf, PerfModel, ShardingOption, Topology
 
 
 class NoopPerfModel(PerfModel):
@@ -19,6 +19,6 @@ class NoopPerfModel(PerfModel):
         for sharding_option in plan:
             for shard in sharding_option.shards:
                 # pyre-ignore [6]: Expected `typing_extensions.SupportsIndex`
-                perfs[shard.rank] += cast(float, shard.perf)
+                perfs[shard.rank] += cast(Perf, shard.perf).total
 
         return max(perfs)

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -10,7 +10,7 @@ import logging
 from decimal import Decimal
 from typing import cast, Dict, List, Optional, Set, Tuple
 
-from torchrec.distributed.planner.types import Proposer, ShardingOption
+from torchrec.distributed.planner.types import Perf, Proposer, ShardingOption
 from torchrec.distributed.planner.utils import prod
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -28,7 +28,8 @@ class GreedyProposer(Proposer):
 
     Args:
         use_depth (bool): When enabled, sharding_options of a fqn are sorted based on
-            `max(shard.perf)`, otherwise sharding_options are sorted by `sum(shard.perf)`.
+            `max(shard.perf.total)`, otherwise sharding_options are sorted by
+            `sum(shard.perf.total)`.
         threshold (Optional[int]): Threshold for early stopping. When specified, the
             proposer stops proposing when the proposals have consecutive worse perf_rating
             than best_perf_rating.
@@ -252,9 +253,9 @@ def _sharding_option_score(
     sharding_option: ShardingOption, use_depth: bool = True
 ) -> float:
     return (
-        max([cast(float, shard.perf) for shard in sharding_option.shards])
+        max([cast(Perf, shard.perf).total for shard in sharding_option.shards])
         if use_depth
-        else sum([cast(float, shard.perf) for shard in sharding_option.shards])
+        else sum([cast(Perf, shard.perf).total for shard in sharding_option.shards])
     )
 
 

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -203,7 +203,7 @@ class EmbeddingStats(Stats):
 
             rank_hbm = f"{round(used_hbm_gb, 1)} ({used_hbm_ratio:.0%})"
             rank_ddr = f"{round(used_ddr_gb, 1)} ({used_ddr_ratio:.0%})"
-            rank_total_perf = f"{round(perf[rank].total, 3)}"
+            rank_perf = _format_perf_breakdown(perf[rank])
             rank_input = f"{round(stats[rank]['input_sizes'], 2)}"
             rank_output = f"{round(stats[rank]['output_sizes'], 2)}"
             rank_shards = " ".join(
@@ -215,7 +215,7 @@ class EmbeddingStats(Stats):
                     rank,
                     rank_hbm,
                     rank_ddr,
-                    rank_total_perf,
+                    rank_perf,
                     rank_input,
                     rank_output,
                     rank_shards,
@@ -265,10 +265,13 @@ class EmbeddingStats(Stats):
             for i, so in enumerate(best_plan):
                 ranks = sorted([cast(int, shard.rank) for shard in so.shards])
                 ranks = _collapse_consecutive_ranks(ranks)
-                shard_perfs = [cast(Perf, shard.perf) for shard in so.shards]
-                shard_total_perfs = str(
-                    round(sum([perf.total for perf in shard_perfs]), 3)
-                )
+
+                so_perf = Perf(fwd_compute=0, fwd_comms=0, bwd_compute=0, bwd_comms=0)
+                for shard in so.shards:
+                    so_perf += cast(Perf, shard.perf)
+
+                shard_perfs = _format_perf_breakdown(so_perf)
+
                 pooling_factor = str(round(sum(so.input_lengths), 3))
                 num_poolings = (
                     cast(List[float], constraints[so.name].num_poolings)
@@ -287,7 +290,7 @@ class EmbeddingStats(Stats):
                         so.fqn,
                         _get_sharding_type_abbr(so.sharding_type),
                         so.compute_kernel,
-                        shard_total_perfs,
+                        shard_perfs,
                         pooling_factor,
                         num_poolings,
                         output,
@@ -321,9 +324,11 @@ class EmbeddingStats(Stats):
         for row in formatted_table:
             self._stats_table.append(f"# {row: <{self._width-3}}#")
 
+        perf_breakdown = "Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms)"
         legend = "Input: MB/iteration, Output: MB/iteration, Shards: number of tables"
         hbm_info = "HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)"
         self._stats_table.append(f"#{'' : ^{self._width-2}}#")
+        self._stats_table.append(f"# {perf_breakdown: <{self._width-3}}#")
         self._stats_table.append(f"# {legend: <{self._width-3}}#")
         self._stats_table.append(f"# {hbm_info: <{self._width-3}}#")
 
@@ -503,6 +508,24 @@ def _get_sharding_type_abbr(sharding_type: str) -> str:
         raise ValueError(
             f"Unrecognized or unsupported sharding type provided: {sharding_type}"
         )
+
+
+def _format_perf_breakdown(perf: Perf) -> str:
+    breakdown = [
+        perf.fwd_compute,
+        perf.fwd_comms,
+        perf.bwd_compute,
+        perf.bwd_comms,
+    ]
+    breakdown_string = ",".join(
+        [str(round(num)) if num >= 1 else round_to_one_sigfig(num) for num in breakdown]
+    )
+
+    return f"{str(round(perf.total, 3))} ({breakdown_string})"
+
+
+def round_to_one_sigfig(x: float) -> str:
+    return f'{float(f"{x:.1g}"):g}'
 
 
 def _format_table(table: List[List[Union[str, int]]]) -> List[str]:

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -83,7 +83,7 @@ class TestProposers(unittest.TestCase):
             proposal = cast(List[ShardingOption], self.greedy_proposer.propose())
             proposal.sort(
                 key=lambda sharding_option: (
-                    max([shard.perf for shard in sharding_option.shards]),
+                    max([shard.perf.total for shard in sharding_option.shards]),
                     sharding_option.name,
                 )
             )
@@ -174,7 +174,7 @@ class TestProposers(unittest.TestCase):
         while proposal:
             proposal.sort(
                 key=lambda sharding_option: (
-                    max([shard.perf for shard in sharding_option.shards]),
+                    max([shard.perf.total for shard in sharding_option.shards]),
                     sharding_option.name,
                 )
             )

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -24,7 +24,7 @@ from torchrec.distributed.planner.shard_estimators import (
     _calculate_storage_specific_sizes,
     EmbeddingPerfEstimator,
 )
-from torchrec.distributed.planner.types import Topology
+from torchrec.distributed.planner.types import Perf, Topology
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.tests.test_quant_model_parallel import _quantize
@@ -60,41 +60,174 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
 
         expected_perfs = {
             ("dense", "data_parallel"): [
-                0.0005062740117544049,
-                0.0005062740117544049,
+                Perf(
+                    fwd_compute=9.356002212235228e-05,
+                    fwd_comms=0,
+                    bwd_compute=0.00018712004424470456,
+                    bwd_comms=0.000225593945387348,
+                ),
+                Perf(
+                    fwd_compute=9.356002212235228e-05,
+                    fwd_comms=0,
+                    bwd_compute=0.00018712004424470456,
+                    bwd_comms=0.000225593945387348,
+                ),
             ],
-            ("fused", "table_wise"): [0.0011095368078055323],
-            ("fused_uvm", "table_wise"): [0.1729105033126532],
-            ("fused_uvm_caching", "table_wise"): [0.040145097917908434],
-            ("fused", "column_wise"): [0.0011095368078055323],
-            ("fused_uvm", "column_wise"): [0.1729105033126532],
-            ("fused_uvm_caching", "column_wise"): [0.040145097917908434],
-            ("fused", "table_column_wise"): [0.0011095368078055323],
-            ("fused_uvm", "table_column_wise"): [0.1729105033126532],
-            ("fused_uvm_caching", "table_column_wise"): [0.040145097917908434],
+            ("fused", "table_wise"): [
+                Perf(
+                    fwd_compute=0.000327460077428233,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.000654920154856466,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm", "table_wise"): [
+                Perf(
+                    fwd_compute=0.05759444891237746,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.11518889782475492,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm_caching", "table_wise"): [
+                Perf(
+                    fwd_compute=0.013339313780795867,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.026678627561591735,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused", "column_wise"): [
+                Perf(
+                    fwd_compute=0.000327460077428233,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.000654920154856466,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm", "column_wise"): [
+                Perf(
+                    fwd_compute=0.05759444891237746,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.11518889782475492,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm_caching", "column_wise"): [
+                Perf(
+                    fwd_compute=0.013339313780795867,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.026678627561591735,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused", "table_column_wise"): [
+                Perf(
+                    fwd_compute=0.000327460077428233,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.000654920154856466,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm", "table_column_wise"): [
+                Perf(
+                    fwd_compute=0.05759444891237746,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.11518889782475492,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
+            ("fused_uvm_caching", "table_column_wise"): [
+                Perf(
+                    fwd_compute=0.013339313780795867,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.026678627561591735,
+                    bwd_comms=6.357828776041667e-05,
+                )
+            ],
             ("fused", "row_wise"): [
-                0.00043569201211068144,
-                0.00043569201211068144,
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
             ],
             ("fused_uvm", "row_wise"): [
-                0.054393095128676475,
-                0.054393095128676475,
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
             ],
             ("fused_uvm_caching", "row_wise"): [
-                0.012695561962491483,
-                0.012695561962491483,
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
             ],
             ("fused", "table_row_wise"): [
-                0.00043569201211068144,
-                0.00043569201211068144,
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
             ],
             ("fused_uvm", "table_row_wise"): [
-                0.054393095128676475,
-                0.054393095128676475,
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
             ],
             ("fused_uvm_caching", "table_row_wise"): [
-                0.012695561962491483,
-                0.012695561962491483,
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
             ],
         }
 
@@ -138,40 +271,40 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         )
 
-        expected_perfs = {
+        expected_total_perfs = {
             ("dense", "data_parallel"): [0.0005062740117544049, 0.0005062740117544049],
             ("fused", "table_wise"): [0.000846718200207288],
             ("fused_uvm", "table_wise"): [0.14336342905081956],
-            ("fused_uvm_caching", "table_wise"): [0.03322849048472447],
+            ("fused_uvm_caching", "table_wise"): [0.03322849048472446],
             ("fused", "column_wise"): [0.000846718200207288],
             ("fused_uvm", "column_wise"): [0.14336342905081956],
-            ("fused_uvm_caching", "column_wise"): [0.03322849048472447],
+            ("fused_uvm_caching", "column_wise"): [0.03322849048472446],
             ("fused", "table_column_wise"): [0.000846718200207288],
             ("fused_uvm", "table_column_wise"): [0.14336342905081956],
-            ("fused_uvm_caching", "table_column_wise"): [0.03322849048472447],
+            ("fused_uvm_caching", "table_column_wise"): [0.03322849048472446],
             ("fused", "row_wise"): [0.0002561205605599394, 0.0002561205605599394],
             ("fused_uvm", "row_wise"): [0.03392836626838235, 0.03392836626838235],
             ("fused_uvm_caching", "row_wise"): [
-                0.007906921553027078,
-                0.007906921553027078,
+                0.007906921553027076,
+                0.007906921553027076,
             ],
             ("fused", "table_row_wise"): [0.0002561205605599394, 0.0002561205605599394],
             ("fused_uvm", "table_row_wise"): [0.03392836626838235, 0.03392836626838235],
             ("fused_uvm_caching", "table_row_wise"): [
-                0.007906921553027078,
-                0.007906921553027078,
+                0.007906921553027076,
+                0.007906921553027076,
             ],
         }
 
-        perfs = {
+        total_perfs = {
             (
                 sharding_option.compute_kernel,
                 sharding_option.sharding_type,
-            ): [shard.perf for shard in sharding_option.shards]
+            ): [cast(Perf, shard.perf).total for shard in sharding_option.shards]
             for sharding_option in sharding_options
         }
 
-        self.assertEqual(expected_perfs, perfs)
+        self.assertEqual(expected_total_perfs, total_perfs)
 
     def test_sequence_2_table_perf(self) -> None:
         tables = [
@@ -196,37 +329,31 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         )
 
-        expected_perfs = {
-            ("dense", "data_parallel"): [
-                0.002690105799714326,
-                0.002690105799714326,
-            ],
+        expected_total_perfs = {
+            ("dense", "data_parallel"): [0.0026901057997143255, 0.0026901057997143255],
             ("fused", "table_wise"): [0.001880471390093715],
             ("fused_uvm", "table_wise"): [0.25958192114736517],
-            ("fused_uvm_caching", "table_wise"): [0.060433813055248066],
+            ("fused_uvm_caching", "table_wise"): [0.06043381305524807],
             ("fused", "column_wise"): [0.001880471390093715],
             ("fused_uvm", "column_wise"): [0.25958192114736517],
-            ("fused_uvm_caching", "column_wise"): [0.060433813055248066],
-            ("fused", "row_wise"): [
-                0.0007915177871551004,
-                0.0007915177871551004,
-            ],
-            ("fused_uvm", "row_wise"): [0.1036341050091912, 0.1036341050091912],
+            ("fused_uvm_caching", "column_wise"): [0.06043381305524807],
+            ("fused", "row_wise"): [0.0007915177871551004, 0.0007915177871551004],
+            ("fused_uvm", "row_wise"): [0.10363410500919118, 0.10363410500919118],
             ("fused_uvm_caching", "row_wise"): [
-                0.024158779217047007,
-                0.024158779217047007,
+                0.024158779217047004,
+                0.024158779217047004,
             ],
         }
 
-        perfs = {
+        total_perfs = {
             (
                 sharding_option.compute_kernel,
                 sharding_option.sharding_type,
-            ): [shard.perf for shard in sharding_option.shards]
+            ): [cast(Perf, shard.perf).total for shard in sharding_option.shards]
             for sharding_option in sharding_options
         }
 
-        self.assertEqual(expected_perfs, perfs)
+        self.assertEqual(expected_total_perfs, total_perfs)
 
     def test_inference_1_table_perf(self) -> None:
         tables = [
@@ -255,21 +382,21 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         )
 
-        expected_perfs = {
+        expected_total_perfs = {
             ("quant", "table_wise"): [0.0001296231579222408],
             ("quant_uvm", "table_wise"): [0.018350937787224266],
             ("quant_uvm_caching", "table_wise"): [0.004269758427175579],
         }
 
-        perfs = {
+        total_perfs = {
             (
                 sharding_option.compute_kernel,
                 sharding_option.sharding_type,
-            ): [shard.perf for shard in sharding_option.shards]
+            ): [cast(Perf, shard.perf).total for shard in sharding_option.shards]
             for sharding_option in sharding_options
         }
 
-        self.assertEqual(perfs, expected_perfs)
+        self.assertEqual(total_perfs, expected_total_perfs)
 
 
 # pyre-ignore[3]


### PR DESCRIPTION
Summary:
Print out the breakdown of perf in stats.py for each rank and each table.

For values >=1, we round the breakdowns into integers. For values < 1, we keep one significant figure.

Also adding a hint line to explain the 4 numbers.

Differential Revision: D45713277

