### PR TITLE
Avoid moving model to GPU before FSDP

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import logging
 from functools import reduce
 from time import perf_counter
 from typing import cast, Dict, List, Optional, Tuple, Union
@@ -54,6 +55,8 @@ from torchrec.distributed.types import (
     ShardingType,
     ShardMetadata,
 )
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _reset_shard_rank(proposal: List[ShardingOption]) -> None:
@@ -225,6 +228,9 @@ class EmbeddingShardingPlanner(ShardingPlanner):
 
         for proposer in self._proposers:
             proposer.load(search_space=search_space)
+
+        device_constraints = [device.storage for device in storage_constraint.devices]
+        logger.info(f"device_constraints {device_constraints}")
 
         for proposer in self._proposers:
             proposal = proposer.propose()

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -76,7 +76,9 @@ def _reserve_dense_storage(
     )
 
     for device in topology.devices:
+        logger.info(f"device storage before dense reservation: {device.storage}")
         device.storage -= dense_tensor_storage
+        logger.info(f"device storage after dense reservation: {device.storage}")
 
     return dense_tensor_storage
 
@@ -99,7 +101,10 @@ def _reserve_kjt_storage(
     )
 
     for device in topology.devices:
+        logger.info(f"device storage before kjt reservation: {device.storage}")
         device.storage -= kjt_storage
+        logger.info(f"device storage after kjt reservation: {device.storage}")
+
 
     return kjt_storage
 
@@ -211,22 +216,22 @@ class HeuristicalStorageReservation(StorageReservation):
 
         _reserve_storage_percentage(reserved_topology, self._percentage)
 
-        self._dense_storage = _reserve_dense_storage(
-            topology=reserved_topology,
-            module=module,
-            shardable_modules=shardable_modules,
-            multiplier=self._parameter_multiplier,
-            dense_tensor_estimate=self._dense_tensor_estimate,
-        )
+        # self._dense_storage = _reserve_dense_storage(
+        #     topology=reserved_topology,
+        #     module=module,
+        #     shardable_modules=shardable_modules,
+        #     multiplier=self._parameter_multiplier,
+        #     dense_tensor_estimate=self._dense_tensor_estimate,
+        # )
 
-        self._kjt_storage = _reserve_kjt_storage(
-            topology=reserved_topology,
-            batch_size=batch_size,
-            input_lengths=input_lengths,
-            input_data_type_size=BIGINT_DTYPE,
-            # 2 pipelined batches each with 10 internal copies
-            multiplier=20,
-        )
+        # self._kjt_storage = _reserve_kjt_storage(
+        #     topology=reserved_topology,
+        #     batch_size=batch_size,
+        #     input_lengths=input_lengths,
+        #     input_data_type_size=BIGINT_DTYPE,
+        #     # 2 pipelined batches each with 10 internal copies
+        #     multiplier=20,
+        # )
 
         return reserved_topology
 


### PR DESCRIPTION
Summary:
Model is moved to GPU before FSDP in current implementation. This might OOM GPU when dense parameter size is >80GB.

Specify device in FSDP wrapper then move the remaining DDP module to GPU.

Reviewed By: richqyz

Differential Revision:
D45791140

Privacy Context Container: 776137792796423

