### PR TITLE
Revert D45006690: Multisect successfully blamed D45006690 for test or build failures

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -706,21 +706,19 @@ class InferGroupedPooledEmbeddingsLookup(
         grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
-        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._embedding_lookups_per_rank: List[
             MetaInferGroupedPooledEmbeddingsLookup
         ] = []
-
-        device_type = "cuda" if device is None or device.type == "cuda" else "meta"
         for rank in range(world_size):
             self._embedding_lookups_per_rank.append(
                 # TODO add position weighted module support
                 MetaInferGroupedPooledEmbeddingsLookup(
                     grouped_configs=grouped_configs_per_rank[rank],
                     # syntax for torchscript
-                    device=torch.device(type=device_type, index=rank),
+                    device=torch.device(f"cuda:{rank}"),
+                    fused_params=fused_params,
                 )
             )
 

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -740,19 +740,15 @@ class InferGroupedEmbeddingsLookup(
         grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
-        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._embedding_lookups_per_rank: List[MetaInferGroupedEmbeddingsLookup] = []
-
-        device_type = "cuda" if device is None or device.type == "cuda" else "meta"
-
         for rank in range(world_size):
             self._embedding_lookups_per_rank.append(
                 MetaInferGroupedEmbeddingsLookup(
                     grouped_configs=grouped_configs_per_rank[rank],
                     # syntax for torchscript
-                    device=torch.device(type=device_type, index=rank),
+                    device=torch.device(f"cuda:{rank}"),
                     fused_params=fused_params,
                 )
             )

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -156,7 +156,6 @@ class ShardedQuantEmbeddingCollection(
         table_name_to_parameter_sharding: Dict[str, ParameterSharding],
         env: ShardingEnv,
         fused_params: Optional[Dict[str, Any]] = None,
-        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
 
@@ -180,10 +179,9 @@ class ShardedQuantEmbeddingCollection(
             for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
         }
 
-        self._device = device
         self._input_dists: List[nn.Module] = []
         self._lookups: List[nn.Module] = []
-        self._create_lookups(fused_params, device)
+        self._create_lookups(fused_params)
         self._output_dists: List[nn.Module] = []
 
         self._feature_splits: List[int] = []
@@ -194,8 +192,6 @@ class ShardedQuantEmbeddingCollection(
 
         self._embedding_dim: int = module.embedding_dim()
         self._need_indices: bool = module.need_indices()
-
-        self._fused_params = fused_params
 
         # This provides consistency between this class and the EmbeddingBagCollection's
         # nn.Module API calls (state_dict, named_modules, etc)
@@ -230,14 +226,11 @@ class ShardedQuantEmbeddingCollection(
         self,
         input_feature_names: List[str],
         device: torch.device,
-        input_dist_device: Optional[torch.device] = None,
     ) -> None:
         feature_names: List[str] = []
         self._feature_splits: List[int] = []
         for sharding in self._sharding_type_to_sharding.values():
-            self._input_dists.append(
-                sharding.create_input_dist(device=input_dist_device)
-            )
+            self._input_dists.append(sharding.create_input_dist())
             feature_names.extend(sharding.feature_names())
             self._feature_splits.append(len(sharding.feature_names()))
         self._features_order: List[int] = []
@@ -254,15 +247,9 @@ class ShardedQuantEmbeddingCollection(
             persistent=False,
         )
 
-    def _create_lookups(
-        self,
-        fused_params: Optional[Dict[str, Any]],
-        device: Optional[torch.device] = None,
-    ) -> None:
+    def _create_lookups(self, fused_params: Optional[Dict[str, Any]]) -> None:
         for sharding in self._sharding_type_to_sharding.values():
-            self._lookups.append(
-                sharding.create_lookup(fused_params=fused_params, device=device)
-            )
+            self._lookups.append(sharding.create_lookup(fused_params=fused_params))
 
     def _create_output_dist(
         self,
@@ -282,7 +269,6 @@ class ShardedQuantEmbeddingCollection(
             self._create_input_dist(
                 input_feature_names=features.keys() if features is not None else [],
                 device=features.device(),
-                input_dist_device=self._device,
             )
             self._has_uninitialized_input_dist = False
         if self._has_uninitialized_output_dist:

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -157,7 +157,7 @@ class QuantBatchedEmbeddingBag(BaseBatchedEmbeddingBag, TBEToRegisterMixIn):
             uvm_host_mapped=True,  # Use cudaHostAlloc for UVM CACHING to fix imbalance numa memory issue
             **(tbe_fused_params(fused_params) or {}),
         )
-        if device is not None:
+        if device is not None and device.type != "meta":
             self._emb_module.initialize_weights()
 
     def init_parameters(self) -> None:

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -280,7 +280,7 @@ class QuantBatchedEmbedding(BaseBatchedEmbedding, TBEToRegisterMixIn):
             uvm_host_mapped=True,  # Use cudaHostAlloc for UVM CACHING to fix imbalance numa memory issue
             **(tbe_fused_params(fused_params) or {}),
         )
-        if device is not None:
+        if device is not None and device.type != "meta":
             self._emb_module.initialize_weights()
 
     @property

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -204,9 +204,8 @@ class InferTwSequenceEmbeddingSharding(
         self, device: Optional[torch.device] = None
     ) -> BaseSparseFeaturesDist[KJTList]:
         return InferTwSparseFeaturesDist(
-            features_per_rank=self.features_per_rank(),
-            world_size=self._world_size,
-            device=device,
+            self.features_per_rank(),
+            self._world_size,
         )
 
     def create_lookup(
@@ -219,7 +218,6 @@ class InferTwSequenceEmbeddingSharding(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
-            device=device,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -356,20 +356,17 @@ class InferTwSparseFeaturesDist(BaseSparseFeaturesDist[KJTList]):
     Args:
         features_per_rank (List[int]): number of features to send to each rank.
         world_size (int): number of devices in the topology.
-        fused_params (Dict[str, Any]): fused parameters of the model.
     """
 
     def __init__(
         self,
         features_per_rank: List[int],
         world_size: int,
-        device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self._dist = KJTOneToAll(
-            splits=features_per_rank,
-            world_size=world_size,
-            device=device,
+            features_per_rank,
+            world_size,
         )
 
     def forward(
@@ -436,13 +433,11 @@ class InferTwEmbeddingSharding(
     """
 
     def create_input_dist(
-        self,
-        device: Optional[torch.device] = None,
+        self, device: Optional[torch.device] = None
     ) -> BaseSparseFeaturesDist[KJTList]:
         return InferTwSparseFeaturesDist(
-            features_per_rank=self.features_per_rank(),
-            world_size=self._world_size,
-            device=device,
+            self.features_per_rank(),
+            self._world_size,
         )
 
     def create_lookup(
@@ -455,7 +450,6 @@ class InferTwEmbeddingSharding(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
-            device=device,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -213,11 +213,7 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
 
 
 class TestQuantECSharder(QuantEmbeddingCollectionSharder):
-    def __init__(
-        self,
-        sharding_type: str,
-        kernel_type: str,
-    ) -> None:
+    def __init__(self, sharding_type: str, kernel_type: str) -> None:
         super().__init__()
         self._sharding_type = sharding_type
         self._kernel_type = kernel_type
@@ -242,9 +238,7 @@ class TestQuantECSharder(QuantEmbeddingCollectionSharder):
             dtype_to_data_type(module.output_dtype())
         )
         fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = True
-        return ShardedQuantEmbeddingCollection(
-            module, params, env, fused_params, device
-        )
+        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
 
 
 class KJTInputWrapper(torch.nn.Module):

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -208,7 +208,6 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
             table_name_to_parameter_sharding=params,
             env=env,
             fused_params=fused_params,
-            device=device,
         )
 
 


### PR DESCRIPTION
Summary:
This diff is reverting D45006690
Depends on D45802234
D45006690: Zero allocation torchrec sharding via meta [QEBC] by s4ayub has been identified to be causing the following test or build failures:

Tests affected:
- [dper_lib/silvertorch/delayed_modules/wrapper_modules/tests:build_prospector_model_test - test_ig_prospector_with_atm_publish (dper_lib.silvertorch.delayed_modules.wrapper_modules.tests.build_prospector_model_test.TestBuildProspectorModel)](https://www.internalfb.com/intern/test/281475065803150/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2047271
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: s4ayub

Differential Revision: D45802243

