### PR TITLE
Fix lazy_extention test

### DIFF
--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -157,9 +157,8 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
 
     # fmt: off
     # pyre-ignore[2, 47]
-    # pyre-fixme[14]: `_infer_parameters` overrides method defined in
     #  `LazyModuleMixin` inconsistently.
-    def _infer_parameters(self: _LazyExtensionProtocol, module, input, kwargs) -> None:
+    def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:
         r"""Infers the size and initializes the parameters according to the
         provided input batch.
         Given a module that contains parameters that were declared inferrable
@@ -169,7 +168,8 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
         The module is set into evaluation mode before running the forward pass in order
         to avoid saving statistics or calculating gradients
         """
-        module.initialize_parameters(*input, **kwargs)
+        kwargs = kwargs if kwargs else {}
+        module.initialize_parameters(*args, **kwargs)
         if module.has_uninitialized_params():
             raise RuntimeError(f'module {self._get_name()} has not been fully initialized')
         module._initialize_hook.remove()

--- a/torchrec/modules/tests/test_lazy_extension.py
+++ b/torchrec/modules/tests/test_lazy_extension.py
@@ -66,13 +66,12 @@ class TestLazyModuleExtensionMixin(unittest.TestCase):
 
         # reproduce the only changes:
         expected_lazy_ext_infer_parameters_src = original_infer_parameters_src.replace(
-            "def _infer_parameters(self: _LazyProtocol, module, input):",
-            "def _infer_parameters(self: _LazyExtensionProtocol, module, input, kwargs) -> None:",
+            "def _infer_parameters(self: _LazyProtocol, module, args, kwargs=None):",
+            "def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:",
         ).replace(
-            "module.initialize_parameters(*input)",
-            "module.initialize_parameters(*input, **kwargs)",
+            "module.initialize_parameters(*args)",
+            "module.initialize_parameters(*args, **kwargs)",
         )
-
         self.assertEqual(
             lazy_ext_infer_parameters_src,
             expected_lazy_ext_infer_parameters_src,


### PR DESCRIPTION
Summary: Test compares sources - there were small difference `input->args, kwargs = kwargs if kwargs else {}`

Differential Revision:
D49276445

Privacy Context Container: L1138451


