### PR TITLE
Reset the Torchrec metrics window buffer in reset()

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -249,6 +249,17 @@ class RecMetricComputation(Metric, abc.ABC):
     def local_compute(self) -> List[MetricComputationReport]:
         return self._compute()
 
+    def reset(self) -> None:
+        super().reset()
+        if self._batch_window_buffers is not None:
+            self._batch_window_buffers = {
+                name: WindowBuffer(
+                    max_size=self._window_size,
+                    max_buffer_count=MAX_BUFFER_COUNT,
+                )
+                for name in self._batch_window_buffers
+            }
+
 
 class RecMetric(nn.Module, abc.ABC):
     r"""The main class template to implement a recommendation metric.

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -248,3 +248,25 @@ class RecMetricTest(unittest.TestCase):
                 batch_size=10,
                 tasks=[DefaultTaskInfo],
             )
+
+    def test_reset(self) -> None:
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=1000,
+            fused_update_limit=0,
+        )
+        ne.update(
+            predictions=self.predictions,
+            labels=self.labels,
+            weights=self.weights,
+        )
+        ne = ne._metrics_computations[0]
+        window_buffer = ne._batch_window_buffers["window_cross_entropy_sum"].buffers
+        self.assertTrue(len(window_buffer) > 0)
+        ne.reset()
+        window_buffer = ne._batch_window_buffers["window_cross_entropy_sum"].buffers
+        self.assertEqual(len(window_buffer), 0)


### PR DESCRIPTION
Summary: The Torchrec metrics RecMetricComputation does not override the reset() API to properly reset the window buffer. Adds reset() override implementation accordingly.

Differential Revision: D46251125

