### PR TITLE
RW sharding compatible with meta sharding

### DIFF
--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -37,8 +37,6 @@ from torchrec.distributed.sharding.tw_sharding import (
     TwSparseFeaturesDist,
 )
 from torchrec.distributed.types import (
-    Awaitable,
-    NoWait,
     NullShardingContext,
     QuantizedCommCodecs,
     ShardedTensorMetadata,


### PR DESCRIPTION
Summary:
The reason of the change:

tgif does "meta" sharding, specifying the device="meta".
But tensors of "meta" device are only handled for TBEs in runtime => as a result rw_sharding will register "meta" tensor without content and it will fail in runtime as it will not be replaced.

The solution:
Creating tensor for arguments only at first runtime using specified device (at runtime that will be cuda:{idx}) and cache it in dictionary that is held by the module.

torch.fx.wrap to make fx pass through the control logic of caching

Reviewed By: s4ayub

Differential Revision:
D47846180

Privacy Context Container: L1138451

