### PR TITLE
fix publish error from fx tracing check in unsharded ebc

### DIFF
--- a/torchrec/models/tests/test_deepfm.py
+++ b/torchrec/models/tests/test_deepfm.py
@@ -150,7 +150,7 @@ class SimpleDeepFMNNTest(unittest.TestCase):
             deep_fm_dimension=5,
         )
         gm = symbolic_trace(deepfm_nn)
-        FileCheck().check("KeyedJaggedTensor").check("cat").check("f2").run(gm.code)
+        FileCheck().check("KeyedJaggedTensor").check("f2").run(gm.code)
 
         features = torch.rand((B, num_dense_features))
         sparse_features = KeyedJaggedTensor.from_offsets_sync(

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -470,7 +470,7 @@ class DLRMTest(unittest.TestCase):
             over_arch_layer_sizes=[5, 1],
         )
         gm = symbolic_trace(sparse_nn)
-        FileCheck().check("KeyedJaggedTensor").check("cat").check("f2").run(gm.code)
+        FileCheck().check("KeyedJaggedTensor").check("f2").run(gm.code)
 
         features = torch.rand((B, dense_in_features))
         sparse_features = KeyedJaggedTensor.from_offsets_sync(

--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import abc
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -19,13 +19,30 @@ from torchrec.modules.embedding_configs import (
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 
-# pyre-ignore[5]
-_orig_module_call = torch.nn.Module.__call__
+@torch.fx.wrap
+def reorder_inverse_indices(
+    inverse_indices: Optional[Tuple[List[str], torch.Tensor]], feature_names: List[str]
+) -> Optional[List[torch.Tensor]]:
+    if inverse_indices is None:
+        return None
+    ordered_inverse_indices = []
+    index_per_name = {name: i for i, name in enumerate(inverse_indices[0])}
+    for feature_name in feature_names:
+        index = index_per_name[feature_name.split("@")[0]]
+        ordered_inverse_indices.append(inverse_indices[1][index])
+    return ordered_inverse_indices
 
 
-@torch.jit.ignore
-def is_fx_tracing() -> bool:
-    return torch.nn.Module.__call__ is not _orig_module_call
+@torch.fx.wrap
+def process_pooled_embeddings(
+    pooled_embeddings: List[torch.Tensor],
+    inverse_indices: Optional[List[torch.Tensor]],
+) -> torch.Tensor:
+    if inverse_indices is not None:
+        pooled_embeddings = torch.ops.fbgemm.group_index_select_dim0(
+            pooled_embeddings, inverse_indices
+        )
+    return torch.cat(pooled_embeddings, dim=1)
 
 
 class EmbeddingBagCollectionInterface(abc.ABC, nn.Module):
@@ -187,9 +204,14 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
         Returns:
             KeyedTensor
         """
-
         pooled_embeddings: List[torch.Tensor] = []
-
+        flat_feature_names: List[str] = []
+        for names in self._feature_names:
+            flat_feature_names.extend(names)
+        inverse_indices = reorder_inverse_indices(
+            inverse_indices=features.inverse_indices_or_none(),
+            feature_names=flat_feature_names,
+        )
         feature_dict = features.to_dict()
         for i, embedding_bag in enumerate(self.embedding_bags.values()):
             for feature_name in self._feature_names[i]:
@@ -200,22 +222,9 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                     per_sample_weights=f.weights() if self._is_weighted else None,
                 ).float()
                 pooled_embeddings.append(res)
-        if features.inverse_indices_or_none() is not None and not is_fx_tracing():
-            inverse_indices = []
-            index_per_name = {
-                name: i for i, name in enumerate(features.inverse_indices()[0])
-            }
-            for table in self._feature_names:
-                for feature_name in table:
-                    index = index_per_name[feature_name.split("@")[0]]
-                    inverse_indices.append(features.inverse_indices()[1][index])
-            pooled_embeddings = torch.ops.fbgemm.group_index_select_dim0(
-                pooled_embeddings, inverse_indices
-            )
-        data = torch.cat(pooled_embeddings, dim=1)
         return KeyedTensor(
             keys=self._embedding_names,
-            values=data,
+            values=process_pooled_embeddings(pooled_embeddings, inverse_indices),
             length_per_key=self._lengths_per_embedding,
         )
 


### PR DESCRIPTION
Summary:
The reindexing logic in the ebc module isn't compatible with fx tracing, due to the KJT containing proxies. To circumvent this we skip this logic with a `is_fx_tracing()` function check.

During mvai's publish flow this introduces a jit error:
```
RuntimeError:
Could not export Python function call 'is_fx_tracing'. Remove calls to Python functions before export. Did you forget to add script or script_method annotation? If this is a nn.ModuleList, add it to __constants__:
  File "/mnt/xarfuse/uid-29063/e95415f6-seed-nspid4026534553_cgpid126435444-ns-4026534550/torchrec/modules/embedding_modules.py", line 203
                ).float()
                pooled_embeddings.append(res)
        if features.inverse_indices_or_none() is not None and not is_fx_tracing():
                                                                  ~~~~~~~~~~~~~ <--- HERE
            inverse_indices = []
            index_per_name = {
```

Differential Revision: D51718962


