### PR TITLE
Fix _infer_parameters doc string for PyTorch #113260

### DIFF
--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -159,8 +159,8 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
     # pyre-ignore[2, 47]
     #  `LazyModuleMixin` inconsistently.
     def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:
-        r"""Infers the size and initializes the parameters according to the
-        provided input batch.
+        r"""Infers the size and initializes the parameters according to the provided input batch.
+
         Given a module that contains parameters that were declared inferrable
         using :class:`torch.nn.parameter.ParameterMode.Infer`, runs a forward pass
         in the complete module using the provided input to initialize all the parameters


### PR DESCRIPTION
Summary: This test is failing doc update on D51224525, i.e. https://www.internalfb.com/sandcastle/workflow/1787929052067532095?entry_point=11

Reviewed By: malfet, kit1980

Differential Revision: D51285033


