### PR TITLE
Add CPU support for EBC load_state_dict unsharded tensors

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -441,12 +441,9 @@ class ShardedEmbeddingBagCollection(
                 )
         self._initialize_torch_state()
 
-        # TODO[zainhuda]: support module device coming from CPU
         if module.device not in [
             torch.device("meta"),
-            torch.device("cpu"),
             "meta",
-            "cpu",
         ]:
             self.load_state_dict(module.state_dict(), strict=False)
 


### PR DESCRIPTION
Summary: Allowing loading state dict from CPU - was blocked before because of failing test. Test has now been amended to new values.

Differential Revision: D46915880

