### PR TITLE
fix SegmentedNE required inputs init

### DIFF
--- a/torchrec/metrics/segmented_ne.py
+++ b/torchrec/metrics/segmented_ne.py
@@ -5,10 +5,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from functools import partial
-from typing import Any, cast, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 import torch
+from torch import distributed as dist
+from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
 from torchrec.metrics.rec_metric import (
     MetricComputationReport,
@@ -20,7 +21,6 @@ from torchrec.metrics.rec_metric import (
 PREDICTIONS = "predictions"
 LABELS = "labels"
 WEIGHTS = "weights"
-SEGMENTS = "segments"
 
 
 def compute_cross_entropy(
@@ -287,3 +287,32 @@ class SegmentedNEMetricComputation(RecMetricComputation):
 class SegmentedNEMetric(RecMetric):
     _namespace: MetricNamespace = MetricNamespace.SEGMENTED_NE
     _computation_class: Type[RecMetricComputation] = SegmentedNEMetricComputation
+
+    def __init__(
+        self,
+        world_size: int,
+        my_rank: int,
+        batch_size: int,
+        tasks: List[RecTaskInfo],
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        window_size: int = 100,
+        fused_update_limit: int = 0,
+        compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
+        process_group: Optional[dist.ProcessGroup] = None,
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        super().__init__(
+            world_size=world_size,
+            my_rank=my_rank,
+            batch_size=batch_size,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            window_size=window_size,
+            fused_update_limit=fused_update_limit,
+            compute_on_all_ranks=compute_on_all_ranks,
+            should_validate_update=should_validate_update,
+            process_group=process_group,
+            **kwargs,
+        )
+        self._required_inputs.add("grouping_keys")


### PR DESCRIPTION
Summary:
Fixing bug where required_inputs set does not have "grouping_keys" key - which then makes it impossible for Segmented NE metric to call "update". The required_inputs set will always be empty.

To fix - Added an init in SegmentedNE to add "grouping_keys" to required_inputs akin to GroupedAUC

Differential Revision: D50747038


