### PR TITLE
Implement NDCG metric for LTR models

### DIFF
--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -29,6 +29,7 @@ class RecMetricEnum(RecMetricEnumBase):
     WEIGHTED_AVG = "weighted_avg"
     TOWER_QPS = "tower_qps"
     ACCURACY = "accuracy"
+    NDCG = "ndcg"
 
 
 @dataclass(unsafe_hash=True, eq=True)

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -53,6 +53,7 @@ class MetricName(MetricNameBase):
     WEIGHTED_AVG = "weighted_avg"
     TOWER_QPS = "qps"
     ACCURACY = "accuracy"
+    NDCG = "ndcg"
 
 
 class MetricNamespaceBase(StrValueMixin, Enum):
@@ -80,6 +81,7 @@ class MetricNamespace(MetricNamespaceBase):
     RECALL_SESSION_LEVEL = "recall_session_level"
 
     TOWER_QPS = "qps"
+    NDCG = "ndcg"
 
 
 class MetricPrefix(StrValueMixin, Enum):


### PR DESCRIPTION
Summary:
This is to implement the NDCG metric with RecMetric for Learning-To-Rank (LTR) models. For NDCG, check details in "Cumulated gain-based evaluation of IR techniques" https://dl.acm.org/doi/10.1145/582415.582418

Following https://www.internalfb.com/intern/wiki/TorchRec/RecMetrics/, this is the first step to create namespace, metric name and enum for NDCG.

Differential Revision: D47298854

