### PR TITLE
EmbeddingsAllToOneReduce set_device for tgif and making it leaf_module

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -805,6 +805,12 @@ class EmbeddingsAllToOneReduce(nn.Module):
         self._world_size = world_size
         self._cat_dim = cat_dim
 
+    # This method can be used by an inference runtime to update the
+    # device information for this module.
+    @torch.jit.export
+    def set_device(self, device_str: str) -> None:
+        self._device = torch.device(device_str)
+
     def forward(
         self,
         tensors: List[torch.Tensor],

--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -140,4 +140,4 @@ class InferCwSequenceEmbeddingDist(
         local_embs: List[torch.Tensor],
         sharding_ctx: Optional[InferSequenceShardingContext] = None,
     ) -> List[torch.Tensor]:
-        return self._dist.forward(local_embs)
+        return self._dist(local_embs)

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -364,4 +364,4 @@ class InferCwPooledEmbeddingDistWithPermute(
         local_embs: List[torch.Tensor],
         sharding_ctx: Optional[NullShardingContext] = None,
     ) -> torch.Tensor:
-        return self._permute.forward(self._dist.forward(local_embs))
+        return self._permute(self._dist(local_embs))

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -167,7 +167,7 @@ class InferRwSequenceEmbeddingDist(
         local_embs: List[torch.Tensor],
         sharding_ctx: Optional[InferSequenceShardingContext] = None,
     ) -> List[torch.Tensor]:
-        return self._dist.forward(local_embs)
+        return self._dist(local_embs)
 
 
 class InferRwSequenceEmbeddingSharding(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -369,9 +369,7 @@ class InferRwPooledEmbeddingDist(
             Awaitable[torch.Tensor]: awaitable of sequence embeddings.
         """
 
-        return self._dist.forward(
-            local_embs,
-        )
+        return self._dist(local_embs)
 
 
 class RwPooledEmbeddingSharding(


### PR DESCRIPTION
Summary:
`EmbeddingsAllToOneReduce` (used by RW sharding) needs the same handling as for `EmbeddingsAllToOne`
- set_device method that predictor can set runtime device
- treat EmbeddingsAllToOneReduce as a leaf module, to keep it as it is during fx tracing
- calling modules via call_module module(args), not module.forward(args) which is call_function for fx and does not preserve module type.

Differential Revision:
D50499592

Privacy Context Container: L1138451


