### PR TITLE
reworked: move tensor concatenation to compute step from update step

### DIFF
--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -50,9 +50,9 @@ def _compute_auc_helper(
 
 def compute_auc(
     n_tasks: int,
-    predictions: torch.Tensor,
-    labels: torch.Tensor,
-    weights: torch.Tensor,
+    predictions: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
     apply_bin: bool = False,
 ) -> torch.Tensor:
     """
@@ -60,10 +60,18 @@ def compute_auc(
 
     Args:
         n_tasks (int): number of tasks.
-        predictions (torch.Tensor): tensor of size (n_tasks, n_examples).
-        labels (torch.Tensor): tensor of size (n_tasks, n_examples).
-        weights (torch.Tensor): tensor of size (n_tasks, n_examples).
+        predictions (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
+        labels (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
+        weights (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
     """
+    # concatenate tensors along dim = -1
+    # pyre-ignore[9]
+    predictions = torch.cat(predictions, dim=-1)
+    # pyre-ignore[9]
+    labels = torch.cat(labels, dim=-1)
+    # pyre-ignore[9]
+    weights = torch.cat(weights, dim=-1)
+
     aucs = []
     for predictions_i, labels_i, weights_i in zip(predictions, labels, weights):
         auc = _compute_auc_helper(predictions_i, labels_i, weights_i, apply_bin)
@@ -73,9 +81,9 @@ def compute_auc(
 
 def compute_auc_per_group(
     n_tasks: int,
-    predictions: torch.Tensor,
-    labels: torch.Tensor,
-    weights: torch.Tensor,
+    predictions: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
     grouping_keys: torch.Tensor,
 ) -> torch.Tensor:
     """
@@ -90,14 +98,25 @@ def compute_auc_per_group(
     Returns:
         torch.Tensor: tensor of size (n_tasks,), average of AUCs per group.
     """
+    # concatenate tensors along dim = -1
+    # pyre-ignore[9]
+    predictions = torch.cat(predictions, dim=-1)
+    # pyre-ignore[9]
+    labels = torch.cat(labels, dim=-1)
+    # pyre-ignore[9]
+    weights = torch.cat(weights, dim=-1)
+
     aucs = []
     if grouping_keys.numel() != 0 and grouping_keys[0] == -1:
         # we added padding  as the first elements during init to avoid floating point exception in sync()
         # removing the paddings to avoid numerical errors.
         grouping_keys = grouping_keys[1:]
-        predictions = predictions[:, 1:]
-        labels = labels[:, 1:]
-        weights = weights[:, 1:]
+        # pyre-ignore[9]
+        predictions = predictions[:, 1:]  # pyre-ignore[6]
+        # pyre-ignore[9]
+        labels = labels[:, 1:]  # pyre-ignore[6]
+        # pyre-ignore[9]
+        weights = weights[:, 1:]  # pyre-ignore[6]
 
     # get unique group indices
     group_indices = torch.unique(grouping_keys)
@@ -162,6 +181,7 @@ class AUCMetricComputation(RecMetricComputation):
 
         self._grouped_auc: bool = grouped_auc
         self._apply_bin: bool = apply_bin
+        self._num_samples: int = 0
         self._add_state(
             PREDICTIONS,
             [],
@@ -204,7 +224,7 @@ class AUCMetricComputation(RecMetricComputation):
     def _init_states(self) -> None:
         if len(getattr(self, PREDICTIONS)) > 0:
             return
-
+        self._num_samples = 0
         getattr(self, PREDICTIONS).append(
             torch.zeros((self._n_tasks, 1), dtype=torch.float, device=self.device)
         )
@@ -241,25 +261,32 @@ class AUCMetricComputation(RecMetricComputation):
         predictions = predictions.float()
         labels = labels.float()
         weights = weights.float()
-        num_samples = getattr(self, PREDICTIONS)[0].size(-1)
         batch_size = predictions.size(-1)
-        start_index = max(num_samples + batch_size - self._window_size, 0)
+        start_index = max(self._num_samples + batch_size - self._window_size, 0)
+        self._num_samples += batch_size
+
         # Using `self.predictions =` will cause Pyre errors.
-        getattr(self, PREDICTIONS)[0] = torch.cat(
-            [
-                cast(torch.Tensor, getattr(self, PREDICTIONS)[0])[:, start_index:],
-                predictions,
-            ],
-            dim=-1,
-        )
-        getattr(self, LABELS)[0] = torch.cat(
-            [cast(torch.Tensor, getattr(self, LABELS)[0])[:, start_index:], labels],
-            dim=-1,
-        )
-        getattr(self, WEIGHTS)[0] = torch.cat(
-            [cast(torch.Tensor, getattr(self, WEIGHTS)[0])[:, start_index:], weights],
-            dim=-1,
-        )
+        w_preds = getattr(self, PREDICTIONS)
+        w_labels = getattr(self, LABELS)
+        w_weights = getattr(self, WEIGHTS)
+
+        w_preds.append(predictions)
+        w_labels.append(labels)
+        w_weights.append(weights)
+
+        while self._num_samples > self._window_size:
+            diff = self._num_samples - self._window_size
+            if diff > w_preds[0].size(-1):
+                self._num_samples -= w_preds[0].size(-1)
+                # Remove the first element from predictions, labels, and weights
+                [lst.pop(0) for lst in [w_preds, w_labels, w_weights]]
+            else:
+                # Update the first element of predictions, labels, and weights
+                # Off by one potentially - keeping legacy behaviour
+                for attribute in [w_preds, w_labels, w_weights]:
+                    attribute[0] = attribute[0][:, diff:]
+                self._num_samples -= diff
+
         if self._grouped_auc:
             if REQUIRED_INPUTS not in kwargs or (
                 (grouping_keys := kwargs[REQUIRED_INPUTS].get(GROUPING_KEYS)) is None
@@ -282,9 +309,9 @@ class AUCMetricComputation(RecMetricComputation):
                 metric_prefix=MetricPrefix.WINDOW,
                 value=compute_auc(
                     self._n_tasks,
-                    cast(torch.Tensor, getattr(self, PREDICTIONS)[0]),
-                    cast(torch.Tensor, getattr(self, LABELS)[0]),
-                    cast(torch.Tensor, getattr(self, WEIGHTS)[0]),
+                    cast(List[torch.Tensor], getattr(self, PREDICTIONS)),
+                    cast(List[torch.Tensor], getattr(self, LABELS)),
+                    cast(List[torch.Tensor], getattr(self, WEIGHTS)),
                     self._apply_bin,
                 ),
             )
@@ -296,10 +323,10 @@ class AUCMetricComputation(RecMetricComputation):
                     metric_prefix=MetricPrefix.WINDOW,
                     value=compute_auc_per_group(
                         self._n_tasks,
-                        cast(torch.Tensor, getattr(self, PREDICTIONS)[0]),
-                        cast(torch.Tensor, getattr(self, LABELS)[0]),
-                        cast(torch.Tensor, getattr(self, WEIGHTS)[0]),
-                        cast(torch.Tensor, getattr(self, GROUPING_KEYS)[0]),
+                        cast(List[torch.Tensor], getattr(self, PREDICTIONS)),
+                        cast(List[torch.Tensor], getattr(self, LABELS)),
+                        cast(List[torch.Tensor], getattr(self, WEIGHTS)),
+                        cast(torch.Tensor, getattr(self, GROUPING_KEYS))[0],
                     ),
                 )
             )

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -48,9 +48,9 @@ class TestGPU(unittest.TestCase):
             labels={"DefaultTask": model_output["label"]},
             weights={"DefaultTask": model_output["weight"]},
         )
-        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
-        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
-        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
+        self.assertEqual(len(auc._metrics_computations[0].predictions), 2)
+        self.assertEqual(len(auc._metrics_computations[0].labels), 2)
+        self.assertEqual(len(auc._metrics_computations[0].weights), 2)
         self.assertEqual(auc._metrics_computations[0].predictions[0].device, device)
         self.assertEqual(auc._metrics_computations[0].labels[0].device, device)
         self.assertEqual(auc._metrics_computations[0].weights[0].device, device)


### PR DESCRIPTION
Summary:
We don't need to concatenate the tensor on every update step, since it is an expensive operation (creates a new tensor and allocates new memory every call, as tensors are contiguous) we can call tensor.concat on the compute step instead. Which happens every compute_interval_step batches. This optimization should boost performance of models using AUC with no regression in metric quality.

An earlier iteration of this was landed (D51176437) and caused a SEV as it appended model output to state indefinitely causing OOMs. This is mitigated in this version by strictly adhering to `self._window_size` checking on every update and evicting old tensors as soon as they exceed this limit.

Differential Revision: D51399384


