### PR TITLE
Fix distributed debug w/ non-equal split

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import unittest
 from typing import Any, Dict, Optional, Tuple, Type
 
@@ -98,6 +99,9 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             sharder_type == SharderType.EMBEDDING_BAG_COLLECTION.value
             or not variable_batch_size
         )
+        # Make sure detail debug will work with non-even collective
+        os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
+
         self._test_sharding(
             # pyre-ignore[6]
             sharders=[


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/115483

In collectives, it's possible to have non-equal split that has a different implementation and the output tensor size will be different, e.g. https://www.internalfb.com/code/fbsource/[460afb1172b5]/fbcode/caffe2/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp?lines=3104. However, TORCH_DISTRIBUTED_DEBUG=DETAIL will assume the output tensor size is the same and does the check and will fail the job if they don't: https://fburl.com/code/mhte9ty8. c10d code should handle this.

Ideally we should check the input size across ranks and make sure they're the same. Maybe for next diff.

Reviewed By: zhangruiskyline

Differential Revision: D52010942


