### PR TITLE
Add dedup flag to EC sharder as option.

### DIFF
--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -51,9 +51,8 @@ def _test_sharding(  # noqa C901
     use_index_dedup: bool = False,
 ) -> None:
     trec_dist.comm_ops.set_gradient_division(False)
-    trec_dist.embedding.set_ec_index_dedup(use_index_dedup)
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        sharder = EmbeddingCollectionSharder()
+        sharder = EmbeddingCollectionSharder(use_index_dedup=use_index_dedup)
         kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
 
         unsharded_model = EmbeddingCollection(


### PR DESCRIPTION
Summary:
Passing as non-global flag will allow us to plan around this feature, and avoid a couple of sharp edge cases such a if a user first shards a model, and then sets the flag. It could be easy to think that they enabled this feature, but it doesn't.

Will remove global flag in a later diff.

Reviewed By: dstaay-fb

Differential Revision: D48607324


