### PR TITLE
Update pyre to latest version

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -10,5 +10,5 @@
     {"import_root": ".", "source": "torchrec"}
   ],
   "strict": true,
-  "version": "0.0.101674562297"
+  "version": "0.0.101683630711"
 }

--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -164,7 +164,7 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
         return super().apply(fn)
 
     # fmt: off
-    # pyre-ignore[2, 47]
+    # pyre-ignore
     def _infer_parameters(self: _LazyExtensionProtocol, module, input, kwargs) -> None:
         r"""Infers the size and initializes the parameters according to the
         provided input batch.
@@ -255,5 +255,5 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
         return result
     # fmt: on
 
-    # pyre-ignore[4]
+    # pyre-ignore
     __call__: Callable[..., Any] = _call_impl


### PR DESCRIPTION
Summary:
Update pyre to latest version.
Should fix the error `ERROR: Could not find a version that satisfies the requirement pyre-check-nightly==0.0.101674562297`

Differential Revision: D46496954

