### PR TITLE
Fix QECSharder to respect shard() device

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -401,7 +401,13 @@ class QuantEmbeddingCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingCollection(
+            module=module,
+            table_name_to_parameter_sharding=params,
+            env=env,
+            fused_params=fused_params,
+            device=device,
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingCollection]:

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -307,7 +307,13 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingBagCollection(
+            module=module,
+            table_name_to_parameter_sharding=params,
+            env=env,
+            fused_params=fused_params,
+            device=device,
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingBagCollection]:


### PR DESCRIPTION
Summary: shard(device) was not propagated to the creation of SQEC

Differential Revision:
D46568796

Privacy Context Container: L1138451

