### PR TITLE
Use hbm bw for uvm caching when we are using prefetching

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -42,6 +42,7 @@ def kernel_bw_lookup(
     hbm_mem_bw: float,
     ddr_mem_bw: float,
     caching_ratio: Optional[float] = None,
+    prefetch_pipeline: bool = False,
 ) -> Optional[float]:
     """
     Calculates the device bandwidth based on given compute device, compute kernel, and
@@ -54,6 +55,7 @@ def kernel_bw_lookup(
         ddr_mem_bw (float): the bandwidth of the system DDR memory.
         caching_ratio (Optional[float]): caching ratio used to determine device bandwidth
             if UVM caching is enabled.
+        prefetch_pipeline (bool): whether prefetch pipeline is enabled.
 
     Returns:
         Optional[float]: the device bandwidth.
@@ -84,4 +86,12 @@ def kernel_bw_lookup(
         )
         / 10,
     }
+
+    if (
+        prefetch_pipeline
+        and compute_device == "cuda"
+        and compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+    ):
+        return lookup.get(("cuda", EmbeddingComputeKernel.FUSED.value))
+
     return lookup.get((compute_device, compute_kernel))

--- a/torchrec/distributed/planner/tests/test_constants.py
+++ b/torchrec/distributed/planner/tests/test_constants.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import List, Optional
+
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.constants import (
+    DDR_MEM_BW,
+    HBM_MEM_BW,
+    kernel_bw_lookup,
+)
+
+
+class TestKernelBWLookup(unittest.TestCase):
+    def test_uvm_caching_bw(self) -> None:
+        compute_device: str = "cuda"
+        computer_kernel: str = EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+
+        caching_ratios: List[float] = [0, 0.25, 0.5, 0.75, 1]
+
+        uvm_caching_bw: list[Optional[float]] = [
+            kernel_bw_lookup(
+                compute_device, computer_kernel, HBM_MEM_BW, DDR_MEM_BW, caching_ratio
+            )
+            for caching_ratio in caching_ratios
+        ]
+        expected_uvm_caching_bw: List[float] = [
+            23643794.96448,
+            28185722.880000003,
+            50895362.457600005,
+            73605002.0352,
+            96314641.6128,
+        ]
+
+        self.assertEqual(expected_uvm_caching_bw, uvm_caching_bw)
+
+    def test_uvm_caching_bw_with_prefetch_pipeline(self) -> None:
+        compute_device: str = "cuda"
+        computer_kernel: str = EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        prefetch_pipeline: bool = True
+
+        caching_ratios: List[float] = [0, 0.25, 0.5, 0.75, 1]
+
+        uvm_caching_bw: list[Optional[float]] = [
+            kernel_bw_lookup(
+                compute_device,
+                computer_kernel,
+                HBM_MEM_BW,
+                DDR_MEM_BW,
+                caching_ratio,
+                prefetch_pipeline,
+            )
+            for caching_ratio in caching_ratios
+        ]
+        print(f"henry uvm_caching_bw {uvm_caching_bw}")
+        expected_uvm_caching_bw: List[float] = [
+            963146416.128,
+            963146416.128,
+            963146416.128,
+            963146416.128,
+            963146416.128,
+        ]
+
+        self.assertEqual(expected_uvm_caching_bw, uvm_caching_bw)


### PR DESCRIPTION
Summary:
Choose to use hbm perf when we are using prefetch_pipeline.

Underlying assumption is that we have correct per table cache_load_factor when using prefetch_pipeline.

Differential Revision: D49084591


