### PR TITLE
Revert D51718962: Multisect successfully blamed "D51718962: [torchrec][vbe] fix publish error from fx tracing check in unsharded ebc" for otest failure

### DIFF
--- a/torchrec/models/tests/test_deepfm.py
+++ b/torchrec/models/tests/test_deepfm.py
@@ -150,7 +150,7 @@ class SimpleDeepFMNNTest(unittest.TestCase):
             deep_fm_dimension=5,
         )
         gm = symbolic_trace(deepfm_nn)
-        FileCheck().check("KeyedJaggedTensor").check("f2").run(gm.code)
+        FileCheck().check("KeyedJaggedTensor").check("cat").check("f2").run(gm.code)
 
         features = torch.rand((B, num_dense_features))
         sparse_features = KeyedJaggedTensor.from_offsets_sync(

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -470,7 +470,7 @@ class DLRMTest(unittest.TestCase):
             over_arch_layer_sizes=[5, 1],
         )
         gm = symbolic_trace(sparse_nn)
-        FileCheck().check("KeyedJaggedTensor").check("f2").run(gm.code)
+        FileCheck().check("KeyedJaggedTensor").check("cat").check("f2").run(gm.code)
 
         features = torch.rand((B, dense_in_features))
         sparse_features = KeyedJaggedTensor.from_offsets_sync(


### PR DESCRIPTION
Summary:
This diff is reverting D51718962
D51718962: [torchrec][vbe] fix publish error from fx tracing check in unsharded ebc by joshuadeng has been identified to be causing the following test failure:

Tests affected:
- [free/modules/tests:sparse_emb_lib_test - test_forward_emb_dim_provided (free.modules.tests.sparse_emb_lib_test.TestEBC)](https://www.internalfb.com/intern/test/844425015829320/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3712055
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: jingsh

Differential Revision: D51948903


