### PR TITLE
Modify lazy extension docstrings

### DIFF
--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -159,8 +159,8 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
     # pyre-ignore[2, 47]
     #  `LazyModuleMixin` inconsistently.
     def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:
-        r"""Infers the size and initializes the parameters according to the
-        provided input batch.
+        r"""Infers the size and initializes the parameters according to the provided input batch.
+
         Given a module that contains parameters that were declared inferrable
         using :class:`torch.nn.parameter.ParameterMode.Infer`, runs a forward pass
         in the complete module using the provided input to initialize all the parameters


### PR DESCRIPTION
Summary:
Created from CodeHub with https://fburl.com/edit-in-codehub

Because a pytorch PR that changes docstrings might break a test that make sure two functions have the same source code.

https://github.com/pytorch/pytorch/pull/113260/files

We need to wait for the diff train though. Otherwise it would break internal tests.

Differential Revision: D51287106


