### PR TITLE
Add the GRADIENT_DIVISION for sequence embedding a2a

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -1016,6 +1016,8 @@ class All2All_Seq_Req(Function):
                         None,
                         sharded_grad_input.numel(),
                     )
+        if GRADIENT_DIVISION:
+            sharded_grad_input.div_(dist.get_world_size(ctx.pg))
         return (None, None, None, sharded_grad_input.view(-1, D))
 
 

--- a/torchrec/distributed/tests/test_comm.py
+++ b/torchrec/distributed/tests/test_comm.py
@@ -181,8 +181,12 @@ class TestAllToAll(unittest.TestCase):
         seq_embs_out = a2a_req.wait()
         seq_embs_out.backward(seq_embs_out)
         grad = input_embeddings.grad
-        # pyre-fixme[16]: Optional type has no attribute `cpu`.
-        assert torch.equal(input_embeddings.cpu().detach(), grad.cpu().detach())
+        assert torch.equal(
+            input_embeddings.cpu().detach(),
+            # pyre-fixme[16]: Optional type has no attribute `cpu`.
+            grad.cpu().detach() * world_size,
+        )
+
         dist.destroy_process_group()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -874,8 +874,11 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
         torch.testing.assert_close(res, output, rtol=rtol, atol=atol)
         res.backward(res)
         grad = _input.grad
-        # pyre-fixme[16]: Optional type has no attribute `cpu`.
-        torch.testing.assert_close(_input.cpu().detach(), grad.cpu().detach())
+        torch.testing.assert_close(
+            _input.cpu().detach(),
+            # pyre-fixme[16]: Optional type has no attribute `cpu`.
+            grad.cpu().detach() * world_size,
+        )
 
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,

--- a/torchrec/distributed/tests/test_sequence_model.py
+++ b/torchrec/distributed/tests/test_sequence_model.py
@@ -282,7 +282,9 @@ class TestSequenceSparseNN(TestSparseNNBase):
         input: ModelInput,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         dense_r = self.dense(input.float_features)
-        sparse_r = self.sparse(input.idlist_features, input.float_features.size(0))
+        # multiply the sparse output by 10 since the model output is not sensitive to the
+        # embedding output. It won't catch the unexpected embedding output without this
+        sparse_r = 10 * self.sparse(input.idlist_features, input.float_features.size(0))
         over_r = self.over(dense_r, sparse_r)
         pred = torch.sigmoid(torch.mean(over_r, dim=1))
         if self.training:


### PR DESCRIPTION
Summary: credits to YLGH who found that we are missing the gardient division for sequence embedding. We also investigated why the existing seq embedding unit tests didn't catch it. We found it was because the sequence embedding contributed very little to the final prediction and loss, so although the sharded model seqeunce embedding gradient don't match the unsharded model sequence embedding, but after the optimizer step, the final prediction is still the same. To fix this, we simply multiply 10 to the sequence embedding output.

Differential Revision: D48090579

