### PR TITLE
Update cost model to include prefetch_compute

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -378,7 +378,7 @@ class EmbeddingStats(Stats):
             for row in formatted_table:
                 self._stats_table.append(f"# {row: <{self._width-3}}#")
 
-            perf_breakdown = "Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms)"
+            perf_breakdown = "Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)"
             legend = (
                 "Input: MB/iteration, Output: MB/iteration, Shards: number of tables"
             )
@@ -487,12 +487,14 @@ class EmbeddingStats(Stats):
         max_fwd_comms_perf_text = f"Maximum of Forward Comms: {_generate_max_text([perf.fwd_comms for perf in perfs])}"
         max_bwd_compute_perf_text = f"Maximum of Backward Compute: {_generate_max_text([perf.bwd_compute for perf in perfs])}"
         max_bwd_comms_perf_text = f"Maximum of Backward Comms: {_generate_max_text([perf.bwd_comms for perf in perfs])}"
+        max_prefetch_compute_perf_text = f"Maximum of Prefetch Compute: {_generate_max_text([perf.prefetch_compute for perf in perfs])}"
 
         sum_of_maxima = (
             max(perf.fwd_compute for perf in perfs)
             + max(perf.fwd_comms for perf in perfs)
             + max(perf.bwd_compute for perf in perfs)
             + max(perf.bwd_comms for perf in perfs)
+            + max(perf.prefetch_compute for perf in perfs)
         )
         sum_of_maxima_text = f"Sum of Maxima: {round(sum_of_maxima, 3)} ms"
 
@@ -502,6 +504,9 @@ class EmbeddingStats(Stats):
         self._stats_table.append(f"# {max_fwd_comms_perf_text : <{self._width-3}}#")
         self._stats_table.append(f"# {max_bwd_compute_perf_text : <{self._width-3}}#")
         self._stats_table.append(f"# {max_bwd_comms_perf_text : <{self._width-3}}#")
+        self._stats_table.append(
+            f"# {max_prefetch_compute_perf_text : <{self._width-3}}#"
+        )
         self._stats_table.append(f"# {sum_of_maxima_text : <{self._width-3}}#")
 
         max_hbm = max(used_hbm)
@@ -628,6 +633,7 @@ def _format_perf_breakdown(perf: Perf) -> str:
         perf.fwd_comms,
         perf.bwd_compute,
         perf.bwd_comms,
+        perf.prefetch_compute,
     ]
     breakdown_string = ",".join(
         [str(round(num)) if num >= 1 else round_to_one_sigfig(num) for num in breakdown]


### PR DESCRIPTION
Summary:
Updated version of D50162035 that uses the new CacheStatistics
interface, and updated for more sharding types.

Jobs with large prefetch streams can be slowed down by large
prefetch_compute blocking backward:
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-leiyuz-test-ip40-b6589377e7?job_attempt=0&version=0&tab=execution_details&env=PRODUCTION

This is because the prefetch work is not balanced as the sharder is
unaware of it.

This diff adds a new dimension to the Perf cost model to hold
prefetch_compute. This is only non-zero when using embedding
offloading via the prefetch pipeline.

We use the cache statistics to estimate the expected number of cache
fetches and then convert this to a prefetch duration estimate based on
memory bandwidth.

For per shard costing, we use the sum of fwd & prefetch, even though
these will attempt to run in parallel. See the comment below for
reasoning.  In the future, once / if we can correctly model dense fwd, 
we can update NoopPerfModel to correctly account for the parallelism 
between forward & prefetch (see https://www.internalfb.com/diff/D51461833?dst_version_fbid=3192784921018181&transaction_fbid=709488211080104 for why we can't do this today).

More details in: https://docs.google.com/document/d/1rcYh6yi23N0USp_T4nySxVnTxllBwiQlRam6EWGIy-g/edit

Reviewed By: henrylhtsang

Differential Revision: D51461817


