### PR TITLE
Remove .int() conversion for sharded

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -118,7 +118,7 @@ def _quantize_weight(
 def _unwrap_kjt(
     features: KeyedJaggedTensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    return features.values().int(), features.offsets().int(), features.weights_or_none()
+    return features.values(), features.offsets(), features.weights_or_none()
 
 
 class QuantBatchedEmbeddingBag(

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -345,6 +345,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             num_float_features=10,
             tables=self.tables,
             weighted_tables=self.weighted_tables,
+            long_indices=False,
         )
 
         # pyre-ignore
@@ -429,6 +430,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             num_float_features=10,
             tables=self.tables,
             weighted_tables=self.weighted_tables,
+            long_indices=False,
         )
 
         torch.testing.assert_close(


### PR DESCRIPTION
Summary:
Aligning with non sharded:

Removing `.int32()` conversion

Differential Revision:
D51210477

Privacy Context Container: L1138451


