### PR TITLE
Fix fp collection module re-materialization from meta

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -434,23 +434,13 @@ def convert_to_fbgemm_types(fused_params: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def init_parameters(module: nn.Module, device: torch.device) -> None:
-    @torch.no_grad()
-    def init_parameters(module: nn.Module) -> None:
-        # Allocate parameters and buffers if over 'meta' device.
-        has_meta_param = False
-        for name, param in module._parameters.items():
-            if isinstance(param, torch.Tensor) and param.device.type == "meta":
-                module._parameters[name] = nn.Parameter(
-                    torch.empty_like(param, device=device),
-                    requires_grad=param.requires_grad,
-                )
-                has_meta_param = True
-        for name, buffer in module._buffers.items():
-            if isinstance(buffer, torch.Tensor) and buffer.device.type == "meta":
-                module._buffers[name] = torch.empty_like(buffer, device=device)
+    with torch.no_grad():
+        has_meta_param = any(t.is_meta for t in module.parameters())
+        if has_meta_param:
+            module.to_empty(device=device)
 
-        # Init parameters if at least one parameter is over 'meta' device.
-        if has_meta_param and hasattr(module, "reset_parameters"):
-            module.reset_parameters()
+            def maybe_reset_parameters(m: nn.Module) -> None:
+                if hasattr(m, "reset_parameters"):
+                    m.reset_parameters()
 
-    module.apply(init_parameters)
+            module.apply(maybe_reset_parameters)

--- a/torchrec/modules/feature_processor_.py
+++ b/torchrec/modules/feature_processor_.py
@@ -175,6 +175,8 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection):
         with torch.no_grad():
             for key, _length in self.max_feature_lengths.items():
                 self.position_weights[key].fill_(1.0)
+                # Re-assign python dict to param dict in case of re-materialization
+                self.position_weights_dict[key] = self.position_weights[key]
 
     def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
         cat_seq = torch.ops.fbgemm.offsets_range(


### PR DESCRIPTION
Summary:
This change fixes a few issues with the current meta device support in PositionWeightedModuleCollection.
- `init_parameters` currently calls `reset_parameters` only if the module has immediate parameters on meta device. This would not correctly call `reset_parameters` on PositionWeightedModuleCollection because the parameters are in a ParameterDict submodule, so the swapped parameters in re-materialization will be left empty. This change fixes `init_parameters` to call `reset_parameters` recursively if meta parameters are found recursively.
- Upon re-materialization, the ParameterDict would be swapped and reset with init values but the python dict would still point to the old meta parameters. We fix this by adding a re-assignment to the `reset_parameters` method.

Added corresponding tests and assertions to capture the above issues.

Differential Revision: D50609724

