### PR TITLE
torchrec][pt2] KeyedTensor pytree flatten/unflatten

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2180,3 +2180,21 @@ class KeyedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             )
             + "\n})\n"
         )
+
+
+def _kt_flatten(
+    kt: KeyedTensor,
+) -> Tuple[List[torch.Tensor], List[str]]:
+    return [torch.tensor(kt._length_per_key, dtype=torch.int64), kt._values], kt._keys
+
+
+def _kt_unflatten(values: List[torch.Tensor], context: List[str]) -> KeyedTensor:
+    return KeyedTensor(context, values[0].tolist(), values[1])
+
+
+def _kt_flatten_spec(kt: KeyedTensor, spec: TreeSpec) -> List[torch.Tensor]:
+    return _kt_flatten(kt)[0]
+
+
+_register_pytree_node(KeyedTensor, _kt_flatten, _kt_unflatten)
+register_pytree_flatten_spec(KeyedTensor, _kt_flatten_spec)


### PR DESCRIPTION
Summary:
Adding flatten/unflatten for KeyedTensor to enable it in pt2 traced models signatures.

We have here conversion length_per_key List[int] <-> Tensor during flatten/unflatten.
This is done to derisk the migration of length_per_key to Tensor D50840897 for launch season.

If that conversion affects performance in pt2 - do length_per_key to Tensor migration ( D50840897 )

Reviewed By: gnahzg

Differential Revision:
D51849555

Privacy Context Container: L1138451


