### PR TITLE
Fix a bug in the torch._export.aot_load API

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -127,7 +127,7 @@ class TestPt2(unittest.TestCase):
                 device = "cuda"
                 # pyre-ignore
                 aot_inductor_module = AOTIRunnerUtil.load(device, so_path)
-                aot_actual_output = aot_inductor_module(inputs)
+                aot_actual_output = aot_inductor_module(*inputs)
                 assert_close(eager_output, aot_actual_output)
 
     def test_kjt_split(self) -> None:
@@ -204,7 +204,7 @@ class TestPt2(unittest.TestCase):
             )
             # pyre-ignore
             aot_inductor_module = AOTIRunnerUtil.load(device, so_path)
-            aot_inductor_module(example_inputs)
+            aot_inductor_module(*example_inputs)
 
             aot_actual_outputs = [
                 aot_inductor_module(*kjt_to_inputs(kjt)) for kjt in input_kjts[1:]


### PR DESCRIPTION
Summary:
tree_flatten_spec should use args instead of *args

clone of https://github.com/pytorch/pytorch/pull/117948 but with some fbcode specific changes

Differential Revision: D52982401


