### PR TITLE
fix unsharded FeatureProcessedEmbeddingBagCollection when passing in excessive features

### DIFF
--- a/torchrec/modules/fp_embedding_modules.py
+++ b/torchrec/modules/fp_embedding_modules.py
@@ -32,7 +32,9 @@ def apply_feature_processors_to_kjt(
             fp_jt = feature_processors[key](jt)
             processed_weights.append(fp_jt.weights())
         else:
-            torch.ones(jt.values().shape[0], device=jt.values().device)
+            processed_weights.append(
+                torch.ones(jt.values().shape[0], device=jt.values().device),
+            )
 
     return KeyedJaggedTensor(
         keys=features.keys(),


### PR DESCRIPTION
Summary: when extra features(keys) are passed to unsharded FeatureProcessedEmbeddingBagCollection, it needs to add dummy 1.0 weights to those excessive features to keep the kjt.weights.numel() same as kjt.values.numel()

Reviewed By: YLGH

Differential Revision: D47978937

