### PR TITLE
Integrate per feature variable batch into VLE arch

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -751,11 +751,21 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         weights = features.weights_or_none()
         if weights is not None and not torch.is_floating_point(weights):
             weights = None
-        return self.emb_module(
-            indices=features.values().long(),
-            offsets=features.offsets().long(),
-            per_sample_weights=weights,
-        )
+        if features.variable_stride_per_key() and isinstance(
+            self.emb_module, SplitTableBatchedEmbeddingBagsCodegen
+        ):
+            return self.emb_module(
+                indices=features.values().long(),
+                offsets=features.offsets().long(),
+                per_sample_weights=weights,
+                batch_size_per_feature_per_rank=features.stride_per_key_per_rank(),
+            )
+        else:
+            return self.emb_module(
+                indices=features.values().long(),
+                offsets=features.offsets().long(),
+                per_sample_weights=weights,
+            )
 
     # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
     def state_dict(

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -110,7 +110,7 @@ class All2AllPooledInfo(object):
         cumsum_dim_sum_per_rank_tensor (Optional[Tensor]): cumulative sum of
             `dim_sum_per_rank`, this is only used by the fast kernel of
             `_recat_pooled_embedding_grad_out`.
-        B_local (int): local batch size before scattering.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
     """
 
     batch_size_per_rank: List[int]
@@ -134,7 +134,8 @@ class All2AllSequenceInfo(object):
         backward_recat_tensor (Tensor): recat tensor for backward.
         input_splits (List[int]): input splits.
         output_splits (List[int]): output splits.
-        variable_batch_size (bool): whether variable batch size is enabled
+        variable_batch_size (bool): whether variable batch size is enabled.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
         permuted_lengths_after_sparse_data_all2all (Optional[Tensor]): lengths of sparse
             features before AlltoAll.
     """
@@ -301,7 +302,7 @@ def alltoall_pooled(
             `_recat_pooled_embedding_grad_out`.
         group (Optional[dist.ProcessGroup]): the process group to work on. If None, the
             default process group will be used.
-        codecs: Optional[QuantizedCommCodecs]: Quantized communication codecs.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
 
     Returns:
         Awaitable[List[Tensor]]: async work handle (`Awaitable`), which can be `wait()` later to get the resulting tensor.

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -23,7 +23,7 @@ from torchrec.distributed.comm_ops import (
 from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.types import Awaitable, QuantizedCommCodecs
 from torchrec.fx.utils import fx_marker
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, pin_and_move
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
@@ -323,7 +323,7 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
             return
 
         input_tensors = [
-            torch.tensor(split, device=device) for split in self._input_splits
+            pin_and_move(torch.tensor(split), device) for split in self._input_splits
         ]
         batch_size_tensor = torch.tensor(
             [input.stride()] * self._workers, device=device

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -19,6 +19,7 @@ from torchrec.distributed.comm_ops import (
     alltoall_sequence,
     reduce_scatter_base_pooled,
     reduce_scatter_v_pooled,
+    variable_batch_alltoall_pooled,
 )
 from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.types import Awaitable, QuantizedCommCodecs
@@ -548,6 +549,7 @@ class PooledEmbeddingsAllToAll(nn.Module):
         device (Optional[torch.device]): device on which buffers will be allocated.
         callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]): callback
             functions.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
 
     Example::
 
@@ -630,6 +632,118 @@ class PooledEmbeddingsAllToAll(nn.Module):
             dim_sum_per_rank=self._dim_sum_per_rank,
             dim_sum_per_rank_tensor=self._dim_sum_per_rank_tensor,
             cumsum_dim_sum_per_rank_tensor=self._cumsum_dim_sum_per_rank_tensor,
+            group=self._pg,
+            codecs=self._codecs,
+        )
+
+        pooled_embedding_awaitable = PooledEmbeddingsAwaitable(
+            tensor_awaitable=tensor_awaitable,
+        )
+        pooled_embedding_awaitable.callbacks.extend(self._callbacks)
+
+        return pooled_embedding_awaitable
+
+    @property
+    def callbacks(self) -> List[Callable[[torch.Tensor], torch.Tensor]]:
+        return self._callbacks
+
+
+class VariableBatchPooledEmbeddingsAllToAll(nn.Module):
+    """
+    Shards batches and collects keys of tensor with a `ProcessGroup` according to
+    `dim_sum_per_rank`.
+
+    Implementation utilizes `variable_batch_alltoall_pooled` operation.
+
+    Args:
+        pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
+        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimensions per rank
+            per feature.
+        device (Optional[torch.device]): device on which buffers will be allocated.
+        callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]): callback
+            functions.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+
+    Example::
+
+        emb_dim_per_rank_per_feature = [[2], [3, 3]]
+        a2a = VariableBatchPooledEmbeddingsAllToAll(
+            pg, emb_dim_per_rank_per_feature, device
+        )
+
+        t0 = torch.rand(6) # 2 * (2 + 1)
+        t1 = torch.rand(24) # 3 * (1 + 3) + 3 * (2 + 2)
+        r0_batch_size_per_rank_per_feature = [[2, 1]]
+        r1_batch_size_per_rank_per_feature = [[1, 3], [2, 2]]
+        r0_batch_size_per_feature_pre_a2a = [2, 1, 3]
+        r1_batch_size_per_feature_pre_a2a = [1, 2, 2]
+
+        rank0_output = a2a(
+            t0, r0_batch_size_per_rank_per_feature, r0_batch_size_per_feature_pre_a2a
+        ).wait()
+        rank1_output = a2a(
+            t1, r1_batch_size_per_rank_per_feature, r1_batch_size_per_feature_pre_a2a
+        ).wait()
+
+        # input splits:
+        #   r0: [2*2, 1*1]
+        #   r1: [1*3 + 3*3, 2*3 + 2*3]
+
+        # output splits:
+        #   r0: [2*2, 1*3 + 3*3]
+        #   r1: [1*2, 2*3 + 2*3]
+
+        print(rank0_output.size())
+            # torch.Size([16])
+            # 2*2 + 1*3 + 3*3
+        print(rank1_output.size())
+            # torch.Size([14])
+            # 1*2 + 2*3 + 2*3
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        emb_dim_per_rank_per_feature: List[List[int]],
+        device: Optional[torch.device] = None,
+        callbacks: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        codecs: Optional[QuantizedCommCodecs] = None,
+    ) -> None:
+        super().__init__()
+        self._pg = pg
+        self._emb_dim_per_rank_per_feature = emb_dim_per_rank_per_feature
+        self._callbacks: List[Callable[[torch.Tensor], torch.Tensor]] = []
+        if callbacks is not None:
+            self._callbacks = callbacks
+        self._codecs = codecs
+
+    def forward(
+        self,
+        local_embs: torch.Tensor,
+        batch_size_per_rank_per_feature: List[List[int]],
+        batch_size_per_feature_pre_a2a: List[int],
+    ) -> PooledEmbeddingsAwaitable:
+        """
+        Performs AlltoAll pooled operation with variable batch size per feature on a
+        pooled embeddings tensor.
+
+        Args:
+            local_embs (torch.Tensor): tensor of values to distribute.
+            batch_size_per_rank_per_feature (List[List[int]]): batch size per rank per
+                feature, post a2a. Used to get the input splits.
+            batch_size_per_feature_pre_a2a (List[int]): local batch size before
+                scattering, used to get the output splits.
+                Ordered by rank_0 feature, rank_1 feature, ...
+
+        Returns:
+            PooledEmbeddingsAwaitable: awaitable of pooled embeddings.
+        """
+
+        tensor_awaitable = variable_batch_alltoall_pooled(
+            a2a_pooled_embs_tensor=local_embs,
+            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
+            batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature,
             group=self._pg,
             codecs=self._codecs,
         )

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -834,9 +834,12 @@ class ShardedEmbeddingCollection(
             ctx.sharding_contexts,
             self._sharding_type_to_sharding,
         ):
-            sharding_ctx.lengths_after_input_dist = features.lengths().view(
-                -1, features.stride()
-            )
+            if features.stride() == 0:
+                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
+                stride = sharding_ctx.batch_size_per_feature_pre_a2a[0]
+            else:
+                stride = features.stride()
+            sharding_ctx.lengths_after_input_dist = features.lengths().view(-1, stride)
             embedding_dim = self._embedding_dim_for_sharding_type(sharding_type)
             ret.append(lookup(features).view(-1, embedding_dim))
         return ret
@@ -878,9 +881,12 @@ class ShardedEmbeddingCollection(
             ctx.sharding_contexts,
             self._sharding_type_to_sharding,
         ):
-            sharding_ctx.lengths_after_input_dist = features.lengths().view(
-                -1, features.stride()
-            )
+            if features.stride() == 0:
+                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
+                stride = sharding_ctx.batch_size_per_feature_pre_a2a[0]
+            else:
+                stride = features.stride()
+            sharding_ctx.lengths_after_input_dist = features.lengths().view(-1, stride)
             embedding_dim = self._embedding_dim_for_sharding_type(sharding_type)
             awaitables_per_sharding.append(
                 odist(lookup(features).view(-1, embedding_dim), sharding_ctx)

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -385,7 +385,7 @@ class GroupedPooledEmbeddingsLookup(
 
         return embeddings_cat_empty_rank_handle(
             embeddings,
-            fx_wrap_tensor_view2d(self._dummy_embs_tensor, sparse_features.stride(), 0),
+            self._dummy_embs_tensor,
             dim=1,
         )
 

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -27,6 +27,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.types import (
     Awaitable,
+    NoWait,
     ParameterSharding,
     QuantizedCommCodecs,
     ShardMetadata,
@@ -218,6 +219,10 @@ def group_tables(
     return grouped_embedding_configs_by_rank
 
 
+C = TypeVar("C", bound=Multistreamable)
+T = TypeVar("T")
+
+
 class KJTListAwaitable(Awaitable[KJTList]):
     """
     Awaitable of KJTList.
@@ -225,14 +230,18 @@ class KJTListAwaitable(Awaitable[KJTList]):
     Args:
         awaitables (List[Awaitable[KeyedJaggedTensor]]): list of `Awaitable` of sparse
             features.
+        ctx (C): sharding context to save the batch size info from the KJT for the
+            embedding AlltoAll.
     """
 
     def __init__(
         self,
         awaitables: List[Awaitable[KeyedJaggedTensor]],
+        ctx: C,
     ) -> None:
         super().__init__()
         self.awaitables = awaitables
+        self.ctx = ctx
 
     def _wait_impl(self) -> KJTList:
         """
@@ -241,15 +250,37 @@ class KJTListAwaitable(Awaitable[KJTList]):
         Returns:
             KJTList: synced `KJTList`.
         """
-
-        return KJTList([w.wait() for w in self.awaitables])
-
-
-C = TypeVar("C", bound=Multistreamable)
-T = TypeVar("T")
+        kjts = [w.wait() for w in self.awaitables]
+        _set_sharding_context_post_a2a(kjts, self.ctx)
+        return KJTList(kjts)
 
 
-def _set_sharding_context(
+def _set_sharding_context_post_a2a(
+    kjts: List[KeyedJaggedTensor],
+    ctx: C,
+) -> None:
+    for kjt, sharding_context in zip(kjts, getattr(ctx, "sharding_contexts", [])):
+        if getattr(sharding_context, "variable_batch_per_feature", False):
+            if (
+                hasattr(sharding_context, "batch_size_per_rank_per_feature")
+                and kjt.stride_per_key_per_rank()
+            ):
+                sharding_context.batch_size_per_rank_per_feature = [
+                    [
+                        kjt.stride_per_key_per_rank()[i][j]
+                        for i in range(len(kjt.stride_per_key_per_rank()))
+                    ]
+                    for j in range(len(kjt.stride_per_key_per_rank()[0]))
+                ]
+        else:
+            if (
+                hasattr(sharding_context, "batch_size_per_rank")
+                and kjt.stride_per_key_per_rank()
+            ):
+                sharding_context.batch_size_per_rank = kjt.stride_per_key_per_rank()[0]
+
+
+def _set_sharding_context_intra_a2a(
     tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
     ctx: C,
 ) -> None:
@@ -258,14 +289,31 @@ def _set_sharding_context(
         getattr(ctx, "sharding_contexts", []),
     ):
         if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
-            if hasattr(sharding_context, "batch_size_per_rank"):
-                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
                 sharding_context.output_splits = awaitable._output_splits["values"]
             if hasattr(sharding_context, "sparse_features_recat"):
                 sharding_context.sparse_features_recat = awaitable._recat
+
+
+def _set_sharding_context_pre_a2a(
+    awaitables: List[Awaitable[Awaitable[KeyedJaggedTensor]]],
+    ctx: C,
+) -> None:
+    for awaitable, sharding_context in zip(
+        awaitables,
+        getattr(ctx, "sharding_contexts", []),
+    ):
+        kjt = (
+            awaitable._obj._obj
+            if isinstance(awaitable, NoWait)
+            else awaitable._input  # pyre-ignore[16]: KJTAllToAllSplitsAwaitable or KJTSplitsAllToAllMeta
+        )
+        if hasattr(sharding_context, "batch_size_per_feature_pre_a2a"):
+            sharding_context.batch_size_per_feature_pre_a2a = kjt.stride_per_key()
+        if hasattr(sharding_context, "variable_batch_per_feature"):
+            sharding_context.variable_batch_per_feature = kjt.variable_stride_per_key()
 
 
 def _split(flat_list: List[T], splits: List[int]) -> List[List[T]]:
@@ -293,6 +341,7 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
         super().__init__()
         self.awaitables = awaitables
         self.ctx = ctx
+        _set_sharding_context_pre_a2a(self.awaitables, self.ctx)
 
     def _wait_impl(self) -> KJTListAwaitable:
         """
@@ -306,14 +355,14 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
             KJTListAwaitable: awaitables for tensors of the sparse features.
         """
         tensors_awaitables = [w.wait() for w in self.awaitables]
-        _set_sharding_context(tensors_awaitables, self.ctx)
-        return KJTListAwaitable(tensors_awaitables)
+        _set_sharding_context_intra_a2a(tensors_awaitables, self.ctx)
+        return KJTListAwaitable(tensors_awaitables, self.ctx)
 
 
 @dataclass
 class KJTSplitsAllToAllMeta:
     pg: dist.ProcessGroup
-    input: KeyedJaggedTensor
+    _input: KeyedJaggedTensor
     splits: List[int]
     splits_tensors: List[torch.Tensor]
     input_splits: List[List[int]]
@@ -336,6 +385,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
         ] = [awaitable for request in requests for awaitable in request.awaitables]
+        for req, ctx in zip(requests, self._contexts):
+            _set_sharding_context_pre_a2a(req.awaitables, ctx)
         self._output_lengths: List[int] = [
             len(request.awaitables) for request in requests
         ]
@@ -370,24 +421,21 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         else:
             splits_per_awaitable = [[] for _ in range(len(self._lengths))]
         tensors_awaitables = []
-        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
-            if not splits:  # NoWait
+        for output_splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+            if not output_splits:  # NoWait
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
                 continue
-            output_splits = splits[:-1]
-            batch_size_per_rank = splits[-1]
             assert isinstance(awaitable, KJTSplitsAllToAllMeta)
             tensors_awaitables.append(
                 KJTAllToAllTensorsAwaitable(
                     pg=awaitable.pg,
-                    input=awaitable.input,
+                    input=awaitable._input,
                     splits=awaitable.splits,
                     input_splits=awaitable.input_splits,
                     output_splits=output_splits,
                     input_tensors=awaitable.input_tensors,
                     labels=awaitable.labels,
-                    batch_size_per_rank=batch_size_per_rank,
                     keys=awaitable.keys,
                     device=awaitable.device,
                     stagger=awaitable.stagger,
@@ -396,8 +444,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables))
+            _set_sharding_context_intra_a2a(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables, ctx))
         return output
 
 
@@ -463,6 +511,9 @@ W = TypeVar("W")
 @dataclass
 class EmbeddingShardingContext(Multistreamable):
     batch_size_per_rank: List[int] = field(default_factory=list)
+    batch_size_per_rank_per_feature: List[List[int]] = field(default_factory=list)
+    batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
+    variable_batch_per_feature: bool = False
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         pass

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -251,10 +251,11 @@ class CwPooledEmbeddingSharding(
             callbacks = [embedding_permute_op]
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            self._pg,
-            self._dim_sum_per_rank(),
-            device,
-            callbacks,
+            pg=self._pg,
+            dim_sum_per_rank=self._dim_sum_per_rank(),
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
+            device=device,
+            callbacks=callbacks,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -145,6 +145,10 @@ class DpSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[Awaitable[SparseFeatures]]: awaitable of awaitable of SparseFeatures.
         """
 
+        if sparse_features.variable_stride_per_key():
+            raise ValueError(
+                "Dense TBE kernel does not support variable batch per feature"
+            )
         return NoWait(cast(Awaitable[KeyedJaggedTensor], NoWait(sparse_features)))
 
 

--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -31,6 +31,8 @@ class SequenceShardingContext(EmbeddingShardingContext):
             KJT bucketize (for row-wise sharding only).
         lengths_after_input_dist (Optional[torch.Tensor]): stores the KJT length after
             input dist.
+        batch_size_per_feature_pre_a2a (List[int]): stores the batch size per feature
+            before input dist.
     """
 
     features_before_input_dist: Optional[KeyedJaggedTensor] = None
@@ -39,6 +41,7 @@ class SequenceShardingContext(EmbeddingShardingContext):
     sparse_features_recat: Optional[torch.Tensor] = None
     unbucketize_permute_tensor: Optional[torch.Tensor] = None
     lengths_after_input_dist: Optional[torch.Tensor] = None
+    batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         if self.features_before_input_dist is not None:

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -295,7 +295,9 @@ class TwPooledEmbeddingDist(
             return self._dist(local_embs)
         else:
             return self._dist(
-                local_embs, batch_size_per_rank=sharding_ctx.batch_size_per_rank
+                local_embs,
+                batch_size_per_rank=sharding_ctx.batch_size_per_rank,
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
             )
 
 

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, cast, Dict, List, Optional, TypeVar, Union
 
 import torch
 import torch.distributed as dist
@@ -14,6 +14,7 @@ from torchrec.distributed.dist_data import (
     KJTAllToAll,
     KJTOneToAll,
     PooledEmbeddingsAllToAll,
+    VariableBatchPooledEmbeddingsAllToAll,
 )
 from torchrec.distributed.embedding_lookup import (
     GroupedPooledEmbeddingsLookup,
@@ -144,6 +145,15 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             dim_sum_per_rank.append(dim_sum)
         return dim_sum_per_rank
 
+    def _emb_dim_per_rank_per_feature(self) -> List[List[int]]:
+        emb_dim_per_rank_per_feature = []
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
+            emb_dim_per_feature = []
+            for grouped_config in grouped_embedding_configs:
+                emb_dim_per_feature += grouped_config.embedding_dims()
+            emb_dim_per_rank_per_feature.append(emb_dim_per_feature)
+        return emb_dim_per_rank_per_feature
+
     def embedding_dims(self) -> List[int]:
         embedding_dims = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
@@ -251,6 +261,8 @@ class TwPooledEmbeddingDist(
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
         dim_sum_per_rank (List[int]): number of features (sum of dimensions) of the
             embedding in each rank.
+        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimension per rank per
+            feature, used for variable batch per feature.
         device (Optional[torch.device]): device on which buffers will be allocated.
         callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]):
         qcomm_codecs_registry (Optional[Dict[str, QuantizedCommCodecs]]):
@@ -260,22 +272,25 @@ class TwPooledEmbeddingDist(
         self,
         pg: dist.ProcessGroup,
         dim_sum_per_rank: List[int],
+        emb_dim_per_rank_per_feature: List[List[int]],
         device: Optional[torch.device] = None,
         callbacks: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__()
-        self._dist = PooledEmbeddingsAllToAll(
-            pg=pg,
-            dim_sum_per_rank=dim_sum_per_rank,
-            device=device,
-            callbacks=callbacks,
-            codecs=qcomm_codecs_registry.get(
-                CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None
-            )
+        self._pg = pg
+        self._dim_sum_per_rank = dim_sum_per_rank
+        self._device = device
+        self._callbacks = callbacks
+        self._codecs: Optional[QuantizedCommCodecs] = (
+            qcomm_codecs_registry.get(CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None)
             if qcomm_codecs_registry
-            else None,
+            else None
         )
+        self._emb_dim_per_rank_per_feature = emb_dim_per_rank_per_feature
+        self._dist: Optional[
+            Union[PooledEmbeddingsAllToAll, VariableBatchPooledEmbeddingsAllToAll]
+        ] = None
 
     def forward(
         self,
@@ -287,17 +302,48 @@ class TwPooledEmbeddingDist(
 
         Args:
             local_embs (torch.Tensor): tensor of values to distribute.
+            sharding_ctx (Optional[EmbeddingShardingContext]): shared context from
+                KJTAllToAll operation.
 
         Returns:
             Awaitable[torch.Tensor]: awaitable of pooled embeddings.
         """
+        if self._dist is None:
+            self._create_output_dist_module(sharding_ctx)
+
         if sharding_ctx is None:
-            return self._dist(local_embs)
+            return cast(PooledEmbeddingsAllToAll, self._dist)(local_embs)
+        elif sharding_ctx.variable_batch_per_feature:
+            return cast(VariableBatchPooledEmbeddingsAllToAll, self._dist)(
+                local_embs,
+                batch_size_per_rank_per_feature=sharding_ctx.batch_size_per_rank_per_feature,
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
+            )
         else:
-            return self._dist(
+            return cast(PooledEmbeddingsAllToAll, self._dist)(
                 local_embs,
                 batch_size_per_rank=sharding_ctx.batch_size_per_rank,
                 batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
+            )
+
+    def _create_output_dist_module(
+        self, sharding_ctx: Optional[EmbeddingShardingContext] = None
+    ) -> None:
+        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
+            self._dist = VariableBatchPooledEmbeddingsAllToAll(
+                pg=self._pg,
+                emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature,
+                device=self._device,
+                callbacks=self._callbacks,
+                codecs=self._codecs,
+            )
+        else:
+            self._dist = PooledEmbeddingsAllToAll(
+                pg=self._pg,
+                dim_sum_per_rank=self._dim_sum_per_rank,
+                device=self._device,
+                callbacks=self._callbacks,
+                codecs=self._codecs,
             )
 
 
@@ -340,9 +386,10 @@ class TwPooledEmbeddingSharding(
     ) -> BaseEmbeddingDist[EmbeddingShardingContext, torch.Tensor, torch.Tensor]:
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            self._pg,
-            self._dim_sum_per_rank(),
-            device if device is not None else self._device,
+            pg=self._pg,
+            dim_sum_per_rank=self._dim_sum_per_rank(),
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
+            device=device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -30,6 +30,14 @@ except ImportError:
     pass
 
 
+def pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+    return (
+        tensor
+        if device.type == "cpu"
+        else tensor.pin_memory().to(device=device, non_blocking=True)
+    )
+
+
 def _cumsum(o: List[int]) -> List[int]:
     ret = [0] * (len(o) + 1)
     for i in range(len(o)):
@@ -624,23 +632,39 @@ def _maybe_compute_stride_kjt_scripted(
     return torch.tensor([_maybe_compute_stride_kjt(keys, stride, lengths, offsets)])
 
 
+def _length_per_key_from_stride_per_key(
+    lengths: torch.Tensor, stride_per_key: List[int]
+) -> List[int]:
+    return [
+        int(torch.sum(chunk).item()) for chunk in torch.split(lengths, stride_per_key)
+    ]
+
+
 def _maybe_compute_length_per_key(
     keys: List[str],
     stride: int,
+    stride_per_key: List[int],
+    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
     offsets: Optional[torch.Tensor],
 ) -> List[int]:
     if length_per_key is None:
         if len(keys) and offsets is not None and len(offsets) > 0:
-            _length: List[int] = torch.sum(
-                torch.diff(offsets).view(-1, stride), dim=1
-            ).tolist()
+            _length: List[int] = (
+                _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
+                if variable_stride_per_key
+                else torch.sum(torch.diff(offsets).view(-1, stride), dim=1).tolist()
+            )
         elif len(keys) and lengths is not None:
             _length: List[int] = (
-                torch.sum(lengths.view(-1, stride), dim=1).tolist()
-                if lengths.numel() != 0
-                else [0] * len(keys)
+                _length_per_key_from_stride_per_key(lengths, stride_per_key)
+                if variable_stride_per_key
+                else (
+                    torch.sum(lengths.view(-1, stride), dim=1).tolist()
+                    if lengths.numel() != 0
+                    else [0] * len(keys)
+                )
             )
         else:
             _length: List[int] = []
@@ -651,6 +675,8 @@ def _maybe_compute_length_per_key(
 def _maybe_compute_offset_per_key(
     keys: List[str],
     stride: int,
+    stride_per_key: List[int],
+    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     offset_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
@@ -658,7 +684,13 @@ def _maybe_compute_offset_per_key(
 ) -> Tuple[List[int], List[int]]:
     if length_per_key is None:
         _length_per_key: List[int] = _maybe_compute_length_per_key(
-            keys, stride, length_per_key, lengths, offsets
+            keys=keys,
+            stride=stride,
+            stride_per_key=stride_per_key,
+            variable_stride_per_key=variable_stride_per_key,
+            length_per_key=length_per_key,
+            lengths=lengths,
+            offsets=offsets,
         )
         return _length_per_key, _cumsum(_length_per_key)
     elif offset_per_key is None:
@@ -725,10 +757,12 @@ class ComputeKJTToJTDict(torch.nn.Module):
         """
         return _maybe_compute_kjt_to_jt_dict(
             stride=keyed_jagged_tensor.stride(),
+            stride_per_key=keyed_jagged_tensor.stride_per_key(),
             keys=keyed_jagged_tensor.keys(),
             length_per_key=keyed_jagged_tensor.length_per_key(),
             values=keyed_jagged_tensor.values(),
             lengths=keyed_jagged_tensor.lengths(),
+            variable_stride_per_key=keyed_jagged_tensor.variable_stride_per_key(),
             weights=keyed_jagged_tensor.weights_or_none(),
             jt_dict=keyed_jagged_tensor._jt_dict,
         )
@@ -737,10 +771,12 @@ class ComputeKJTToJTDict(torch.nn.Module):
 @torch.fx.wrap
 def _maybe_compute_kjt_to_jt_dict(
     stride: int,
+    stride_per_key: List[int],
     keys: List[str],
     length_per_key: List[int],
     values: torch.Tensor,
     lengths: torch.Tensor,
+    variable_stride_per_key: bool,
     weights: Optional[torch.Tensor],
     jt_dict: Optional[Dict[str, JaggedTensor]],
 ) -> Dict[str, JaggedTensor]:
@@ -750,21 +786,28 @@ def _maybe_compute_kjt_to_jt_dict(
     if jt_dict is None:
         _jt_dict: Dict[str, JaggedTensor] = {}
         values_list = torch.split(values, length_per_key)
-        lengths_tuple = torch.unbind(
-            lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
-        )
-        offsets_tuple = torch.unbind(
-            _batched_lengths_to_offsets(lengths.view(-1, stride))
-            if lengths.numel() != 0
-            else lengths,
-            dim=0,
-        )
+        if variable_stride_per_key:
+            split_lengths = torch.split(lengths, stride_per_key)
+            split_offsets = [
+                torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+                for lengths in split_lengths
+            ]
+        else:
+            split_lengths = torch.unbind(
+                lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
+            )
+            split_offsets = torch.unbind(
+                _batched_lengths_to_offsets(lengths.view(-1, stride))
+                if lengths.numel() != 0
+                else lengths,
+                dim=0,
+            )
 
         if weights is not None:
             weights_list = torch.split(weights, length_per_key)
             for idx, key in enumerate(keys):
-                length = lengths_tuple[idx]
-                offset = offsets_tuple[idx]
+                length = split_lengths[idx]
+                offset = split_offsets[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -773,8 +816,8 @@ def _maybe_compute_kjt_to_jt_dict(
                 )
         else:
             for idx, key in enumerate(keys):
-                length = lengths_tuple[idx]
-                offset = offsets_tuple[idx]
+                length = split_lengths[idx]
+                offset = split_offsets[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -966,6 +1009,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets (Optional[torch.Tensor]): jagged slices, represented as cumulative
             offsets.
         stride (Optional[int]): number of examples per batch.
+        stride_per_key_per_rank (Optional[List[List[int]]]): batch size
+            (number of examples) per key per rank, with the outer list representing the
+            keys and the inner list representing the values.
+            Each value in the inner list represents the number of examples in the batch
+            from the rank of its index in a distributed context.
         length_per_key (Optional[List[int]]): start length for each key.
         offset_per_key (Optional[List[int]]): start offset for each key and final
             offset.
@@ -1012,6 +1060,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
         # Below exposed to ensure torch.script-able
         length_per_key: Optional[List[int]] = None,
         offset_per_key: Optional[List[int]] = None,
@@ -1027,20 +1076,38 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             _assert_tensor_has_no_elements_or_has_integers(lengths, "lengths")
         self._lengths: Optional[torch.Tensor] = lengths
         self._offsets: Optional[torch.Tensor] = offsets
-        if torch.jit.is_tracing():
-            stride = _maybe_compute_stride_kjt_scripted(keys, stride, lengths, offsets)[
-                0
-            ]
-        else:
-            stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
 
-        self._stride: int = stride
+        self._stride_per_key_per_rank: List[List[int]] = []
+        self._variable_stride_per_key: bool = False
+        self._stride: int = -1
+
+        if stride_per_key_per_rank is not None and stride_per_key_per_rank:
+            first_key_stride = stride_per_key_per_rank[0]
+            if stride is None:
+                self._stride_per_key_per_rank = stride_per_key_per_rank
+                if all(s == first_key_stride for s in stride_per_key_per_rank):
+                    self._stride = self.stride_per_key()[0]
+                self._variable_stride_per_key = True
+            else:
+                self._stride = stride
+                assert all(s == first_key_stride for s in stride_per_key_per_rank)
+                self._stride_per_key_per_rank = stride_per_key_per_rank
+        else:
+            if torch.jit.is_tracing():
+                stride = _maybe_compute_stride_kjt_scripted(
+                    keys, stride, lengths, offsets
+                )[0]
+            else:
+                stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
+            self._stride = stride
+            self._stride_per_key_per_rank = [[stride]] * len(self._keys)
 
         # lazy fields
         self._length_per_key: Optional[List[int]] = length_per_key
         self._offset_per_key: Optional[List[int]] = offset_per_key
         self._index_per_key: Optional[Dict[str, int]] = index_per_key
         self._jt_dict: Optional[Dict[str, JaggedTensor]] = jt_dict
+        self._lengths_offset_per_key: List[int] = []
 
     @staticmethod
     def from_offsets_sync(
@@ -1049,6 +1116,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1056,6 +1124,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             offsets=offsets,
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1066,6 +1135,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1073,6 +1143,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             lengths=lengths,
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1082,7 +1153,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     ) -> "KeyedJaggedTensor":
         if len(kjt_list) == 0:
             raise ValueError("Can't concat empty KJT list")
-        stride: int = kjt_list[0].stride()
+
         is_weighted: bool = kjt_list[0].weights_or_none() is not None
         has_length_per_key: bool = True
 
@@ -1091,12 +1162,17 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         value_list: List[torch.Tensor] = []
         weight_list: List[torch.Tensor] = []
         length_list: List[torch.Tensor] = []
+        stride_per_key_per_rank: List[List[int]] = []
+        stride: Optional[int] = None
+        variable_stride_per_key_list = [
+            kjt.variable_stride_per_key() for kjt in kjt_list
+        ]
+        assert all(variable_stride_per_key_list) or not any(
+            variable_stride_per_key_list
+        ), "variable stride per key must be consistent for all KJTs"
+        variable_stride_per_key = all(variable_stride_per_key_list)
 
         for kjt in kjt_list:
-            if kjt.stride() != stride:
-                raise ValueError(
-                    f"Can only merge KJTs of the same stride ({stride} != kjt.stride())"
-                )
             curr_is_weighted: bool = kjt.weights_or_none() is not None
             if is_weighted != curr_is_weighted:
                 raise ValueError("Can't merge weighted KJT with unweighted KJT")
@@ -1112,6 +1188,12 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if is_weighted:
                 weight_list.append(kjt.weights())
             length_list.append(kjt.lengths())
+            if variable_stride_per_key:
+                stride_per_key_per_rank += kjt.stride_per_key_per_rank()
+            elif stride is None:
+                stride = kjt.stride()
+            else:
+                assert stride == kjt.stride(), "strides must be consistent for all KJTs"
 
         return KeyedJaggedTensor(
             keys=keys,
@@ -1119,6 +1201,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=torch.cat(weight_list, dim=0) if is_weighted else None,
             lengths=torch.cat(length_list, dim=0),
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank
+            if variable_stride_per_key
+            else None,
             length_per_key=length_per_key if has_length_per_key else None,
         )
 
@@ -1144,6 +1229,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     @staticmethod
     def empty_like(kjt: "KeyedJaggedTensor") -> "KeyedJaggedTensor":
+        stride, stride_per_key_per_rank = (
+            (None, kjt.stride_per_key_per_rank())
+            if kjt.variable_stride_per_key()
+            else (kjt.stride(), None)
+        )
         return KeyedJaggedTensor(
             keys=[],
             values=torch.tensor([], device=kjt.device(), dtype=kjt.values().dtype),
@@ -1151,7 +1241,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if kjt.weights_or_none() is None
             else torch.tensor([], device=kjt.device(), dtype=kjt.weights().dtype),
             lengths=torch.tensor([], device=kjt.device(), dtype=kjt.lengths().dtype),
-            stride=kjt.stride(),
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
 
     @staticmethod
@@ -1206,7 +1297,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_vals_list: List[torch.Tensor] = []
         kjt_lens_list: List[torch.Tensor] = []
         kjt_weights_list: List[torch.Tensor] = []
+        stride_per_key: List[int] = []
         for jt in jt_dict.values():
+            stride_per_key.append(len(jt.lengths()))
             kjt_vals_list.append(jt.values())
             kjt_lens_list.append(jt.lengths())
             weight = jt.weights_or_none()
@@ -1217,11 +1310,18 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_weights = (
             torch.concat(kjt_weights_list) if len(kjt_weights_list) > 0 else None
         )
+        kjt_stride, kjt_stride_per_key_per_rank = (
+            (stride_per_key[0], None)
+            if all(s == stride_per_key[0] for s in stride_per_key)
+            else (None, [[stride] for stride in stride_per_key])
+        )
         kjt = KeyedJaggedTensor(
             keys=kjt_keys,
             values=kjt_vals,
             weights=kjt_weights,
             lengths=kjt_lens,
+            stride=kjt_stride,
+            stride_per_key_per_rank=kjt_stride_per_key_per_rank,
         ).sync()
         return kjt
 
@@ -1269,6 +1369,15 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def stride(self) -> int:
         return self._stride
 
+    def stride_per_key(self) -> List[int]:
+        return [sum(stride) for stride in self._stride_per_key_per_rank]
+
+    def stride_per_key_per_rank(self) -> List[List[int]]:
+        return self._stride_per_key_per_rank
+
+    def variable_stride_per_key(self) -> bool:
+        return self._variable_stride_per_key
+
     def _key_indices(self) -> Dict[str, int]:
         _index_per_key: Dict[str, int] = _maybe_compute_index_per_key(
             self._keys,
@@ -1279,11 +1388,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def length_per_key(self) -> List[int]:
         _length_per_key = _maybe_compute_length_per_key(
-            self._keys,
-            self.stride(),
-            self._length_per_key,
-            self._lengths,
-            self._offsets,
+            keys=self._keys,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            length_per_key=self._length_per_key,
+            lengths=self._lengths,
+            offsets=self._offsets,
         )
         self._length_per_key = _length_per_key
         return _length_per_key
@@ -1293,12 +1404,14 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key(self) -> List[int]:
         _length_per_key, _offset_per_key = _maybe_compute_offset_per_key(
-            self._keys,
-            self.stride(),
-            self._length_per_key,
-            self._offset_per_key,
-            self._lengths,
-            self._offsets,
+            keys=self._keys,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            length_per_key=self._length_per_key,
+            offset_per_key=self._offset_per_key,
+            lengths=self._lengths,
+            offsets=self._offsets,
         )
         self._length_per_key = _length_per_key
         self._offset_per_key = _offset_per_key
@@ -1306,6 +1419,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key_or_none(self) -> Optional[List[int]]:
         return self._offset_per_key
+
+    def lengths_offset_per_key(self) -> List[int]:
+        if not self._lengths_offset_per_key:
+            self._lengths_offset_per_key = _cumsum(self.stride_per_key())
+        return self._lengths_offset_per_key
 
     def split(self, segments: List[int]) -> List["KeyedJaggedTensor"]:
         split_list: List[KeyedJaggedTensor] = []
@@ -1317,6 +1435,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             end = start + segment
             end_offset = _offset_per_key[end]
             keys: List[str] = self._keys[start:end]
+            stride, stride_per_key_per_rank = (
+                (None, self.stride_per_key_per_rank()[start:end])
+                if self.variable_stride_per_key()
+                else (self._stride, None)
+            )
             if segment == len(self._keys):
                 # no torch slicing required
                 split_list.append(
@@ -1326,7 +1449,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         weights=self.weights_or_none(),
                         lengths=self._lengths,
                         offsets=self._offsets,
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=self._length_per_key,
                         offset_per_key=self._offset_per_key,
                         index_per_key=self._index_per_key,
@@ -1356,7 +1480,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         offsets=torch.tensor(
                             empty_int_list, device=self.device(), dtype=torch.int
                         ),
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=None,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1373,10 +1498,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         if self.weights_or_none() is None
                         else self.weights()[start_offset:end_offset],
                         lengths=self.lengths()[
-                            start * self._stride : end * self._stride
+                            self.lengths_offset_per_key()[
+                                start
+                            ] : self.lengths_offset_per_key()[end]
                         ],
                         offsets=None,
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=split_length_per_key,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1398,32 +1526,67 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
         length_per_key = self.length_per_key()
         permuted_keys: List[str] = []
+        permuted_stride_per_key_per_rank: List[List[int]] = []
         permuted_length_per_key: List[int] = []
         permuted_lengths_sum = 0
         for index in indices:
-            key = self._keys[index]
+            key = self.keys()[index]
             permuted_keys.append(key)
-            permuted_lengths_sum += length_per_key[index]
+            permuted_stride_per_key_per_rank.append(
+                self.stride_per_key_per_rank()[index]
+            )
             permuted_length_per_key.append(length_per_key[index])
-        (
-            permuted_lengths,
-            permuted_values,
-            permuted_weights,
-        ) = torch.ops.fbgemm.permute_2D_sparse_data(
-            indices_tensor,
-            self.lengths().view(len(self._keys), -1),
-            self.values(),
-            self.weights_or_none(),
-            permuted_lengths_sum,
+            permuted_lengths_sum += length_per_key[index]
+        if self.variable_stride_per_key():
+            length_per_key_tensor = pin_and_move(
+                torch.tensor(self.length_per_key()), self.device()
+            )
+            stride_per_key_tensor = pin_and_move(
+                torch.tensor(self.stride_per_key()), self.device()
+            )
+            (_, permuted_lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
+                indices_tensor,
+                stride_per_key_tensor,
+                self.lengths(),
+                None,
+                None,
+            )
+            (
+                _,
+                permuted_values,
+                permuted_weights,
+            ) = torch.ops.fbgemm.permute_1D_sparse_data(
+                indices_tensor,
+                length_per_key_tensor,
+                self.values(),
+                self.weights_or_none(),
+                None,
+            )
+        else:
+            (
+                permuted_lengths,
+                permuted_values,
+                permuted_weights,
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                indices_tensor,
+                self.lengths().view(len(self._keys), -1),
+                self.values(),
+                self.weights_or_none(),
+                permuted_lengths_sum,
+            )
+        stride, optional_permuted_stride_per_key_per_rank = (
+            (None, permuted_stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
         )
-
         kjt = KeyedJaggedTensor(
             keys=permuted_keys,
             values=permuted_values,
             weights=permuted_weights,
             lengths=permuted_lengths.view(-1),
             offsets=None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=optional_permuted_stride_per_key_per_rank,
             length_per_key=permuted_length_per_key if len(permuted_keys) > 0 else None,
             offset_per_key=None,
             index_per_key=None,
@@ -1445,19 +1608,25 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=None
             if self.weights_or_none() is None
             else self.weights()[start_offset:end_offset],
-            lengths=self.lengths()[index * self._stride : (index + 1) * self._stride],
+            lengths=self.lengths()[
+                self.lengths_offset_per_key()[index] : self.lengths_offset_per_key()[
+                    index + 1
+                ]
+            ],
             offsets=None,
         )
 
     def to_dict(self) -> Dict[str, JaggedTensor]:
         _jt_dict = _maybe_compute_kjt_to_jt_dict(
-            self.stride(),
-            self.keys(),
-            self.length_per_key(),
-            self.values(),
-            self.lengths(),
-            self.weights_or_none(),
-            self._jt_dict,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            keys=self.keys(),
+            length_per_key=self.length_per_key(),
+            lengths=self.lengths(),
+            values=self.values(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            weights=self.weights_or_none(),
+            jt_dict=self._jt_dict,
         )
         self._jt_dict = _jt_dict
         return _jt_dict
@@ -1485,6 +1654,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
+        stride, stride_per_key_per_rank = (
+            (None, self._stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
+        )
         length_per_key = self._length_per_key
         offset_per_key = self._offset_per_key
         index_per_key = self._index_per_key
@@ -1502,7 +1676,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             offsets=offsets.to(device, non_blocking=non_blocking)
             if offsets is not None
             else None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
             length_per_key=length_per_key,
             offset_per_key=offset_per_key,
             index_per_key=index_per_key,
@@ -1514,7 +1689,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             return "KeyedJaggedTensor()\n"
         offsets = self.offsets()
 
-        step = (len(offsets) - 1) // len(self._keys)
         return (
             "KeyedJaggedTensor({\n"
             + ",\n".join(
@@ -1525,8 +1699,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         self._values,
                         self._weights,
                         offsets,
-                        index * step,
-                        (index + 1) * step,
+                        sum(self.stride_per_key()[:index]),
+                        sum(self.stride_per_key()[: index + 1]),
                     )
                     for index in range(len(self._keys))
                 ]
@@ -1538,6 +1712,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
+        stride, stride_per_key_per_rank = (
+            (None, self._stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
+        )
 
         return KeyedJaggedTensor(
             keys=self._keys,
@@ -1545,7 +1724,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights.pin_memory() if weights is not None else None,
             lengths=lengths.pin_memory() if lengths is not None else None,
             offsets=offsets.pin_memory() if offsets is not None else None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
             length_per_key=self._length_per_key,
             offset_per_key=self._offset_per_key,
             index_per_key=self._index_per_key,

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -1746,8 +1746,9 @@ class TestKeyedJaggedTensorScripting(unittest.TestCase):
                 return KeyedJaggedTensor.dist_init(
                     keys=input.keys(),
                     tensors=input.dist_tensors(),
-                    batch_size_per_rank=[2, 2],
                     recat=torch.tensor([]),
+                    num_workers=2,
+                    variable_stride_per_key=False,
                 )
 
         m = MyModule()

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -532,6 +532,23 @@ class TestJaggedTensor(unittest.TestCase):
         # TODO: T88149179
         self.assertTrue(torch.equal(j_offset.offsets(), j_lens.offsets().int()))
 
+        stride_per_key_per_rank = [[3], [5]]
+        j_offset = KeyedJaggedTensor.from_offsets_sync(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+
+        j_lens = KeyedJaggedTensor.from_lengths_sync(
+            values=values,
+            keys=keys,
+            lengths=lengths,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+        self.assertTrue(torch.equal(j_offset.lengths(), j_lens.lengths()))
+        self.assertTrue(torch.equal(j_offset.offsets(), j_lens.offsets().int()))
+
     def test_empty(self) -> None:
         jt = JaggedTensor.empty(values_dtype=torch.int64)
 
@@ -720,6 +737,38 @@ JaggedTensor({
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
+    def test_from_jt_dict_vb(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+        stride_per_key_per_rank = [[2], [4]]
+
+        jag_tensor = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+        jag_tensor_dict = jag_tensor.to_dict()
+        kjt = KeyedJaggedTensor.from_jt_dict(jag_tensor_dict)
+        j0 = kjt["index_0"]
+        j1 = kjt["index_1"]
+
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
+        self.assertTrue(
+            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
+        )
+        self.assertTrue(
+            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
+        )
+
 
 class TestJaggedTensorTracing(unittest.TestCase):
     def test_jagged_tensor(self) -> None:
@@ -859,6 +908,36 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
+    def test_key_lookup_vb(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+        stride_per_key_per_rank = [[2], [4]]
+
+        jag_tensor = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+        j0 = jag_tensor["index_0"]
+        j1 = jag_tensor["index_1"]
+
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(isinstance(j0, JaggedTensor))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
+        self.assertTrue(
+            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
+        )
+        self.assertTrue(
+            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
+        )
+
     def test_to_dict(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -888,33 +967,70 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         )
 
     def test_pytree(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        j0 = JaggedTensor(
+            values=values,
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+        )
+        elems, spec = pytree.tree_flatten(j0)
+        j1 = pytree.tree_unflatten(elems, spec)
+
+        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
+        self.assertIsNone(j0.weights_or_none())
+        self.assertIsNone(j1.weights_or_none())
+        self.assertTrue(torch.equal(j0.values(), j1.values()))
+
+        values = [
+            torch.Tensor([1.0]),
+            torch.Tensor(),
+            torch.Tensor([7.0, 8.0]),
+            torch.Tensor([10.0, 11.0, 12.0]),
+        ]
+        weights = [
+            torch.Tensor([1.0]),
+            torch.Tensor(),
+            torch.Tensor([7.0, 8.0]),
+            torch.Tensor([10.0, 11.0, 12.0]),
+        ]
+        j0 = JaggedTensor.from_dense(
+            values=values,
+            weights=weights,
+        )
+        elems, spec = pytree.tree_flatten(j0)
+        j1 = pytree.tree_unflatten(elems, spec)
+
+        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
+        self.assertTrue(torch.equal(j0.weights(), j1.weights()))
+        self.assertTrue(torch.equal(j0.values(), j1.values()))
+
+    def test_to_dict_vb(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
         keys = ["index_0", "index_1"]
         offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+        stride_per_key_per_rank = [[2], [4]]
 
-        jag_tensor0 = KeyedJaggedTensor(
+        jag_tensor = KeyedJaggedTensor(
             values=values,
             keys=keys,
             offsets=offsets,
             weights=weights,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
-        elems, spec = pytree.tree_flatten(jag_tensor0)
-        jag_tensor = pytree.tree_unflatten(elems, spec)
-
-        j0 = jag_tensor["index_0"]
-        j1 = jag_tensor["index_1"]
+        jag_tensor_dict = jag_tensor.to_dict()
+        j0 = jag_tensor_dict["index_0"]
+        j1 = jag_tensor_dict["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
-        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5, 1.5])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 3])))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
         self.assertTrue(
-            torch.equal(j1.weights(), torch.Tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
+            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
         )
         self.assertTrue(
-            torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
+            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
     def test_empty(self) -> None:
@@ -1017,6 +1133,49 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
+    def test_split_vb(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+        keys = ["index_0", "index_1", "index_2", "index_3"]
+        lengths = torch.IntTensor([2, 0, 1, 1, 1, 3, 0, 2])
+        stride_per_key_per_rank = [[3], [0], [1], [4]]
+        jag_tensor = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            lengths=lengths,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+        j0, j1, j2 = jag_tensor.split([1, 1, 2])
+
+        self.assertTrue(isinstance(j0, KeyedJaggedTensor))
+        self.assertEqual(j0.keys(), ["index_0"])
+        self.assertEqual(j1.keys(), ["index_1"])
+        self.assertEqual(j2.keys(), ["index_2", "index_3"])
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([])))
+        self.assertTrue(torch.equal(j1.values(), torch.Tensor([])))
+        self.assertTrue(torch.equal(j2.lengths(), torch.IntTensor([1, 1, 3, 0, 2])))
+        self.assertTrue(
+            torch.equal(j2.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]))
+        )
+
+        j0, j1, j2, j3 = jag_tensor.split([0, 3, 0, 1])
+        self.assertTrue(isinstance(j0, KeyedJaggedTensor))
+        self.assertEqual(j0.keys(), [])
+        self.assertEqual(j1.keys(), ["index_0", "index_1", "index_2"])
+        self.assertEqual(j2.keys(), [])
+        self.assertEqual(j3.keys(), ["index_3"])
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([2, 0, 1, 1])))
+        self.assertTrue(torch.equal(j1.values(), torch.Tensor([1.0, 2.0, 3.0, 4.0])))
+        self.assertTrue(torch.equal(j2.lengths(), torch.IntTensor([])))
+        self.assertTrue(torch.equal(j2.values(), torch.Tensor([])))
+        self.assertTrue(torch.equal(j3.lengths(), torch.IntTensor([1, 3, 0, 2])))
+        self.assertTrue(
+            torch.equal(j3.values(), torch.Tensor([5.0, 6.0, 7.0, 8.0, 9.0, 10.0]))
+        )
+
     def test_zero_split(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -1042,7 +1201,7 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([2, 0, 1, 1, 1, 3])))
         self.assertTrue(torch.equal(j1.weights(), weights))
         self.assertTrue(torch.equal(j1.values(), values))
-        self.assertEqual(j0.stride(), 3)
+        self.assertEqual(j1.stride(), 3)
 
     def test_permute_w_weights(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
@@ -1112,6 +1271,41 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(
                 permuted_jag_tensor.lengths(),
                 torch.IntTensor([1, 1, 1, 0, 2, 0, 0, 3, 0]),
+            )
+        )
+        self.assertEqual(permuted_jag_tensor.weights_or_none(), None)
+
+    def test_permute_vb(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        lengths = torch.IntTensor([1, 0, 1, 3, 0, 1, 0, 2, 0])
+        keys = ["index_0", "index_1", "index_2"]
+        stride_per_key_per_rank = [[2], [4], [3]]
+
+        jag_tensor = KeyedJaggedTensor.from_lengths_sync(
+            values=values,
+            keys=keys,
+            lengths=lengths,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+
+        indices = [1, 0, 2]
+        permuted_jag_tensor = jag_tensor.permute(indices)
+
+        self.assertEqual(permuted_jag_tensor.keys(), ["index_1", "index_0", "index_2"])
+        self.assertEqual(
+            permuted_jag_tensor.offset_per_key(),
+            [0, 5, 6, 8],
+        )
+        self.assertTrue(
+            torch.equal(
+                permuted_jag_tensor.values(),
+                torch.Tensor([2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 7.0, 8.0]),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                permuted_jag_tensor.lengths(),
+                torch.IntTensor([1, 3, 0, 1, 1, 0, 0, 2, 0]),
             )
         )
         self.assertEqual(permuted_jag_tensor.weights_or_none(), None)
@@ -1377,6 +1571,39 @@ KeyedJaggedTensor({
 """,
         )
 
+    def test_string_vb(self) -> None:
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
+        stride_per_key_per_rank = [[1, 1], [1, 3]]
+
+        jag_tensor = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+
+        print(str(jag_tensor))
+
+        self.assertEqual(
+            str(jag_tensor),
+            """\
+KeyedJaggedTensor({
+    "index_0": {
+        "values": [[1.0, 2.0], []],
+        "weights": [[1.0, 0.5], []]
+    },
+    "index_1": {
+        "values": [[3.0], [4.0], [5.0], [6.0, 7.0, 8.0]],
+        "weights": [[1.5], [1.0], [0.5], [1.0, 1.0, 1.5]]
+    }
+})
+""",
+        )
+
     # pyre-ignore[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
@@ -1526,6 +1753,14 @@ class TestKeyedJaggedTensorScripting(unittest.TestCase):
         m = MyModule()
         torch.jit.script(m)
 
+    def test_scriptable_split(self) -> None:
+        class MyModule(torch.nn.Module):
+            def forward(self, input: KeyedJaggedTensor) -> List[KeyedJaggedTensor]:
+                return input.split([1, 0, 1])
+
+        m = MyModule()
+        torch.jit.script(m)
+
     def test_scriptable_init(self) -> None:
         def create_kjt() -> KeyedJaggedTensor:
             return KeyedJaggedTensor.from_offsets_sync(
@@ -1535,8 +1770,18 @@ class TestKeyedJaggedTensorScripting(unittest.TestCase):
                 offsets=torch.tensor([0, 0, 2, 2, 3, 4, 5, 5, 8], dtype=torch.int32),
             )
 
+        def create_vb_kjt() -> KeyedJaggedTensor:
+            return KeyedJaggedTensor.from_offsets_sync(
+                values=torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+                weights=torch.tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5]),
+                keys=["index_0", "index_1"],
+                offsets=torch.tensor([0, 0, 2, 2, 3, 4, 5, 5, 8], dtype=torch.int32),
+                stride_per_key_per_rank=[[2], [4]],
+            )
+
         # assert that we can script KJT creation
         torch.jit.script(create_kjt)
+        torch.jit.script(create_vb_kjt)
 
 
 class TestKeyedJaggedTensorTracingScripting(unittest.TestCase):
@@ -1907,22 +2152,23 @@ class TestComputeKJTToJTDict(unittest.TestCase):
             weights=torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5]),
             keys=["index_0", "index_1"],
             offsets=torch.IntTensor([0, 0, 2, 2, 3, 4, 5, 5, 8]),
+            stride_per_key_per_rank=[[0, 2], [3, 3]],
         )
 
         out = m(input)
 
         i0 = out["index_0"]
-        self.assertTrue(torch.equal(i0._values, torch.tensor([1.0, 2.0, 3.0])))
-        self.assertTrue(torch.equal(i0._weights, torch.tensor([1.0, 0.5, 1.5])))
-        self.assertTrue(torch.equal(i0._lengths, torch.tensor([0, 2, 0, 1])))
-        self.assertTrue(torch.equal(i0._offsets, torch.tensor([0, 0, 2, 2, 3])))
+        self.assertTrue(torch.equal(i0._values, torch.tensor([1.0, 2.0])))
+        self.assertTrue(torch.equal(i0._weights, torch.tensor([1.0, 0.5])))
+        self.assertTrue(torch.equal(i0._lengths, torch.tensor([0, 2])))
+        self.assertTrue(torch.equal(i0._offsets, torch.tensor([0, 0, 2])))
 
         i1 = out["index_1"]
         self.assertTrue(
-            torch.equal(i1._values, torch.tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
+            torch.equal(i1._values, torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
         )
         self.assertTrue(
-            torch.equal(i1._weights, torch.tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
+            torch.equal(i1._weights, torch.tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
         )
-        self.assertTrue(torch.equal(i1._lengths, torch.tensor([1, 1, 0, 3])))
-        self.assertTrue(torch.equal(i1._offsets, torch.tensor([0, 1, 2, 2, 5])))
+        self.assertTrue(torch.equal(i1._lengths, torch.tensor([0, 1, 1, 1, 0, 3])))
+        self.assertTrue(torch.equal(i1._offsets, torch.tensor([0, 0, 1, 2, 3, 3, 6])))


### PR DESCRIPTION
Summary:
- Enables per feature variable batch for VLE
  - KJT and input dist changes to support are implicit
  - we use the KJT info to determine whether to use per feature variable batch for embedding lookup and output dist

Differential Revision: D47404026

