### PR TITLE
Implement XAUC metric for watch time prediction

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -45,6 +45,7 @@ from torchrec.metrics.segmented_ne import SegmentedNEMetric
 from torchrec.metrics.throughput import ThroughputMetric
 from torchrec.metrics.tower_qps import TowerQPSMetric
 from torchrec.metrics.weighted_avg import WeightedAvgMetric
+from torchrec.metrics.xauc import XAUCMetric
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.RECALL_SESSION_LEVEL: RecallSessionMetric,
     RecMetricEnum.ACCURACY: AccuracyMetric,
     RecMetricEnum.NDCG: NDCGMetric,
+    RecMetricEnum.XAUC: XAUCMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -32,6 +32,7 @@ class RecMetricEnum(RecMetricEnumBase):
     TOWER_QPS = "tower_qps"
     ACCURACY = "accuracy"
     NDCG = "ndcg"
+    XAUC = "xauc"
 
 
 @dataclass(unsafe_hash=True, eq=True)

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -57,6 +57,7 @@ class MetricName(MetricNameBase):
     TOWER_QPS = "qps"
     ACCURACY = "accuracy"
     NDCG = "ndcg"
+    XAUC = "xauc"
 
 
 class MetricNamespaceBase(StrValueMixin, Enum):
@@ -87,6 +88,7 @@ class MetricNamespace(MetricNamespaceBase):
 
     TOWER_QPS = "qps"
     NDCG = "ndcg"
+    XAUC = "xauc"
 
 
 class MetricPrefix(StrValueMixin, Enum):

--- a/torchrec/metrics/tests/test_xauc.py
+++ b/torchrec/metrics/tests/test_xauc.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict
+
+import torch
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.xauc import XAUCMetric
+
+
+WORLD_SIZE = 4
+BATCH_SIZE = 10
+
+
+def generate_model_output() -> Dict[str, torch._tensor.Tensor]:
+    return {
+        "predictions": torch.tensor([[0.1, 0.2, 0.3, 0.4, 0.5]]),
+        "labels": torch.tensor([[0.2, 0.1, 0.3, 0.5, 0.25]]),
+        "weights": torch.tensor([[1.0, 1.0, 1.0, 0.0, 1.0]]),
+        "expected_xauc": torch.tensor([0.6667]),
+    }
+
+
+class XAUCMetricTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.xauc = XAUCMetric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+        )
+
+    def test_xauc(self) -> None:
+        model_output = generate_model_output()
+        self.xauc.update(
+            predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
+            labels={DefaultTaskInfo.name: model_output["labels"][0]},
+            weights={DefaultTaskInfo.name: model_output["weights"][0]},
+        )
+        metric = self.xauc.compute()
+        actual_metric = metric[f"xauc-{DefaultTaskInfo.name}|lifetime_xauc"]
+        expected_metric = model_output["expected_xauc"]
+
+        torch.testing.assert_close(
+            actual_metric,
+            expected_metric,
+            atol=1e-4,
+            rtol=1e-4,
+            check_dtype=False,
+            equal_nan=True,
+            msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
+        )

--- a/torchrec/metrics/xauc.py
+++ b/torchrec/metrics/xauc.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, cast, Dict, List, Optional, Type
+
+import torch
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+)
+
+
+ERROR_SUM = "error_sum"
+WEIGHTED_NUM_PAIRS = "weighted_num_pairs"
+
+
+def compute_xauc(
+    error_sum: torch.Tensor, weighted_num_pairs: torch.Tensor
+) -> torch.Tensor:
+    return torch.where(
+        weighted_num_pairs == 0.0, 0.0, error_sum / weighted_num_pairs
+    ).double()
+
+
+def compute_error_sum(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    predictions = predictions.double()
+
+    errors = []
+    for predictions_i, labels_i, weights_i in zip(predictions, labels, weights):
+        preds_x, preds_y = torch.meshgrid(predictions_i, predictions_i)
+        labels_x, labels_y = torch.meshgrid(labels_i, labels_i)
+        weights_x, weights_y = torch.meshgrid(weights_i, weights_i)
+        weights_flag = weights_x * weights_y
+        match = torch.logical_or(
+            torch.logical_and(preds_x > preds_y, labels_x > labels_y),
+            torch.logical_and(preds_x < preds_y, labels_x < labels_y),
+        )
+        match = (
+            weights_flag
+            * torch.logical_or(
+                match, torch.logical_and(preds_x == preds_y, labels_x == labels_y)
+            ).double()
+        )
+        errors.append(torch.sum(torch.triu(match, diagonal=1)).view(1))
+
+    return torch.cat(errors)
+
+
+def compute_weighted_num_pairs(weights: torch.Tensor) -> torch.Tensor:
+    num_pairs = []
+    for weight_i in weights:
+        weights_x, weights_y = torch.meshgrid(weight_i, weight_i)
+        weights_flag = weights_x * weights_y
+        num_pairs.append(torch.sum(torch.triu(weights_flag, diagonal=1)).view(1))
+
+    return torch.cat(num_pairs)
+
+
+def get_xauc_states(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> Dict[str, torch.Tensor]:
+    return {
+        "error_sum": compute_error_sum(labels, predictions, weights),
+        "weighted_num_pairs": compute_weighted_num_pairs(weights),
+    }
+
+
+class XAUCMetricComputation(RecMetricComputation):
+    r"""
+    This class implements the RecMetricComputation for XAUC.
+
+    The constructor arguments are defined in RecMetricComputation.
+    See the docstring of RecMetricComputation for more detail.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._add_state(
+            "error_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "weighted_num_pairs",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+
+    # pyre-fixme[14]: `update` overrides method defined in `RecMetricComputation`
+    #  inconsistently.
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+    ) -> None:
+        if predictions is None or weights is None:
+            raise RecMetricException(
+                "Inputs 'predictions' and 'weights' should not be None for XAUCMetricComputation update"
+            )
+        states = get_xauc_states(labels, predictions, weights)
+        num_samples = predictions.shape[-1]
+        for state_name, state_value in states.items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
+
+    def _compute(self) -> List[MetricComputationReport]:
+        return [
+            MetricComputationReport(
+                name=MetricName.XAUC,
+                metric_prefix=MetricPrefix.LIFETIME,
+                value=compute_xauc(
+                    cast(torch.Tensor, self.error_sum),
+                    cast(torch.Tensor, self.weighted_num_pairs),
+                ),
+            ),
+            MetricComputationReport(
+                name=MetricName.XAUC,
+                metric_prefix=MetricPrefix.WINDOW,
+                value=compute_xauc(
+                    self.get_window_state(ERROR_SUM),
+                    self.get_window_state(WEIGHTED_NUM_PAIRS),
+                ),
+            ),
+        ]
+
+
+class XAUCMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.XAUC
+    _computation_class: Type[RecMetricComputation] = XAUCMetricComputation


### PR DESCRIPTION
Summary:
XAUC evaluates whether the ordinal information is preserved. e.g. if label_x < label_y and pred_x < pred_y, then xauc=1
The final XAUC metric is the average of all in-batch pairs.

Differential Revision: D50255933

