### PR TITLE
Back out "Explicitly provide serialized_type_name in registering JaggedTensor pytree"

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -571,12 +571,7 @@ def _jt_flatten_spec(t: JaggedTensor, spec: TreeSpec) -> List[Optional[torch.Ten
     return [getattr(t, a) for a in JaggedTensor._fields]
 
 
-_register_pytree_node(
-    JaggedTensor,
-    _jt_flatten,
-    _jt_unflatten,
-    serialized_type_name=f"{JaggedTensor.__module__}.{JaggedTensor.__name__}",
-)
+_register_pytree_node(JaggedTensor, _jt_flatten, _jt_unflatten)
 register_pytree_flatten_spec(JaggedTensor, _jt_flatten_spec)
 
 


### PR DESCRIPTION
Summary:
Original commit changeset: 3aa730a15c9d

Original Phabricator Diff: D51312977

Reviewed By: malaybag

Differential Revision: D51367713


