### PR TITLE
Make the interface of MC-EBC closer to regular EBC

### DIFF
--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -10,7 +10,11 @@ from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingBagCollectionInterface,
+)
 from torchrec.modules.managed_collision_modules import ManagedCollisionModule
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
@@ -58,7 +62,7 @@ def evict(
     return
 
 
-class ManagedCollisionEmbeddingBagCollection(nn.Module):
+class ManagedCollisionEmbeddingBagCollection(EmbeddingBagCollectionInterface):
     """
     ManagedCollisionEmbeddingBagCollection represents a EmbeddingBagCollection module and a set of managed collision modules.
     The inputs into the MC-EBC will first be modified by the managed collision module before being passed into the embedding bag collection.
@@ -145,3 +149,13 @@ class ManagedCollisionEmbeddingBagCollection(nn.Module):
         evict(evictions, self._embedding_bag_collection)
 
         return ret
+
+    def is_weighted(self) -> bool:
+        return self._embedding_bag_collection.is_weighted()
+
+    def embedding_bag_configs(self) -> List[EmbeddingBagConfig]:
+        return self._embedding_bag_collection.embedding_bag_configs()
+
+    @property
+    def device(self) -> torch.device:
+        return self._embedding_bag_collection.device

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -62,6 +62,10 @@ class TriviallyManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
 
         mc_ebc = ManagedCollisionEmbeddingBagCollection(ebc, mc_modules)
 
+        self.assertEqual(mc_ebc.is_weighted(), ebc.is_weighted())
+        self.assertEqual(mc_ebc.embedding_bag_configs(), ebc.embedding_bag_configs())
+        self.assertEqual(mc_ebc.device, ebc.device)
+
         pooled_embeddings = mc_ebc(features)
 
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])


### PR DESCRIPTION
Summary: Specifically, adding const methods like `is_weighted`, `embedding_bag_configs` or `device`, to make switch from EBC to MC-EBC more straightforward

Differential Revision: D48011839

