### PR TITLE
Fix hbm-promoted table prefetch estimate.

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -166,6 +166,8 @@ class EmbeddingPerfEstimator(ShardEstimator):
                 caching_ratio is not None
                 and sharding_option.cache_params is not None
                 and sharding_option.cache_params.stats is not None
+                and sharding_option.compute_kernel
+                == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
             ):
                 _stats = sharding_option.cache_params.stats
                 expected_cache_fetches = (


### PR DESCRIPTION
Summary:
Fixes a bug where promoted tables were erroneously more expensive in
the planner.

Previously, when an embedding offload table was scaled up to use
memory budget and there was enough budget to promote it to dedicated
HBM, and there was a fused param default for cache_load_factor,
prefetch_compute delay was incorrectly calculated to assume it was
still uvm_caching with the given default CLF. HBM only tables should
always have 0 prefetch_compute cost.

Kudos to Henry who quickly identified this problem & proposed the
solution implemented here.

Reviewed By: henrylhtsang

Differential Revision: D52649994


