### PR TITLE
Inference CW sharding for EBC

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -34,6 +34,7 @@ from torchrec.distributed.fused_params import (
     is_fused_param_register_tbe,
 )
 from torchrec.distributed.quant_state import ShardedQuantEmbeddingModuleState
+from torchrec.distributed.sharding.cw_sharding import InferCwPooledEmbeddingSharding
 from torchrec.distributed.sharding.rw_sharding import InferRwPooledEmbeddingSharding
 from torchrec.distributed.sharding.tw_sharding import InferTwEmbeddingSharding
 from torchrec.distributed.types import (
@@ -67,6 +68,10 @@ def create_infer_embedding_bag_sharding(
         return InferTwEmbeddingSharding(sharding_infos, env, device=None)
     elif sharding_type == ShardingType.ROW_WISE.value:
         return InferRwPooledEmbeddingSharding(sharding_infos, env, device=None)
+    elif sharding_type == ShardingType.COLUMN_WISE.value:
+        return InferCwPooledEmbeddingSharding(
+            sharding_infos, env, device=None, permute_embeddings=True
+        )
     else:
         raise ValueError(f"Sharding type not supported {sharding_type}")
 

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -12,7 +12,11 @@ import torch.distributed as dist  # noqa
 from fbgemm_gpu.permute_pooled_embedding_modules_split import (
     PermutePooledEmbeddingsSplit,
 )
-from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.dist_data import EmbeddingsAllToOne
+from torchrec.distributed.embedding_lookup import (
+    GroupedPooledEmbeddingsLookup,
+    InferGroupedPooledEmbeddingsLookup,
+)
 from torchrec.distributed.embedding_sharding import (
     BaseEmbeddingDist,
     BaseEmbeddingLookup,
@@ -23,14 +27,19 @@ from torchrec.distributed.embedding_sharding import (
 from torchrec.distributed.embedding_types import (
     BaseGroupedFeatureProcessor,
     EmbeddingComputeKernel,
+    KJTList,
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.sharding.tw_sharding import (
     BaseTwEmbeddingSharding,
+    InferTwSparseFeaturesDist,
     TwPooledEmbeddingDist,
     TwSparseFeaturesDist,
 )
 from torchrec.distributed.types import (
+    Awaitable,
+    NoWait,
+    NullShardingContext,
     QuantizedCommCodecs,
     ShardedTensorMetadata,
     ShardingEnv,
@@ -132,8 +141,7 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
         self,
         sharding_infos: List[EmbeddingShardingInfo],
     ) -> List[List[ShardedEmbeddingTable]]:
-        # pyre-fixme[16]: `Optional` has no attribute `size`.
-        world_size = self._pg.size()
+        world_size: int = self._env.world_size
         tables_per_rank: List[List[ShardedEmbeddingTable]] = [
             [] for i in range(world_size)
         ]
@@ -253,3 +261,108 @@ class CwPooledEmbeddingSharding(
             callbacks,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
+
+
+class InferCwPooledEmbeddingSharding(
+    BaseCwEmbeddingSharding[
+        NullShardingContext, KJTList, List[torch.Tensor], torch.Tensor
+    ]
+):
+    def create_input_dist(
+        self, device: Optional[torch.device] = None
+    ) -> BaseSparseFeaturesDist[KJTList]:
+        return InferTwSparseFeaturesDist(
+            self.features_per_rank(),
+            self._world_size,
+        )
+
+    def create_lookup(
+        self,
+        device: Optional[torch.device] = None,
+        fused_params: Optional[Dict[str, Any]] = None,
+        feature_processor: Optional[BaseGroupedFeatureProcessor] = None,
+    ) -> BaseEmbeddingLookup[KJTList, List[torch.Tensor]]:
+        return InferGroupedPooledEmbeddingsLookup(
+            grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
+            world_size=self._world_size,
+            fused_params=fused_params,
+        )
+
+    def create_output_dist(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]:
+        device = device if device is not None else self._device
+        assert device is not None
+
+        dist_out = InferCwPooledEmbeddingDist(
+            device,
+            self._world_size,
+        )
+
+        if self._permute_embeddings and self._embedding_order != list(
+            range(len(self._embedding_order))
+        ):
+            return InferCwPooledEmbeddingDistWithPermute(
+                device, self._world_size, self._embedding_dims, self._embedding_order
+            )
+
+        return dist_out
+
+
+class InferCwPooledEmbeddingDist(
+    BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]
+):
+    def __init__(
+        self,
+        device: torch.device,
+        world_size: int,
+    ) -> None:
+        super().__init__()
+        self._dist: EmbeddingsAllToOne = EmbeddingsAllToOne(
+            device=device, world_size=world_size, cat_dim=1
+        )
+
+    def forward(
+        self,
+        local_embs: List[torch.Tensor],
+        sharding_ctx: Optional[NullShardingContext] = None,
+    ) -> torch.Tensor:
+        return self._dist.forward(
+            local_embs,
+        )
+
+
+@torch.fx.wrap
+def _fx_wrap_permute(
+    permute_module: PermutePooledEmbeddingsSplit, input: torch.Tensor
+) -> torch.Tensor:
+    return permute_module.forward(input)
+
+
+class InferCwPooledEmbeddingDistWithPermute(
+    BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]
+):
+    def __init__(
+        self,
+        device: torch.device,
+        world_size: int,
+        embedding_dims: List[int],
+        permute: List[int],
+    ) -> None:
+        super().__init__()
+        self._dist: EmbeddingsAllToOne = EmbeddingsAllToOne(
+            device=device, world_size=world_size, cat_dim=1
+        )
+        self._permute: PermutePooledEmbeddingsSplit = PermutePooledEmbeddingsSplit(
+            embs_dims=embedding_dims,
+            permute=permute,
+            device=device,
+        )
+
+    def forward(
+        self,
+        local_embs: List[torch.Tensor],
+        sharding_ctx: Optional[NullShardingContext] = None,
+    ) -> torch.Tensor:
+        return self._permute.forward(self._dist.forward(local_embs))

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -215,3 +215,49 @@ class InferShardingsTest(unittest.TestCase):
         gm_script = torch.jit.script(gm)
         gm_script_output = gm_script(*inputs[0])
         assert_close(sharded_output, gm_script_output)
+
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs available",
+    )
+    def test_cw(self) -> None:
+        num_embeddings = 64
+        emb_dim = 512
+        emb_dim_4 = 512 // 4
+        world_size = 2
+        batch_size = 4
+        local_device = torch.device("cuda:0")
+        mi = _model(
+            num_embeddings,
+            emb_dim,
+            world_size,
+            batch_size,
+            dense_device=local_device,
+            sparse_device=local_device,
+            quant_state_dict_split_scale_bias=True,
+        )
+
+        non_sharded_model = mi.quant_model
+        sharded_model = _shard_qebc(
+            mi,
+            sharding_type=ShardingType.COLUMN_WISE,
+            device=local_device,
+            expected_shards=[
+                ((0, 0, num_embeddings, emb_dim_4), "rank:0/cuda:0"),
+                ((0, 1 * emb_dim_4, num_embeddings, emb_dim_4), "rank:1/cuda:1"),
+                ((0, 2 * emb_dim_4, num_embeddings, emb_dim_4), "rank:0/cuda:0"),
+                ((0, 3 * emb_dim_4, num_embeddings, emb_dim_4), "rank:1/cuda:1"),
+            ],
+        )
+        inputs = [
+            model_input_to_forward_args(inp.to(local_device))
+            for inp in prep_inputs(mi, world_size, batch_size)
+        ]
+        sharded_model.load_state_dict(non_sharded_model.state_dict())
+        # torchrec.distributed.test_utils.test_sharding.copy_state_dict(sharded_model.state_dict(), non_sharded_model.state_dict()) does not work for CW due to non-trivial qscaleshift copy which is handled in shardedQEBC load_state_dict
+
+        # We need this first inference to make all lazy init in forward
+        sharded_output = sharded_model(*inputs[0])
+        non_sharded_output = non_sharded_model(*inputs[0])
+        assert_close(non_sharded_output, sharded_output)

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -206,6 +206,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -268,6 +269,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -361,6 +363,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -503,6 +506,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -584,6 +588,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -666,6 +671,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )
@@ -746,6 +752,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 (ShardingType.TABLE_WISE.value, False),
                 (ShardingType.TABLE_WISE.value, True),
                 (ShardingType.ROW_WISE.value, True),
+                (ShardingType.COLUMN_WISE.value, True),
             ]
         ),
     )


### PR DESCRIPTION
Summary:
CW sharding for EBC

quant_embedding_kernel.py

Change temporary hack of using table.embedding_dim as the size of table. For CW sharding we can have only part of the columns in the table.
The main reason why table.embedding_dim was used here was the changed number of columns (shape[1]) of the tensor for row-wise quantized tensor (fbgemm rowwise stores quantization scale and shift in the same tensor).

We changed that splitting additional quantization parameters to separate tensor.

cw_sharding.py

Adding Dists which work like a training ones except:
 - no usage of processgroup (we are in single process environment in inference)
 - EmbeddingsAllToOne instead of EmbeddingsAllToAll

test_quant_model_parallel.py
quant_embeddingbag.py

Registration of CW sharding

Differential Revision: D45285130

