### PR TITLE
Refactor to move Move QEC output JT preparation steps to constructor of QEC

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -179,6 +179,7 @@ def _construct_jagged_tensors_cw(
     embedding_names_per_rank: List[List[str]],
     need_indices: bool,
     features_to_permute_indices: Dict[str, torch.Tensor],
+    key_to_feature_permuted_coordinates: Dict[str, torch.Tensor],
 ) -> Dict[str, JaggedTensor]:
     ret: Dict[str, JaggedTensor] = {}
     stride = features[0].stride()
@@ -199,23 +200,8 @@ def _construct_jagged_tensors_cw(
                 list(torch.split(feature.values(), feature.length_per_key()))
             )
 
-    key_to_feature_coordinates: Dict[str, List[Tuple[int, int]]] = {}
-    for rank, embedding_names in enumerate(embedding_names_per_rank):
-        for idx_in_rank, embedding_name in enumerate(embedding_names):
-            if embedding_name not in key_to_feature_coordinates:
-                key_to_feature_coordinates[embedding_name] = torch.jit.annotate(
-                    List[Tuple[int, int]], []
-                )
-            key_to_feature_coordinates[embedding_name].append((rank, idx_in_rank))
-
-    for key, coordinates in key_to_feature_coordinates.items():
-        permuted_coordinates: List[Tuple[int, int]] = coordinates
-
-        if key in features_to_permute_indices:
-            permuted_coordinates = [(-1, -1)] * len(coordinates)
-            permute_indices: List[int] = features_to_permute_indices[key].tolist()
-            for i, permute_idx in enumerate(permute_indices):
-                permuted_coordinates[i] = coordinates[permute_idx]
+    for key, permuted_coordinate_tensor in key_to_feature_permuted_coordinates.items():
+        permuted_coordinates: List[List[int]] = permuted_coordinate_tensor.tolist()
 
         rank0, idx_in_rank0 = permuted_coordinates[0]
         ret[key] = JaggedTensor(
@@ -241,6 +227,7 @@ def _construct_jagged_tensors(
     need_indices: bool,
     rw_unbucketize_tensor: Optional[torch.Tensor],
     cw_features_to_permute_indices: Dict[str, torch.Tensor],
+    key_to_feature_permuted_coordinates: Dict[str, torch.Tensor],
 ) -> Dict[str, JaggedTensor]:
 
     # Validating sharding type and parameters
@@ -272,6 +259,7 @@ def _construct_jagged_tensors(
             embedding_names_per_rank,
             need_indices,
             cw_features_to_permute_indices,
+            key_to_feature_permuted_coordinates,
         )
     else:  # sharding_type == ShardingType.TABLE_WISE.value
         return _construct_jagged_tensors_tw(embeddings, features, need_indices)
@@ -288,6 +276,7 @@ def output_jt_dict(
     features_to_permute_indices: Dict[str, torch.Tensor],
     unbucketize_tensors: List[torch.Tensor],
     unbucketize_tensor_idxs_per_sharding: List[int],
+    key_to_feature_permuted_coordinates_per_sharding: List[Dict[str, torch.Tensor]],
 ) -> Dict[str, JaggedTensor]:
     jt_dict: Dict[str, JaggedTensor] = {}
     for (
@@ -297,6 +286,7 @@ def output_jt_dict(
         embedding_names_per_rank,
         unbucketize_tensor_idx,
         features_before_input_dist,
+        key_to_feature_permuted_coordinates,
     ) in zip(
         sharding_types,
         emb_per_sharding,
@@ -304,6 +294,7 @@ def output_jt_dict(
         embedding_names_per_rank_per_sharding,
         unbucketize_tensor_idxs_per_sharding,
         features_before_input_dist_per_sharding,
+        key_to_feature_permuted_coordinates_per_sharding,
     ):
         jt_dict.update(
             _construct_jagged_tensors(
@@ -317,6 +308,7 @@ def output_jt_dict(
                 if unbucketize_tensor_idx != -1
                 else None,
                 cw_features_to_permute_indices=features_to_permute_indices,
+                key_to_feature_permuted_coordinates=key_to_feature_permuted_coordinates,
             )
         )
     return jt_dict
@@ -375,6 +367,9 @@ class ShardedQuantEmbeddingCollection(
                 sharding.embedding_names_per_rank()
             )
         self._features_to_permute_indices: Dict[str, torch.Tensor] = {}
+        self._key_to_feature_permuted_coordinates_per_sharding: List[
+            Dict[str, torch.Tensor]
+        ] = [{} for i in range(len(self._embedding_names_per_rank_per_sharding))]
         if ShardingType.COLUMN_WISE.value in self._sharding_type_to_sharding:
             sharding = self._sharding_type_to_sharding[ShardingType.COLUMN_WISE.value]
             # CW partition must be same for all CW sharded parameters
@@ -386,6 +381,8 @@ class ShardedQuantEmbeddingCollection(
                     module.embedding_configs(), table_name_to_parameter_sharding
                 )
             )
+
+            self._generate_permute_coordinates_per_feature_per_sharding()
 
         self._device = device
         self._input_dists: List[nn.Module] = []
@@ -495,6 +492,46 @@ class ShardedQuantEmbeddingCollection(
                 else:
                     ret[feature_name] = tensor
         return ret
+
+    def _generate_permute_coordinates_per_feature_per_sharding(
+        self,
+    ) -> None:
+        key_to_feature_permuted_coordinates_per_sharding: List[
+            Dict[str, List[Tuple[int, int]]]
+        ] = [{} for i in range(len(self._embedding_names_per_rank_per_sharding))]
+
+        for idx, embedding_names_per_rank in enumerate(
+            self._embedding_names_per_rank_per_sharding
+        ):
+            for rank, embedding_names in enumerate(embedding_names_per_rank):
+                for idx_in_rank, embedding_name in enumerate(embedding_names):
+                    if (
+                        embedding_name
+                        not in key_to_feature_permuted_coordinates_per_sharding[idx]
+                    ):
+                        key_to_feature_permuted_coordinates_per_sharding[idx][
+                            embedding_name
+                        ] = torch.jit.annotate(List[Tuple[int, int]], [])
+                    key_to_feature_permuted_coordinates_per_sharding[idx][
+                        embedding_name
+                    ].append((rank, idx_in_rank))
+
+            for (
+                key,
+                coordinates,
+            ) in key_to_feature_permuted_coordinates_per_sharding[idx].items():
+                permuted_coordinates: List[Tuple[int, int]] = coordinates
+
+                if key in self._features_to_permute_indices:
+                    permuted_coordinates = [(-1, -1)] * len(coordinates)
+                    permute_indices: List[int] = self._features_to_permute_indices[
+                        key
+                    ].tolist()
+                    for i, permute_idx in enumerate(permute_indices):
+                        permuted_coordinates[i] = coordinates[permute_idx]
+                self._key_to_feature_permuted_coordinates_per_sharding[idx][
+                    key
+                ] = torch.tensor(permuted_coordinates)
 
     def _create_input_dist(
         self,
@@ -646,6 +683,7 @@ class ShardedQuantEmbeddingCollection(
             unbucketize_tensor_idxs_per_sharding=unbucketize_tensor_idxs_per_sharding,
             unbucketize_tensors=unbucketize_tensors,
             features_to_permute_indices=self._features_to_permute_indices,
+            key_to_feature_permuted_coordinates_per_sharding=self._key_to_feature_permuted_coordinates_per_sharding,
         )
 
     # pyre-ignore

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -528,6 +528,93 @@ class InferShardingsTest(unittest.TestCase):
 
     # pyre-ignore
     @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs available",
+    )
+    def test_cw_irregular_shard_placement(self) -> None:
+        num_embeddings = 64
+        emb_dim = 384
+        emb_dim_2 = emb_dim // 2
+        emb_dim_3 = emb_dim // 3
+        local_size = 4
+        world_size = 4
+        batch_size = 4
+        local_device = torch.device("cuda:0")
+        mi = _model(
+            num_embeddings,
+            emb_dim,
+            world_size,
+            batch_size,
+            dense_device=local_device,
+            sparse_device=local_device,
+            quant_state_dict_split_scale_bias=True,
+            num_features=3,
+        )
+
+        non_sharded_model = mi.quant_model
+        expected_shards = [
+            [
+                ((0, 0, num_embeddings, emb_dim_2), "rank:2/cuda:2"),
+                ((0, 1 * emb_dim_2, num_embeddings, emb_dim_2), "rank:1/cuda:1"),
+            ],
+            [
+                ((0, 0, num_embeddings, emb_dim_2), "rank:0/cuda:0"),
+                ((0, 1 * emb_dim_2, num_embeddings, emb_dim_2), "rank:3/cuda:3"),
+            ],
+            [
+                ((0, 0, num_embeddings, emb_dim_3), "rank:0/cuda:0"),
+                ((0, 1 * emb_dim_3, num_embeddings, emb_dim_3), "rank:2/cuda:2"),
+                ((0, 2 * emb_dim_3, num_embeddings, emb_dim_3), "rank:3/cuda:3"),
+            ],
+        ]
+
+        sharder = TestQuantEBCSharder(
+            sharding_type=ShardingType.COLUMN_WISE.value,
+            kernel_type=EmbeddingComputeKernel.QUANT.value,
+            shardable_params=[table.name for table in mi.tables],
+        )
+
+        module_plan = construct_module_sharding_plan(
+            non_sharded_model._module.sparse.ebc,
+            per_param_sharding={
+                "table_0": column_wise(ranks=[2, 1]),
+                "table_1": column_wise(ranks=[0, 3]),
+                "table_2": column_wise(ranks=[0, 2, 3]),
+            },
+            # pyre-ignore
+            sharder=sharder,
+            local_size=local_size,
+            world_size=world_size,
+        )
+
+        plan = ShardingPlan(plan={"_module.sparse.ebc": module_plan})
+
+        sharded_model = _shard_qebc(
+            mi,
+            sharding_type=ShardingType.COLUMN_WISE,
+            device=local_device,
+            expected_shards=expected_shards,
+            plan=plan,
+        )
+        inputs = [
+            model_input_to_forward_args(inp.to(local_device))
+            for inp in prep_inputs(mi, world_size, batch_size)
+        ]
+        sharded_model.load_state_dict(non_sharded_model.state_dict())
+        # torchrec.distributed.test_utils.test_sharding.copy_state_dict(sharded_model.state_dict(), non_sharded_model.state_dict()) does not work for CW due to non-trivial qscaleshift copy which is handled in shardedQEBC load_state_dict
+
+        # We need this first inference to make all lazy init in forward
+        sharded_output = sharded_model(*inputs[0])
+        non_sharded_output = non_sharded_model(*inputs[0])
+        assert_close(non_sharded_output, sharded_output)
+
+        gm: torch.fx.GraphModule = symbolic_trace(sharded_model)
+        gm_script = torch.jit.script(gm)
+        gm_script_output = gm_script(*inputs[0])
+        assert_close(sharded_output, gm_script_output)
+
+    # pyre-ignore
+    @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
     )

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.quantization as quant
 import torchrec as trec
 import torchrec.quant as trec_quant
-from torchrec.modules.embedding_configs import TrecQuantConfig
+from torchrec.modules.embedding_configs import QuantConfig
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollectionInterface,
     EmbeddingCollectionInterface,
@@ -52,12 +52,12 @@ def quantize_embeddings(
     output_dtype: torch.dtype = torch.float,
     per_table_weight_dtype: Optional[Dict[str, torch.dtype]] = None,
 ) -> nn.Module:
-    qconfig = TrecQuantConfig(
+    qconfig = QuantConfig(
         activation=quant.PlaceholderObserver.with_args(dtype=output_dtype),
         weight=quant.PlaceholderObserver.with_args(dtype=dtype),
         per_table_weight_dtype=per_table_weight_dtype,
     )
-    qconfig_spec: Dict[Type[nn.Module], TrecQuantConfig] = {
+    qconfig_spec: Dict[Type[nn.Module], QuantConfig] = {
         trec.EmbeddingBagCollection: qconfig,
     }
     mapping: Dict[Type[nn.Module], Type[nn.Module]] = {

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -206,7 +206,7 @@ class EmbeddingConfig(BaseEmbeddingConfig):
     pass
 
 
-class TrecQuantConfig(NamedTuple):
+class QuantConfig(NamedTuple):
     activation: torch.quantization.PlaceholderObserver
     weight: torch.quantization.PlaceholderObserver
     per_table_weight_dtype: Optional[Dict[str, torch.dtype]] = None

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -8,7 +8,7 @@
 import copy
 import itertools
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, cast, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -20,15 +20,17 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
 from torch import Tensor
 from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import (
+    BaseEmbeddingConfig,
     DATA_TYPE_NUM_BITS,
     data_type_to_sparse_type,
     DataType,
     dtype_to_data_type,
     EmbeddingBagConfig,
     EmbeddingConfig,
+    EmbeddingTableConfig,
     pooling_type_to_pooling_mode,
     PoolingType,
-    TrecQuantConfig,
+    QuantConfig,
 )
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection as OriginalEmbeddingBagCollection,
@@ -167,6 +169,23 @@ def quantize_state_dict(
                 quant_weight, scale_shift = quant_res, None
         table_name_to_quantized_weights[table_name] = (quant_weight, scale_shift)
     return device
+
+
+def _update_embedding_configs(
+    embedding_configs: List[BaseEmbeddingConfig],
+    quant_config: Union[QuantConfig, torch.quantization.QConfig],
+) -> None:
+    per_table_weight_dtype = (
+        quant_config.per_table_weight_dtype
+        if isinstance(quant_config, QuantConfig) and quant_config.per_table_weight_dtype
+        else {}
+    )
+    for config in embedding_configs:
+        config.data_type = dtype_to_data_type(
+            per_table_weight_dtype[config.name]
+            if config.name in per_table_weight_dtype
+            else quant_config.weight().dtype
+        )
 
 
 class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin):
@@ -431,29 +450,17 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         assert hasattr(
             module, "qconfig"
         ), "EmbeddingBagCollection input float module must have qconfig defined"
-        per_table_weight_dtype = (
-            module.qconfig.per_table_weight_dtype
-            if isinstance(module.qconfig, TrecQuantConfig)
-            else None
-        )
-        data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         embedding_bag_configs = copy.deepcopy(module.embedding_bag_configs())
-        table_name_to_data_type: Dict[str, DataType] = {}
-        for config in embedding_bag_configs:
-            if (
-                per_table_weight_dtype is not None
-                and config.name in per_table_weight_dtype
-            ):
-                config.data_type = dtype_to_data_type(
-                    per_table_weight_dtype[config.name]
-                )
-            else:
-                config.data_type = data_type
-            table_name_to_data_type[config.name] = config.data_type
+        _update_embedding_configs(
+            cast(List[BaseEmbeddingConfig], embedding_bag_configs),
+            module.qconfig,
+        )
 
         table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] = {}
         device = quantize_state_dict(
-            module, table_name_to_quantized_weights, table_name_to_data_type
+            module,
+            table_name_to_quantized_weights,
+            {table.name: table.data_type for table in embedding_bag_configs},
         )
         return cls(
             embedding_bag_configs,
@@ -684,31 +691,18 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         assert hasattr(
             module, "qconfig"
         ), "EmbeddingCollection input float module must have qconfig defined"
-        per_table_weight_dtype = (
-            module.qconfig.per_table_weight_dtype
-            if isinstance(module.qconfig, TrecQuantConfig)
-            else None
+        embedding_configs = copy.deepcopy(module.embedding_configs())
+        _update_embedding_configs(
+            cast(List[BaseEmbeddingConfig], embedding_configs), module.qconfig
         )
-        data_type = dtype_to_data_type(module.qconfig.weight().dtype)
-        tables = copy.deepcopy(module.embedding_configs())
-        table_name_to_data_type: Dict[str, DataType] = {}
-        for config in tables:
-            if (
-                per_table_weight_dtype is not None
-                and config.name in per_table_weight_dtype
-            ):
-                config.data_type = dtype_to_data_type(
-                    per_table_weight_dtype[config.name]
-                )
-            else:
-                config.data_type = data_type
-            table_name_to_data_type[config.name] = config.data_type
         table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] = {}
         device = quantize_state_dict(
-            module, table_name_to_quantized_weights, table_name_to_data_type
+            module,
+            table_name_to_quantized_weights,
+            {table.name: table.data_type for table in embedding_configs},
         )
         return cls(
-            tables,
+            embedding_configs,
             device=device,
             need_indices=module.need_indices(),
             output_dtype=module.qconfig.activation().dtype,


### PR DESCRIPTION
Summary:
Move QEC output JT preparation steps to constructor of QEC

https://www.internalfb.com/code/fbsource/[70ae7e1cf66a]/fbcode/torchrec/distributed/quant_embedding.py?lines=202

Now it happens on each forward. But it depends only on the sharding plan and can be precalculated at the creation.

Reviewed By: IvanKobzarev

Differential Revision: D49641538

