### PR TITLE
Enable DDP test

### DIFF
--- a/torchrec/distributed/composable/tests/test_ddp.py
+++ b/torchrec/distributed/composable/tests/test_ddp.py
@@ -42,7 +42,12 @@ class DDPTest(unittest.TestCase):
         else:
             device: torch.device = torch.device("cpu")
             backend = "gloo"
-        dist.init_process_group(backend=backend)
+        dist.init_process_group(
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
+            init_method=f"file://{os.path.join(path, 'dist_rdvz')}",
+        )
         num_float_features = 32
 
         tables = [
@@ -94,7 +99,12 @@ class DDPTest(unittest.TestCase):
         else:
             device: torch.device = torch.device("cpu")
             backend = "gloo"
-        dist.init_process_group(backend=backend)
+        dist.init_process_group(
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
+            init_method=f"file://{os.path.join(path, 'dist_rdvz')}",
+        )
         num_float_features = 32
 
         tables = [


### PR DESCRIPTION
Summary: Enables DDP test to run in sandbox envs with network restrictions by using FileStore instead of TCPStore

Differential Revision: D52802276


