### PR TITLE
dynamically set session_key for session_ids in NDCG

### DIFF
--- a/torchrec/metrics/ndcg.py
+++ b/torchrec/metrics/ndcg.py
@@ -307,4 +307,6 @@ class NDCGMetric(RecMetric):
             process_group=process_group,
             **kwargs,
         )
-        self._required_inputs.add("session_id")
+        # session_key is set through front end config
+        # pyre-ignore[6]
+        self._required_inputs.add(kwargs["session_key"])


### PR DESCRIPTION
Summary: Previously session_key was hardcoded to "session_id" which is unsuitable as all models do not have the same session_key. Now the defined session_key from config will be used as the key instead.

Differential Revision: D53067426


