### PR TITLE
Back out "move tensor concatenation to compute step from update step"

### DIFF
--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -177,23 +177,6 @@ class AUCMetricValueTest(unittest.TestCase):
         actual_auc = self.auc.compute()["auc-DefaultTask|window_auc"]
         torch.allclose(expected_auc, actual_auc)
 
-    def test_calc_multiple_updates(self) -> None:
-        expected_auc = torch.tensor([0.4464], dtype=torch.float)
-        # first batch
-        self.labels["DefaultTask"] = torch.tensor([1, 0, 0])
-        self.predictions["DefaultTask"] = torch.tensor([0.2, 0.6, 0.8])
-        self.weights["DefaultTask"] = torch.tensor([0.13, 0.2, 0.5])
-
-        self.auc.update(**self.batches)
-        # second batch
-        self.labels["DefaultTask"] = torch.tensor([1, 1])
-        self.predictions["DefaultTask"] = torch.tensor([0.4, 0.9])
-        self.weights["DefaultTask"] = torch.tensor([0.8, 0.75])
-
-        self.auc.update(**self.batches)
-        multiple_batch = self.auc.compute()["auc-DefaultTask|window_auc"]
-        torch.allclose(expected_auc, multiple_batch)
-
 
 def generate_model_outputs_cases() -> Iterable[Dict[str, torch._tensor.Tensor]]:
     return [

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -48,9 +48,9 @@ class TestGPU(unittest.TestCase):
             labels={"DefaultTask": model_output["label"]},
             weights={"DefaultTask": model_output["weight"]},
         )
-        self.assertEqual(len(auc._metrics_computations[0].predictions), 2)
-        self.assertEqual(len(auc._metrics_computations[0].labels), 2)
-        self.assertEqual(len(auc._metrics_computations[0].weights), 2)
+        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
+        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
+        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
         self.assertEqual(auc._metrics_computations[0].predictions[0].device, device)
         self.assertEqual(auc._metrics_computations[0].labels[0].device, device)
         self.assertEqual(auc._metrics_computations[0].weights[0].device, device)


### PR DESCRIPTION
Summary:
OOM issues on MAST, changing AUC to optionally apply tensor cats in update or compute.

Original commit changeset: 891c8b1de5f1

Original Phabricator Diff: D51176437

Differential Revision: D51270369


