### PR TITLE
AUC metric optionally move concat to compute step instead of update through flag

### DIFF
--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -434,15 +434,15 @@ class MetricModuleTest(unittest.TestCase):
         # 3 (tensors) * 4 (float)
         self.assertEqual(metric_module.get_memory_usage(), 12)
         metric_module.update(gen_test_batch(128))
-        # 24 (initial states) + 3 (tensors) * 128 (batch_size) * 4 (float)
-        self.assertEqual(metric_module.get_memory_usage(), 1548)
+        # 3 (tensors) * 128 (batch_size) * 4 (float)
+        self.assertEqual(metric_module.get_memory_usage(), 1536)
 
         # Test memory usage over multiple updates does not increase unexpectedly, we don't need to force OOM as just knowing if the memory usage is increeasing how we expect is enough
         for _ in range(10):
             metric_module.update(gen_test_batch(128))
 
-        # 24 initial states + 3 tensors * 128 batch size * 4 float * 11 updates - 12 initial memory
-        self.assertEqual(metric_module.get_memory_usage(), 16908)
+        # 3 tensors * 128 batch size * 4 float * 11 updates
+        self.assertEqual(metric_module.get_memory_usage(), 16896)
 
         # Ensure reset frees memory correctly
         metric_module.reset()


### PR DESCRIPTION
Summary:
Previously unlanded D51399384 due to issues with some models. Introducing it again but through an experimental flag as this optimization can benefit many models. This should not conflict with any models running AUC metric. The feature flag is akin to fusing task computation in RecMetrics as that feature as well does not work across all families of models. 

The change in this diff is:
We don't need to concatenate the tensor on every update step, since it is an expensive operation (creates a new tensor and allocates new memory every call, as tensors are contiguous) we can call tensor.concat on the compute step instead. Which happens every compute_interval_step batches. This optimization should boost performance of models using AUC with no regression in metric quality.

Differential Revision: D53027097


