### PR TITLE
handle EmbeddingBagCollectionsSparseArch in serialization

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -446,9 +446,7 @@ class ShardedEmbeddingBagCollection(
         self._initialize_torch_state()
 
         # TODO[zainhuda]: support module device coming from CPU
-        if module.device not in [
-            torch.device("meta"),
-            torch.device("cpu"),
+        if module.device not in ["meta", "cpu"] and module.device.type not in [
             "meta",
             "cpu",
         ]:


### PR DESCRIPTION
Summary:
This adds support for the new EBC-based sparse arch along side our existing support for PooledEmbeddingArch.

It's mostly analagous to the work done for PEA. The only complication is the `regroup_as_dict` operation, where we are turning a `List[KeyedTensor]` into a `Dict[str, Tensor]` and optionally casting to bf16. This happens separately from the rest of the sparse arch, but contains KJT code so we can't trace it.

I solved this by pulling out `regroup_as_dict` as making it a method of `EmbeddingBagCollectionsSparseArch`, and doing a similar swap + custom op trick as we do for the sparse arch itself. I think this will be reasonably durable (I don't expect the usage pattern to change very much), but obviously long term we want to avoid special-casing stuff like this (cc ezyang on the need for good KJT tracing :P )

Differential Revision: D47803009

