### PR TITLE
Fix embedding lookup device init

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -492,7 +492,7 @@ class KJTOneToAll(nn.Module):
         self._splits = splits
         self._world_size = world_size
         self._device_type = (
-            "cuda" if device is None or device.type == "cuda" else "meta"
+            "meta" if device is not None and device.type == "meta" else "cuda"
         )
         assert self._world_size == len(splits)
 

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -758,7 +758,7 @@ class InferGroupedPooledEmbeddingsLookup(
             MetaInferGroupedPooledEmbeddingsLookup
         ] = []
 
-        device_type = "cuda" if device is None or device.type == "cuda" else "meta"
+        device_type = "meta" if device is not None and device.type == "meta" else "cuda"
         for rank in range(world_size):
             self._embedding_lookups_per_rank.append(
                 # TODO add position weighted module support
@@ -791,8 +791,7 @@ class InferGroupedEmbeddingsLookup(
         super().__init__()
         self._embedding_lookups_per_rank: List[MetaInferGroupedEmbeddingsLookup] = []
 
-        device_type = "cuda" if device is None or device.type == "cuda" else "meta"
-
+        device_type = "meta" if device is not None and device.type == "meta" else "cuda"
         for rank in range(world_size):
             self._embedding_lookups_per_rank.append(
                 MetaInferGroupedEmbeddingsLookup(

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -401,7 +401,9 @@ class QuantEmbeddingCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingCollection]:

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -307,7 +307,9 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingBagCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingBagCollection]:


### PR DESCRIPTION
Summary:
Previously, if you pass in cpu device, then it'll go to meta...but we only want to go to meta if they explicitly set meta device.

With this, now even cpu device will go to cuda, that may not be "correct" behavior but it's how it was before.

Reviewed By: 842974287

Differential Revision: D46736834

