### PR TITLE
Fix transcript error from reading type

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -136,6 +136,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
         self._device: torch.device = (
             device if device is not None else torch.device("cpu")
         )
+        self._table_name_to_dtype: Dict[str, torch.dtype] = {}
 
         table_names = set()
         for embedding_config in tables:
@@ -147,6 +148,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                 if embedding_config.data_type == DataType.FP32
                 else torch.float16
             )
+            self._table_name_to_dtype[embedding_config.name] = dtype
             self.embedding_bags[embedding_config.name] = nn.EmbeddingBag(
                 num_embeddings=embedding_config.num_embeddings,
                 embedding_dim=embedding_config.embedding_dim,
@@ -182,13 +184,15 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
         pooled_embeddings: List[torch.Tensor] = []
 
         feature_dict = features.to_dict()
-        for i, embedding_bag in enumerate(self.embedding_bags.values()):
+        for i, (table_name, embedding_bag) in enumerate(self.embedding_bags.items()):
             for feature_name in self._feature_names[i]:
                 f = feature_dict[feature_name]
                 res = embedding_bag(
                     input=f.values(),
                     offsets=f.offsets(),
-                    per_sample_weights=f.weights().type(embedding_bag.weight.dtype)
+                    per_sample_weights=f.weights().type(
+                        self._table_name_to_dtype[table_name]
+                    )
                     if self._is_weighted
                     else None,
                 ).float()


### PR DESCRIPTION
Summary: Previous diff ran into torchscript error. Because torchscript wouldn't have embedding_bag yet, hence the type is a proxy. By saving the dtype in a separate dict, this solves the problem.

Differential Revision: D46939723

