### PR TITLE
changes to o2_predictor_benchmark to partially support tgif models

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -21,6 +21,13 @@ from torchrec.modules.embedding_modules import (
 )
 
 
+def trim_torch_package_prefix_from_typename(typename: str) -> str:
+    if typename.startswith("<torch_package_"):
+        # Trim off <torch_package_x> prefix.
+        typename = ".".join(typename.split(".")[1:])
+    return typename
+
+
 def quantize_feature(
     module: torch.nn.Module, inputs: Tuple[torch.Tensor, ...]
 ) -> Tuple[torch.Tensor, ...]:


### PR DESCRIPTION
Summary:
now model loading has no issues, added a few todos in code (major one is adding batching queue replay)

also keep running into cyclical dependency issue... because `predictor/benchmark_util`, `umia_v1/tools/predictor_benchmark_util` and `o2_predictor_benchmark` seem to not have clear boundary... a lot of torchrec stuff are in `predictor/benchmark_util`, the diff restructures things a bit:
- split torchrec part of `predictor/benchmark_util` into `predictor/trec_benchmark`
- added some tgif related util file

Differential Revision: D46267569

