### PR TITLE
Remove empty embeddings view(batch_size, 0)

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -649,6 +649,11 @@ class MetaInferGroupedPooledEmbeddingsLookup(
         self,
         sparse_features: KeyedJaggedTensor,
     ) -> torch.Tensor:
+        if len(self.grouped_configs) == 0:
+            return fx_wrap_tensor_view2d(
+                self._dummy_embs_tensor, sparse_features.stride(), 0
+            )
+
         embeddings: List[torch.Tensor] = []
         features_by_group = sparse_features.split(
             self._feature_splits,
@@ -668,7 +673,8 @@ class MetaInferGroupedPooledEmbeddingsLookup(
 
         return embeddings_cat_empty_rank_handle(
             embeddings,
-            fx_wrap_tensor_view2d(self._dummy_embs_tensor, sparse_features.stride(), 0),
+            # Not used as empty configs case is handled by guard
+            self._dummy_embs_tensor,
             dim=1,
         )
 


### PR DESCRIPTION
Summary:
This is specific of app graph split, doing .view(sparse_features.stride()) after for cycle adds full-kjt sparse_features to merge network (it gets everything after lookups).

We know at tracing time if we have empty embeddings.

Reviewed By: dstaay-fb

Differential Revision:
D50060310

Privacy Context Container: L1138451


