### PR TITLE
use nn.Module training flag to enable eval

### DIFF
--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -60,7 +60,6 @@ class SparseArch(nn.Module):
             mch_hash_func=mch_hash_func if mch_size else None,
             input_hash_size=4000,
             device=device,
-            is_train=True,
             eviction_interval=2,
             eviction_policy=DistanceLFU_EvictionPolicy(),
         )
@@ -70,7 +69,6 @@ class SparseArch(nn.Module):
             mch_size=mch_size,
             mch_hash_func=mch_hash_func if mch_size else None,
             device=device,
-            is_train=True,
             input_hash_size=4000,
             eviction_interval=2,
             eviction_policy=DistanceLFU_EvictionPolicy(),

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -22,7 +22,7 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
-    def test_zch_ebc(self) -> None:
+    def test_zch_ebc_train(self) -> None:
         device = torch.device("cpu")
         zch_size = 20
         update_interval = 2
@@ -46,7 +46,6 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
                 MCHManagedCollisionModule(
                     zch_size=zch_size,
                     device=device,
-                    is_train=True,
                     eviction_interval=update_interval,
                     eviction_policy=DistanceLFU_EvictionPolicy(),
                 ),
@@ -144,6 +143,119 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
             )
         )
 
+    def test_zch_ebc_eval(self) -> None:
+        device = torch.device("cpu")
+        zch_size = 20
+        update_interval = 2
+        update_size = 10
+
+        embedding_configs = [
+            EmbeddingBagConfig(
+                name="t1",
+                embedding_dim=8,
+                num_embeddings=zch_size,
+                feature_names=["f1", "f2"],
+            ),
+        ]
+        ebc = EmbeddingBagCollection(
+            tables=embedding_configs,
+            device=device,
+        )
+        mc_modules = {
+            "t1": cast(
+                ManagedCollisionModule,
+                MCHManagedCollisionModule(
+                    zch_size=zch_size,
+                    device=device,
+                    eviction_interval=update_interval,
+                    eviction_policy=DistanceLFU_EvictionPolicy(),
+                ),
+            ),
+        }
+        mcc = ManagedCollisionCollection(
+            managed_collision_modules=mc_modules,
+            # pyre-ignore[6]
+            embedding_configs=embedding_configs,
+        )
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            ebc,
+            mcc,
+            return_remapped_features=True,
+        )
+
+        update_one = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1", "f2"],
+            values=torch.concat(
+                [
+                    torch.arange(1000, 1000 + update_size, dtype=torch.int64),
+                    torch.arange(
+                        1000 + update_size,
+                        1000 + 2 * update_size,
+                        dtype=torch.int64,
+                    ),
+                ]
+            ),
+            lengths=torch.ones((2 * update_size,), dtype=torch.int64),
+            weights=None,
+        )
+        _, remapped_kjt1 = mc_ebc.forward(update_one)
+        _, remapped_kjt2 = mc_ebc.forward(update_one)
+
+        assert torch.all(
+            # pyre-ignore[16]
+            remapped_kjt1["f1"].values()
+            == zch_size - 1
+        ), "all remapped ids should be mapped to end of range"
+        assert torch.all(
+            remapped_kjt1["f2"].values() == zch_size - 1
+        ), "all remapped ids should be mapped to end of range"
+
+        assert torch.all(
+            remapped_kjt2["f1"].values() == torch.arange(0, 10, dtype=torch.int64)
+        )
+        assert torch.all(
+            remapped_kjt2["f2"].values()
+            == torch.cat(
+                [
+                    torch.arange(10, 19, dtype=torch.int64),
+                    torch.tensor([zch_size - 1], dtype=torch.int64),  # empty value
+                ]
+            )
+        )
+
+        # Trigger eval mode, zch should not update
+        mc_ebc.eval()
+
+        update_two = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f1", "f2"],
+            values=torch.concat(
+                [
+                    torch.arange(2000, 2000 + update_size, dtype=torch.int64),
+                    torch.arange(
+                        1000 + update_size,
+                        1000 + 2 * update_size,
+                        dtype=torch.int64,
+                    ),
+                ]
+            ),
+            lengths=torch.ones((2 * update_size,), dtype=torch.int64),
+            weights=None,
+        )
+        _, remapped_kjt3 = mc_ebc.forward(update_two)
+        _, remapped_kjt4 = mc_ebc.forward(update_two)
+
+        assert torch.all(
+            remapped_kjt3["f1"].values() == zch_size - 1
+        ), "all remapped ids should be mapped to end of range"
+
+        assert torch.all(remapped_kjt3["f2"].values() == remapped_kjt2["f2"].values())
+
+        assert torch.all(
+            remapped_kjt4["f1"].values() == zch_size - 1
+        ), "all remapped ids should be mapped to end of range"
+
+        assert torch.all(remapped_kjt4["f2"].values() == remapped_kjt2["f2"].values())
+
     def test_mch_ebc(self) -> None:
         device = torch.device("cpu")
         zch_size = 10
@@ -174,7 +286,6 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
                     zch_size=zch_size,
                     mch_size=mch_size,
                     device=device,
-                    is_train=True,
                     eviction_interval=update_interval,
                     eviction_policy=DistanceLFU_EvictionPolicy(),
                     mch_hash_func=preprocess_func,
@@ -208,7 +319,6 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
             weights=None,
         )
         _, remapped_kjt1 = mc_ebc.forward(update_one)
-
         _, remapped_kjt2 = mc_ebc.forward(update_one)
 
         assert torch.all(


### PR DESCRIPTION
Summary: Switch to using native pytorch api for checking training or not (eval).

Differential Revision: D49033866


