### PR TITLE
Remove refcycle in SequenceEmbeddingsAwaitable

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -911,15 +911,13 @@ class SequenceEmbeddingsAwaitable(Awaitable[torch.Tensor]):
     ) -> None:
         super().__init__()
         self._tensor_awaitable = tensor_awaitable
-        self._unbucketize_permute_tensor = unbucketize_permute_tensor
-        self._embedding_dim = embedding_dim
 
-        if self._unbucketize_permute_tensor is not None:
+        if unbucketize_permute_tensor is not None:
             self.callbacks.append(
                 lambda ret: torch.index_select(
-                    ret.view(-1, self._embedding_dim),
+                    ret.view(-1, embedding_dim),
                     0,
-                    self._unbucketize_permute_tensor,
+                    unbucketize_permute_tensor,
                 )
             )
 


### PR DESCRIPTION
Summary:
Remove the reference cycle that points the callback of SequenceEmbeddingsAwaitable back to itself. This refcycle causes many GPU tensors to stay alive, since this refcycle holds references to Tensor objects (preventing them from being reclaimed until a gc collect).

According to python's gc, when disabling automatic garbage collection, we should ensure that our program removes all reference cycles.

> Since the collector supplements the reference counting already used in Python, you can disable the collector if you are sure your program does not create reference cycles.

https://docs.python.org/3/library/gc.html

Differential Revision: D46737088

Pulled By: aaronenyeshi

