### PR TITLE
Add adamW optimizer as a dense optimizer type in structured trainer

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -46,6 +46,7 @@ class OptimType(Enum):
     SHAMPOO = "SHAMPOO"
     SHAMPOO_V2 = "SHAMPOO_V2"
     LION = "LION"
+    ADAMW = "ADAMW"
 
 
 @unique


### PR DESCRIPTION
Summary:
In umia_v1, IG has some experiment running with adamW optimizer, which is not available in structured trainer.
code pointer in umia_v1 train_utils: https://fburl.com/code/minm7a05


This diff simply add one more optimizer type, without actually using it just yet.

Differential Revision:
D51684717

Privacy Context Container: L1138451


