### PR TITLE
Fix fxing of TableWise for cpu output

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -726,9 +726,6 @@ class EmbeddingsAllToOne(nn.Module):
         """
         assert len(tensors) == self._world_size
         is_target_device_cpu: bool = self._device.type == "cpu"
-        if is_target_device_cpu and tensors[0].device.type == "cpu":
-            # assume all tensors on cpu
-            return torch.cat(tensors, self._cat_dim)
 
         non_cat_size = tensors[0].size(1 - self._cat_dim)
         # if src device is cuda, target device is cpu:


### PR DESCRIPTION
Summary: We do not need sharding when inputs are on CPU => remove this if that breaks fx

Differential Revision:
D47838289

Privacy Context Container: L1138451

