### PR TITLE
Forward fix LazyModuleMixin _infer_parameters test

### DIFF
--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -171,7 +171,7 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
         """
         module.initialize_parameters(*input, **kwargs)
         if module.has_uninitialized_params():
-            raise RuntimeError('module {} has not been fully initialized'.format(self._get_name()))
+            raise RuntimeError(f'module {self._get_name()} has not been fully initialized')
         module._initialize_hook.remove()
         module._load_hook.remove()
         delattr(module, '_initialize_hook')


### PR DESCRIPTION
This fixes internal test breakage after this PR:  https://github.com/pytorch/pytorch/pull/105436

Error:
```
1) torchrec.modules.tests.test_lazy_extension.TestLazyModuleExtensionMixin: test_source_code_parity_on_infer_parameters
    1) AssertionError: '    [758 chars]rror(\'module {} has not been fully initialize[292 chars]me\n' != '    [758 chars]rror(f\'module {self._get_name()} has not been[284 chars]me\n'
    Diff is 1212 characters long. Set self.maxDiff to None to see it. : Please make sure `LazyModuleExtensionMixin._infer_parameters` has the same source code as `LazyModuleMixin._infer_parameters` except the expected difference that is checked in this unit test.
      File "torchrec/modules/tests/test_lazy_extension.py", line 76, in test_source_code_parity_on_infer_parameters
        self.assertEqual(
```

Test:
```
atalman@38668.od /data/sandcastle/boxes/fbsource/fbcode (81b7e2cb1)]$ buck2 test '@fbcode//mode/dev-nosan' fbcode//torchrec/modules/tests:test_lazy_extension -- --exact 'torchrec/modules/tests:test_lazy_extension - torchrec.modules.tests.test_lazy_extension.TestLazyModuleExtensionMixin: test_source_code_parity_on_infer_parameters'
File changed: fbcode//torchrec/modules/lazy_extension.py
Buck UI: https://www.internalfb.com/buck2/d7549611-38f4-4c5b-94f7-23e0dee340de
Test UI: https://www.internalfb.com/intern/testinfra/testrun/4785074791858178
Network: Up: 0 B  Down: 0 B
Jobs completed: 6. Time elapsed: 14.1s.
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
[atalman@38668.od /data/sandcastle/boxes/fbsource/fbcode (81b7e2cb1)]$ buck2 test '@fbcode//mode/dev-nosan' fbcode//torchrec/modules/tests:test_lazy_extension -- --exact 'torchrec/modules/tests:test_lazy_extension - torchrec.modules.tests.test_lazy_extension.TestLazyModuleExtensionMixin: test_source_code_parity_on_infer_parameters'
Buck UI: https://www.internalfb.com/buck2/b8dda81f-2368-425e-8191-0cb2f86f8851
Test UI: https://www.internalfb.com/intern/testinfra/testrun/281475300492460
Network: Up: 0 B  Down: 0 B
Jobs completed: 6. Time elapsed: 13.3s.
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```