### PR TITLE
Back out torchrec per feature variable batch support diff stack

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -751,21 +751,11 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         weights = features.weights_or_none()
         if weights is not None and not torch.is_floating_point(weights):
             weights = None
-        if features.variable_stride_per_key() and isinstance(
-            self.emb_module, SplitTableBatchedEmbeddingBagsCodegen
-        ):
-            return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
-                per_sample_weights=weights,
-                batch_size_per_feature_per_rank=features.stride_per_key_per_rank(),
-            )
-        else:
-            return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
-                per_sample_weights=weights,
-            )
+        return self.emb_module(
+            indices=features.values().long(),
+            offsets=features.offsets().long(),
+            per_sample_weights=weights,
+        )
 
     # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
     def state_dict(

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -110,7 +110,7 @@ class All2AllPooledInfo(object):
         cumsum_dim_sum_per_rank_tensor (Optional[Tensor]): cumulative sum of
             `dim_sum_per_rank`, this is only used by the fast kernel of
             `_recat_pooled_embedding_grad_out`.
-        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+        B_local (int): local batch size before scattering.
     """
 
     batch_size_per_rank: List[int]
@@ -118,31 +118,6 @@ class All2AllPooledInfo(object):
     dim_sum_per_rank_tensor: Optional[Tensor]
     cumsum_dim_sum_per_rank_tensor: Optional[Tensor]
     codecs: Optional[QuantizedCommCodecs] = None
-
-
-@dataclass
-class VariableBatchAll2AllPooledInfo(object):
-    """
-    The data class that collects the attributes when calling the
-    `variable_batch_alltoall_pooled` operation.
-
-    Attributes:
-        batch_size_per_rank_per_feature (List[List[int]]): batch size per rank per
-            feature.
-        batch_size_per_feature_pre_a2a (List[int]): local batch size before scattering.
-        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimension per rank
-            per feature
-        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
-        input_splits (Optional[List[int]]): input splits of tensor all to all.
-        output_splits (Optional[List[int]]): output splits of tensor all to all.
-    """
-
-    batch_size_per_rank_per_feature: List[List[int]]
-    batch_size_per_feature_pre_a2a: List[int]
-    emb_dim_per_rank_per_feature: List[List[int]]
-    codecs: Optional[QuantizedCommCodecs] = None
-    input_splits: Optional[List[int]] = None
-    output_splits: Optional[List[int]] = None
 
 
 @dataclass
@@ -159,8 +134,7 @@ class All2AllSequenceInfo(object):
         backward_recat_tensor (Tensor): recat tensor for backward.
         input_splits (List[int]): input splits.
         output_splits (List[int]): output splits.
-        variable_batch_size (bool): whether variable batch size is enabled.
-        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+        variable_batch_size (bool): whether variable batch size is enabled
         permuted_lengths_after_sparse_data_all2all (Optional[Tensor]): lengths of sparse
             features before AlltoAll.
     """
@@ -327,10 +301,10 @@ def alltoall_pooled(
             `_recat_pooled_embedding_grad_out`.
         group (Optional[dist.ProcessGroup]): the process group to work on. If None, the
             default process group will be used.
-        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+        codecs: Optional[QuantizedCommCodecs]: Quantized communication codecs.
 
     Returns:
-        Awaitable[Tensor]: async work handle (`Awaitable`), which can be `wait()` later to get the resulting tensor.
+        Awaitable[List[Tensor]]: async work handle (`Awaitable`), which can be `wait()` later to get the resulting tensor.
 
     .. warning::
         `alltoall_pooled` is experimental and subject to change.
@@ -351,32 +325,6 @@ def alltoall_pooled(
         codecs=codecs,
     )
     All2All_Pooled_Req.apply(group, myreq, a2ai, a2a_pooled_embs_tensor)
-    return myreq
-
-
-def variable_batch_alltoall_pooled(
-    a2a_pooled_embs_tensor: Tensor,
-    batch_size_per_rank_per_feature: List[List[int]],
-    batch_size_per_feature_pre_a2a: List[int],
-    emb_dim_per_rank_per_feature: List[List[int]],
-    group: Optional[dist.ProcessGroup] = None,
-    codecs: Optional[QuantizedCommCodecs] = None,
-) -> Awaitable[Tensor]:
-
-    if group is None:
-        group = dist.distributed_c10d._get_default_group()
-
-    if dist.get_world_size(group) <= 1:
-        return NoWait(a2a_pooled_embs_tensor)
-
-    myreq = Request(group, device=a2a_pooled_embs_tensor.device)
-    a2ai = VariableBatchAll2AllPooledInfo(
-        batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
-        batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
-        emb_dim_per_rank_per_feature=emb_dim_per_rank_per_feature,
-        codecs=codecs,
-    )
-    Variable_Batch_All2All_Pooled_Req.apply(group, myreq, a2ai, a2a_pooled_embs_tensor)
     return myreq
 
 
@@ -901,206 +849,6 @@ class All2All_Pooled_Wait(Function):
             ]
             output_split_sizes = [
                 D_local_sum * B_rank for B_rank in batch_size_per_rank
-            ]
-
-        sharded_grad_input = torch.empty(
-            sum(output_split_sizes),
-            device=sharded_grad_output.device,
-            dtype=sharded_grad_output.dtype,
-        )
-        with record_function("## alltoall_bwd_single ##"):
-            req = dist.all_to_all_single(
-                output=sharded_grad_input,
-                input=sharded_grad_output,
-                output_split_sizes=output_split_sizes,
-                input_split_sizes=input_split_sizes,
-                group=pg,
-                async_op=True,
-            )
-        myreq.req = req
-        myreq.tensor = sharded_grad_input
-        myreq.qcomm_ctx = qcomm_ctx
-
-        return (None, None, myreq.dummy_tensor)
-
-
-class Variable_Batch_All2All_Pooled_Req(Function):
-    @staticmethod
-    # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
-    def forward(
-        # pyre-fixme[2]: Parameter must be annotated.
-        ctx,
-        pg: dist.ProcessGroup,
-        myreq: Request[Tensor],
-        a2ai: VariableBatchAll2AllPooledInfo,
-        input_embeddings: Tensor,
-    ) -> Tensor:
-        my_rank = dist.get_rank(pg)
-
-        # get input splits
-        world_size = dist.get_world_size(pg)
-        input_split_sizes = [0 for _ in range(world_size)]
-        if a2ai.batch_size_per_rank_per_feature:
-            for i in range(world_size):
-                curr_size = 0
-                for batch_size, emb_dim in zip(
-                    a2ai.batch_size_per_rank_per_feature[i],
-                    a2ai.emb_dim_per_rank_per_feature[my_rank],
-                ):
-                    curr_size += batch_size * emb_dim
-                input_split_sizes[i] = curr_size
-        a2ai.input_splits = input_split_sizes
-
-        # get output splits
-        output_split_sizes = [0 for _ in range(world_size)]
-        ind = 0
-        for i in range(world_size):
-            curr_size = 0
-            for emb_dim in a2ai.emb_dim_per_rank_per_feature[i]:
-                curr_size += a2ai.batch_size_per_feature_pre_a2a[ind] * emb_dim
-                ind += 1
-            output_split_sizes[i] = curr_size
-        a2ai.output_splits = output_split_sizes
-
-        sharded_input_embeddings = input_embeddings.view(-1)
-        qcomm_ctx = None
-
-        if a2ai.codecs is not None:
-            codecs = none_throws(a2ai.codecs)
-            qcomm_ctx = codecs.forward.create_context()
-            sharded_input_embeddings = codecs.forward.encode(
-                sharded_input_embeddings,
-                qcomm_ctx,
-            )
-            output_split_sizes = [
-                codecs.forward.calc_quantized_size(
-                    split,
-                    qcomm_ctx,
-                )
-                for split in output_split_sizes
-            ]
-            input_split_sizes = [
-                codecs.forward.calc_quantized_size(
-                    split,
-                    qcomm_ctx,
-                )
-                for split in input_split_sizes
-            ]
-
-        sharded_output_embeddings = torch.empty(
-            sum(output_split_sizes),
-            dtype=sharded_input_embeddings.dtype,
-            device=sharded_input_embeddings.device,
-        )
-
-        with record_function("## alltoall_fwd_single ##"):
-            req = dist.all_to_all_single(
-                output=sharded_output_embeddings,
-                input=sharded_input_embeddings,
-                output_split_sizes=output_split_sizes,
-                input_split_sizes=input_split_sizes,
-                group=pg,
-                async_op=True,
-            )
-
-        myreq.req = req
-        myreq.tensor = sharded_output_embeddings
-        myreq.qcomm_ctx = qcomm_ctx
-        myreq.a2ai = a2ai
-        myreq.wait_function = Variable_Batch_All2All_Pooled_Wait
-        ctx.myreq = myreq
-        ctx.pg = pg
-        return myreq.dummy_tensor
-
-    @staticmethod
-    # pyre-fixme[2]: Parameter must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def backward(ctx, *unused) -> Tuple[None, None, None, Tensor]:
-        myreq = ctx.myreq
-        a2ai = myreq.a2ai
-        assert myreq.req is not None
-        myreq.req.wait()
-        myreq.req = None
-        grad_output = myreq.tensor
-
-        if a2ai.codecs is not None:
-            codecs = none_throws(a2ai.codecs)
-            grad_input = codecs.backward.decode(grad_output, myreq.qcomm_ctx)
-        else:
-            grad_input = grad_output
-        if GRADIENT_DIVISION:
-            grad_input.div_(dist.get_world_size(ctx.pg))
-        myreq.tensor = None
-        myreq.dummy_tensor = None
-        return (None, None, None, grad_input)
-
-
-class Variable_Batch_All2All_Pooled_Wait(Function):
-    @staticmethod
-    # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
-    def forward(
-        # pyre-fixme[2]: Parameter must be annotated.
-        ctx,
-        pg: dist.ProcessGroup,
-        myreq: Request[Tensor],
-        *dummy_tensor: Tensor,
-    ) -> Tensor:
-        a2ai = myreq.a2ai
-        ctx.a2ai = a2ai
-        assert myreq.req is not None
-        myreq.req.wait()
-        sharded_output_embeddings = myreq.tensor
-        myreq.req = None
-        myreq.tensor = None
-        ctx.pg = pg
-        ctx.myreq = myreq
-
-        if a2ai.codecs is not None:
-            codecs = none_throws(a2ai.codecs)
-            sharded_output_embeddings = codecs.forward.decode(
-                sharded_output_embeddings,
-                myreq.qcomm_ctx,
-            )
-        # the return result is a 1-d tensor, like: f_0_s_0, f_0_s1, ..., f_n_s_0, f_n_s_k
-        # f_0, f_1, ... , f_n are ordered by features on each rank
-        return sharded_output_embeddings
-
-    @staticmethod
-    # pyre-fixme[14]: `backward` overrides method defined in `Function` inconsistently.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def backward(ctx, grad_output: Tensor) -> Tuple[None, None, Tensor]:
-        myreq = ctx.myreq
-        a2ai = ctx.a2ai
-        pg = ctx.pg
-
-        assert a2ai.input_splits is not None
-        assert a2ai.output_splits is not None
-        input_split_sizes = a2ai.output_splits
-        output_split_sizes = a2ai.input_splits
-
-        sharded_grad_output = grad_output.contiguous()
-        qcomm_ctx = None
-
-        if a2ai.codecs is not None:
-            codecs = none_throws(a2ai.codecs)
-            qcomm_ctx = codecs.backward.create_context()
-            sharded_grad_output = codecs.backward.encode(
-                sharded_grad_output,
-                qcomm_ctx,
-            )
-            input_split_sizes = [
-                codecs.backward.calc_quantized_size(
-                    split,
-                    qcomm_ctx,
-                )
-                for split in input_split_sizes
-            ]
-            output_split_sizes = [
-                codecs.backward.calc_quantized_size(
-                    split,
-                    qcomm_ctx,
-                )
-                for split in output_split_sizes
             ]
 
         sharded_grad_input = torch.empty(

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -834,12 +834,9 @@ class ShardedEmbeddingCollection(
             ctx.sharding_contexts,
             self._sharding_type_to_sharding,
         ):
-            if features.stride() == 0:
-                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
-                stride = sharding_ctx.batch_size_per_feature_pre_a2a[0]
-            else:
-                stride = features.stride()
-            sharding_ctx.lengths_after_input_dist = features.lengths().view(-1, stride)
+            sharding_ctx.lengths_after_input_dist = features.lengths().view(
+                -1, features.stride()
+            )
             embedding_dim = self._embedding_dim_for_sharding_type(sharding_type)
             ret.append(lookup(features).view(-1, embedding_dim))
         return ret
@@ -881,12 +878,9 @@ class ShardedEmbeddingCollection(
             ctx.sharding_contexts,
             self._sharding_type_to_sharding,
         ):
-            if features.stride() == 0:
-                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
-                stride = sharding_ctx.batch_size_per_feature_pre_a2a[0]
-            else:
-                stride = features.stride()
-            sharding_ctx.lengths_after_input_dist = features.lengths().view(-1, stride)
+            sharding_ctx.lengths_after_input_dist = features.lengths().view(
+                -1, features.stride()
+            )
             embedding_dim = self._embedding_dim_for_sharding_type(sharding_type)
             awaitables_per_sharding.append(
                 odist(lookup(features).view(-1, embedding_dim), sharding_ctx)

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -385,7 +385,7 @@ class GroupedPooledEmbeddingsLookup(
 
         return embeddings_cat_empty_rank_handle(
             embeddings,
-            self._dummy_embs_tensor,
+            fx_wrap_tensor_view2d(self._dummy_embs_tensor, sparse_features.stride(), 0),
             dim=1,
         )
 

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -27,7 +27,6 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.types import (
     Awaitable,
-    NoWait,
     ParameterSharding,
     QuantizedCommCodecs,
     ShardMetadata,
@@ -219,10 +218,6 @@ def group_tables(
     return grouped_embedding_configs_by_rank
 
 
-C = TypeVar("C", bound=Multistreamable)
-T = TypeVar("T")
-
-
 class KJTListAwaitable(Awaitable[KJTList]):
     """
     Awaitable of KJTList.
@@ -230,18 +225,14 @@ class KJTListAwaitable(Awaitable[KJTList]):
     Args:
         awaitables (List[Awaitable[KeyedJaggedTensor]]): list of `Awaitable` of sparse
             features.
-        ctx (C): sharding context to save the batch size info from the KJT for the
-            embedding AlltoAll.
     """
 
     def __init__(
         self,
         awaitables: List[Awaitable[KeyedJaggedTensor]],
-        ctx: C,
     ) -> None:
         super().__init__()
         self.awaitables = awaitables
-        self.ctx = ctx
 
     def _wait_impl(self) -> KJTList:
         """
@@ -250,37 +241,15 @@ class KJTListAwaitable(Awaitable[KJTList]):
         Returns:
             KJTList: synced `KJTList`.
         """
-        kjts = [w.wait() for w in self.awaitables]
-        _set_sharding_context_post_a2a(kjts, self.ctx)
-        return KJTList(kjts)
+
+        return KJTList([w.wait() for w in self.awaitables])
 
 
-def _set_sharding_context_post_a2a(
-    kjts: List[KeyedJaggedTensor],
-    ctx: C,
-) -> None:
-    for kjt, sharding_context in zip(kjts, getattr(ctx, "sharding_contexts", [])):
-        if getattr(sharding_context, "variable_batch_per_feature", False):
-            if (
-                hasattr(sharding_context, "batch_size_per_rank_per_feature")
-                and kjt.stride_per_key_per_rank()
-            ):
-                sharding_context.batch_size_per_rank_per_feature = [
-                    [
-                        kjt.stride_per_key_per_rank()[i][j]
-                        for i in range(len(kjt.stride_per_key_per_rank()))
-                    ]
-                    for j in range(len(kjt.stride_per_key_per_rank()[0]))
-                ]
-        else:
-            if (
-                hasattr(sharding_context, "batch_size_per_rank")
-                and kjt.stride_per_key_per_rank()
-            ):
-                sharding_context.batch_size_per_rank = kjt.stride_per_key_per_rank()[0]
+C = TypeVar("C", bound=Multistreamable)
+T = TypeVar("T")
 
 
-def _set_sharding_context_intra_a2a(
+def _set_sharding_context(
     tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
     ctx: C,
 ) -> None:
@@ -289,31 +258,14 @@ def _set_sharding_context_intra_a2a(
         getattr(ctx, "sharding_contexts", []),
     ):
         if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
+            if hasattr(sharding_context, "batch_size_per_rank"):
+                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
                 sharding_context.output_splits = awaitable._output_splits["values"]
             if hasattr(sharding_context, "sparse_features_recat"):
                 sharding_context.sparse_features_recat = awaitable._recat
-
-
-def _set_sharding_context_pre_a2a(
-    awaitables: List[Awaitable[Awaitable[KeyedJaggedTensor]]],
-    ctx: C,
-) -> None:
-    for awaitable, sharding_context in zip(
-        awaitables,
-        getattr(ctx, "sharding_contexts", []),
-    ):
-        kjt = (
-            awaitable._obj._obj
-            if isinstance(awaitable, NoWait)
-            else awaitable._input  # pyre-ignore[16]: KJTAllToAllSplitsAwaitable or KJTSplitsAllToAllMeta
-        )
-        if hasattr(sharding_context, "batch_size_per_feature_pre_a2a"):
-            sharding_context.batch_size_per_feature_pre_a2a = kjt.stride_per_key()
-        if hasattr(sharding_context, "variable_batch_per_feature"):
-            sharding_context.variable_batch_per_feature = kjt.variable_stride_per_key()
 
 
 def _split(flat_list: List[T], splits: List[int]) -> List[List[T]]:
@@ -341,7 +293,6 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
         super().__init__()
         self.awaitables = awaitables
         self.ctx = ctx
-        _set_sharding_context_pre_a2a(self.awaitables, self.ctx)
 
     def _wait_impl(self) -> KJTListAwaitable:
         """
@@ -355,14 +306,14 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
             KJTListAwaitable: awaitables for tensors of the sparse features.
         """
         tensors_awaitables = [w.wait() for w in self.awaitables]
-        _set_sharding_context_intra_a2a(tensors_awaitables, self.ctx)
-        return KJTListAwaitable(tensors_awaitables, self.ctx)
+        _set_sharding_context(tensors_awaitables, self.ctx)
+        return KJTListAwaitable(tensors_awaitables)
 
 
 @dataclass
 class KJTSplitsAllToAllMeta:
     pg: dist.ProcessGroup
-    _input: KeyedJaggedTensor
+    input: KeyedJaggedTensor
     splits: List[int]
     splits_tensors: List[torch.Tensor]
     input_splits: List[List[int]]
@@ -385,8 +336,6 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
         ] = [awaitable for request in requests for awaitable in request.awaitables]
-        for req, ctx in zip(requests, self._contexts):
-            _set_sharding_context_pre_a2a(req.awaitables, ctx)
         self._output_lengths: List[int] = [
             len(request.awaitables) for request in requests
         ]
@@ -421,21 +370,24 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         else:
             splits_per_awaitable = [[] for _ in range(len(self._lengths))]
         tensors_awaitables = []
-        for output_splits, awaitable in zip(splits_per_awaitable, self._awaitables):
-            if not output_splits:  # NoWait
+        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+            if not splits:  # NoWait
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
                 continue
+            output_splits = splits[:-1]
+            batch_size_per_rank = splits[-1]
             assert isinstance(awaitable, KJTSplitsAllToAllMeta)
             tensors_awaitables.append(
                 KJTAllToAllTensorsAwaitable(
                     pg=awaitable.pg,
-                    input=awaitable._input,
+                    input=awaitable.input,
                     splits=awaitable.splits,
                     input_splits=awaitable.input_splits,
                     output_splits=output_splits,
                     input_tensors=awaitable.input_tensors,
                     labels=awaitable.labels,
+                    batch_size_per_rank=batch_size_per_rank,
                     keys=awaitable.keys,
                     device=awaitable.device,
                     stagger=awaitable.stagger,
@@ -444,8 +396,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context_intra_a2a(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables, ctx))
+            _set_sharding_context(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables))
         return output
 
 
@@ -511,9 +463,6 @@ W = TypeVar("W")
 @dataclass
 class EmbeddingShardingContext(Multistreamable):
     batch_size_per_rank: List[int] = field(default_factory=list)
-    batch_size_per_rank_per_feature: List[List[int]] = field(default_factory=list)
-    batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
-    variable_batch_per_feature: bool = False
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         pass

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -251,11 +251,10 @@ class CwPooledEmbeddingSharding(
             callbacks = [embedding_permute_op]
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            pg=self._pg,
-            dim_sum_per_rank=self._dim_sum_per_rank(),
-            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
-            device=device,
-            callbacks=callbacks,
+            self._pg,
+            self._dim_sum_per_rank(),
+            device,
+            callbacks,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -145,10 +145,6 @@ class DpSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[Awaitable[SparseFeatures]]: awaitable of awaitable of SparseFeatures.
         """
 
-        if sparse_features.variable_stride_per_key():
-            raise ValueError(
-                "Dense TBE kernel does not support variable batch per feature"
-            )
         return NoWait(cast(Awaitable[KeyedJaggedTensor], NoWait(sparse_features)))
 
 

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -256,11 +256,6 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
 
-        if sparse_features.variable_stride_per_key():
-            raise ValueError(
-                "Variable batch per feature is not supported with row-wise sharding"
-            )
-
         (
             bucketized_features,
             self.unbucketize_permute_tensor,
@@ -294,7 +289,6 @@ class RwPooledEmbeddingDist(
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__()
-        self._pg: dist.ProcessGroup = pg
 
         self._dist = PooledEmbeddingsReduceScatter(
             pg,
@@ -323,10 +317,6 @@ class RwPooledEmbeddingDist(
         if sharding_ctx is None:
             return self._dist(local_embs)
         else:
-            if local_embs.numel() == 0 and local_embs.shape == torch.Size([0]):
-                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
-                b_local = sharding_ctx.batch_size_per_feature_pre_a2a[0]
-                local_embs = local_embs.view(b_local * self._pg.size(), 0)
             return self._dist(local_embs, input_splits=sharding_ctx.batch_size_per_rank)
 
 

--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -31,8 +31,6 @@ class SequenceShardingContext(EmbeddingShardingContext):
             KJT bucketize (for row-wise sharding only).
         lengths_after_input_dist (Optional[torch.Tensor]): stores the KJT length after
             input dist.
-        batch_size_per_feature_pre_a2a (List[int]): stores the batch size per feature
-            before input dist.
     """
 
     features_before_input_dist: Optional[KeyedJaggedTensor] = None
@@ -41,7 +39,6 @@ class SequenceShardingContext(EmbeddingShardingContext):
     sparse_features_recat: Optional[torch.Tensor] = None
     unbucketize_permute_tensor: Optional[torch.Tensor] = None
     lengths_after_input_dist: Optional[torch.Tensor] = None
-    batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         if self.features_before_input_dist is not None:

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, cast, Dict, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -14,7 +14,6 @@ from torchrec.distributed.dist_data import (
     KJTAllToAll,
     KJTOneToAll,
     PooledEmbeddingsAllToAll,
-    VariableBatchPooledEmbeddingsAllToAll,
 )
 from torchrec.distributed.embedding_lookup import (
     GroupedPooledEmbeddingsLookup,
@@ -145,15 +144,6 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             dim_sum_per_rank.append(dim_sum)
         return dim_sum_per_rank
 
-    def _emb_dim_per_rank_per_feature(self) -> List[List[int]]:
-        emb_dim_per_rank_per_feature = []
-        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
-            emb_dim_per_feature = []
-            for grouped_config in grouped_embedding_configs:
-                emb_dim_per_feature += grouped_config.embedding_dims()
-            emb_dim_per_rank_per_feature.append(emb_dim_per_feature)
-        return emb_dim_per_rank_per_feature
-
     def embedding_dims(self) -> List[int]:
         embedding_dims = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
@@ -261,8 +251,6 @@ class TwPooledEmbeddingDist(
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
         dim_sum_per_rank (List[int]): number of features (sum of dimensions) of the
             embedding in each rank.
-        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimension per rank per
-            feature, used for variable batch per feature.
         device (Optional[torch.device]): device on which buffers will be allocated.
         callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]):
         qcomm_codecs_registry (Optional[Dict[str, QuantizedCommCodecs]]):
@@ -272,25 +260,22 @@ class TwPooledEmbeddingDist(
         self,
         pg: dist.ProcessGroup,
         dim_sum_per_rank: List[int],
-        emb_dim_per_rank_per_feature: List[List[int]],
         device: Optional[torch.device] = None,
         callbacks: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__()
-        self._pg = pg
-        self._dim_sum_per_rank = dim_sum_per_rank
-        self._device = device
-        self._callbacks = callbacks
-        self._codecs: Optional[QuantizedCommCodecs] = (
-            qcomm_codecs_registry.get(CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None)
+        self._dist = PooledEmbeddingsAllToAll(
+            pg=pg,
+            dim_sum_per_rank=dim_sum_per_rank,
+            device=device,
+            callbacks=callbacks,
+            codecs=qcomm_codecs_registry.get(
+                CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None
+            )
             if qcomm_codecs_registry
-            else None
+            else None,
         )
-        self._emb_dim_per_rank_per_feature = emb_dim_per_rank_per_feature
-        self._dist: Optional[
-            Union[PooledEmbeddingsAllToAll, VariableBatchPooledEmbeddingsAllToAll]
-        ] = None
 
     def forward(
         self,
@@ -302,48 +287,15 @@ class TwPooledEmbeddingDist(
 
         Args:
             local_embs (torch.Tensor): tensor of values to distribute.
-            sharding_ctx (Optional[EmbeddingShardingContext]): shared context from
-                KJTAllToAll operation.
 
         Returns:
             Awaitable[torch.Tensor]: awaitable of pooled embeddings.
         """
-        if self._dist is None:
-            self._create_output_dist_module(sharding_ctx)
-
         if sharding_ctx is None:
-            return cast(PooledEmbeddingsAllToAll, self._dist)(local_embs)
-        elif sharding_ctx.variable_batch_per_feature:
-            return cast(VariableBatchPooledEmbeddingsAllToAll, self._dist)(
-                local_embs,
-                batch_size_per_rank_per_feature=sharding_ctx.batch_size_per_rank_per_feature,
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
-            )
+            return self._dist(local_embs)
         else:
-            return cast(PooledEmbeddingsAllToAll, self._dist)(
-                local_embs,
-                batch_size_per_rank=sharding_ctx.batch_size_per_rank,
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
-            )
-
-    def _create_output_dist_module(
-        self, sharding_ctx: Optional[EmbeddingShardingContext] = None
-    ) -> None:
-        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
-            self._dist = VariableBatchPooledEmbeddingsAllToAll(
-                pg=self._pg,
-                emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature,
-                device=self._device,
-                callbacks=self._callbacks,
-                codecs=self._codecs,
-            )
-        else:
-            self._dist = PooledEmbeddingsAllToAll(
-                pg=self._pg,
-                dim_sum_per_rank=self._dim_sum_per_rank,
-                device=self._device,
-                callbacks=self._callbacks,
-                codecs=self._codecs,
+            return self._dist(
+                local_embs, batch_size_per_rank=sharding_ctx.batch_size_per_rank
             )
 
 
@@ -386,10 +338,9 @@ class TwPooledEmbeddingSharding(
     ) -> BaseEmbeddingDist[EmbeddingShardingContext, torch.Tensor, torch.Tensor]:
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            pg=self._pg,
-            dim_sum_per_rank=self._dim_sum_per_rank(),
-            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
-            device=device if device is not None else self._device,
+            self._pg,
+            self._dim_sum_per_rank(),
+            device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -328,11 +328,6 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[KeyedJaggedTensor]: awaitable of KeyedJaggedTensor.
         """
 
-        if sparse_features.variable_stride_per_key():
-            raise ValueError(
-                "Variable batch per feature is not supported with table-wise-row-wise sharding"
-            )
-
         bucketized_features = bucketize_kjt_before_all2all(
             sparse_features,
             num_buckets=self._local_size,
@@ -450,19 +445,7 @@ class TwRwPooledEmbeddingDist(
             local_rank = self._rank % self._intra_pg.size()
             batch_size_per_rank = batch_size_per_rank_by_cross_group[local_rank]
             rs_result = self._intra_dist(local_embs, input_splits=lengths).wait()
-            return self._cross_dist(
-                rs_result,
-                batch_size_per_rank=batch_size_per_rank,
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
-            )
-        elif sharding_ctx is not None:
-            if local_embs.numel() == 0 and local_embs.shape == torch.Size([0]):
-                assert len(set(sharding_ctx.batch_size_per_feature_pre_a2a)) == 1
-                b_local = sharding_ctx.batch_size_per_feature_pre_a2a[0]
-                local_embs = local_embs.view(
-                    b_local * self._intra_pg.size() * self._cross_pg.size(), 0
-                )
-            return self._cross_dist(self._intra_dist(local_embs).wait())
+            return self._cross_dist(rs_result, batch_size_per_rank=batch_size_per_rank)
         else:
             return self._cross_dist(self._intra_dist(local_embs).wait())
 

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -395,13 +395,13 @@ class TestOverArch(nn.Module):
 def _post_sparsenn_forward(
     ebc: KeyedTensor,
     fp_ebc: Optional[KeyedTensor],
-    w_ebc: Optional[KeyedTensor],
+    w_ebc: KeyedTensor,
     batch_size: Optional[int] = None,
 ) -> KeyedTensor:
     if batch_size is None or ebc.values().size(0) == batch_size:
         ebc_values = ebc.values()
         fp_ebc_values = fp_ebc.values() if fp_ebc is not None else None
-        w_ebc_values = w_ebc.values() if w_ebc is not None else None
+        w_ebc_values = w_ebc.values()
     else:
         ebc_values = torch.zeros(
             batch_size,
@@ -420,56 +420,33 @@ def _post_sparsenn_forward(
             fp_ebc_values[: fp_ebc.values().size(0), :] = fp_ebc.values()
         else:
             fp_ebc_values = None
-        if w_ebc is not None:
-            w_ebc_values = torch.zeros(
-                batch_size,
-                w_ebc.values().size(1),
-                dtype=w_ebc.values().dtype,
-                device=w_ebc.values().device,
-            )
-            w_ebc_values[: w_ebc.values().size(0), :] = w_ebc.values()
-        else:
-            w_ebc_values = None
-
-    if fp_ebc is None and w_ebc is None:
-        return KeyedTensor(
-            keys=ebc.keys(),
-            length_per_key=ebc.length_per_key(),
-            values=ebc_values,
+        w_ebc_values = torch.zeros(
+            batch_size,
+            w_ebc.values().size(1),
+            dtype=w_ebc.values().dtype,
+            device=w_ebc.values().device,
         )
-    elif fp_ebc is None and w_ebc is not None:
-        return KeyedTensor(
+        w_ebc_values[: w_ebc.values().size(0), :] = w_ebc.values()
+    result = (
+        KeyedTensor(
             keys=ebc.keys() + w_ebc.keys(),
             length_per_key=ebc.length_per_key() + w_ebc.length_per_key(),
-            values=torch.cat(
-                [ebc_values, torch.jit._unwrap_optional(w_ebc_values)], dim=1
-            ),
+            values=torch.cat([ebc_values, w_ebc_values], dim=1),
         )
-    elif fp_ebc is not None and w_ebc is None:
-        return KeyedTensor(
-            keys=ebc.keys() + fp_ebc.keys(),
-            length_per_key=ebc.length_per_key() + fp_ebc.length_per_key(),
-            values=torch.cat(
-                [ebc_values, torch.jit._unwrap_optional(fp_ebc_values)], dim=1
-            ),
-        )
-    else:
-        assert fp_ebc is not None and w_ebc is not None
-        return KeyedTensor(
+        if fp_ebc is None
+        else KeyedTensor(
             keys=ebc.keys() + fp_ebc.keys() + w_ebc.keys(),
             length_per_key=ebc.length_per_key()
             + fp_ebc.length_per_key()
             + w_ebc.length_per_key(),
             # Comment to torch.jit._unwrap_optional fp_ebc_values is inferred as Optional[Tensor] as it can be None when fp_ebc is None. But at this point we now that it has a value and doing jit._unwrap_optional will tell jit to treat it as Tensor type.
             values=torch.cat(
-                [
-                    ebc_values,
-                    torch.jit._unwrap_optional(fp_ebc_values),
-                    torch.jit._unwrap_optional(w_ebc_values),
-                ],
+                [ebc_values, torch.jit._unwrap_optional(fp_ebc_values), w_ebc_values],
                 dim=1,
             ),
         )
+    )
+    return result
 
 
 class TestSparseArch(nn.Module):
@@ -536,20 +513,16 @@ class TestSparseArch(nn.Module):
                 tables=tables,
                 device=device,
             )
-        self.weighted_ebc: Optional[EmbeddingBagCollection] = (
-            EmbeddingBagCollection(
-                tables=weighted_tables,
-                is_weighted=True,
-                device=device,
-            )
-            if weighted_tables
-            else None
+        self.weighted_ebc: EmbeddingBagCollection = EmbeddingBagCollection(
+            tables=weighted_tables,
+            is_weighted=True,
+            device=device,
         )
 
     def forward(
         self,
         features: KeyedJaggedTensor,
-        weighted_features: Optional[KeyedJaggedTensor] = None,
+        weighted_features: KeyedJaggedTensor,
         batch_size: Optional[int] = None,
     ) -> KeyedTensor:
         fp_features = features
@@ -562,11 +535,7 @@ class TestSparseArch(nn.Module):
         fp_ebc: Optional[KeyedTensor] = (
             self.fp_ebc(fp_features) if self.fp_ebc is not None else None
         )
-        w_ebc = (
-            self.weighted_ebc(weighted_features)
-            if self.weighted_ebc is not None and weighted_features is not None
-            else None
-        )
+        w_ebc = self.weighted_ebc(weighted_features)
         result = _post_sparsenn_forward(ebc, fp_ebc, w_ebc, batch_size)
         return result
 
@@ -660,9 +629,7 @@ class TestSparseNN(TestSparseNNBase, CopyableMixin):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         dense_r = self.dense(input.float_features)
         sparse_r = self.sparse(
-            features=input.idlist_features,
-            weighted_features=input.idscore_features,
-            batch_size=input.float_features.size(0),
+            input.idlist_features, input.idscore_features, input.float_features.size(0)
         )
         over_r = self.over(dense_r, sparse_r)
         pred = torch.sigmoid(torch.mean(over_r, dim=1)) + self.dummy_ones

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -8,7 +8,7 @@
 import itertools
 import random
 import unittest
-from typing import Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Dict, Generator, List, Optional, Tuple, TypeVar, Union
 
 import hypothesis.strategies as st
 import torch
@@ -23,7 +23,6 @@ from torchrec.distributed.dist_data import (
     PooledEmbeddingsAllToAll,
     PooledEmbeddingsReduceScatter,
     SequenceEmbeddingsAllToAll,
-    VariableBatchPooledEmbeddingsAllToAll,
 )
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
@@ -35,10 +34,10 @@ from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
-T = TypeVar("T", int, float, List[int])
+T = TypeVar("T", int, float)
 
 # Lightly adapted from Stack Overflow #10823877
-def _flatten(iterable: Iterable[T]) -> Generator[T, None, None]:
+def _flatten(iterable: List[T]) -> Generator[T, None, None]:
     iterator, sentinel, stack = iter(iterable), object(), []
     while True:
         value = next(iterator, sentinel)
@@ -109,86 +108,6 @@ def _generate_sparse_features_batch(
         out_jagged.append(
             KeyedJaggedTensor.from_lengths_sync(
                 keys=out_keys,
-                lengths=_to_tensor(
-                    [lengths[key][j] for key, j in key_index],
-                    torch.int,
-                ),
-                values=_to_tensor(
-                    [values[key][j] for key, j in key_index],
-                    torch.int,
-                ),
-                weights=_to_tensor(
-                    [weights[key][j] for key, j in key_index],
-                    torch.float,
-                )
-                if weights
-                else None,
-            )
-        )
-    return in_jagged, out_jagged
-
-
-def _generate_variable_batch_sparse_features_batch(
-    keys: List[str],
-    splits: List[int],
-    batch_size_per_rank_per_feature: List[List[List[int]]],
-    is_weighted: bool = False,
-) -> Tuple[List[KeyedJaggedTensor], List[KeyedJaggedTensor]]:
-    world_size = len(splits)
-    offsets = [0] + list(itertools.accumulate(splits))
-    values = {}
-    lengths = {}
-    weights = {} if is_weighted else None
-
-    for i, key in enumerate(keys):
-        lengths[key] = [
-            [
-                random.randint(0, 10)
-                for _ in range(sum(batch_size_per_rank_per_feature[rank][i]))
-            ]
-            for rank in range(world_size)
-        ]
-        values[key] = [
-            [random.randint(0, 1000) for _ in range(sum(lengths[key][j]))]
-            for j in range(world_size)
-        ]
-
-        if weights:
-            weights[key] = [
-                [random.random() for _ in range(sum(lengths[key][j]))]
-                for j in range(world_size)
-            ]
-
-    in_jagged: List[KeyedJaggedTensor] = []
-    out_jagged: List[KeyedJaggedTensor] = []
-    for i in range(world_size):
-        in_jagged.append(
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=keys,
-                stride_per_key_per_rank=batch_size_per_rank_per_feature[i],
-                lengths=_to_tensor([lengths[key][i] for key in keys], torch.int),
-                values=_to_tensor([values[key][i] for key in keys], torch.int),
-                weights=_to_tensor([weights[key][i] for key in keys], torch.float)
-                if weights
-                else None,
-            )
-        )
-        key_index = []
-        out_keys = keys[offsets[i] : offsets[i + 1]]
-        key_indices = [keys.index(k) for k in out_keys]
-        batch_sizes_by_rank = list(zip(*batch_size_per_rank_per_feature))
-        for key in out_keys:
-            for j in range(world_size):
-                key_index.append((key, j))
-
-        out_jagged.append(
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=out_keys,
-                # pyre-ignore[6]
-                stride_per_key_per_rank=[
-                    list(_flatten(batch_sizes_by_rank[key_idx]))
-                    for key_idx in key_indices
-                ],
                 lengths=_to_tensor(
                     [lengths[key][j] for key, j in key_index],
                     torch.int,
@@ -292,6 +211,7 @@ class KJTAllToAllTest(MultiProcessTestBase):
         output: KeyedJaggedTensor,
         backend: str,
         splits: List[int],
+        batch_size_per_rank: List[int],
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         device = torch.device(f"cuda:{rank}")
@@ -355,66 +275,7 @@ class KJTAllToAllTest(MultiProcessTestBase):
                     "output": output[rank],
                     "backend": backend,
                     "splits": splits,
-                }
-            )
-
-        self._run_multi_process_test_per_rank(
-            callable=self._run_test_dist,
-            world_size=world_size,
-            kwargs_per_rank=kwargs_per_rank,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
-    # pyre-fixme[56]
-    @given(
-        backend=st.sampled_from(["nccl"]),
-        B=st.integers(min_value=1, max_value=2),
-        features=st.integers(min_value=3, max_value=4),
-        is_weighted=st.booleans(),
-        variable_batch_per_rank=st.booleans(),
-    )
-    @settings(max_examples=4, deadline=None)
-    def test_variable_batch_features(
-        self,
-        backend: str,
-        B: int,
-        features: int,
-        is_weighted: bool,
-        variable_batch_per_rank: bool,
-    ) -> None:
-        keys = [f"F{feature}" for feature in range(features)]
-        rank0_split = random.randint(0, features)
-        splits = [rank0_split, features - rank0_split]
-        world_size = 2
-
-        if variable_batch_per_rank:
-            batch_size_per_rank_per_feature = [
-                [[random.randint(B, B + 4)] for _ in range(features)]
-                for _ in range(world_size)
-            ]
-        else:
-            batch_size_per_rank_per_feature = [
-                [[random.randint(B, B + 4)] for _ in range(features)]
-            ] * world_size
-
-        _input, output = _generate_variable_batch_sparse_features_batch(
-            keys=keys,
-            splits=splits,
-            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
-            is_weighted=is_weighted,
-        )
-
-        kwargs_per_rank = []
-        for rank in range(world_size):
-            kwargs_per_rank.append(
-                {
-                    "_input": _input[rank],
-                    "output": output[rank],
-                    "backend": backend,
-                    "splits": splits,
+                    "batch_size_per_rank": batch_size_per_rank,
                 }
             )
 
@@ -1144,258 +1005,6 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
                     "qcomms_config": qcomms_config,
                 }
             )
-        self._run_multi_process_test_per_rank(
-            callable=self._run_test_dist,
-            world_size=world_size,
-            kwargs_per_rank=kwargs_per_rank,
-        )
-
-
-class VariableBatchPooledEmbeddingsAllToAllTest(MultiProcessTestBase):
-    @classmethod
-    def _run_test_dist(
-        cls,
-        rank: int,
-        world_size: int,
-        _input: torch.Tensor,
-        output: torch.Tensor,
-        backend: str,
-        emb_dim_per_rank_per_feature: List[List[int]],
-        batch_size_per_rank_per_feature: List[List[int]],
-        batch_size_per_feature_pre_a2a: List[int],
-        qcomms_config: Optional[QCommsConfig] = None,
-    ) -> None:
-        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
-        pg = dist.group.WORLD
-        if backend == "gloo":
-            device = torch.device("cpu")
-        else:
-            device = torch.device(f"cuda:{rank}")
-        _input = _input.to(device=device)
-        output = output.to(device=device)
-
-        codecs = get_qcomm_codecs(qcomms_config)
-
-        a2a = VariableBatchPooledEmbeddingsAllToAll(
-            # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
-            #  `Optional[_distributed_c10d.ProcessGroup]`.
-            pg=pg,
-            emb_dim_per_rank_per_feature=emb_dim_per_rank_per_feature,
-            device=device,
-            codecs=codecs,
-        )
-        _input.requires_grad = True
-        res = a2a(
-            local_embs=_input,
-            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
-            batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
-        ).wait()
-        res.backward(res)
-
-        atol, rtol = None, None
-        if qcomms_config is not None:
-            atol, rtol = 0.01, 0.01
-            if (
-                qcomms_config.forward_precision == CommType.FP8
-                or qcomms_config.backward_precision == CommType.FP8
-            ):
-                atol, rtol = 0.05, 0.05
-
-        torch.testing.assert_close(res, output, rtol=rtol, atol=atol)
-
-        torch.testing.assert_close(
-            _input.cpu().detach().div_(world_size),
-            # pyre-ignore
-            _input.grad.cpu().detach(),
-            atol=atol,
-            rtol=rtol,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
-    # pyre-fixme[56]
-    @given(
-        backend=st.sampled_from(["nccl"]),
-        features=st.integers(min_value=3, max_value=4),
-        B=st.integers(min_value=2, max_value=3),
-        is_reversed=st.booleans(),
-        qcomms_config=st.sampled_from(
-            [
-                None,
-                QCommsConfig(
-                    forward_precision=CommType.FP16,
-                    backward_precision=CommType.FP16,
-                ),
-                QCommsConfig(
-                    forward_precision=CommType.FP16,
-                    backward_precision=CommType.BF16,
-                ),
-                QCommsConfig(
-                    forward_precision=CommType.FP16,
-                    backward_precision=CommType.FP16,
-                    backward_loss_scale=128.0,
-                ),
-                QCommsConfig(
-                    forward_precision=CommType.FP32,
-                    backward_precision=CommType.BF16,
-                ),
-                QCommsConfig(
-                    forward_precision=CommType.FP8,
-                    backward_precision=CommType.FP8,
-                ),
-                QCommsConfig(
-                    forward_precision=CommType.FP8,
-                    backward_precision=CommType.BF16,
-                ),
-            ]
-        ),
-    )
-    @settings(max_examples=4, deadline=None)
-    def test_variable_batch_pooled_embeddings(
-        self,
-        backend: str,
-        B: int,
-        features: int,
-        is_reversed: bool,
-        qcomms_config: Optional[QCommsConfig],
-    ) -> None:
-        world_size = 2
-        keys = [f"F{feature}" for feature in range(features)]
-        dims = random.sample([8, 16, 32] * features, features)
-        rank0_split = random.randint(1, features - 1)
-        splits = [rank0_split, features - rank0_split]
-        if is_reversed:
-            splits.reverse()
-        emb_dim_per_rank_per_feature = []
-        f_id = 0
-        for split in splits:
-            emb_dim_per_feature = []
-            for _ in range(split):
-                emb_dim_per_feature.append(dims[f_id])
-                f_id += 1
-            emb_dim_per_rank_per_feature.append(emb_dim_per_feature)
-
-        batch_size_per_rank_per_feature_pre_a2a = []
-        for _ in range(world_size):
-            batch_size_per_feature = [random.randint(B, B + 4) for _ in keys]
-            batch_size_per_rank_per_feature_pre_a2a.append(batch_size_per_feature)
-
-        batch_size_per_rank_per_feature_post_a2a_per_rank = []
-        fid = 0
-        for i in range(world_size):
-            batch_size_per_rank_per_feature_post_a2a = [[] for _ in range(world_size)]
-            split = splits[i]
-            for _ in range(split):
-                for j in range(world_size):
-                    batch_size_per_rank_per_feature_post_a2a[j].append(
-                        batch_size_per_rank_per_feature_pre_a2a[j][fid]
-                    )
-                fid += 1
-            batch_size_per_rank_per_feature_post_a2a_per_rank.append(
-                batch_size_per_rank_per_feature_post_a2a
-            )
-
-        """
-        before input dist:
-        r_0
-        f_0: [1, 2], [3, 4]
-        f_1: [5, 6]
-        f_2: [1],    [2],   [3]
-
-        r_1
-        f_0: [1, 2]
-        f_1: [5, 6], [3, 4]
-        f_2: [1],    [2]
-
-        after input dist (splits: [1, 2]):
-        r_0
-        f_0: [1, 2], [3, 4], [1, 2]
-
-        r_1
-        f_1: [5, 6], [5, 6], [3, 4]
-        f_2: [1], [2], [3], [1], [2]
-
-        output layout
-        r_0:
-        [r_0_f_0_s_0, r_0_f_0_s_1, r_1_f_0_s_0]
-
-        r_1:
-        [r_0_f_1_s_0, r_0_f_2_s_0, r_0_f_2_s_1, r_0_f_2_s_2,
-         r_1_f_1_s_0, r_1_f_1_s_1, r_1_f_2_s_0, r_1_f_2_s_1]
-
-        after output dist
-        r_0:
-        [r_0_f_0_s_0, r_0_f_0_s_1, r_0_f_1_s_0, r_0_f_2_s_0, r_0_f_2_s_1, r_0_f_2_s_2]
-
-        r_1:
-        [r_1_f_0_s_0, r_1_f_1_s_0, r_1_f_1_s_1, r_1_f_2_s_0, r_1_f_2_s_1]
-        """
-
-        def _generate_variable_batch_pooled_embedding_batch(
-            keys: List[str],
-            dims: List[int],
-            splits: List[int],
-            batch_size_per_rank_per_feature: List[List[int]],
-        ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-            world_size = len(splits)
-            offsets = [0] + list(itertools.accumulate(splits))
-            local_embs = {}
-
-            feature_ind = 0
-            for key, dim in zip(keys, dims):
-                for rank in range(world_size):
-                    local_batch_size = batch_size_per_rank_per_feature[rank][
-                        feature_ind
-                    ]
-                    if rank not in local_embs:
-                        local_embs[rank] = {}
-                    local_embs[rank][key] = torch.rand(
-                        dim * local_batch_size, dtype=torch.float
-                    )
-                feature_ind += 1
-
-            in_tensor: List[torch.Tensor] = []
-            out_tensor: List[torch.Tensor] = []
-            for i in range(world_size):
-                in_keys = keys[offsets[i] : offsets[i + 1]]
-                input_tensor_list = []
-                for rank in range(world_size):
-                    input_tensor_list += [local_embs[rank][key] for key in in_keys]
-                input_tensor = torch.cat(input_tensor_list)
-                in_tensor.append(input_tensor)
-
-                output_tensor = torch.cat([local_embs[i][key] for key in keys])
-                out_tensor.append(output_tensor)
-
-            return in_tensor, out_tensor
-
-        _input, output = _generate_variable_batch_pooled_embedding_batch(
-            keys=keys,
-            dims=dims,
-            splits=splits,
-            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature_pre_a2a,
-        )
-
-        kwargs_per_rank = []
-        for rank in range(world_size):
-            kwargs_per_rank.append(
-                {
-                    "_input": _input[rank],
-                    "output": output[rank],
-                    "backend": backend,
-                    "emb_dim_per_rank_per_feature": emb_dim_per_rank_per_feature,
-                    "batch_size_per_rank_per_feature": batch_size_per_rank_per_feature_post_a2a_per_rank[
-                        rank
-                    ],
-                    "batch_size_per_feature_pre_a2a": batch_size_per_rank_per_feature_pre_a2a[
-                        rank
-                    ],
-                    "qcomms_config": qcomms_config,
-                }
-            )
-
         self._run_multi_process_test_per_rank(
             callable=self._run_test_dist,
             world_size=world_size,

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -9,13 +9,11 @@ import unittest
 from typing import Any, Dict, Optional, Tuple, Type
 
 import torch
-from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import assume, given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.test_utils.test_model import (
-    TestSparseNN,
     TestTowerCollectionSparseNN,
     TestTowerSparseNN,
 )
@@ -23,7 +21,6 @@ from torchrec.distributed.test_utils.test_model_parallel import ModelParallelTes
 from torchrec.distributed.test_utils.test_sharding import (
     create_test_sharder,
     SharderType,
-    sharding_single_rank_test,
 )
 from torchrec.distributed.types import ShardingType
 from torchrec.test_utils import skip_if_asan_class
@@ -203,44 +200,6 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 3,
-        "Not enough GPUs, this test requires at least three GPUs",
-    )
-    # pyre-fixme[56]
-    @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.TABLE_ROW_WISE.value,
-                ShardingType.TABLE_COLUMN_WISE.value,
-            ]
-        ),
-    )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
-    def test_sharding_empty_rank(self, sharding_type: str) -> None:
-        table = self.tables[0]
-        embedding_groups = {"group_0": table.feature_names}
-        self._run_multi_process_test(
-            callable=sharding_single_rank_test,
-            world_size=4,
-            local_size=2,
-            model_class=TestSparseNN,
-            tables=[table],
-            embedding_groups=embedding_groups,
-            sharders=[
-                create_test_sharder(
-                    SharderType.EMBEDDING_BAG_COLLECTION.value,
-                    sharding_type,
-                    EmbeddingComputeKernel.FUSED.value,
-                    device=torch.device("cuda"),
-                )
-            ],
-            optim=EmbOptimType.EXACT_SGD,
-            backend="nccl",
-            constraints={table.name: ParameterConstraints(min_partition=4)},
-            variable_batch_size=True,
         )
 
     @unittest.skipIf(

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -37,12 +37,13 @@ from torch.autograd.profiler import record_function
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.fx.node import Node
 from torchrec.distributed.dist_data import KJTAllToAll, KJTAllToAllTensorsAwaitable
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     KJTListAwaitable,
     KJTListSplitsAwaitable,
 )
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
-from torchrec.distributed.types import Awaitable, NoWait
+from torchrec.distributed.types import Awaitable
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable, Pipelineable
 
@@ -216,7 +217,7 @@ T = TypeVar("T")
 
 
 # TODO: remove after packaging issue is resolved.
-def _set_sharding_context_intra_a2a(
+def _set_sharding_context(
     tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
     ctx: C,
 ) -> None:
@@ -225,6 +226,8 @@ def _set_sharding_context_intra_a2a(
         getattr(ctx, "sharding_contexts", []),
     ):
         if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
+            if hasattr(sharding_context, "batch_size_per_rank"):
+                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
@@ -234,30 +237,10 @@ def _set_sharding_context_intra_a2a(
 
 
 # TODO: remove after packaging issue is resolved.
-def _set_sharding_context_pre_a2a(
-    awaitables: List[Awaitable[Awaitable[KeyedJaggedTensor]]],
-    ctx: C,
-) -> None:
-    for awaitable, sharding_context in zip(
-        awaitables,
-        getattr(ctx, "sharding_contexts", []),
-    ):
-        kjt = (
-            awaitable._obj._obj
-            if isinstance(awaitable, NoWait)
-            else awaitable._input  # pyre-ignore[16]: KJTAllToAllSplitsAwaitable or KJTSplitsAllToAllMeta
-        )
-        if hasattr(sharding_context, "batch_size_per_feature_pre_a2a"):
-            sharding_context.batch_size_per_feature_pre_a2a = kjt.stride_per_key()
-        if hasattr(sharding_context, "variable_batch_per_feature"):
-            sharding_context.variable_batch_per_feature = kjt.variable_stride_per_key()
-
-
-# TODO: remove after packaging issue is resolved.
 @dataclass
 class KJTSplitsAllToAllMeta:
     pg: dist.ProcessGroup
-    _input: KeyedJaggedTensor
+    input: KeyedJaggedTensor
     splits: List[int]
     splits_tensors: List[torch.Tensor]
     input_splits: List[List[int]]
@@ -288,8 +271,6 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
         ] = [awaitable for request in requests for awaitable in request.awaitables]
-        for req, ctx in zip(requests, self._contexts):
-            _set_sharding_context_pre_a2a(req.awaitables, ctx)
         self._output_lengths: List[int] = [
             len(request.awaitables) for request in requests
         ]
@@ -324,21 +305,24 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         else:
             splits_per_awaitable = [[] for _ in range(len(self._lengths))]
         tensors_awaitables = []
-        for output_splits, awaitable in zip(splits_per_awaitable, self._awaitables):
-            if not output_splits:  # NoWait
+        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+            if not splits:  # NoWait
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
                 continue
+            output_splits = splits[:-1]
+            batch_size_per_rank = splits[-1]
             assert isinstance(awaitable, KJTSplitsAllToAllMeta)
             tensors_awaitables.append(
                 KJTAllToAllTensorsAwaitable(
                     pg=awaitable.pg,
-                    input=awaitable._input,
+                    input=awaitable.input,
                     splits=awaitable.splits,
                     input_splits=awaitable.input_splits,
                     output_splits=output_splits,
                     input_tensors=awaitable.input_tensors,
                     labels=awaitable.labels,
+                    batch_size_per_rank=batch_size_per_rank,
                     keys=awaitable.keys,
                     device=awaitable.device,
                     stagger=awaitable.stagger,
@@ -347,8 +331,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context_intra_a2a(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables, ctx))
+            _set_sharding_context(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables))
         return output
 
 
@@ -535,7 +519,7 @@ class KJTAllToAllForward:
             splits_tensors.append(batch_size_tensor)
             return KJTSplitsAllToAllMeta(
                 pg=self._pg,
-                _input=input,
+                input=input,
                 splits=self._splits,
                 splits_tensors=splits_tensors,
                 input_splits=input_splits,

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -30,14 +30,6 @@ except ImportError:
     pass
 
 
-def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
-    return (
-        tensor
-        if device.type == "cpu"
-        else tensor.pin_memory().to(device=device, non_blocking=True)
-    )
-
-
 def _cumsum(o: List[int]) -> List[int]:
     ret = [0] * (len(o) + 1)
     for i in range(len(o)):
@@ -632,39 +624,23 @@ def _maybe_compute_stride_kjt_scripted(
     return torch.tensor([_maybe_compute_stride_kjt(keys, stride, lengths, offsets)])
 
 
-def _length_per_key_from_stride_per_key(
-    lengths: torch.Tensor, stride_per_key: List[int]
-) -> List[int]:
-    return [
-        int(torch.sum(chunk).item()) for chunk in torch.split(lengths, stride_per_key)
-    ]
-
-
 def _maybe_compute_length_per_key(
     keys: List[str],
     stride: int,
-    stride_per_key: List[int],
-    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
     offsets: Optional[torch.Tensor],
 ) -> List[int]:
     if length_per_key is None:
         if len(keys) and offsets is not None and len(offsets) > 0:
-            _length: List[int] = (
-                _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
-                if variable_stride_per_key
-                else torch.sum(torch.diff(offsets).view(-1, stride), dim=1).tolist()
-            )
+            _length: List[int] = torch.sum(
+                torch.diff(offsets).view(-1, stride), dim=1
+            ).tolist()
         elif len(keys) and lengths is not None:
             _length: List[int] = (
-                _length_per_key_from_stride_per_key(lengths, stride_per_key)
-                if variable_stride_per_key
-                else (
-                    torch.sum(lengths.view(-1, stride), dim=1).tolist()
-                    if lengths.numel() != 0
-                    else [0] * len(keys)
-                )
+                torch.sum(lengths.view(-1, stride), dim=1).tolist()
+                if lengths.numel() != 0
+                else [0] * len(keys)
             )
         else:
             _length: List[int] = []
@@ -675,8 +651,6 @@ def _maybe_compute_length_per_key(
 def _maybe_compute_offset_per_key(
     keys: List[str],
     stride: int,
-    stride_per_key: List[int],
-    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     offset_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
@@ -684,13 +658,7 @@ def _maybe_compute_offset_per_key(
 ) -> Tuple[List[int], List[int]]:
     if length_per_key is None:
         _length_per_key: List[int] = _maybe_compute_length_per_key(
-            keys=keys,
-            stride=stride,
-            stride_per_key=stride_per_key,
-            variable_stride_per_key=variable_stride_per_key,
-            length_per_key=length_per_key,
-            lengths=lengths,
-            offsets=offsets,
+            keys, stride, length_per_key, lengths, offsets
         )
         return _length_per_key, _cumsum(_length_per_key)
     elif offset_per_key is None:
@@ -757,12 +725,10 @@ class ComputeKJTToJTDict(torch.nn.Module):
         """
         return _maybe_compute_kjt_to_jt_dict(
             stride=keyed_jagged_tensor.stride(),
-            stride_per_key=keyed_jagged_tensor.stride_per_key(),
             keys=keyed_jagged_tensor.keys(),
             length_per_key=keyed_jagged_tensor.length_per_key(),
             values=keyed_jagged_tensor.values(),
             lengths=keyed_jagged_tensor.lengths(),
-            variable_stride_per_key=keyed_jagged_tensor.variable_stride_per_key(),
             weights=keyed_jagged_tensor.weights_or_none(),
             jt_dict=keyed_jagged_tensor._jt_dict,
         )
@@ -771,12 +737,10 @@ class ComputeKJTToJTDict(torch.nn.Module):
 @torch.fx.wrap
 def _maybe_compute_kjt_to_jt_dict(
     stride: int,
-    stride_per_key: List[int],
     keys: List[str],
     length_per_key: List[int],
     values: torch.Tensor,
     lengths: torch.Tensor,
-    variable_stride_per_key: bool,
     weights: Optional[torch.Tensor],
     jt_dict: Optional[Dict[str, JaggedTensor]],
 ) -> Dict[str, JaggedTensor]:
@@ -786,28 +750,21 @@ def _maybe_compute_kjt_to_jt_dict(
     if jt_dict is None:
         _jt_dict: Dict[str, JaggedTensor] = {}
         values_list = torch.split(values, length_per_key)
-        if variable_stride_per_key:
-            split_lengths = torch.split(lengths, stride_per_key)
-            split_offsets = [
-                torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
-                for lengths in split_lengths
-            ]
-        else:
-            split_lengths = torch.unbind(
-                lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
-            )
-            split_offsets = torch.unbind(
-                _batched_lengths_to_offsets(lengths.view(-1, stride))
-                if lengths.numel() != 0
-                else lengths,
-                dim=0,
-            )
+        lengths_tuple = torch.unbind(
+            lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
+        )
+        offsets_tuple = torch.unbind(
+            _batched_lengths_to_offsets(lengths.view(-1, stride))
+            if lengths.numel() != 0
+            else lengths,
+            dim=0,
+        )
 
         if weights is not None:
             weights_list = torch.split(weights, length_per_key)
             for idx, key in enumerate(keys):
-                length = split_lengths[idx]
-                offset = split_offsets[idx]
+                length = lengths_tuple[idx]
+                offset = offsets_tuple[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -816,8 +773,8 @@ def _maybe_compute_kjt_to_jt_dict(
                 )
         else:
             for idx, key in enumerate(keys):
-                length = split_lengths[idx]
-                offset = split_offsets[idx]
+                length = lengths_tuple[idx]
+                offset = offsets_tuple[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -1009,11 +966,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets (Optional[torch.Tensor]): jagged slices, represented as cumulative
             offsets.
         stride (Optional[int]): number of examples per batch.
-        stride_per_key_per_rank (Optional[List[List[int]]]): batch size
-            (number of examples) per key per rank, with the outer list representing the
-            keys and the inner list representing the values.
-            Each value in the inner list represents the number of examples in the batch
-            from the rank of its index in a distributed context.
         length_per_key (Optional[List[int]]): start length for each key.
         offset_per_key (Optional[List[int]]): start offset for each key and final
             offset.
@@ -1060,7 +1012,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
-        stride_per_key_per_rank: Optional[List[List[int]]] = None,
         # Below exposed to ensure torch.script-able
         length_per_key: Optional[List[int]] = None,
         offset_per_key: Optional[List[int]] = None,
@@ -1076,38 +1027,20 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             _assert_tensor_has_no_elements_or_has_integers(lengths, "lengths")
         self._lengths: Optional[torch.Tensor] = lengths
         self._offsets: Optional[torch.Tensor] = offsets
-
-        self._stride_per_key_per_rank: List[List[int]] = []
-        self._variable_stride_per_key: bool = False
-        self._stride: int = -1
-
-        if stride_per_key_per_rank is not None and stride_per_key_per_rank:
-            first_key_stride = stride_per_key_per_rank[0]
-            if stride is None:
-                self._stride_per_key_per_rank = stride_per_key_per_rank
-                if all(s == first_key_stride for s in stride_per_key_per_rank):
-                    self._stride = self.stride_per_key()[0]
-                self._variable_stride_per_key = True
-            else:
-                self._stride = stride
-                assert all(s == first_key_stride for s in stride_per_key_per_rank)
-                self._stride_per_key_per_rank = stride_per_key_per_rank
+        if torch.jit.is_tracing():
+            stride = _maybe_compute_stride_kjt_scripted(keys, stride, lengths, offsets)[
+                0
+            ]
         else:
-            if torch.jit.is_tracing():
-                stride = _maybe_compute_stride_kjt_scripted(
-                    keys, stride, lengths, offsets
-                )[0]
-            else:
-                stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
-            self._stride = stride
-            self._stride_per_key_per_rank = [[stride]] * len(self._keys)
+            stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
+
+        self._stride: int = stride
 
         # lazy fields
         self._length_per_key: Optional[List[int]] = length_per_key
         self._offset_per_key: Optional[List[int]] = offset_per_key
         self._index_per_key: Optional[Dict[str, int]] = index_per_key
         self._jt_dict: Optional[Dict[str, JaggedTensor]] = jt_dict
-        self._lengths_offset_per_key: List[int] = []
 
     @staticmethod
     def from_offsets_sync(
@@ -1116,7 +1049,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
-        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1124,7 +1056,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             offsets=offsets,
             stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1135,7 +1066,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
-        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1143,7 +1073,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             lengths=lengths,
             stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1153,7 +1082,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     ) -> "KeyedJaggedTensor":
         if len(kjt_list) == 0:
             raise ValueError("Can't concat empty KJT list")
-
+        stride: int = kjt_list[0].stride()
         is_weighted: bool = kjt_list[0].weights_or_none() is not None
         has_length_per_key: bool = True
 
@@ -1162,17 +1091,12 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         value_list: List[torch.Tensor] = []
         weight_list: List[torch.Tensor] = []
         length_list: List[torch.Tensor] = []
-        stride_per_key_per_rank: List[List[int]] = []
-        stride: Optional[int] = None
-        variable_stride_per_key_list = [
-            kjt.variable_stride_per_key() for kjt in kjt_list
-        ]
-        assert all(variable_stride_per_key_list) or not any(
-            variable_stride_per_key_list
-        ), "variable stride per key must be consistent for all KJTs"
-        variable_stride_per_key = all(variable_stride_per_key_list)
 
         for kjt in kjt_list:
+            if kjt.stride() != stride:
+                raise ValueError(
+                    f"Can only merge KJTs of the same stride ({stride} != kjt.stride())"
+                )
             curr_is_weighted: bool = kjt.weights_or_none() is not None
             if is_weighted != curr_is_weighted:
                 raise ValueError("Can't merge weighted KJT with unweighted KJT")
@@ -1188,12 +1112,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if is_weighted:
                 weight_list.append(kjt.weights())
             length_list.append(kjt.lengths())
-            if variable_stride_per_key:
-                stride_per_key_per_rank += kjt.stride_per_key_per_rank()
-            elif stride is None:
-                stride = kjt.stride()
-            else:
-                assert stride == kjt.stride(), "strides must be consistent for all KJTs"
 
         return KeyedJaggedTensor(
             keys=keys,
@@ -1201,9 +1119,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=torch.cat(weight_list, dim=0) if is_weighted else None,
             lengths=torch.cat(length_list, dim=0),
             stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank
-            if variable_stride_per_key
-            else None,
             length_per_key=length_per_key if has_length_per_key else None,
         )
 
@@ -1229,11 +1144,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     @staticmethod
     def empty_like(kjt: "KeyedJaggedTensor") -> "KeyedJaggedTensor":
-        stride, stride_per_key_per_rank = (
-            (None, kjt.stride_per_key_per_rank())
-            if kjt.variable_stride_per_key()
-            else (kjt.stride(), None)
-        )
         return KeyedJaggedTensor(
             keys=[],
             values=torch.tensor([], device=kjt.device(), dtype=kjt.values().dtype),
@@ -1241,8 +1151,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if kjt.weights_or_none() is None
             else torch.tensor([], device=kjt.device(), dtype=kjt.weights().dtype),
             lengths=torch.tensor([], device=kjt.device(), dtype=kjt.lengths().dtype),
-            stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
+            stride=kjt.stride(),
         )
 
     @staticmethod
@@ -1297,9 +1206,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_vals_list: List[torch.Tensor] = []
         kjt_lens_list: List[torch.Tensor] = []
         kjt_weights_list: List[torch.Tensor] = []
-        stride_per_key: List[int] = []
         for jt in jt_dict.values():
-            stride_per_key.append(len(jt.lengths()))
             kjt_vals_list.append(jt.values())
             kjt_lens_list.append(jt.lengths())
             weight = jt.weights_or_none()
@@ -1310,18 +1217,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_weights = (
             torch.concat(kjt_weights_list) if len(kjt_weights_list) > 0 else None
         )
-        kjt_stride, kjt_stride_per_key_per_rank = (
-            (stride_per_key[0], None)
-            if all(s == stride_per_key[0] for s in stride_per_key)
-            else (None, [[stride] for stride in stride_per_key])
-        )
         kjt = KeyedJaggedTensor(
             keys=kjt_keys,
             values=kjt_vals,
             weights=kjt_weights,
             lengths=kjt_lens,
-            stride=kjt_stride,
-            stride_per_key_per_rank=kjt_stride_per_key_per_rank,
         ).sync()
         return kjt
 
@@ -1369,15 +1269,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def stride(self) -> int:
         return self._stride
 
-    def stride_per_key(self) -> List[int]:
-        return [sum(stride) for stride in self._stride_per_key_per_rank]
-
-    def stride_per_key_per_rank(self) -> List[List[int]]:
-        return self._stride_per_key_per_rank
-
-    def variable_stride_per_key(self) -> bool:
-        return self._variable_stride_per_key
-
     def _key_indices(self) -> Dict[str, int]:
         _index_per_key: Dict[str, int] = _maybe_compute_index_per_key(
             self._keys,
@@ -1388,13 +1279,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def length_per_key(self) -> List[int]:
         _length_per_key = _maybe_compute_length_per_key(
-            keys=self._keys,
-            stride=self.stride(),
-            stride_per_key=self.stride_per_key(),
-            variable_stride_per_key=self.variable_stride_per_key(),
-            length_per_key=self._length_per_key,
-            lengths=self._lengths,
-            offsets=self._offsets,
+            self._keys,
+            self.stride(),
+            self._length_per_key,
+            self._lengths,
+            self._offsets,
         )
         self._length_per_key = _length_per_key
         return _length_per_key
@@ -1404,14 +1293,12 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key(self) -> List[int]:
         _length_per_key, _offset_per_key = _maybe_compute_offset_per_key(
-            keys=self._keys,
-            stride=self.stride(),
-            stride_per_key=self.stride_per_key(),
-            variable_stride_per_key=self.variable_stride_per_key(),
-            length_per_key=self._length_per_key,
-            offset_per_key=self._offset_per_key,
-            lengths=self._lengths,
-            offsets=self._offsets,
+            self._keys,
+            self.stride(),
+            self._length_per_key,
+            self._offset_per_key,
+            self._lengths,
+            self._offsets,
         )
         self._length_per_key = _length_per_key
         self._offset_per_key = _offset_per_key
@@ -1419,11 +1306,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key_or_none(self) -> Optional[List[int]]:
         return self._offset_per_key
-
-    def lengths_offset_per_key(self) -> List[int]:
-        if not self._lengths_offset_per_key:
-            self._lengths_offset_per_key = _cumsum(self.stride_per_key())
-        return self._lengths_offset_per_key
 
     def split(self, segments: List[int]) -> List["KeyedJaggedTensor"]:
         split_list: List[KeyedJaggedTensor] = []
@@ -1435,11 +1317,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             end = start + segment
             end_offset = _offset_per_key[end]
             keys: List[str] = self._keys[start:end]
-            stride, stride_per_key_per_rank = (
-                (None, self.stride_per_key_per_rank()[start:end])
-                if self.variable_stride_per_key()
-                else (self._stride, None)
-            )
             if segment == len(self._keys):
                 # no torch slicing required
                 split_list.append(
@@ -1449,8 +1326,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         weights=self.weights_or_none(),
                         lengths=self._lengths,
                         offsets=self._offsets,
-                        stride=stride,
-                        stride_per_key_per_rank=stride_per_key_per_rank,
+                        stride=self._stride,
                         length_per_key=self._length_per_key,
                         offset_per_key=self._offset_per_key,
                         index_per_key=self._index_per_key,
@@ -1480,8 +1356,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         offsets=torch.tensor(
                             empty_int_list, device=self.device(), dtype=torch.int
                         ),
-                        stride=stride,
-                        stride_per_key_per_rank=stride_per_key_per_rank,
+                        stride=self._stride,
                         length_per_key=None,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1498,13 +1373,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         if self.weights_or_none() is None
                         else self.weights()[start_offset:end_offset],
                         lengths=self.lengths()[
-                            self.lengths_offset_per_key()[
-                                start
-                            ] : self.lengths_offset_per_key()[end]
+                            start * self._stride : end * self._stride
                         ],
                         offsets=None,
-                        stride=stride,
-                        stride_per_key_per_rank=stride_per_key_per_rank,
+                        stride=self._stride,
                         length_per_key=split_length_per_key,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1526,67 +1398,32 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
         length_per_key = self.length_per_key()
         permuted_keys: List[str] = []
-        permuted_stride_per_key_per_rank: List[List[int]] = []
         permuted_length_per_key: List[int] = []
         permuted_lengths_sum = 0
         for index in indices:
-            key = self.keys()[index]
+            key = self._keys[index]
             permuted_keys.append(key)
-            permuted_stride_per_key_per_rank.append(
-                self.stride_per_key_per_rank()[index]
-            )
-            permuted_length_per_key.append(length_per_key[index])
             permuted_lengths_sum += length_per_key[index]
-        if self.variable_stride_per_key():
-            length_per_key_tensor = _pin_and_move(
-                torch.tensor(self.length_per_key()), self.device()
-            )
-            stride_per_key_tensor = _pin_and_move(
-                torch.tensor(self.stride_per_key()), self.device()
-            )
-            (_, permuted_lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
-                indices_tensor,
-                stride_per_key_tensor,
-                self.lengths(),
-                None,
-                None,
-            )
-            (
-                _,
-                permuted_values,
-                permuted_weights,
-            ) = torch.ops.fbgemm.permute_1D_sparse_data(
-                indices_tensor,
-                length_per_key_tensor,
-                self.values(),
-                self.weights_or_none(),
-                None,
-            )
-        else:
-            (
-                permuted_lengths,
-                permuted_values,
-                permuted_weights,
-            ) = torch.ops.fbgemm.permute_2D_sparse_data(
-                indices_tensor,
-                self.lengths().view(len(self._keys), -1),
-                self.values(),
-                self.weights_or_none(),
-                permuted_lengths_sum,
-            )
-        stride, optional_permuted_stride_per_key_per_rank = (
-            (None, permuted_stride_per_key_per_rank)
-            if self.variable_stride_per_key()
-            else (self._stride, None)
+            permuted_length_per_key.append(length_per_key[index])
+        (
+            permuted_lengths,
+            permuted_values,
+            permuted_weights,
+        ) = torch.ops.fbgemm.permute_2D_sparse_data(
+            indices_tensor,
+            self.lengths().view(len(self._keys), -1),
+            self.values(),
+            self.weights_or_none(),
+            permuted_lengths_sum,
         )
+
         kjt = KeyedJaggedTensor(
             keys=permuted_keys,
             values=permuted_values,
             weights=permuted_weights,
             lengths=permuted_lengths.view(-1),
             offsets=None,
-            stride=stride,
-            stride_per_key_per_rank=optional_permuted_stride_per_key_per_rank,
+            stride=self._stride,
             length_per_key=permuted_length_per_key if len(permuted_keys) > 0 else None,
             offset_per_key=None,
             index_per_key=None,
@@ -1608,25 +1445,19 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=None
             if self.weights_or_none() is None
             else self.weights()[start_offset:end_offset],
-            lengths=self.lengths()[
-                self.lengths_offset_per_key()[index] : self.lengths_offset_per_key()[
-                    index + 1
-                ]
-            ],
+            lengths=self.lengths()[index * self._stride : (index + 1) * self._stride],
             offsets=None,
         )
 
     def to_dict(self) -> Dict[str, JaggedTensor]:
         _jt_dict = _maybe_compute_kjt_to_jt_dict(
-            stride=self.stride(),
-            stride_per_key=self.stride_per_key(),
-            keys=self.keys(),
-            length_per_key=self.length_per_key(),
-            lengths=self.lengths(),
-            values=self.values(),
-            variable_stride_per_key=self.variable_stride_per_key(),
-            weights=self.weights_or_none(),
-            jt_dict=self._jt_dict,
+            self.stride(),
+            self.keys(),
+            self.length_per_key(),
+            self.values(),
+            self.lengths(),
+            self.weights_or_none(),
+            self._jt_dict,
         )
         self._jt_dict = _jt_dict
         return _jt_dict
@@ -1654,11 +1485,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
-        stride, stride_per_key_per_rank = (
-            (None, self._stride_per_key_per_rank)
-            if self.variable_stride_per_key()
-            else (self._stride, None)
-        )
         length_per_key = self._length_per_key
         offset_per_key = self._offset_per_key
         index_per_key = self._index_per_key
@@ -1676,8 +1502,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             offsets=offsets.to(device, non_blocking=non_blocking)
             if offsets is not None
             else None,
-            stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
+            stride=self._stride,
             length_per_key=length_per_key,
             offset_per_key=offset_per_key,
             index_per_key=index_per_key,
@@ -1689,6 +1514,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             return "KeyedJaggedTensor()\n"
         offsets = self.offsets()
 
+        step = (len(offsets) - 1) // len(self._keys)
         return (
             "KeyedJaggedTensor({\n"
             + ",\n".join(
@@ -1699,8 +1525,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         self._values,
                         self._weights,
                         offsets,
-                        sum(self.stride_per_key()[:index]),
-                        sum(self.stride_per_key()[: index + 1]),
+                        index * step,
+                        (index + 1) * step,
                     )
                     for index in range(len(self._keys))
                 ]
@@ -1712,11 +1538,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
-        stride, stride_per_key_per_rank = (
-            (None, self._stride_per_key_per_rank)
-            if self.variable_stride_per_key()
-            else (self._stride, None)
-        )
 
         return KeyedJaggedTensor(
             keys=self._keys,
@@ -1724,8 +1545,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights.pin_memory() if weights is not None else None,
             lengths=lengths.pin_memory() if lengths is not None else None,
             offsets=offsets.pin_memory() if offsets is not None else None,
-            stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
+            stride=self._stride,
             length_per_key=self._length_per_key,
             offset_per_key=self._offset_per_key,
             index_per_key=self._index_per_key,
@@ -1733,23 +1553,23 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         )
 
     def dist_labels(self) -> List[str]:
-        labels = ["strides", "lengths", "values"]
+        labels = ["lengths", "values"]
         if self.weights_or_none() is not None:
             labels.append("weights")
         return labels
 
     def dist_splits(self, key_splits: List[int]) -> List[List[int]]:
-        num_strides_per_split = key_splits
-        batch_size_per_split = _sum_by_splits(self.stride_per_key(), key_splits)
+        batch_size_per_split = _sum_by_splits(
+            [self.stride()] * len(self.keys()), key_splits
+        )
         length_per_split = _sum_by_splits(self.length_per_key(), key_splits)
-        splits = [num_strides_per_split, batch_size_per_split, length_per_split]
+        splits = [batch_size_per_split, length_per_split]
         if self.weights_or_none() is not None:
             splits.append(length_per_split)
         return splits
 
     def dist_tensors(self) -> List[torch.Tensor]:
-        strides = _pin_and_move(torch.tensor(self.stride_per_key()), self.device())
-        tensors = [strides, self.lengths(), self.values()]
+        tensors = [self.lengths(), self.values()]
         if self.weights_or_none() is not None:
             tensors.append(self.weights())
         return tensors
@@ -1758,77 +1578,40 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def dist_init(
         keys: List[str],
         tensors: List[torch.Tensor],
+        batch_size_per_rank: List[int],
         recat: Optional[torch.Tensor],
-        num_workers: int,
-        variable_stride_per_key: bool,
     ) -> "KeyedJaggedTensor":
-        assert len(tensors) in [3, 4]
-        stride_per_key_tensor = tensors[0]
-        lengths = tensors[1]
-        values = tensors[2]
-        weights = tensors[3] if len(tensors) == 4 else None
+        assert len(tensors) in [2, 3]
+        lengths = tensors[0]
+        values = tensors[1]
+        weights = tensors[2] if len(tensors) == 3 else None
 
-        stride_per_key_per_rank: List[List[int]] = stride_per_key_tensor.view(
-            num_workers, len(keys)
-        ).T.tolist()
-
-        strides_cumsum: List[int] = torch.ops.fbgemm.asynchronous_complete_cumsum(
-            stride_per_key_tensor
-        ).tolist()
-        cumsum_lengths = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
-        length_per_key = (
-            cumsum_lengths[strides_cumsum[1:]] - cumsum_lengths[strides_cumsum[:-1]]
-        )
-
-        if recat is not None and recat.numel() > 0:
-            with record_function("## all2all_data:recat_values ##"):
-                stride_per_rank = stride_per_key_per_rank[0]
-                if not variable_stride_per_key and all(
-                    s == stride_per_rank[0] for s in stride_per_rank
-                ):
-                    (
-                        lengths,
-                        values,
-                        weights,
-                    ) = torch.ops.fbgemm.permute_2D_sparse_data(
+        with record_function("## all2all_data:recat_values ##"):
+            if recat is not None and recat.numel() > 0:
+                if all(bs == batch_size_per_rank[0] for bs in batch_size_per_rank):
+                    lengths, values, weights = torch.ops.fbgemm.permute_2D_sparse_data(
                         recat,
-                        lengths.view(-1, stride_per_rank[0]),
+                        lengths.view(-1, batch_size_per_rank[0]),
                         values,
                         weights,
                         values.numel(),
                     )
                     lengths = lengths.view(-1)
-
-                else:
-                    (_, lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
+                else:  # variable batch size
+                    lengths, values, weights = torch.ops.fbgemm.permute_1D_sparse_data(
                         recat,
-                        stride_per_key_tensor,
-                        lengths,
-                        None,
-                        None,
-                    )
-                    (_, values, weights,) = torch.ops.fbgemm.permute_1D_sparse_data(
-                        recat,
-                        length_per_key,
+                        lengths.view(-1),
                         values,
                         weights,
-                        None,
+                        values.numel(),
                     )
-
-        if stride_per_key_per_rank and not variable_stride_per_key:
-            stride = sum(stride_per_key_per_rank[0])
-        else:
-            stride = None
-            if variable_stride_per_key and not stride_per_key_per_rank:
-                stride_per_key_per_rank = [[0]] * len(keys)
 
         kjt = KeyedJaggedTensor(
             keys=keys,
             values=values,
             weights=weights,
             lengths=lengths,
-            stride=stride,
-            stride_per_key_per_rank=stride_per_key_per_rank,
+            stride=sum(batch_size_per_rank),
         )
         return kjt.sync()
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -532,23 +532,6 @@ class TestJaggedTensor(unittest.TestCase):
         # TODO: T88149179
         self.assertTrue(torch.equal(j_offset.offsets(), j_lens.offsets().int()))
 
-        stride_per_key_per_rank = [[3], [5]]
-        j_offset = KeyedJaggedTensor.from_offsets_sync(
-            values=values,
-            keys=keys,
-            offsets=offsets,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-
-        j_lens = KeyedJaggedTensor.from_lengths_sync(
-            values=values,
-            keys=keys,
-            lengths=lengths,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-        self.assertTrue(torch.equal(j_offset.lengths(), j_lens.lengths()))
-        self.assertTrue(torch.equal(j_offset.offsets(), j_lens.offsets().int()))
-
     def test_empty(self) -> None:
         jt = JaggedTensor.empty(values_dtype=torch.int64)
 
@@ -737,38 +720,6 @@ JaggedTensor({
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
-    def test_from_jt_dict_vb(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
-        keys = ["index_0", "index_1"]
-        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
-        stride_per_key_per_rank = [[2], [4]]
-
-        jag_tensor = KeyedJaggedTensor(
-            values=values,
-            keys=keys,
-            offsets=offsets,
-            weights=weights,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-        jag_tensor_dict = jag_tensor.to_dict()
-        kjt = KeyedJaggedTensor.from_jt_dict(jag_tensor_dict)
-        j0 = kjt["index_0"]
-        j1 = kjt["index_1"]
-
-        self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
-        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
-        self.assertTrue(
-            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
-        )
-        self.assertTrue(
-            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
-        )
-
 
 class TestJaggedTensorTracing(unittest.TestCase):
     def test_jagged_tensor(self) -> None:
@@ -908,36 +859,6 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
-    def test_key_lookup_vb(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
-        keys = ["index_0", "index_1"]
-        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
-        stride_per_key_per_rank = [[2], [4]]
-
-        jag_tensor = KeyedJaggedTensor(
-            values=values,
-            keys=keys,
-            offsets=offsets,
-            weights=weights,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-        j0 = jag_tensor["index_0"]
-        j1 = jag_tensor["index_1"]
-
-        self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
-        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
-        self.assertTrue(
-            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
-        )
-        self.assertTrue(
-            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
-        )
-
     def test_to_dict(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -967,70 +888,33 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         )
 
     def test_pytree(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-        j0 = JaggedTensor(
-            values=values,
-            lengths=torch.IntTensor([1, 0, 2, 3]),
-        )
-        elems, spec = pytree.tree_flatten(j0)
-        j1 = pytree.tree_unflatten(elems, spec)
-
-        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
-        self.assertIsNone(j0.weights_or_none())
-        self.assertIsNone(j1.weights_or_none())
-        self.assertTrue(torch.equal(j0.values(), j1.values()))
-
-        values = [
-            torch.Tensor([1.0]),
-            torch.Tensor(),
-            torch.Tensor([7.0, 8.0]),
-            torch.Tensor([10.0, 11.0, 12.0]),
-        ]
-        weights = [
-            torch.Tensor([1.0]),
-            torch.Tensor(),
-            torch.Tensor([7.0, 8.0]),
-            torch.Tensor([10.0, 11.0, 12.0]),
-        ]
-        j0 = JaggedTensor.from_dense(
-            values=values,
-            weights=weights,
-        )
-        elems, spec = pytree.tree_flatten(j0)
-        j1 = pytree.tree_unflatten(elems, spec)
-
-        self.assertTrue(torch.equal(j0.lengths(), j1.lengths()))
-        self.assertTrue(torch.equal(j0.weights(), j1.weights()))
-        self.assertTrue(torch.equal(j0.values(), j1.values()))
-
-    def test_to_dict_vb(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
         keys = ["index_0", "index_1"]
         offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
-        stride_per_key_per_rank = [[2], [4]]
 
-        jag_tensor = KeyedJaggedTensor(
+        jag_tensor0 = KeyedJaggedTensor(
             values=values,
             keys=keys,
             offsets=offsets,
             weights=weights,
-            stride_per_key_per_rank=stride_per_key_per_rank,
         )
-        jag_tensor_dict = jag_tensor.to_dict()
-        j0 = jag_tensor_dict["index_0"]
-        j1 = jag_tensor_dict["index_1"]
+        elems, spec = pytree.tree_flatten(jag_tensor0)
+        jag_tensor = pytree.tree_unflatten(elems, spec)
+
+        j0 = jag_tensor["index_0"]
+        j1 = jag_tensor["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0])))
-        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 1, 3])))
+        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
+        self.assertTrue(torch.equal(j0.weights(), torch.Tensor([1.0, 0.5, 1.5])))
+        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
+        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([1, 1, 3])))
         self.assertTrue(
-            torch.equal(j1.weights(), torch.Tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
+            torch.equal(j1.weights(), torch.Tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
         )
         self.assertTrue(
-            torch.equal(j1.values(), torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
+            torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
     def test_empty(self) -> None:
@@ -1133,49 +1017,6 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(j1.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
 
-    def test_split_vb(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
-        keys = ["index_0", "index_1", "index_2", "index_3"]
-        lengths = torch.IntTensor([2, 0, 1, 1, 1, 3, 0, 2])
-        stride_per_key_per_rank = [[3], [0], [1], [4]]
-        jag_tensor = KeyedJaggedTensor(
-            values=values,
-            keys=keys,
-            lengths=lengths,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-        j0, j1, j2 = jag_tensor.split([1, 1, 2])
-
-        self.assertTrue(isinstance(j0, KeyedJaggedTensor))
-        self.assertEqual(j0.keys(), ["index_0"])
-        self.assertEqual(j1.keys(), ["index_1"])
-        self.assertEqual(j2.keys(), ["index_2", "index_3"])
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([2, 0, 1])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([1.0, 2.0, 3.0])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([])))
-        self.assertTrue(torch.equal(j1.values(), torch.Tensor([])))
-        self.assertTrue(torch.equal(j2.lengths(), torch.IntTensor([1, 1, 3, 0, 2])))
-        self.assertTrue(
-            torch.equal(j2.values(), torch.Tensor([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]))
-        )
-
-        j0, j1, j2, j3 = jag_tensor.split([0, 3, 0, 1])
-        self.assertTrue(isinstance(j0, KeyedJaggedTensor))
-        self.assertEqual(j0.keys(), [])
-        self.assertEqual(j1.keys(), ["index_0", "index_1", "index_2"])
-        self.assertEqual(j2.keys(), [])
-        self.assertEqual(j3.keys(), ["index_3"])
-        self.assertTrue(torch.equal(j0.lengths(), torch.IntTensor([])))
-        self.assertTrue(torch.equal(j0.values(), torch.Tensor([])))
-        self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([2, 0, 1, 1])))
-        self.assertTrue(torch.equal(j1.values(), torch.Tensor([1.0, 2.0, 3.0, 4.0])))
-        self.assertTrue(torch.equal(j2.lengths(), torch.IntTensor([])))
-        self.assertTrue(torch.equal(j2.values(), torch.Tensor([])))
-        self.assertTrue(torch.equal(j3.lengths(), torch.IntTensor([1, 3, 0, 2])))
-        self.assertTrue(
-            torch.equal(j3.values(), torch.Tensor([5.0, 6.0, 7.0, 8.0, 9.0, 10.0]))
-        )
-
     def test_zero_split(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -1201,7 +1042,7 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.equal(j1.lengths(), torch.IntTensor([2, 0, 1, 1, 1, 3])))
         self.assertTrue(torch.equal(j1.weights(), weights))
         self.assertTrue(torch.equal(j1.values(), values))
-        self.assertEqual(j1.stride(), 3)
+        self.assertEqual(j0.stride(), 3)
 
     def test_permute_w_weights(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
@@ -1271,41 +1112,6 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             torch.equal(
                 permuted_jag_tensor.lengths(),
                 torch.IntTensor([1, 1, 1, 0, 2, 0, 0, 3, 0]),
-            )
-        )
-        self.assertEqual(permuted_jag_tensor.weights_or_none(), None)
-
-    def test_permute_vb(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-        lengths = torch.IntTensor([1, 0, 1, 3, 0, 1, 0, 2, 0])
-        keys = ["index_0", "index_1", "index_2"]
-        stride_per_key_per_rank = [[2], [4], [3]]
-
-        jag_tensor = KeyedJaggedTensor.from_lengths_sync(
-            values=values,
-            keys=keys,
-            lengths=lengths,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-
-        indices = [1, 0, 2]
-        permuted_jag_tensor = jag_tensor.permute(indices)
-
-        self.assertEqual(permuted_jag_tensor.keys(), ["index_1", "index_0", "index_2"])
-        self.assertEqual(
-            permuted_jag_tensor.offset_per_key(),
-            [0, 5, 6, 8],
-        )
-        self.assertTrue(
-            torch.equal(
-                permuted_jag_tensor.values(),
-                torch.Tensor([2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 7.0, 8.0]),
-            )
-        )
-        self.assertTrue(
-            torch.equal(
-                permuted_jag_tensor.lengths(),
-                torch.IntTensor([1, 3, 0, 1, 1, 0, 0, 2, 0]),
             )
         )
         self.assertEqual(permuted_jag_tensor.weights_or_none(), None)
@@ -1571,39 +1377,6 @@ KeyedJaggedTensor({
 """,
         )
 
-    def test_string_vb(self) -> None:
-        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-        weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
-        keys = ["index_0", "index_1"]
-        offsets = torch.IntTensor([0, 2, 2, 3, 4, 5, 8])
-        stride_per_key_per_rank = [[1, 1], [1, 3]]
-
-        jag_tensor = KeyedJaggedTensor(
-            values=values,
-            keys=keys,
-            offsets=offsets,
-            weights=weights,
-            stride_per_key_per_rank=stride_per_key_per_rank,
-        )
-
-        print(str(jag_tensor))
-
-        self.assertEqual(
-            str(jag_tensor),
-            """\
-KeyedJaggedTensor({
-    "index_0": {
-        "values": [[1.0, 2.0], []],
-        "weights": [[1.0, 0.5], []]
-    },
-    "index_1": {
-        "values": [[3.0], [4.0], [5.0], [6.0, 7.0, 8.0]],
-        "weights": [[1.5], [1.0], [0.5], [1.0, 1.0, 1.5]]
-    }
-})
-""",
-        )
-
     # pyre-ignore[56]
     @unittest.skipIf(
         torch.cuda.device_count() <= 0,
@@ -1746,18 +1519,9 @@ class TestKeyedJaggedTensorScripting(unittest.TestCase):
                 return KeyedJaggedTensor.dist_init(
                     keys=input.keys(),
                     tensors=input.dist_tensors(),
+                    batch_size_per_rank=[2, 2],
                     recat=torch.tensor([]),
-                    num_workers=2,
-                    variable_stride_per_key=False,
                 )
-
-        m = MyModule()
-        torch.jit.script(m)
-
-    def test_scriptable_split(self) -> None:
-        class MyModule(torch.nn.Module):
-            def forward(self, input: KeyedJaggedTensor) -> List[KeyedJaggedTensor]:
-                return input.split([1, 0, 1])
 
         m = MyModule()
         torch.jit.script(m)
@@ -1771,18 +1535,8 @@ class TestKeyedJaggedTensorScripting(unittest.TestCase):
                 offsets=torch.tensor([0, 0, 2, 2, 3, 4, 5, 5, 8], dtype=torch.int32),
             )
 
-        def create_vb_kjt() -> KeyedJaggedTensor:
-            return KeyedJaggedTensor.from_offsets_sync(
-                values=torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
-                weights=torch.tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5]),
-                keys=["index_0", "index_1"],
-                offsets=torch.tensor([0, 0, 2, 2, 3, 4, 5, 5, 8], dtype=torch.int32),
-                stride_per_key_per_rank=[[2], [4]],
-            )
-
         # assert that we can script KJT creation
         torch.jit.script(create_kjt)
-        torch.jit.script(create_vb_kjt)
 
 
 class TestKeyedJaggedTensorTracingScripting(unittest.TestCase):
@@ -2153,23 +1907,22 @@ class TestComputeKJTToJTDict(unittest.TestCase):
             weights=torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5]),
             keys=["index_0", "index_1"],
             offsets=torch.IntTensor([0, 0, 2, 2, 3, 4, 5, 5, 8]),
-            stride_per_key_per_rank=[[0, 2], [3, 3]],
         )
 
         out = m(input)
 
         i0 = out["index_0"]
-        self.assertTrue(torch.equal(i0._values, torch.tensor([1.0, 2.0])))
-        self.assertTrue(torch.equal(i0._weights, torch.tensor([1.0, 0.5])))
-        self.assertTrue(torch.equal(i0._lengths, torch.tensor([0, 2])))
-        self.assertTrue(torch.equal(i0._offsets, torch.tensor([0, 0, 2])))
+        self.assertTrue(torch.equal(i0._values, torch.tensor([1.0, 2.0, 3.0])))
+        self.assertTrue(torch.equal(i0._weights, torch.tensor([1.0, 0.5, 1.5])))
+        self.assertTrue(torch.equal(i0._lengths, torch.tensor([0, 2, 0, 1])))
+        self.assertTrue(torch.equal(i0._offsets, torch.tensor([0, 0, 2, 2, 3])))
 
         i1 = out["index_1"]
         self.assertTrue(
-            torch.equal(i1._values, torch.tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]))
+            torch.equal(i1._values, torch.tensor([4.0, 5.0, 6.0, 7.0, 8.0]))
         )
         self.assertTrue(
-            torch.equal(i1._weights, torch.tensor([1.5, 1.0, 0.5, 1.0, 1.0, 1.5]))
+            torch.equal(i1._weights, torch.tensor([1.0, 0.5, 1.0, 1.0, 1.5]))
         )
-        self.assertTrue(torch.equal(i1._lengths, torch.tensor([0, 1, 1, 1, 0, 3])))
-        self.assertTrue(torch.equal(i1._offsets, torch.tensor([0, 0, 1, 2, 3, 3, 6])))
+        self.assertTrue(torch.equal(i1._lengths, torch.tensor([1, 1, 0, 3])))
+        self.assertTrue(torch.equal(i1._offsets, torch.tensor([0, 1, 2, 2, 5])))


### PR DESCRIPTION
Summary:
back out
- [torchrec] Remove pin_and_move import from jagged_tensor in KJTAllToAllSplitsAwaitable
- [torchrec] Integrate per feature variable batch into VLE arch
- [torchrec] Add variable batch per feature output dist
- [torchrec] Enable variable batch per feature input dist
- [torchrec][VB] Add stride per key to KJT

Differential Revision: D48591426

