### PR TITLE
Fix docs build workflow permission

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build_docs_job:
     runs-on: ${{ matrix.os }}
+    permissions:
+      # Grant write permission here so that the doc can be pushed to gh-pages branch
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
As reported by @henrylhtsang , the docs build workflow has been failing since we downgrade the default GITHUB_TOKEN permission to read-only org-wide.  Write permission needs to be granted explicitly by the workflow now.

### Testing

Run the workflow manually with my branch https://github.com/pytorch/torchrec/actions/runs/7574439344