### PR TITLE
Uneven sharding for TGIF DI publish flow

### DIFF
--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -504,7 +504,7 @@ def get_block_sizes_runtime_device(
     block_sizes: List[int],
     runtime_device: torch.device,
     tensor_cache: Dict[str, Tuple[torch.Tensor, List[torch.Tensor]]],
-    embedding_shard_metadata: Optional[List[List[int]]],
+    embedding_shard_metadata: Optional[List[List[int]]] = None,
 ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
     cache_key: str = "__block_sizes"
     if cache_key not in tensor_cache:
@@ -520,7 +520,7 @@ def get_block_sizes_runtime_device(
                 torch.tensor(
                     row_pos,
                     device=runtime_device,
-                    dtype=torch.int32,
+                    dtype=torch.int64,
                 )
                 for row_pos in embedding_shard_metadata
             ],


### PR DESCRIPTION
Summary:
As titled. This diff is to create uneven sharding for tgif publish.
It first call construct_module_sharding_plan (D50856714) with row_wise(placement) so it creates a first come first fill sharding plan, i.e. tensor size of 20 on sharding placement = [10, 8, 5, 2] will result in a sharding plan of [10, 8, 2, 0]
In `InferRwSequenceEmbeddingSharding`, it creates bucket_size_pos [0, 10, 18, 20] and then
It utilizes `block_bucketize_sparse_features` with variable bucket_sizes in forward stage D50868649
Finally, it run the publish flow.

Differential Revision:
D51219009

Privacy Context Container: L1138451

