### PR TITLE
Add uvm caching compute kernel to mch sharders

### DIFF
--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -264,7 +264,10 @@ class BaseManagedCollisionEmbeddingCollectionSharder(BaseEmbeddingSharder[M]):
         sharding_type: str,
         compute_device_type: str,
     ) -> List[str]:
-        return [EmbeddingComputeKernel.FUSED.value]
+        return [
+            EmbeddingComputeKernel.FUSED.value,
+            EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+        ]
 
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return list(


### PR DESCRIPTION
Summary: Add uvm caching to allowed kernels.

Reviewed By: dstaay-fb

Differential Revision: D52919490


