### PR TITLE
Enable Embedding Dim Bucketer

### DIFF
--- a/torchrec/distributed/tests/test_emb_dim_bucketer.py
+++ b/torchrec/distributed/tests/test_emb_dim_bucketer.py
@@ -13,9 +13,13 @@ from typing import List, Tuple
 from torchrec.distributed.embedding_dim_bucketer import (
     EmbDimBucketer,
     EmbDimBucketerPolicy,
+    should_do_dim_bucketing,
 )
 
-from torchrec.distributed.embedding_types import ShardedEmbeddingTable
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    ShardedEmbeddingTable,
+)
 from torchrec.modules.embedding_configs import DataType
 
 
@@ -36,6 +40,7 @@ class TestEmbDimBucketer(unittest.TestCase):
                     embedding_dim=buckets[i % num_buckets],
                     num_embeddings=random.randint(100, 500000),
                     data_type=DataType.FP16,
+                    compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING,
                 )
             )
         return embeddings, len(buckets)
@@ -86,3 +91,7 @@ class TestEmbDimBucketer(unittest.TestCase):
 
         for i in range(emb_dim_bucketer.bucket_count()):
             self.assertTrue(i in emb_dim_bucketer.emb_dim_buckets.values())
+
+    def test_should_do_dim_bucketing(self) -> None:
+        embedding_tables, _ = self.gen_tables()
+        self.assertFalse(should_do_dim_bucketing(embedding_tables))


### PR DESCRIPTION
Summary:
Enabling Embedding Dim Bucketer when UVM CACHING is used with "sparse-dist-prefetch" pipeline.

Default policy in such case is CACHLINE_BUCKETS, otherwise, SINGLE_BUCKET policy is used which is equivalent to having no buckets.

Differential Revision: D50132647

