### PR TITLE
Improve planner error print when the largest table cannot fit in a device at all or when storage reservation is too restrictive

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -213,7 +213,10 @@ class GreedyPerfPartitioner(Partitioner):
             if not success:
                 raise PlannerError(
                     error_type=PlannerErrorType.PARTITION,
-                    message=f"Device partition failed. Couldn't find a rank for shard {shard}, devices: {devices}",
+                    message=(
+                        f"Device partition failed. Couldn't find a rank for shard {shard} of table {sharding_option.name}, "
+                        f"largest device storage: {max(devices, key=lambda device: device.storage).storage}"
+                    ),
                 )
 
     @staticmethod


### PR DESCRIPTION
Summary:
Add a warning when it is not possible to fit a table in the devices at all. E.g., when we have an extremely large table but we are doing table_wise sharding, or when storage reservation is too restrictive.

In that case, we print out the name of the table and the sharding_type. We also print out the percentage of storage reseration.

Also print the last planner error.

Note that this would still work when there are more than one proposal.

Reviewed By: ge0405

Differential Revision: D46285104

