### PR TITLE
Optional dtype params for empty JT/KJT constructors

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -211,12 +211,22 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         self._offsets: Optional[torch.Tensor] = offsets
 
     @staticmethod
-    def empty(is_weighted: bool = False) -> "JaggedTensor":
-        weights = torch.tensor([]) if is_weighted else None
+    def empty(
+        is_weighted: bool = False,
+        device: Optional[torch.device] = None,
+        values_dtype: Optional[torch.dtype] = None,
+        weights_dtype: Optional[torch.dtype] = None,
+        lengths_dtype: torch.dtype = torch.int32,
+    ) -> "JaggedTensor":
+        weights = (
+            torch.tensor([], dtype=weights_dtype, device=device)
+            if is_weighted
+            else None
+        )
         return JaggedTensor(
-            values=torch.tensor([]),
-            offsets=torch.tensor([]),
-            lengths=torch.tensor([]),
+            values=torch.tensor([], dtype=values_dtype, device=device),
+            offsets=torch.tensor([], dtype=lengths_dtype, device=device),
+            lengths=torch.tensor([], dtype=lengths_dtype, device=device),
             weights=weights,
         )
 
@@ -937,17 +947,21 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     @staticmethod
     def empty(
-        is_weighted: bool = False, device: Optional[torch.device] = None
+        is_weighted: bool = False,
+        device: Optional[torch.device] = None,
+        values_dtype: Optional[torch.dtype] = None,
+        weights_dtype: Optional[torch.dtype] = None,
+        lengths_dtype: torch.dtype = torch.int32,
     ) -> "KeyedJaggedTensor":
         weights = None
         if is_weighted is True:
-            weights = torch.tensor([], device=device) if device else torch.tensor([])
+            weights = torch.tensor([], dtype=weights_dtype, device=device)
 
         return KeyedJaggedTensor(
             keys=[],
-            values=torch.tensor([], device=device) if device else torch.tensor([]),
+            values=torch.tensor([], dtype=values_dtype, device=device),
             weights=weights,
-            lengths=torch.tensor([], device=device) if device else torch.tensor([]),
+            lengths=torch.tensor([], dtype=lengths_dtype, device=device),
             stride=0,
         )
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -431,10 +431,10 @@ class TestJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.equal(j_offset.offsets(), j_lens.offsets().int()))
 
     def test_empty(self) -> None:
-        jt = JaggedTensor.empty()
+        jt = JaggedTensor.empty(values_dtype=torch.int64)
 
-        self.assertTrue(torch.equal(jt.values(), torch.tensor([])))
-        self.assertTrue(torch.equal(jt.offsets(), torch.tensor([])))
+        self.assertTrue(torch.equal(jt.values(), torch.tensor([], dtype=torch.int64)))
+        self.assertTrue(torch.equal(jt.offsets(), torch.tensor([], dtype=torch.int32)))
 
     def test_2d(self) -> None:
         values = torch.Tensor([[i * 0.5, i * 1.0, i * 1.5] for i in range(1, 4)])


### PR DESCRIPTION
Summary:
There are cases in which an empty KJT / JT must ensure some tensor type compatibility. By default each values / lengths / weights tensor owned by the KJT will be instantiated as float tensor types. This may not work though if we pass the tensors through some downstream operators which expect integer-type tensors. By adding optional tensor type params, we should be able to guard against these cases.

Additionally, as tensor constructors default to taking `None` device param values, we should be able to remove extraneous conditions during initialization.

Differential Revision: D46959241

