### PR TITLE
Make FP Embedding Modules FX + Scriptable

### DIFF
--- a/torchrec/modules/tests/test_feature_processor_.py
+++ b/torchrec/modules/tests/test_feature_processor_.py
@@ -8,7 +8,12 @@
 import unittest
 
 import torch
-from torchrec.modules.feature_processor_ import PositionWeightedModule
+
+from torchrec.fx.tracer import symbolic_trace
+from torchrec.modules.feature_processor_ import (
+    PositionWeightedModule,
+    PositionWeightedModuleCollection,
+)
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
@@ -30,7 +35,6 @@ class PositionWeightedModuleTest(unittest.TestCase):
 
         jt = features["f1"]
         weighted_features = pw(jt)
-        print("weighted features", weighted_features)
 
         self.assertEqual(weighted_features.weights().size(), (3,))
 
@@ -40,3 +44,50 @@ class PositionWeightedModuleTest(unittest.TestCase):
 
         pw_f1 = weighted_features.weights().detach()
         self.assertTrue(torch.allclose(pw_f1_ref, pw_f1))
+
+        position_weighted_module_gm = symbolic_trace(pw)
+        position_weighted_module_gm_script = torch.jit.script(
+            position_weighted_module_gm
+        )
+
+        weighted_features_gm_script = position_weighted_module_gm_script(jt)
+        torch.testing.assert_close(
+            weighted_features.values(), weighted_features_gm_script.values()
+        )
+        torch.testing.assert_close(
+            weighted_features.lengths(), weighted_features_gm_script.lengths()
+        )
+
+
+class PositionWeightedCollectionModuleTest(unittest.TestCase):
+    def test_populate_weights(self) -> None:
+        position_weighted_module_collection = PositionWeightedModuleCollection(
+            {"f1": 10, "f2": 10}
+        )
+
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        )
+
+        fp_kjt = position_weighted_module_collection(features)
+
+        position_weighted_module_collection_gm = symbolic_trace(
+            position_weighted_module_collection
+        )
+        position_weighted_module_collection_gm_script = torch.jit.script(
+            position_weighted_module_collection_gm
+        )
+        fp_kjt_gm_script = position_weighted_module_collection_gm_script(features)
+
+        torch.testing.assert_close(fp_kjt.values(), fp_kjt_gm_script.values())
+        torch.testing.assert_close(fp_kjt.lengths(), fp_kjt_gm_script.lengths())
+        torch.testing.assert_close(
+            fp_kjt.length_per_key(), fp_kjt_gm_script.length_per_key()
+        )

--- a/torchrec/modules/tests/test_fp_embedding_modules.py
+++ b/torchrec/modules/tests/test_fp_embedding_modules.py
@@ -9,15 +9,21 @@ import unittest
 from typing import cast
 
 import torch
+
+from torchrec.fx.tracer import symbolic_trace
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.modules.feature_processor_ import FeatureProcessor, PositionWeightedModule
+from torchrec.modules.feature_processor_ import (
+    FeatureProcessor,
+    PositionWeightedModule,
+    PositionWeightedModuleCollection,
+)
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
-    def test_populate_weights(self) -> None:
+    def test_position_weighted_module_ebc(self) -> None:
         #     0       1        2  <-- batch
         # 0   [0,1] None    [2]
         # 1   [3]    [4]    [5,6,7]
@@ -51,3 +57,63 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
         self.assertEqual(pooled_embeddings.values().size(), (3, 16))
         self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
+
+        # Currently non-collections currently are not trace-able
+        # fp_ebc_gm_script = torch.jit.script(symbolic_trace(fp_ebc))
+        # pooled_embeddings_gm_script = fp_ebc_gm_script(features)
+
+        # torch.testing.assert_close(
+        #     pooled_embeddings_gm_script.values(), pooled_embeddings.values()
+        # )
+
+        # torch.testing.assert_close(
+        #     pooled_embeddings_gm_script.offset_per_key(),
+        #     pooled_embeddings.offset_per_key(),
+        # )
+
+
+class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCase):
+    def test_position_weighted_collection_module_ebc(self) -> None:
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        )
+
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="t1", embedding_dim=8, num_embeddings=16, feature_names=["f1"]
+                ),
+                EmbeddingBagConfig(
+                    name="t2", embedding_dim=8, num_embeddings=16, feature_names=["f2"]
+                ),
+            ],
+            is_weighted=True,
+        )
+
+        fp_ebc = FeatureProcessedEmbeddingBagCollection(
+            ebc, PositionWeightedModuleCollection({"f1": 10, "f2": 10})
+        )
+
+        pooled_embeddings = fp_ebc(features)
+        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
+        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
+        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
+
+        fp_ebc_gm_script = torch.jit.script(symbolic_trace(fp_ebc))
+        pooled_embeddings_gm_script = fp_ebc_gm_script(features)
+
+        torch.testing.assert_close(
+            pooled_embeddings_gm_script.values(), pooled_embeddings.values()
+        )
+
+        torch.testing.assert_close(
+            pooled_embeddings_gm_script.offset_per_key(),
+            pooled_embeddings.offset_per_key(),
+        )


### PR DESCRIPTION
Summary:
ATT

Mostly massaging code, and depending on inputs in constructor (embedding table names), rather than kt.keys()

Reviewed By: yuchenhao

Differential Revision: D47598549

