### PR TITLE
Add an unsync method to KeyedJaggedTensor

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -194,6 +194,8 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             offsets.
     """
 
+    _fields = ["_values", "_weights", "_lengths", "_offsets"]
+
     def __init__(
         self,
         values: torch.Tensor,
@@ -547,6 +549,24 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             )
             + "\n})\n"
         )
+
+
+def _jt_flatten(
+    t: JaggedTensor,
+) -> Tuple[List[Optional[torch.Tensor]], None]:
+    return [getattr(t, a) for a in JaggedTensor._fields], None
+
+
+def _jt_unflatten(values: List[Optional[torch.Tensor]], context: None) -> JaggedTensor:
+    return JaggedTensor(*values)
+
+
+def _jt_flatten_spec(t: JaggedTensor, spec: TreeSpec) -> List[Optional[torch.Tensor]]:
+    return [getattr(t, a) for a in JaggedTensor._fields]
+
+
+_register_pytree_node(JaggedTensor, _jt_flatten, _jt_unflatten)
+register_pytree_flatten_spec(JaggedTensor, _jt_flatten_spec)
 
 
 def _assert_tensor_has_no_elements_or_has_integers(

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1085,6 +1085,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         self.offset_per_key()
         return self
 
+    def unsync(self) -> "KeyedJaggedTensor":
+        self._length_per_key = None
+        self._offset_per_key = None
+        return self
+
     def device(self) -> torch.device:
         return self._values.device
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -10,6 +10,7 @@ import unittest
 from typing import List, Tuple
 
 import torch
+import torch.utils._pytree as pytree
 from torch.testing import FileCheck
 from torchrec.fx import symbolic_trace
 from torchrec.sparse.jagged_tensor import (
@@ -735,6 +736,36 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         jag_tensor_dict = jag_tensor.to_dict()
         j0 = jag_tensor_dict["index_0"]
         j1 = jag_tensor_dict["index_1"]
+
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5, 1.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 3])))
+        self.assertTrue(
+            torch.equal(j1.weights(), torch.Tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
+        )
+        self.assertTrue(
+            torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
+        )
+
+    def test_pytree(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+
+        jag_tensor0 = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+        )
+        elems, spec = pytree.tree_flatten(jag_tensor0)
+        jag_tensor = pytree.tree_unflatten(elems, spec)
+
+        j0 = jag_tensor["index_0"]
+        j1 = jag_tensor["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
         self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -552,6 +552,43 @@ JaggedTensor({
 """,
         )
 
+    def test_pytree(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        j0 = JaggedTensor(
+            values=values,
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+        )
+        elems, spec = pytree.tree_flatten(j0)
+        j1 = pytree.tree_unflatten(elems, spec)
+
+        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
+        self.assertIsNone(j0.weights_or_none())
+        self.assertIsNone(j1.weights_or_none())
+        self.assertTrue(torch.equal(j0.values(), j1.values()))
+
+        values = [
+            torch.Tensor([1.0]),
+            torch.Tensor(),
+            torch.Tensor([7.0, 8.0]),
+            torch.Tensor([10.0, 11.0, 12.0]),
+        ]
+        weights = [
+            torch.Tensor([1.0]),
+            torch.Tensor(),
+            torch.Tensor([7.0, 8.0]),
+            torch.Tensor([10.0, 11.0, 12.0]),
+        ]
+        j0 = JaggedTensor.from_dense(
+            values=values,
+            weights=weights,
+        )
+        elems, spec = pytree.tree_flatten(j0)
+        j1 = pytree.tree_unflatten(elems, spec)
+
+        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
+        self.assertTrue(torch.equal(j0.weights(), j1.weights()))
+        self.assertTrue(torch.equal(j0.values(), j1.values()))
+
     def test_from_jt_dict(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])


### PR DESCRIPTION
Summary:
In some situations, I need to clear the cached fields on a KeyedJaggedTensor.
In particular, if I'm passing a KJT to tracing, clearing the cached fields
ensures that I trace the recomputation of these fields inside the model,
which is typically what I want because otherwise I do not know that the fields
are related during model tracing.

Reviewed By: dstaay-fb

Differential Revision: D47797243

