### PR TITLE
allow initialize weights even on meta device

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -311,7 +311,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
                 row_alignment=row_alignment,
                 feature_table_map=feature_table_map,
             )
-            if device != torch.device("meta") and weight_lists is None:
+            if weight_lists is None:
                 emb_module.initialize_weights()
             self._emb_modules.append(emb_module)
 
@@ -602,7 +602,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 output_dtype=data_type_to_sparse_type(dtype_to_data_type(output_dtype)),
                 row_alignment=row_alignment,
             )
-            if device != torch.device("meta") and weight_lists is None:
+            if weight_lists is None:
                 emb_module.initialize_weights()
 
             self._emb_modules.append(emb_module)

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -153,6 +153,24 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
             quant_state_dict_split_scale_bias,
         )
 
+    def test_create_on_meta_device_without_providing_weights(self) -> None:
+        emb_bag = EmbeddingBagConfig(
+            name="t1",
+            embedding_dim=16,
+            num_embeddings=10,
+            feature_names=["f1"],
+        )
+        QuantEmbeddingBagCollection(
+            [emb_bag], is_weighted=False, device=torch.device("meta")
+        )
+        emb = EmbeddingConfig(
+            name="t1",
+            embedding_dim=16,
+            num_embeddings=10,
+            feature_names=["f1"],
+        )
+        QuantEmbeddingCollection([emb], device=torch.device("meta"))
+
     def test_shared_tables(self) -> None:
         eb_config = EmbeddingBagConfig(
             name="t1", embedding_dim=16, num_embeddings=10, feature_names=["f1", "f2"]


### PR DESCRIPTION
Summary: We should do tbe weights initialization if weights are not provided regardless of the device. Otherwise, if we create ebc/ec on meta device without passing in weights, we will hit an error when trying to get weights from the tbe module.

Differential Revision: D48835377

