### PR TITLE
Refactor test_quant_pruning.py using shared util funcs

### DIFF
--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -479,7 +479,7 @@ def create_test_model(
     quant_state_dict_split_scale_bias: bool = False,
     num_features: int = 1,
     num_float_features: int = 8,
-    num_weight_features: int = 1,
+    num_weighted_features: int = 1,
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
     weight_dtype: torch.dtype = torch.qint8,
 ) -> TestModelInfo:
@@ -489,7 +489,7 @@ def create_test_model(
         sparse_device=sparse_device,
         num_features=num_features,
         num_float_features=num_float_features,
-        num_weighted_features=num_weight_features,
+        num_weighted_features=num_weighted_features,
         topology=topology,
     )
 
@@ -546,23 +546,24 @@ def create_test_model(
     return mi
 
 
-def create_test_model_ebc_only(
+def create_test_model_ebc_only_no_quantize(
     num_embeddings: int,
     emb_dim: int,
     world_size: int,
     batch_size: int,
-    num_features: int,
     dense_device: torch.device,
     sparse_device: torch.device,
-    quant_state_dict_split_scale_bias: bool = False,
+    num_features: int = 1,
+    num_float_features: int = 8,
+    num_weighted_features: int = 1,
 ) -> TestModelInfo:
     topology: Topology = Topology(world_size=world_size, compute_device="cuda")
     mi = TestModelInfo(
         dense_device=dense_device,
         sparse_device=sparse_device,
         num_features=num_features,
-        num_float_features=8,
-        num_weighted_features=1,
+        num_float_features=num_float_features,
+        num_weighted_features=num_weighted_features,
         topology=topology,
     )
 
@@ -606,6 +607,32 @@ def create_test_model_ebc_only(
         )
     )
     mi.model.training = False
+    return mi
+
+
+def create_test_model_ebc_only(
+    num_embeddings: int,
+    emb_dim: int,
+    world_size: int,
+    batch_size: int,
+    dense_device: torch.device,
+    sparse_device: torch.device,
+    num_features: int = 1,
+    num_float_features: int = 8,
+    num_weighted_features: int = 1,
+    quant_state_dict_split_scale_bias: bool = False,
+) -> TestModelInfo:
+    mi = create_test_model_ebc_only_no_quantize(
+        num_embeddings=num_embeddings,
+        emb_dim=emb_dim,
+        world_size=world_size,
+        batch_size=batch_size,
+        dense_device=dense_device,
+        sparse_device=sparse_device,
+        num_features=num_features,
+        num_float_features=num_float_features,
+        num_weighted_features=num_weighted_features,
+    )
     mi.quant_model = quantize(
         module=mi.model,
         inplace=False,

--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -65,6 +65,7 @@ def _sharded_quant_ebc_model() -> Tuple[torch.nn.Module, List[KeyedJaggedTensor]
         world_size,
         batch_size,
         num_features=2,
+        num_weighted_features=1,
         dense_device=local_device,
         sparse_device=local_device,
         quant_state_dict_split_scale_bias=True,

--- a/torchrec/distributed/tests/test_quant_pruning.py
+++ b/torchrec/distributed/tests/test_quant_pruning.py
@@ -5,45 +5,39 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
 import io
 import unittest
 from typing import Dict, List, Tuple
 
 import torch
-from torchrec.distributed.embedding_types import EmbeddingComputeKernel, ShardingType
-from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
-from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.embedding_types import ShardingType
 from torchrec.distributed.quant_state import sharded_tbes_weights_spec, WeightSpec
-from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.infer_utils import (
     assert_close,
     assert_weight_spec,
     create_test_model,
+    create_test_model_ebc_only_no_quantize,
     model_input_to_forward_args,
     prep_inputs,
     quantize,
     shard_qebc,
-    TestQuantEBCSharder,
 )
-from torchrec.distributed.types import ShardingEnv
 from torchrec.fx import symbolic_trace
-from torchrec.modules.embedding_configs import EmbeddingBagConfig
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.quant.embedding_modules import (
     MODULE_ATTR_EMB_CONFIG_NAME_TO_PRUNING_INDICES_REMAPPING_DICT,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
+SPARSE_NN_EBC_MODULE = "_module.sparse.ebc"
+SEQUENTIAL_NN_EBC_MODULE = "0"
+
 
 def prune_and_quantize_model(
-    model: torch.nn.Module, pruning_ebc_dict: Dict[str, torch.Tensor]
+    model: torch.nn.Module,
+    pruning_ebc_dict: Dict[str, torch.Tensor],
+    ebc_target: str,
 ) -> torch.nn.Module:
-    ebc = model.get_submodule("_module.sparse.ebc")
+    ebc = model.get_submodule(ebc_target)
     setattr(
         ebc,
         MODULE_ATTR_EMB_CONFIG_NAME_TO_PRUNING_INDICES_REMAPPING_DICT,
@@ -58,6 +52,64 @@ def prune_and_quantize_model(
     )
 
     return quant_model
+
+
+def get_even_indices_pruning_ebc_dict(
+    table_key: str, num_embeddings: int
+) -> Dict[str, torch.Tensor]:
+    pruning_ebc_dict: Dict[str, torch.Tensor] = {}
+    remapping_indices = torch.full(
+        fill_value=-1, size=[num_embeddings], dtype=torch.int32
+    )
+
+    # Prune element at even index position
+    for i in range(200):
+        if i % 2 == 0:
+            continue
+        remapping_indices[i] = i // 2
+
+    pruning_ebc_dict[table_key] = remapping_indices
+    return pruning_ebc_dict
+
+
+def create_quant_and_sharded_ebc_models(
+    num_embedding: int,
+    emb_dim: int,
+    world_size: int,
+    batch_size: int,
+    sharding_type: ShardingType,
+    device: torch.device,
+) -> Tuple[torch.nn.Module, torch.nn.Module]:
+    mi = create_test_model_ebc_only_no_quantize(
+        num_embedding,
+        emb_dim,
+        world_size,
+        batch_size,
+        num_features=1,
+        num_weighted_features=0,
+        dense_device=device,
+        sparse_device=device,
+    )
+    mi.model.to(device)
+
+    pruning_ebc_dict = get_even_indices_pruning_ebc_dict("table_0", num_embedding)
+    quant_model = prune_and_quantize_model(
+        mi.model, pruning_ebc_dict, SEQUENTIAL_NN_EBC_MODULE
+    )
+
+    quant_model = quant_model[0]
+    mi.quant_model = quant_model
+
+    sharded_model = shard_qebc(
+        mi,
+        sharding_type=sharding_type,
+        device=device,
+        expected_shards=None,
+    )
+
+    sharded_model.load_state_dict(quant_model.state_dict())
+
+    return quant_model, sharded_model
 
 
 class QuantPruneTest(unittest.TestCase):
@@ -104,7 +156,9 @@ class QuantPruneTest(unittest.TestCase):
         )
         pruning_ebc_dict["table_1"] = table_1_remapping_indices
 
-        quant_model = prune_and_quantize_model(mi.model, pruning_ebc_dict)
+        quant_model = prune_and_quantize_model(
+            mi.model, pruning_ebc_dict, SPARSE_NN_EBC_MODULE
+        )
         mi.quant_model = quant_model
 
         expected_shards = [
@@ -164,103 +218,20 @@ class QuantPruneTest(unittest.TestCase):
     )
     def test_qebc_pruned_tw_one_ebc(self) -> None:
         batch_size: int = 1
-        # hash, dim, pruned_hash
-        table_specs: List[Tuple[int, int, int]] = [
-            (200, 10, 100),
-        ]
-        world_size = 2
+        world_size: int = 2
         local_device = torch.device("cuda:0")
-        topology: Topology = Topology(
-            world_size=world_size, compute_device=local_device.type
-        )
+        num_embedding = 200
+        emb_dim = 10
+        sharding_type = ShardingType.TABLE_WISE
 
-        tables = [
-            EmbeddingBagConfig(
-                num_embeddings=num_emb,
-                embedding_dim=emb_dim,
-                name="table_" + str(i),
-                feature_names=["feature_" + str(i)],
-            )
-            for i, (num_emb, emb_dim, _) in enumerate(table_specs)
-        ]
-
-        # quantize api only work with submodule. Wrap ebc inside nn.Sequential
-        model = torch.nn.Sequential(
-            EmbeddingBagCollection(
-                tables=tables,
-                device=local_device,
-            )
-        )
-        model.to(local_device)
-        model.training = False
-
-        pruning_ebc_dict: Dict[str, torch.Tensor] = {}
-        table_0_spec = table_specs[0]
-        table_0_num_emb: int = table_0_spec[0]
-        table_0_emb_dim: int = table_0_spec[1]
-        table_0_remapping_indices = torch.full(
-            fill_value=-1, size=[table_0_num_emb], dtype=torch.int32
-        )
-
-        # Prune element at even index position
-        for i in range(200):
-            if i % 2 == 0:
-                continue
-            table_0_remapping_indices[i] = i // 2
-
-        pruning_ebc_dict["table_0"] = table_0_remapping_indices
-
-        setattr(
-            model[0],
-            MODULE_ATTR_EMB_CONFIG_NAME_TO_PRUNING_INDICES_REMAPPING_DICT,
-            pruning_ebc_dict,
-        )
-
-        quant_state_dict_split_scale_bias = True
-        quant_model = quantize(
-            module=model,
-            inplace=False,
-            quant_state_dict_split_scale_bias=quant_state_dict_split_scale_bias,
-        )
-
-        quant_model = quant_model[0]
-
-        sharder = TestQuantEBCSharder(
-            sharding_type=ShardingType.TABLE_WISE.value,
-            kernel_type=EmbeddingComputeKernel.QUANT.value,
-            shardable_params=[table.name for table in tables],
-        )
-
-        quant_model_copy = copy.deepcopy(quant_model)
-        topology: Topology = Topology(world_size=world_size, compute_device="cuda")
-
-        planner = EmbeddingShardingPlanner(
-            topology=topology,
+        quant_model, sharded_model = create_quant_and_sharded_ebc_models(
+            num_embedding=num_embedding,
+            emb_dim=emb_dim,
+            world_size=world_size,
             batch_size=batch_size,
-            enumerator=EmbeddingEnumerator(
-                topology=topology,
-                batch_size=batch_size,
-                estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
-                    EmbeddingStorageEstimator(topology=topology),
-                ],
-            ),
-        )
-        plan = planner.plan(
-            quant_model_copy,
-            # pyre-ignore
-            [sharder],
-        )
-
-        sharded_model = _shard_modules(
-            module=quant_model_copy,
-            # pyre-ignore
-            sharders=[sharder],
+            sharding_type=sharding_type,
             device=local_device,
-            plan=plan,
-            env=ShardingEnv.from_local(world_size=2, rank=0),
         )
-        sharded_model.load_state_dict(quant_model.state_dict())
 
         kjt = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0"],
@@ -274,8 +245,8 @@ class QuantPruneTest(unittest.TestCase):
 
         assert_close(q_output["feature_0"], s_output["feature_0"])
 
-        assert_close(q_output["feature_0"][0], torch.tensor([0.0] * table_0_emb_dim))
-        assert_close(q_output["feature_0"][2], torch.tensor([0.0] * table_0_emb_dim))
+        assert_close(q_output["feature_0"][0], torch.tensor([0.0] * emb_dim))
+        assert_close(q_output["feature_0"][2], torch.tensor([0.0] * emb_dim))
 
     # pyre-ignore
     @unittest.skipIf(
@@ -319,7 +290,9 @@ class QuantPruneTest(unittest.TestCase):
         )
         pruning_ebc_dict["table_0"] = table_0_remapping_indices
 
-        quant_model = prune_and_quantize_model(mi.model, pruning_ebc_dict)
+        quant_model = prune_and_quantize_model(
+            mi.model, pruning_ebc_dict, SPARSE_NN_EBC_MODULE
+        )
         mi.quant_model = quant_model
 
         expected_shards = [
@@ -385,103 +358,20 @@ class QuantPruneTest(unittest.TestCase):
     )
     def test_qebc_pruned_cw_one_ebc(self) -> None:
         batch_size: int = 1
-        # hash, dim, pruned_hash
-        table_specs: List[Tuple[int, int, int]] = [
-            (200, 512, 100),
-        ]
-        world_size = 2
+        world_size: int = 2
         local_device = torch.device("cuda:0")
-        topology: Topology = Topology(
-            world_size=world_size, compute_device=local_device.type
-        )
+        num_embedding = 200
+        emb_dim = 512
+        sharding_type = ShardingType.COLUMN_WISE
 
-        tables = [
-            EmbeddingBagConfig(
-                num_embeddings=num_emb,
-                embedding_dim=emb_dim,
-                name="table_" + str(i),
-                feature_names=["feature_" + str(i)],
-            )
-            for i, (num_emb, emb_dim, _) in enumerate(table_specs)
-        ]
-
-        # quantize api only work with submodule. Wrap ebc inside nn.Sequential
-        model = torch.nn.Sequential(
-            EmbeddingBagCollection(
-                tables=tables,
-                device=local_device,
-            )
-        )
-        model.to(local_device)
-        model.training = False
-
-        pruning_ebc_dict: Dict[str, torch.Tensor] = {}
-        table_0_spec = table_specs[0]
-        table_0_num_emb: int = table_0_spec[0]
-        table_0_emb_dim: int = table_0_spec[1]
-        table_0_remapping_indices = torch.full(
-            fill_value=-1, size=[table_0_num_emb], dtype=torch.int32
-        )
-
-        # Prune element at even index position
-        for i in range(200):
-            if i % 2 == 0:
-                continue
-            table_0_remapping_indices[i] = i // 2
-
-        pruning_ebc_dict["table_0"] = table_0_remapping_indices
-
-        setattr(
-            model[0],
-            MODULE_ATTR_EMB_CONFIG_NAME_TO_PRUNING_INDICES_REMAPPING_DICT,
-            pruning_ebc_dict,
-        )
-
-        quant_state_dict_split_scale_bias = True
-        quant_model = quantize(
-            module=model,
-            inplace=False,
-            quant_state_dict_split_scale_bias=quant_state_dict_split_scale_bias,
-        )
-
-        quant_model = quant_model[0]
-
-        sharder = TestQuantEBCSharder(
-            sharding_type=ShardingType.COLUMN_WISE.value,
-            kernel_type=EmbeddingComputeKernel.QUANT.value,
-            shardable_params=[table.name for table in tables],
-        )
-
-        quant_model_copy = copy.deepcopy(quant_model)
-        topology: Topology = Topology(world_size=world_size, compute_device="cuda")
-
-        planner = EmbeddingShardingPlanner(
-            topology=topology,
+        quant_model, sharded_model = create_quant_and_sharded_ebc_models(
+            num_embedding=num_embedding,
+            emb_dim=emb_dim,
+            world_size=world_size,
             batch_size=batch_size,
-            enumerator=EmbeddingEnumerator(
-                topology=topology,
-                batch_size=batch_size,
-                estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
-                    EmbeddingStorageEstimator(topology=topology),
-                ],
-            ),
-        )
-        plan = planner.plan(
-            quant_model_copy,
-            # pyre-ignore
-            [sharder],
-        )
-
-        sharded_model = _shard_modules(
-            module=quant_model_copy,
-            # pyre-ignore
-            sharders=[sharder],
+            sharding_type=sharding_type,
             device=local_device,
-            plan=plan,
-            env=ShardingEnv.from_local(world_size=2, rank=0),
         )
-        sharded_model.load_state_dict(quant_model.state_dict())
 
         kjt = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0"],
@@ -495,6 +385,6 @@ class QuantPruneTest(unittest.TestCase):
 
         assert_close(q_output["feature_0"], s_output["feature_0"])
 
-        assert_close(q_output["feature_0"][0], torch.tensor([0.0] * table_0_emb_dim))
-        assert_close(q_output["feature_0"][2], torch.tensor([0.0] * table_0_emb_dim))
-        assert_close(q_output["feature_0"][4], torch.tensor([0.0] * table_0_emb_dim))
+        assert_close(q_output["feature_0"][0], torch.tensor([0.0] * emb_dim))
+        assert_close(q_output["feature_0"][2], torch.tensor([0.0] * emb_dim))
+        assert_close(q_output["feature_0"][4], torch.tensor([0.0] * emb_dim))


### PR DESCRIPTION
Summary: In torchrec/distributed/tests/test_quant_pruning.py, function test_qebc_pruned_tw_one_ebc and test_qebc_pruned_cw_one_ebc have a lot of common code. Refactoring to use existing util functions to reduce duplicate code.

Differential Revision: D52711139


