### PR TITLE
sharded tbes weights from unsharded

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -408,6 +408,10 @@ class ShardedQuantEmbeddingCollection(
             IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
         ] = get_tbes_to_register_from_iterable(self._lookups)
 
+        self._tbes_configs: Dict[
+            IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
+        ] = tbes
+
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(tbes.keys())
@@ -447,6 +451,14 @@ class ShardedQuantEmbeddingCollection(
                         self.embeddings[table_name].register_buffer(
                             "weight", lookup_state_dict[key]
                         )
+
+    def tbes_configs(
+        self,
+    ) -> Dict[IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig]:
+        return self._tbes_configs
+
+    def embedding_configs(self) -> List[EmbeddingConfig]:
+        return self._embedding_configs
 
     def _generate_permute_indices_per_feature(
         self,

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -142,6 +142,10 @@ class ShardedQuantEmbeddingBagCollection(
             IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
         ] = get_tbes_to_register_from_iterable(self._lookups)
 
+        self._tbes_configs: Dict[
+            IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
+        ] = tbes
+
         # Optional registration of TBEs for model post processing utilities
         if is_fused_param_register_tbe(fused_params):
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(tbes.keys())
@@ -181,6 +185,14 @@ class ShardedQuantEmbeddingBagCollection(
                         self.embedding_bags[table_name].register_buffer(
                             "weight", lookup_state_dict[key]
                         )
+
+    def tbes_configs(
+        self,
+    ) -> Dict[IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig]:
+        return self._tbes_configs
+
+    def embedding_bag_configs(self) -> List[EmbeddingBagConfig]:
+        return self._embedding_bag_configs
 
     def _create_input_dist(
         self,

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -96,6 +96,23 @@ class DataType(Enum):
         return self.value
 
 
+def bit_width(data_type: DataType) -> int:
+    if data_type in {DataType.INT64}:
+        return 64
+    if data_type in {DataType.FP32, DataType.INT32}:
+        return 32
+    elif data_type in {DataType.FP16, DataType.BF16}:
+        return 16
+    elif data_type in {DataType.INT8, DataType.UINT8}:
+        return 8
+    elif data_type == DataType.INT4:
+        return 4
+    elif data_type == DataType.INT2:
+        return 2
+    else:
+        raise ValueError(f"Unsupported data type {data_type}")
+
+
 class ShardingType(Enum):
     """
     Well-known sharding types, used by inter-module optimizations.


### PR DESCRIPTION
Summary:
Exposing tbes_configs: `Dict[IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig]` for Sharded Quant Modules.
And Introducing `sharded_tbes_weights` to prepare sharded tbes weights with 'xl_weights' fqns:
```

def sharded_tbes_weights(
    unsharded_weights: Dict[str, torch.Tensor],
    sharded_model: torch.nn.Module,
) -> Dict[str, torch.Tensor]:
    # Prepares TBEs quant sharded weights map from TBEs quant unsharded weights map.
    # TBEs weights are mapped per table_name, in quant_state_dict_split_scale_bias mode
    # INPUT:
    # unsharded_weights {fqn, Tensor}
    # Example input:
    # {
    #   "seq_arch.embeddings.table_0.weight": Tensor,
    #   "seq_arch.embeddings.table_0.weight_qscale": Tensor,
    #   "seq_arch.embeddings.table_0.weight_qbias": Tensor,
    # }
    # sharded_module
    #
    # OUTPUT:
    # Sharded mapping corresponding sharded module named buffers:
    #
    # {embedding_module_fqn}.tbes.{tbe_idx}.{table_idx}.{table_name}.weight -> ShardedTensor
    # Example output:
    # {
    #   "seq_arch.embeddings.tbes.0.0.table_0.weight": Tensor,
    #   "seq_arch.embeddings.tbes.0.0.table_0.weight_qscale": Tensor,
    #   "seq_arch.embeddings.tbes.0.0.table_0.weight_qbias": Tensor,
    #   "seq_arch.embeddings.tbes.1.0.table_0.weight": Tensor,
    #   "seq_arch.embeddings.tbes.1.0.table_0.weight_qscale": Tensor,
    #   "seq_arch.embeddings.tbes.1.0.table_0.weight_qbias": Tensor,
    # }
```

Differential Revision:
D48868910

Privacy Context Container: L1138451

