### PR TITLE
Remove pin_and_move import from jagged_tensor in KJTAllToAllSplitsAwaitable

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -30,7 +30,7 @@ except ImportError:
     pass
 
 
-def pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     return (
         tensor
         if device.type == "cpu"
@@ -1538,10 +1538,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             permuted_length_per_key.append(length_per_key[index])
             permuted_lengths_sum += length_per_key[index]
         if self.variable_stride_per_key():
-            length_per_key_tensor = pin_and_move(
+            length_per_key_tensor = _pin_and_move(
                 torch.tensor(self.length_per_key()), self.device()
             )
-            stride_per_key_tensor = pin_and_move(
+            stride_per_key_tensor = _pin_and_move(
                 torch.tensor(self.stride_per_key()), self.device()
             )
             (_, permuted_lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
@@ -1748,7 +1748,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         return splits
 
     def dist_tensors(self) -> List[torch.Tensor]:
-        strides = pin_and_move(torch.tensor(self.stride_per_key()), self.device())
+        strides = _pin_and_move(torch.tensor(self.stride_per_key()), self.device())
         tensors = [strides, self.lengths(), self.values()]
         if self.weights_or_none() is not None:
             tensors.append(self.weights())


### PR DESCRIPTION
Summary: this import is breaking internally due to backward incompatibility

Reviewed By: drdarshan

Differential Revision: D48584788

