### PR TITLE
Remove usage of `segment_sum_csr` in calculating `length_per_key`

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -631,9 +631,9 @@ def _maybe_compute_stride_kjt_scripted(
 def _length_per_key_from_stride_per_key(
     lengths: torch.Tensor, stride_per_key: List[int]
 ) -> List[int]:
-    return [
-        int(torch.sum(chunk).item()) for chunk in torch.split(lengths, stride_per_key)
-    ]
+    return torch.cat(
+        [torch.sum(chunk).view(1) for chunk in torch.split(lengths, stride_per_key)]
+    ).tolist()
 
 
 def _maybe_compute_length_per_key(


### PR DESCRIPTION
Summary: "The kernel is not suitable for the case where the number of segments is small and each segment is large because we parallelize different segments across thread blocks and use one thread block per segment. In your case, if every element is in the same segment, this op will be very slow."

Differential Revision: D51046476


