### PR TITLE
Add negative storage solution and error

### DIFF
--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -120,7 +120,8 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
             context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
         )
 
-        self.assertEqual(self.planner._num_proposals, 4)
+        # since it has negative storage_constraint
+        self.assertEqual(self.planner._num_proposals, 0)
 
     def test_fail_then_rerun(self) -> None:
         tables = [


### PR DESCRIPTION
Summary: Raise an error if available hbm for embedding tables is negative. Also print out possible solutions.

Reviewed By: bigning

Differential Revision: D47891135

