### PR TITLE
fix fbgemm backward compat for PermutePooledEmbeddings

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -9,6 +9,7 @@ import copy
 import logging
 
 from collections import OrderedDict
+from itertools import accumulate
 from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
 
 import torch
@@ -28,6 +29,21 @@ from torchrec.types import CopyMixIn
 logger: logging.Logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
+try:
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_cpu"
+    )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
+    )
+except OSError:
+    pass
+
+# OSS
+try:
+    pass
+except ImportError:
+    pass
 
 """
 torch.package safe functions from pyre_extensions. However, pyre_extensions is
@@ -438,3 +454,45 @@ def init_parameters(module: nn.Module, device: torch.device) -> None:
                     m.reset_parameters()
 
             module.apply(maybe_reset_parameters)
+
+
+# TODO remove and use FBGEMM version once changes are in the package
+class PermutePooledEmbeddings:
+    def __init__(
+        self,
+        embs_dims: List[int],
+        permute: List[int],
+        device: Optional[torch.device] = None,
+    ) -> None:
+        logging.info("Using Permute Pooled Embeddings")
+        self._offset_dim_list: torch.Tensor = torch.tensor(
+            [0] + list(accumulate(embs_dims)), device=device, dtype=torch.int64
+        )
+
+        self._permute: torch.Tensor = torch.tensor(
+            permute, device=device, dtype=torch.int64
+        )
+
+        inv_permute: List[int] = [0] * len(permute)
+        for i, p in enumerate(permute):
+            inv_permute[p] = i
+
+        self._inv_permute: torch.Tensor = torch.tensor(
+            inv_permute, device=device, dtype=torch.int64
+        )
+
+        inv_embs_dims = [embs_dims[i] for i in permute]
+
+        self._inv_offset_dim_list: torch.Tensor = torch.tensor(
+            [0] + list(accumulate(inv_embs_dims)), device=device, dtype=torch.int64
+        )
+
+    def __call__(self, pooled_embs: torch.Tensor) -> torch.Tensor:
+        result = torch.ops.fbgemm.permute_pooled_embs_auto_grad(
+            pooled_embs,
+            self._offset_dim_list.to(device=pooled_embs.device),
+            self._permute.to(device=pooled_embs.device),
+            self._inv_offset_dim_list.to(device=pooled_embs.device),
+            self._inv_permute.to(device=pooled_embs.device),
+        )
+        return result


### PR DESCRIPTION
Summary: We modified `PermutePooledEmbeddings` in fbgemm directory, but due to packaging it will still be using the original version. The original version is a module that has registered buffers that will show up in the state dict causing incompatibility. This diff moves the new non state dict version inside torchrec to avoid the packaging issue.

Differential Revision: D51500998


