### PR TITLE
Add pytree support to KeyedJaggedTensor

### DIFF
--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -10,6 +10,7 @@ import unittest
 from typing import List, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch.testing import FileCheck
 from torchrec.fx import symbolic_trace
 from torchrec.sparse.jagged_tensor import (
@@ -735,6 +736,36 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         jag_tensor_dict = jag_tensor.to_dict()
         j0 = jag_tensor_dict["index_0"]
         j1 = jag_tensor_dict["index_1"]
+
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5, 1.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 3])))
+        self.assertTrue(
+            torch.equal(j1.weights(), torch.Tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
+        )
+        self.assertTrue(
+            torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
+        )
+
+    def test_pytree(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+
+        jag_tensor0 = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+        )
+        elems, spec = pytree.tree_flatten(jag_tensor0)
+        jag_tensor = pytree.tree_unflatten(elems, spec)
+
+        j0 = jag_tensor["index_0"]
+        j1 = jag_tensor["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
         self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))


### PR DESCRIPTION
Summary:
This makes it possible to export models that take KeyedJaggedTensor
as input.

For folks who don't know pytrees: pytrees are an abstraction that allow you to easily run functions on all of the internal contents of a data structure. For example, a tree_map on a tuple would apply an operation to every element of the tuple. To make KJTs pytree'able, I simply register every field on pytree as something that pytree knows about.

Differential Revision: D47769501

