### PR TITLE
Support EBC load_state_dict for unsharded tensors

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -232,7 +232,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             else:
                 plan = planner.plan(module, sharders)
         self._plan: ShardingPlan = plan
-
         self._dmp_wrapped_module: nn.Module = self._init_dmp(module)
         self._optim: CombinedOptimizer = self._init_optim(self._dmp_wrapped_module)
 

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -354,6 +354,9 @@ class FusedEmbeddingBagCollection(
 
         self._optimizer_type = optimizer_type
         self._optimizer_kwargs = optimizer_kwargs
+        self._device: torch.device = (
+            device if device is not None else torch.device("cpu")
+        )
 
         emb_optim_and_kwargs = convert_optimizer_type_and_kwargs(
             optimizer_type, optimizer_kwargs
@@ -499,6 +502,10 @@ class FusedEmbeddingBagCollection(
 
     def _get_name(self) -> str:
         return "FusedEmbeddingBagCollection"
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
 
     def embedding_bag_configs(self) -> List[EmbeddingBagConfig]:
         return self._embedding_bag_configs


### PR DESCRIPTION
Summary:
Addresses https://github.com/pytorch/torchrec/issues/1165 but for `EBC` as well
Extension of D46158165
Fixed a bug too where tbe_module overwrites the module in the sharded EBC init.

{gif:ezoq6rkt}

Differential Revision: D46653763

