### PR TITLE
MemoryBalancedPartitioner

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -43,7 +43,11 @@ from torchrec.distributed.planner.types import (
     StorageReservation,
     Topology,
 )
-from torchrec.distributed.planner.utils import bytes_to_gb, storage_repr_in_gb
+from torchrec.distributed.planner.utils import (
+    bytes_to_gb,
+    reset_shard_rank,
+    storage_repr_in_gb,
+)
 from torchrec.distributed.sharding_plan import get_default_sharders, placement
 from torchrec.distributed.types import (
     EmbeddingModuleShardingPlan,
@@ -55,12 +59,6 @@ from torchrec.distributed.types import (
     ShardingType,
     ShardMetadata,
 )
-
-
-def _reset_shard_rank(proposal: List[ShardingOption]) -> None:
-    for sharding_option in proposal:
-        for shard in sharding_option.shards:
-            shard.rank = None
 
 
 def _to_sharding_plan(
@@ -282,7 +280,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                     proposer.feedback(partitionable=False)
 
                 # clear shard.rank for each sharding_option
-                _reset_shard_rank(proposal)
+                reset_shard_rank(proposal)
                 proposal = proposer.propose()
 
         if best_plan:

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -7,10 +7,10 @@
 
 import operator
 from functools import reduce
-from typing import Any, Iterable, Optional, Type, Union
+from typing import Any, Iterable, List, Optional, Type, Union
 
 import torch
-from torchrec.distributed.planner.types import Storage
+from torchrec.distributed.planner.types import ShardingOption, Storage
 
 # pyre-ignore[2]
 def sharder_name(t: Type[Any]) -> str:
@@ -55,3 +55,9 @@ def storage_repr_in_gb(storage: Optional[Storage]) -> str:
         f"Storage(hbm = {round(bytes_to_gb(storage.hbm), 3)} GB, "
         f"ddr = {round(bytes_to_gb(storage.ddr), 3)} GB)"
     )
+
+
+def reset_shard_rank(proposal: List[ShardingOption]) -> None:
+    for sharding_option in proposal:
+        for shard in sharding_option.shards:
+            shard.rank = None


### PR DESCRIPTION
Summary:
Refactored Dharak's diffs D47073930 and D47567911.

Create a partitioner that calls the default GreedyPerfPartitioner a few times with different storage constraint, using binary search, to figure out a sharding plan that uses the least memory provided that the perf isn't impacted a lot.

Note that here `reserved_hbm_size` still matters, unlike the original diff. We recommend using a small `reserved_hbm_size` and allow the partitioner to figure out how much hbm storage is actually needed.

This diff only add the partitioner to the library. It does not enable it.

Differential Revision: D47731441

