### PR TITLE
dynamo export test for KJT split, permute

### DIFF
--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -33,6 +33,7 @@ from torchrec.distributed.planner.shard_estimators import (
 )
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.infer_utils import (
+    assert_close,
     KJTInputWrapper,
     model_input_to_forward_args,
     model_input_to_forward_args_kjt,
@@ -477,18 +478,6 @@ class ModelTraceScriptTest(unittest.TestCase):
             if test_type == FxJitTestType.FX_JIT:
                 gm_script = torch.jit.script(gm)
                 gm_script_output = gm_script(*inputs[0])
-
-                # pyre-ignore
-                # TODO: Add JaggedTensor check to assert_close
-                def assert_close(expected, got) -> None:
-                    if isinstance(expected, dict):
-                        for feature, jt_e in expected.items():
-                            jt_got = got[feature]
-                            torch.testing.assert_close(jt_e.lengths(), jt_got.lengths())
-                            torch.testing.assert_close(jt_e.values(), jt_got.values())
-                            torch.testing.assert_close(jt_e.offsets(), jt_got.offsets())
-                    else:
-                        torch.testing.assert_close(expected, got)
 
                 if isinstance(eager_output, Awaitable):
                     eager_output = eager_output.wait()

--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import copy
+import re
+import unittest
+from contextlib import contextmanager
+from typing import List
+
+import torch
+import torch._dynamo.skipfiles
+from fbgemm_gpu import sparse_ops  # noqa: F401, E402
+from torch._dynamo import skipfiles
+from torch._export import dynamic_dim
+from torchrec.distributed.test_utils.infer_utils import (
+    assert_close,
+    KJTInputExportWrapper,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+def make_kjt(values: List[int], lengths: List[int]) -> KeyedJaggedTensor:
+    values_tensor = torch.tensor(values, dtype=torch.int32)
+    lengths_tensor = torch.tensor(lengths, dtype=torch.int32)
+    torch._check(torch.sum(lengths_tensor).item() == values_tensor.size(0))
+    kjt = KeyedJaggedTensor(
+        keys=[f"key{i}" for i in range(len(lengths))],
+        values=values_tensor,
+        lengths=lengths_tensor,
+    )
+    dynamic_dim(kjt._values, 0)
+    return kjt
+
+
+# TODO(ivankobzarev): Remove once torchrec is not in dynamo skipfiles
+@contextmanager
+# pyre-ignore
+def dynamo_skipfiles_allow(exclude_from_skipfiles_pattern: str):
+    original_FBCODE_SKIP_DIRS_RE = copy.deepcopy(skipfiles.FBCODE_SKIP_DIRS_RE)
+    new_FBCODE_SKIP_DIRS = {
+        s for s in skipfiles.FBCODE_SKIP_DIRS if exclude_from_skipfiles_pattern not in s
+    }
+    skipfiles.FBCODE_SKIP_DIRS_RE = re.compile(
+        # pyre-ignore
+        f".*({'|'.join(map(re.escape, new_FBCODE_SKIP_DIRS))})"
+    )
+    yield
+    skipfiles.FBCODE_SKIP_DIRS_RE = original_FBCODE_SKIP_DIRS_RE
+
+
+class TestPt2(unittest.TestCase):
+    def _test_kjt_input_module(
+        self,
+        kjt_input_module: torch.nn.Module,
+        kjt_keys: List[str],
+        # pyre-ignore
+        inputs,
+    ) -> None:
+        with dynamo_skipfiles_allow("torchrec"):
+            EM: torch.nn.Module = KJTInputExportWrapper(kjt_input_module, kjt_keys)
+            eager_output = EM(*inputs)
+            x = torch._dynamo.export(EM, same_signature=True)(*inputs)
+
+            export_gm = x.graph_module
+            export_gm_output = export_gm(*inputs)
+
+            assert_close(eager_output, export_gm_output)
+
+    def test_kjt_split(self) -> None:
+        class M(torch.nn.Module):
+            def forward(self, kjt: KeyedJaggedTensor, segments: List[int]):
+                return kjt.split(segments)
+
+        kjt: KeyedJaggedTensor = make_kjt([2, 3, 4, 5, 6], [1, 2, 1, 1])
+        segments: List[int] = [1, 2, 1]
+        self._test_kjt_input_module(
+            M(), kjt.keys(), (kjt._values, kjt._lengths, segments)
+        )
+
+    def test_kjt_permute(self) -> None:
+        class M(torch.nn.Module):
+            def forward(self, kjt: KeyedJaggedTensor, indices: List[int]):
+                return kjt.permute(indices)
+
+        kjt: KeyedJaggedTensor = make_kjt([2, 3, 4, 5, 6], [1, 2, 1, 1])
+        indices: List[int] = [1, 0, 3, 2]
+        self._test_kjt_input_module(
+            M(), kjt.keys(), (kjt._values, kjt._lengths, indices)
+        )

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -29,6 +29,13 @@ try:
 except ImportError:
     pass
 
+try:
+    from torch._dynamo import is_compiling as is_torchdynamo_compiling
+except Exception:
+
+    def is_torchdynamo_compiling():  # type: ignore[misc]
+        return False
+
 
 def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     return (
@@ -1524,6 +1531,16 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 )
             else:
                 split_length_per_key = _length_per_key[start:end]
+
+                if not torch.jit.is_scripting() and is_torchdynamo_compiling():
+                    # Checks for dynamo dynamic shapes tracing
+                    torch._check_is_size(start_offset)
+                    torch._check_is_size(end_offset)
+                    torch._check_is_size(end_offset - start_offset)
+                    torch._check(start_offset <= self._values.size(0))
+                    torch._check(end_offset <= self._values.size(0))
+                    torch._check(end_offset >= start_offset)
+
                 split_list.append(
                     KeyedJaggedTensor(
                         keys=keys,


### PR DESCRIPTION
Summary:
Making KJT split pt2 dynamic shapes traceable

Tests for permute, split

Patching dynamo skipfiles to enable torchrec dynamo tracing.
Will be removed after removing torchrec frok skipfiles.

Differential Revision:
D51258965

Privacy Context Container: L1138451


