### PR TITLE
Filter CUDA 12 from Build Matrix

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import json
 import os
 

--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -1,0 +1,14 @@
+import os
+import json
+
+full_matrix_string = os.environ("MAT")
+full_matrix = json.loads(full_matrix_string)
+
+new_matrix_entries = []
+
+for entry in full_matrix['include']:
+    if entry['gpu_arch_version'] != "12.1":
+        new_matrix_entries.append(entry)
+
+new_matrix = {'include': new_matrix_entries}
+print(json.dumps(new_matrix))

--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-full_matrix_string = os.environ("MAT")
+full_matrix_string = os.environ["MAT"]
 full_matrix = json.loads(full_matrix_string)
 
 new_matrix_entries = []

--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-def main() -> None:
+def main():
     """
     Since FBGEMM doesn't publish CUDA 12 binaries, torchrec will not work with
     CUDA 12. As a result, we filter out CUDA 12 from the build matrix that

--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -1,14 +1,26 @@
-import os
 import json
+import os
 
-full_matrix_string = os.environ["MAT"]
-full_matrix = json.loads(full_matrix_string)
 
-new_matrix_entries = []
+def main() -> None:
+    """
+    Since FBGEMM doesn't publish CUDA 12 binaries, torchrec will not work with
+    CUDA 12. As a result, we filter out CUDA 12 from the build matrix that
+    determines with nightly builds are run.
+    """
 
-for entry in full_matrix['include']:
-    if entry['gpu_arch_version'] != "12.1":
-        new_matrix_entries.append(entry)
+    full_matrix_string = os.environ["MAT"]
+    full_matrix = json.loads(full_matrix_string)
 
-new_matrix = {'include': new_matrix_entries}
-print(json.dumps(new_matrix))
+    new_matrix_entries = []
+
+    for entry in full_matrix["include"]:
+        if entry["gpu_arch_version"] != "12.1":
+            new_matrix_entries.append(entry)
+
+    new_matrix = {"include": new_matrix_entries}
+    print(json.dumps(new_matrix))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -39,7 +39,7 @@ jobs:
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
   build:
-    needs: generate-matrix
+    needs: filter-matrix
     name: pytorch/torchrec
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -24,7 +24,6 @@ jobs:
     steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
     - name: Checkout torchrec repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -15,6 +15,21 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       with-rocm: false
+  filter-matrix:
+    needs: generate-matrix
+    runs-on: linux.2xlarge
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+    - name: Filter Generated Built Matrix
+      id: filter
+      env:
+        MAT: ${{ needs.generate-matrix.outputs.matrix }}
+      runs: |
+        set -ex
+        MATRIX_BLOB="$(python filter.py)"
+        echo "${MATRIX_BLOB}"
+        echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
   build:
     needs: generate-matrix
     name: pytorch/torchrec
@@ -24,7 +39,7 @@ jobs:
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       pre-script: ""
       post-script: ""
       package-name: torchrec

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -1,6 +1,7 @@
 name: Build Linux Wheels
 
 on:
+  pull_request:
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -28,7 +28,7 @@ jobs:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       run: |
         set -ex
-        MATRIX_BLOB="$(python filter.py)"
+        MATRIX_BLOB="$(python .github/scripts/filter.py)"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
   build:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -22,12 +22,21 @@ jobs:
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Checkout torchrec repository
+      uses: actions/checkout@v3
+      with:
+        repository: pytorch/torchrec
     - name: Filter Generated Built Matrix
       id: filter
       env:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
       run: |
         set -ex
+        pwd
+        ls
         MATRIX_BLOB="$(python .github/scripts/filter.py)"
         echo "${MATRIX_BLOB}"
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -23,7 +23,6 @@ jobs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:
     - uses: actions/setup-python@v4
-      with:
     - name: Checkout torchrec repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -26,7 +26,7 @@ jobs:
       id: filter
       env:
         MAT: ${{ needs.generate-matrix.outputs.matrix }}
-      runs: |
+      run: |
         set -ex
         MATRIX_BLOB="$(python filter.py)"
         echo "${MATRIX_BLOB}"


### PR DESCRIPTION
Since FBGEMM doesn't support CUDA 12 binaries, torchrec cannot successfully build wheels with CUDA 12 support. This PR excludes CUDA 12 from the build matrix for torchrec binaries.