### PR TITLE
Do not do noop kjt.split

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -532,8 +532,12 @@ class MetaInferGroupedEmbeddingsLookup(
         sparse_features: KeyedJaggedTensor,
     ) -> torch.Tensor:
         embeddings: List[torch.Tensor] = []
-        features_by_group = sparse_features.split(
-            self._feature_splits,
+        features_by_group = (
+            [sparse_features]
+            if len(self._feature_splits) == 1
+            else sparse_features.split(
+                self._feature_splits,
+            )
         )
         for i in range(len(self._emb_modules)):
             embeddings.append(
@@ -659,8 +663,12 @@ class MetaInferGroupedPooledEmbeddingsLookup(
             )
 
         embeddings: List[torch.Tensor] = []
-        features_by_group = sparse_features.split(
-            self._feature_splits,
+        features_by_group = (
+            [sparse_features]
+            if len(self._feature_splits) == 1
+            else sparse_features.split(
+                self._feature_splits,
+            )
         )
         # syntax for torchscript
         for i, (config, emb_op) in enumerate(

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -566,8 +566,10 @@ class ShardedQuantEmbeddingCollection(
                     self._features_order,
                     self._features_order_tensor,
                 )
-            features_by_sharding = features.split(
-                self._feature_splits,
+            features_by_sharding = (
+                [features]
+                if len(self._feature_splits) == 1
+                else features.split(self._feature_splits)
             )
 
             for i in range(len(self._input_dists)):

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -266,7 +266,11 @@ class ShardedQuantEmbeddingBagCollection(
                     self._features_order,
                     self._features_order_tensor,
                 )
-            features_by_shards = features.split(self._feature_splits)
+            features_by_shards = (
+                [features]
+                if len(self._feature_splits) == 1
+                else features.split(self._feature_splits)
+            )
             return ListOfKJTList(
                 [
                     self._input_dists[i].forward(features_by_shards[i])


### PR DESCRIPTION
Summary:
We have 3 places where we do split:
 - kjt by sharding type (most 1-element split, when we use only one sharding type)
 - by rank
- by group config (mostly 1-element split)

Those one element list lead to recreation of KJT, which is additional cost in inference.

We know that at tracing time and can reuse original KJT in this case.

Differential Revision:
D50079311

Privacy Context Container: L1138451


