### PR TITLE
Extract fused params from constraints and override the fused params from sharders

### DIFF
--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -18,6 +18,7 @@ from torch.distributed.optim import (
 )
 from torchrec import distributed as trec_dist
 from torchrec.distributed.embedding import (
+    create_sharding_infos_by_sharding,
     EmbeddingCollectionSharder,
     ShardedEmbeddingCollection,
 )
@@ -34,6 +35,10 @@ from torchrec.distributed.test_utils.multi_process import (
 )
 from torchrec.distributed.test_utils.test_sharding import copy_state_dict
 from torchrec.distributed.types import (
+    BoundsCheckMode,
+    CacheAlgorithm,
+    CacheParams,
+    DataType,
     ModuleSharder,
     QuantizedCommCodecs,
     ShardingEnv,
@@ -274,6 +279,31 @@ class ShardedEmbeddingCollectionParallelTest(MultiProcessTestBase):
             ),
         ]
 
+        constraints = {
+            "table_0": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LRU,
+                    load_factor=0.1,
+                    reserved_memory=8.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.IGNORE,
+            ),
+            "table_1": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LFU,
+                    load_factor=0.2,
+                    reserved_memory=0.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=False,
+                stochastic_rounding=True,
+                bounds_check_mode=BoundsCheckMode.NONE,
+            ),
+        }
+
         # Rank 0
         #             instance 0   instance 1  instance 2
         # "feature_0"   [0, 1]       None        [2]
@@ -324,6 +354,144 @@ class ShardedEmbeddingCollectionParallelTest(MultiProcessTestBase):
             backend="nccl"
             if (torch.cuda.is_available() and torch.cuda.device_count() >= 2)
             else "gloo",
+            constraints=constraints,
             is_data_parallel=(sharding_type == ShardingType.DATA_PARALLEL.value),
             use_apply_optimizer_in_backward=use_apply_optimizer_in_backward,
         )
+
+
+class CreateShardingInfoTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+            EmbeddingConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+        ]
+
+        self.constraints = {
+            "table_0": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LRU,
+                    load_factor=0.1,
+                    reserved_memory=8.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.IGNORE,
+            ),
+            "table_1": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LFU,
+                    load_factor=0.2,
+                    reserved_memory=0.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.NONE,
+            ),
+        }
+
+        self.model = EmbeddingCollection(tables=self.tables)
+        self.sharder = EmbeddingCollectionSharder()
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size=1, compute_device="cpu"),
+            constraints=self.constraints,
+        )
+        self.expected_plan = planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
+
+        self.expected_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            fused_params=None,
+        )
+
+    def test_create_sharding_infos_by_sharding_override(self) -> None:
+        """
+        Test that fused_params from sharders get overridden.
+        """
+
+        # with sharder fused params that will get overridden
+        sharder_fused_params = {"enforce_hbm": False}
+        overriden_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),
+            fused_params=sharder_fused_params,
+        )
+        for sharding_type, overriden_sharding_info in overriden_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, overriden_sharding_info):
+                self.assertEqual(a.fused_params, b.fused_params)
+
+        # with sharder fused params that won't get overridden
+        sharder_fused_params = {"ABC": True}
+        not_overriden_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),
+            fused_params=sharder_fused_params,
+        )
+        for (
+            sharding_type,
+            not_overriden_sharding_info,
+        ) in not_overriden_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, not_overriden_sharding_info):
+                self.assertNotEqual(a.fused_params, b.fused_params)
+
+    def test_create_sharding_infos_by_sharding_combine(self) -> None:
+        """
+        Test that fused_params can get info from both sharder and constraints.
+        """
+
+        new_constraints = copy.deepcopy(self.constraints)
+
+        # remove two fused_params from constraints
+        for _, parameter_constraints in new_constraints.items():
+            parameter_constraints.enforce_hbm = None
+            parameter_constraints.stochastic_rounding = None
+
+        new_planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size=1, compute_device="cpu"),
+            constraints=new_constraints,
+        )
+        new_plan = new_planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
+
+        # provide that two fused params from sharder
+        sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": False}
+
+        combined_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            fused_params=sharder_fused_params,
+        )
+
+        # directly assertion won't work, since sharding_infos also have parameter_sharding
+        for sharding_type, combined_sharding_info in combined_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, combined_sharding_info):
+                self.assertEqual(a.fused_params, b.fused_params)
+
+        # provide that two fused params from sharder wrongly
+        sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": True}
+        wrong_combined_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            fused_params=sharder_fused_params,
+        )
+        for (
+            sharding_type,
+            wrong_combined_sharding_info,
+        ) in wrong_combined_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, wrong_combined_sharding_info):
+                self.assertNotEqual(a.fused_params, b.fused_params)

--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -14,12 +14,14 @@ from typing import Any, Dict, List, Optional
 import hypothesis.strategies as st
 import torch
 import torch.nn as nn
+
 from hypothesis import assume, given, settings, Verbosity
 from torch.distributed.optim import (
     _apply_optimizer_in_backward as apply_optimizer_in_backward,
 )
 from torchrec import distributed as trec_dist
 from torchrec.distributed.embeddingbag import (
+    create_sharding_infos_by_sharding,
     EmbeddingBagCollectionSharder,
     ShardedEmbeddingBagCollection,
 )
@@ -36,6 +38,10 @@ from torchrec.distributed.test_utils.multi_process import (
 )
 from torchrec.distributed.test_utils.test_sharding import copy_state_dict
 from torchrec.distributed.types import (
+    BoundsCheckMode,
+    CacheAlgorithm,
+    CacheParams,
+    DataType,
     ModuleSharder,
     QuantizedCommCodecs,
     ShardingEnv,
@@ -306,6 +312,31 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             ),
         ]
 
+        constraints = {
+            "table_0": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LRU,
+                    load_factor=0.1,
+                    reserved_memory=8.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.IGNORE,
+            ),
+            "table_1": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LFU,
+                    load_factor=0.2,
+                    reserved_memory=0.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=False,
+                stochastic_rounding=True,
+                bounds_check_mode=BoundsCheckMode.NONE,
+            ),
+        }
+
         # Rank 0
         #             instance 0   instance 1  instance 2
         # "feature_0"   [0, 1]       None        [2]
@@ -356,6 +387,149 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             backend="nccl"
             if (torch.cuda.is_available() and torch.cuda.device_count() >= 2)
             else "gloo",
+            constraints=constraints,
             is_data_parallel=(sharding_type == ShardingType.DATA_PARALLEL.value),
             use_apply_optimizer_in_backward=use_apply_optimizer_in_backward,
         )
+
+
+class CreateShardingInfoTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tables = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=4,
+                num_embeddings=4,
+            ),
+        ]
+
+        self.constraints = {
+            "table_0": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LRU,
+                    load_factor=0.1,
+                    reserved_memory=8.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.IGNORE,
+            ),
+            "table_1": ParameterConstraints(
+                cache_params=CacheParams(
+                    algorithm=CacheAlgorithm.LFU,
+                    load_factor=0.2,
+                    reserved_memory=0.0,
+                    precision=DataType.FP16,
+                ),
+                enforce_hbm=True,
+                stochastic_rounding=False,
+                bounds_check_mode=BoundsCheckMode.NONE,
+            ),
+        }
+
+        self.model = EmbeddingBagCollection(tables=self.tables)
+        self.sharder = EmbeddingBagCollectionSharder()
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size=1, compute_device="cpu"),
+            constraints=self.constraints,
+        )
+        self.expected_plan = planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
+
+        self.expected_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            prefix="embedding_bags.",
+            fused_params=None,
+        )
+
+    def test_create_sharding_infos_by_sharding_override(self) -> None:
+        """
+        Test that fused_params from sharders get overridden.
+        """
+
+        # with sharder fused params that will get overridden
+        sharder_fused_params = {"enforce_hbm": False}
+        overriden_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),
+            prefix="embedding_bags.",
+            fused_params=sharder_fused_params,
+        )
+        for sharding_type, overriden_sharding_info in overriden_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, overriden_sharding_info):
+                self.assertEqual(a.fused_params, b.fused_params)
+
+        # with sharder fused params that won't get overridden
+        sharder_fused_params = {"ABC": True}
+        not_overriden_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            self.expected_plan.get_plan_for_module(""),
+            prefix="embedding_bags.",
+            fused_params=sharder_fused_params,
+        )
+        for (
+            sharding_type,
+            not_overriden_sharding_info,
+        ) in not_overriden_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, not_overriden_sharding_info):
+                self.assertNotEqual(a.fused_params, b.fused_params)
+
+    def test_create_sharding_infos_by_sharding_combine(self) -> None:
+        """
+        Test that fused_params can get info from both sharder and constraints.
+        """
+
+        new_constraints = copy.deepcopy(self.constraints)
+
+        # remove two fused_params from constraints
+        for _, parameter_constraints in new_constraints.items():
+            parameter_constraints.enforce_hbm = None
+            parameter_constraints.stochastic_rounding = None
+
+        new_planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size=1, compute_device="cpu"),
+            constraints=new_constraints,
+        )
+        new_plan = new_planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
+
+        # provide that two fused params from sharder
+        sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": False}
+
+        combined_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            prefix="embedding_bags.",
+            fused_params=sharder_fused_params,
+        )
+
+        # directly assertion won't work, since sharding_infos also have parameter_sharding
+        for sharding_type, combined_sharding_info in combined_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, combined_sharding_info):
+                self.assertEqual(a.fused_params, b.fused_params)
+
+        # provide that two fused params from sharder wrongly
+        sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": True}
+        wrong_combined_sharding_infos = create_sharding_infos_by_sharding(
+            self.model,
+            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+            prefix="embedding_bags.",
+            fused_params=sharder_fused_params,
+        )
+        for (
+            sharding_type,
+            wrong_combined_sharding_info,
+        ) in wrong_combined_sharding_infos.items():
+            expected_sharding_info = self.expected_sharding_infos[sharding_type]
+            for a, b in zip(expected_sharding_info, wrong_combined_sharding_info):
+                self.assertNotEqual(a.fused_params, b.fused_params)

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -52,7 +52,9 @@ from torchrec.distributed.types import (
     ShardMetadata,
 )
 from torchrec.distributed.utils import (
+    add_params_from_parameter_sharding,
     append_prefix,
+    convert_to_fbgemm_types,
     filter_state_dict,
     merge_fused_params,
     optimizer_type_to_emb_opt_type,
@@ -167,7 +169,12 @@ def create_sharding_infos_by_sharding(
             optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
                 optimizer_class
             )
-        fused_params = merge_fused_params(fused_params, optimizer_params)
+
+        per_table_fused_params = merge_fused_params(fused_params, optimizer_params)
+        per_table_fused_params = add_params_from_parameter_sharding(
+            per_table_fused_params, parameter_sharding
+        )
+        per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
 
         sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
             (
@@ -187,7 +194,7 @@ def create_sharding_infos_by_sharding(
                     ),
                     param_sharding=parameter_sharding,
                     param=param,
-                    fused_params=fused_params,
+                    fused_params=per_table_fused_params,
                 )
             )
         )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -94,6 +94,10 @@ def _to_sharding_plan(
             sharding_type=sharding_type,
             compute_kernel=sharding_option.compute_kernel,
             ranks=[cast(int, shard.rank) for shard in shards],
+            cache_params=sharding_option.cache_params,
+            enforce_hbm=sharding_option.enforce_hbm,
+            stochastic_rounding=sharding_option.stochastic_rounding,
+            bounds_check_mode=sharding_option.bounds_check_mode,
         )
         plan[sharding_option.path] = module_plan
     return ShardingPlan(plan)

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -66,11 +66,24 @@ class EmbeddingPerfEstimator(ShardEstimator):
         for sharding_option in sharding_options:
             sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
+
             caching_ratio = (
-                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
-                if hasattr(sharder, "fused_params") and sharder.fused_params
+                self._constraints[  # pyre-ignore[16]
+                    sharding_option.name
+                ].cache_params.load_factor
+                if self._constraints
+                and self._constraints.get(sharding_option.name)
+                and self._constraints[sharding_option.name].cache_params
                 else None
             )
+            # TODO: remove after deprecating fused_params in sharder
+            if caching_ratio is None:
+                caching_ratio = (
+                    sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                    if hasattr(sharder, "fused_params") and sharder.fused_params
+                    else None
+                )
+
             num_poolings = (
                 cast(List[float], self._constraints[sharding_option.name].num_poolings)
                 if self._constraints
@@ -711,11 +724,24 @@ class EmbeddingStorageEstimator(ShardEstimator):
         for sharding_option in sharding_options:
             sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
+
             caching_ratio = (
-                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
-                if hasattr(sharder, "fused_params") and sharder.fused_params
+                self._constraints[  # pyre-ignore[16]
+                    sharding_option.name
+                ].cache_params.load_factor
+                if self._constraints
+                and self._constraints.get(sharding_option.name)
+                and self._constraints[sharding_option.name].cache_params
                 else None
             )
+            # TODO: remove after deprecating fused_params in sharder
+            if caching_ratio is None:
+                caching_ratio = (
+                    sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                    if hasattr(sharder, "fused_params") and sharder.fused_params
+                    else None
+                )
+
             num_poolings = (
                 cast(List[float], self._constraints[sharding_option.name].num_poolings)
                 if self._constraints

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -23,7 +23,12 @@ from torchrec.distributed.planner.constants import (
     INTRA_NODE_BANDWIDTH,
     POOLING_FACTOR,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingPlan
+from torchrec.distributed.types import (
+    BoundsCheckMode,
+    CacheParams,
+    ModuleSharder,
+    ShardingPlan,
+)
 from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
 
 # ---- Perf ---- #
@@ -244,6 +249,10 @@ class ShardingOption:
         partition_by: str,
         compute_kernel: str,
         shards: List[Shard],
+        cache_params: Optional[CacheParams] = None,
+        enforce_hbm: Optional[bool] = None,
+        stochastic_rounding: Optional[bool] = None,
+        bounds_check_mode: Optional[BoundsCheckMode] = None,
         dependency: Optional[str] = None,
     ) -> None:
         self.name = name
@@ -257,6 +266,10 @@ class ShardingOption:
         # relevant to planner output, must be populated if sharding option
         # part of final solution
         self.shards = shards
+        self.cache_params = cache_params
+        self.enforce_hbm = enforce_hbm
+        self.stochastic_rounding = stochastic_rounding
+        self.bounds_check_mode = bounds_check_mode
         self.dependency = dependency
         self._is_pooled: Optional[bool] = None
 

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -375,6 +375,10 @@ class ParameterConstraints:
     num_poolings: Optional[List[float]] = None  # number of poolings per sample in batch
     batch_sizes: Optional[List[int]] = None  # batch size per input feature
     is_weighted: bool = False
+    cache_params: Optional[CacheParams] = None
+    enforce_hbm: Optional[bool] = None
+    stochastic_rounding: Optional[bool] = None
+    bounds_check_mode: Optional[BoundsCheckMode] = None
 
 
 class PlannerErrorType(Enum):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -439,6 +439,14 @@ class ModuleShardingPlan:
 
 
 @dataclass
+class CacheParams:
+    algorithm: Optional[CacheAlgorithm] = None
+    load_factor: Optional[float] = None
+    reserved_memory: Optional[float] = None
+    precision: Optional[DataType] = None
+
+
+@dataclass
 class ParameterSharding:
     """
         Describes the sharding of the parameter.
@@ -448,6 +456,10 @@ class ParameterSharding:
         compute_kernel (str): compute kernel to be used by this parameter.
         ranks (Optional[List[int]]): rank of each shard.
         sharding_spec (Optional[ShardingSpec]): list of ShardMetadata for each shard.
+        cache_params (Optional[CacheParams]): cache params for embedding lookup.
+        enforce_hbm (Optional[bool]): whether to use HBM.
+        stochastic_rounding (Optional[bool]): whether to use stochastic rounding.
+        bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -462,6 +474,10 @@ class ParameterSharding:
     compute_kernel: str
     ranks: Optional[List[int]] = None
     sharding_spec: Optional[ShardingSpec] = None
+    cache_params: Optional[CacheParams] = None
+    enforce_hbm: Optional[bool] = None
+    stochastic_rounding: Optional[bool] = None
+    bounds_check_mode: Optional[BoundsCheckMode] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -55,6 +55,46 @@ from torch.nn.modules.module import _addindent
 from torchrec.streamable import Multistreamable
 
 
+@unique
+class BoundsCheckMode(Enum):
+    # Raise an exception (CPU) or device-side assert (CUDA)
+    FATAL = 0
+    # Log the first out-of-bounds instance per kernel, and set to zero.
+    WARNING = 1
+    # Set to zero.
+    IGNORE = 2
+    # No bounds checks.
+    NONE = 3
+
+
+@unique
+class CacheAlgorithm(Enum):
+    LRU = 0
+    LFU = 1
+
+
+# moved DataType here to avoid circular import
+# TODO: organize types and dependencies
+@unique
+class DataType(Enum):
+    """
+    Our fusion implementation supports only certain types of data
+    so it makes sense to retrict in a non-fused version as well.
+    """
+
+    FP32 = "FP32"
+    FP16 = "FP16"
+    INT64 = "INT64"
+    INT32 = "INT32"
+    INT8 = "INT8"
+    UINT8 = "UINT8"
+    INT4 = "INT4"
+    INT2 = "INT2"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class ShardingType(Enum):
     """
     Well-known sharding types, used by inter-module optimizations.

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import logging
 
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
@@ -14,10 +15,23 @@ import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from torch import nn
 from torchrec import optim as trec_optim
-from torchrec.distributed.types import ShardedModule
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.types import (
+    BoundsCheckMode,
+    CacheAlgorithm,
+    DataType,
+    ParameterSharding,
+    ShardedModule,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import (
+    data_type_to_sparse_type,
+    to_fbgemm_bounds_check_mode,
+    to_fbgemm_cache_algorithm,
+)
 from torchrec.types import CopyMixIn
 
-
+logger: logging.Logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
@@ -321,6 +335,87 @@ def merge_fused_params(
     _fused_params = copy.deepcopy(fused_params)
     _fused_params.update(param_fused_params)
     return _fused_params
+
+
+def add_params_from_parameter_sharding(
+    fused_params: Optional[Dict[str, Any]],
+    parameter_sharding: ParameterSharding,
+) -> Dict[str, Any]:
+    """
+    Extract params from parameter sharding and then add them to fused_params.
+
+    Params from parameter sharding will override the ones in fused_params if they
+    exist already.
+
+    Args:
+        fused_params (Optional[Dict[str, Any]]): the existing fused_params
+        parameter_sharding (ParameterSharding): the parameter sharding to use
+
+    Returns:
+        [Dict[str, Any]]: the fused_params dictionary with params from parameter
+        sharding added.
+
+    """
+    if fused_params is None:
+        fused_params = {}
+
+    # update fused_params using params from parameter_sharding
+    # this will take precidence over the fused_params provided from sharders
+    if parameter_sharding.cache_params is not None:
+        cache_params = parameter_sharding.cache_params
+        if cache_params.algorithm is not None:
+            fused_params["cache_algorithm"] = cache_params.algorithm
+        if cache_params.load_factor is not None:
+            fused_params["cache_load_factor"] = cache_params.load_factor
+        if cache_params.reserved_memory is not None:
+            fused_params["cache_reserved_memory"] = cache_params.reserved_memory
+        if cache_params.precision is not None:
+            fused_params["cache_precision"] = cache_params.precision
+
+    if parameter_sharding.enforce_hbm is not None:
+        fused_params["enforce_hbm"] = parameter_sharding.enforce_hbm
+
+    if parameter_sharding.stochastic_rounding is not None:
+        fused_params["stochastic_rounding"] = parameter_sharding.stochastic_rounding
+
+    if parameter_sharding.bounds_check_mode is not None:
+        fused_params["bounds_check_mode"] = parameter_sharding.bounds_check_mode
+
+    # print warning if sharding_type is data_parallel or kernel is dense
+    if parameter_sharding.sharding_type == ShardingType.DATA_PARALLEL.value:
+        logger.warning(
+            f"Sharding Type is {parameter_sharding.sharding_type}, "
+            "caching params will be ignored"
+        )
+    elif parameter_sharding.compute_kernel == EmbeddingComputeKernel.DENSE.value:
+        logger.warning(
+            f"Compute Kernel is {parameter_sharding.compute_kernel}, "
+            "caching params will be ignored"
+        )
+
+    return fused_params
+
+
+def convert_to_fbgemm_types(fused_params: Dict[str, Any]) -> Dict[str, Any]:
+    if "cache_precision" in fused_params:
+        if isinstance(fused_params["cache_precision"], DataType):
+            fused_params["cache_precision"] = data_type_to_sparse_type(
+                fused_params["cache_precision"]
+            )
+
+    if "cache_algorithm" in fused_params:
+        if isinstance(fused_params["cache_algorithm"], CacheAlgorithm):
+            fused_params["cache_algorithm"] = to_fbgemm_cache_algorithm(
+                fused_params["cache_algorithm"]
+            )
+
+    if "bounds_check_mode" in fused_params:
+        if isinstance(fused_params["bounds_check_mode"], BoundsCheckMode):
+            fused_params["bounds_check_mode"] = to_fbgemm_bounds_check_mode(
+                fused_params["bounds_check_mode"]
+            )
+
+    return fused_params
 
 
 def init_parameters(module: nn.Module, device: torch.device) -> None:

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -13,7 +13,12 @@ from typing import Callable, Dict, List, Optional
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import PoolingMode
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    BoundsCheckMode as FbgemmBoundsCheckMode,
+    CacheAlgorithm as FbgemmCacheAlgorithm,
+    PoolingMode,
+)
+from torchrec.distributed.types import BoundsCheckMode, CacheAlgorithm, DataType
 
 
 @unique
@@ -21,26 +26,6 @@ class PoolingType(Enum):
     SUM = "SUM"
     MEAN = "MEAN"
     NONE = "NONE"
-
-
-@unique
-class DataType(Enum):
-    """
-    Our fusion implementation supports only certain types of data
-    so it makes sense to retrict in a non-fused version as well.
-    """
-
-    FP32 = "FP32"
-    FP16 = "FP16"
-    INT64 = "INT64"
-    INT32 = "INT32"
-    INT8 = "INT8"
-    UINT8 = "UINT8"
-    INT4 = "INT4"
-    INT2 = "INT2"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
@@ -51,6 +36,30 @@ DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
     DataType.INT4: 4,
     DataType.INT2: 2,
 }
+
+
+def to_fbgemm_bounds_check_mode(
+    bounds_check_mode: BoundsCheckMode,
+) -> FbgemmBoundsCheckMode:
+    if bounds_check_mode == BoundsCheckMode.FATAL:
+        return FbgemmBoundsCheckMode.FATAL
+    elif bounds_check_mode == BoundsCheckMode.WARNING:
+        return FbgemmBoundsCheckMode.WARNING
+    elif bounds_check_mode == BoundsCheckMode.IGNORE:
+        return FbgemmBoundsCheckMode.IGNORE
+    elif bounds_check_mode == BoundsCheckMode.NONE:
+        return FbgemmBoundsCheckMode.NONE
+    else:
+        raise Exception(f"Invalid bounds check mode {bounds_check_mode}")
+
+
+def to_fbgemm_cache_algorithm(cache_algorithm: CacheAlgorithm) -> FbgemmCacheAlgorithm:
+    if cache_algorithm == CacheAlgorithm.LRU:
+        return FbgemmCacheAlgorithm.LRU
+    elif cache_algorithm == CacheAlgorithm.LFU:
+        return FbgemmCacheAlgorithm.LFU
+    else:
+        raise Exception(f"Invalid cache algorithm {cache_algorithm}")
 
 
 def dtype_to_data_type(dtype: torch.dtype) -> DataType:


### PR DESCRIPTION
Summary:
1. extract fused params from parameter_sharding of each table
2. override the fused params from sharders, if there are any
3. add unit tests for each sharded module to show
(a) passing fused_params this way doesn't break anything
(b) fused_params from parameter_sharding overrides that of sharders
4. convert fused params in torchrec types to fbgemm types before passing onto fbgemm kernels
5. Add warning when sharding type is data parallel or compute kernel is dense.

Differential Revision: D45824598

