### PR TITLE
Fix another NDCG Metric issue on GPU

### DIFF
--- a/torchrec/metrics/ndcg.py
+++ b/torchrec/metrics/ndcg.py
@@ -250,7 +250,7 @@ class NDCGComputation(RecMetricComputation):
             exponential_gain=self._exponential_gain,
         )
         for state_name, state_value in states.items():
-            state = getattr(self, state_name)
+            state = getattr(self, state_name).to(labels.device)
             state += state_value
             self._aggregate_window_state(state_name, state_value, predictions.shape[-1])
 


### PR DESCRIPTION
Summary:
When trained with GPU, the workflow had error  'RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:4 and cpu!'  f510077567 

This diff is to fix this issue.

Previous fix: D51603318

Reviewed By: zainhuda

Differential Revision: D51955452


