### PR TITLE
Add option to balance modules to partitioners

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -9,7 +9,7 @@ import copy
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import cast, List
+from typing import cast, Dict, List
 
 from torchrec.distributed.planner.perf_models import NoopPerfModel
 
@@ -58,6 +58,7 @@ class ShardingOptionGroup:
     sharding_options: List[ShardingOption]
     storage_sum: Storage
     perf_sum: float
+    param_count: int
 
 
 class SortBy(Enum):
@@ -66,8 +67,20 @@ class SortBy(Enum):
 
 
 def _group_and_sort_non_uniform_sharding_options(
-    sharding_options: List[ShardingOption], sort_by: SortBy = SortBy.STORAGE
+    sharding_options: List[ShardingOption],
+    sort_by: SortBy = SortBy.STORAGE,
+    balance_modules: bool = False,
 ) -> List[ShardingOptionGroup]:
+
+    # count modules by name
+    param_count: Dict[str, int] = {}
+    for sharding_option in sharding_options:
+        path = sharding_option.path
+        if path not in param_count:
+            param_count[path] = 0
+        param_count[path] += 1
+    logger.info(f"param_count is {param_count}")
+
     sharding_option_groups_by_dependency = {}
     for sharding_option in sharding_options:
         if sharding_option.partition_by == PartitionByType.UNIFORM.value:
@@ -79,6 +92,8 @@ def _group_and_sort_non_uniform_sharding_options(
                 [sharding_option],
                 sharding_option.total_storage,
                 sharding_option.total_perf,
+                # negative value to indicate that smaller modules should be sorted first
+                param_count=-param_count[sharding_option.path],
             )
         else:
             sharding_option_groups_by_dependency[group_key].sharding_options.append(
@@ -90,25 +105,44 @@ def _group_and_sort_non_uniform_sharding_options(
             sharding_option_groups_by_dependency[
                 group_key
             ].perf_sum += sharding_option.total_perf
+
     sharding_option_groups = list(sharding_option_groups_by_dependency.values())
 
+    sort_by_attributes: List[str] = []
+    if balance_modules:
+        sort_by_attributes.append("param_count")
+
     if sort_by == SortBy.STORAGE:
-        sharding_option_groups.sort(key=lambda group: group.storage_sum, reverse=True)
+        sort_by_attributes.append("storage_sum")
     elif sort_by == SortBy.PERF:
-        sharding_option_groups.sort(key=lambda group: group.perf_sum, reverse=True)
+        sort_by_attributes.append("perf_sum")
     else:
         raise RuntimeError(f"Unexpected sort_by: {sort_by}")
+
+    sharding_option_groups.sort(
+        key=lambda group: [getattr(group, attr) for attr in sort_by_attributes],
+        reverse=True,
+    )
 
     return sharding_option_groups
 
 
 class GreedyPerfPartitioner(Partitioner):
-    """
-    Greedy Partitioner
+    """Greedy Partitioner
+
+    Args:
+        sort_by (SortBy): Sort sharding options by storage or perf in
+            descending order (i.e., large tables will be placed first).
+        balance_modules (bool): Whether to sort by modules first, where
+            smaller modules will be sorted first. In effect, this will place
+            tables in each module in a balanced way.
     """
 
-    def __init__(self, sort_by: SortBy = SortBy.STORAGE) -> None:
+    def __init__(
+        self, sort_by: SortBy = SortBy.STORAGE, balance_modules: bool = False
+    ) -> None:
         self._sort_by = sort_by
+        self._balance_modules = balance_modules
 
     def partition(
         self,
@@ -186,7 +220,7 @@ class GreedyPerfPartitioner(Partitioner):
         # group the rest sharding options by colocation type (co-host, co-device, none)
         # and sort the groups by storage in reverse order
         sharding_option_groups = _group_and_sort_non_uniform_sharding_options(
-            proposal, sort_by=self._sort_by
+            proposal, sort_by=self._sort_by, balance_modules=self._balance_modules
         )
 
         for sharding_option_group in sharding_option_groups:
@@ -335,13 +369,29 @@ class GreedyPerfPartitioner(Partitioner):
 
 
 class MemoryBalancedPartitioner(Partitioner):
-    """
-    Memory balanced Partitioner.
+    """Memory balanced Partitioner.
+
+    Args:
+        max_search_count (int): Maximum number of times to call the
+            GreedyPartitioner.
+        tolerance (float): The maximum acceptable difference between the
+            original plan and the new plan. If tolerance is 1, that means a new
+            plan will be rejected if its perf is 200% of the original plan
+            (i.e., the plan is 100% worse).
+        balance_modules (bool): Whether to sort by modules first, where
+            smaller modules will be sorted first. In effect, this will place
+            tables in each module in a balanced way.
     """
 
-    def __init__(self, max_search_count: int = 10, tolerance: float = 0.02) -> None:
+    def __init__(
+        self,
+        max_search_count: int = 10,
+        tolerance: float = 0.02,
+        balance_modules: bool = False,
+    ) -> None:
         self._max_search_count: int = max_search_count
         self._tolerance: float = tolerance
+        self._balance_modules: bool = balance_modules
 
     def partition(
         self,
@@ -354,7 +404,9 @@ class MemoryBalancedPartitioner(Partitioner):
         of memory.
         """
         _perf_model: PerfModel = NoopPerfModel(storage_constraint)
-        _partitioner = GreedyPerfPartitioner(sort_by=SortBy.PERF)
+        _partitioner = GreedyPerfPartitioner(
+            sort_by=SortBy.PERF, balance_modules=self._balance_modules
+        )
         # copying storage_constraint, since we modify it in place
         _topology: Topology = copy.deepcopy(storage_constraint)
 


### PR DESCRIPTION
Summary:
This diff will make sure module count on GPUs are balanced. The way we do it is to sort the tables from a smaller module first.

This should work fine with dependency (aka towers), since dependency is either child_path or starts with child_path, which is the path.

Differential Revision: D51180772


