### PR TITLE
Change pytorch nightly cuda version from 11.7 to 11.8

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
     - name: Install Dependencies
       shell: bash
       run: |
@@ -173,7 +173,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
     # download wheel from GHA
     - name: Download wheel
       uses: actions/download-artifact@v2

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
     - name: Install Dependencies
       shell: bash
       run: |
@@ -166,7 +166,7 @@ jobs:
     - name: Install PyTorch and CUDA
       shell: bash
       run: |
-        conda install -n build_binary -y pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+        conda install -n build_binary -y pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
     # download wheel from GHA
     - name: Download wheel
       uses: actions/download-artifact@v2

--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ TorchRec is a PyTorch domain library built to provide common sparsity & parallel
 
 # Installation
 
-Torchrec requires Python >= 3.7 and CUDA >= 11.0 (CUDA is highly recommended for performance but not required). The example below shows how to install with CUDA 11.6. This setup assumes you have conda installed.
+Torchrec requires Python >= 3.7 and CUDA >= 11.0 (CUDA is highly recommended for performance but not required). The example below shows how to install with CUDA 11.8. This setup assumes you have conda installed.
 
 ## Binaries
 
@@ -29,12 +29,12 @@ TO use the library without cuda, use the *-cpu fbgemm installations. However, th
 
 Nightly
 
-conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+conda install pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
 pip install torchrec_nightly
 
 Stable
 
-conda install pytorch pytorch-cuda=11.7 -c pytorch -c nvidia
+conda install pytorch pytorch-cuda=11.8 -c pytorch -c nvidia
 pip install torchrec
 
 If you have no CUDA device:
@@ -63,7 +63,7 @@ We are currently iterating on the setup experience. For now, we provide manual i
 
 1. Install pytorch. See [pytorch documentation](https://pytorch.org/get-started/locally/)
    ```
-   conda install pytorch pytorch-cuda=11.7 -c pytorch-nightly -c nvidia
+   conda install pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
    ```
 
 2. Install Requirements


### PR DESCRIPTION
PyTorch stopped supporting cuda 11.7 for nightly, see https://pytorch.org/blog/deprecation-cuda-python-support/

The last pytorch for cuda 11.7 was released 20 days ago. See https://anaconda.org/pytorch-nightly/pytorch/files

Updating the version should fix the Push Binary Nightly GHA.

Note that while release_build.yml also uses 11.7, but pytorch-test still supports cuda 11.7 for now. Hence we are not changing it right now.

Differential Revision: D47386684

