### PR TITLE
Remove iopath and panads from install requirements

### DIFF
--- a/install-requirements.txt
+++ b/install-requirements.txt
@@ -1,6 +1,4 @@
 fbgemm-gpu-nightly
-iopath
-pandas
 tabulate
-torchmetrics
+torchmetrics==1.0.3
 tqdm


### PR DESCRIPTION
Summary:
1. iopath and panads are not needed for main function of torchrec.
2. Add version for torchmetrics, following requirements.txt
3. In the future, we will remove tabulate.

Differential Revision: D48892139

