### PR TITLE
test_pt2 fix for OSS and gpu compat

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -6,12 +6,21 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import sys
 import unittest
 from typing import List, Tuple
 
 import torch
 import torch._dynamo.skipfiles
-from caffe2.test.inductor.test_aot_inductor import AOTInductorModelRunner
+
+try:
+    # pyre-ignore
+    from caffe2.test.inductor.test_aot_inductor import AOTInductorModelRunner
+except (unittest.SkipTest, ImportError):
+    if __name__ == "__main__":
+        sys.exit(0)
+
+
 from fbgemm_gpu import sparse_ops  # noqa: F401, E402
 from torch._export import dynamic_dim
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -147,6 +156,11 @@ class TestPt2(unittest.TestCase):
             test_aot_inductor=False,
         )
 
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs available",
+    )
     def test_sharded_quant_ebc_dynamo_export_aot_inductor(self) -> None:
         sharded_model, input_kjts = _sharded_quant_ebc_model()
         kjt = input_kjts[0]


### PR DESCRIPTION
Summary:
AOTInductor supports only A100, H100 gpus.

Import for AOTInductorRunner can not be done in OSS - not running this in OSS.

Differential Revision:
D51984891

Privacy Context Container: L1138451


