### PR TITLE
Fix test_quant_pooled_emb_arch_model_parallel

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -162,7 +162,6 @@ class InferenceModelParallelTestBase(unittest.TestCase):
         # materialize inference sharded model on one device for dense part
         local_model = local_model.copy(cuda_device)
 
-        # Load model state from the global model.
         copy_state_dict(local_model.state_dict(), global_model.state_dict())
 
         # Run a single training step of the sharded model.


### PR DESCRIPTION
Summary:
We do not need to test quant_split_scale_mode for PEA as it only used for CW/RW shardings.

Add super() call to init parent properties (failed for qcomm_* missing)

Differential Revision: D49279015


