### PR TITLE
Support MTIA device type

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -571,6 +571,11 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
                 managed.append(
                     compute_kernel_to_embedding_location(table.compute_kernel)
                 )
+            elif device is not None and device.type == "mtia":
+                compute_devices.append(ComputeDevice.MTIA)
+                # Set EmbeddingLocation.HOST to make embedding op in FBGEMM choose CPU path.
+                # But the tensor will still be created on MTIA with device type "mtia".
+                managed.append(EmbeddingLocation.HOST)
             else:
                 compute_devices.append(ComputeDevice.CPU)
                 managed.append(EmbeddingLocation.HOST)
@@ -853,6 +858,11 @@ class BatchedFusedEmbeddingBag(
                 managed.append(
                     compute_kernel_to_embedding_location(table.compute_kernel)
                 )
+            elif device is not None and device.type == "mtia":
+                compute_devices.append(ComputeDevice.MTIA)
+                # Set EmbeddingLocation.HOST to make embedding op in FBGEMM choose CPU path.
+                # But the tensor will still be created on MTIA with device type "mtia".
+                managed.append(EmbeddingLocation.HOST)
             else:
                 compute_devices.append(ComputeDevice.CPU)
                 managed.append(EmbeddingLocation.HOST)

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -499,8 +499,11 @@ class KJTOneToAll(nn.Module):
         super().__init__()
         self._splits = splits
         self._world_size = world_size
-        self._device_type = (
-            "meta" if device is not None and device.type == "meta" else "cuda"
+        # If no device is provided, use "cuda".
+        self._device_type: str = (
+            device.type
+            if device is not None and device.type in {"meta", "cuda", "mtia"}
+            else "cuda"
         )
         assert self._world_size == len(splits)
 

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -424,7 +424,7 @@ class ShardedEmbeddingBagCollection(
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
                     device_ids=[device]
-                    if self._device and self._device.type == "gpu"
+                    if self._device and (self._device.type in {"gpu", "mtia"})
                     else None,
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -64,6 +64,11 @@ def kernel_bw_lookup(
         ("cpu", EmbeddingComputeKernel.DENSE.value): 0.5 * ddr_mem_bw,
         ("cpu", EmbeddingComputeKernel.FUSED.value): 1 * ddr_mem_bw,
         ("cpu", EmbeddingComputeKernel.QUANT.value): 1 * ddr_mem_bw,
+        # TODO: Determine the correct value later. MTIA uses values same as CPU's.
+        # MTIA
+        ("mtia", EmbeddingComputeKernel.DENSE.value): 0.5 * ddr_mem_bw,
+        ("mtia", EmbeddingComputeKernel.FUSED.value): 1 * ddr_mem_bw,
+        ("mtia", EmbeddingComputeKernel.QUANT.value): 1 * ddr_mem_bw,
         # CUDA
         ("cuda", EmbeddingComputeKernel.DENSE.value): 0.5 * hbm_mem_bw,
         ("cuda", EmbeddingComputeKernel.FUSED.value): 1 * hbm_mem_bw,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -132,6 +132,7 @@ class Topology:
         assert compute_device in [
             "cpu",
             "cuda",
+            "mtia",
         ], f"unsupported compute device {compute_device}"
 
         self._compute_device = compute_device

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -43,8 +43,8 @@ def placement(
     """
 
     param_device = compute_device
-    if compute_device == "cuda":
-        param_device = torch.device("cuda", rank % local_size)
+    if compute_device in {"cuda", "mtia"}:
+        param_device = torch.device(compute_device, rank % local_size)
     return f"rank:{rank}/{param_device}"
 
 

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -60,8 +60,8 @@ def placement(
     local_size: int,
 ) -> str:
     param_device = compute_device
-    if compute_device == "cuda":
-        param_device = torch.device("cuda", rank % local_size)
+    if compute_device in {"cuda", "mtia"}:
+        param_device = torch.device(compute_device, rank % local_size)
     return f"rank:{rank}/{param_device}"
 
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -848,8 +848,13 @@ class ModuleSharder(abc.ABC, Generic[M]):
         compute kernel.
         """
 
-        assert compute_device_type in {"cuda", "cpu"}
-        storage_map = {"cuda": ParameterStorage.HBM, "cpu": ParameterStorage.DDR}
+        assert compute_device_type in {"cuda", "cpu", "mtia"}
+        storage_map = {
+            "cuda": ParameterStorage.HBM,
+            "cpu": ParameterStorage.DDR,
+            # TODO: Update it later. Setting for MTIA is same as CPU's for now.
+            "mtia": ParameterStorage.DDR,
+        }
         return {
             storage_map[compute_device_type].value: tensor.element_size()
             * tensor.nelement()


### PR DESCRIPTION
Summary:
Enable MTIA device in TorchRec.
- The fbgemm ops used for CUDA and CPU don't have same schema. We have to let the FBGEMM training chose CPU one after setting the device type as MTIA.
- Misc fix in TorchRec to make sure it knows the device type MTIA.

Differential Revision: D45276862

