### PR TITLE
minor - simplify multi-byte unicode char in log message

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -390,7 +390,7 @@ class GroupedPooledEmbeddingsLookup(
                 ):
                     logging.error(
                         "Invalid setting on SplitTableBatchedEmbeddingBagsCodegen modules. prefetch_pipeline must be set to True.\n"
-                        "If you don’t turn on prefetch_pipeline, cache locations might be wrong in backward and can cause wrong results.\n"
+                        "If you don't turn on prefetch_pipeline, cache locations might be wrong in backward and can cause wrong results.\n"
                     )
                 if hasattr(emb_op.emb_module, "prefetch"):
                     emb_op.emb_module.prefetch(


### PR DESCRIPTION
Summary:
As title. The log message was (inadvertently?) encoding a ' as a
multi-byte ’ sequence (fancy unicode codepoint 8217 /
U+2019 RIGHT SINGLE QUOTATION MARK -
https://www.codetable.net/decimal/8217). This can make searching for
the log message harder to match. Switch to a simple ascii apostophe
(codepoint 39).

Reviewed By: bigning

Differential Revision: D51726626


