### PR TITLE
Use randn instead of empty for dummy param

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -279,10 +279,10 @@ class TestDenseArch(nn.Module):
             in_features=num_float_features, out_features=8, device=device
         )
 
-        self.dummy_param = torch.nn.Parameter(torch.empty(2, device=device))
+        self.dummy_param = torch.nn.Parameter(torch.zeros(2, device=device))
         self.register_buffer(
             "dummy_buffer",
-            torch.nn.Parameter(torch.empty(1, device=device)),
+            torch.nn.Parameter(torch.zeros(1, device=device)),
         )
 
     def forward(self, dense_input: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary:
ATT - see
https://github.com/pytorch/torchrec/issues/1268

Differential Revision: D47366578

