### PR TITLE
Fix class desription for EmbeddingsAllToOneReduce

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -786,25 +786,21 @@ class VariableBatchPooledEmbeddingsAllToAll(nn.Module):
 
 class EmbeddingsAllToOneReduce(nn.Module):
     """
-    Merges the pooled/sequence embedding tensor on each device into single tensor.
+    Merges the pooled embedding tensor on each device into single tensor.
 
     Args:
         device (torch.device): device on which buffer will be allocated.
         world_size (int): number of devices in the topology.
-        cat_dim (int): which dimension you would like to concatenate on.
-            For pooled embedding it is 1; for sequence embedding it is 0.
     """
 
     def __init__(
         self,
         device: torch.device,
         world_size: int,
-        cat_dim: int,
     ) -> None:
         super().__init__()
         self._device = device
         self._world_size = world_size
-        self._cat_dim = cat_dim
 
     # This method can be used by an inference runtime to update the
     # device information for this module.
@@ -817,7 +813,7 @@ class EmbeddingsAllToOneReduce(nn.Module):
         tensors: List[torch.Tensor],
     ) -> torch.Tensor:
         """
-        Performs AlltoOne operation with Reduce on pooled/sequence embeddings tensors.
+        Performs AlltoOne operation with Reduce on pooled embeddings tensors.
 
         Args:
             tensors (List[torch.Tensor]): list of embedding tensors.

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -335,7 +335,7 @@ class InferRwPooledEmbeddingDist(
     BaseEmbeddingDist[NullShardingContext, List[torch.Tensor], torch.Tensor]
 ):
     """
-    Redistributes sequence embedding tensor in RW fashion with an AlltoOne operation.
+    Redistributes pooled embedding tensor in RW fashion with an AlltoOne operation.
 
     Args:
         device (torch.device): device on which the tensors will be communicated to.
@@ -351,7 +351,6 @@ class InferRwPooledEmbeddingDist(
         self._dist: EmbeddingsAllToOneReduce = EmbeddingsAllToOneReduce(
             device=device,
             world_size=world_size,
-            cat_dim=1,
         )
 
     def forward(


### PR DESCRIPTION
Summary: EmbeddingsAllToOneReduce is only used for pooled embedding, not sequence embedding. Sequence embedding go through SeqEmbeddingsAllToOne instead

Differential Revision: D51402848


