### PR TITLE
Making physical and logical size the same for QEBC/QEC shardable parameters (#1175)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -9,7 +9,18 @@ import abc
 import copy
 import itertools
 from dataclasses import dataclass
-from typing import Any, cast, Dict, Iterator, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import torch
 import torch.distributed as dist
@@ -427,7 +438,10 @@ def _gen_named_parameters_by_table_dense(
         yield (table_name, weight)
 
 
-class BaseBatchedEmbedding(BaseEmbedding):
+SplitWeightType = TypeVar("SplitWeightType")
+
+
+class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -491,13 +505,14 @@ class BaseBatchedEmbedding(BaseEmbedding):
         self.flush()
         return get_state_dict(
             self._config.embedding_tables,
+            # pyre-ignore
             self.split_embedding_weights(),
             self._pg,
             destination,
             prefix,
         )
 
-    def split_embedding_weights(self) -> List[torch.Tensor]:
+    def split_embedding_weights(self) -> List[SplitWeightType]:
         return self.emb_module.split_embedding_weights()
 
     @property
@@ -543,7 +558,7 @@ class BaseBatchedEmbedding(BaseEmbedding):
             yield name, param
 
 
-class BatchedFusedEmbedding(BaseBatchedEmbedding, FusedOptimizerModule):
+class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerModule):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -634,7 +649,7 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding, FusedOptimizerModule):
         self._emb_module.flush()
 
 
-class BatchedDenseEmbedding(BaseBatchedEmbedding):
+class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -684,7 +699,7 @@ class BatchedDenseEmbedding(BaseBatchedEmbedding):
         )
 
 
-class BaseBatchedEmbeddingBag(BaseEmbedding):
+class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -756,13 +771,14 @@ class BaseBatchedEmbeddingBag(BaseEmbedding):
         self.flush()
         return get_state_dict(
             self._config.embedding_tables,
+            # pyre-ignore
             self.split_embedding_weights(),
             self._pg,
             destination,
             prefix,
         )
 
-    def split_embedding_weights(self) -> List[torch.Tensor]:
+    def split_embedding_weights(self) -> List[SplitWeightType]:
         return self.emb_module.split_embedding_weights()
 
     @property
@@ -808,7 +824,9 @@ class BaseBatchedEmbeddingBag(BaseEmbedding):
             yield name, param
 
 
-class BatchedFusedEmbeddingBag(BaseBatchedEmbeddingBag, FusedOptimizerModule):
+class BatchedFusedEmbeddingBag(
+    BaseBatchedEmbeddingBag[torch.Tensor], FusedOptimizerModule
+):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,
@@ -902,7 +920,7 @@ class BatchedFusedEmbeddingBag(BaseBatchedEmbeddingBag, FusedOptimizerModule):
         self._emb_module.flush()
 
 
-class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag):
+class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     def __init__(
         self,
         config: GroupedEmbeddingConfig,

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -8,7 +8,7 @@
 import abc
 import logging
 from collections import defaultdict, OrderedDict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -54,6 +54,7 @@ def get_state_dict(
         nn.ModuleList,
         List[Union[nn.Module, torch.Tensor]],
         List[torch.Tensor],
+        List[Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]],
     ],
     pg: Optional[dist.ProcessGroup] = None,
     destination: Optional[Dict[str, Any]] = None,
@@ -76,14 +77,25 @@ def get_state_dict(
 
     for embedding_table, param in zip(embedding_tables, params):
         key = get_key_from_embedding_table(embedding_table)
-        assert embedding_table.local_rows == param.size(0)
-        if embedding_table.compute_kernel not in [
+        is_quant = embedding_table.compute_kernel in [
             EmbeddingComputeKernel.QUANT,
             EmbeddingComputeKernel.QUANT_UVM,
             EmbeddingComputeKernel.QUANT_UVM_CACHING,
-        ]:
+        ]
+        qscale = None
+        qbias = None
+        if is_quant:
+            # For QUANT* param is Tuple[torch.Tensor, Optional[torch.Tensor]] where first argument is the weight table, the second is optional quantization extra information, depending on quantization type. e.g. for fbgemm rowwise quantization this is scale and shift for each row.
+            assert isinstance(param, tuple)
+            qscale = param[1]
+            qbias = param[2]
+            param = param[0]
+
+        assert embedding_table.local_rows == param.size(0)
+
+        if qscale is not None:
             assert embedding_table.local_cols == param.size(1)
-        # for inference there is no pg, all tensors are local
+
         if embedding_table.global_metadata is not None and pg is not None:
             # set additional field of sharded tensor based on local tensor properties
             embedding_table.global_metadata.tensor_properties.dtype = param.dtype
@@ -97,6 +109,10 @@ def get_state_dict(
             )
         else:
             destination[key] = param
+            if qscale is not None:
+                destination[f"{key}_qscale"] = qscale
+            if qbias is not None:
+                destination[f"{key}_qbias"] = qbias
 
     if pg is not None:
         # Populate the remaining destinations that have a global metadata

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -448,7 +448,9 @@ class MetaInferGroupedEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbedding:
+        ) -> BaseBatchedEmbedding[
+            Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        ]:
             return QuantBatchedEmbedding(
                 config=config,
                 device=device,
@@ -565,7 +567,9 @@ class MetaInferGroupedPooledEmbeddingsLookup(
             config: GroupedEmbeddingConfig,
             device: Optional[torch.device] = None,
             fused_params: Optional[Dict[str, Any]] = None,
-        ) -> BaseBatchedEmbeddingBag:
+        ) -> BaseBatchedEmbeddingBag[
+            Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        ]:
             return QuantBatchedEmbeddingBag(
                 config=config,
                 device=device,

--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -15,6 +15,9 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 
 FUSED_PARAM_REGISTER_TBE_BOOL: str = "__register_tbes_in_named_modules"
+FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
+    "__register_quant_state_dict_split_scale_bias"
+)
 
 
 class TBEToRegisterMixIn:
@@ -42,6 +45,16 @@ def is_fused_param_register_tbe(fused_params: Optional[Dict[str, Any]]) -> bool:
     )
 
 
+def is_fused_param_quant_state_dict_split_scale_bias(
+    fused_params: Optional[Dict[str, Any]]
+) -> bool:
+    return (
+        fused_params
+        and FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS in fused_params
+        and fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS]
+    )
+
+
 def tbe_fused_params(
     fused_params: Optional[Dict[str, Any]]
 ) -> Optional[Dict[str, Any]]:
@@ -51,5 +64,7 @@ def tbe_fused_params(
     fused_params_for_tbe = dict(fused_params)
     if FUSED_PARAM_REGISTER_TBE_BOOL in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_REGISTER_TBE_BOOL)
+    if FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS)
 
     return fused_params_for_tbe

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -29,6 +29,7 @@ from torchrec.distributed.embeddingbag import (
     create_sharding_infos_by_sharding,
 )
 from torchrec.distributed.fused_params import (
+    FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
     get_tbes_to_register_from_iterable,
     is_fused_param_register_tbe,
 )
@@ -48,6 +49,7 @@ from torchrec.modules.embedding_configs import (
 from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
 from torchrec.quant.embedding_modules import (
     EmbeddingBagCollection as QuantEmbeddingBagCollection,
+    MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
@@ -136,13 +138,24 @@ class ShardedQuantEmbeddingBagCollection(
         ):
             lookup_state_dict = lookup.state_dict()
             for key in lookup_state_dict:
-                if not key.endswith(".weight"):
+                if key.endswith(".weight"):
+                    table_name = key[: -len(".weight")]
+                    # Register as buffer because this is an inference model, and can potentially use uint8 types.
+                    self.embedding_bags[table_name].register_buffer(
+                        "weight", lookup_state_dict[key]
+                    )
+                elif key.endswith("weight_qscale"):
+                    table_name = key[: -len(".weight_qscale")]
+                    self.embedding_bags[table_name].register_buffer(
+                        "weight_qscale", lookup_state_dict[key]
+                    )
+                elif key.endswith("weight_qbias"):
+                    table_name = key[: -len(".weight_qbias")]
+                    self.embedding_bags[table_name].register_buffer(
+                        "weight_qbias", lookup_state_dict[key]
+                    )
+                else:
                     continue
-                table_name = key[: -len(".weight")]
-                # Register as buffer because this is an inference model, and can potentially use uint8 types.
-                self.embedding_bags[table_name].register_buffer(
-                    "weight", lookup_state_dict[key]
-                )
 
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):
@@ -290,6 +303,9 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
+        )
+        fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
+            module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
         return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
 


### PR DESCRIPTION
Summary:

At the moment for quantized EBC/EC `.table_name.weight` tensor does not have the expected logical size of table (num_emb, emb_dim). It has the size ~(num_emb, round_up(emb_dim + 4, 16)) (depends on data type and internal fbgemm tbe implementation), the additional columns are used to store quantized scale and shift for each row. (rowwise quantization).

TBEs api to express it - `tbe.split_weight(split_scale_shift=True)` which provides views to the tensors,  that represent table weight uint8 `(num_emb, emb_dim)` and weight_qscaleshift `(num_emb, ~4)` for additional tensor (Optional Tensor).

If to specify split_scale_shift=False - that will be returned as one tensor, update to which needs internal TBE knowledge.

In current torchrec state of code split_scale_shift=False is used so the size of quantized `table_name.weight` is different to logical size.

This blocks us to add CW/RW sharding for quantized EBC/EC, providing sharding information etc. and adds complexity on interpreting this weight: it shows up in sharding plan, those additional columns.

__What we want to do__:

To use split_scale_shift=True and to register separately `ebc.table_name.weight` and `ebc.table_name.weight_qscaleshift` to represent the additional quantization info.

__Changes in torchrec modules__:

This is done for Quantized sharded and unsharded models, copy_state_dict(unsharded_model, sharded_model) works fine.

BaseBatchedEmbeddingBag is Generic parameterized:
`def split_embedding_weights(self) -> List[SplitWeightType]:`
 to support previous interface for non-quant kernels:
`def split_embedding_weights(self) -> List[torch.Tensor]:`
and non-quant kernels:
`def split_embedding_weights(self) -> List[Tuple[torch.Tensor, Optional[torch.Tensor]]:`

__Changes in tests__:
This breaks contract for `shard_modules` to not add additional fqns (for quant -> quant_sharded we are not adding) => changed to use `_shard_modules` for quant use cases.

Differential Revision:
D46267744

Privacy Context Container: L1138451

