### PR TITLE
Fix scripting for creating empty jagged tensors

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -246,14 +246,13 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights_dtype: Optional[torch.dtype] = None,
         lengths_dtype: torch.dtype = torch.int32,
     ) -> "JaggedTensor":
-        weights = torch.jit.annotate(Optional[torch.Tensor], None)
-        if is_weighted:
-            weights = torch.empty((0), dtype=weights_dtype, device=device)
-
+        weights = (
+            torch.empty(0, dtype=weights_dtype, device=device) if is_weighted else None
+        )
         return JaggedTensor(
-            values=torch.empty((0), dtype=values_dtype, device=device),
-            offsets=torch.empty((0), dtype=lengths_dtype, device=device),
-            lengths=torch.empty((0), dtype=lengths_dtype, device=device),
+            values=torch.empty(0, dtype=values_dtype, device=device),
+            offsets=torch.empty(0, dtype=lengths_dtype, device=device),
+            lengths=torch.empty(0, dtype=lengths_dtype, device=device),
             weights=weights,
         )
 
@@ -1274,15 +1273,14 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         weights_dtype: Optional[torch.dtype] = None,
         lengths_dtype: torch.dtype = torch.int32,
     ) -> "KeyedJaggedTensor":
-        weights = torch.jit.annotate(Optional[torch.Tensor], None)
-        if is_weighted:
-            weights = torch.empty((0), dtype=weights_dtype, device=device)
-
+        weights = (
+            torch.empty(0, dtype=weights_dtype, device=device) if is_weighted else None
+        )
         return KeyedJaggedTensor(
             keys=torch.jit.annotate(List[str], []),
-            values=torch.empty((0), dtype=values_dtype, device=device),
+            values=torch.empty(0, dtype=values_dtype, device=device),
             weights=weights,
-            lengths=torch.empty((0), dtype=lengths_dtype, device=device),
+            lengths=torch.empty(0, dtype=lengths_dtype, device=device),
             stride=0,
         )
 
@@ -1295,11 +1293,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         )
         return KeyedJaggedTensor(
             keys=[],
-            values=torch.tensor([], device=kjt.device(), dtype=kjt.values().dtype),
+            values=torch.empty(0, device=kjt.device(), dtype=kjt.values().dtype),
             weights=None
             if kjt.weights_or_none() is None
-            else torch.tensor([], device=kjt.device(), dtype=kjt.weights().dtype),
-            lengths=torch.tensor([], device=kjt.device(), dtype=kjt.lengths().dtype),
+            else torch.empty(0, device=kjt.device(), dtype=kjt.weights().dtype),
+            lengths=torch.empty(0, device=kjt.device(), dtype=kjt.lengths().dtype),
             stride=stride,
             stride_per_key_per_rank=stride_per_key_per_rank,
         )

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -556,6 +556,9 @@ class TestJaggedTensor(unittest.TestCase):
         self.assertTrue(torch.equal(jt.values(), torch.tensor([], dtype=torch.int64)))
         self.assertTrue(torch.equal(jt.offsets(), torch.tensor([], dtype=torch.int32)))
 
+        jt_from_script = torch.jit.script(JaggedTensor.empty)()
+        self.assertEqual(jt_from_script.to_dense(), [])
+
     def test_2d(self) -> None:
         values = torch.Tensor([[i * 0.5, i * 1.0, i * 1.5] for i in range(1, 4)])
         offsets = torch.IntTensor([0, 2, 2, 3])
@@ -1098,6 +1101,11 @@ class TestKeyedJaggedTensor(unittest.TestCase):
 
         kjt_2 = KeyedJaggedTensor.empty()
         self.assertEqual(kjt_2.to_dict(), {})
+
+        kjt_from_script = torch.jit.script(KeyedJaggedTensor.empty)()
+        kjt_like = torch.jit.script(KeyedJaggedTensor.empty_like)(kjt_from_script)
+        self.assertEqual(kjt_from_script.to_dict(), {})
+        self.assertEqual(kjt_like.to_dict(), {})
 
     def test_empty_to_dict(self) -> None:
         keys = ["index_0", "index_1"]


### PR DESCRIPTION
Summary: Allow jit script to use these functions

Differential Revision: D51877345


