### PR TITLE
Add test case for CW sharding infer quant model with multiple tables

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.quantization as quant
 import torchrec as trec
 import torchrec.quant as trec_quant
-from torchrec.modules.embedding_configs import TrecQuantConfig
+from torchrec.modules.embedding_configs import QuantConfig
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollectionInterface,
     EmbeddingCollectionInterface,
@@ -52,12 +52,12 @@ def quantize_embeddings(
     output_dtype: torch.dtype = torch.float,
     per_table_weight_dtype: Optional[Dict[str, torch.dtype]] = None,
 ) -> nn.Module:
-    qconfig = TrecQuantConfig(
+    qconfig = QuantConfig(
         activation=quant.PlaceholderObserver.with_args(dtype=output_dtype),
         weight=quant.PlaceholderObserver.with_args(dtype=dtype),
         per_table_weight_dtype=per_table_weight_dtype,
     )
-    qconfig_spec: Dict[Type[nn.Module], TrecQuantConfig] = {
+    qconfig_spec: Dict[Type[nn.Module], QuantConfig] = {
         trec.EmbeddingBagCollection: qconfig,
     }
     mapping: Dict[Type[nn.Module], Type[nn.Module]] = {

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -206,7 +206,7 @@ class EmbeddingConfig(BaseEmbeddingConfig):
     pass
 
 
-class TrecQuantConfig(NamedTuple):
+class QuantConfig(NamedTuple):
     activation: torch.quantization.PlaceholderObserver
     weight: torch.quantization.PlaceholderObserver
     per_table_weight_dtype: Optional[Dict[str, torch.dtype]] = None

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -8,7 +8,7 @@
 import copy
 import itertools
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, cast, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -20,15 +20,17 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
 from torch import Tensor
 from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import (
+    BaseEmbeddingConfig,
     DATA_TYPE_NUM_BITS,
     data_type_to_sparse_type,
     DataType,
     dtype_to_data_type,
     EmbeddingBagConfig,
     EmbeddingConfig,
+    EmbeddingTableConfig,
     pooling_type_to_pooling_mode,
     PoolingType,
-    TrecQuantConfig,
+    QuantConfig,
 )
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection as OriginalEmbeddingBagCollection,
@@ -167,6 +169,23 @@ def quantize_state_dict(
                 quant_weight, scale_shift = quant_res, None
         table_name_to_quantized_weights[table_name] = (quant_weight, scale_shift)
     return device
+
+
+def _update_embedding_configs(
+    embedding_configs: List[BaseEmbeddingConfig],
+    quant_config: Union[QuantConfig, torch.quantization.QConfig],
+) -> None:
+    per_table_weight_dtype = (
+        quant_config.per_table_weight_dtype
+        if isinstance(quant_config, QuantConfig) and quant_config.per_table_weight_dtype
+        else {}
+    )
+    for config in embedding_configs:
+        config.data_type = dtype_to_data_type(
+            per_table_weight_dtype[config.name]
+            if config.name in per_table_weight_dtype
+            else quant_config.weight().dtype
+        )
 
 
 class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin):
@@ -431,29 +450,17 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         assert hasattr(
             module, "qconfig"
         ), "EmbeddingBagCollection input float module must have qconfig defined"
-        per_table_weight_dtype = (
-            module.qconfig.per_table_weight_dtype
-            if isinstance(module.qconfig, TrecQuantConfig)
-            else None
-        )
-        data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         embedding_bag_configs = copy.deepcopy(module.embedding_bag_configs())
-        table_name_to_data_type: Dict[str, DataType] = {}
-        for config in embedding_bag_configs:
-            if (
-                per_table_weight_dtype is not None
-                and config.name in per_table_weight_dtype
-            ):
-                config.data_type = dtype_to_data_type(
-                    per_table_weight_dtype[config.name]
-                )
-            else:
-                config.data_type = data_type
-            table_name_to_data_type[config.name] = config.data_type
+        _update_embedding_configs(
+            cast(List[BaseEmbeddingConfig], embedding_bag_configs),
+            module.qconfig,
+        )
 
         table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] = {}
         device = quantize_state_dict(
-            module, table_name_to_quantized_weights, table_name_to_data_type
+            module,
+            table_name_to_quantized_weights,
+            {table.name: table.data_type for table in embedding_bag_configs},
         )
         return cls(
             embedding_bag_configs,
@@ -684,31 +691,18 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         assert hasattr(
             module, "qconfig"
         ), "EmbeddingCollection input float module must have qconfig defined"
-        per_table_weight_dtype = (
-            module.qconfig.per_table_weight_dtype
-            if isinstance(module.qconfig, TrecQuantConfig)
-            else None
+        embedding_configs = copy.deepcopy(module.embedding_configs())
+        _update_embedding_configs(
+            cast(List[BaseEmbeddingConfig], embedding_configs), module.qconfig
         )
-        data_type = dtype_to_data_type(module.qconfig.weight().dtype)
-        tables = copy.deepcopy(module.embedding_configs())
-        table_name_to_data_type: Dict[str, DataType] = {}
-        for config in tables:
-            if (
-                per_table_weight_dtype is not None
-                and config.name in per_table_weight_dtype
-            ):
-                config.data_type = dtype_to_data_type(
-                    per_table_weight_dtype[config.name]
-                )
-            else:
-                config.data_type = data_type
-            table_name_to_data_type[config.name] = config.data_type
         table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] = {}
         device = quantize_state_dict(
-            module, table_name_to_quantized_weights, table_name_to_data_type
+            module,
+            table_name_to_quantized_weights,
+            {table.name: table.data_type for table in embedding_configs},
         )
         return cls(
-            tables,
+            embedding_configs,
             device=device,
             need_indices=module.need_indices(),
             output_dtype=module.qconfig.activation().dtype,


### PR DESCRIPTION
Summary:
As titled

Test below cases
Test sharding plans for QEC/QEBC, when some tables are permuted, some tables are not
Example:
Tuple meaning: (table_name, column_index)

world_size:2
rank 0:
[
	(table_0, 1),
	(table_1, 0)
]

rank 1:
[
	(table_0, 0),
	(table_1, 1),
]

Differential Revision: D49641519

