### PR TITLE
Revert D51399384: Multisect successfully blamed "D51399384: [torchrec][recmetrics] reworked: move tensor concatenation to compute step from update step" for otest failure

### DIFF
--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -161,7 +161,6 @@ class AUCMetricValueTest(unittest.TestCase):
         )
 
         expected_auc = torch.tensor([0], dtype=torch.float)
-
         self.auc.update(**self.batches)
         actual_auc = self.auc.compute()["auc-DefaultTask|window_auc"]
         torch.allclose(expected_auc, actual_auc)
@@ -177,37 +176,6 @@ class AUCMetricValueTest(unittest.TestCase):
         self.auc.update(**self.batches)
         actual_auc = self.auc.compute()["auc-DefaultTask|window_auc"]
         torch.allclose(expected_auc, actual_auc)
-
-    def test_calc_multiple_updates(self) -> None:
-        expected_auc = torch.tensor([0.4464], dtype=torch.float)
-        # first batch
-        self.labels["DefaultTask"] = torch.tensor([1, 0, 0])
-        self.predictions["DefaultTask"] = torch.tensor([0.2, 0.6, 0.8])
-        self.weights["DefaultTask"] = torch.tensor([0.13, 0.2, 0.5])
-
-        self.auc.update(**self.batches)
-        # second batch
-        self.labels["DefaultTask"] = torch.tensor([1, 1])
-        self.predictions["DefaultTask"] = torch.tensor([0.4, 0.9])
-        self.weights["DefaultTask"] = torch.tensor([0.8, 0.75])
-
-        self.auc.update(**self.batches)
-        multiple_batch = self.auc.compute()["auc-DefaultTask|window_auc"]
-        torch.allclose(expected_auc, multiple_batch)
-
-    def test_stress_auc(self) -> None:
-        # window size is only 100, so we should expect expected AUC to be same
-        expected_auc = torch.tensor([1.0], dtype=torch.float)
-        # first batch
-        self.labels["DefaultTask"] = torch.tensor([[1, 0, 0, 1, 1]])
-        self.predictions["DefaultTask"] = torch.tensor([[1, 0, 0, 1, 1]])
-        self.weights["DefaultTask"] = torch.tensor([[1] * 5])
-
-        for _ in range(1000):
-            self.auc.update(**self.batches)
-
-        result = self.auc.compute()["auc-DefaultTask|window_auc"]
-        torch.allclose(expected_auc, result)
 
 
 def generate_model_outputs_cases() -> Iterable[Dict[str, torch._tensor.Tensor]]:

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -48,9 +48,9 @@ class TestGPU(unittest.TestCase):
             labels={"DefaultTask": model_output["label"]},
             weights={"DefaultTask": model_output["weight"]},
         )
-        self.assertEqual(len(auc._metrics_computations[0].predictions), 2)
-        self.assertEqual(len(auc._metrics_computations[0].labels), 2)
-        self.assertEqual(len(auc._metrics_computations[0].weights), 2)
+        self.assertEqual(len(auc._metrics_computations[0].predictions), 1)
+        self.assertEqual(len(auc._metrics_computations[0].labels), 1)
+        self.assertEqual(len(auc._metrics_computations[0].weights), 1)
         self.assertEqual(auc._metrics_computations[0].predictions[0].device, device)
         self.assertEqual(auc._metrics_computations[0].labels[0].device, device)
         self.assertEqual(auc._metrics_computations[0].weights[0].device, device)


### PR DESCRIPTION
Summary:
This diff is reverting D51399384
D51399384: [torchrec][recmetrics] reworked: move tensor concatenation to compute step from update step by zainhuda has been identified to be causing the following test failure:

Tests affected:
- [aps_models/exploration/ig/tests:e2e_esr_multi_table_train_local_gpu_test - aps_models.exploration.ig.tests.e2e_esr_multi_table_train_local_gpu_test.TestE2EESRTrainLocalGPU: test_local_multi_process_training](https://www.internalfb.com/intern/test/281475099588398/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3785687
Here are the tasks that are relevant to this breakage:


We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D52164472


