### PR TITLE
Make kjt split torchscriptable

### DIFF
--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -508,3 +508,15 @@ class ModelTraceScriptTest(unittest.TestCase):
             # _recursive_compile_class for that is enough
             torch.jit._script._recursive_compile_class(clz, fake_range())
         torch.jit.script(KeyedJaggedTensor.from_jt_dict)
+
+    def test_jitscript_kjt(self) -> None:
+        def kjt_split(segments: List[int]) -> List[KeyedJaggedTensor]:
+            kjt = KeyedJaggedTensor(
+                keys=["a", "b", "c"],
+                values=torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+                lengths=torch.tensor([2, 0, 1, 1, 1, 2]),
+            )
+            return kjt.split(segments)
+
+        sm = torch.jit.script(kjt_split)
+        sm([1, 0, 2, 0])

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1152,21 +1152,28 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                     )
                 )
             elif segment == 0:
+                empty_int_list: List[int] = torch.jit.annotate(List[int], [])
                 split_list.append(
                     KeyedJaggedTensor(
                         keys=keys,
                         values=torch.tensor(
-                            [], device=self.device(), dtype=self._values.dtype
+                            empty_int_list,
+                            device=self.device(),
+                            dtype=self._values.dtype,
                         ),
                         weights=None
                         if self.weights_or_none() is None
                         else torch.tensor(
-                            [],
+                            empty_int_list,
                             device=self.device(),
                             dtype=self.weights().dtype,
                         ),
-                        lengths=torch.tensor([], device=self.device(), dtype=torch.int),
-                        offsets=torch.tensor([], device=self.device(), dtype=torch.int),
+                        lengths=torch.tensor(
+                            empty_int_list, device=self.device(), dtype=torch.int
+                        ),
+                        offsets=torch.tensor(
+                            empty_int_list, device=self.device(), dtype=torch.int
+                        ),
                         stride=self._stride,
                         length_per_key=None,
                         offset_per_key=None,


### PR DESCRIPTION
Summary: Make kjt split torchscriptable, needed for some models.

Differential Revision:
D47265322

Privacy Context Container: L1138451

