### PR TITLE
Include python 3.11 in cpu ci

### DIFF
--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -32,6 +32,9 @@ jobs:
             - os: linux.2xlarge
               python-version: '3.10'
               python-tag: "py310"
+            - os: linux.2xlarge
+              python-version: '3.11'
+              python-tag: "py311"
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: ${{ matrix.os }}

--- a/torchrec/__init__.py
+++ b/torchrec/__init__.py
@@ -25,3 +25,10 @@ from torchrec.sparse.jagged_tensor import (  # noqa
     KeyedTensor,
 )
 from torchrec.streamable import Multistreamable, Pipelineable  # noqa
+
+try:
+    # pyre-ignore[21]
+    # @manual=//torchrec/fb:version
+    from .version import __version__, github_version  # noqa
+except ImportError:
+    pass


### PR DESCRIPTION
Summary: test-infra already builds python 3.11. We should test it as well.

Differential Revision: D48874189

