### PR TITLE
Make test_keyed standalone and remove HPC dependency

### DIFF
--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List
 
 import torch
 import torch.distributed as dist
-from hpc.optimizers.optimizer_modules import OptimizerModule
 from torch.autograd import Variable
 from torch.distributed._shard import sharded_tensor, sharding_spec
 from torchrec.optim.keyed import (
@@ -24,13 +23,18 @@ from torchrec.optim.keyed import (
 from torchrec.test_utils import get_free_port
 
 
-class DummyOptimizerModule(OptimizerModule):
+class DummyOptimizerModule:
     def __init__(
         self,
         tensor: torch.Tensor,
     ) -> None:
-        super(DummyOptimizerModule, self).__init__()
         self.tensor = tensor
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"tensor": self.tensor}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.tensor.detach().copy_(state_dict["tensor"])
 
 
 class TestKeyedOptimizer(unittest.TestCase):


### PR DESCRIPTION
Summary:
We remove the `hpc.optimizers` dependency on `optimizer_modules` by enhancing the `DummyOptimizerModule` under `test_keyed.py`. This ensures that the tests are standalone, and can be properly OSS'ed.

Thanks to joshuadeng for catching the error!

Differential Revision: D51599854


