### PR TITLE
Making physical and logical size the same for QEBC/QEC shardable parameters

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -407,7 +407,7 @@ class MetaInferGroupedEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbedding:
+        ) -> BaseBatchedEmbedding[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
             return QuantBatchedEmbedding(
                 config=config,
                 device=device,
@@ -524,7 +524,7 @@ class MetaInferGroupedPooledEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbeddingBag:
+        ) -> BaseBatchedEmbeddingBag[Tuple[torch.Tensor, Optional[torch.Tensor]]]:
             return QuantBatchedEmbeddingBag(
                 config=config,
                 device=device,

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -383,9 +383,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         )
 
         expected_total_perfs = {
-            ("quant", "table_wise"): [0.0001296231579222408],
-            ("quant_uvm", "table_wise"): [0.018350937787224266],
-            ("quant_uvm_caching", "table_wise"): [0.004269758427175579],
+            ("quant", "table_wise"): [0.00010892300302767036],
+            ("quant_uvm", "table_wise"): [0.01637795392204734],
+            ("quant_uvm_caching", "table_wise"): [0.0038054723505752935],
         }
 
         total_perfs = {

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -206,13 +206,19 @@ class ShardedQuantEmbeddingCollection(
         ):
             lookup_state_dict = lookup.state_dict()
             for key in lookup_state_dict:
-                if not key.endswith(".weight"):
+                if key.endswith(".weight"):
+                    table_name = key[: -len(".weight")]
+                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
+                    self.embeddings[table_name].register_buffer(
+                        "weight", lookup_state_dict[key]
+                    )
+                elif key.endswith(".weight_qscaleshift"):
+                    table_name = key[: -len(".weight_qscaleshift")]
+                    self.embeddings[table_name].register_buffer(
+                        "weight_qscaleshift", lookup_state_dict[key]
+                    )
+                else:
                     continue
-                table_name = key[: -len(".weight")]
-                # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                self.embeddings[table_name].register_buffer(
-                    "weight", lookup_state_dict[key]
-                )
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -135,13 +135,19 @@ class ShardedQuantEmbeddingBagCollection(
         ):
             lookup_state_dict = lookup.state_dict()
             for key in lookup_state_dict:
-                if not key.endswith(".weight"):
+                if key.endswith(".weight"):
+                    table_name = key[: -len(".weight")]
+                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
+                    self.embedding_bags[table_name].register_buffer(
+                        "weight", lookup_state_dict[key]
+                    )
+                elif key.endswith("weight_qscaleshift"):
+                    table_name = key[: -len(".weight_qscaleshift")]
+                    self.embedding_bags[table_name].register_buffer(
+                        "weight_qscaleshift", lookup_state_dict[key]
+                    )
+                else:
                     continue
-                table_name = key[: -len(".weight")]
-                # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                self.embedding_bags[table_name].register_buffer(
-                    "weight", lookup_state_dict[key]
-                )
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -21,7 +21,7 @@ from torchrec.distributed.planner.shard_estimators import (
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
-from torchrec.distributed.shard import shard_modules
+from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.test_model import (
     _get_default_rtol_and_atol,
     ModelInput,
@@ -318,7 +318,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
         quant_model = _quantize(model, inplace=True, output_type=output_type)
 
-        sharded_model = shard_modules(
+        sharded_model = _shard_modules(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -15,7 +15,7 @@ from hypothesis import given, settings, Verbosity
 from torch import nn, quantization as quant
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
-from torchrec.distributed.shard import shard_modules
+from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNNBase
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     InferenceModelParallelTestBase,
@@ -152,7 +152,7 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
 
         quant_model = _quantize(model)
 
-        sharded_quant_model = shard_modules(
+        sharded_quant_model = _shard_modules(
             module=quant_model,
             sharders=[
                 cast(

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -268,8 +268,8 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         for (_key, tables), emb_module in zip(
             self._key_to_tables.items(), self._emb_modules
         ):
-            for embedding_config, (weight, _) in zip(
-                tables, emb_module.split_embedding_weights(split_scale_shifts=False)
+            for embedding_config, (weight, qscaleshift) in zip(
+                tables, emb_module.split_embedding_weights(split_scale_shifts=True)
             ):
                 self.embedding_bags[embedding_config.name] = torch.nn.Module()
                 # register as a buffer so it's exposed in state_dict.
@@ -278,6 +278,9 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
                 # Additionally, we cannot expose uint8 weights as parameters due to autograd restrictions.
                 self.embedding_bags[embedding_config.name].register_buffer(
                     "weight", weight
+                )
+                self.embedding_bags[embedding_config.name].register_buffer(
+                    "weight_qscaleshift", qscaleshift
                 )
         self.register_tbes = register_tbes
         if register_tbes:
@@ -514,8 +517,11 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             # TODO: register as param instead of buffer
             # however, since this is only needed for inference, we do not need to expose it as part of parameters.
             # Additionally, we cannot expose uint8 weights as parameters due to autograd restrictions.
-            weights_list = emb_module.split_embedding_weights(split_scale_shifts=False)
+            weights_list = emb_module.split_embedding_weights(split_scale_shifts=True)
             self.embeddings[config.name].register_buffer("weight", weights_list[0][0])
+            self.embeddings[config.name].register_buffer(
+                "weight_qscaleshift", weights_list[0][1]
+            )
 
             if not config.feature_names:
                 config.feature_names = [config.name]

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -78,7 +78,9 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         # test state dict
         state_dict = ebc.state_dict()
         quantized_state_dict = qebc.state_dict()
-        self.assertEqual(state_dict.keys(), quantized_state_dict.keys())
+        self.assertTrue(
+            set(state_dict.keys()).issubset(set(quantized_state_dict.keys()))
+        )
 
     # pyre-fixme[56]
     @given(
@@ -339,7 +341,9 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         test_model.ebc = QuantEmbeddingBagCollection.from_float(ebc)
 
         state_dict = test_model.state_dict()
-        self.assertEqual(state_dict.keys(), before_quant_state_dict.keys())
+        self.assertTrue(
+            set(before_quant_state_dict.keys()).issubset(set(state_dict.keys()))
+        )
         test_model.load_state_dict(state_dict)
 
     def test_trace_and_script(self) -> None:


### PR DESCRIPTION
Summary:
At the moment for quantized EBC/EC `.table_name.weight` tensor does not have the expected logical size of table (num_emb, emb_dim). It has the size ~(num_emb, round_up(emb_dim + 4, 16)) (depends on data type and internal fbgemm tbe implementation), the additional columns are used to store quantized scale and shift for each row. (rowwise quantization).

TBEs api to express it - `tbe.split_weight(split_scale_shift=True)` which provides views to the tensors,  that represent table weight uint8 `(num_emb, emb_dim)` and weight_qscaleshift `(num_emb, ~4)` for additional tensor (Optional Tensor).

If to specify split_scale_shift=False - that will be returned as one tensor, update to which needs internal TBE knowledge.

In current torchrec state of code split_scale_shift=False is used so the size of quantized `table_name.weight` is different to logical size.

This blocks us to add CW/RW sharding for quantized EBC/EC, providing sharding information etc. and adds complexity on interpreting this weight: it shows up in sharding plan, those additional columns.

__What we want to do__:

To use split_scale_shift=True and to register separately `ebc.table_name.weight` and `ebc.table_name.weight_qscaleshift` to represent the additional quantization info.

__Changes in torchrec modules__:

This is done for Quantized sharded and unsharded models, copy_state_dict(unsharded_model, sharded_model) works fine.

BaseBatchedEmbeddingBag is Generic parameterized:
`def split_embedding_weights(self) -> List[SplitWeightType]:`
 to support previous interface for non-quant kernels:
`def split_embedding_weights(self) -> List[torch.Tensor]:`
and non-quant kernels:
`def split_embedding_weights(self) -> List[Tuple[torch.Tensor, Optional[torch.Tensor]]:`

__Changes in tests__:
This breaks contract for `shard_modules` to not add additional fqns (for quant -> quant_sharded we are not adding) => changed to use `_shard_modules` for quant use cases.

# The reason of publishing flows failures for umia and prospector: [internal only]: P745445222

Differential Revision:
D45605917

Privacy Context Container: L1138451

