### PR TITLE
Disable Python 3.12 validate temporarily

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -21,6 +21,11 @@ if [[ ${MATRIX_GPU_ARCH_TYPE} = 'rocm' ]]; then
     exit 0
 fi
 
+if [[ ${MATRIX_PYTHON_VERSION} = '3.12' ]]; then
+    echo "Temporarily disable validation for Python 3.12"
+    exit 0
+fi
+
 if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then
     export CUDA_VERSION="cu118"
 else


### PR DESCRIPTION
Summary: Disabling python 3.12 for validating binaries until Torch elastic issue: https://github.com/pytorch/torchrec/actions/runs/7451087265 is resolved

Differential Revision: D52809181


