### PR TITLE
Revert D46566230: Multisect successfully blamed D46566230 for test or build failures

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import math
 from typing import cast, Dict, List, Optional, Tuple, Type
 
@@ -38,8 +37,6 @@ from torchrec.distributed.planner.utils import prod, sharder_name
 from torchrec.distributed.types import CommOp, ModuleSharder, ShardingType
 
 from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
-
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 class EmbeddingPerfEstimator(ShardEstimator):
@@ -111,19 +108,9 @@ class EmbeddingPerfEstimator(ShardEstimator):
             module = sharding_option.module[1]
 
             # TODO remove this hack once feature processor is disaggregated
-            has_feature_processor = False
-            if (
-                hasattr(module, "_feature_processor")
-                and hasattr(module._feature_processor, "feature_processor_modules")
-                and isinstance(
-                    module._feature_processor.feature_processor_modules,
-                    nn.ModuleDict,
-                )
-                and sharding_option.name
-                in module._feature_processor.feature_processor_modules.keys()
-            ):
-                has_feature_processor = True
-                logger.info(f"Table {sharding_option.name} has feature processor.")
+            has_feature_processor = (
+                True if getattr(module, "feature_processor", None) else False
+            )
 
             if isinstance(module, EmbeddingBagCollectionInterface):
                 is_weighted = module.is_weighted()


### PR DESCRIPTION
Summary:
This diff is reverting D46566230
D46566230: [torchrec] Fix the has_feature_processor flag bug that makes every table weighted by henrylhtsang has been identified to be causing the following test or build failures:

Tests affected:
- [aps_models/ads/icvr/tests:icvr_fqn_test - test_fqn (aps_models.ads.icvr.tests.icvr_fqn_test.ICVRFqnTest)](https://www.internalfb.com/intern/test/281475073983925/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2365517
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D47144345

