### PR TITLE
disable dynamic wheels github action

### DIFF
--- a/.github/workflows/build_dynamic_embedding_wheels.yml
+++ b/.github/workflows/build_dynamic_embedding_wheels.yml
@@ -2,12 +2,13 @@ name: Build Dynamic Embedding Wheels
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+  # TODO: re-enable when fixed
+  # pull_request:
+  #   branches:
+  #     - main
+  # push:
+  #   branches:
+  #     - main
   release:
     types:
       - published


### PR DESCRIPTION
Summary:
Disabling the failing actions.

The error I saw in some failed run was
```
Error: No space left on device : '/home/runner/runners/2.309.0/_diag/pages/a64d24ca-372a-48da-b47c-f0f259a4f28d_8a494106-46b0-5da0-b8cd-bc43f34f9836_1.log'
```

This happens around the time when torch stable is updated from 2.0.1 to 2.1.0.

One potential fix would be migrating from github machines to pytorch aws machines, but I wasn't able to make it work. So disabling for now.

Differential Revision: D50128576


