### PR TITLE
Randomize num ids per feature

### DIFF
--- a/torchrec/datasets/tests/test_random.py
+++ b/torchrec/datasets/tests/test_random.py
@@ -18,6 +18,7 @@ class RandomDataLoader(unittest.TestCase):
             batch_size=16,
             hash_sizes=[100, 200],
             ids_per_features=[100, 200],
+            min_ids_per_features=[100, 200],
             num_dense=5,
         )
 
@@ -47,6 +48,7 @@ class RandomDataLoader(unittest.TestCase):
             batch_size=16,
             hash_size=100,
             ids_per_features=[100, 200],
+            min_ids_per_features=[100, 200],
             num_dense=5,
         )
 
@@ -75,6 +77,7 @@ class RandomDataLoader(unittest.TestCase):
             keys=["feat1", "feat2"],
             batch_size=16,
             hash_size=100,
+            min_ids_per_feature=50,
             ids_per_feature=50,
             num_dense=5,
         )
@@ -105,6 +108,7 @@ class RandomDataLoader(unittest.TestCase):
             batch_size=16,
             hash_size=100,
             ids_per_feature=50,
+            min_ids_per_feature=50,
             num_dense=5,
             num_generated_batches=-1,
         )


### PR DESCRIPTION
Summary: To be a good citizen, I changed the default behavior to sample from 0 to num ids. This necessitated fixing some unit tests which had assumed that the number of ids would be fixed. I can also NOT change the default, but it seems like a good idea for the random dataset to actually have random ids by default.

Differential Revision: D48569957

