### PR TITLE
allow putting tbe buffers (except weights) on cpu even if current device is meta

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -401,7 +401,9 @@ class QuantEmbeddingCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingCollection]:

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -169,6 +169,7 @@ class QuantBatchedEmbeddingBag(
             feature_table_map=self._feature_table_map,
             row_alignment=16,
             uvm_host_mapped=True,  # Use cudaHostAlloc for UVM CACHING to fix imbalance numa memory issue
+            only_weights_on_meta=True,  # When we use meta device, we still want buffers other than weights to be on cpu
             **(tbe_fused_params(fused_params) or {}),
         )
         if device is not None:
@@ -316,6 +317,7 @@ class QuantBatchedEmbedding(
             feature_table_map=self._feature_table_map,
             row_alignment=16,
             uvm_host_mapped=True,  # Use cudaHostAlloc for UVM CACHING to fix imbalance numa memory issue
+            only_weights_on_meta=True,  # When we use meta device, we still want buffers other than weights to be on cpu
             **(tbe_fused_params(fused_params) or {}),
         )
         if device is not None:

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -307,7 +307,9 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
             module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
         )
-        return ShardedQuantEmbeddingBagCollection(module, params, env, fused_params)
+        return ShardedQuantEmbeddingBagCollection(
+            module, params, env, fused_params, device=device
+        )
 
     @property
     def module_type(self) -> Type[QuantEmbeddingBagCollection]:


### PR DESCRIPTION
Summary: When we enable meta sharding, we want to leave the buffers on cpu except the weights so that we won't loose meta info like `rows_per_table` etc.

Differential Revision: D46665580

