### PR TITLE
Use caching_ratio from constraints to override caching_ratio from sharders

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -94,6 +94,10 @@ def _to_sharding_plan(
             sharding_type=sharding_type,
             compute_kernel=sharding_option.compute_kernel,
             ranks=[cast(int, shard.rank) for shard in shards],
+            cache_params=sharding_option.cache_params,
+            enforce_hbm=sharding_option.enforce_hbm,
+            stochastic_rounding=sharding_option.stochastic_rounding,
+            bounds_check_mode=sharding_option.bounds_check_mode,
         )
         plan[sharding_option.path] = module_plan
     return ShardingPlan(plan)

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -66,11 +66,24 @@ class EmbeddingPerfEstimator(ShardEstimator):
         for sharding_option in sharding_options:
             sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
+
             caching_ratio = (
-                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
-                if hasattr(sharder, "fused_params") and sharder.fused_params
+                self._constraints[  # pyre-ignore[16]
+                    sharding_option.name
+                ].cache_params.load_factor
+                if self._constraints
+                and self._constraints.get(sharding_option.name)
+                and self._constraints[sharding_option.name].cache_params
                 else None
             )
+            # TODO: remove after deprecating fused_params in sharder
+            if caching_ratio is None:
+                caching_ratio = (
+                    sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                    if hasattr(sharder, "fused_params") and sharder.fused_params
+                    else None
+                )
+
             num_poolings = (
                 cast(List[float], self._constraints[sharding_option.name].num_poolings)
                 if self._constraints
@@ -711,11 +724,24 @@ class EmbeddingStorageEstimator(ShardEstimator):
         for sharding_option in sharding_options:
             sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
+
             caching_ratio = (
-                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
-                if hasattr(sharder, "fused_params") and sharder.fused_params
+                self._constraints[  # pyre-ignore[16]
+                    sharding_option.name
+                ].cache_params.load_factor
+                if self._constraints
+                and self._constraints.get(sharding_option.name)
+                and self._constraints[sharding_option.name].cache_params
                 else None
             )
+            # TODO: remove after deprecating fused_params in sharder
+            if caching_ratio is None:
+                caching_ratio = (
+                    sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                    if hasattr(sharder, "fused_params") and sharder.fused_params
+                    else None
+                )
+
             num_poolings = (
                 cast(List[float], self._constraints[sharding_option.name].num_poolings)
                 if self._constraints

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -23,7 +23,12 @@ from torchrec.distributed.planner.constants import (
     INTRA_NODE_BANDWIDTH,
     POOLING_FACTOR,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingPlan
+from torchrec.distributed.types import (
+    BoundsCheckMode,
+    CacheParams,
+    ModuleSharder,
+    ShardingPlan,
+)
 from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
 
 # ---- Perf ---- #
@@ -244,6 +249,10 @@ class ShardingOption:
         partition_by: str,
         compute_kernel: str,
         shards: List[Shard],
+        cache_params: Optional[CacheParams] = None,
+        enforce_hbm: Optional[bool] = None,
+        stochastic_rounding: Optional[bool] = None,
+        bounds_check_mode: Optional[BoundsCheckMode] = None,
         dependency: Optional[str] = None,
     ) -> None:
         self.name = name
@@ -257,6 +266,10 @@ class ShardingOption:
         # relevant to planner output, must be populated if sharding option
         # part of final solution
         self.shards = shards
+        self.cache_params = cache_params
+        self.enforce_hbm = enforce_hbm
+        self.stochastic_rounding = stochastic_rounding
+        self.bounds_check_mode = bounds_check_mode
         self.dependency = dependency
         self._is_pooled: Optional[bool] = None
 

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -375,6 +375,10 @@ class ParameterConstraints:
     num_poolings: Optional[List[float]] = None  # number of poolings per sample in batch
     batch_sizes: Optional[List[int]] = None  # batch size per input feature
     is_weighted: bool = False
+    cache_params: Optional[CacheParams] = None
+    enforce_hbm: Optional[bool] = None
+    stochastic_rounding: Optional[bool] = None
+    bounds_check_mode: Optional[BoundsCheckMode] = None
 
 
 class PlannerErrorType(Enum):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -439,6 +439,14 @@ class ModuleShardingPlan:
 
 
 @dataclass
+class CacheParams:
+    algorithm: Optional[CacheAlgorithm] = None
+    load_factor: Optional[float] = None
+    reserved_memory: Optional[float] = None
+    precision: Optional[DataType] = None
+
+
+@dataclass
 class ParameterSharding:
     """
         Describes the sharding of the parameter.
@@ -448,6 +456,10 @@ class ParameterSharding:
         compute_kernel (str): compute kernel to be used by this parameter.
         ranks (Optional[List[int]]): rank of each shard.
         sharding_spec (Optional[ShardingSpec]): list of ShardMetadata for each shard.
+        cache_params (Optional[CacheParams]): cache params for embedding lookup.
+        enforce_hbm (Optional[bool]): whether to use HBM.
+        stochastic_rounding (Optional[bool]): whether to use stochastic rounding.
+        bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -462,6 +474,10 @@ class ParameterSharding:
     compute_kernel: str
     ranks: Optional[List[int]] = None
     sharding_spec: Optional[ShardingSpec] = None
+    cache_params: Optional[CacheParams] = None
+    enforce_hbm: Optional[bool] = None
+    stochastic_rounding: Optional[bool] = None
+    bounds_check_mode: Optional[BoundsCheckMode] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -55,6 +55,46 @@ from torch.nn.modules.module import _addindent
 from torchrec.streamable import Multistreamable
 
 
+@unique
+class BoundsCheckMode(Enum):
+    # Raise an exception (CPU) or device-side assert (CUDA)
+    FATAL = 0
+    # Log the first out-of-bounds instance per kernel, and set to zero.
+    WARNING = 1
+    # Set to zero.
+    IGNORE = 2
+    # No bounds checks.
+    NONE = 3
+
+
+@unique
+class CacheAlgorithm(Enum):
+    LRU = 0
+    LFU = 1
+
+
+# moved DataType here to avoid circular import
+# TODO: organize types and dependencies
+@unique
+class DataType(Enum):
+    """
+    Our fusion implementation supports only certain types of data
+    so it makes sense to retrict in a non-fused version as well.
+    """
+
+    FP32 = "FP32"
+    FP16 = "FP16"
+    INT64 = "INT64"
+    INT32 = "INT32"
+    INT8 = "INT8"
+    UINT8 = "UINT8"
+    INT4 = "INT4"
+    INT2 = "INT2"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class ShardingType(Enum):
     """
     Well-known sharding types, used by inter-module optimizations.


### PR DESCRIPTION
Summary: Use cache_load_factor in planner using constraints. If constraints do not have cache_load_factor, then we try to get it from sharders.fused_params.

Differential Revision: D45824597

