### PR TITLE
fix world size 1 for 2D lengths

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -72,6 +72,11 @@ except Exception:
 torch.fx.wrap("len")
 
 
+@torch.fx.wrap
+def flatten_feature_lengths(features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+    return features.flatten_lengths() if features.lengths().dim() > 1 else features
+
+
 def create_infer_embedding_bag_sharding(
     sharding_type: str,
     sharding_infos: List[EmbeddingShardingInfo],
@@ -278,6 +283,8 @@ class ShardedQuantEmbeddingBagCollection(
                     self._features_order,
                     self._features_order_tensor,
                 )
+            else:
+                features = flatten_feature_lengths(features)
             features_by_shards = (
                 [features]
                 if len(self._feature_splits) == 1

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1671,6 +1671,27 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         )
         return kjt
 
+    def flatten_lengths(self) -> "KeyedJaggedTensor":
+        stride, stride_per_key_per_rank = (
+            (None, self.stride_per_key_per_rank())
+            if self.variable_stride_per_key()
+            else (self._stride, None)
+        )
+        return KeyedJaggedTensor(
+            keys=self._keys,
+            values=self._values,
+            weights=self._weights,
+            lengths=self.lengths().view(-1),
+            offsets=None,
+            stride=stride,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+            length_per_key=self.length_per_key(),
+            offset_per_key=None,
+            index_per_key=None,
+            jt_dict=None,
+            inverse_indices=None,
+        )
+
     def __getitem__(self, key: str) -> JaggedTensor:
         offset_per_key = self.offset_per_key()
         index = self._key_indices()[key]


### PR DESCRIPTION
Summary: when world_size=1 and lengths is created as 2d, sharded EBC will skip flattening kjt lengths

Differential Revision: D53068678


