### PR TITLE
Trying to fix the hotloading incompatibility issue

### DIFF
--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -21,6 +21,9 @@ from torchrec.distributed.fp_embeddingbag import (
     FeatureProcessedEmbeddingBagCollectionSharder,
 )
 from torchrec.distributed.fused_embeddingbag import FusedEmbeddingBagCollectionSharder
+from torchrec.distributed.mc_embeddingbag import (
+    ManagedCollisionEmbeddingBagCollectionSharder,
+)
 from torchrec.distributed.planner.constants import MIN_CW_DIM
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
@@ -43,6 +46,7 @@ def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
         cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),
+        cast(ModuleSharder[nn.Module], ManagedCollisionEmbeddingBagCollectionSharder()),
     ]
 
 

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -17,8 +17,15 @@ from torchrec.distributed.sharding_plan import (
     column_wise,
     construct_module_sharding_plan,
     data_parallel,
+    EmbeddingBagCollectionSharder,
+    EmbeddingCollectionSharder,
+    FeatureProcessedEmbeddingBagCollectionSharder,
+    FusedEmbeddingBagCollectionSharder,
     get_module_to_default_sharders,
+    ManagedCollisionEmbeddingBagCollectionSharder,
     ParameterShardingGenerator,
+    QuantEmbeddingBagCollectionSharder,
+    QuantEmbeddingCollectionSharder,
     row_wise,
     table_row_wise,
     table_wise,
@@ -39,7 +46,17 @@ from torchrec.distributed.types import (
     ShardMetadata,
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+)
+from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
+from torchrec.modules.fused_embedding_modules import FusedEmbeddingBagCollection
+from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingBagCollection
+from torchrec.quant.embedding_modules import (
+    EmbeddingBagCollection as QuantEmbeddingBagCollection,
+    EmbeddingCollection as QuantEmbeddingCollection,
+)
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class
@@ -680,3 +697,44 @@ movie_id  [0, 0]           [2048, 32]     rank:0/cuda:0
 movie_id  [2048, 0]        [2048, 32]     rank:0/cuda:1
 """
         self.assertEqual(expected.strip(), str(plan))
+
+    def test_module_to_default_sharders(self) -> None:
+        default_sharder_map = get_module_to_default_sharders()
+        self.assertCountEqual(
+            default_sharder_map,
+            [
+                EmbeddingBagCollection,
+                FeatureProcessedEmbeddingBagCollection,
+                EmbeddingCollection,
+                FusedEmbeddingBagCollection,
+                QuantEmbeddingBagCollection,
+                QuantEmbeddingCollection,
+                ManagedCollisionEmbeddingBagCollection,
+            ],
+        )
+        self.assertIsInstance(
+            default_sharder_map[EmbeddingBagCollection], EmbeddingBagCollectionSharder
+        )
+        self.assertIsInstance(
+            default_sharder_map[FeatureProcessedEmbeddingBagCollection],
+            FeatureProcessedEmbeddingBagCollectionSharder,
+        )
+        self.assertIsInstance(
+            default_sharder_map[EmbeddingCollection], EmbeddingCollectionSharder
+        )
+        self.assertIsInstance(
+            default_sharder_map[FusedEmbeddingBagCollection],
+            FusedEmbeddingBagCollectionSharder,
+        )
+        self.assertIsInstance(
+            default_sharder_map[QuantEmbeddingBagCollection],
+            QuantEmbeddingBagCollectionSharder,
+        )
+        self.assertIsInstance(
+            default_sharder_map[QuantEmbeddingCollection],
+            QuantEmbeddingCollectionSharder,
+        )
+        self.assertIsInstance(
+            default_sharder_map[ManagedCollisionEmbeddingBagCollection],
+            ManagedCollisionEmbeddingBagCollectionSharder,
+        )


### PR DESCRIPTION
Summary:
Having discussion with jgk, we believe this is the right fix:

check this out https://fburl.com/code/v60tnefc

here we require https://fburl.com/code/gf6v4asr

torchrec

https://fburl.com/code/jn8eoyxs is not part of "//torchrec/distributed:distributed"

distributed uses model_parallel
model_parallel uses sharding_plan
sharding_plan includes fp_embeddingbag

BUT it does not include mc_embeddingbag

so the better solve instead of D48973797 would be to add mc_embeddingbag in https://fburl.com/code/td7f2682

then this dependency will roll up into

mc_embeddingbag -> sharding_plan -> model_parallel -> distributed -> https://fburl.com/code/zjxooggp -> https://fburl.com/code/xgpq1y3m

Differential Revision: D48912014


