### PR TITLE
Take cache_load_factor from sharder if sharding option doesn't have it

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -329,7 +329,16 @@ class EmbeddingStats(Stats):
                     or so.sharding_type == ShardingType.TABLE_COLUMN_WISE.value
                     else f"{so.tensor.shape[1]}"
                 )
-                cache_load_factor = str(so.cache_load_factor)
+                sharder_cache_load_factor = (
+                    sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                    if hasattr(sharder, "fused_params") and sharder.fused_params
+                    else None
+                )
+                cache_load_factor = str(
+                    so.cache_load_factor
+                    if so.cache_load_factor is not None
+                    else sharder_cache_load_factor
+                )
                 hash_size = so.tensor.shape[0]
                 param_table.append(
                     [


### PR DESCRIPTION
Summary: Sometimes cache_load_factor is passed through sharders. This is not the ideal way of passing cache_load_factor, but for the time being, we still allow it. So we should reflect that in the stats printout.

Differential Revision: D52921387


