### PR TITLE
Fix memory issue when loading state dict

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -439,9 +439,12 @@ class ShardedEmbeddingCollection(
                 else:
                     dim = state_dict[key].metadata().shards_metadata[0].shard_sizes[1]
                     # CW multiple shards are merged
-                    state_dict[key] = torch.cat(
-                        [shard.tensor.view(-1) for shard in local_shards], dim=0
-                    ).view(-1, dim)
+                    if len(local_shards) > 1:
+                        state_dict[key] = torch.cat(
+                            [s.tensor.view(-1) for s in local_shards], dim=0
+                        ).view(-1, dim)
+                    else:
+                        state_dict[key] = local_shards[0].tensor.view(-1, dim)
             else:
                 local_shards = []
                 for shard in model_shards:

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -461,9 +461,12 @@ class ShardedEmbeddingBagCollection(
             else:
                 dim = state_dict[key].metadata().shards_metadata[0].shard_sizes[1]
                 # CW multiple shards are merged
-                state_dict[key] = torch.cat(
-                    [s.tensor.view(-1) for s in local_shards], dim=0
-                ).view(-1, dim)
+                if len(local_shards) > 1:
+                    state_dict[key] = torch.cat(
+                        [s.tensor.view(-1) for s in local_shards], dim=0
+                    ).view(-1, dim)
+                else:
+                    state_dict[key] = local_shards[0].tensor.view(-1, dim)
 
     def _initialize_torch_state(self) -> None:  # noqa
         """


### PR DESCRIPTION
Summary:
ATT

if we have only one local shard we shouldn't torch.cat (which temporarily allocates new CUDA memory).

In the case of column wise with multiple shards, we can actually fix this

in our plan we need to ensure that all shards are in increasing order, that way if any rank has > 1 shard placed on it they will be contiguous, and thus we can view it with the correct (-1, embedding_dim), and account for correct offsets

Differential Revision: D46805928

