### PR TITLE
Convert numbers to GB, and make clear if something is local or global

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -43,6 +43,7 @@ from torchrec.distributed.planner.types import (
     StorageReservation,
     Topology,
 )
+from torchrec.distributed.planner.utils import bytes_to_gb, storage_repr_in_gb
 from torchrec.distributed.sharding_plan import get_default_sharders, placement
 from torchrec.distributed.types import (
     EmbeddingModuleShardingPlan,
@@ -315,8 +316,8 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             storage_reservation_solution = (
                 (
                     f"\n\t  Storage reservation percentage: {self._storage_reservation._percentage}, "
-                    f"\n\t  Storage reservation dense storage: {self._storage_reservation._dense_storage}, "
-                    f"\n\t  Storage reservation kjt storage: {self._storage_reservation._kjt_storage}, "
+                    f"\n\t  Per rank reservation for dense storage: {storage_repr_in_gb(self._storage_reservation._dense_storage)}, "
+                    f"\n\t  Per rank reservation for kjt storage: {storage_repr_in_gb(self._storage_reservation._kjt_storage)}, "  # pyre-ignore[16]
                 )
                 if isinstance(self._storage_reservation, HeuristicalStorageReservation)
                 else f"\n\t  Storage reservation percentage: {self._storage_reservation._percentage}, "  # pyre-ignore[16]
@@ -326,11 +327,11 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                 "\nPossible solutions:"
                 f"\n  1) Increase the number of devices ({self._topology.world_size})"
                 f"\n  2) Reduce the model size ("
-                f"\n\t  Global storage: {global_storage_capacity.hbm}, "
-                f"\n\t  Hardware memory: {self._topology.devices[0].storage}, "
+                f"\n\t  Global storage: {round(bytes_to_gb(global_storage_capacity.hbm), 3)} GB, "
+                f"\n\t  Per rank hardware memory: {storage_repr_in_gb(self._topology.devices[0].storage)}, "
                 f"{storage_reservation_solution}"
-                f"\n\t  Available for model parallel: {global_storage_constraints}, "
-                f"\n\t  Requirement for model parallel: {lowest_storage})"
+                f"\n\t  Global storage available for model parallel: {storage_repr_in_gb(global_storage_constraints)}, "
+                f"\n\t  Global storage requirement for model parallel: {storage_repr_in_gb(lowest_storage)})"
                 f"\n  3) Reduce local batch size ({self._batch_size})"
                 "\n  4) Remove planner constraints that might be reducing search space or available storage\n"
             )

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -7,9 +7,10 @@
 
 import operator
 from functools import reduce
-from typing import Any, Iterable, Type, Union
+from typing import Any, Iterable, Optional, Type, Union
 
 import torch
+from torchrec.distributed.planner.types import Storage
 
 # pyre-ignore[2]
 def sharder_name(t: Type[Any]) -> str:
@@ -45,3 +46,12 @@ def placement(
     if compute_device == "cuda":
         param_device = torch.device("cuda", rank % local_size)
     return f"rank:{rank}/{param_device}"
+
+
+def storage_repr_in_gb(storage: Optional[Storage]) -> str:
+    if storage is None:
+        return ""
+    return (
+        f"Storage(hbm = {round(bytes_to_gb(storage.hbm), 3)} GB, "
+        f"ddr = {round(bytes_to_gb(storage.ddr), 3)} GB)"
+    )


### PR DESCRIPTION
Summary: When the planner couldn't find a plan, print the planner error message numbers in GB instead of in bytes for better readability. Also make it clear if something is per rank or global.

Differential Revision: D47887074

