### PR TITLE
Add tests for group_tables in hbm cases

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -198,6 +198,12 @@ class GroupedEmbeddingConfig:
             dim_sum += table.num_features() * table.local_cols
         return dim_sum
 
+    def table_names(self) -> List[str]:
+        table_names = []
+        for table in self.embedding_tables:
+            table_names.append(table.name)
+        return table_names
+
     def feature_names(self) -> List[str]:
         feature_names = []
         for table in self.embedding_tables:

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import random
+import unittest
+from typing import List
+
+from torchrec.distributed.embedding_lookup import EmbeddingComputeKernel
+
+from torchrec.distributed.embedding_sharding import group_tables
+from torchrec.distributed.embedding_types import (
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.modules.embedding_configs import DataType, PoolingType
+
+
+class TestGroupTablesPerRank(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        random.seed(42)
+
+        self.num_tables = 50
+        self.data_type_options = [DataType.FP16, DataType.FP32]
+        self.has_feature_processor_options = [False, True]
+        self.fused_params_group_options = [{}]  # TODO
+        self.embedding_dim_options = list(range(160, 320, 40))
+
+    def test_group_tables_per_rank_for_hbm(self) -> None:
+        data_types = [
+            random.choice(self.data_type_options) for _ in range(self.num_tables)
+        ]
+        pooling_types = [
+            random.choice(list(PoolingType)) for _ in range(self.num_tables)
+        ]
+        has_feature_processors = [
+            random.choice(self.has_feature_processor_options)
+            for _ in range(self.num_tables)
+        ]
+        fused_params_groups = [
+            random.choice(self.fused_params_group_options)
+            for _ in range(self.num_tables)
+        ]
+        compute_kernels = [EmbeddingComputeKernel.FUSED for _ in range(self.num_tables)]
+        embedding_dims = [
+            random.choice(self.embedding_dim_options) for _ in range(self.num_tables)
+        ]
+
+        embedding_tables = [
+            ShardedEmbeddingTable(
+                name=f"table_{i}",
+                data_type=data_type,
+                pooling=pooling_type,
+                has_feature_processor=has_feature_processor,
+                fused_params=fused_param_group,
+                compute_kernel=compute_kernel,
+                embedding_dim=embedding_dim,
+                num_embeddings=10000,
+            )
+            for i, (
+                data_type,
+                pooling_type,
+                has_feature_processor,
+                fused_param_group,
+                compute_kernel,
+                embedding_dim,
+            ) in enumerate(
+                zip(
+                    data_types,
+                    pooling_types,
+                    has_feature_processors,
+                    fused_params_groups,
+                    compute_kernels,
+                    embedding_dims,
+                )
+            )
+        ]
+
+        # since we don't have access to _group_tables_per_rank
+        tables_per_rank: List[List[ShardedEmbeddingTable]] = [embedding_tables]
+
+        # taking only the list for the first rank
+        table_groups: List[GroupedEmbeddingConfig] = group_tables(tables_per_rank)[0]
+        table_names_by_groups = [
+            table_group.table_names() for table_group in table_groups
+        ]
+
+        expected_table_names_by_groups = [
+            ["table_32", "table_38"],
+            ["table_8", "table_33"],
+            ["table_24", "table_34", "table_41"],
+            ["table_2", "table_22", "table_23", "table_30", "table_36"],
+            ["table_27", "table_46"],
+            ["table_16", "table_18", "table_19", "table_40"],
+            ["table_20", "table_21", "table_31", "table_37", "table_42", "table_48"],
+            ["table_5", "table_14", "table_17", "table_28"],
+            [
+                "table_0",
+                "table_1",
+                "table_6",
+                "table_7",
+                "table_10",
+                "table_35",
+                "table_45",
+                "table_47",
+                "table_49",
+            ],
+            ["table_4", "table_44"],
+            ["table_9", "table_11", "table_12", "table_13", "table_15", "table_29"],
+            ["table_3", "table_25", "table_26", "table_39", "table_43"],
+        ]
+        self.assertEqual(table_names_by_groups, expected_table_names_by_groups)


### PR DESCRIPTION
Summary:
Adding a unit test for group_tables.

This way of testing isn't very reliable, since it just look at how the tables are grouped. Also it relies on ordering of the GroupedEmbeddingConfig, which is not ideal. But we should add that later.

Differential Revision: D50482054


