### PR TITLE
update dmp top-level param copy behavior

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -243,7 +243,9 @@ def copy_to_device(
     if isinstance(copy_module, CopyMixIn):
         return copy_module.copy(to_device)
     copied_param = {
-        name: torch.nn.Parameter(_copy_if_device_match(param.data))
+        name: torch.nn.Parameter(
+            _copy_if_device_match(param.data), requires_grad=param.requires_grad
+        )
         for name, param in copy_module.named_parameters(recurse=False)
     }
     copied_buffer = {


### PR DESCRIPTION
Summary:
otherwise require_grad will default to True and model loading can get this error
 {F1078207638}

Reviewed By: pengtxiafb

Differential Revision: D48302949

