### PR TITLE
tbe import with _inference

### DIFF
--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -9,7 +9,7 @@ import copy
 from typing import Any, Dict, List, Mapping, TypeVar, Union
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops import (
+from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from torch.distributed import _remote_device


### PR DESCRIPTION
Summary:
fbgemm tbe imports via split_table_batched_embeddings_ops is deprecated.
Using split_table_batched_embeddings_ops_inference

Differential Revision:
D46941813

Privacy Context Container: L1138451

