### PR TITLE
Minimize gpu -> cpu data transfers in `_length_per_key_from_stride_per_key`

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -631,9 +631,10 @@ def _maybe_compute_stride_kjt_scripted(
 def _length_per_key_from_stride_per_key(
     lengths: torch.Tensor, stride_per_key: List[int]
 ) -> List[int]:
-    return [
-        int(torch.sum(chunk).item()) for chunk in torch.split(lengths, stride_per_key)
-    ]
+    stride_per_key_offsets = _to_offsets(
+        _pin_and_move(torch.tensor(stride_per_key, dtype=torch.int32), lengths.device)
+    )
+    return torch.ops.fbgemm.segment_sum_csr(1, stride_per_key_offsets, lengths).tolist()
 
 
 def _maybe_compute_length_per_key(


### PR DESCRIPTION
Summary: when there are a lot of features, we end up doing many small gpu -> cpu data transfers. instead of calling item on each feature split, concat into single tensor then do a single data transfer.

Differential Revision: D50865587


