### PR TITLE
Add variable batch per feature support to KJT, updated input dist, output dist, and VLE

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -751,11 +751,21 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         weights = features.weights_or_none()
         if weights is not None and not torch.is_floating_point(weights):
             weights = None
-        return self.emb_module(
-            indices=features.values().long(),
-            offsets=features.offsets().long(),
-            per_sample_weights=weights,
-        )
+        if features.variable_stride_per_key() and isinstance(
+            self.emb_module, SplitTableBatchedEmbeddingBagsCodegen
+        ):
+            return self.emb_module(
+                indices=features.values().long(),
+                offsets=features.offsets().long(),
+                per_sample_weights=weights,
+                batch_size_per_feature_per_rank=features.stride_per_key_per_rank(),
+            )
+        else:
+            return self.emb_module(
+                indices=features.values().long(),
+                offsets=features.offsets().long(),
+                per_sample_weights=weights,
+            )
 
     # pyre-fixme[14]: `state_dict` overrides method defined in `Module` inconsistently.
     def state_dict(

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -110,7 +110,7 @@ class All2AllPooledInfo(object):
         cumsum_dim_sum_per_rank_tensor (Optional[Tensor]): cumulative sum of
             `dim_sum_per_rank`, this is only used by the fast kernel of
             `_recat_pooled_embedding_grad_out`.
-        B_local (int): local batch size before scattering.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
     """
 
     batch_size_per_rank: List[int]
@@ -118,6 +118,31 @@ class All2AllPooledInfo(object):
     dim_sum_per_rank_tensor: Optional[Tensor]
     cumsum_dim_sum_per_rank_tensor: Optional[Tensor]
     codecs: Optional[QuantizedCommCodecs] = None
+
+
+@dataclass
+class VariableBatchAll2AllPooledInfo(object):
+    """
+    The data class that collects the attributes when calling the
+    `variable_batch_alltoall_pooled` operation.
+
+    Attributes:
+        batch_size_per_rank_per_feature (List[List[int]]): batch size per rank per
+            feature.
+        batch_size_per_feature_pre_a2a (List[int]): local batch size before scattering.
+        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimension per rank
+            per feature
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+        input_splits (Optional[List[int]]): input splits of tensor all to all.
+        output_splits (Optional[List[int]]): output splits of tensor all to all.
+    """
+
+    batch_size_per_rank_per_feature: List[List[int]]
+    batch_size_per_feature_pre_a2a: List[int]
+    emb_dim_per_rank_per_feature: List[List[int]]
+    codecs: Optional[QuantizedCommCodecs] = None
+    input_splits: Optional[List[int]] = None
+    output_splits: Optional[List[int]] = None
 
 
 @dataclass
@@ -134,7 +159,8 @@ class All2AllSequenceInfo(object):
         backward_recat_tensor (Tensor): recat tensor for backward.
         input_splits (List[int]): input splits.
         output_splits (List[int]): output splits.
-        variable_batch_size (bool): whether variable batch size is enabled
+        variable_batch_size (bool): whether variable batch size is enabled.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
         permuted_lengths_after_sparse_data_all2all (Optional[Tensor]): lengths of sparse
             features before AlltoAll.
     """
@@ -301,10 +327,10 @@ def alltoall_pooled(
             `_recat_pooled_embedding_grad_out`.
         group (Optional[dist.ProcessGroup]): the process group to work on. If None, the
             default process group will be used.
-        codecs: Optional[QuantizedCommCodecs]: Quantized communication codecs.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
 
     Returns:
-        Awaitable[List[Tensor]]: async work handle (`Awaitable`), which can be `wait()` later to get the resulting tensor.
+        Awaitable[Tensor]: async work handle (`Awaitable`), which can be `wait()` later to get the resulting tensor.
 
     .. warning::
         `alltoall_pooled` is experimental and subject to change.
@@ -325,6 +351,32 @@ def alltoall_pooled(
         codecs=codecs,
     )
     All2All_Pooled_Req.apply(group, myreq, a2ai, a2a_pooled_embs_tensor)
+    return myreq
+
+
+def variable_batch_alltoall_pooled(
+    a2a_pooled_embs_tensor: Tensor,
+    batch_size_per_rank_per_feature: List[List[int]],
+    batch_size_per_feature_pre_a2a: List[int],
+    emb_dim_per_rank_per_feature: List[List[int]],
+    group: Optional[dist.ProcessGroup] = None,
+    codecs: Optional[QuantizedCommCodecs] = None,
+) -> Awaitable[Tensor]:
+
+    if group is None:
+        group = dist.distributed_c10d._get_default_group()
+
+    if dist.get_world_size(group) <= 1:
+        return NoWait(a2a_pooled_embs_tensor)
+
+    myreq = Request(group, device=a2a_pooled_embs_tensor.device)
+    a2ai = VariableBatchAll2AllPooledInfo(
+        batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
+        batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
+        emb_dim_per_rank_per_feature=emb_dim_per_rank_per_feature,
+        codecs=codecs,
+    )
+    Variable_Batch_All2All_Pooled_Req.apply(group, myreq, a2ai, a2a_pooled_embs_tensor)
     return myreq
 
 
@@ -849,6 +901,206 @@ class All2All_Pooled_Wait(Function):
             ]
             output_split_sizes = [
                 D_local_sum * B_rank for B_rank in batch_size_per_rank
+            ]
+
+        sharded_grad_input = torch.empty(
+            sum(output_split_sizes),
+            device=sharded_grad_output.device,
+            dtype=sharded_grad_output.dtype,
+        )
+        with record_function("## alltoall_bwd_single ##"):
+            req = dist.all_to_all_single(
+                output=sharded_grad_input,
+                input=sharded_grad_output,
+                output_split_sizes=output_split_sizes,
+                input_split_sizes=input_split_sizes,
+                group=pg,
+                async_op=True,
+            )
+        myreq.req = req
+        myreq.tensor = sharded_grad_input
+        myreq.qcomm_ctx = qcomm_ctx
+
+        return (None, None, myreq.dummy_tensor)
+
+
+class Variable_Batch_All2All_Pooled_Req(Function):
+    @staticmethod
+    # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
+    def forward(
+        # pyre-fixme[2]: Parameter must be annotated.
+        ctx,
+        pg: dist.ProcessGroup,
+        myreq: Request[Tensor],
+        a2ai: VariableBatchAll2AllPooledInfo,
+        input_embeddings: Tensor,
+    ) -> Tensor:
+        my_rank = dist.get_rank(pg)
+
+        # get input splits
+        world_size = dist.get_world_size(pg)
+        input_split_sizes = [0 for _ in range(world_size)]
+        if a2ai.batch_size_per_rank_per_feature:
+            for i in range(world_size):
+                curr_size = 0
+                for batch_size, emb_dim in zip(
+                    a2ai.batch_size_per_rank_per_feature[i],
+                    a2ai.emb_dim_per_rank_per_feature[my_rank],
+                ):
+                    curr_size += batch_size * emb_dim
+                input_split_sizes[i] = curr_size
+        a2ai.input_splits = input_split_sizes
+
+        # get output splits
+        output_split_sizes = [0 for _ in range(world_size)]
+        ind = 0
+        for i in range(world_size):
+            curr_size = 0
+            for emb_dim in a2ai.emb_dim_per_rank_per_feature[i]:
+                curr_size += a2ai.batch_size_per_feature_pre_a2a[ind] * emb_dim
+                ind += 1
+            output_split_sizes[i] = curr_size
+        a2ai.output_splits = output_split_sizes
+
+        sharded_input_embeddings = input_embeddings.view(-1)
+        qcomm_ctx = None
+
+        if a2ai.codecs is not None:
+            codecs = none_throws(a2ai.codecs)
+            qcomm_ctx = codecs.forward.create_context()
+            sharded_input_embeddings = codecs.forward.encode(
+                sharded_input_embeddings,
+                qcomm_ctx,
+            )
+            output_split_sizes = [
+                codecs.forward.calc_quantized_size(
+                    split,
+                    qcomm_ctx,
+                )
+                for split in output_split_sizes
+            ]
+            input_split_sizes = [
+                codecs.forward.calc_quantized_size(
+                    split,
+                    qcomm_ctx,
+                )
+                for split in input_split_sizes
+            ]
+
+        sharded_output_embeddings = torch.empty(
+            sum(output_split_sizes),
+            dtype=sharded_input_embeddings.dtype,
+            device=sharded_input_embeddings.device,
+        )
+
+        with record_function("## alltoall_fwd_single ##"):
+            req = dist.all_to_all_single(
+                output=sharded_output_embeddings,
+                input=sharded_input_embeddings,
+                output_split_sizes=output_split_sizes,
+                input_split_sizes=input_split_sizes,
+                group=pg,
+                async_op=True,
+            )
+
+        myreq.req = req
+        myreq.tensor = sharded_output_embeddings
+        myreq.qcomm_ctx = qcomm_ctx
+        myreq.a2ai = a2ai
+        myreq.wait_function = Variable_Batch_All2All_Pooled_Wait
+        ctx.myreq = myreq
+        ctx.pg = pg
+        return myreq.dummy_tensor
+
+    @staticmethod
+    # pyre-fixme[2]: Parameter must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def backward(ctx, *unused) -> Tuple[None, None, None, Tensor]:
+        myreq = ctx.myreq
+        a2ai = myreq.a2ai
+        assert myreq.req is not None
+        myreq.req.wait()
+        myreq.req = None
+        grad_output = myreq.tensor
+
+        if a2ai.codecs is not None:
+            codecs = none_throws(a2ai.codecs)
+            grad_input = codecs.backward.decode(grad_output, myreq.qcomm_ctx)
+        else:
+            grad_input = grad_output
+        if GRADIENT_DIVISION:
+            grad_input.div_(dist.get_world_size(ctx.pg))
+        myreq.tensor = None
+        myreq.dummy_tensor = None
+        return (None, None, None, grad_input)
+
+
+class Variable_Batch_All2All_Pooled_Wait(Function):
+    @staticmethod
+    # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
+    def forward(
+        # pyre-fixme[2]: Parameter must be annotated.
+        ctx,
+        pg: dist.ProcessGroup,
+        myreq: Request[Tensor],
+        *dummy_tensor: Tensor,
+    ) -> Tensor:
+        a2ai = myreq.a2ai
+        ctx.a2ai = a2ai
+        assert myreq.req is not None
+        myreq.req.wait()
+        sharded_output_embeddings = myreq.tensor
+        myreq.req = None
+        myreq.tensor = None
+        ctx.pg = pg
+        ctx.myreq = myreq
+
+        if a2ai.codecs is not None:
+            codecs = none_throws(a2ai.codecs)
+            sharded_output_embeddings = codecs.forward.decode(
+                sharded_output_embeddings,
+                myreq.qcomm_ctx,
+            )
+        # the return result is a 1-d tensor, like: f_0_s_0, f_0_s1, ..., f_n_s_0, f_n_s_k
+        # f_0, f_1, ... , f_n are ordered by features on each rank
+        return sharded_output_embeddings
+
+    @staticmethod
+    # pyre-fixme[14]: `backward` overrides method defined in `Function` inconsistently.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def backward(ctx, grad_output: Tensor) -> Tuple[None, None, Tensor]:
+        myreq = ctx.myreq
+        a2ai = ctx.a2ai
+        pg = ctx.pg
+
+        assert a2ai.input_splits is not None
+        assert a2ai.output_splits is not None
+        input_split_sizes = a2ai.output_splits
+        output_split_sizes = a2ai.input_splits
+
+        sharded_grad_output = grad_output.contiguous()
+        qcomm_ctx = None
+
+        if a2ai.codecs is not None:
+            codecs = none_throws(a2ai.codecs)
+            qcomm_ctx = codecs.backward.create_context()
+            sharded_grad_output = codecs.backward.encode(
+                sharded_grad_output,
+                qcomm_ctx,
+            )
+            input_split_sizes = [
+                codecs.backward.calc_quantized_size(
+                    split,
+                    qcomm_ctx,
+                )
+                for split in input_split_sizes
+            ]
+            output_split_sizes = [
+                codecs.backward.calc_quantized_size(
+                    split,
+                    qcomm_ctx,
+                )
+                for split in output_split_sizes
             ]
 
         sharded_grad_input = torch.empty(

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -19,6 +19,7 @@ from torchrec.distributed.comm_ops import (
     alltoall_sequence,
     reduce_scatter_base_pooled,
     reduce_scatter_v_pooled,
+    variable_batch_alltoall_pooled,
 )
 from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.types import Awaitable, QuantizedCommCodecs
@@ -92,7 +93,9 @@ def _get_recat(
                 recat.append(i + j * local_split)
 
         # variable batch size
-        if batch_size_per_rank is not None:
+        if batch_size_per_rank is not None and any(
+            bs != batch_size_per_rank[0] for bs in batch_size_per_rank
+        ):
             batch_size_per_feature = list(
                 itertools.chain.from_iterable(
                     itertools.repeat(x, local_split) for x in batch_size_per_rank
@@ -135,8 +138,6 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
 
     Args:
         input_tensors (List[torch.Tensor]): tensor of splits to redistribute.
-        num_workers (int): total ranks.
-        device (torch.device): device on which buffers are allocated.
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
     """
 
@@ -184,11 +185,11 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
         input_tensors (List[torch.Tensor]): provided KJT tensors (ie. lengths, values)
             to redistribute according to splits.
         labels (List[str]): labels for each provided tensor.
-        batch_size_per_rank (List[int]): batch size per rank, to support variable batch
-            size.
         keys (List[str]): KJT keys after AlltoAll.
         device (torch.device): device on which buffers will be allocated.
         stagger (int): stagger value to apply to recat tensor.
+        stride_per_rank (Optional[List[int]]): stride per rank in the non variable
+            batch per feature case.
     """
 
     def __init__(
@@ -200,10 +201,10 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
         output_splits: List[List[int]],
         input_tensors: List[torch.Tensor],
         labels: List[str],
-        batch_size_per_rank: List[int],
         keys: List[str],
         device: torch.device,
         stagger: int,
+        stride_per_rank: Optional[List[int]],
     ) -> None:
         super().__init__()
         self._workers: int = pg.size()
@@ -213,17 +214,15 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
         self._splits = splits
         self._input_splits: Dict[str, List[int]] = dict(zip(labels, input_splits))
         self._output_splits: Dict[str, List[int]] = dict(zip(labels, output_splits))
-        self._batch_size_per_rank = batch_size_per_rank
         self._keys = keys
         self._stagger = stagger
+        self._stride_per_rank = stride_per_rank
         self._recat: Optional[torch.Tensor] = _get_recat(
             local_split=splits[pg.rank()],
             num_splits=len(splits),
             stagger=stagger,
             device=device,
-            batch_size_per_rank=batch_size_per_rank
-            if len(set(batch_size_per_rank)) > 1
-            else None,
+            batch_size_per_rank=self._stride_per_rank,
         )
         if self._workers == 1:
             return
@@ -271,8 +270,10 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
         return type(self._input).dist_init(
             keys=self._keys,
             tensors=self._output_tensors,
-            batch_size_per_rank=self._batch_size_per_rank,
+            variable_stride_per_key=self._input.variable_stride_per_key(),
+            num_workers=self._workers,
             recat=self._recat,
+            stride_per_rank=self._stride_per_rank,
         )
 
 
@@ -318,19 +319,26 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
         self._keys = keys
         self._stagger = stagger
         self._output_splits: List[List[int]] = self._input_splits
-        self._batch_size_per_rank: List[int] = [input.stride()]
+        self._stride_per_rank: Optional[List[int]] = (
+            None
+            if self._input.variable_stride_per_key()
+            else [self._input.stride()] * self._workers
+        )
         if self._workers == 1:
             return
 
         input_tensors = [
-            torch.tensor(split, device=device) for split in self._input_splits
+            torch.tensor(splits, device=device) for splits in self._input_splits
         ]
-        batch_size_tensor = torch.tensor(
-            [input.stride()] * self._workers, device=device
-        )
-        input_tensors.append(batch_size_tensor)
+        if not self._input.variable_stride_per_key():
+            input_tensors.append(
+                torch.tensor([input.stride()] * self._workers, device=device)
+            )
 
-        self._splits_awaitable = SplitsAllToAllAwaitable(input_tensors, self._pg)
+        self._splits_awaitable = SplitsAllToAllAwaitable(
+            input_tensors,
+            self._pg,
+        )
 
     def _wait_impl(self) -> KJTAllToAllTensorsAwaitable:
         """
@@ -342,8 +350,11 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
 
         if self._workers > 1:
             output_list = self._splits_awaitable.wait()
-            self._output_splits = output_list[:-1]
-            self._batch_size_per_rank = output_list[-1]
+            if self._input.variable_stride_per_key():
+                self._output_splits = output_list
+            else:
+                self._output_splits = output_list[:-1]
+                self._stride_per_rank = output_list[-1]
 
         return KJTAllToAllTensorsAwaitable(
             pg=self._pg,
@@ -353,10 +364,10 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
             output_splits=self._output_splits,
             input_tensors=self._input_tensors,
             labels=self._labels,
-            batch_size_per_rank=self._batch_size_per_rank,
             keys=self._keys,
             device=self._device,
             stagger=self._stagger,
+            stride_per_rank=self._stride_per_rank,
         )
 
 
@@ -563,6 +574,7 @@ class PooledEmbeddingsAllToAll(nn.Module):
         device (Optional[torch.device]): device on which buffers will be allocated.
         callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]): callback
             functions.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
 
     Example::
 
@@ -605,7 +617,9 @@ class PooledEmbeddingsAllToAll(nn.Module):
         )
 
     def forward(
-        self, local_embs: torch.Tensor, batch_size_per_rank: Optional[List[int]] = None
+        self,
+        local_embs: torch.Tensor,
+        batch_size_per_rank: Optional[List[int]] = None,
     ) -> PooledEmbeddingsAwaitable:
         """
         Performs AlltoAll pooled operation on pooled embeddings tensor.
@@ -619,9 +633,7 @@ class PooledEmbeddingsAllToAll(nn.Module):
             PooledEmbeddingsAwaitable: awaitable of pooled embeddings.
         """
 
-        if local_embs.numel() == 0:
-            local_embs.view(local_embs.size(0) * self._pg.size(), 0)
-        if batch_size_per_rank is None:
+        if not batch_size_per_rank:
             B_global = local_embs.size(0)
             assert (
                 B_global % self._pg.size() == 0
@@ -634,6 +646,118 @@ class PooledEmbeddingsAllToAll(nn.Module):
             dim_sum_per_rank=self._dim_sum_per_rank,
             dim_sum_per_rank_tensor=self._dim_sum_per_rank_tensor,
             cumsum_dim_sum_per_rank_tensor=self._cumsum_dim_sum_per_rank_tensor,
+            group=self._pg,
+            codecs=self._codecs,
+        )
+
+        pooled_embedding_awaitable = PooledEmbeddingsAwaitable(
+            tensor_awaitable=tensor_awaitable,
+        )
+        pooled_embedding_awaitable.callbacks.extend(self._callbacks)
+
+        return pooled_embedding_awaitable
+
+    @property
+    def callbacks(self) -> List[Callable[[torch.Tensor], torch.Tensor]]:
+        return self._callbacks
+
+
+class VariableBatchPooledEmbeddingsAllToAll(nn.Module):
+    """
+    Shards batches and collects keys of tensor with a `ProcessGroup` according to
+    `dim_sum_per_rank`.
+
+    Implementation utilizes `variable_batch_alltoall_pooled` operation.
+
+    Args:
+        pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
+        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimensions per rank
+            per feature.
+        device (Optional[torch.device]): device on which buffers will be allocated.
+        callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]): callback
+            functions.
+        codecs (Optional[QuantizedCommCodecs]): quantized communication codecs.
+
+    Example::
+
+        emb_dim_per_rank_per_feature = [[2], [3, 3]]
+        a2a = VariableBatchPooledEmbeddingsAllToAll(
+            pg, emb_dim_per_rank_per_feature, device
+        )
+
+        t0 = torch.rand(6) # 2 * (2 + 1)
+        t1 = torch.rand(24) # 3 * (1 + 3) + 3 * (2 + 2)
+        r0_batch_size_per_rank_per_feature = [[2, 1]]
+        r1_batch_size_per_rank_per_feature = [[1, 3], [2, 2]]
+        r0_batch_size_per_feature_pre_a2a = [2, 1, 3]
+        r1_batch_size_per_feature_pre_a2a = [1, 2, 2]
+
+        rank0_output = a2a(
+            t0, r0_batch_size_per_rank_per_feature, r0_batch_size_per_feature_pre_a2a
+        ).wait()
+        rank1_output = a2a(
+            t1, r1_batch_size_per_rank_per_feature, r1_batch_size_per_feature_pre_a2a
+        ).wait()
+
+        # input splits:
+        #   r0: [2*2, 1*1]
+        #   r1: [1*3 + 3*3, 2*3 + 2*3]
+
+        # output splits:
+        #   r0: [2*2, 1*3 + 3*3]
+        #   r1: [1*2, 2*3 + 2*3]
+
+        print(rank0_output.size())
+            # torch.Size([16])
+            # 2*2 + 1*3 + 3*3
+        print(rank1_output.size())
+            # torch.Size([14])
+            # 1*2 + 2*3 + 2*3
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        emb_dim_per_rank_per_feature: List[List[int]],
+        device: Optional[torch.device] = None,
+        callbacks: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        codecs: Optional[QuantizedCommCodecs] = None,
+    ) -> None:
+        super().__init__()
+        self._pg = pg
+        self._emb_dim_per_rank_per_feature = emb_dim_per_rank_per_feature
+        self._callbacks: List[Callable[[torch.Tensor], torch.Tensor]] = []
+        if callbacks is not None:
+            self._callbacks = callbacks
+        self._codecs = codecs
+
+    def forward(
+        self,
+        local_embs: torch.Tensor,
+        batch_size_per_rank_per_feature: List[List[int]],
+        batch_size_per_feature_pre_a2a: List[int],
+    ) -> PooledEmbeddingsAwaitable:
+        """
+        Performs AlltoAll pooled operation with variable batch size per feature on a
+        pooled embeddings tensor.
+
+        Args:
+            local_embs (torch.Tensor): tensor of values to distribute.
+            batch_size_per_rank_per_feature (List[List[int]]): batch size per rank per
+                feature, post a2a. Used to get the input splits.
+            batch_size_per_feature_pre_a2a (List[int]): local batch size before
+                scattering, used to get the output splits.
+                Ordered by rank_0 feature, rank_1 feature, ...
+
+        Returns:
+            PooledEmbeddingsAwaitable: awaitable of pooled embeddings.
+        """
+
+        tensor_awaitable = variable_batch_alltoall_pooled(
+            a2a_pooled_embs_tensor=local_embs,
+            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
+            batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature,
             group=self._pg,
             codecs=self._codecs,
         )

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -763,6 +763,10 @@ class ShardedEmbeddingCollection(
         ctx: EmbeddingCollectionContext,
         features: KeyedJaggedTensor,
     ) -> Awaitable[Awaitable[KJTList]]:
+        if features.variable_stride_per_key():
+            raise ValueError(
+                "Variable batch per feature is not supported with EmbeddingCollection"
+            )
         if self._has_uninitialized_input_dist:
             self._create_input_dist(input_feature_names=features.keys())
             self._has_uninitialized_input_dist = False

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -383,9 +383,16 @@ class GroupedPooledEmbeddingsLookup(
 
                 embeddings.append(emb_op(features))
 
+        dummy_embedding = (
+            self._dummy_embs_tensor
+            if sparse_features.variable_stride_per_key()
+            else fx_wrap_tensor_view2d(
+                self._dummy_embs_tensor, sparse_features.stride(), 0
+            )
+        )
         return embeddings_cat_empty_rank_handle(
             embeddings,
-            fx_wrap_tensor_view2d(self._dummy_embs_tensor, sparse_features.stride(), 0),
+            dummy_embedding,
             dim=1,
         )
 

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -27,6 +27,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.types import (
     Awaitable,
+    NoWait,
     ParameterSharding,
     QuantizedCommCodecs,
     ShardMetadata,
@@ -218,6 +219,10 @@ def group_tables(
     return grouped_embedding_configs_by_rank
 
 
+C = TypeVar("C", bound=Multistreamable)
+T = TypeVar("T")
+
+
 class KJTListAwaitable(Awaitable[KJTList]):
     """
     Awaitable of KJTList.
@@ -225,14 +230,18 @@ class KJTListAwaitable(Awaitable[KJTList]):
     Args:
         awaitables (List[Awaitable[KeyedJaggedTensor]]): list of `Awaitable` of sparse
             features.
+        ctx (C): sharding context to save the batch size info from the KJT for the
+            embedding AlltoAll.
     """
 
     def __init__(
         self,
         awaitables: List[Awaitable[KeyedJaggedTensor]],
+        ctx: C,
     ) -> None:
         super().__init__()
         self.awaitables = awaitables
+        self.ctx = ctx
 
     def _wait_impl(self) -> KJTList:
         """
@@ -241,15 +250,31 @@ class KJTListAwaitable(Awaitable[KJTList]):
         Returns:
             KJTList: synced `KJTList`.
         """
-
-        return KJTList([w.wait() for w in self.awaitables])
-
-
-C = TypeVar("C", bound=Multistreamable)
-T = TypeVar("T")
+        kjts = [w.wait() for w in self.awaitables]
+        _set_sharding_context_post_a2a(kjts, self.ctx)
+        return KJTList(kjts)
 
 
-def _set_sharding_context(
+def _set_sharding_context_post_a2a(
+    kjts: List[KeyedJaggedTensor],
+    ctx: C,
+) -> None:
+    for kjt, sharding_context in zip(kjts, getattr(ctx, "sharding_contexts", [])):
+        if (
+            hasattr(sharding_context, "batch_size_per_rank_per_feature")
+            and kjt.variable_stride_per_key()
+            and kjt.stride_per_key_per_rank()
+        ):
+            sharding_context.batch_size_per_rank_per_feature = [
+                [
+                    kjt.stride_per_key_per_rank()[i][j]
+                    for i in range(len(kjt.stride_per_key_per_rank()))
+                ]
+                for j in range(len(kjt.stride_per_key_per_rank()[0]))
+            ]
+
+
+def _set_sharding_context_intra_a2a(
     tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
     ctx: C,
 ) -> None:
@@ -258,14 +283,36 @@ def _set_sharding_context(
         getattr(ctx, "sharding_contexts", []),
     ):
         if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
-            if hasattr(sharding_context, "batch_size_per_rank"):
-                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
                 sharding_context.output_splits = awaitable._output_splits["values"]
             if hasattr(sharding_context, "sparse_features_recat"):
                 sharding_context.sparse_features_recat = awaitable._recat
+            if (
+                hasattr(sharding_context, "batch_size_per_rank")
+                and awaitable._stride_per_rank is not None
+            ):
+                sharding_context.batch_size_per_rank = awaitable._stride_per_rank
+
+
+def _set_sharding_context_pre_a2a(
+    awaitables: List[Awaitable[Awaitable[KeyedJaggedTensor]]],
+    ctx: C,
+) -> None:
+    for awaitable, sharding_context in zip(
+        awaitables,
+        getattr(ctx, "sharding_contexts", []),
+    ):
+        kjt = (
+            awaitable._obj._obj
+            if isinstance(awaitable, NoWait)
+            else awaitable._input  # pyre-ignore[16]: KJTAllToAllSplitsAwaitable or KJTSplitsAllToAllMeta
+        )
+        if hasattr(sharding_context, "batch_size_per_feature_pre_a2a"):
+            sharding_context.batch_size_per_feature_pre_a2a = kjt.stride_per_key()
+        if hasattr(sharding_context, "variable_batch_per_feature"):
+            sharding_context.variable_batch_per_feature = kjt.variable_stride_per_key()
 
 
 def _split(flat_list: List[T], splits: List[int]) -> List[List[T]]:
@@ -293,6 +340,7 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
         super().__init__()
         self.awaitables = awaitables
         self.ctx = ctx
+        _set_sharding_context_pre_a2a(self.awaitables, self.ctx)
 
     def _wait_impl(self) -> KJTListAwaitable:
         """
@@ -306,14 +354,14 @@ class KJTListSplitsAwaitable(Awaitable[Awaitable[KJTList]], Generic[C]):
             KJTListAwaitable: awaitables for tensors of the sparse features.
         """
         tensors_awaitables = [w.wait() for w in self.awaitables]
-        _set_sharding_context(tensors_awaitables, self.ctx)
-        return KJTListAwaitable(tensors_awaitables)
+        _set_sharding_context_intra_a2a(tensors_awaitables, self.ctx)
+        return KJTListAwaitable(tensors_awaitables, self.ctx)
 
 
 @dataclass
 class KJTSplitsAllToAllMeta:
     pg: dist.ProcessGroup
-    input: KeyedJaggedTensor
+    _input: KeyedJaggedTensor
     splits: List[int]
     splits_tensors: List[torch.Tensor]
     input_splits: List[List[int]]
@@ -322,6 +370,7 @@ class KJTSplitsAllToAllMeta:
     keys: List[str]
     device: torch.device
     stagger: int
+    splits_cumsum: List[int]
 
 
 class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
@@ -336,6 +385,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
         ] = [awaitable for request in requests for awaitable in request.awaitables]
+        for req, ctx in zip(requests, self._contexts):
+            _set_sharding_context_pre_a2a(req.awaitables, ctx)
         self._output_lengths: List[int] = [
             len(request.awaitables) for request in requests
         ]
@@ -359,7 +410,7 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                 input_tensors=splits_tensors,
                 pg=pg,
             )
-            if splits_tensors and pg
+            if splits_tensors and pg is not None
             else None
         )
 
@@ -375,29 +426,33 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
                 continue
-            output_splits = splits[:-1]
-            batch_size_per_rank = splits[-1]
             assert isinstance(awaitable, KJTSplitsAllToAllMeta)
+            if awaitable._input.variable_stride_per_key():
+                output_splits = splits
+                stride_per_rank = None
+            else:
+                output_splits = splits[:-1]
+                stride_per_rank = splits[-1]
             tensors_awaitables.append(
                 KJTAllToAllTensorsAwaitable(
                     pg=awaitable.pg,
-                    input=awaitable.input,
+                    input=awaitable._input,
                     splits=awaitable.splits,
                     input_splits=awaitable.input_splits,
                     output_splits=output_splits,
                     input_tensors=awaitable.input_tensors,
                     labels=awaitable.labels,
-                    batch_size_per_rank=batch_size_per_rank,
                     keys=awaitable.keys,
                     device=awaitable.device,
                     stagger=awaitable.stagger,
+                    stride_per_rank=stride_per_rank,
                 )
             )
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables))
+            _set_sharding_context_intra_a2a(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables, ctx))
         return output
 
 
@@ -463,6 +518,9 @@ W = TypeVar("W")
 @dataclass
 class EmbeddingShardingContext(Multistreamable):
     batch_size_per_rank: List[int] = field(default_factory=list)
+    batch_size_per_rank_per_feature: List[List[int]] = field(default_factory=list)
+    batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
+    variable_batch_per_feature: bool = False
 
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         pass

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -251,10 +251,11 @@ class CwPooledEmbeddingSharding(
             callbacks = [embedding_permute_op]
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            self._pg,
-            self._dim_sum_per_rank(),
-            device,
-            callbacks,
+            pg=self._pg,
+            dim_sum_per_rank=self._dim_sum_per_rank(),
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
+            device=device,
+            callbacks=callbacks,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -145,6 +145,10 @@ class DpSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[Awaitable[SparseFeatures]]: awaitable of awaitable of SparseFeatures.
         """
 
+        if sparse_features.variable_stride_per_key():
+            raise ValueError(
+                "Dense TBE kernel does not support variable batch per feature"
+            )
         return NoWait(cast(Awaitable[KeyedJaggedTensor], NoWait(sparse_features)))
 
 

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -256,6 +256,11 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
 
+        if sparse_features.variable_stride_per_key():
+            raise ValueError(
+                "Variable batch per feature is not supported with row-wise sharding"
+            )
+
         (
             bucketized_features,
             self.unbucketize_permute_tensor,

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, cast, Dict, List, Optional, TypeVar, Union
 
 import torch
 import torch.distributed as dist
@@ -14,6 +14,7 @@ from torchrec.distributed.dist_data import (
     KJTAllToAll,
     KJTOneToAll,
     PooledEmbeddingsAllToAll,
+    VariableBatchPooledEmbeddingsAllToAll,
 )
 from torchrec.distributed.embedding_lookup import (
     GroupedPooledEmbeddingsLookup,
@@ -144,6 +145,15 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             dim_sum_per_rank.append(dim_sum)
         return dim_sum_per_rank
 
+    def _emb_dim_per_rank_per_feature(self) -> List[List[int]]:
+        emb_dim_per_rank_per_feature = []
+        for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
+            emb_dim_per_feature = []
+            for grouped_config in grouped_embedding_configs:
+                emb_dim_per_feature += grouped_config.embedding_dims()
+            emb_dim_per_rank_per_feature.append(emb_dim_per_feature)
+        return emb_dim_per_rank_per_feature
+
     def embedding_dims(self) -> List[int]:
         embedding_dims = []
         for grouped_embedding_configs in self._grouped_embedding_configs_per_rank:
@@ -251,6 +261,8 @@ class TwPooledEmbeddingDist(
         pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
         dim_sum_per_rank (List[int]): number of features (sum of dimensions) of the
             embedding in each rank.
+        emb_dim_per_rank_per_feature (List[List[int]]): embedding dimension per rank per
+            feature, used for variable batch per feature.
         device (Optional[torch.device]): device on which buffers will be allocated.
         callbacks (Optional[List[Callable[[torch.Tensor], torch.Tensor]]]):
         qcomm_codecs_registry (Optional[Dict[str, QuantizedCommCodecs]]):
@@ -260,22 +272,25 @@ class TwPooledEmbeddingDist(
         self,
         pg: dist.ProcessGroup,
         dim_sum_per_rank: List[int],
+        emb_dim_per_rank_per_feature: List[List[int]],
         device: Optional[torch.device] = None,
         callbacks: Optional[List[Callable[[torch.Tensor], torch.Tensor]]] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
         super().__init__()
-        self._dist = PooledEmbeddingsAllToAll(
-            pg=pg,
-            dim_sum_per_rank=dim_sum_per_rank,
-            device=device,
-            callbacks=callbacks,
-            codecs=qcomm_codecs_registry.get(
-                CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None
-            )
+        self._pg = pg
+        self._dim_sum_per_rank = dim_sum_per_rank
+        self._device = device
+        self._callbacks = callbacks
+        self._codecs: Optional[QuantizedCommCodecs] = (
+            qcomm_codecs_registry.get(CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name, None)
             if qcomm_codecs_registry
-            else None,
+            else None
         )
+        self._emb_dim_per_rank_per_feature = emb_dim_per_rank_per_feature
+        self._dist: Optional[
+            Union[PooledEmbeddingsAllToAll, VariableBatchPooledEmbeddingsAllToAll]
+        ] = None
 
     def forward(
         self,
@@ -287,15 +302,47 @@ class TwPooledEmbeddingDist(
 
         Args:
             local_embs (torch.Tensor): tensor of values to distribute.
+            sharding_ctx (Optional[EmbeddingShardingContext]): shared context from
+                KJTAllToAll operation.
 
         Returns:
             Awaitable[torch.Tensor]: awaitable of pooled embeddings.
         """
+        if self._dist is None:
+            self._create_output_dist_module(sharding_ctx)
+
         if sharding_ctx is None:
-            return self._dist(local_embs)
+            return cast(PooledEmbeddingsAllToAll, self._dist)(local_embs)
+        elif sharding_ctx.variable_batch_per_feature:
+            return cast(VariableBatchPooledEmbeddingsAllToAll, self._dist)(
+                local_embs,
+                batch_size_per_rank_per_feature=sharding_ctx.batch_size_per_rank_per_feature,
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
+            )
         else:
-            return self._dist(
-                local_embs, batch_size_per_rank=sharding_ctx.batch_size_per_rank
+            return cast(PooledEmbeddingsAllToAll, self._dist)(
+                local_embs,
+                batch_size_per_rank=sharding_ctx.batch_size_per_rank,
+            )
+
+    def _create_output_dist_module(
+        self, sharding_ctx: Optional[EmbeddingShardingContext] = None
+    ) -> None:
+        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
+            self._dist = VariableBatchPooledEmbeddingsAllToAll(
+                pg=self._pg,
+                emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature,
+                device=self._device,
+                callbacks=self._callbacks,
+                codecs=self._codecs,
+            )
+        else:
+            self._dist = PooledEmbeddingsAllToAll(
+                pg=self._pg,
+                dim_sum_per_rank=self._dim_sum_per_rank,
+                device=self._device,
+                callbacks=self._callbacks,
+                codecs=self._codecs,
             )
 
 
@@ -338,9 +385,10 @@ class TwPooledEmbeddingSharding(
     ) -> BaseEmbeddingDist[EmbeddingShardingContext, torch.Tensor, torch.Tensor]:
         assert self._pg is not None
         return TwPooledEmbeddingDist(
-            self._pg,
-            self._dim_sum_per_rank(),
-            device if device is not None else self._device,
+            pg=self._pg,
+            dim_sum_per_rank=self._dim_sum_per_rank(),
+            emb_dim_per_rank_per_feature=self._emb_dim_per_rank_per_feature(),
+            device=device if device is not None else self._device,
             qcomm_codecs_registry=self.qcomm_codecs_registry,
         )
 

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -328,6 +328,11 @@ class TwRwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
             Awaitable[KeyedJaggedTensor]: awaitable of KeyedJaggedTensor.
         """
 
+        if sparse_features.variable_stride_per_key():
+            raise ValueError(
+                "Variable batch per feature is not supported with table-wise-row-wise sharding"
+            )
+
         bucketized_features = bucketize_kjt_before_all2all(
             sparse_features,
             num_buckets=self._local_size,

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -8,7 +8,7 @@
 import itertools
 import random
 import unittest
-from typing import Dict, Generator, List, Optional, Tuple, TypeVar, Union
+from typing import Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import hypothesis.strategies as st
 import torch
@@ -23,6 +23,7 @@ from torchrec.distributed.dist_data import (
     PooledEmbeddingsAllToAll,
     PooledEmbeddingsReduceScatter,
     SequenceEmbeddingsAllToAll,
+    VariableBatchPooledEmbeddingsAllToAll,
 )
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
@@ -34,10 +35,10 @@ from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
-T = TypeVar("T", int, float)
+T = TypeVar("T", int, float, List[int])
 
 # Lightly adapted from Stack Overflow #10823877
-def _flatten(iterable: List[T]) -> Generator[T, None, None]:
+def _flatten(iterable: Iterable[T]) -> Generator[T, None, None]:
     iterator, sentinel, stack = iter(iterable), object(), []
     while True:
         value = next(iterator, sentinel)
@@ -108,6 +109,86 @@ def _generate_sparse_features_batch(
         out_jagged.append(
             KeyedJaggedTensor.from_lengths_sync(
                 keys=out_keys,
+                lengths=_to_tensor(
+                    [lengths[key][j] for key, j in key_index],
+                    torch.int,
+                ),
+                values=_to_tensor(
+                    [values[key][j] for key, j in key_index],
+                    torch.int,
+                ),
+                weights=_to_tensor(
+                    [weights[key][j] for key, j in key_index],
+                    torch.float,
+                )
+                if weights
+                else None,
+            )
+        )
+    return in_jagged, out_jagged
+
+
+def _generate_variable_batch_sparse_features_batch(
+    keys: List[str],
+    splits: List[int],
+    batch_size_per_rank_per_feature: List[List[List[int]]],
+    is_weighted: bool = False,
+) -> Tuple[List[KeyedJaggedTensor], List[KeyedJaggedTensor]]:
+    world_size = len(splits)
+    offsets = [0] + list(itertools.accumulate(splits))
+    values = {}
+    lengths = {}
+    weights = {} if is_weighted else None
+
+    for i, key in enumerate(keys):
+        lengths[key] = [
+            [
+                random.randint(0, 10)
+                for _ in range(sum(batch_size_per_rank_per_feature[rank][i]))
+            ]
+            for rank in range(world_size)
+        ]
+        values[key] = [
+            [random.randint(0, 1000) for _ in range(sum(lengths[key][j]))]
+            for j in range(world_size)
+        ]
+
+        if weights:
+            weights[key] = [
+                [random.random() for _ in range(sum(lengths[key][j]))]
+                for j in range(world_size)
+            ]
+
+    in_jagged: List[KeyedJaggedTensor] = []
+    out_jagged: List[KeyedJaggedTensor] = []
+    for i in range(world_size):
+        in_jagged.append(
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=keys,
+                stride_per_key_per_rank=batch_size_per_rank_per_feature[i],
+                lengths=_to_tensor([lengths[key][i] for key in keys], torch.int),
+                values=_to_tensor([values[key][i] for key in keys], torch.int),
+                weights=_to_tensor([weights[key][i] for key in keys], torch.float)
+                if weights
+                else None,
+            )
+        )
+        key_index = []
+        out_keys = keys[offsets[i] : offsets[i + 1]]
+        key_indices = [keys.index(k) for k in out_keys]
+        batch_sizes_by_rank = list(zip(*batch_size_per_rank_per_feature))
+        for key in out_keys:
+            for j in range(world_size):
+                key_index.append((key, j))
+
+        out_jagged.append(
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=out_keys,
+                # pyre-ignore[6]
+                stride_per_key_per_rank=[
+                    list(_flatten(batch_sizes_by_rank[key_idx]))
+                    for key_idx in key_indices
+                ],
                 lengths=_to_tensor(
                     [lengths[key][j] for key, j in key_index],
                     torch.int,
@@ -211,7 +292,6 @@ class KJTAllToAllTest(MultiProcessTestBase):
         output: KeyedJaggedTensor,
         backend: str,
         splits: List[int],
-        batch_size_per_rank: List[int],
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         device = torch.device(f"cuda:{rank}")
@@ -275,7 +355,66 @@ class KJTAllToAllTest(MultiProcessTestBase):
                     "output": output[rank],
                     "backend": backend,
                     "splits": splits,
-                    "batch_size_per_rank": batch_size_per_rank,
+                }
+            )
+
+        self._run_multi_process_test_per_rank(
+            callable=self._run_test_dist,
+            world_size=world_size,
+            kwargs_per_rank=kwargs_per_rank,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        backend=st.sampled_from(["nccl"]),
+        B=st.integers(min_value=1, max_value=2),
+        features=st.integers(min_value=3, max_value=4),
+        is_weighted=st.booleans(),
+        variable_batch_per_rank=st.booleans(),
+    )
+    @settings(max_examples=4, deadline=None)
+    def test_variable_batch_features(
+        self,
+        backend: str,
+        B: int,
+        features: int,
+        is_weighted: bool,
+        variable_batch_per_rank: bool,
+    ) -> None:
+        keys = [f"F{feature}" for feature in range(features)]
+        rank0_split = random.randint(0, features)
+        splits = [rank0_split, features - rank0_split]
+        world_size = 2
+
+        if variable_batch_per_rank:
+            batch_size_per_rank_per_feature = [
+                [[random.randint(B, B + 4)] for _ in range(features)]
+                for _ in range(world_size)
+            ]
+        else:
+            batch_size_per_rank_per_feature = [
+                [[random.randint(B, B + 4)] for _ in range(features)]
+            ] * world_size
+
+        _input, output = _generate_variable_batch_sparse_features_batch(
+            keys=keys,
+            splits=splits,
+            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
+            is_weighted=is_weighted,
+        )
+
+        kwargs_per_rank = []
+        for rank in range(world_size):
+            kwargs_per_rank.append(
+                {
+                    "_input": _input[rank],
+                    "output": output[rank],
+                    "backend": backend,
+                    "splits": splits,
                 }
             )
 
@@ -1005,6 +1144,258 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
                     "qcomms_config": qcomms_config,
                 }
             )
+        self._run_multi_process_test_per_rank(
+            callable=self._run_test_dist,
+            world_size=world_size,
+            kwargs_per_rank=kwargs_per_rank,
+        )
+
+
+class VariableBatchPooledEmbeddingsAllToAllTest(MultiProcessTestBase):
+    @classmethod
+    def _run_test_dist(
+        cls,
+        rank: int,
+        world_size: int,
+        _input: torch.Tensor,
+        output: torch.Tensor,
+        backend: str,
+        emb_dim_per_rank_per_feature: List[List[int]],
+        batch_size_per_rank_per_feature: List[List[int]],
+        batch_size_per_feature_pre_a2a: List[int],
+        qcomms_config: Optional[QCommsConfig] = None,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        pg = dist.group.WORLD
+        if backend == "gloo":
+            device = torch.device("cpu")
+        else:
+            device = torch.device(f"cuda:{rank}")
+        _input = _input.to(device=device)
+        output = output.to(device=device)
+
+        codecs = get_qcomm_codecs(qcomms_config)
+
+        a2a = VariableBatchPooledEmbeddingsAllToAll(
+            # pyre-fixme[6]: For 1st param expected `ProcessGroup` but got
+            #  `Optional[_distributed_c10d.ProcessGroup]`.
+            pg=pg,
+            emb_dim_per_rank_per_feature=emb_dim_per_rank_per_feature,
+            device=device,
+            codecs=codecs,
+        )
+        _input.requires_grad = True
+        res = a2a(
+            local_embs=_input,
+            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature,
+            batch_size_per_feature_pre_a2a=batch_size_per_feature_pre_a2a,
+        ).wait()
+        res.backward(res)
+
+        atol, rtol = None, None
+        if qcomms_config is not None:
+            atol, rtol = 0.01, 0.01
+            if (
+                qcomms_config.forward_precision == CommType.FP8
+                or qcomms_config.backward_precision == CommType.FP8
+            ):
+                atol, rtol = 0.05, 0.05
+
+        torch.testing.assert_close(res, output, rtol=rtol, atol=atol)
+
+        torch.testing.assert_close(
+            _input.cpu().detach().div_(world_size),
+            # pyre-ignore
+            _input.grad.cpu().detach(),
+            atol=atol,
+            rtol=rtol,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        backend=st.sampled_from(["nccl"]),
+        features=st.integers(min_value=3, max_value=4),
+        B=st.integers(min_value=2, max_value=3),
+        is_reversed=st.booleans(),
+        qcomms_config=st.sampled_from(
+            [
+                None,
+                QCommsConfig(
+                    forward_precision=CommType.FP16,
+                    backward_precision=CommType.FP16,
+                ),
+                QCommsConfig(
+                    forward_precision=CommType.FP16,
+                    backward_precision=CommType.BF16,
+                ),
+                QCommsConfig(
+                    forward_precision=CommType.FP16,
+                    backward_precision=CommType.FP16,
+                    backward_loss_scale=128.0,
+                ),
+                QCommsConfig(
+                    forward_precision=CommType.FP32,
+                    backward_precision=CommType.BF16,
+                ),
+                QCommsConfig(
+                    forward_precision=CommType.FP8,
+                    backward_precision=CommType.FP8,
+                ),
+                QCommsConfig(
+                    forward_precision=CommType.FP8,
+                    backward_precision=CommType.BF16,
+                ),
+            ]
+        ),
+    )
+    @settings(max_examples=4, deadline=None)
+    def test_variable_batch_pooled_embeddings(
+        self,
+        backend: str,
+        B: int,
+        features: int,
+        is_reversed: bool,
+        qcomms_config: Optional[QCommsConfig],
+    ) -> None:
+        world_size = 2
+        keys = [f"F{feature}" for feature in range(features)]
+        dims = random.sample([8, 16, 32] * features, features)
+        rank0_split = random.randint(1, features - 1)
+        splits = [rank0_split, features - rank0_split]
+        if is_reversed:
+            splits.reverse()
+        emb_dim_per_rank_per_feature = []
+        f_id = 0
+        for split in splits:
+            emb_dim_per_feature = []
+            for _ in range(split):
+                emb_dim_per_feature.append(dims[f_id])
+                f_id += 1
+            emb_dim_per_rank_per_feature.append(emb_dim_per_feature)
+
+        batch_size_per_rank_per_feature_pre_a2a = []
+        for _ in range(world_size):
+            batch_size_per_feature = [random.randint(B, B + 4) for _ in keys]
+            batch_size_per_rank_per_feature_pre_a2a.append(batch_size_per_feature)
+
+        batch_size_per_rank_per_feature_post_a2a_per_rank = []
+        fid = 0
+        for i in range(world_size):
+            batch_size_per_rank_per_feature_post_a2a = [[] for _ in range(world_size)]
+            split = splits[i]
+            for _ in range(split):
+                for j in range(world_size):
+                    batch_size_per_rank_per_feature_post_a2a[j].append(
+                        batch_size_per_rank_per_feature_pre_a2a[j][fid]
+                    )
+                fid += 1
+            batch_size_per_rank_per_feature_post_a2a_per_rank.append(
+                batch_size_per_rank_per_feature_post_a2a
+            )
+
+        """
+        before input dist:
+        r_0
+        f_0: [1, 2], [3, 4]
+        f_1: [5, 6]
+        f_2: [1],    [2],   [3]
+
+        r_1
+        f_0: [1, 2]
+        f_1: [5, 6], [3, 4]
+        f_2: [1],    [2]
+
+        after input dist (splits: [1, 2]):
+        r_0
+        f_0: [1, 2], [3, 4], [1, 2]
+
+        r_1
+        f_1: [5, 6], [5, 6], [3, 4]
+        f_2: [1], [2], [3], [1], [2]
+
+        output layout
+        r_0:
+        [r_0_f_0_s_0, r_0_f_0_s_1, r_1_f_0_s_0]
+
+        r_1:
+        [r_0_f_1_s_0, r_0_f_2_s_0, r_0_f_2_s_1, r_0_f_2_s_2,
+         r_1_f_1_s_0, r_1_f_1_s_1, r_1_f_2_s_0, r_1_f_2_s_1]
+
+        after output dist
+        r_0:
+        [r_0_f_0_s_0, r_0_f_0_s_1, r_0_f_1_s_0, r_0_f_2_s_0, r_0_f_2_s_1, r_0_f_2_s_2]
+
+        r_1:
+        [r_1_f_0_s_0, r_1_f_1_s_0, r_1_f_1_s_1, r_1_f_2_s_0, r_1_f_2_s_1]
+        """
+
+        def _generate_variable_batch_pooled_embedding_batch(
+            keys: List[str],
+            dims: List[int],
+            splits: List[int],
+            batch_size_per_rank_per_feature: List[List[int]],
+        ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+            world_size = len(splits)
+            offsets = [0] + list(itertools.accumulate(splits))
+            local_embs = {}
+
+            feature_ind = 0
+            for key, dim in zip(keys, dims):
+                for rank in range(world_size):
+                    local_batch_size = batch_size_per_rank_per_feature[rank][
+                        feature_ind
+                    ]
+                    if rank not in local_embs:
+                        local_embs[rank] = {}
+                    local_embs[rank][key] = torch.rand(
+                        dim * local_batch_size, dtype=torch.float
+                    )
+                feature_ind += 1
+
+            in_tensor: List[torch.Tensor] = []
+            out_tensor: List[torch.Tensor] = []
+            for i in range(world_size):
+                in_keys = keys[offsets[i] : offsets[i + 1]]
+                input_tensor_list = []
+                for rank in range(world_size):
+                    input_tensor_list += [local_embs[rank][key] for key in in_keys]
+                input_tensor = torch.cat(input_tensor_list)
+                in_tensor.append(input_tensor)
+
+                output_tensor = torch.cat([local_embs[i][key] for key in keys])
+                out_tensor.append(output_tensor)
+
+            return in_tensor, out_tensor
+
+        _input, output = _generate_variable_batch_pooled_embedding_batch(
+            keys=keys,
+            dims=dims,
+            splits=splits,
+            batch_size_per_rank_per_feature=batch_size_per_rank_per_feature_pre_a2a,
+        )
+
+        kwargs_per_rank = []
+        for rank in range(world_size):
+            kwargs_per_rank.append(
+                {
+                    "_input": _input[rank],
+                    "output": output[rank],
+                    "backend": backend,
+                    "emb_dim_per_rank_per_feature": emb_dim_per_rank_per_feature,
+                    "batch_size_per_rank_per_feature": batch_size_per_rank_per_feature_post_a2a_per_rank[
+                        rank
+                    ],
+                    "batch_size_per_feature_pre_a2a": batch_size_per_rank_per_feature_pre_a2a[
+                        rank
+                    ],
+                    "qcomms_config": qcomms_config,
+                }
+            )
+
         self._run_multi_process_test_per_rank(
             callable=self._run_test_dist,
             world_size=world_size,

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -36,11 +36,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
     )
     # pyre-fixme[56]
     @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.ROW_WISE.value,
-            ]
-        ),
+        sharding_type=st.just(ShardingType.ROW_WISE.value),
         kernel_type=st.sampled_from(
             [
                 EmbeddingComputeKernel.DENSE.value,
@@ -64,7 +60,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
-        variable_batch_size=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_rw(
@@ -75,7 +70,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
-        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -92,7 +86,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
             backend="nccl",
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
-            variable_batch_size=variable_batch_size,
         )
 
     @unittest.skipIf(
@@ -101,17 +94,9 @@ class SequenceModelParallelTest(MultiProcessTestBase):
     )
     # pyre-fixme[56]
     @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.DATA_PARALLEL.value,
-            ]
-        ),
-        kernel_type=st.sampled_from(
-            [
-                EmbeddingComputeKernel.DENSE.value,
-            ]
-        ),
-        apply_optimizer_in_backward_config=st.sampled_from([None]),
+        sharding_type=st.just(ShardingType.DATA_PARALLEL.value),
+        kernel_type=st.just(EmbeddingComputeKernel.DENSE.value),
+        apply_optimizer_in_backward_config=st.just(None),
         # TODO - need to enable optimizer overlapped behavior for data_parallel tables
         # apply_optimizer_in_backward_config=st.booleans(),
     )
@@ -141,11 +126,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
     )
     # pyre-fixme[56]
     @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.TABLE_WISE.value,
-            ]
-        ),
+        sharding_type=st.just(ShardingType.TABLE_WISE.value),
         kernel_type=st.sampled_from(
             [
                 EmbeddingComputeKernel.DENSE.value,
@@ -169,7 +150,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
-        variable_batch_size=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_tw(
@@ -180,7 +160,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
-        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -197,7 +176,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
             backend="nccl",
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
-            variable_batch_size=variable_batch_size,
+            variable_batch_size=False,
         )
 
     @unittest.skipIf(
@@ -206,11 +185,7 @@ class SequenceModelParallelTest(MultiProcessTestBase):
     )
     # pyre-fixme[56]
     @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.COLUMN_WISE.value,
-            ]
-        ),
+        sharding_type=st.just(ShardingType.COLUMN_WISE.value),
         kernel_type=st.sampled_from(
             [
                 EmbeddingComputeKernel.DENSE.value,
@@ -226,7 +201,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
                 },
             ]
         ),
-        variable_batch_size=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_nccl_cw(
@@ -236,7 +210,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         apply_optimizer_in_backward_config: Optional[
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
-        variable_batch_size: bool,
     ) -> None:
         assume(
             apply_optimizer_in_backward_config is None
@@ -251,11 +224,45 @@ class SequenceModelParallelTest(MultiProcessTestBase):
             ],
             backend="nccl",
             constraints={
-                table.name: ParameterConstraints(min_partition=16)
+                table.name: ParameterConstraints(min_partition=8)
                 for table in self.tables
             },
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
-            variable_batch_size=variable_batch_size,
+            variable_batch_size=False,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+                ShardingType.ROW_WISE.value,
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=3, deadline=None)
+    def test_sharding_variable_batch(
+        self,
+        sharding_type: str,
+    ) -> None:
+        self._test_sharding(
+            sharders=[
+                TestEmbeddingCollectionSharder(
+                    sharding_type=sharding_type,
+                    kernel_type=EmbeddingComputeKernel.FUSED.value,
+                )
+            ],
+            backend="nccl",
+            constraints={
+                table.name: ParameterConstraints(min_partition=4)
+                for table in self.tables
+            },
+            variable_batch_size=True,
         )
 
     # pyre-fixme[56]

--- a/torchrec/distributed/train_pipeline.py
+++ b/torchrec/distributed/train_pipeline.py
@@ -37,13 +37,12 @@ from torch.autograd.profiler import record_function
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.fx.node import Node
 from torchrec.distributed.dist_data import KJTAllToAll, KJTAllToAllTensorsAwaitable
-from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
 from torchrec.distributed.embedding_sharding import (
     KJTListAwaitable,
     KJTListSplitsAwaitable,
 )
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
-from torchrec.distributed.types import Awaitable
+from torchrec.distributed.types import Awaitable, NoWait
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable, Pipelineable
 
@@ -192,6 +191,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
     ) -> None:
         super().__init__()
         self.num_workers: int = pg.size()
+
         with record_function("## all2all_data:kjt splits ##"):
             self._output_tensor: torch.Tensor = torch.empty(
                 [self.num_workers * len(input_tensors)],
@@ -217,7 +217,7 @@ T = TypeVar("T")
 
 
 # TODO: remove after packaging issue is resolved.
-def _set_sharding_context(
+def _set_sharding_context_intra_a2a(
     tensors_awaitables: List[Awaitable[KeyedJaggedTensor]],
     ctx: C,
 ) -> None:
@@ -226,21 +226,44 @@ def _set_sharding_context(
         getattr(ctx, "sharding_contexts", []),
     ):
         if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
-            if hasattr(sharding_context, "batch_size_per_rank"):
-                sharding_context.batch_size_per_rank = awaitable._batch_size_per_rank
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
                 sharding_context.output_splits = awaitable._output_splits["values"]
             if hasattr(sharding_context, "sparse_features_recat"):
                 sharding_context.sparse_features_recat = awaitable._recat
+            if (
+                hasattr(sharding_context, "batch_size_per_rank")
+                and awaitable._stride_per_rank is not None
+            ):
+                sharding_context.batch_size_per_rank = awaitable._stride_per_rank
+
+
+# TODO: remove after packaging issue is resolved.
+def _set_sharding_context_pre_a2a(
+    awaitables: List[Awaitable[Awaitable[KeyedJaggedTensor]]],
+    ctx: C,
+) -> None:
+    for awaitable, sharding_context in zip(
+        awaitables,
+        getattr(ctx, "sharding_contexts", []),
+    ):
+        kjt = (
+            awaitable._obj._obj
+            if isinstance(awaitable, NoWait)
+            else awaitable._input  # pyre-ignore[16]: KJTAllToAllSplitsAwaitable or KJTSplitsAllToAllMeta
+        )
+        if hasattr(sharding_context, "batch_size_per_feature_pre_a2a"):
+            sharding_context.batch_size_per_feature_pre_a2a = kjt.stride_per_key()
+        if hasattr(sharding_context, "variable_batch_per_feature"):
+            sharding_context.variable_batch_per_feature = kjt.variable_stride_per_key()
 
 
 # TODO: remove after packaging issue is resolved.
 @dataclass
 class KJTSplitsAllToAllMeta:
     pg: dist.ProcessGroup
-    input: KeyedJaggedTensor
+    _input: KeyedJaggedTensor
     splits: List[int]
     splits_tensors: List[torch.Tensor]
     input_splits: List[List[int]]
@@ -271,6 +294,8 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
         ] = [awaitable for request in requests for awaitable in request.awaitables]
+        for req, ctx in zip(requests, self._contexts):
+            _set_sharding_context_pre_a2a(req.awaitables, ctx)
         self._output_lengths: List[int] = [
             len(request.awaitables) for request in requests
         ]
@@ -294,7 +319,7 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                 input_tensors=splits_tensors,
                 pg=pg,
             )
-            if splits_tensors and pg
+            if splits_tensors and pg is not None
             else None
         )
 
@@ -310,29 +335,33 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
                 continue
-            output_splits = splits[:-1]
-            batch_size_per_rank = splits[-1]
             assert isinstance(awaitable, KJTSplitsAllToAllMeta)
+            if awaitable._input.variable_stride_per_key():
+                output_splits = splits
+                stride_per_rank = None
+            else:
+                output_splits = splits[:-1]
+                stride_per_rank = splits[-1]
             tensors_awaitables.append(
                 KJTAllToAllTensorsAwaitable(
                     pg=awaitable.pg,
-                    input=awaitable.input,
+                    input=awaitable._input,
                     splits=awaitable.splits,
                     input_splits=awaitable.input_splits,
                     output_splits=output_splits,
                     input_tensors=awaitable.input_tensors,
                     labels=awaitable.labels,
-                    batch_size_per_rank=batch_size_per_rank,
                     keys=awaitable.keys,
                     device=awaitable.device,
                     stagger=awaitable.stagger,
+                    stride_per_rank=stride_per_rank,
                 )
             )
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables))
+            _set_sharding_context_intra_a2a(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables, ctx))
         return output
 
 
@@ -511,15 +540,15 @@ class KJTAllToAllForward:
             input_splits = input.dist_splits(self._splits)
             device = input.values().device
             splits_tensors = [
-                torch.tensor(split, device=device) for split in input_splits
+                torch.tensor(splits, device=device) for splits in input_splits
             ]
-            batch_size_tensor = torch.tensor(
-                [input.stride()] * self._pg.size(), device=device
-            )
-            splits_tensors.append(batch_size_tensor)
+            if not input.variable_stride_per_key():
+                splits_tensors.append(
+                    torch.tensor([input.stride()] * self._pg.size(), device=device)
+                )
             return KJTSplitsAllToAllMeta(
                 pg=self._pg,
-                input=input,
+                _input=input,
                 splits=self._splits,
                 splits_tensors=splits_tensors,
                 input_splits=input_splits,

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -30,6 +30,14 @@ except ImportError:
     pass
 
 
+def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+    return (
+        tensor
+        if device.type == "cpu"
+        else tensor.pin_memory().to(device=device, non_blocking=True)
+    )
+
+
 def _cumsum(o: List[int]) -> List[int]:
     ret = [0] * (len(o) + 1)
     for i in range(len(o)):
@@ -624,23 +632,39 @@ def _maybe_compute_stride_kjt_scripted(
     return torch.tensor([_maybe_compute_stride_kjt(keys, stride, lengths, offsets)])
 
 
+def _length_per_key_from_stride_per_key(
+    lengths: torch.Tensor, stride_per_key: List[int]
+) -> List[int]:
+    return [
+        int(torch.sum(chunk).item()) for chunk in torch.split(lengths, stride_per_key)
+    ]
+
+
 def _maybe_compute_length_per_key(
     keys: List[str],
     stride: int,
+    stride_per_key: List[int],
+    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
     offsets: Optional[torch.Tensor],
 ) -> List[int]:
     if length_per_key is None:
         if len(keys) and offsets is not None and len(offsets) > 0:
-            _length: List[int] = torch.sum(
-                torch.diff(offsets).view(-1, stride), dim=1
-            ).tolist()
+            _length: List[int] = (
+                _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
+                if variable_stride_per_key
+                else torch.sum(torch.diff(offsets).view(-1, stride), dim=1).tolist()
+            )
         elif len(keys) and lengths is not None:
             _length: List[int] = (
-                torch.sum(lengths.view(-1, stride), dim=1).tolist()
-                if lengths.numel() != 0
-                else [0] * len(keys)
+                _length_per_key_from_stride_per_key(lengths, stride_per_key)
+                if variable_stride_per_key
+                else (
+                    torch.sum(lengths.view(-1, stride), dim=1).tolist()
+                    if lengths.numel() != 0
+                    else [0] * len(keys)
+                )
             )
         else:
             _length: List[int] = []
@@ -651,6 +675,8 @@ def _maybe_compute_length_per_key(
 def _maybe_compute_offset_per_key(
     keys: List[str],
     stride: int,
+    stride_per_key: List[int],
+    variable_stride_per_key: bool,
     length_per_key: Optional[List[int]],
     offset_per_key: Optional[List[int]],
     lengths: Optional[torch.Tensor],
@@ -658,7 +684,13 @@ def _maybe_compute_offset_per_key(
 ) -> Tuple[List[int], List[int]]:
     if length_per_key is None:
         _length_per_key: List[int] = _maybe_compute_length_per_key(
-            keys, stride, length_per_key, lengths, offsets
+            keys=keys,
+            stride=stride,
+            stride_per_key=stride_per_key,
+            variable_stride_per_key=variable_stride_per_key,
+            length_per_key=length_per_key,
+            lengths=lengths,
+            offsets=offsets,
         )
         return _length_per_key, _cumsum(_length_per_key)
     elif offset_per_key is None:
@@ -725,10 +757,12 @@ class ComputeKJTToJTDict(torch.nn.Module):
         """
         return _maybe_compute_kjt_to_jt_dict(
             stride=keyed_jagged_tensor.stride(),
+            stride_per_key=keyed_jagged_tensor.stride_per_key(),
             keys=keyed_jagged_tensor.keys(),
             length_per_key=keyed_jagged_tensor.length_per_key(),
             values=keyed_jagged_tensor.values(),
             lengths=keyed_jagged_tensor.lengths(),
+            variable_stride_per_key=keyed_jagged_tensor.variable_stride_per_key(),
             weights=keyed_jagged_tensor.weights_or_none(),
             jt_dict=keyed_jagged_tensor._jt_dict,
         )
@@ -737,10 +771,12 @@ class ComputeKJTToJTDict(torch.nn.Module):
 @torch.fx.wrap
 def _maybe_compute_kjt_to_jt_dict(
     stride: int,
+    stride_per_key: List[int],
     keys: List[str],
     length_per_key: List[int],
     values: torch.Tensor,
     lengths: torch.Tensor,
+    variable_stride_per_key: bool,
     weights: Optional[torch.Tensor],
     jt_dict: Optional[Dict[str, JaggedTensor]],
 ) -> Dict[str, JaggedTensor]:
@@ -750,21 +786,28 @@ def _maybe_compute_kjt_to_jt_dict(
     if jt_dict is None:
         _jt_dict: Dict[str, JaggedTensor] = {}
         values_list = torch.split(values, length_per_key)
-        lengths_tuple = torch.unbind(
-            lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
-        )
-        offsets_tuple = torch.unbind(
-            _batched_lengths_to_offsets(lengths.view(-1, stride))
-            if lengths.numel() != 0
-            else lengths,
-            dim=0,
-        )
+        if variable_stride_per_key:
+            split_lengths = torch.split(lengths, stride_per_key)
+            split_offsets = [
+                torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+                for lengths in split_lengths
+            ]
+        else:
+            split_lengths = torch.unbind(
+                lengths.view(-1, stride) if lengths.numel() != 0 else lengths, dim=0
+            )
+            split_offsets = torch.unbind(
+                _batched_lengths_to_offsets(lengths.view(-1, stride))
+                if lengths.numel() != 0
+                else lengths,
+                dim=0,
+            )
 
         if weights is not None:
             weights_list = torch.split(weights, length_per_key)
             for idx, key in enumerate(keys):
-                length = lengths_tuple[idx]
-                offset = offsets_tuple[idx]
+                length = split_lengths[idx]
+                offset = split_offsets[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -773,8 +816,8 @@ def _maybe_compute_kjt_to_jt_dict(
                 )
         else:
             for idx, key in enumerate(keys):
-                length = lengths_tuple[idx]
-                offset = offsets_tuple[idx]
+                length = split_lengths[idx]
+                offset = split_offsets[idx]
                 _jt_dict[key] = JaggedTensor(
                     lengths=length,
                     offsets=offset,
@@ -966,6 +1009,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets (Optional[torch.Tensor]): jagged slices, represented as cumulative
             offsets.
         stride (Optional[int]): number of examples per batch.
+        stride_per_key_per_rank (Optional[List[List[int]]]): batch size
+            (number of examples) per key per rank, with the outer list representing the
+            keys and the inner list representing the values.
+            Each value in the inner list represents the number of examples in the batch
+            from the rank of its index in a distributed context.
         length_per_key (Optional[List[int]]): start length for each key.
         offset_per_key (Optional[List[int]]): start offset for each key and final
             offset.
@@ -1012,6 +1060,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
         # Below exposed to ensure torch.script-able
         length_per_key: Optional[List[int]] = None,
         offset_per_key: Optional[List[int]] = None,
@@ -1027,20 +1076,38 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             _assert_tensor_has_no_elements_or_has_integers(lengths, "lengths")
         self._lengths: Optional[torch.Tensor] = lengths
         self._offsets: Optional[torch.Tensor] = offsets
-        if torch.jit.is_tracing():
-            stride = _maybe_compute_stride_kjt_scripted(keys, stride, lengths, offsets)[
-                0
-            ]
-        else:
-            stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
 
-        self._stride: int = stride
+        self._stride_per_key_per_rank: List[List[int]] = []
+        self._variable_stride_per_key: bool = False
+        self._stride: int = -1
+
+        if stride_per_key_per_rank is not None:
+            if stride is not None:
+                raise ValueError(
+                    "Cannot initialize KJT with both `stride` and `stride_per_key_per_rank`"
+                )
+            self._stride_per_key_per_rank = stride_per_key_per_rank
+            self._variable_stride_per_key = True
+            if not stride_per_key_per_rank:
+                self._stride = 0
+            elif all(s == self.stride_per_key()[0] for s in self.stride_per_key()):
+                self._stride = self.stride_per_key()[0]
+        else:
+            if torch.jit.is_tracing():
+                stride = _maybe_compute_stride_kjt_scripted(
+                    keys, stride, lengths, offsets
+                )[0]
+            else:
+                stride = _maybe_compute_stride_kjt(keys, stride, lengths, offsets)
+            self._stride = stride
+            self._stride_per_key_per_rank = [[stride]] * len(self._keys)
 
         # lazy fields
         self._length_per_key: Optional[List[int]] = length_per_key
         self._offset_per_key: Optional[List[int]] = offset_per_key
         self._index_per_key: Optional[Dict[str, int]] = index_per_key
         self._jt_dict: Optional[Dict[str, JaggedTensor]] = jt_dict
+        self._lengths_offset_per_key: List[int] = []
 
     @staticmethod
     def from_offsets_sync(
@@ -1049,6 +1116,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offsets: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1056,6 +1124,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             offsets=offsets,
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1066,6 +1135,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: torch.Tensor,
         weights: Optional[torch.Tensor] = None,
         stride: Optional[int] = None,
+        stride_per_key_per_rank: Optional[List[List[int]]] = None,
     ) -> "KeyedJaggedTensor":
         kjt = KeyedJaggedTensor(
             keys=keys,
@@ -1073,6 +1143,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights,
             lengths=lengths,
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
         return kjt.sync()
 
@@ -1082,7 +1153,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     ) -> "KeyedJaggedTensor":
         if len(kjt_list) == 0:
             raise ValueError("Can't concat empty KJT list")
-        stride: int = kjt_list[0].stride()
+
         is_weighted: bool = kjt_list[0].weights_or_none() is not None
         has_length_per_key: bool = True
 
@@ -1091,12 +1162,17 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         value_list: List[torch.Tensor] = []
         weight_list: List[torch.Tensor] = []
         length_list: List[torch.Tensor] = []
+        stride_per_key_per_rank: List[List[int]] = []
+        stride: Optional[int] = None
+        variable_stride_per_key_list = [
+            kjt.variable_stride_per_key() for kjt in kjt_list
+        ]
+        assert all(variable_stride_per_key_list) or not any(
+            variable_stride_per_key_list
+        ), "variable stride per key must be consistent for all KJTs"
+        variable_stride_per_key = all(variable_stride_per_key_list)
 
         for kjt in kjt_list:
-            if kjt.stride() != stride:
-                raise ValueError(
-                    f"Can only merge KJTs of the same stride ({stride} != kjt.stride())"
-                )
             curr_is_weighted: bool = kjt.weights_or_none() is not None
             if is_weighted != curr_is_weighted:
                 raise ValueError("Can't merge weighted KJT with unweighted KJT")
@@ -1112,6 +1188,12 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if is_weighted:
                 weight_list.append(kjt.weights())
             length_list.append(kjt.lengths())
+            if variable_stride_per_key:
+                stride_per_key_per_rank += kjt.stride_per_key_per_rank()
+            elif stride is None:
+                stride = kjt.stride()
+            else:
+                assert stride == kjt.stride(), "strides must be consistent for all KJTs"
 
         return KeyedJaggedTensor(
             keys=keys,
@@ -1119,6 +1201,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=torch.cat(weight_list, dim=0) if is_weighted else None,
             lengths=torch.cat(length_list, dim=0),
             stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank
+            if variable_stride_per_key
+            else None,
             length_per_key=length_per_key if has_length_per_key else None,
         )
 
@@ -1144,6 +1229,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     @staticmethod
     def empty_like(kjt: "KeyedJaggedTensor") -> "KeyedJaggedTensor":
+        stride, stride_per_key_per_rank = (
+            (None, kjt.stride_per_key_per_rank())
+            if kjt.variable_stride_per_key()
+            else (kjt.stride(), None)
+        )
         return KeyedJaggedTensor(
             keys=[],
             values=torch.tensor([], device=kjt.device(), dtype=kjt.values().dtype),
@@ -1151,7 +1241,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             if kjt.weights_or_none() is None
             else torch.tensor([], device=kjt.device(), dtype=kjt.weights().dtype),
             lengths=torch.tensor([], device=kjt.device(), dtype=kjt.lengths().dtype),
-            stride=kjt.stride(),
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
         )
 
     @staticmethod
@@ -1206,7 +1297,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_vals_list: List[torch.Tensor] = []
         kjt_lens_list: List[torch.Tensor] = []
         kjt_weights_list: List[torch.Tensor] = []
+        stride_per_key: List[int] = []
         for jt in jt_dict.values():
+            stride_per_key.append(len(jt.lengths()))
             kjt_vals_list.append(jt.values())
             kjt_lens_list.append(jt.lengths())
             weight = jt.weights_or_none()
@@ -1217,11 +1310,18 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_weights = (
             torch.concat(kjt_weights_list) if len(kjt_weights_list) > 0 else None
         )
+        kjt_stride, kjt_stride_per_key_per_rank = (
+            (stride_per_key[0], None)
+            if all(s == stride_per_key[0] for s in stride_per_key)
+            else (None, [[stride] for stride in stride_per_key])
+        )
         kjt = KeyedJaggedTensor(
             keys=kjt_keys,
             values=kjt_vals,
             weights=kjt_weights,
             lengths=kjt_lens,
+            stride=kjt_stride,
+            stride_per_key_per_rank=kjt_stride_per_key_per_rank,
         ).sync()
         return kjt
 
@@ -1269,6 +1369,15 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def stride(self) -> int:
         return self._stride
 
+    def stride_per_key(self) -> List[int]:
+        return [sum(stride) for stride in self._stride_per_key_per_rank]
+
+    def stride_per_key_per_rank(self) -> List[List[int]]:
+        return self._stride_per_key_per_rank
+
+    def variable_stride_per_key(self) -> bool:
+        return self._variable_stride_per_key
+
     def _key_indices(self) -> Dict[str, int]:
         _index_per_key: Dict[str, int] = _maybe_compute_index_per_key(
             self._keys,
@@ -1279,11 +1388,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def length_per_key(self) -> List[int]:
         _length_per_key = _maybe_compute_length_per_key(
-            self._keys,
-            self.stride(),
-            self._length_per_key,
-            self._lengths,
-            self._offsets,
+            keys=self._keys,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            length_per_key=self._length_per_key,
+            lengths=self._lengths,
+            offsets=self._offsets,
         )
         self._length_per_key = _length_per_key
         return _length_per_key
@@ -1293,12 +1404,14 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key(self) -> List[int]:
         _length_per_key, _offset_per_key = _maybe_compute_offset_per_key(
-            self._keys,
-            self.stride(),
-            self._length_per_key,
-            self._offset_per_key,
-            self._lengths,
-            self._offsets,
+            keys=self._keys,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            length_per_key=self._length_per_key,
+            offset_per_key=self._offset_per_key,
+            lengths=self._lengths,
+            offsets=self._offsets,
         )
         self._length_per_key = _length_per_key
         self._offset_per_key = _offset_per_key
@@ -1306,6 +1419,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def offset_per_key_or_none(self) -> Optional[List[int]]:
         return self._offset_per_key
+
+    def lengths_offset_per_key(self) -> List[int]:
+        if not self._lengths_offset_per_key:
+            self._lengths_offset_per_key = _cumsum(self.stride_per_key())
+        return self._lengths_offset_per_key
 
     def split(self, segments: List[int]) -> List["KeyedJaggedTensor"]:
         split_list: List[KeyedJaggedTensor] = []
@@ -1317,6 +1435,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             end = start + segment
             end_offset = _offset_per_key[end]
             keys: List[str] = self._keys[start:end]
+            stride, stride_per_key_per_rank = (
+                (None, self.stride_per_key_per_rank()[start:end])
+                if self.variable_stride_per_key()
+                else (self._stride, None)
+            )
             if segment == len(self._keys):
                 # no torch slicing required
                 split_list.append(
@@ -1326,7 +1449,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         weights=self.weights_or_none(),
                         lengths=self._lengths,
                         offsets=self._offsets,
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=self._length_per_key,
                         offset_per_key=self._offset_per_key,
                         index_per_key=self._index_per_key,
@@ -1356,7 +1480,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         offsets=torch.tensor(
                             empty_int_list, device=self.device(), dtype=torch.int
                         ),
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=None,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1373,10 +1498,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         if self.weights_or_none() is None
                         else self.weights()[start_offset:end_offset],
                         lengths=self.lengths()[
-                            start * self._stride : end * self._stride
+                            self.lengths_offset_per_key()[
+                                start
+                            ] : self.lengths_offset_per_key()[end]
                         ],
                         offsets=None,
-                        stride=self._stride,
+                        stride=stride,
+                        stride_per_key_per_rank=stride_per_key_per_rank,
                         length_per_key=split_length_per_key,
                         offset_per_key=None,
                         index_per_key=None,
@@ -1398,32 +1526,67 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
         length_per_key = self.length_per_key()
         permuted_keys: List[str] = []
+        permuted_stride_per_key_per_rank: List[List[int]] = []
         permuted_length_per_key: List[int] = []
         permuted_lengths_sum = 0
         for index in indices:
-            key = self._keys[index]
+            key = self.keys()[index]
             permuted_keys.append(key)
-            permuted_lengths_sum += length_per_key[index]
+            permuted_stride_per_key_per_rank.append(
+                self.stride_per_key_per_rank()[index]
+            )
             permuted_length_per_key.append(length_per_key[index])
-        (
-            permuted_lengths,
-            permuted_values,
-            permuted_weights,
-        ) = torch.ops.fbgemm.permute_2D_sparse_data(
-            indices_tensor,
-            self.lengths().view(len(self._keys), -1),
-            self.values(),
-            self.weights_or_none(),
-            permuted_lengths_sum,
+            permuted_lengths_sum += length_per_key[index]
+        if self.variable_stride_per_key():
+            length_per_key_tensor = _pin_and_move(
+                torch.tensor(self.length_per_key()), self.device()
+            )
+            stride_per_key_tensor = _pin_and_move(
+                torch.tensor(self.stride_per_key()), self.device()
+            )
+            (_, permuted_lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
+                indices_tensor,
+                stride_per_key_tensor,
+                self.lengths(),
+                None,
+                None,
+            )
+            (
+                _,
+                permuted_values,
+                permuted_weights,
+            ) = torch.ops.fbgemm.permute_1D_sparse_data(
+                indices_tensor,
+                length_per_key_tensor,
+                self.values(),
+                self.weights_or_none(),
+                None,
+            )
+        else:
+            (
+                permuted_lengths,
+                permuted_values,
+                permuted_weights,
+            ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                indices_tensor,
+                self.lengths().view(len(self._keys), -1),
+                self.values(),
+                self.weights_or_none(),
+                permuted_lengths_sum,
+            )
+        stride, optional_permuted_stride_per_key_per_rank = (
+            (None, permuted_stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
         )
-
         kjt = KeyedJaggedTensor(
             keys=permuted_keys,
             values=permuted_values,
             weights=permuted_weights,
             lengths=permuted_lengths.view(-1),
             offsets=None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=optional_permuted_stride_per_key_per_rank,
             length_per_key=permuted_length_per_key if len(permuted_keys) > 0 else None,
             offset_per_key=None,
             index_per_key=None,
@@ -1445,19 +1608,25 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=None
             if self.weights_or_none() is None
             else self.weights()[start_offset:end_offset],
-            lengths=self.lengths()[index * self._stride : (index + 1) * self._stride],
+            lengths=self.lengths()[
+                self.lengths_offset_per_key()[index] : self.lengths_offset_per_key()[
+                    index + 1
+                ]
+            ],
             offsets=None,
         )
 
     def to_dict(self) -> Dict[str, JaggedTensor]:
         _jt_dict = _maybe_compute_kjt_to_jt_dict(
-            self.stride(),
-            self.keys(),
-            self.length_per_key(),
-            self.values(),
-            self.lengths(),
-            self.weights_or_none(),
-            self._jt_dict,
+            stride=self.stride(),
+            stride_per_key=self.stride_per_key(),
+            keys=self.keys(),
+            length_per_key=self.length_per_key(),
+            lengths=self.lengths(),
+            values=self.values(),
+            variable_stride_per_key=self.variable_stride_per_key(),
+            weights=self.weights_or_none(),
+            jt_dict=self._jt_dict,
         )
         self._jt_dict = _jt_dict
         return _jt_dict
@@ -1485,6 +1654,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
+        stride, stride_per_key_per_rank = (
+            (None, self._stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
+        )
         length_per_key = self._length_per_key
         offset_per_key = self._offset_per_key
         index_per_key = self._index_per_key
@@ -1502,7 +1676,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             offsets=offsets.to(device, non_blocking=non_blocking)
             if offsets is not None
             else None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
             length_per_key=length_per_key,
             offset_per_key=offset_per_key,
             index_per_key=index_per_key,
@@ -1514,7 +1689,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             return "KeyedJaggedTensor()\n"
         offsets = self.offsets()
 
-        step = (len(offsets) - 1) // len(self._keys)
         return (
             "KeyedJaggedTensor({\n"
             + ",\n".join(
@@ -1525,8 +1699,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         self._values,
                         self._weights,
                         offsets,
-                        index * step,
-                        (index + 1) * step,
+                        sum(self.stride_per_key()[:index]),
+                        sum(self.stride_per_key()[: index + 1]),
                     )
                     for index in range(len(self._keys))
                 ]
@@ -1538,6 +1712,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights = self._weights
         lengths = self._lengths
         offsets = self._offsets
+        stride, stride_per_key_per_rank = (
+            (None, self._stride_per_key_per_rank)
+            if self.variable_stride_per_key()
+            else (self._stride, None)
+        )
 
         return KeyedJaggedTensor(
             keys=self._keys,
@@ -1545,7 +1724,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             weights=weights.pin_memory() if weights is not None else None,
             lengths=lengths.pin_memory() if lengths is not None else None,
             offsets=offsets.pin_memory() if offsets is not None else None,
-            stride=self._stride,
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
             length_per_key=self._length_per_key,
             offset_per_key=self._offset_per_key,
             index_per_key=self._index_per_key,
@@ -1554,22 +1734,27 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
     def dist_labels(self) -> List[str]:
         labels = ["lengths", "values"]
+        if self.variable_stride_per_key():
+            labels.append("strides")
         if self.weights_or_none() is not None:
             labels.append("weights")
         return labels
 
     def dist_splits(self, key_splits: List[int]) -> List[List[int]]:
-        batch_size_per_split = _sum_by_splits(
-            [self.stride()] * len(self.keys()), key_splits
-        )
+        batch_size_per_split = _sum_by_splits(self.stride_per_key(), key_splits)
         length_per_split = _sum_by_splits(self.length_per_key(), key_splits)
         splits = [batch_size_per_split, length_per_split]
+        if self.variable_stride_per_key():
+            splits.append(key_splits)
         if self.weights_or_none() is not None:
             splits.append(length_per_split)
         return splits
 
     def dist_tensors(self) -> List[torch.Tensor]:
         tensors = [self.lengths(), self.values()]
+        if self.variable_stride_per_key():
+            strides = _pin_and_move(torch.tensor(self.stride_per_key()), self.device())
+            tensors.append(strides)
         if self.weights_or_none() is not None:
             tensors.append(self.weights())
         return tensors
@@ -1578,42 +1763,98 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def dist_init(
         keys: List[str],
         tensors: List[torch.Tensor],
-        batch_size_per_rank: List[int],
+        variable_stride_per_key: bool,
+        num_workers: int,
         recat: Optional[torch.Tensor],
+        stride_per_rank: Optional[List[int]],
     ) -> "KeyedJaggedTensor":
-        assert len(tensors) in [2, 3]
+        assert len(tensors) in [2, 3, 4]
         lengths = tensors[0]
         values = tensors[1]
-        weights = tensors[2] if len(tensors) == 3 else None
-
-        with record_function("## all2all_data:recat_values ##"):
-            if recat is not None and recat.numel() > 0:
-                if all(bs == batch_size_per_rank[0] for bs in batch_size_per_rank):
-                    lengths, values, weights = torch.ops.fbgemm.permute_2D_sparse_data(
-                        recat,
-                        lengths.view(-1, batch_size_per_rank[0]),
-                        values,
-                        weights,
-                        values.numel(),
-                    )
-                    lengths = lengths.view(-1)
-                else:  # variable batch size
-                    lengths, values, weights = torch.ops.fbgemm.permute_1D_sparse_data(
-                        recat,
-                        lengths.view(-1),
-                        values,
-                        weights,
-                        values.numel(),
-                    )
-
-        kjt = KeyedJaggedTensor(
-            keys=keys,
-            values=values,
-            weights=weights,
-            lengths=lengths,
-            stride=sum(batch_size_per_rank),
+        stride_per_rank_per_key = tensors[2] if variable_stride_per_key else None
+        weights = (
+            tensors[-1]
+            if (variable_stride_per_key and len(tensors) == 4)
+            or (not variable_stride_per_key and len(tensors) == 3)
+            else None
         )
-        return kjt.sync()
+
+        if variable_stride_per_key:
+            assert stride_per_rank_per_key is not None
+            stride_per_key_per_rank: List[List[int]] = stride_per_rank_per_key.view(
+                num_workers, len(keys)
+            ).T.tolist()
+            strides_cumsum: List[int] = torch.ops.fbgemm.asynchronous_complete_cumsum(
+                stride_per_rank_per_key
+            ).tolist()
+            cumsum_lengths = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+            length_per_key = (
+                cumsum_lengths[strides_cumsum[1:]] - cumsum_lengths[strides_cumsum[:-1]]
+            )
+            with record_function("## all2all_data:recat_values ##"):
+                if recat is not None and recat.numel() > 0:
+                    (_, lengths, _,) = torch.ops.fbgemm.permute_1D_sparse_data(
+                        recat,
+                        stride_per_rank_per_key,
+                        lengths,
+                        None,
+                        None,
+                    )
+                    (_, values, weights,) = torch.ops.fbgemm.permute_1D_sparse_data(
+                        recat,
+                        length_per_key,
+                        values,
+                        weights,
+                        None,
+                    )
+            if not stride_per_key_per_rank:
+                stride_per_key_per_rank = [[0]] * len(keys)
+            kjt = KeyedJaggedTensor(
+                keys=keys,
+                values=values,
+                weights=weights,
+                lengths=lengths,
+                stride_per_key_per_rank=stride_per_key_per_rank,
+            )
+            return kjt.sync()
+        else:
+            assert stride_per_rank is not None
+            with record_function("## all2all_data:recat_values ##"):
+                if recat is not None and recat.numel() > 0:
+                    stride = stride_per_rank[0]
+                    if all(s == stride for s in stride_per_rank):
+                        (
+                            lengths,
+                            values,
+                            weights,
+                        ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                            recat,
+                            lengths.view(-1, stride),
+                            values,
+                            weights,
+                            values.numel(),
+                        )
+                        lengths = lengths.view(-1)
+                    else:  # variable batch size per rank
+                        (
+                            lengths,
+                            values,
+                            weights,
+                        ) = torch.ops.fbgemm.permute_1D_sparse_data(
+                            recat,
+                            lengths.view(-1),
+                            values,
+                            weights,
+                            values.numel(),
+                        )
+            kjt = KeyedJaggedTensor(
+                keys=keys,
+                values=values,
+                weights=weights,
+                lengths=lengths,
+                stride=sum(stride_per_rank),
+            )
+            return kjt.sync()
 
 
 def _kjt_flatten(


### PR DESCRIPTION
Summary:
Relanding VBE support in TorchRec from original diff stack, for more context on changes see diffs for each part:
- D48584788 [torchrec] Remove pin_and_move import from jagged_tensor in KJTAllToAllSplitsAwaitable
- D47404026 [torchrec] Integrate per feature variable batch into VLE arch
- D47377596 [torchrec] Add variable batch per feature output dist
- D47049094 **less relevant** [torchrec] Enable variable batch per feature input dist
- D46907357 [torchrec][VB] Add stride per key to KJT

We reverted the stack due to a bug with sequence embeddings that have variable batch per rank. The issue was that in the new input dist we no longer generated the recat tensor for variable batch per rank case, as the recat for variable batch size per feature was general enough to support the constant batch size per key but variable batch per rank case. The sequence embedding a2a uses the recat tensor, and in cases with variable batch per rank they expect the recat tensor generated with batch size per rank.

# new changes
- In the previous implementation we handled batch size per feature the same we transmit lengths and values tensors through the 2 step collective process of splits then tensors. However there are 2 main issues with this approach
  - empty ranks do not have batch size information
    - hacky to reshape empty tensors later to have global batch size as first dim
    - don't have batch size per rank to create recat tensor
  - we don't have access to batch size per rank tensor in KJTAlltoAllTensorsAwaitable
    - the context with recat gets saved in KJTAlltoAllTensorsAwaitable, but we won't get batch size info till we call into dist_init
    - it'd be very hacky to try to extract batch size per rank from
- The new implementation distributes the batch size per key in the initial splits collective and provides a global view of batch size per key per rank to every rank. The benefits include:
  - we can now generate batch size per rank in the non variable batch per feature case that solves the recat problem and fixes the issues with empty ranks
  - one less collective/kernel launch in SDD, as we fuse the batch size per key transmission into the splits a2a
- changes new input dist changes on top of original changes: D48600208

Differential Revision: D48625064

