### PR TITLE
Remove torchrec BoundsCheckMode and CacheAlgorithm

### DIFF
--- a/torchrec/distributed/tests/test_utils.py
+++ b/torchrec/distributed/tests/test_utils.py
@@ -410,25 +410,21 @@ class AddParamsFromParameterShardingTest(unittest.TestCase):
 class ConvertFusedParamsTest(unittest.TestCase):
     def test_convert_to_fbgemm_types(self) -> None:
         per_table_fused_params = {
-            "cache_algorithm": CacheAlgorithm.LFU,
             "cache_precision": DataType.FP32,
-            "bounds_check_mode": BoundsCheckMode.WARNING,
+            "weights_precision": DataType.FP32,
+            "output_dtype": DataType.FP32,
         }
-        self.assertTrue(
-            isinstance(per_table_fused_params["cache_algorithm"], CacheAlgorithm)
-        )
         self.assertTrue(isinstance(per_table_fused_params["cache_precision"], DataType))
         self.assertTrue(
-            isinstance(per_table_fused_params["bounds_check_mode"], BoundsCheckMode)
+            isinstance(per_table_fused_params["weights_precision"], DataType)
         )
+        self.assertTrue(isinstance(per_table_fused_params["output_dtype"], DataType))
 
         per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
-        self.assertFalse(
-            isinstance(per_table_fused_params["cache_algorithm"], CacheAlgorithm)
-        )
         self.assertFalse(
             isinstance(per_table_fused_params["cache_precision"], DataType)
         )
         self.assertFalse(
-            isinstance(per_table_fused_params["bounds_check_mode"], BoundsCheckMode)
+            isinstance(per_table_fused_params["weights_precision"], DataType)
         )
+        self.assertFalse(isinstance(per_table_fused_params["output_dtype"], DataType))

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -23,6 +23,11 @@ from typing import (
     Union,
 )
 
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    BoundsCheckMode,
+    CacheAlgorithm,
+)
+
 from torch.autograd.profiler import record_function
 from torchrec.types import ModuleNoCopyMixin
 
@@ -100,24 +105,6 @@ def _tabulate(
     )
     rows.insert(1, " | ".join(["-" * width for width in col_widths]))
     return "\n".join(rows)
-
-
-@unique
-class BoundsCheckMode(Enum):
-    # Raise an exception (CPU) or device-side assert (CUDA)
-    FATAL = 0
-    # Log the first out-of-bounds instance per kernel, and set to zero.
-    WARNING = 1
-    # Set to zero.
-    IGNORE = 2
-    # No bounds checks.
-    NONE = 3
-
-
-@unique
-class CacheAlgorithm(Enum):
-    LRU = 0
-    LFU = 1
 
 
 # moved DataType here to avoid circular import

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -17,18 +17,12 @@ from torch import nn
 from torchrec import optim as trec_optim
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.types import (
-    BoundsCheckMode,
-    CacheAlgorithm,
     DataType,
     ParameterSharding,
     ShardedModule,
     ShardingType,
 )
-from torchrec.modules.embedding_configs import (
-    data_type_to_sparse_type,
-    to_fbgemm_bounds_check_mode,
-    to_fbgemm_cache_algorithm,
-)
+from torchrec.modules.embedding_configs import data_type_to_sparse_type
 from torchrec.types import CopyMixIn
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -418,16 +412,16 @@ def convert_to_fbgemm_types(fused_params: Dict[str, Any]) -> Dict[str, Any]:
                 fused_params["cache_precision"]
             )
 
-    if "cache_algorithm" in fused_params:
-        if isinstance(fused_params["cache_algorithm"], CacheAlgorithm):
-            fused_params["cache_algorithm"] = to_fbgemm_cache_algorithm(
-                fused_params["cache_algorithm"]
+    if "weights_precision" in fused_params:
+        if isinstance(fused_params["weights_precision"], DataType):
+            fused_params["weights_precision"] = data_type_to_sparse_type(
+                fused_params["weights_precision"]
             )
 
-    if "bounds_check_mode" in fused_params:
-        if isinstance(fused_params["bounds_check_mode"], BoundsCheckMode):
-            fused_params["bounds_check_mode"] = to_fbgemm_bounds_check_mode(
-                fused_params["bounds_check_mode"]
+    if "output_dtype" in fused_params:
+        if isinstance(fused_params["output_dtype"], DataType):
+            fused_params["output_dtype"] = data_type_to_sparse_type(
+                fused_params["output_dtype"]
             )
 
     return fused_params

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -13,12 +13,8 @@ from typing import Callable, Dict, List, NamedTuple, Optional
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
-    BoundsCheckMode as FbgemmBoundsCheckMode,
-    CacheAlgorithm as FbgemmCacheAlgorithm,
-    PoolingMode,
-)
-from torchrec.distributed.types import BoundsCheckMode, CacheAlgorithm, DataType
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import PoolingMode
+from torchrec.distributed.types import DataType
 
 
 @unique
@@ -37,30 +33,6 @@ DATA_TYPE_NUM_BITS: Dict[DataType, int] = {
     DataType.INT4: 4,
     DataType.INT2: 2,
 }
-
-
-def to_fbgemm_bounds_check_mode(
-    bounds_check_mode: BoundsCheckMode,
-) -> FbgemmBoundsCheckMode:
-    if bounds_check_mode == BoundsCheckMode.FATAL:
-        return FbgemmBoundsCheckMode.FATAL
-    elif bounds_check_mode == BoundsCheckMode.WARNING:
-        return FbgemmBoundsCheckMode.WARNING
-    elif bounds_check_mode == BoundsCheckMode.IGNORE:
-        return FbgemmBoundsCheckMode.IGNORE
-    elif bounds_check_mode == BoundsCheckMode.NONE:
-        return FbgemmBoundsCheckMode.NONE
-    else:
-        raise Exception(f"Invalid bounds check mode {bounds_check_mode}")
-
-
-def to_fbgemm_cache_algorithm(cache_algorithm: CacheAlgorithm) -> FbgemmCacheAlgorithm:
-    if cache_algorithm == CacheAlgorithm.LRU:
-        return FbgemmCacheAlgorithm.LRU
-    elif cache_algorithm == CacheAlgorithm.LFU:
-        return FbgemmCacheAlgorithm.LFU
-    else:
-        raise Exception(f"Invalid cache algorithm {cache_algorithm}")
 
 
 def dtype_to_data_type(dtype: torch.dtype) -> DataType:


### PR DESCRIPTION
Summary:
Removing torchrec BoundsCheckMode and CacheAlgorithm since they are confusing and we don't really use them except passing them to fbgemm.

One can still import them from torchrec.distributed.types

Differential Revision: D50582955


