### PR TITLE
MCH ZCH ManagedCollision Modules and Collection

### DIFF
--- a/torchrec/distributed/mc_module.py
+++ b/torchrec/distributed/mc_module.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import math
+from collections import defaultdict, OrderedDict
+from dataclasses import dataclass
+from itertools import accumulate
+from typing import Any, cast, DefaultDict, Dict, Iterator, List, Optional, Type
+
+import torch
+
+from torch import nn
+from torch.distributed._shard.sharded_tensor import Shard
+from torchrec.distributed.comm import get_local_rank
+from torchrec.distributed.embedding import (
+    EmbeddingCollectionAwaitable,
+    EmbeddingCollectionContext,
+    EmbeddingCollectionSharder,
+)
+from torchrec.distributed.embedding_sharding import (
+    EmbeddingSharding,
+    EmbeddingShardingContext,
+    EmbeddingShardingInfo,
+    KJTListSplitsAwaitable,
+)
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    GroupedEmbeddingConfig,
+    KJTList,
+)
+from torchrec.distributed.sharding.rw_sequence_sharding import (
+    RwSequenceEmbeddingDist,
+    RwSequenceEmbeddingSharding,
+)
+from torchrec.distributed.sharding.rw_sharding import (
+    BaseRwEmbeddingSharding,
+    RwSparseFeaturesDist,
+)
+from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardedModule,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingType,
+    ShardMetadata,
+)
+from torchrec.distributed.utils import append_prefix
+from torchrec.modules.embedding_configs import (
+    DataType,
+    EmbeddingTableConfig,
+    PoolingType,
+)
+from torchrec.modules.managed_collision_modules import MCHManagedCollisionModule
+from torchrec.modules.mc_embedding_modules import (
+    apply_managed_collision_modules_to_kjt,
+    ManagedCollisionCollection,
+)
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+def _calculate_rw_shard_sizes(
+    hash_size: int,
+    num_devices: int,
+) -> List[int]:
+    """
+    see https://fburl.com/code/y94h768g
+    """
+    block_size: int = math.ceil(hash_size / num_devices)
+    last_rank: int = hash_size // block_size
+    last_block_size: int = hash_size - block_size * last_rank
+    shard_sizes: List[int] = []
+    for rank in range(num_devices):
+        if rank < last_rank:
+            local_row: int = block_size
+        elif rank == last_rank:
+            local_row: int = last_block_size
+        else:
+            local_row: int = 0
+        shard_sizes.append(local_row)
+    return shard_sizes
+
+
+def _lengths_to_offsets(lengths: List[int], keep_last: bool = False) -> List[int]:
+    assert len(lengths) > 0
+    offsets = [0] + list(accumulate(lengths))
+    if not keep_last:
+        offsets.pop()
+    return offsets
+
+
+class ManagedCollisionCollectionAwaitable(EmbeddingCollectionAwaitable):
+    pass
+
+
+@dataclass
+class ManagedCollisionCollectionContext(EmbeddingCollectionContext):
+    pass
+
+
+def create_sharding_infos_by_sharding(
+    table_name_to_features: Dict[str, List[str]],
+    table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+) -> Dict[str, List[EmbeddingShardingInfo]]:
+    sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = {}
+    table_names = list(table_name_to_features.keys())
+    for table_name in table_names:
+        assert table_name in table_name_to_parameter_sharding
+        parameter_sharding = table_name_to_parameter_sharding[table_name]
+        if parameter_sharding.sharding_type not in sharding_type_to_sharding_infos:
+            sharding_type_to_sharding_infos[parameter_sharding.sharding_type] = []
+
+        sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
+            (
+                EmbeddingShardingInfo(
+                    embedding_config=EmbeddingTableConfig(
+                        # NOTE placeholder as not actually used for materialization
+                        num_embeddings=2**16,
+                        # NOTE placeholder as not actually used for materialization
+                        embedding_dim=2**3,
+                        name=table_name,
+                        data_type=DataType.FP32,
+                        feature_names=copy.deepcopy(table_name_to_features[table_name]),
+                        pooling=PoolingType.NONE,
+                        embedding_names=copy.deepcopy(
+                            table_name_to_features[table_name]
+                        ),
+                    ),
+                    param_sharding=parameter_sharding,
+                    param=nn.Parameter(
+                        torch.empty((1, 1, 1), device=torch.device("meta")),
+                        requires_grad=False,
+                    ),
+                )
+            )
+        )
+
+    return sharding_type_to_sharding_infos
+
+
+def create_embedding_sharding(
+    sharding_type: str,
+    sharding_infos: List[EmbeddingShardingInfo],
+    env: ShardingEnv,
+    device: Optional[torch.device] = None,
+    qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+) -> EmbeddingSharding[
+    SequenceShardingContext, KeyedJaggedTensor, torch.Tensor, torch.Tensor
+]:
+    if sharding_type == ShardingType.ROW_WISE.value:
+        return RwSequenceEmbeddingSharding(
+            sharding_infos=sharding_infos,
+            env=env,
+            device=device,
+            qcomm_codecs_registry=qcomm_codecs_registry,
+        )
+    else:
+        raise ValueError(f"Sharding not supported {sharding_type}")
+
+
+class ShardedManagedCollisionCollection(
+    ShardedModule[
+        KJTList,
+        KJTList,
+        Dict[str, JaggedTensor],
+        ManagedCollisionCollectionContext,
+    ]
+):
+    def __init__(
+        self,
+        module: ManagedCollisionCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        ec_sharder: EmbeddingCollectionSharder,
+        # TODO - maybe we need this to manage unsharded/sharded consistency/state consistency
+        env: ShardingEnv,
+        device: torch.device,
+        sharding_type_to_sharding: Optional[
+            Dict[
+                str,
+                EmbeddingSharding[
+                    EmbeddingShardingContext,
+                    KeyedJaggedTensor,
+                    torch.Tensor,
+                    torch.Tensor,
+                ],
+            ]
+        ] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__()
+
+        self._device = device
+        self._env = env
+        self._table_name_to_parameter_sharding: Dict[
+            str, ParameterSharding
+        ] = copy.deepcopy(table_name_to_parameter_sharding)
+
+        self._features_to_mc: Dict[str, str] = module._features_to_mc
+        self._mc_to_features: Dict[str, List[str]] = module._mc_to_features
+
+        if sharding_type_to_sharding is None:
+            sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
+                self._mc_to_features,
+                self._table_name_to_parameter_sharding,
+            )
+            self._sharding_type_to_sharding: Dict[
+                str,
+                EmbeddingSharding[
+                    SequenceShardingContext,
+                    KeyedJaggedTensor,
+                    torch.Tensor,
+                    torch.Tensor,
+                ],
+            ] = {
+                sharding_type: create_embedding_sharding(
+                    sharding_type=sharding_type,
+                    sharding_infos=embedding_confings,
+                    env=env,
+                    device=device,
+                    qcomm_codecs_registry=qcomm_codecs_registry,
+                )
+                for sharding_type, embedding_confings in sharding_type_to_sharding_infos.items()
+            }
+        else:
+            self._sharding_type_to_sharding = cast(
+                Dict[
+                    str,
+                    EmbeddingSharding[
+                        SequenceShardingContext,
+                        KeyedJaggedTensor,
+                        torch.Tensor,
+                        torch.Tensor,
+                    ],
+                ],
+                sharding_type_to_sharding,
+            )
+
+        self._embedding_names_per_sharding: List[List[str]] = []
+        for sharding in self._sharding_type_to_sharding.values():
+            self._embedding_names_per_sharding.append(sharding.embedding_names())
+
+        self._has_uninitialized_input_dists: bool = True
+        self._input_dists: List[nn.Module] = []
+        self._managed_collision_modules = nn.ModuleDict()
+        self._create_managed_collision_modules(module)
+        self._output_dists: List[nn.Module] = []
+        self._create_output_dists()
+
+        self._initialize_torch_state()
+
+    def _initialize_torch_state(self) -> None:
+        self._model_parallel_mc_buffer_name_to_sharded_tensor = OrderedDict()
+        for table_name, mc_module in self._managed_collision_modules.items():
+            if (
+                table_sharding_type := self._table_name_to_parameter_sharding[
+                    table_name
+                ].sharding_type
+                == ShardingType.ROW_WISE.value
+            ):
+                mc_module_state_dict = mc_module.state_dict()
+                prefix = table_name + "."
+                for (
+                    buffer_name,
+                    buffer_tensor,
+                ) in mc_module.named_buffers():
+                    if buffer_name in mc_module_state_dict:
+                        buffer_tensor = mc_module_state_dict[buffer_name]
+                        if isinstance(mc_module, MCHManagedCollisionModule):
+                            zch_block_sizes = self._mc_module_name_global_metadata[
+                                table_name
+                            ]["zch_block_sizes"]
+                            assert zch_block_sizes[
+                                self._env.rank
+                            ] == buffer_tensor.size(0)
+                            zch_block_offsets = self._mc_module_name_global_metadata[
+                                table_name
+                            ]["zch_block_offsets"]
+                            self._model_parallel_mc_buffer_name_to_sharded_tensor[
+                                prefix + buffer_name
+                            ] = ShardedTensor._init_from_local_shards(
+                                [
+                                    Shard(
+                                        tensor=buffer_tensor,
+                                        metadata=ShardMetadata(
+                                            shard_offsets=[
+                                                zch_block_offsets[self._env.rank]
+                                            ],
+                                            shard_sizes=[buffer_tensor.size(0)],
+                                            placement=(
+                                                f"rank:{self._env.rank}/cuda:"
+                                                f"{get_local_rank(self._env.world_size, self._env.rank)}"
+                                            ),
+                                        ),
+                                    )
+                                ],
+                                torch.Size([zch_block_offsets[-1]]),
+                                process_group=self._env.process_group,
+                            )
+                        else:
+                            raise RuntimeError(
+                                "RW-sharding is currently only supported "
+                                f"for MCHManagedCollisionModules: {mc_module}"
+                            )
+
+            else:
+                raise AssertionError(
+                    f"Invalid MC table sharding_type: {table_sharding_type}."
+                )
+
+        def _post_state_dict_hook(
+            module: ShardedManagedCollisionCollection,
+            destination: Dict[str, torch.Tensor],
+            prefix: str,
+            _local_metadata: Dict[str, Any],
+        ) -> None:
+            for (
+                mc_buffer_name,
+                sharded_tensor,
+            ) in module._model_parallel_mc_buffer_name_to_sharded_tensor.items():
+                destination_key = f"{prefix}_managed_collision_modules.{mc_buffer_name}"
+                destination[destination_key] = sharded_tensor
+
+        def _load_state_dict_pre_hook(
+            module: "ShardedManagedCollisionCollection",
+            state_dict: Dict[str, Any],
+            prefix: str,
+            *args: Any,
+        ) -> None:
+            for (
+                mc_buffer_name,
+                _sharded_tensor,
+            ) in module._model_parallel_mc_buffer_name_to_sharded_tensor.items():
+                key = f"{prefix}_managed_collision_modules.{mc_buffer_name}"
+                if key in state_dict:
+                    if isinstance(state_dict[key], ShardedTensor):
+                        local_shards = state_dict[key].local_shards()
+                        state_dict[key] = local_shards[0].tensor
+                    else:
+                        raise RuntimeError(
+                            f"Unexpected state_dict key type {type(state_dict[key])} found for {key}"
+                        )
+
+        self._register_state_dict_hook(_post_state_dict_hook)
+        self._register_load_state_dict_pre_hook(
+            _load_state_dict_pre_hook, with_module=True
+        )
+
+    def _create_managed_collision_modules(
+        self, module: ManagedCollisionCollection
+    ) -> None:
+        self._mc_module_name_global_metadata: DefaultDict[
+            str, DefaultDict[str, List[int]]
+        ] = defaultdict(lambda: defaultdict(list))
+        for sharding_type, sharding in self._sharding_type_to_sharding.items():
+            if sharding_type == ShardingType.ROW_WISE.value:
+                assert isinstance(sharding, BaseRwEmbeddingSharding)
+                grouped_embedding_configs: List[
+                    GroupedEmbeddingConfig
+                ] = sharding._grouped_embedding_configs
+                for group_config in grouped_embedding_configs:
+                    for table in group_config.embedding_tables:
+                        table_name = table.name
+                        mc_module = module._managed_collision_modules[table_name]
+                        block_sizes = _calculate_rw_shard_sizes(
+                            mc_module._max_output_id, self._env.world_size
+                        )
+                        block_starting_offset = _lengths_to_offsets(
+                            block_sizes, keep_last=False
+                        )
+                        # TODO make cleaner. add abstract/default method to mc_module
+                        #   to update all appropiate internal values?
+                        if isinstance(mc_module, MCHManagedCollisionModule):
+                            zch_block_sizes = _calculate_rw_shard_sizes(
+                                mc_module._zch_size, self._env.world_size
+                            )
+                            mc_module._zch_size = zch_block_sizes[self._env.rank]
+                            zch_block_offsets = _lengths_to_offsets(
+                                zch_block_sizes, keep_last=True
+                            )
+                            self._mc_module_name_global_metadata[table_name][
+                                "zch_block_sizes"
+                            ] = zch_block_sizes
+                            self._mc_module_name_global_metadata[table_name][
+                                "zch_block_offsets"
+                            ] = zch_block_offsets
+                        self._managed_collision_modules[
+                            table_name
+                        ] = mc_module.rebuild_with_max_output_id(
+                            max_output_id=block_sizes[self._env.rank],
+                            remapping_range_start_index=block_starting_offset[
+                                self._env.rank
+                            ],
+                            device=self._device,
+                        )
+
+    def _create_input_dists(
+        self,
+        input_feature_names: List[str],
+    ) -> None:
+        feature_names: List[str] = []
+        self._feature_splits: List[int] = []
+        for sharding_type, sharding in self._sharding_type_to_sharding.items():
+            if sharding_type == ShardingType.ROW_WISE.value:
+                assert isinstance(sharding, BaseRwEmbeddingSharding)
+                num_features = sharding._get_num_features()
+                orig_feature_hash_sizes = sharding._get_feature_hash_sizes()
+                assert len(orig_feature_hash_sizes) == num_features
+                updated_feature_hash_sizes: List[int] = []
+                grouped_embedding_configs: List[
+                    GroupedEmbeddingConfig
+                ] = sharding._grouped_embedding_configs
+                for group_config in grouped_embedding_configs:
+                    for table in group_config.embedding_tables:
+                        table_name = table.name
+                        max_input_id = self._managed_collision_modules[
+                            table_name
+                        ]._max_input_id
+                        updated_feature_hash_sizes.extend(
+                            table.num_features() * [max_input_id]
+                        )
+                assert len(updated_feature_hash_sizes) == num_features
+                input_dist = RwSparseFeaturesDist(
+                    # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
+                    #  `Optional[ProcessGroup]`.
+                    pg=sharding._pg,
+                    num_features=sharding._get_num_features(),
+                    feature_hash_sizes=updated_feature_hash_sizes,
+                    device=sharding._device,
+                    is_sequence=True,
+                    has_feature_processor=False,
+                    need_pos=False,
+                )
+                self._input_dists.append(input_dist)
+                feature_names.extend(sharding.feature_names())
+                self._feature_splits.append(len(sharding.feature_names()))
+            else:
+                raise RuntimeError(f"Invalid MC sharding_type: {sharding_type}.")
+
+        self._features_order: List[int] = []
+        for f in feature_names:
+            self._features_order.append(input_feature_names.index(f))
+        self._features_order = (
+            []
+            if self._features_order == list(range(len(self._features_order)))
+            else self._features_order
+        )
+        self.register_buffer(
+            "_features_order_tensor",
+            torch.tensor(self._features_order, device=self._device, dtype=torch.int32),
+            persistent=False,
+        )
+
+    def _create_output_dists(
+        self,
+    ) -> None:
+        for sharding_type, sharding in self._sharding_type_to_sharding.items():
+            if sharding_type == ShardingType.ROW_WISE.value:
+                assert isinstance(sharding, BaseRwEmbeddingSharding)
+                self._output_dists.append(
+                    RwSequenceEmbeddingDist(
+                        # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
+                        #  `Optional[ProcessGroup]`.
+                        sharding._pg,
+                        sharding._get_num_features(),
+                        sharding._device,
+                        qcomm_codecs_registry=sharding.qcomm_codecs_registry,
+                    )
+                )
+            else:
+                raise RuntimeError(f"Invalid MC sharding_type: {sharding_type}.")
+
+    # pyre-ignore
+    def input_dist(
+        self,
+        ctx: ManagedCollisionCollectionContext,
+        features: KeyedJaggedTensor,
+        mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> Awaitable[Awaitable[KJTList]]:
+        self._mc_kwargs = mc_kwargs
+
+        if self._has_uninitialized_input_dists:
+            self._create_input_dists(input_feature_names=features.keys())
+            self._has_uninitialized_input_dists = False
+
+        with torch.no_grad():
+            # NOTE shared features not currently supported
+            features = apply_managed_collision_modules_to_kjt(
+                features,
+                self._managed_collision_modules,
+                self._features_to_mc,
+                mode="preprocess",
+            )
+            if self._features_order:
+                features = features.permute(
+                    self._features_order,
+                    self._features_order_tensor,
+                )
+            features_by_sharding = features.split(
+                self._feature_splits,
+            )
+            awaitables = []
+            for input_dist, features in zip(self._input_dists, features_by_sharding):
+                awaitables.append(input_dist(features))
+                ctx.sharding_contexts.append(
+                    SequenceShardingContext(
+                        features_before_input_dist=features,
+                        unbucketize_permute_tensor=input_dist.unbucketize_permute_tensor
+                        if isinstance(input_dist, RwSparseFeaturesDist)
+                        else None,
+                    )
+                )
+
+        return KJTListSplitsAwaitable(awaitables, ctx)
+
+    def _apply_mc_modules_to_kjt_list(
+        self,
+        dist_input: KJTList,
+        mode: Optional[str] = None,
+        mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> KJTList:
+        return KJTList(
+            [
+                apply_managed_collision_modules_to_kjt(
+                    features,
+                    self._managed_collision_modules,
+                    self._features_to_mc,
+                    mode=mode,
+                    mc_kwargs=mc_kwargs,
+                )
+                for features in dist_input
+            ]
+        )
+
+    def _kjt_list_to_tensor_list(
+        self,
+        kjt_list: KJTList,
+    ) -> List[torch.Tensor]:
+        remapped_ids_ret: List[torch.Tensor] = []
+        for kjt in kjt_list:
+            remapped_ids_ret.append(kjt.values().view(-1, 1))
+        return remapped_ids_ret
+
+    def compute(
+        self,
+        ctx: ManagedCollisionCollectionContext,
+        dist_input: KJTList,
+    ) -> KJTList:
+        mc_local_remapped_dist_input = self._apply_mc_modules_to_kjt_list(
+            dist_input,
+            mc_kwargs=self._mc_kwargs,
+        )
+        for features, sharding_ctx in zip(
+            mc_local_remapped_dist_input,
+            ctx.sharding_contexts,
+        ):
+            sharding_ctx.lengths_after_input_dist = features.lengths().view(
+                -1, features.stride()
+            )
+        return mc_local_remapped_dist_input
+
+    def output_dist(
+        self,
+        ctx: ManagedCollisionCollectionContext,
+        output: KJTList,
+    ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
+        local_remapped_kjt_list = output
+        global_remapped_kjt_list = self._apply_mc_modules_to_kjt_list(
+            local_remapped_kjt_list,
+            mode="local_to_global",
+        )
+        global_remapped = self._kjt_list_to_tensor_list(global_remapped_kjt_list)
+        awaitables_per_sharding: List[Awaitable[torch.Tensor]] = []
+        features_before_all2all_per_sharding: List[KeyedJaggedTensor] = []
+        for odist, remapped_ids, sharding_ctx in zip(
+            self._output_dists,
+            global_remapped,
+            ctx.sharding_contexts,
+        ):
+            awaitables_per_sharding.append(odist(remapped_ids, sharding_ctx))
+            features_before_all2all_per_sharding.append(
+                # pyre-fixme[6]: For 1st argument expected `KeyedJaggedTensor` but
+                #  got `Optional[KeyedJaggedTensor]`.
+                sharding_ctx.features_before_input_dist
+            )
+        return ManagedCollisionCollectionAwaitable(
+            awaitables_per_sharding=awaitables_per_sharding,
+            features_per_sharding=features_before_all2all_per_sharding,
+            embedding_names_per_sharding=self._embedding_names_per_sharding,
+            need_indices=False,
+            features_to_permute_indices=None,
+        )
+
+    def create_context(self) -> ManagedCollisionCollectionContext:
+        return ManagedCollisionCollectionContext(sharding_contexts=[])
+
+    def sharded_parameter_names(self, prefix: str = "") -> Iterator[str]:
+        for fqn, _ in self.named_parameters():
+            yield append_prefix(prefix, fqn)
+        for fqn, _ in self.named_buffers():
+            yield append_prefix(prefix, fqn)
+
+
+class ManagedCollisionCollectionSharder(
+    BaseEmbeddingSharder[ManagedCollisionCollection]
+):
+    def __init__(
+        self,
+        ec_sharder: Optional[EmbeddingCollectionSharder] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        self._ec_sharder: EmbeddingCollectionSharder = (
+            ec_sharder or EmbeddingCollectionSharder(self.qcomm_codecs_registry)
+        )
+
+    def shard(
+        self,
+        module: ManagedCollisionCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+        sharding_type_to_sharding: Optional[
+            Dict[
+                str,
+                EmbeddingSharding[
+                    EmbeddingShardingContext,
+                    KeyedJaggedTensor,
+                    torch.Tensor,
+                    torch.Tensor,
+                ],
+            ]
+        ] = None,
+    ) -> ShardedManagedCollisionCollection:
+
+        if device is None:
+            device = torch.device("cuda")
+
+        return ShardedManagedCollisionCollection(
+            module,
+            params,
+            ec_sharder=self._ec_sharder,
+            env=env,
+            device=device,
+            sharding_type_to_sharding=sharding_type_to_sharding,
+        )
+
+    def shardable_parameters(
+        self, module: ManagedCollisionCollection
+    ) -> Dict[str, torch.nn.Parameter]:
+        return self._ec_sharder.shardable_parameters(module._embedding_collection)
+
+    @property
+    def module_type(self) -> Type[ManagedCollisionCollection]:
+        return ManagedCollisionCollection
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        types = [
+            ShardingType.ROW_WISE.value,
+        ]
+        return types

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -228,7 +228,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             torch.tensor(
                 feature_block_sizes,
                 device=device,
-                dtype=torch.int32,
+                dtype=torch.int64,
             ),
         )
         self._dist = KJTAllToAll(

--- a/torchrec/modules/managed_collision_modules.py
+++ b/torchrec/modules/managed_collision_modules.py
@@ -8,9 +8,10 @@
 #!/usr/bin/env python3
 
 import abc
-from typing import Optional
+from typing import Any, Callable, cast, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
+import torch.distributed as dist
 
 from torch import nn
 from torchrec.sparse.jagged_tensor import JaggedTensor
@@ -18,11 +19,14 @@ from torchrec.sparse.jagged_tensor import JaggedTensor
 
 class ManagedCollisionModule(nn.Module):
     """
-    Abstract base class for feature processor.
+    Abstract base class for ManagedCollisionModule.
+    Maps input ids to range [0, max_output_id).
 
     Args:
-        max_output_id: Number of physical slots for ids in down stream embedding bag
-        max_input_id: Number of logical ids to manage
+        max_output_id (int): Max output value of remapped ids.
+        max_input_id (int): Max value of input range i.e. [0, max_input_id)
+        remapping_range_start_index (int): Relative start index of remapping range
+        device (torch.device): default compute device.
 
     Example::
         jt = JaggedTensor(...)
@@ -30,39 +34,72 @@ class ManagedCollisionModule(nn.Module):
         mcm_jt = mcm(fp)
     """
 
-    def __init__(self, max_output_id: int, max_input_id: int = 2**40) -> None:
+    def __init__(
+        self,
+        max_output_id: int,
+        device: torch.device,
+        remapping_range_start_index: int = 0,
+        max_input_id: int = 2**40,
+    ) -> None:
         # slots is the number of rows to map from global id to
         # for example, if we want to manage 1000 ids to 10 slots
         super().__init__()
         self._max_input_id: int = max_input_id
+        self._remapping_range_start_index = remapping_range_start_index
         self._max_output_id = max_output_id
+        self._device = device
 
     @abc.abstractmethod
-    def forward(
+    def preprocess(self, features: JaggedTensor) -> JaggedTensor:
+        pass
+
+    @abc.abstractmethod
+    def profile(
         self,
         features: JaggedTensor,
-    ) -> JaggedTensor:
-        """
-        Args:
-        features (JaggedTensor]): feature representation
-
-        Returns:
-            JaggedTensor: modified JT
-        """
+    ) -> None:
         pass
 
     @abc.abstractmethod
     def evict(self) -> Optional[torch.Tensor]:
         """
-        Returns None if no eviction should be done tihs iteration. Otherwise, return ids of slots to reset.
+        Returns None if no eviction should be done this iteration. Otherwise, return ids of slots to reset.
         On eviction, this module should reset its state for those slots, with the assumptionn that the downstream module
         will handle this properly.
         """
         pass
 
     @abc.abstractmethod
+    def remap(self, features: JaggedTensor) -> JaggedTensor:
+        pass
+
+    def local_map_global_offset(self) -> int:
+        """
+        Returns the offset in the global id space of the current map.
+        """
+        return self._remapping_range_start_index
+
+    @abc.abstractmethod
+    def forward(
+        self,
+        features: JaggedTensor,
+        mc_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> JaggedTensor:
+        """
+        Args:
+        features (JaggedTensor]): feature representation
+        mc_kwargs (Optional[Dict[str, Any]]): optional args dict to pass to MC module
+        Returns:
+            JaggedTensor: modified JT
+        """
+        pass
+
+    @abc.abstractmethod
     def rebuild_with_max_output_id(
-        self, max_output_id: int, device: torch.device
+        self,
+        max_output_id: int,
+        remapping_range_start_index: int,
+        device: torch.device,
     ) -> "ManagedCollisionModule":
         """
         Used for creating local MC modules for RW sharding, hack for now
@@ -72,9 +109,15 @@ class ManagedCollisionModule(nn.Module):
 
 class TrivialManagedCollisionModule(ManagedCollisionModule):
     def __init__(
-        self, max_output_id: int, device: torch.device, max_input_id: int = 2**64
+        self,
+        max_output_id: int,
+        device: torch.device,
+        remapping_range_start_index: int = 0,
+        max_input_id: int = 2**64,
     ) -> None:
-        super().__init__(max_output_id, max_input_id)
+        super().__init__(
+            max_output_id, device, remapping_range_start_index, max_input_id
+        )
         self.register_buffer(
             "count",
             torch.zeros(
@@ -83,12 +126,9 @@ class TrivialManagedCollisionModule(ManagedCollisionModule):
             ),
         )
 
-    def forward(
-        self,
-        features: JaggedTensor,
-    ) -> JaggedTensor:
+    @torch.no_grad()
+    def preprocess(self, features: JaggedTensor) -> JaggedTensor:
         values = features.values() % self._max_output_id
-        self.count[values] += 1
         return JaggedTensor(
             values=values,
             lengths=features.lengths(),
@@ -96,14 +136,817 @@ class TrivialManagedCollisionModule(ManagedCollisionModule):
             weights=features.weights_or_none(),
         )
 
+    @torch.no_grad()
+    def profile(
+        self,
+        features: JaggedTensor,
+    ) -> None:
+        values = features.values()
+        self.count[values] += 1
+
+    @torch.no_grad()
+    def remap(self, features: JaggedTensor) -> JaggedTensor:
+        # no-op as self.preprocess maps input to correct range
+        values = features.values()
+        return JaggedTensor(
+            values=values,
+            lengths=features.lengths(),
+            offsets=features.offsets(),
+            weights=features.weights_or_none(),
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        features: JaggedTensor,
+        mc_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> JaggedTensor:
+        self.profile(features)
+        return self.remap(features)
+
+    @torch.no_grad()
     def evict(self) -> Optional[torch.Tensor]:
         return None
 
     def rebuild_with_max_output_id(
-        self, max_output_id: int, device: Optional[torch.device] = None
+        self,
+        max_output_id: int,
+        remapping_range_start_index: int,
+        device: Optional[torch.device] = None,
     ) -> "TrivialManagedCollisionModule":
         return type(self)(
             max_output_id=max_output_id,
+            remapping_range_start_index=remapping_range_start_index,
             device=device or self._device,
             max_input_id=self._max_input_id,
+        )
+
+
+class MCHEvictionPolicyMetadataInfo(NamedTuple):
+    metadata_name: str
+    is_mch_metadata: bool
+    is_history_metadata: bool
+
+
+class MCHEvictionPolicy(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def metadata_info(self) -> List[MCHEvictionPolicyMetadataInfo]:
+        pass
+
+    @abc.abstractmethod
+    def record_history_metadata(
+        self,
+        current_iter: int,
+        incoming_ids: torch.Tensor,
+        history_metadata: Dict[str, torch.Tensor],
+    ) -> None:
+        """
+        Args:
+        current_iter (int): current iteration
+        incoming_ids (torch.Tensor): incoming ids
+        history_metadata (Dict[str, torch.Tensor]): history metadata dict
+
+        Compute and record metadata based on incoming ids
+            for the implemented eviction policy.
+        """
+        pass
+
+    @abc.abstractmethod
+    def coalesce_history_metadata(
+        self,
+        current_iter: int,
+        history_metadata: Dict[str, torch.Tensor],
+        unique_ids_counts: torch.Tensor,
+        unique_inverse_mapping: torch.Tensor,
+        additional_ids: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Args:
+        history_metadata (Dict[str, torch.Tensor]): history metadata dict
+        additional_ids (torch.Tensor): additional ids to be used as part of history
+        unique_inverse_mapping (torch.Tensor): torch.unique inverse mapping generated from
+            torch.cat[history_accumulator, additional_ids]. used to map history metadata tensor
+            indices to their coalesced tensor indices.
+
+        Coalesce metadata history buffers and return dict of processed metadata tensors.
+        """
+        pass
+
+    @abc.abstractmethod
+    def update_metadata_and_generate_eviction_scores(
+        self,
+        current_iter: int,
+        mch_size: int,
+        coalesced_history_argsort_mapping: torch.Tensor,
+        coalesced_history_sorted_unique_ids_counts: torch.Tensor,
+        coalesced_history_mch_matching_elements_mask: torch.Tensor,
+        coalesced_history_mch_matching_indices: torch.Tensor,
+        mch_metadata: Dict[str, torch.Tensor],
+        coalesced_history_metadata: Dict[str, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Args:
+
+
+        Returns Tuple of (evicted_indices, selected_new_indices) where:
+            evicted_indices are indices in the mch map to be evicted, and
+            selected_new_indices are the indices of the ids in the coalesced
+            history that are to be added to the mch.
+        """
+        pass
+
+    def _compute_selected_eviction_and_replacement_indices(
+        self,
+        pivot: int,
+        eviction_scores: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # NOTE these are like indices
+        argsorted_eviction_scores = torch.argsort(
+            eviction_scores, descending=True, stable=True
+        )
+
+        # indices with values >= zch_size in the top zch_size scores correspond
+        #   to new incoming ids to be added to zch
+        selected_new_ids_mask = argsorted_eviction_scores[:pivot] >= pivot
+        # indices with values < zch_size outside the top zch_size scores correspond
+        #   to existing zch ids to be evicted
+        evicted_ids_mask = argsorted_eviction_scores[pivot:] < pivot
+        evicted_indices = argsorted_eviction_scores[pivot:][evicted_ids_mask]
+        selected_new_indices = (
+            argsorted_eviction_scores[:pivot][selected_new_ids_mask] - pivot
+        )
+
+        return evicted_indices, selected_new_indices
+
+
+class LFU_EvictionPolicy(MCHEvictionPolicy):
+    def __init__(self) -> None:
+        self._metadata_info = [
+            MCHEvictionPolicyMetadataInfo(
+                metadata_name="counts",
+                is_mch_metadata=True,
+                is_history_metadata=False,
+            ),
+        ]
+
+    @property
+    def metadata_info(self) -> List[MCHEvictionPolicyMetadataInfo]:
+        return self._metadata_info
+
+    def record_history_metadata(
+        self,
+        current_iter: int,
+        incoming_ids: torch.Tensor,
+        history_metadata: Dict[str, torch.Tensor],
+    ) -> None:
+        # no-op; no history buffers
+        pass
+
+    def coalesce_history_metadata(
+        self,
+        current_iter: int,
+        history_metadata: Dict[str, torch.Tensor],
+        unique_ids_counts: torch.Tensor,
+        unique_inverse_mapping: torch.Tensor,
+        additional_ids: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        # no-op; no history buffers
+        return {}
+
+    def update_metadata_and_generate_eviction_scores(
+        self,
+        current_iter: int,
+        mch_size: int,
+        coalesced_history_argsort_mapping: torch.Tensor,
+        coalesced_history_sorted_unique_ids_counts: torch.Tensor,
+        coalesced_history_mch_matching_elements_mask: torch.Tensor,
+        coalesced_history_mch_matching_indices: torch.Tensor,
+        mch_metadata: Dict[str, torch.Tensor],
+        coalesced_history_metadata: Dict[str, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        mch_counts = mch_metadata["counts"]
+        # update metadata for matching ids
+        mch_counts[
+            coalesced_history_mch_matching_indices
+        ] += coalesced_history_sorted_unique_ids_counts[
+            coalesced_history_mch_matching_elements_mask
+        ]
+
+        # incoming non-matching ids
+        new_sorted_uniq_ids_counts = coalesced_history_sorted_unique_ids_counts[
+            ~coalesced_history_mch_matching_elements_mask
+        ]
+
+        merged_counts = torch.cat(
+            [
+                mch_counts,
+                new_sorted_uniq_ids_counts,
+            ]
+        )
+        # calculate evicted and replacement indices
+        (
+            evicted_indices,
+            selected_new_indices,
+        ) = self._compute_selected_eviction_and_replacement_indices(
+            mch_size,
+            merged_counts,
+        )
+
+        # update metadata for evicted ids
+        mch_counts[evicted_indices] = new_sorted_uniq_ids_counts[selected_new_indices]
+
+        return evicted_indices, selected_new_indices
+
+
+class DistanceLFU_EvictionPolicy(MCHEvictionPolicy):
+    def __init__(self, decay_exponent: int = 2) -> None:
+        self._metadata_info = [
+            MCHEvictionPolicyMetadataInfo(
+                metadata_name="counts",
+                is_mch_metadata=True,
+                is_history_metadata=False,
+            ),
+            MCHEvictionPolicyMetadataInfo(
+                metadata_name="last_access_iter",
+                is_mch_metadata=True,
+                is_history_metadata=True,
+            ),
+        ]
+        self._decay_exponent = decay_exponent
+
+    @property
+    def metadata_info(self) -> List[MCHEvictionPolicyMetadataInfo]:
+        return self._metadata_info
+
+    def record_history_metadata(
+        self,
+        current_iter: int,
+        incoming_ids: torch.Tensor,
+        history_metadata: Dict[str, torch.Tensor],
+    ) -> None:
+        history_last_access_iter = history_metadata["last_access_iter"]
+        history_last_access_iter[:] = current_iter
+
+    def coalesce_history_metadata(
+        self,
+        current_iter: int,
+        history_metadata: Dict[str, torch.Tensor],
+        unique_ids_counts: torch.Tensor,
+        unique_inverse_mapping: torch.Tensor,
+        additional_ids: Optional[torch.Tensor] = None,
+    ) -> Dict[str, torch.Tensor]:
+        coalesced_history_metadata: Dict[str, torch.Tensor] = {}
+        history_last_access_iter = history_metadata["last_access_iter"]
+        if additional_ids is not None:
+            history_last_access_iter = torch.cat(
+                [
+                    history_last_access_iter,
+                    torch.full_like(additional_ids, current_iter),
+                ]
+            )
+        coalesced_history_metadata["last_access_iter"] = torch.zeros_like(
+            unique_ids_counts
+        ).scatter_reduce_(
+            0,
+            unique_inverse_mapping,
+            history_last_access_iter,
+            reduce="amax",
+            include_self=False,
+        )
+        return coalesced_history_metadata
+
+    def update_metadata_and_generate_eviction_scores(
+        self,
+        current_iter: int,
+        mch_size: int,
+        coalesced_history_argsort_mapping: torch.Tensor,
+        coalesced_history_sorted_unique_ids_counts: torch.Tensor,
+        coalesced_history_mch_matching_elements_mask: torch.Tensor,
+        coalesced_history_mch_matching_indices: torch.Tensor,
+        mch_metadata: Dict[str, torch.Tensor],
+        coalesced_history_metadata: Dict[str, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        mch_counts = mch_metadata["counts"]
+        mch_last_access_iter = mch_metadata["last_access_iter"]
+
+        # sort coalesced history metadata
+        coalesced_history_metadata["last_access_iter"].copy_(
+            coalesced_history_metadata["last_access_iter"][
+                coalesced_history_argsort_mapping
+            ]
+        )
+        coalesced_history_sorted_uniq_ids_last_access_iter = coalesced_history_metadata[
+            "last_access_iter"
+        ]
+
+        # update metadata for matching ids
+        mch_counts[
+            coalesced_history_mch_matching_indices
+        ] += coalesced_history_sorted_unique_ids_counts[
+            coalesced_history_mch_matching_elements_mask
+        ]
+        mch_last_access_iter[
+            coalesced_history_mch_matching_indices
+        ] = coalesced_history_sorted_uniq_ids_last_access_iter[
+            coalesced_history_mch_matching_elements_mask
+        ]
+
+        # incoming non-matching ids
+        new_sorted_uniq_ids_counts = coalesced_history_sorted_unique_ids_counts[
+            ~coalesced_history_mch_matching_elements_mask
+        ]
+        new_sorted_uniq_ids_last_access = (
+            coalesced_history_sorted_uniq_ids_last_access_iter[
+                ~coalesced_history_mch_matching_elements_mask
+            ]
+        )
+        merged_counts = torch.cat(
+            [
+                mch_counts,
+                new_sorted_uniq_ids_counts,
+            ]
+        )
+        merged_access_iter = torch.cat(
+            [
+                mch_last_access_iter,
+                new_sorted_uniq_ids_last_access,
+            ]
+        )
+        merged_weighted_distance = torch.pow(
+            current_iter - merged_access_iter + 1,
+            self._decay_exponent,
+        )
+        # merged eviction scores are the eviction scores calculated for the
+        #   tensor torch.cat[_mch_sorted_raw_ids, frequency_sorted_uniq_ids[~matching_eles]]
+        # lower scores are evicted first.
+        merged_eviction_scores = torch.div(merged_counts, merged_weighted_distance)
+
+        # calculate evicted and replacement indices
+        (
+            evicted_indices,
+            selected_new_indices,
+        ) = self._compute_selected_eviction_and_replacement_indices(
+            mch_size,
+            merged_eviction_scores,
+        )
+
+        # update metadata for evicted ids
+        mch_counts[evicted_indices] = new_sorted_uniq_ids_counts[selected_new_indices]
+        mch_last_access_iter[evicted_indices] = new_sorted_uniq_ids_last_access[
+            selected_new_indices
+        ]
+
+        return evicted_indices, selected_new_indices
+
+
+class MCHManagedCollisionModule(ManagedCollisionModule):
+    def __init__(
+        self,
+        # total output range size incl. zch (i.e. total_size >= zch_size)
+        max_output_id: int,
+        device: torch.device,
+        # hash_func(input_ids, hash_size) -> hashed_input_ids
+        hash_func: Callable[[torch.Tensor, int], torch.Tensor],
+        is_train: bool,
+        # max rolling tracking window size in number of _total_ IDs
+        max_history_size: int,
+        zch_size: int,
+        eviction_policy: MCHEvictionPolicy,
+        force_update_on_step: int = -1,
+        #####
+        remapping_range_start_index: int = 0,
+        max_input_id: int = 2**62,
+    ) -> None:
+        super().__init__(
+            max_output_id, device, remapping_range_start_index, max_input_id
+        )
+
+        self._is_train = is_train
+        self._max_history_size = max_history_size
+        assert (
+            self._max_output_id >= zch_size
+        ), "zch_size must be less then or equal to max_output_id"
+        self._zch_size = zch_size
+        assert self._zch_size > 0, "zch_size must be > 0"
+        self._hash_size: int = self._max_output_id - self._zch_size
+        assert self._hash_size > 0, (
+            "hash_size (= max_output_id - zch_size) must be "
+            ">= 1 for valid output mapping for non-ZCH IDs"
+        )
+        self._hash_func = hash_func
+        self._remapping_range_start_index = remapping_range_start_index
+        self._force_update_on_step: int = (
+            force_update_on_step
+            if force_update_on_step > 0
+            else torch.iinfo(torch.int32).max
+        )
+        self._eviction_policy = eviction_policy
+
+        self._current_iter: int = 0
+        self._most_recent_update_iter: int = 0
+
+        ## ------ mch info ------
+        self.register_buffer(
+            "_mch_sorted_raw_ids",
+            torch.full(
+                (self._zch_size + 1,),
+                torch.iinfo(torch.int64).max,
+                dtype=torch.int64,
+                device=self._device,
+            ),
+        )
+        self.register_buffer(
+            "_mch_remapped_ids_mapping",
+            torch.arange(self._zch_size, dtype=torch.int64, device=self._device),
+        )
+
+        ## ------ history info ------
+        if self._is_train:
+            self.register_buffer(
+                "_history_accumulator",
+                torch.empty(
+                    self._max_history_size,
+                    dtype=torch.int64,
+                    device=self._device,
+                ),
+                # not checkpointed
+                persistent=False,
+            )
+            self._mch_metadata: Dict[str, torch.Tensor] = {}
+            self._history_metadata: Dict[str, torch.Tensor] = {}
+            self._init_metadata_buffers()
+            self._current_history_buffer_offset: int = 0
+            self._evicted_emb_indices: torch.Tensor = torch.empty(
+                (1,), device=self._device
+            )
+            self._evicted: bool = False
+
+        # HACK for checkpointing
+        # currently changing world_size between
+        # saving/loading is not supported
+
+        self._world_size: int = 1
+        if dist.is_initialized():
+            self._world_size = dist.get_world_size()
+
+        def _post_state_dict_hook(
+            module: MCHManagedCollisionModule,
+            destination: Dict[str, torch.Tensor],
+            prefix: str,
+            _local_metadata: Dict[str, Any],
+        ) -> None:
+            # trim sorted_raw_ids anchor
+            destination[prefix + "_mch_sorted_raw_ids"] = destination[
+                prefix + "_mch_sorted_raw_ids"
+            ][:-1]
+            # update _mch_remapped_ids_mapping from local to global mapping
+            destination[prefix + "_mch_remapped_ids_mapping"].add_(
+                self.local_map_global_offset()
+            )
+            # self._device doesn't update if module.to(..) is called
+            device = destination[prefix + "_mch_sorted_raw_ids"].device
+            destination[prefix + "_current_iter_tensor"] = torch.full(
+                (1,), self._current_iter, dtype=torch.int64, device=device
+            )
+            destination[prefix + "_most_recent_update_iter_tensor"] = torch.full(
+                (1,),
+                self._most_recent_update_iter,
+                dtype=torch.int64,
+                device=device,
+            )
+            destination[prefix + "_world_size_tensor"] = torch.full(
+                (1,), self._world_size, dtype=torch.int64, device=device
+            )
+
+        def _load_state_dict_pre_hook(
+            module: "MCHManagedCollisionModule",
+            state_dict: Dict[str, torch.Tensor],
+            prefix: str,
+            *args: Any,
+        ) -> None:
+            # add sorted_raw_ids anchor
+            state_dict[prefix + "_mch_sorted_raw_ids"] = torch.cat(
+                [
+                    state_dict[prefix + "_mch_sorted_raw_ids"],
+                    torch.tensor(
+                        [torch.iinfo(torch.int64).max],
+                        dtype=torch.int64,
+                        device=state_dict[prefix + "_mch_sorted_raw_ids"].device,
+                    ),
+                ]
+            )
+            # update _mch_remapped_ids_mapping from global to local mapping
+            state_dict[prefix + "_mch_remapped_ids_mapping"].sub_(
+                self.local_map_global_offset()
+            )
+            module._current_iter = cast(
+                int, state_dict.pop(prefix + "_current_iter_tensor").item()
+            )
+            module._most_recent_update_iter = cast(
+                int, state_dict.pop(prefix + "_most_recent_update_iter_tensor").item()
+            )
+            # HACK for checkpointing continued
+            module._world_size = cast(
+                int, state_dict.pop(prefix + "_world_size_tensor").item()
+            )
+            if dist.is_initialized():
+                assert dist.get_world_size() == module._world_size
+            else:
+                assert module._world_size == 1
+
+        self._register_state_dict_hook(_post_state_dict_hook)
+        self._register_load_state_dict_pre_hook(
+            _load_state_dict_pre_hook, with_module=True
+        )
+
+    def _init_metadata_buffers(self) -> None:
+        eviction_metadata_info = self._eviction_policy.metadata_info
+        for metadata in eviction_metadata_info:
+            metadata_name, is_mch_metadata, is_history_metadata = metadata
+            # mch_metadata
+            if is_mch_metadata:
+                buffer_name = "_mch_" + metadata_name
+                self.register_buffer(
+                    buffer_name,
+                    torch.zeros(
+                        (self._zch_size,),
+                        dtype=torch.int64,
+                        device=self._device,
+                    ),
+                )
+                self._mch_metadata[metadata_name] = getattr(self, buffer_name)
+            # history_metadata
+            if is_history_metadata:
+                buffer_name = "_history_" + metadata_name
+                self.register_buffer(
+                    buffer_name,
+                    torch.zeros(
+                        self._max_history_size,
+                        dtype=torch.int64,
+                        device=self._device,
+                    ),
+                    # not checkpointed
+                    persistent=False,
+                )
+                self._history_metadata[metadata_name] = getattr(self, buffer_name)
+
+    @torch.no_grad()
+    def preprocess(self, features: JaggedTensor) -> JaggedTensor:
+        values = self._hash_func(features.values(), self._max_input_id)
+        return JaggedTensor(
+            values=values,
+            lengths=features.lengths(),
+            offsets=features.offsets(),
+            weights=features.weights_or_none(),
+        )
+
+    @torch.no_grad()
+    def _match_indices(
+        self, sorted_sequence: torch.Tensor, search_values: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        searched_indices = torch.searchsorted(sorted_sequence, search_values)
+        retrieved_ids = sorted_sequence[searched_indices]
+        matching_eles = retrieved_ids == search_values
+        matched_indices = searched_indices[matching_eles]
+        return (matching_eles, matched_indices)
+
+    @torch.no_grad()
+    def _sort_mch_buffers(self) -> None:
+        mch_sorted_raw_ids = self._mch_sorted_raw_ids[:-1]
+        argsorted_sorted_raw_ids = torch.argsort(mch_sorted_raw_ids, stable=True)
+        mch_sorted_raw_ids.copy_(mch_sorted_raw_ids[argsorted_sorted_raw_ids])
+        self._mch_remapped_ids_mapping.copy_(
+            self._mch_remapped_ids_mapping[argsorted_sorted_raw_ids]
+        )
+        for mch_metadata_buffer in self._mch_metadata.values():
+            mch_metadata_buffer.copy_(mch_metadata_buffer[argsorted_sorted_raw_ids])
+
+    @torch.no_grad()
+    def _update_and_evict(
+        self,
+        uniq_ids: torch.Tensor,
+        uniq_ids_counts: torch.Tensor,
+        uniq_ids_metadata: Dict[str, torch.Tensor],
+    ) -> None:
+        argsorted_uniq_ids_counts = torch.argsort(
+            uniq_ids_counts, descending=True, stable=True
+        )
+        frequency_sorted_uniq_ids = uniq_ids[argsorted_uniq_ids_counts]
+        frequency_sorted_uniq_ids_counts = uniq_ids_counts[argsorted_uniq_ids_counts]
+
+        matching_eles, matched_indices = self._match_indices(
+            self._mch_sorted_raw_ids, frequency_sorted_uniq_ids
+        )
+
+        new_frequency_sorted_uniq_ids = frequency_sorted_uniq_ids[~matching_eles]
+
+        # evicted_indices are indices in the mch map to be evicted, and
+        #   selected_new_indices are the indices of the ids in the coalesced
+        #   history that are to be added to the mch.
+        (
+            evicted_indices,
+            selected_new_indices,
+        ) = self._eviction_policy.update_metadata_and_generate_eviction_scores(
+            self._current_iter,
+            self._zch_size,
+            argsorted_uniq_ids_counts,
+            frequency_sorted_uniq_ids_counts,
+            matching_eles,
+            matched_indices,
+            self._mch_metadata,
+            uniq_ids_metadata,
+        )
+
+        self._mch_sorted_raw_ids[evicted_indices] = new_frequency_sorted_uniq_ids[
+            selected_new_indices
+        ]
+
+        # NOTE evicted ids for emb reset
+        # if evicted flag is already set, then existing evicted ids havent been
+        # consumed by evict(). append new evicted ids to the list
+        if self._evicted:
+            self._evicted_emb_indices = torch.unique(
+                torch.cat(
+                    [
+                        self._evicted_emb_indices,
+                        self._mch_remapped_ids_mapping[evicted_indices],
+                    ]
+                )
+            )
+        else:
+            self._evicted_emb_indices = self._mch_remapped_ids_mapping[evicted_indices]
+        self._evicted = True
+
+        # re-sort for next search
+        self._sort_mch_buffers()
+
+    @torch.no_grad()
+    def _coalesce_history(self, additional_ids: Optional[torch.Tensor] = None) -> None:
+        current_history_accumulator = self._history_accumulator[
+            : self._current_history_buffer_offset
+        ]
+        if additional_ids is not None:
+            current_history_accumulator = torch.cat(
+                [current_history_accumulator, additional_ids]
+            )
+        uniq_ids, uniq_inverse_mapping, uniq_ids_counts = torch.unique(
+            current_history_accumulator,
+            return_inverse=True,
+            return_counts=True,
+        )
+        coalesced_eviction_history_metadata = (
+            self._eviction_policy.coalesce_history_metadata(
+                self._current_iter,
+                {
+                    metadata_name: metadata_buffer[
+                        : self._current_history_buffer_offset
+                    ]
+                    for metadata_name, metadata_buffer in self._history_metadata.items()
+                },
+                uniq_ids_counts,
+                uniq_inverse_mapping,
+                additional_ids=additional_ids,
+            )
+        )
+        self._update_and_evict(
+            uniq_ids, uniq_ids_counts, coalesced_eviction_history_metadata
+        )
+        # reset buffer offset
+        self._current_history_buffer_offset = 0
+        # update most recent update step
+        self._most_recent_update_iter = self._current_iter
+
+    @torch.no_grad()
+    def profile(
+        self,
+        features: JaggedTensor,
+        force_update: bool = False,
+        count_multiplier: Optional[int] = None,
+    ) -> None:
+        if self._is_train and self.training:
+            multiplier = (
+                count_multiplier
+                if count_multiplier is not None and count_multiplier > 1
+                else 1
+            )
+            values = features.values()
+            if multiplier > 1:
+                values = values.repeat(multiplier)
+            num_incoming_values = values.size(0)
+            free_elements = self._max_history_size - self._current_history_buffer_offset
+            # check if need to coalesce by one of the following conditions:
+            # 1. buffer will be full with incoming ids
+            # 2. current iteration has reached max update step
+            # 3. force update is set
+            if (
+                num_incoming_values >= free_elements
+                or self._current_iter - self._most_recent_update_iter
+                >= self._force_update_on_step
+                or force_update
+            ):
+                self._coalesce_history(values)
+            else:
+                self._history_accumulator[
+                    self._current_history_buffer_offset : self._current_history_buffer_offset
+                    + num_incoming_values
+                ] = values
+                self._eviction_policy.record_history_metadata(
+                    self._current_iter,
+                    values,
+                    {
+                        metadata_name: metadata_buffer[
+                            self._current_history_buffer_offset : self._current_history_buffer_offset
+                            + num_incoming_values
+                        ]
+                        for metadata_name, metadata_buffer in self._history_metadata.items()
+                    },
+                )
+                self._current_history_buffer_offset += num_incoming_values
+
+            self._current_iter += 1
+
+    @torch.no_grad()
+    def remap(self, features: JaggedTensor) -> JaggedTensor:
+        values = features.values()
+        remapped_ids = torch.empty_like(values)
+
+        # compute overlap between incoming IDs and remapping table
+        searched_indices = torch.searchsorted(self._mch_sorted_raw_ids, values)
+        retrieved_indices = self._mch_sorted_raw_ids[searched_indices]
+        # identify matching inputs IDs
+        matching_indices = retrieved_indices == values
+        # update output with remapped matching IDs
+        remapped_ids[matching_indices] = self._mch_remapped_ids_mapping[
+            searched_indices[matching_indices]
+        ]
+        # select non-matching values
+        non_matching_values = values[~matching_indices]
+        # hash non-matching values
+        hashed_non_matching = self._hash_func(non_matching_values, self._hash_size)
+        # offset hash ids to their starting range
+        remapped_ids[~matching_indices] = hashed_non_matching + self._zch_size
+
+        return JaggedTensor(
+            values=remapped_ids,
+            lengths=features.lengths(),
+            offsets=features.offsets(),
+            weights=features.weights_or_none(),
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        features: JaggedTensor,
+        mc_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> JaggedTensor:
+        """
+        Args:
+        features (JaggedTensor]): feature representation
+        mc_kwargs (Optional[Dict[str, Any]]: optional args dict to pass to MC module
+            MCHManagedCollisionModule supports:
+                1. force_update (bool): force update this step
+                2. count_multiplier (int): if provided, multiply
+                    count of incoming ids by this value
+        Returns:
+            JaggedTensor: modified JT
+        """
+        force_update = (
+            mc_kwargs.get("force_update", False) if mc_kwargs is not None else False
+        )
+        count_multiplier = (
+            mc_kwargs.get("count_multiplier", None) if mc_kwargs is not None else None
+        )
+        self.profile(
+            features,
+            force_update=force_update,
+            count_multiplier=count_multiplier,
+        )
+        return self.remap(features)
+
+    @torch.no_grad()
+    def evict(self) -> Optional[torch.Tensor]:
+        if self._evicted:
+            self._evicted = False
+            return self._evicted_emb_indices
+        else:
+            return None
+
+    def rebuild_with_max_output_id(
+        self,
+        max_output_id: int,
+        remapping_range_start_index: int,
+        device: Optional[torch.device] = None,
+    ) -> "MCHManagedCollisionModule":
+        return type(self)(
+            max_output_id=max_output_id,
+            remapping_range_start_index=remapping_range_start_index,
+            zch_size=self._zch_size,
+            device=device or self._device,
+            max_input_id=self._max_input_id,
+            is_train=self._is_train,
+            max_history_size=self._max_history_size,
+            hash_func=self._hash_func,
+            force_update_on_step=self._force_update_on_step,
+            eviction_policy=self._eviction_policy,
         )

--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -6,13 +6,13 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.managed_collision_modules import ManagedCollisionModule
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 
 @torch.fx.wrap
@@ -20,24 +20,40 @@ def apply_managed_collision_modules_to_kjt(
     features: KeyedJaggedTensor,
     managed_collisions: nn.ModuleDict,
     feature_to_table: Dict[str, str],
+    mode: Optional[str] = None,
+    mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> KeyedJaggedTensor:
-
     if len(features.keys()) == 0:
         return features
 
     features_dict = features.to_dict()
     managed_ids = []
-
     for key in features.keys():
         jt = features_dict[key]
-        table_name = feature_to_table[key]
-        if table_name in managed_collisions:
-            mc_jt = managed_collisions[table_name](jt)
+        if key in feature_to_table:
+            table_name = feature_to_table[key]
+            mc_module = managed_collisions[table_name]
+            if mode == "preprocess":
+                mc_jt = mc_module.preprocess(jt)
+                mc_jt_values = mc_jt.values()
+            elif mode == "local_to_global":
+                local_to_global_offset = mc_module.local_map_global_offset()
+                mc_jt_values = jt.values() + local_to_global_offset
+            else:
+                mc_jt = mc_module(
+                    jt,
+                    mc_kwargs=mc_kwargs.get(table_name, None)
+                    if mc_kwargs is not None
+                    else None,
+                )
+                mc_jt_values = mc_jt.values()
         else:
             mc_jt = jt
-        managed_ids.append(mc_jt.values())
+            mc_jt_values = mc_jt.values()
 
-    return KeyedJaggedTensor(
+        managed_ids.append(mc_jt_values)
+
+    mc_kjt = KeyedJaggedTensor(
         keys=features.keys(),
         values=torch.cat(managed_ids),
         weights=features.weights_or_none(),
@@ -49,6 +65,8 @@ def apply_managed_collision_modules_to_kjt(
         index_per_key=features._index_per_key,
     )
 
+    return mc_kjt
+
 
 def evict(
     evictions: Dict[str, Optional[torch.Tensor]], ebc: EmbeddingBagCollection
@@ -56,6 +74,91 @@ def evict(
     # evicts ids corresponding with table name from ebcs
     # If none, do a no-op
     return
+
+
+class ManagedCollisionCollection(nn.Module):
+    """
+    ManagedCollisionCollection represents a collection of managed collision modules.
+    The inputs passed to the MCC will be remapped by the managed collision modules
+        and returned.
+    Args:
+        feature_to_mc: Dict of feature name to its managed collision module to use.
+        managed_collision_modules: Dict of managed collision modules
+
+    Example:
+        feature_to_mc = {
+            "f1": "t1",
+            "f2": "t2",
+        }
+        mc_modules = {
+            "t1": ManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            "t2":
+                ManagedCollisionModule(
+                    max_output_id=16, max_input_id=32, device=device
+                ),
+            ),
+        }
+
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(ebc, mc_modules)
+        Dict[str, JaggedTensor] = mc_ebc(kjt)
+    """
+
+    def __init__(
+        self,
+        feature_to_mc: Dict[str, str],
+        managed_collision_modules: Dict[str, ManagedCollisionModule],
+    ) -> None:
+        super().__init__()
+        self._device: torch.device = list(managed_collision_modules.values())[0]._device
+        self._features_to_mc = feature_to_mc
+        self._managed_collision_modules = nn.ModuleDict(managed_collision_modules)
+        self._mc_to_features: Dict[str, List[str]] = defaultdict(list)
+        for feature_name, mc_name in feature_to_mc.items():
+            self._mc_to_features[mc_name].append(feature_name)
+        for mc_name in self._mc_to_features.keys():
+            if mc_name not in self._managed_collision_modules:
+                raise ValueError(
+                    f"{mc_name} is not present in managed_collision_modules"
+                )
+
+    def compute(
+        self,
+        features: KeyedJaggedTensor,
+        mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> KeyedJaggedTensor:
+        features = apply_managed_collision_modules_to_kjt(
+            features,
+            self._managed_collision_modules,
+            self._features_to_mc,
+            mode="preprocess",
+        )
+        mc_features = apply_managed_collision_modules_to_kjt(
+            features,
+            self._managed_collision_modules,
+            self._features_to_mc,
+            mc_kwargs=mc_kwargs,
+        )
+
+        return mc_features
+
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+        mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> Dict[str, JaggedTensor]:
+        """
+        Args:
+            features (KeyedJaggedTensor): KJT of form [F X B X L].
+            mc_kwargs (Optional[Dict[str, Dict[str, Any]]]): optional args dict to
+                pass to MC modules
+        Returns:
+            Dict[str, JaggedTensor] of remapped features
+        """
+        mc_features = self.compute(features, mc_kwargs)
+
+        return mc_features.to_dict()
 
 
 class ManagedCollisionEmbeddingBagCollection(nn.Module):
@@ -68,6 +171,8 @@ class ManagedCollisionEmbeddingBagCollection(nn.Module):
     Args:
         embedding_bag_collection: EmbeddingBagCollection to lookup embeddings
         managed_collision_modules: Dict of managed collision modules
+        return_remapped_features (bool): whether to return remapped input features
+            in addition to embeddings
 
     Example:
         ebc = EmbeddingBagCollection(
@@ -99,49 +204,79 @@ class ManagedCollisionEmbeddingBagCollection(nn.Module):
     def __init__(
         self,
         embedding_bag_collection: EmbeddingBagCollection,
-        managed_collision_modules: Dict[str, ManagedCollisionModule],
+        managed_collision_modules: Union[
+            ManagedCollisionCollection, Dict[str, ManagedCollisionModule]
+        ],
+        return_remapped_features: bool = False,
     ) -> None:
         super().__init__()
         self._embedding_bag_collection = embedding_bag_collection
-        self._managed_collision_modules = nn.ModuleDict(managed_collision_modules)
+        self._return_remapped_features = return_remapped_features
 
         self._features_to_tables: Dict[str, str] = {}
         self._table_to_features: Dict[str, List[str]] = defaultdict(list)
+        for table in self._embedding_bag_collection.embedding_bag_configs():
+            for feature in table.feature_names:
+                assert feature not in self._features_to_tables, (
+                    "shared (same input feature to multiple tables) is "
+                    "not currently supported."
+                )
+                self._features_to_tables[feature] = table.name
+                self._table_to_features[table.name].append(feature)
+
+        if isinstance(managed_collision_modules, ManagedCollisionCollection):
+            self._managed_collision_collection: ManagedCollisionCollection = (
+                managed_collision_modules
+            )
+            managed_collision_modules = (
+                self._managed_collision_collection._managed_collision_modules
+            )
+        else:
+            self._managed_collision_collection = ManagedCollisionCollection(
+                self._features_to_tables,
+                managed_collision_modules,
+            )
+
         for table in self._embedding_bag_collection.embedding_bag_configs():
             if table.name not in managed_collision_modules:
                 raise ValueError(
                     f"{table.name} is not present in managed_collision_modules"
                 )
-
             assert (
-                self._managed_collision_modules[table.name]._max_output_id
+                managed_collision_modules[table.name]._max_output_id
                 == table.num_embeddings
-            ), f"max_output_id in managed collision module for {table.name} must match {table.num_embeddings=}"
-
-            for feature in table.feature_names:
-                self._features_to_tables[feature] = table.name
-                self._table_to_features[table.name].append(feature)
+            ), (
+                f"max_output_id in managed collision module for {table.name} "
+                f"must match {table.num_embeddings=}"
+            )
 
     def forward(
         self,
         features: KeyedJaggedTensor,
-    ) -> KeyedTensor:
+        mc_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> Union[KeyedTensor, Tuple[KeyedTensor, Dict[str, JaggedTensor]]]:
         """
         Args:
             features (KeyedJaggedTensor): KJT of form [F X B X L].
-
+            mc_kwargs (Optional[Dict[str, Dict[str, Any]]]): optional args dict to
+                pass to MC modules
         Returns:
-            KeyedTensor
+            KeyedTensor or Tuple[KeyedTensor, Dict[str, JaggedTensor]]
         """
 
-        mc_features = apply_managed_collision_modules_to_kjt(
-            features, self._managed_collision_modules, self._features_to_tables
-        )
+        mc_features = self._managed_collision_collection.compute(features, mc_kwargs)
+
         ret = self._embedding_bag_collection(mc_features)
 
         evictions: Dict[str, Optional[torch.Tensor]] = {}
-        for table, managed_collision_module in self._managed_collision_modules.items():
+        for (
+            table,
+            managed_collision_module,
+        ) in self._managed_collision_collection._managed_collision_modules.items():
             evictions[table] = managed_collision_module.evict()
         evict(evictions, self._embedding_bag_collection)
 
-        return ret
+        if not self._return_remapped_features:
+            return ret
+        else:
+            return ret, mc_features.to_dict()

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -12,7 +12,9 @@ import torch
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.managed_collision_modules import (
+    DistanceLFU_EvictionPolicy,
     ManagedCollisionModule,
+    MCHManagedCollisionModule,
     TrivialManagedCollisionModule,
 )
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingBagCollection
@@ -69,3 +71,172 @@ class TriviallyManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
         self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
 
         print("state dict", mc_ebc.state_dict())
+
+
+class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
+    def test_zch_managed_ebc(self) -> None:
+        device = torch.device("cpu")
+        table_size = 100
+        zch_size = 50
+
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="t1", embedding_dim=8, num_embeddings=100, feature_names=["f1"]
+                ),
+            ],
+            device=device,
+        )
+        mc_modules = {
+            "t1": cast(
+                ManagedCollisionModule,
+                MCHManagedCollisionModule(
+                    max_output_id=table_size,
+                    device=device,
+                    is_train=True,
+                    max_history_size=zch_size,
+                    zch_size=zch_size,
+                    hash_func=lambda input_ids, hash_size: torch.remainder(
+                        input_ids, hash_size
+                    ),
+                    eviction_policy=DistanceLFU_EvictionPolicy(),
+                ),
+            ),
+        }
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            ebc,
+            mc_modules,
+            return_remapped_features=True,
+        )
+
+        ################ 1 ################
+        # values in first id set will be tracked but won't trigger zch update
+        # output values should therefore be in hashed range
+        update_one_size = zch_size // 2
+        update_one = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1"],
+            values=torch.arange(
+                start=0, end=update_one_size, step=1, dtype=torch.int64
+            ),
+            lengths=torch.ones((update_one_size,), dtype=torch.int64),
+            weights=None,
+        )
+        _, remapped_jt1 = mc_ebc.forward(
+            update_one,
+            mc_kwargs={
+                "t1": {
+                    "force_update": False,
+                }
+            },
+        )
+        remapped_jt = remapped_jt1
+        assert remapped_jt is not None
+        assert torch.all(
+            # pyre-ignore[6]
+            remapped_jt["f1"].values()
+            >= zch_size
+        ), "no remapped ids should be in zch_range"
+
+        ################ 2 ################
+        # second id set is same as first. as max_coalesce_history_size == zch_size
+        # this will trigger a coalesce and the output values should be in zch_range
+        _, remapped_jt2 = mc_ebc.forward(
+            update_one,
+            mc_kwargs={
+                "t1": {
+                    "force_update": False,
+                }
+            },
+        )
+        remapped_jt = remapped_jt2
+        assert remapped_jt is not None
+        assert torch.all(
+            # pyre-ignore[6]
+            remapped_jt["f1"].values()
+            < zch_size
+        ), "all remapped ids should be in zch_range"
+
+        ################ 3 ################
+        # third id set will fill remainder of unused zch_range.
+        # by setting count_multiplier to 5, coalesce will be triggered
+        # output values should be in zch_range.
+        update_two_size = zch_size - update_one_size
+        update_two = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1"],
+            values=torch.arange(
+                start=update_one_size,
+                end=update_one_size + update_two_size,
+                step=1,
+                dtype=torch.int64,
+            ),
+            lengths=torch.ones((update_two_size,), dtype=torch.int64),
+            weights=None,
+        )
+        _, remapped_jt3 = mc_ebc.forward(
+            update_two,
+            mc_kwargs={"t1": {"force_update": False, "count_multiplier": 5}},
+        )
+        remapped_jt = remapped_jt3
+        assert remapped_jt is not None
+        assert torch.all(
+            # pyre-ignore[6]
+            remapped_jt["f1"].values()
+            < zch_size
+        ), "all remapped ids should be in zch_range"
+
+        ################ 4 ################
+        # fourth id set is same size as first and will overwrite it via eviction.
+        # output values should be in zch_range _and_ same as remapped update_one ids
+        update_three_size = update_one_size
+        update_three = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1"],
+            values=torch.arange(
+                start=update_one_size + update_two_size,
+                end=update_one_size + update_two_size + update_three_size,
+                step=1,
+                dtype=torch.int64,
+            ),
+            lengths=torch.ones((update_three_size,), dtype=torch.int64),
+            weights=None,
+        )
+        _, remapped_jt4 = mc_ebc.forward(
+            update_three,
+            mc_kwargs={"t1": {"force_update": True, "count_multiplier": 3}},
+        )
+        remapped_jt = remapped_jt4
+        assert remapped_jt is not None
+        assert torch.all(
+            # pyre-ignore[6]
+            remapped_jt4["f1"].values().sort(stable=True)[0]
+            # pyre-ignore[6]
+            == remapped_jt2["f1"].values().sort(stable=True)[0]
+        ), "all remapped ids should match evicted update_one"
+
+        ################ 5 ################
+        # fifth id set is not part of current mapped zch
+        # and will not trigger a zch_update.
+        # output values should be in hashed range.
+        update_four_size = zch_size - 1
+        update_four = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1"],
+            values=torch.arange(
+                start=update_one_size + update_two_size + update_three_size,
+                end=update_one_size
+                + update_two_size
+                + update_three_size
+                + update_four_size,
+                step=1,
+                dtype=torch.int64,
+            ),
+            lengths=torch.ones((update_four_size,), dtype=torch.int64),
+            weights=None,
+        )
+
+        _, remapped_jt5 = mc_ebc.forward(update_four)
+        remapped_jt = remapped_jt5
+        assert remapped_jt is not None
+        assert torch.all(
+            # pyre-ignore[6]
+            remapped_jt["f1"].values()
+            >= zch_size
+        ), "no remapped ids should be in zch_range"


### PR DESCRIPTION
Summary:
1. Implements (and improves) ZCH modules from D43720052, D46272266, D45584047 to TorchRec MC-EBC
2. Supports distributed/sharded MCH (mix of 1:1 zch + hashing for unmapped)
3. Rewrite of MC/MC-EBC design (to support features such as returning remapped ids, pass arguments to MC module)
4. New MCHManagedCollisionModule which generalizes MC design and allows adding new eviction policy via well-defined interface
5. Standalone ManagedCollisionCollection for distributed zch support without embedding table
6. Sharding+checkpointing support, along with standalone ShardedManagedCollisionCollection

Reviewed By: dstaay-fb, YLGH

Differential Revision: D47982926

