### PR TITLE
sync sample weights dtype with embedding table

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -188,7 +188,9 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                 res = embedding_bag(
                     input=f.values(),
                     offsets=f.offsets(),
-                    per_sample_weights=f.weights() if self._is_weighted else None,
+                    per_sample_weights=f.weights().type(embedding_bag.weight.dtype)
+                    if self._is_weighted
+                    else None,
                 ).float()
                 pooled_embeddings.append(res)
         data = torch.cat(pooled_embeddings, dim=1)


### PR DESCRIPTION
Summary:
The TBEs allow embedding_table.weights dtype and per sample weights to be different dtypes (e.g. table is FP16, weights are FP32)

https://pxl.cl/2PfnF

Make the unsharded EBC have this behavior tom by casting sample weights dtype. Note that .type is a no op if the tensor is already that dtype

Differential Revision: D46903186

