### PR TITLE
Fix TWRW empty rank issue for vbe

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -703,14 +703,15 @@ def reduce_scatter_v_per_feature_pooled(
 
     myreq = Request(group, device=input.device)
 
-    input_splits = []
-    for rank in range(world_size):
-        rank_splits = 0
-        for batch_size, emb_dim in zip(
-            batch_size_per_rank_per_feature[rank], embedding_dims
-        ):
-            rank_splits += batch_size * emb_dim
-        input_splits.append(rank_splits)
+    input_splits = [0 for _ in range(world_size)]
+    if batch_size_per_rank_per_feature:
+        for rank in range(world_size):
+            rank_splits = 0
+            for batch_size, emb_dim in zip(
+                batch_size_per_rank_per_feature[rank], embedding_dims
+            ):
+                rank_splits += batch_size * emb_dim
+            input_splits[rank] = rank_splits
 
     input_sizes = [torch.Size([s]) for s in input_splits]
 

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -536,6 +536,8 @@ class TwRwPooledEmbeddingDist(
         Reorders `batch_size_per_rank_per_feature_stagger` so it's aligned with
         reordered features after AlltoAll.
         """
+        if not batch_size_per_rank_per_feature_stagger:
+            return [[]] * local_size, []
         batch_size_per_rank_per_feature_by_cross_group: List[List[List[int]]] = []
         batch_size_per_feature_sum_by_cross_group: List[List[int]] = []
         for local_rank in range(local_size):

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -214,12 +214,14 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         sharding_type=st.sampled_from(
             [
                 ShardingType.TABLE_ROW_WISE.value,
-                ShardingType.TABLE_COLUMN_WISE.value,
             ]
         ),
+        variable_batch_per_feature=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
-    def test_sharding_empty_rank(self, sharding_type: str) -> None:
+    def test_sharding_empty_rank(
+        self, sharding_type: str, variable_batch_per_feature: bool
+    ) -> None:
         table = self.tables[0]
         embedding_groups = {"group_0": table.feature_names}
         self._run_multi_process_test(
@@ -241,6 +243,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             backend="nccl",
             constraints={table.name: ParameterConstraints(min_partition=4)},
             variable_batch_size=True,
+            variable_batch_per_feature=variable_batch_per_feature,
+            weighted_tables=None,
         )
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary: The way we do input dist for vbe, we don't send batch size info to empty ranks. We handled this for tw/cw in pooled embs a2a, this diff adds support for twrw in reduce scatter

Differential Revision: D51957445


