### PR TITLE
fix segmented ne on GPU

### DIFF
--- a/torchrec/metrics/segmented_ne.py
+++ b/torchrec/metrics/segmented_ne.py
@@ -106,10 +106,10 @@ def get_segemented_ne_states(
 ) -> Dict[str, torch.Tensor]:
     groups = torch.unique(grouping_keys)
     cross_entropy, weighted_num_samples, pos_labels, neg_labels = (
-        torch.zeros(num_groups),
-        torch.zeros(num_groups),
-        torch.zeros(num_groups),
-        torch.zeros(num_groups),
+        torch.zeros(num_groups).to(labels.device),
+        torch.zeros(num_groups).to(labels.device),
+        torch.zeros(num_groups).to(labels.device),
+        torch.zeros(num_groups).to(labels.device),
     )
     for group in groups:
         group_mask = grouping_keys == group


### PR DESCRIPTION
Summary:
Previously, using the Segmented NE metric on GPU failed in 

f512851804

 with the error: Expected all tensors to be on the same device, but found at least two devices. This diff ensures that the `get_segemented_ne_states` function returns tensors that are on the correct device that the model is being trained on.

Differential Revision: D52223889


