### PR TITLE
Fix the unit test of index dedup

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -677,25 +677,22 @@ class ShardedEmbeddingCollection(
         feature_names: List[str],
     ) -> None:
         feature_index = 0
-        for i, lookup in enumerate(self._lookups):
+        for i, sharding in enumerate(self._sharding_type_to_sharding.values()):
             feature_hash_size: List[int] = []
             feature_hash_size_lengths: List[int] = []
-            for group_config in lookup.grouped_configs:
-                for table in group_config.embedding_tables:
-                    table_hash_size = [0] * table.num_features()
-                    table_hash_size[-1] = table.num_embeddings
-                    feature_hash_size.extend(table_hash_size)
+            for table in sharding.embedding_tables():
+                table_hash_size = [0] * table.num_features()
+                table_hash_size[-1] = table.num_embeddings
+                feature_hash_size.extend(table_hash_size)
 
-                    table_hash_size = [0] * table.num_features()
-                    table_hash_size[0] = table.num_features()
-                    feature_hash_size_lengths.extend(table_hash_size)
+                table_hash_size = [0] * table.num_features()
+                table_hash_size[0] = table.num_features()
+                feature_hash_size_lengths.extend(table_hash_size)
 
-                    # Sanity check for feature orders
-                    for f in range(table.num_features()):
-                        assert (
-                            feature_names[feature_index + f] == table.feature_names[f]
-                        )
-                    feature_index += table.num_features()
+                # Sanity check for feature orders
+                for f in range(table.num_features()):
+                    assert feature_names[feature_index + f] == table.feature_names[f]
+                feature_index += table.num_features()
 
             feature_hash_size_cumsum: List[int] = [0] + list(
                 accumulate(feature_hash_size)

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -608,6 +608,9 @@ class EmbeddingSharding(abc.ABC, Generic[C, F, T, W], FeatureShardingMixIn):
     def embedding_names_per_rank(self) -> List[List[str]]:
         pass
 
+    def embedding_tables(self) -> List[ShardedEmbeddingTable]:
+        raise NotImplementedError
+
 
 @dataclass
 class EmbeddingShardingInfo:

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -122,6 +122,12 @@ class BaseDpEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             feature_names.extend(grouped_config.feature_names())
         return feature_names
 
+    def embedding_tables(self) -> List[ShardedEmbeddingTable]:
+        embedding_tables = []
+        for grouped_config in self._grouped_embedding_configs:
+            embedding_tables.extend(grouped_config.embedding_tables)
+        return embedding_tables
+
 
 class DpSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
     """

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -175,6 +175,12 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             feature_names.extend(grouped_config.feature_names())
         return feature_names
 
+    def embedding_tables(self) -> List[ShardedEmbeddingTable]:
+        embedding_tables = []
+        for grouped_config in self._grouped_embedding_configs:
+            embedding_tables.extend(grouped_config.embedding_tables)
+        return embedding_tables
+
     def _get_num_features(self) -> int:
         return sum(
             group_config.num_features()

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -193,6 +193,13 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                 feature_names.extend(grouped_config.feature_names())
         return feature_names
 
+    def embedding_tables(self) -> List[ShardedEmbeddingTable]:
+        embedding_tables = []
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
+            for grouped_config in grouped_embedding_configs:
+                embedding_tables.extend(grouped_config.embedding_tables)
+        return embedding_tables
+
     def feature_names_per_rank(self) -> List[List[str]]:
         feature_names = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:


### PR DESCRIPTION
Summary: Support the table-wise and column-wise sharding by getting the hash size info from embedding tables rather then lookups.

Differential Revision: D48491116

