### PR TITLE
Clean up AWS credentials when building wheels

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -12,6 +12,10 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
@@ -58,6 +62,3 @@ jobs:
       package-name: torchrec
       smoke-test-script: ""
       trigger-event: ${{ github.event_name }}
-    secrets:
-      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
-      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This fixes the failures when building torchrec wheel using Nova build job.

Note that the credential `AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID` has been revoked and we are not using it anymore.  I can see it is still used in `.github/workflows/release_build.yml`, so please take priority action to:

* Either switch to ODIC like how we do it in Nova https://github.com/pytorch/test-infra/pull/4865.  Please reach out to me if you need help on this.
* Or remove the workflow if it has been replaced by Nova.