### PR TITLE
Update pytree registration to new api

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1875,28 +1875,7 @@ def _kjt_flatten_spec(
     return [getattr(t, a) for a in KeyedJaggedTensor._fields]
 
 
-try:
-
-    def _kjt_to_str(spec: TreeSpec, child_strings: List[str]) -> str:
-        assert spec.type == KeyedJaggedTensor
-        return f"K({json.dumps([spec.context, ','.join(child_strings)])})"
-
-    # pyre-ignore[3]
-    def _maybe_str_to_kjt(str_spec: str):
-        if not str_spec.startswith("K"):
-            return None
-        assert str_spec[1] == "("
-        assert str_spec[-1] == ")"
-        r = json.loads(str_spec[2:-1])
-        return KeyedJaggedTensor, r[0], r[1]
-
-    # pyre-ignore
-    _register_pytree_node(
-        KeyedJaggedTensor, _kjt_flatten, _kjt_unflatten, _kjt_to_str, _maybe_str_to_kjt
-    )
-
-except TypeError:
-    _register_pytree_node(KeyedJaggedTensor, _kjt_flatten, _kjt_unflatten)
+_register_pytree_node(KeyedJaggedTensor, _kjt_flatten, _kjt_unflatten)
 register_pytree_flatten_spec(KeyedJaggedTensor, _kjt_flatten_spec)
 
 


### PR DESCRIPTION
Summary:
Resolves short-term code changes by D48747343 needed to support breaking changes due to PT api change in OSS but not yet synced internally.   Diff train expected to land 11am PST, Aug 29. must rebase past that point.

- UPDATE diff train import as: D47848392, good to land past that point.

Reviewed By: angelayi

Differential Revision: D48784113

