### PR TITLE
Remove deprecated variable_batch_size flag from sharder

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -336,7 +336,6 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         self,
         fused_params: Optional[Dict[str, Any]] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
-        variable_batch_size: bool = False,  # deprecated, TODO: remove on or after 03/31/2023
     ) -> None:
         super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
 


### PR DESCRIPTION
Summary: we kept this in the constructor args to maintain back compat for mvai who already built torchrec pkg last year

Reviewed By: YLGH

Differential Revision: D48528343

