### PR TITLE
Gradient scaling in embedding_lookup

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -42,6 +42,11 @@ def set_gradient_division(val: bool) -> None:
     GRADIENT_DIVISION = val
 
 
+def get_gradient_division() -> bool:
+    global GRADIENT_DIVISION
+    return GRADIENT_DIVISION
+
+
 """
 Some commonly used notations for comm ops:
     B - batch size
@@ -666,6 +671,7 @@ class All2All_Pooled_Req(Function):
         dim_sum_per_rank = a2ai.dim_sum_per_rank
         batch_size_per_rank = a2ai.batch_size_per_rank
         B_local = batch_size_per_rank[my_rank]
+
         assert B_global == sum(batch_size_per_rank)
 
         sharded_input_embeddings = input_embeddings.view(-1)

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -202,6 +202,9 @@ class DpPooledEmbeddingSharding(
             pg=self._env.process_group,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
+            # For data parallel we need to turn always gradient scaling in for weights
+            # because get_gradient_scaling from comm_ops only affects model_parallel tables, not DP
+            scale_weight_gradients=False,
         )
 
     def create_output_dist(


### PR DESCRIPTION
Summary:
ATT

Currently if gradient division is turned on for model parallel,

we need to scale back up the weights grads for KJT

Reviewed By: dstaay-fb, RenfeiChen-FB

Differential Revision: D46002672

