### PR TITLE
change aligment for cpu

### DIFF
--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -383,9 +383,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         )
 
         expected_total_perfs = {
-            ("quant", "table_wise"): [0.0001296231579222408],
-            ("quant_uvm", "table_wise"): [0.018350937787224266],
-            ("quant_uvm_caching", "table_wise"): [0.004269758427175579],
+            ("quant", "table_wise"): [0.00012272310629071731],
+            ("quant_uvm", "table_wise"): [0.017693276498831956],
+            ("quant_uvm_caching", "table_wise"): [0.00411499640164215],
         }
 
         total_perfs = {

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -244,7 +244,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         self._table_name_to_quantized_weights: Optional[
             Dict[str, Tuple[Tensor, Tensor]]
         ] = None
-
+        self._alignment = 1 if self._device == torch.device("cpu") else 16
         table_names = set()
         for table in self._embedding_bag_configs:
             if table.name in table_names:
@@ -292,7 +292,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
                 weight_lists=weight_lists,
                 device=device,
                 output_dtype=data_type_to_sparse_type(dtype_to_data_type(output_dtype)),
-                row_alignment=16,
+                row_alignment=self._alignment,
                 feature_table_map=feature_table_map,
             )
             if device != torch.device("meta") and weight_lists is None:
@@ -528,6 +528,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         self._need_indices: bool = need_indices
         self._output_dtype = output_dtype
         self._device = device
+        self._alignment = 1 if self._device == torch.device("cpu") else 16
 
         table_names = set()
         for config in tables:
@@ -564,7 +565,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 weight_lists=weight_lists,
                 device=device,
                 output_dtype=data_type_to_sparse_type(dtype_to_data_type(output_dtype)),
-                row_alignment=16,
+                row_alignment=self._alignment,
             )
             if device != torch.device("meta") and weight_lists is None:
                 emb_module.initialize_weights()


### PR DESCRIPTION
Summary:
* change QEC aligement back to 1 for CPU execution.
* QEC is only used for CPU execution as of now and for GPU QEC we use sharded version so

Reviewed By: s4ayub

Differential Revision: D46524943

