### PR TITLE
remove .int() for cpu indices and values

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -118,7 +118,14 @@ def _quantize_weight(
 def _unwrap_kjt(
     features: KeyedJaggedTensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    return features.values().int(), features.offsets().int(), features.weights_or_none()
+    if features.device().type == "cuda":
+        return (
+            features.values().int(),
+            features.offsets().int(),
+            features.weights_or_none(),
+        )
+    else:
+        return features.values(), features.offsets(), features.weights_or_none()
 
 
 class QuantBatchedEmbeddingBag(


### PR DESCRIPTION
Summary: CPU DI is serving large model with big embedding tables (2TB), the value and indices would overflow with .int() conversion. Remove .int() just for CPU

Reviewed By: tissue3

Differential Revision: D52225777


