### PR TITLE
sort the shard by perf instead of storage

### DIFF
--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -703,7 +703,7 @@ class TestMemoryBalancedPartitioner(unittest.TestCase):
         memory_balanced_expected_ranks = {
             "table_0": [0],
             "table_1": [1],
-            "table_2": [1],
+            "table_2": [0],
         }
         self.assertEqual(memory_balanced_ranks, memory_balanced_expected_ranks)
 

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -307,6 +307,14 @@ class ShardingOption:
         return storage
 
     @property
+    def total_perf(self) -> float:
+        perf: float = 0
+        for shard in self.shards:
+            # pyre-ignore: Undefined attribute [16]
+            perf += shard.perf.total
+        return perf
+
+    @property
     def is_pooled(self) -> bool:
         if self._is_pooled is not None:
             return self._is_pooled


### PR DESCRIPTION
Summary:
We tried this idea before with default GreedyPartitioner, but we didn't land it, because:
1. we don't see significantly QPS improvment
2. Concern that if we don't place the largest shard first, it may end-up with not finding a plan

but with the memoryBalancedPartitioner, in order to pusrse memryBalanced, we see very perf-imlbalanced plan for ads FM model on APS.

here is one before/after plan:
before:
https://www.internalfb.com/intern/everpaste/?handle=GD9CQhfUInYhieQEANW6oPyEmXEObsIXAAAz

after:
https://www.internalfb.com/intern/everpaste/?handle=GE6FQhdC2AlbY60AANFsOJbtk5AKbsIXAAAz

it's significatnly more balanced.

Reviewed By: henrylhtsang

Differential Revision: D50425650


