### PR TITLE
Enable CW sharding for sharded quant modules

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -15,6 +15,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import EmbeddingLoca
 from torch import fx, nn
 from torch.nn.modules.module import _addindent
 from torchrec.distributed.types import (
+    get_tensor_size_bytes,
     ModuleSharder,
     ParameterStorage,
     QuantizedCommCodecs,
@@ -395,7 +396,7 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
-        tensor_bytes = tensor.element_size() * tensor.nelement()
+        tensor_bytes = get_tensor_size_bytes(tensor)
         if compute_kernel in {
             EmbeddingComputeKernel.FUSED_UVM.value,
             EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
@@ -411,8 +412,7 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                 "mtia": ParameterStorage.DDR,
             }
             return {
-                storage_map[compute_device_type].value: tensor.element_size()
-                * tensor.nelement()
+                storage_map[compute_device_type].value: get_tensor_size_bytes(tensor)
             }
 
 
@@ -501,7 +501,7 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
-        tensor_bytes = tensor.element_size() * tensor.nelement() + tensor.shape[0] * 4
+        tensor_bytes = get_tensor_size_bytes(tensor) + tensor.shape[0] * 4
         if compute_kernel in {
             EmbeddingComputeKernel.QUANT_UVM.value,
             EmbeddingComputeKernel.QUANT_UVM_CACHING.value,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -445,6 +445,7 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         types = [
             ShardingType.TABLE_WISE.value,
             ShardingType.ROW_WISE.value,
+            ShardingType.COLUMN_WISE.value,
         ]
 
         return types

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -21,7 +21,7 @@ from torchrec.distributed.planner.types import (
     Topology,
 )
 from torchrec.distributed.planner.utils import sharder_name, storage_repr_in_gb
-from torchrec.distributed.types import ModuleSharder
+from torchrec.distributed.types import get_tensor_size_bytes, ModuleSharder
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -30,14 +30,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 def _get_module_size(module: nn.Module, multiplier: float) -> int:
     parameters_size = sum(
         [
-            multiplier * parameter.element_size() * parameter.nelement()
+            multiplier * get_tensor_size_bytes(parameter)
             for parameter in module.parameters()
         ]
     )
 
-    buffers_size = sum(
-        [buffer.element_size() * buffer.nelement() for buffer in module.buffers()]
-    )
+    buffers_size = sum([get_tensor_size_bytes(buffer) for buffer in module.buffers()])
 
     return round(parameters_size + buffers_size)
 

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -392,6 +392,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
                 0.005390052899352861,
                 0.005390052899352861,
             ],
+            ("quant", "column_wise"): [0.0001296231579222408],
+            ("quant_uvm", "column_wise"): [0.018350937787224266],
+            ("quant_uvm_caching", "column_wise"): [0.004269758427175579],
         }
 
         total_perfs = {

--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -26,7 +26,9 @@ from torchrec.distributed.embedding_types import (
     ShardedEmbeddingModule,
 )
 from torchrec.distributed.types import ParameterSharding, ShardingType
+from torchrec.modules.embedding_configs import DataType
 from torchrec.streamable import Multistreamable
+from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
 
 Out = TypeVar("Out")
 CompIn = TypeVar("CompIn")
@@ -83,6 +85,11 @@ class ShardedQuantEmbeddingModuleState(
                 tbe.split_embedding_weights_with_scale_bias(split_scale_bias_mode=2),
                 config.embedding_tables,
             ):
+                if table.data_type == DataType.INT4:
+                    tbe_split_w = UInt4Tensor(tbe_split_w)
+                elif table.data_type == DataType.INT2:
+                    tbe_split_w = UInt2Tensor(tbe_split_w)
+
                 # weight shards section:
                 assert table.local_metadata
                 metadata: ShardMetadata = copy.deepcopy(table.local_metadata)

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -165,6 +165,7 @@ def quantize(
     output_type: torch.dtype = torch.float,
     register_tbes: bool = False,
     quant_state_dict_split_scale_bias: bool = False,
+    weight_dtype: torch.dtype = torch.qint8,
 ) -> torch.nn.Module:
     module_types: List[Type[torch.nn.Module]] = [
         torchrec.modules.embedding_modules.EmbeddingBagCollection,
@@ -179,7 +180,7 @@ def quantize(
 
     qconfig = quant.QConfig(
         activation=quant.PlaceholderObserver.with_args(dtype=output_type),
-        weight=quant.PlaceholderObserver.with_args(dtype=torch.qint8),
+        weight=quant.PlaceholderObserver.with_args(dtype=weight_dtype),
     )
     return quant.quantize_dynamic(
         module,

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -36,6 +36,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.profiler import record_function
 from torchmetrics import Metric
+from torchrec.distributed.types import get_tensor_size_bytes
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
 from torchrec.metrics.metrics_namespace import (
     compose_metric_key,
@@ -696,9 +697,7 @@ class RecMetric(nn.Module, abc.ABC):
         while attributes_q:
             attribute = attributes_q.popleft()
             if isinstance(attribute, torch.Tensor):
-                tensor_map[attribute] = (
-                    attribute.size().numel() * attribute.element_size()
-                )
+                tensor_map[attribute] = get_tensor_size_bytes(attribute)
             elif isinstance(attribute, WindowBuffer):
                 attributes_q.extend(attribute.buffers)
             elif isinstance(attribute, Mapping):

--- a/torchrec/quant/tests/test_tensor_types.py
+++ b/torchrec/quant/tests/test_tensor_types.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
+
+
+class QuantUtilsTest(unittest.TestCase):
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "Not enough GPUs available",
+    )
+    def test_uint42_tensor(self) -> None:
+        t_u8 = torch.tensor(
+            [
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+                [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF],
+            ],
+            dtype=torch.uint8,
+        )
+        t_u4 = UInt4Tensor(t_u8)
+        t_u4.detach()
+
+        t_u4.to(torch.device("cuda"))
+        assert torch.equal(t_u4.view(torch.uint8), t_u8)
+        t_u2 = UInt2Tensor(t_u8)
+        t_u2.to(torch.device("cuda"))
+        assert torch.equal(t_u2.view(torch.uint8), t_u8)
+
+        for t in [t_u4[:, :8], t_u4[:, 8:]]:
+            assert t.size(1) == 8
+        t_u4[:, :8].copy_(t_u4[:, 8:])
+
+        for t in [t_u2[:, 4:8], t_u2[:, 8:12]]:
+            assert t.size(1) == 4
+
+        t_u2[:, 4:8].copy_(t_u2[:, 8:12])

--- a/torchrec/tensor_types.py
+++ b/torchrec/tensor_types.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-ignore-all-errors[2, 3, 4, 6, 13, 14, 20]
+
+import itertools
+from typing import List, Tuple
+
+import torch
+import torch._prims_common as utils
+
+
+def down_size(N: int, size: torch.Size) -> Tuple[int, int]:
+    assert size[-1] % N == 0, f"{size} last dim not divisible by {N}"
+    return (*size[:-1], size[-1] // N)
+
+
+def up_size(N: int, size: torch.Size) -> Tuple[int, int]:
+    return (*size[:-1], size[-1] * N)
+
+
+def fill_defaults(args, n, defaults_tail):
+    """
+    __torch_dispatch__ doesn't guarantee the number of arguments you are
+    passed (e.g., defaulted arguments are not passed); but usually it is
+    convenient to pad out the arguments list with defaults.  This function
+    helps you do that.
+    Args:
+        args: the list of positional arguments passed to __torch_dispatch__
+        n: the number of arguments you are expecting to get
+        defaults_tail: default values for the arguments, starting from the
+            end of the list
+    Example:
+        >>> fill_defaults([1, 2, 3], 5, [3, 4, 5])
+        [1, 2, 3, 4, 5]
+        >>> fill_defaults([1, 2, 3], 5, [None, None, None])
+        [1, 2, 3, None, None]]
+    """
+    if n - len(defaults_tail) > len(args):
+        raise RuntimeError("not enough defaults to fill arguments")
+    r = list(args)
+    for i in range(len(args), n):
+        r.append(defaults_tail[i - n + len(defaults_tail)])
+    return r
+
+
+def find_arg_of_type(it, t):
+    for x in it:
+        if isinstance(x, t):
+            return x
+    return None
+
+
+class UIntXTensor(torch.Tensor):
+    """
+    A Tensor subclass of uint8 dtype, that represents Tensor with X-bit elements.
+    The last dimension must be divisible by (8 // X).
+
+    __torch_dispatch__ special handling:
+    .view(dtype=torch.uint8) - returns the underlying uint8 data.
+
+    .slice,.view - works in UIntX units, dimension values must be divisible by (8 // X).
+
+    .detach,.clone - work as an op on underlying uint8 data.
+    """
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @staticmethod
+    def __new__(cls, N, elem):
+        assert elem.dtype is torch.uint8
+        # pyre-ignore
+        return torch.Tensor._make_wrapper_subclass(
+            cls, up_size(N, elem.shape), dtype=torch.uint8
+        )
+
+    def __init__(self, N: int, elem: torch.Tensor) -> None:
+        self.N: int = N
+        self.elem: torch.Tensor = elem
+
+    # pyre-ignore
+    def tolist(self) -> List:
+        return self.elem.tolist()
+
+    def __repr__(self) -> str:
+        return f"UInt{8 // self.N}Tensor(shape={self.shape}, elem={self.elem})"
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs=None):  # noqa: C901
+        if func is torch.ops.aten.detach.default:
+            # Temp workaround to avoid 'Cannot set version_counter for inference tensor'
+            with torch.inference_mode(False):
+                (self,) = args
+                return cls(func(self.elem))
+        elif func is torch.ops.aten.clone.default:
+            (self,) = args
+            return cls(func(self.elem))
+        elif func is torch.ops.aten.copy_.default:
+            (self, src) = args
+            self.elem.copy_(src.elem)
+            return self
+        elif func is torch.ops.aten.view.dtype:
+            # .view(dtype=uint8) is the way to get the underlying uint8 data
+            self, dtype = args
+            if dtype == torch.uint8:
+                return self.elem
+        elif func is torch.ops.aten._to_copy.default:
+            (self,) = args
+            dtype = find_arg_of_type(
+                itertools.chain(args, kwargs.values()), torch.dtype
+            )
+            device = find_arg_of_type(
+                itertools.chain(args, kwargs.values()), torch.device
+            )
+            # Handle only to device
+            if device:
+                assert dtype is None or dtype == torch.uint8
+                return cls(self.elem.to(device))
+        elif func is torch.ops.aten.slice.Tensor:
+            self, dim, start, end, step = fill_defaults(args, 5, [0, None, None, 1])
+            if dim == self.dim() - 1:
+                # hard case
+                if step != 1:
+                    raise NotImplementedError(f"slice step={step}")
+                assert start % self.N == 0, start
+                assert end >= self.shape[dim] or end % self.N == 0, end
+                return cls(
+                    torch.ops.aten.slice.Tensor(
+                        self.elem, dim, start // self.N, end // self.N, 1
+                    ),
+                )
+            else:
+                return cls(
+                    torch.ops.aten.slice.Tensor(self.elem, dim, start, end, step),
+                )
+        if func is torch.ops.aten.view.default:
+            self, size = args
+            size = utils.infer_size(size, self.numel())
+            assert not kwargs
+            return cls(self.elem.reshape(down_size(self.N, size)))
+        elif func is torch.ops.aten.select.int:
+            self, dim, index = args
+            if dim != self.dim() - 1:
+                return cls(torch.ops.aten.select.int(self.elem, dim, index))
+            else:
+                raise NotImplementedError(f"select dim={dim}")
+
+        raise NotImplementedError(f"{func} args:{args} kwargs:{kwargs}")
+
+
+class UInt4Tensor(UIntXTensor):
+    N: int = 2
+
+    @staticmethod
+    def __new__(cls, elem: torch.Tensor):
+        return UIntXTensor.__new__(cls, cls.N, elem)
+
+    def __init__(self, elem: torch.Tensor) -> None:
+        super().__init__(UInt4Tensor.N, elem)
+
+
+class UInt2Tensor(UIntXTensor):
+    N: int = 4
+
+    @staticmethod
+    def __new__(cls, elem: torch.Tensor):
+        return UIntXTensor.__new__(cls, cls.N, elem)
+
+    def __init__(self, elem: torch.Tensor) -> None:
+        super().__init__(UInt2Tensor.N, elem)


### PR DESCRIPTION
Summary: Enabling CW sharding for quant after UInt4 tensor

Reviewed By: gnahzg

Differential Revision:
D50695974

Privacy Context Container: L1138451


