### PR TITLE
Add BoundsCheckMode and CacheAlgorithm as torchrec types

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -55,6 +55,46 @@ from torch.nn.modules.module import _addindent
 from torchrec.streamable import Multistreamable
 
 
+@unique
+class BoundsCheckMode(Enum):
+    # Raise an exception (CPU) or device-side assert (CUDA)
+    FATAL = 0
+    # Log the first out-of-bounds instance per kernel, and set to zero.
+    WARNING = 1
+    # Set to zero.
+    IGNORE = 2
+    # No bounds checks.
+    NONE = 3
+
+
+@unique
+class CacheAlgorithm(Enum):
+    LRU = 0
+    LFU = 1
+
+
+# moved DataType here to avoid circular import
+# TODO: organize types and dependencies
+@unique
+class DataType(Enum):
+    """
+    Our fusion implementation supports only certain types of data
+    so it makes sense to retrict in a non-fused version as well.
+    """
+
+    FP32 = "FP32"
+    FP16 = "FP16"
+    INT64 = "INT64"
+    INT32 = "INT32"
+    INT8 = "INT8"
+    UINT8 = "UINT8"
+    INT4 = "INT4"
+    INT2 = "INT2"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class ShardingType(Enum):
     """
     Well-known sharding types, used by inter-module optimizations.

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -13,7 +13,12 @@ from typing import Callable, Dict, List, Optional
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import PoolingMode
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    BoundsCheckMode as FbgemmBoundsCheckMode,
+    CacheAlgorithm as FbgemmCacheAlgorithm,
+    PoolingMode,
+)
+from torchrec.distributed.types import BoundsCheckMode, CacheAlgorithm, DataType
 
 
 @unique
@@ -21,26 +26,6 @@ class PoolingType(Enum):
     SUM = "SUM"
     MEAN = "MEAN"
     NONE = "NONE"
-
-
-@unique
-class DataType(Enum):
-    """
-    Our fusion implementation supports only certain types of data
-    so it makes sense to retrict in a non-fused version as well.
-    """
-
-    FP32 = "FP32"
-    FP16 = "FP16"
-    INT64 = "INT64"
-    INT32 = "INT32"
-    INT8 = "INT8"
-    UINT8 = "UINT8"
-    INT4 = "INT4"
-    INT2 = "INT2"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
@@ -51,6 +36,30 @@ DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
     DataType.INT4: 4,
     DataType.INT2: 2,
 }
+
+
+def to_fbgemm_bounds_check_mode(
+    bounds_check_mode: BoundsCheckMode,
+) -> FbgemmBoundsCheckMode:
+    if bounds_check_mode == BoundsCheckMode.FATAL:
+        return FbgemmBoundsCheckMode.FATAL
+    elif bounds_check_mode == BoundsCheckMode.WARNING:
+        return FbgemmBoundsCheckMode.WARNING
+    elif bounds_check_mode == BoundsCheckMode.IGNORE:
+        return FbgemmBoundsCheckMode.IGNORE
+    elif bounds_check_mode == BoundsCheckMode.NONE:
+        return FbgemmBoundsCheckMode.NONE
+    else:
+        raise Exception(f"Invalid bounds check mode {bounds_check_mode}")
+
+
+def to_fbgemm_cache_algorithm(cache_algorithm: CacheAlgorithm) -> FbgemmCacheAlgorithm:
+    if cache_algorithm == CacheAlgorithm.LRU:
+        return FbgemmCacheAlgorithm.LRU
+    elif cache_algorithm == CacheAlgorithm.LFU:
+        return FbgemmCacheAlgorithm.LFU
+    else:
+        raise Exception(f"Invalid cache algorithm {cache_algorithm}")
 
 
 def dtype_to_data_type(dtype: torch.dtype) -> DataType:


### PR DESCRIPTION
Summary: In this diff, we add add BoundsCheckMode and CacheAlgorithm as torchrec types. Before we pass them into fbgemm api, we will convert them to fbgemm types.

Differential Revision: D46010148

