### PR TITLE
Support padding indices in embedding collection modules

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -137,6 +137,12 @@ class BaseEmbeddingConfig:
     # enable this flag to support rw_sharding
     need_pos: bool = False
 
+    # if the table has a padding index, the embedding at padding_idx will not
+    # contribute to the gradient. Values at this index will remain as a fixed
+    # pad. The embedding at padding_idx will default to all zeros, but can be
+    # updated to another value.
+    padding_idx: Optional[int] = None
+
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:
             return sqrt(1 / self.num_embeddings)

--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -178,6 +178,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                 num_embeddings=embedding_config.num_embeddings,
                 embedding_dim=embedding_config.embedding_dim,
                 mode=pooling_type_to_str(embedding_config.pooling),
+                padding_idx=embedding_config.padding_idx,
                 device=self._device,
                 include_last_offset=True,
                 dtype=dtype,
@@ -377,11 +378,17 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
             self.embeddings[config.name] = nn.Embedding(
                 num_embeddings=config.num_embeddings,
                 embedding_dim=config.embedding_dim,
+                padding_idx=config.padding_idx,
                 device=device,
                 dtype=dtype,
             )
             if config.init_fn is not None:
                 config.init_fn(self.embeddings[config.name].weight)
+                if config.padding_idx is not None:
+                    nn.init.constant_(
+                        self.embeddings[config.name].weight[config.padding_idx],
+                        0.0,
+                    )
 
             if not config.feature_names:
                 config.feature_names = [config.name]


### PR DESCRIPTION
Summary: We currently do not support this functionality in embedding collection operations. However, there are emerging use cases where this will be more useful.

Differential Revision: D52356440


