### PR TITLE
Add init_fn to configs

### DIFF
--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -7,6 +7,8 @@
 
 import copy
 import unittest
+
+from functools import partial
 from typing import Any, Dict, List, Optional
 
 import hypothesis.strategies as st
@@ -70,6 +72,7 @@ def _test_sharding(  # noqa C901
     use_apply_optimizer_in_backward: bool = False,
 ) -> None:
     trec_dist.comm_ops.set_gradient_division(False)
+
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
         initial_state_dict = {
@@ -292,12 +295,14 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
                 feature_names=["feature_0"],
                 embedding_dim=4,
                 num_embeddings=4,
+                init_fn=partial(torch.nn.init.normal_, mean=0.0, std=1.5),
             ),
             EmbeddingBagConfig(
                 name="table_1",
                 feature_names=["feature_1"],
                 embedding_dim=4,
                 num_embeddings=4,
+                init_fn=partial(torch.nn.init.uniform_, a=-0.036, b=0.036),
             ),
         ]
 

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -518,6 +518,18 @@ class ShardedEmbeddingCollection(
             self._pre_load_state_dict_hook, with_module=True
         )
 
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        if self._device and self._device.type == "meta":
+            return
+        # Initialize embedding weights with init_fn
+        for table_config in self._embedding_configs:
+            assert table_config.init_fn is not None
+            param = self.embeddings[f"{table_config.name}"].weight
+            # pyre-ignore
+            table_config.init_fn(param)
+
     def _generate_permute_indices_per_feature(
         self,
         embedding_configs: List[EmbeddingConfig],

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -548,6 +548,18 @@ class ShardedEmbeddingBagCollection(
         self._register_load_state_dict_pre_hook(
             self._pre_load_state_dict_hook, with_module=True
         )
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        if self._device and self._device.type == "meta":
+            return
+
+        # Initialize embedding bags weights with init_fn
+        for table_config in self._embedding_bag_configs:
+            assert table_config.init_fn is not None
+            param = self.embedding_bags[f"{table_config.name}"].weight
+            # pyre-ignore
+            table_config.init_fn(param)
 
     def _create_input_dist(
         self,

--- a/torchrec/models/experimental/test_transformerdlrm.py
+++ b/torchrec/models/experimental/test_transformerdlrm.py
@@ -224,7 +224,7 @@ class DLRMTransformerTest(unittest.TestCase):
             sparse_features=sparse_features,
         )
         self.assertEqual(logits.size(), (B, 1))
-        expected_logits = torch.tensor([[0.1659], [0.3247]])
+        expected_logits = torch.tensor([[-0.2593], [-0.1043]])
         self.assertTrue(
             torch.allclose(
                 logits,

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -66,14 +66,14 @@ class SparseArchTest(unittest.TestCase):
         expected_values = torch.tensor(
             [
                 [
-                    [-0.7499, -1.2665, 1.0143],
-                    [-0.7499, -1.2665, 1.0143],
-                    [3.2276, 2.9643, -0.3816],
+                    [-0.4518, -0.0242, 0.3637],
+                    [-0.4518, -0.0242, 0.3637],
+                    [0.2940, -0.2385, -0.0074],
                 ],
                 [
-                    [0.0082, 0.6241, -0.1119],
-                    [0.0082, 0.6241, -0.1119],
-                    [2.0722, -2.2734, -1.6307],
+                    [-0.5452, -0.0231, -0.1907],
+                    [-0.5452, -0.0231, -0.1907],
+                    [-0.3530, -0.5551, -0.3342],
                 ],
             ]
         )
@@ -396,7 +396,7 @@ class DLRMTest(unittest.TestCase):
         )
         self.assertEqual(logits.size(), (B, 1))
 
-        expected_logits = torch.tensor([[0.5805], [0.5909]])
+        expected_logits = torch.tensor([[-0.2593], [-0.2487]])
         self.assertTrue(
             torch.allclose(
                 logits,
@@ -801,7 +801,7 @@ class DLRM_ProjectionTest(unittest.TestCase):
         )
         self.assertEqual(logits.size(), (B, 1))
 
-        expected_logits = torch.tensor([[-0.0036], [-0.0260]])
+        expected_logits = torch.tensor([[-0.4603], [-0.4639]])
         self.assertTrue(
             torch.allclose(
                 logits,
@@ -1097,7 +1097,7 @@ class DLRM_DCNTest(unittest.TestCase):
         )
         self.assertEqual(logits.size(), (B, 1))
 
-        expected_logits = torch.tensor([[1.5232], [0.1726]])
+        expected_logits = torch.tensor([[0.0455], [0.0408]])
         self.assertTrue(
             torch.allclose(
                 logits,

--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from functools import partial
 
 import torch
 import torch.fx
@@ -21,10 +22,18 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 class EmbeddingBagCollectionTest(unittest.TestCase):
     def test_unweighted(self) -> None:
         eb1_config = EmbeddingBagConfig(
-            name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
+            name="t1",
+            embedding_dim=3,
+            num_embeddings=10,
+            feature_names=["f1"],
+            init_fn=partial(torch.nn.init.normal_, mean=0.0, std=1.5),
         )
         eb2_config = EmbeddingBagConfig(
-            name="t2", embedding_dim=4, num_embeddings=10, feature_names=["f2"]
+            name="t2",
+            embedding_dim=4,
+            num_embeddings=10,
+            feature_names=["f2"],
+            init_fn=partial(torch.nn.init.uniform_, a=-0.036, b=0.036),
         )
         ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
 


### PR DESCRIPTION
Summary: Use case where we want to initialize embedding weights to be normal distribution. Here we create a generalized way of initializing table parameters. Usually folks init params after model creation, but since EmbeddingBags are typcially done with meta device, provide this option

Reviewed By: dstaay-fb

Differential Revision: D46207027

