### PR TITLE
Revert D49256608: Multisect successfully blamed "D49256608: [TorchRec] enable CPU row-wise sharding" for test or build failures

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -350,12 +350,12 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         types = [
             ShardingType.DATA_PARALLEL.value,
             ShardingType.TABLE_WISE.value,
-            ShardingType.ROW_WISE.value,
             ShardingType.COLUMN_WISE.value,
             ShardingType.TABLE_COLUMN_WISE.value,
         ]
         if compute_device_type in {"cuda"}:
             types += [
+                ShardingType.ROW_WISE.value,
                 ShardingType.TABLE_ROW_WISE.value,
             ]
 


### PR DESCRIPTION
Summary:
This diff is reverting D49256608
D49256608: [TorchRec] enable CPU row-wise sharding by jiayisuse has been identified to be causing the following test or build failures:

Tests affected:
- [torchrec/github/examples/retrieval/tests:test_two_tower_train - torchrec.github.examples.retrieval.tests.test_two_tower_train.TrainTest: test_train_function](https://www.internalfb.com/intern/test/281475048734207/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3072404
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: jiayisuse

Differential Revision: D49361458


