### PR TITLE
Replace `constraints` with `dynamic_shapes` in caffe2/test/cpp & torchrec/distributed/tests/test_pt2

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -23,7 +23,6 @@ except (unittest.SkipTest, ImportError):
 
 
 from fbgemm_gpu import sparse_ops  # noqa: F401, E402
-from torch._export import dynamic_dim
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.infer_utils import (
@@ -49,7 +48,6 @@ def make_kjt(values: List[int], lengths: List[int]) -> KeyedJaggedTensor:
         values=values_tensor,
         lengths=lengths_tensor,
     )
-    dynamic_dim(kjt._values, 0)
     return kjt
 
 


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `caffe2/test/cpp` and `torchrec/distributed/test/test_pt2`.

Differential Revision: D52977354


