### PR TITLE
Fix respecting device arg

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -29,6 +29,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.fused_params import (
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
+    FUSED_PARAM_REGISTER_TBE_BOOL,
     get_tbes_to_register_from_iterable,
     is_fused_param_quant_state_dict_split_scale_bias,
     is_fused_param_register_tbe,
@@ -533,9 +534,14 @@ class QuantEmbeddingCollectionSharder(
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
         )
-        fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
-            module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
-        )
+        if FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS not in fused_params:
+            fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
+                module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
+            )
+        if FUSED_PARAM_REGISTER_TBE_BOOL not in fused_params:
+            fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = getattr(
+                module, FUSED_PARAM_REGISTER_TBE_BOOL, False
+            )
         return ShardedQuantEmbeddingCollection(
             module=module,
             table_name_to_parameter_sharding=params,

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -29,6 +29,7 @@ from torchrec.distributed.embeddingbag import (
 )
 from torchrec.distributed.fused_params import (
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
+    FUSED_PARAM_REGISTER_TBE_BOOL,
     get_tbes_to_register_from_iterable,
     is_fused_param_quant_state_dict_split_scale_bias,
     is_fused_param_register_tbe,
@@ -317,9 +318,15 @@ class QuantEmbeddingBagCollectionSharder(
         fused_params["output_dtype"] = data_type_to_sparse_type(
             dtype_to_data_type(module.output_dtype())
         )
-        fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
-            module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
-        )
+        if FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS not in fused_params:
+            fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS] = getattr(
+                module, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
+            )
+        if FUSED_PARAM_REGISTER_TBE_BOOL not in fused_params:
+            fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = getattr(
+                module, FUSED_PARAM_REGISTER_TBE_BOOL, False
+            )
+
         return ShardedQuantEmbeddingBagCollection(
             module, params, env, fused_params, device=device
         )

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -273,6 +273,7 @@ class InferCwPooledEmbeddingSharding(
         return InferTwSparseFeaturesDist(
             self.features_per_rank(),
             self._world_size,
+            device if device is not None else self._device,
         )
 
     def create_lookup(
@@ -285,6 +286,7 @@ class InferCwPooledEmbeddingSharding(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
+            device=device if device is not None else self._device,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -190,6 +190,7 @@ class InferRwSequenceEmbeddingSharding(
             world_size=self._world_size,
             num_features=num_features,
             feature_hash_sizes=feature_hash_sizes,
+            device=device if device is not None else self._device,
             is_sequence=True,
             has_feature_processor=self._has_feature_processor,
             need_pos=False,

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -485,6 +485,7 @@ class InferRwPooledEmbeddingSharding(
             world_size=self._world_size,
             num_features=num_features,
             feature_hash_sizes=feature_hash_sizes,
+            device=device if device is not None else self._device,
         )
 
     def create_lookup(
@@ -497,6 +498,7 @@ class InferRwPooledEmbeddingSharding(
             grouped_configs_per_rank=self._grouped_embedding_configs_per_rank,
             world_size=self._world_size,
             fused_params=fused_params,
+            device=device if device is not None else self._device,
         )
 
     def create_output_dist(


### PR DESCRIPTION
Summary:
1. Recently added inference shardings did not respect (propagate further) device argument.

2. Making specified explicitly `fused_params` at sharding take precedense (like --force) over module attributes

Reviewed By: s4ayub

Differential Revision:
D47155148

Privacy Context Container: L1138451

