### PR TITLE
MC-EBC implementation

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -356,6 +356,10 @@ class ShardedEmbeddingBagCollection(
             config.name for config in self._embedding_bag_configs
         ]
 
+        self._table_name_to_config: Dict[str, EmbeddingBagConfig] = {
+            config.name: config for config in self._embedding_bag_configs
+        }
+
         self.module_sharding_plan: EmbeddingModuleShardingPlan = cast(
             EmbeddingModuleShardingPlan,
             {

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Iterator, List, Optional, Type
+
+import torch
+from torch import nn
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    KJTList,
+    ShardedEmbeddingModule,
+)
+from torchrec.distributed.embeddingbag import (
+    EmbeddingBagCollectionContext,
+    EmbeddingBagCollectionSharder,
+    ShardedEmbeddingBagCollection,
+)
+from torchrec.distributed.sharding.rw_sharding import RwSparseFeaturesDist
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.distributed.utils import append_prefix
+from torchrec.modules.mc_embedding_modules import (
+    apply_managed_collision_modules_to_kjt,
+    ManagedCollisionEmbeddingBagCollection,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+
+
+class ShardedManagedCollisionEmbeddingBagCollection(
+    ShardedEmbeddingModule[
+        KJTList, List[torch.Tensor], KeyedTensor, EmbeddingBagCollectionContext
+    ]
+):
+    def __init__(
+        self,
+        module: ManagedCollisionEmbeddingBagCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        ebc_sharder: EmbeddingBagCollectionSharder,
+        # pyre-ignore
+        managed_collision_module_sharders: Optional[List],
+        # TODO - maybe we need this to manage unsharded/sharded consistency/state consistency
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+
+        self._device = device
+        self._env = env
+
+        self._embedding_bag_collection: ShardedEmbeddingBagCollection = (
+            ebc_sharder.shard(
+                module._embedding_bag_collection,
+                table_name_to_parameter_sharding,
+                env=env,
+                device=device,
+            )
+        )
+
+        self._features_to_tables: Dict[str, str] = module._features_to_tables
+
+        self._managed_collision_modules = nn.ModuleDict()
+        for table_name, mc_module in module._managed_collision_modules.items():
+            if (
+                table_name_to_parameter_sharding[table_name].sharding_type
+                == ShardingType.ROW_WISE.value
+            ):
+                max_output_id = (
+                    mc_module._max_output_id + self._env.world_size - 1
+                ) // self._env.world_size
+                self._managed_collision_modules[
+                    table_name
+                ] = mc_module.rebuild_with_max_output_id(
+                    max_output_id, device=self._device
+                )
+            elif (
+                table_name_to_parameter_sharding[table_name].sharding_type
+                == ShardingType.TABLE_WISE.value
+            ):
+                max_output_id = mc_module._max_output_id
+                self._managed_collision_modules[
+                    table_name
+                ] = mc_module.rebuild_with_max_output_id(
+                    max_output_id, device=self._device
+                )
+
+        # TODO BELOW IS HACKY - JUST FOR MVP
+        self._rw_feature_hash_sizes: List[int] = []
+        for table, parameter_sharding in table_name_to_parameter_sharding.items():
+            if parameter_sharding.sharding_type == ShardingType.ROW_WISE.value:
+                max_input_id = self._managed_collision_modules[table]._max_input_id
+                rw_feature_block_size = (
+                    max_input_id + self._env.world_size - 1
+                ) // self._env.world_size
+                self._rw_feature_hash_sizes.append(rw_feature_block_size)
+
+        # pyre-ignore
+        self._table_to_tbe_and_index = {}
+        for lookup in self._embedding_bag_collection._lookups:
+            if isinstance(lookup, GroupedPooledEmbeddingsLookup):
+                for emb_module in lookup._emb_modules:
+                    for table_idx, table in enumerate(
+                        emb_module._config.embedding_tables
+                    ):
+                        self._table_to_tbe_and_index[table.name] = (
+                            emb_module._emb_module,
+                            torch.tensor(
+                                [table_idx], dtype=torch.int, device=self._device
+                            ),
+                        )
+        self._buffer_ids: torch.Tensor = torch.tensor(
+            [0], device=self._device, dtype=torch.int
+        )
+
+    # pyre-ignore
+    def input_dist(
+        self, ctx: EmbeddingBagCollectionContext, features: KeyedJaggedTensor
+    ) -> Awaitable[Awaitable[KJTList]]:
+        if self._embedding_bag_collection._has_uninitialized_input_dist:
+            # PART OF THE HACK FOR MVAP
+            self._embedding_bag_collection._create_input_dist(features.keys())
+            self._embedding_bag_collection._has_uninitialized_input_dist = False
+
+            for input_dist in self._embedding_bag_collection._input_dists:
+                if isinstance(input_dist, RwSparseFeaturesDist):
+                    print(
+                        "overriding with feature block size",
+                        self._rw_feature_hash_sizes,
+                    )
+                    input_dist.register_buffer(
+                        "_feature_block_sizes_tensor",
+                        torch.tensor(
+                            self._rw_feature_hash_sizes,
+                            device=self._device,
+                            dtype=torch.int32,
+                        ),
+                    )
+
+        return self._embedding_bag_collection.input_dist(ctx, features)
+
+    def _apply_mc_modules_to_kjt_list(self, dist_input: KJTList) -> KJTList:
+        return KJTList(
+            [
+                apply_managed_collision_modules_to_kjt(
+                    features,
+                    self._managed_collision_modules,
+                    self._features_to_tables,
+                )
+                for features in dist_input
+            ]
+        )
+
+    def _evict(self, evictions_per_table: Dict[str, Optional[torch.Tensor]]) -> None:
+        for table, evictions_indices_for_table in evictions_per_table.items():
+            if evictions_indices_for_table is not None:
+                (tbe, logical_table_ids) = self._table_to_tbe_and_index[table]
+                pruned_indices_offsets = torch.tensor(
+                    [0, evictions_indices_for_table.shape[0]],
+                    dtype=torch.long,
+                    device=self._device,
+                )
+
+                with torch.no_grad():
+                    # embeddings, and optimizer state will be reset
+                    tbe.reset_embedding_weight_momentum(
+                        pruned_indices=evictions_indices_for_table.long(),
+                        pruned_indices_offsets=pruned_indices_offsets,
+                        logical_table_ids=logical_table_ids,
+                        buffer_ids=self._buffer_ids,
+                    )
+                    table_weight_param = (
+                        self._embedding_bag_collection.embedding_bags.get_parameter(
+                            f"{table}.weight"
+                        )
+                    )
+
+                    init_fn = self._embedding_bag_collection._table_name_to_config[
+                        table
+                    ].init_fn
+
+                    # pyre-ignore
+                    # Set evicted indices to original init_fn instead of all zeros
+                    table_weight_param[evictions_indices_for_table] = init_fn(
+                        table_weight_param[evictions_indices_for_table]
+                    )
+
+    def compute(
+        self,
+        ctx: EmbeddingBagCollectionContext,
+        dist_input: KJTList,
+    ) -> List[torch.Tensor]:
+
+        evictions_per_table: Dict[str, Optional[torch.Tensor]] = {}
+        # TODO refactor this to be cleaner...
+        for table, managed_collision_module in self._managed_collision_modules.items():
+            if table not in self._table_to_tbe_and_index:
+                continue
+            evictions_per_table[table] = managed_collision_module.evict()
+        self._evict(evictions_per_table)
+
+        # TODO batch the evictions instead of doing it per table. Need to group by TBE
+        mc_features = self._apply_mc_modules_to_kjt_list(dist_input)
+        return self._embedding_bag_collection.compute(ctx, mc_features)
+
+    def output_dist(
+        self,
+        ctx: EmbeddingBagCollectionContext,
+        output: List[torch.Tensor],
+    ) -> LazyAwaitable[KeyedTensor]:
+        # TODO investigate if we can overlap eviction with this
+        return self._embedding_bag_collection.output_dist(ctx, output)
+
+    def create_context(self) -> EmbeddingBagCollectionContext:
+        return self._embedding_bag_collection.create_context()
+
+    def sharded_parameter_names(self, prefix: str = "") -> Iterator[str]:
+        for fqn, _ in self.named_parameters():
+            yield append_prefix(prefix, fqn)
+        for fqn, _ in self.named_buffers():
+            yield append_prefix(prefix, fqn)
+
+
+class ManagedCollisionEmbeddingBagCollectionSharder(
+    BaseEmbeddingSharder[ManagedCollisionEmbeddingBagCollection]
+):
+    def __init__(
+        self,
+        ebc_sharder: Optional[EmbeddingBagCollectionSharder] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        self._ebc_sharder: EmbeddingBagCollectionSharder = (
+            ebc_sharder or EmbeddingBagCollectionSharder(self.qcomm_codecs_registry)
+        )
+
+    def shard(
+        self,
+        module: ManagedCollisionEmbeddingBagCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> ShardedManagedCollisionEmbeddingBagCollection:
+
+        if device is None:
+            device = torch.device("cuda")
+
+        return ShardedManagedCollisionEmbeddingBagCollection(
+            module,
+            params,
+            ebc_sharder=self._ebc_sharder,
+            managed_collision_module_sharders=[],
+            env=env,
+            device=device,
+        )
+
+    def shardable_parameters(
+        self, module: ManagedCollisionEmbeddingBagCollection
+    ) -> Dict[str, torch.nn.Parameter]:
+        return self._ebc_sharder.shardable_parameters(module._embedding_bag_collection)
+
+    @property
+    def module_type(self) -> Type[ManagedCollisionEmbeddingBagCollection]:
+        return ManagedCollisionEmbeddingBagCollection
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.TABLE_WISE.value,
+            ShardingType.ROW_WISE.value,
+        ]
+        return types

--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from typing import cast, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.mc_embeddingbag import (
+    ManagedCollisionEmbeddingBagCollectionSharder,
+    ShardedManagedCollisionEmbeddingBagCollection,
+)
+from torchrec.distributed.shard import _shard_modules
+
+from torchrec.distributed.sharding_plan import (
+    construct_module_sharding_plan,
+    row_wise,
+    table_wise,
+)
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.managed_collision_modules import (
+    ManagedCollisionModule,
+    TrivialManagedCollisionModule,
+)
+from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingBagCollection
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+
+class SparseArch(nn.Module):
+    def __init__(
+        self,
+        tables: List[EmbeddingBagConfig],
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+
+        self._mc_ebc: ManagedCollisionEmbeddingBagCollection = (
+            ManagedCollisionEmbeddingBagCollection(
+                EmbeddingBagCollection(
+                    tables=tables,
+                    device=device,
+                ),
+                cast(
+                    Dict[str, ManagedCollisionModule],
+                    {
+                        "table_0": TrivialManagedCollisionModule(
+                            max_output_id=16, max_input_id=32, device=device
+                        ),
+                        "table_1": TrivialManagedCollisionModule(
+                            max_output_id=32, max_input_id=32, device=device
+                        ),
+                    },
+                ),
+            )
+        )
+
+    def forward(self, kjt: KeyedJaggedTensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        mc_ebc_out = self._mc_ebc(kjt)
+        pred = torch.cat(
+            [mc_ebc_out[key] for key in ["feature_0", "feature_1"]],
+            dim=1,
+        )
+        loss = pred.mean()
+        return loss, pred
+
+
+def _test_sharding(  # noqa C901
+    tables: List[EmbeddingBagConfig],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+
+        sparse_arch = SparseArch(tables, torch.device("meta"))
+        module_sharding_plan = construct_module_sharding_plan(
+            sparse_arch._mc_ebc,
+            per_param_sharding={"table_0": row_wise(), "table_1": table_wise(rank=0)},
+            local_size=local_size,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+            sharder=sharder,
+        )
+
+        sharded_sparse_arch = _shard_modules(
+            module=copy.deepcopy(sparse_arch),
+            plan=ShardingPlan({"_mc_ebc": module_sharding_plan}),
+            env=ShardingEnv.from_process_group(ctx.pg),
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        assert isinstance(
+            sharded_sparse_arch._mc_ebc, ShardedManagedCollisionEmbeddingBagCollection
+        )
+
+        # sharded model
+        # each rank gets a subbatch
+        sharded_model_pred = sharded_sparse_arch(kjt_input_per_rank[ctx.rank])[0]
+        # torch.stack(unsharded_model_preds).mean().backward()
+        sharded_model_pred.mean().backward()
+
+        if ctx.rank == 0:
+            param = (
+                sharded_sparse_arch._mc_ebc._embedding_bag_collection.embedding_bags[
+                    "table_0"
+                ].weight
+            )
+            param.fill_(100.0)
+            sharded_sparse_arch._mc_ebc._evict({"table_0": torch.tensor([0, 2, 4, 6])})
+            # these indices will retain their original value of 100.0
+            torch.testing.assert_close(
+                param[[1, 3, 5, 7]], 100.0 * torch.ones_like(param[[1, 3, 5, 7]])
+            )
+            # these indices will be reset to values that are in uniform(-1, 1)
+            assert torch.all((param[[0, 2, 4, 6]] < 1.0)).item()
+
+
+@skip_if_asan_class
+class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_sharding_mc_ebc(self) -> None:
+
+        WORLD_SIZE = 2
+
+        embedding_bag_config = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=32,
+            ),
+        ]
+
+        # Rank 0
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [0, 1]       None        [2]
+        # "feature_1"   [0, 1]       None        [2]
+
+        # Rank 1
+        #             instance 0   instance 1  instance 2
+        # "feature_0"   [3, 2]       [1,2]       [0,1,2,3]
+        # "feature_1"   [2, 3]       None        [2]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [10000000, 10000001, 10000002, 1000000, 1000001, 20000002],
+                ),
+                lengths=torch.LongTensor([2, 0, 1, 2, 0, 1]),
+                weights=None,
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [
+                        200003,
+                        2000002,
+                        200001,
+                        2000002,
+                        2000000,
+                        200001,
+                        2000002,
+                        2000003,
+                        3141592,
+                        65358979,
+                        323846,
+                    ],
+                ),
+                lengths=torch.LongTensor([2, 2, 4, 1, 1, 1]),
+                weights=None,
+            ),
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_sharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_bag_config,
+            kjt_input_per_rank=kjt_input_per_rank,
+            sharder=ManagedCollisionEmbeddingBagCollectionSharder(),
+            backend="nccl",
+        )

--- a/torchrec/modules/managed_collision_modules.py
+++ b/torchrec/modules/managed_collision_modules.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import abc
+from typing import Optional
+
+import torch
+
+from torch import nn
+from torchrec.sparse.jagged_tensor import JaggedTensor
+
+
+class ManagedCollisionModule(nn.Module):
+    """
+    Abstract base class for feature processor.
+
+    Args:
+        max_output_id: Number of physical slots for ids in down stream embedding bag
+        max_input_id: Number of logical ids to manage
+
+    Example::
+        jt = JaggedTensor(...)
+        mcm = ManagedCollisionModule(...)
+        mcm_jt = mcm(fp)
+    """
+
+    def __init__(self, max_output_id: int, max_input_id: int = 2**40) -> None:
+        # slots is the number of rows to map from global id to
+        # for example, if we want to manage 1000 ids to 10 slots
+        super().__init__()
+        self._max_input_id: int = max_input_id
+        self._max_output_id = max_output_id
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        features: JaggedTensor,
+    ) -> JaggedTensor:
+        """
+        Args:
+        features (JaggedTensor]): feature representation
+
+        Returns:
+            JaggedTensor: modified JT
+        """
+        pass
+
+    @abc.abstractmethod
+    def evict(self) -> Optional[torch.Tensor]:
+        """
+        Returns None if no eviction should be done tihs iteration. Otherwise, return ids of slots to reset.
+        On eviction, this module should reset its state for those slots, with the assumptionn that the downstream module
+        will handle this properly.
+        """
+        pass
+
+    @abc.abstractmethod
+    def rebuild_with_max_output_id(
+        self, max_output_id: int, device: torch.device
+    ) -> "ManagedCollisionModule":
+        """
+        Used for creating local MC modules for RW sharding, hack for now
+        """
+        pass
+
+
+class TrivialManagedCollisionModule(ManagedCollisionModule):
+    def __init__(
+        self, max_output_id: int, device: torch.device, max_input_id: int = 2**64
+    ) -> None:
+        super().__init__(max_output_id, max_input_id)
+        self.register_buffer(
+            "count",
+            torch.zeros(
+                (max_output_id,),
+                device=device,
+            ),
+        )
+
+    def forward(
+        self,
+        features: JaggedTensor,
+    ) -> JaggedTensor:
+        values = features.values() % self._max_output_id
+        self.count[values] += 1
+        return JaggedTensor(
+            values=values,
+            lengths=features.lengths(),
+            offsets=features.offsets(),
+            weights=features.weights_or_none(),
+        )
+
+    def evict(self) -> Optional[torch.Tensor]:
+        return None
+
+    def rebuild_with_max_output_id(
+        self, max_output_id: int, device: Optional[torch.device] = None
+    ) -> "TrivialManagedCollisionModule":
+        return type(self)(
+            max_output_id=max_output_id,
+            device=device or self._device,
+            max_input_id=self._max_input_id,
+        )

--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.managed_collision_modules import ManagedCollisionModule
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+
+
+@torch.fx.wrap
+def apply_managed_collision_modules_to_kjt(
+    features: KeyedJaggedTensor,
+    managed_collisions: nn.ModuleDict,
+    feature_to_table: Dict[str, str],
+) -> KeyedJaggedTensor:
+
+    if len(features.keys()) == 0:
+        return features
+
+    features_dict = features.to_dict()
+    managed_ids = []
+
+    for key in features.keys():
+        jt = features_dict[key]
+        table_name = feature_to_table[key]
+        if table_name in managed_collisions:
+            mc_jt = managed_collisions[table_name](jt)
+        else:
+            mc_jt = jt
+        managed_ids.append(mc_jt.values())
+
+    return KeyedJaggedTensor(
+        keys=features.keys(),
+        values=torch.cat(managed_ids),
+        weights=features.weights_or_none(),
+        lengths=features.lengths(),
+        offsets=features._offsets,
+        stride=features._stride,
+        length_per_key=features._length_per_key,
+        offset_per_key=features._offset_per_key,
+        index_per_key=features._index_per_key,
+    )
+
+
+def evict(
+    evictions: Dict[str, Optional[torch.Tensor]], ebc: EmbeddingBagCollection
+) -> None:
+    # evicts ids corresponding with table name from ebcs
+    # If none, do a no-op
+    return
+
+
+class ManagedCollisionEmbeddingBagCollection(nn.Module):
+    """
+    ManagedCollisionEmbeddingBagCollection represents a EmbeddingBagCollection module and a set of managed collision modules.
+    The inputs into the MC-EBC will first be modified by the managed collision module before being passed into the embedding bag collection.
+
+    For details of input and output types, see EmbeddingBagCollection
+
+    Args:
+        embedding_bag_collection: EmbeddingBagCollection to lookup embeddings
+        managed_collision_modules: Dict of managed collision modules
+
+    Example:
+        ebc = EmbeddingBagCollection(
+                tables=[
+                    EmbeddingBagConfig(
+                        name="t1", embedding_dim=8, num_embeddings=16, feature_names=["f1"]
+                    ),
+                    EmbeddingBagConfig(
+                        name="t2", embedding_dim=8, num_embeddings=16, feature_names=["f2"]
+                    ),
+                ],
+                device=device,
+            )
+        mc_modules = {
+            "t1": ManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            "t2":
+                ManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            ),
+        }
+
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(ebc, mc_modules)
+        kt = mc_ebc(kjt)
+    """
+
+    def __init__(
+        self,
+        embedding_bag_collection: EmbeddingBagCollection,
+        managed_collision_modules: Dict[str, ManagedCollisionModule],
+    ) -> None:
+        super().__init__()
+        self._embedding_bag_collection = embedding_bag_collection
+        self._managed_collision_modules = nn.ModuleDict(managed_collision_modules)
+
+        self._features_to_tables: Dict[str, str] = {}
+        self._table_to_features: Dict[str, List[str]] = defaultdict(list)
+        for table in self._embedding_bag_collection.embedding_bag_configs():
+            if table.name not in managed_collision_modules:
+                raise ValueError(
+                    f"{table.name} is not present in managed_collision_modules"
+                )
+
+            assert (
+                self._managed_collision_modules[table.name]._max_output_id
+                == table.num_embeddings
+            ), f"max_output_id in managed collision module for {table.name} must match {table.num_embeddings=}"
+
+            for feature in table.feature_names:
+                self._features_to_tables[feature] = table.name
+                self._table_to_features[table.name].append(feature)
+
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+    ) -> KeyedTensor:
+        """
+        Args:
+            features (KeyedJaggedTensor): KJT of form [F X B X L].
+
+        Returns:
+            KeyedTensor
+        """
+
+        mc_features = apply_managed_collision_modules_to_kjt(
+            features, self._managed_collision_modules, self._features_to_tables
+        )
+        ret = self._embedding_bag_collection(mc_features)
+
+        evictions: Dict[str, Optional[torch.Tensor]] = {}
+        for table, managed_collision_module in self._managed_collision_modules.items():
+            evictions[table] = managed_collision_module.evict()
+        evict(evictions, self._embedding_bag_collection)
+
+        return ret

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import cast
+
+import torch
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.managed_collision_modules import (
+    ManagedCollisionModule,
+    TrivialManagedCollisionModule,
+)
+from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class TriviallyManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
+    def test_trivial_managed_ebc(self) -> None:
+        device = torch.device("cpu")
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([100, 101, 102, 103, 104, 105, 106, 107]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        ).to(device)
+
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="t1", embedding_dim=8, num_embeddings=16, feature_names=["f1"]
+                ),
+                EmbeddingBagConfig(
+                    name="t2", embedding_dim=8, num_embeddings=16, feature_names=["f2"]
+                ),
+            ],
+            device=device,
+        )
+        mc_modules = {
+            "t1": cast(
+                ManagedCollisionModule,
+                TrivialManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            ),
+            "t2": cast(
+                ManagedCollisionModule,
+                TrivialManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            ),
+        }
+
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(ebc, mc_modules)
+
+        pooled_embeddings = mc_ebc(features)
+
+        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
+        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
+        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
+
+        print("state dict", mc_ebc.state_dict())


### PR DESCRIPTION
Summary:
ATT

Some follow up discussion:

- How do we ensure RW sharded MC module can be resharded to table wise/row wise with different world sizes. What is the story for inference? Also revisit whether we need to create sharded implementations of MC modules for state dict management.

- Eviction API for TBE/regular embedding bags. We can't just set things to zero (need to respect the init_fn).

Reviewed By: dstaay-fb

Differential Revision:
D47280814

Privacy Context Container: L1123788

