### PR TITLE
Automatically infer batch size in Torchrec DLRM model

### DIFF
--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -98,14 +98,12 @@ class SparseArch(nn.Module):
 
         sparse_features: KeyedTensor = self.embedding_bag_collection(features)
 
-        B: int = features.stride()
-
         sparse: Dict[str, torch.Tensor] = sparse_features.to_dict()
         sparse_values: List[torch.Tensor] = []
         for name in self.sparse_feature_names:
             sparse_values.append(sparse[name])
 
-        return torch.cat(sparse_values, dim=1).reshape(B, self.F, self.D)
+        return torch.cat(sparse_values, dim=1).reshape(-1, self.F, self.D)
 
     @property
     def sparse_feature_names(self) -> List[str]:


### PR DESCRIPTION
Summary:
Working on enabling APS DLRM publishing and noticed that `torch.fx.GraphModule` cannot load input sparse feature's stride after some operations, thus making the publishing job failed as in https://www.internalfb.com/intern/everpaste/?handle=GKBtBhUpwo6n7GMCAEFP7CinsIdDbsIXAAAB

By inferring the batch size automatically as in this diff, the error got bypassed and publish succeeded.

This auto-inferring should perform the same as before.

Differential Revision: D46744432

