### PR TITLE
Merge logs torchrec/distributed/planner/stats.py

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 from collections import defaultdict
 from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
@@ -390,8 +391,7 @@ class EmbeddingStats(Stats):
 
         self._stats_table.append("#" * self._width)
 
-        for row in self._stats_table:
-            logger.info(row)
+        logger.info(os.linesep + os.linesep.join(self._stats_table))
 
     def _get_shard_stats(
         self,


### PR DESCRIPTION
Summary:
Instead of printing multiple log lines, by printing one we get the benefit of offloading large amount of content to manifold. P812922746 notice how each line of the stats table is not printing logger prefix.

**Impact
Characters: 334075 reduced (~75.4% total characters reduced)
Lines:  1213 reduced (45.48~% total lines)**

Reviewed By: dstaay-fb, satgera, wilson100hong

Differential Revision: D48619298


