### PR TITLE
Fix forward for D51601041

### DIFF
--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -15,11 +15,15 @@ import torch
 
 from torch import nn
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig
-from torchrec.sparse.jagged_tensor import (
-    ComputeJTDictToKJT,
-    JaggedTensor,
-    KeyedJaggedTensor,
-)
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+try:
+    from torchrec.sparse.jagged_tensor import ComputeJTDictToKJT
+except ImportError:
+    # Dummy implementation, use try catch for torch package compatibility issue
+    torch._C._log_api_usage_once(
+        "ImportError ComputeJTDictToKJT, ignoring, but possible incompatiblity with torch.package"
+    )
 
 
 @torch.fx.wrap


### PR DESCRIPTION
Summary:
D51601041 causes a torch package backward compatibility problem, this diff imports ComputeJTDictToKJT which creates a new dependency from torchrec/modules to torchrec/sparse, since the problem module was built a while ago, it has torchrec/sparse inside torch package but doesn't have torchrec/modules, it encounters this error, https://fburl.com/mlhub/f8be5yru

> ImportError("cannot import name 'ComputeJTDictToKJT' from '<torch_package_1>.torchrec.sparse.jagged_tensor'

This diff did a lazy import so that only model with zch enabled will use this

Reviewed By: dstaay-fb

Differential Revision: D53208002


