### PR TITLE
pass in device when sharding QEBC and QEC

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -407,7 +407,9 @@ class QuantEmbeddingCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingCollection]:

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -315,7 +315,9 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingBagCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingBagCollection]:


### PR DESCRIPTION
Summary: ATT, we want to pass in the device as the argument as well.

Differential Revision: D46650256

