### PR TITLE
Pass tracer to update_param_annotations

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -913,6 +913,7 @@ class SeqEmbeddingsAllToOne(nn.Module):
         return torch.ops.fbgemm.all_to_one_device(
             tensors,
             self._device,
+            # tensors[0].device,
         )
 
 


### PR DESCRIPTION
Summary: In _fx_script_lowered_module the customized tracer should also be passed into and used as the tracer of update_param_annotations.

Differential Revision: D48882553

