### PR TITLE
Update Nova Wheels Build Without RoCM

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -1,7 +1,6 @@
 name: Build Linux Wheels
 
 on:
-  pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -1,8 +1,7 @@
 name: Build Linux Wheels
 
 on:
-  # TODO: Renable after fixed @omkar
-  # pull_request:
+  pull_request:
   push:
     branches:
       - nightly
@@ -16,29 +15,21 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
+      with-rocm: false
   build:
     needs: generate-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - repository: pytorch/torchrec
-            pre-script: ""
-            post-script: ""
-            smoke-test-script: ""
-            package-name: torchrec
-    name: ${{ matrix.repository }}
+    name: pytorch/torchrec
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
-      repository: ${{ matrix.repository }}
+      repository: pytorch/torchrec
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: ${{ matrix.pre-script }}
-      post-script: ${{ matrix.post-script }}
-      package-name: ${{ matrix.package-name }}
-      smoke-test-script: ${{ matrix.smoke-test-script }}
+      pre-script: ""
+      post-script: ""
+      package-name: torchrec
+      smoke-test-script: ""
       trigger-event: ${{ github.event_name }}
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/version.py
+++ b/version.py
@@ -14,4 +14,4 @@
 # 0.1.0bN  # Beta release
 # 0.1.0rcN  # Release Candidate
 # 0.1.0  # Final release
-__version__ = "0.3.2"
+__version__ = "0.4.0"


### PR DESCRIPTION
This PR:
* Cleans up the Linux Wheels Build pipeline for Nova
* Updates the version on master to 0.4.0 (as suggested by @henrylhtsang )
* Excludes RoCM from the Build Matrix

Note that CUDA 11.8 builds are failing due to an FBGEMM issue. I will put up a follow-up PR to exclude CUDA 12 from the supported matrix.