### PR TITLE
Add flushing and reset_cache_states to pre-hook and hook of state_dict and load_state_dict

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -529,6 +529,9 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
     def flush(self) -> None:
         pass
 
+    def purge(self) -> None:
+        pass
+
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
@@ -648,6 +651,9 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
 
     def flush(self) -> None:
         self._emb_module.flush()
+
+    def purge(self) -> None:
+        self._emb_module.reset_cache_states()
 
 
 class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
@@ -810,6 +816,9 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
     def flush(self) -> None:
         pass
 
+    def purge(self) -> None:
+        pass
+
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
@@ -934,6 +943,9 @@ class BatchedFusedEmbeddingBag(
 
     def flush(self) -> None:
         self._emb_module.flush()
+
+    def purge(self) -> None:
+        self._emb_module.reset_cache_states()
 
 
 class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -276,6 +276,14 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
             ) in embedding_kernel.named_parameters_by_table():
                 yield (table_name, tbe_slice)
 
+    def flush(self) -> None:
+        for emb_module in self._emb_modules:
+            emb_module.flush()
+
+    def purge(self) -> None:
+        for emb_module in self._emb_modules:
+            emb_module.purge()
+
 
 class CommOpGradientScaling(torch.autograd.Function):
     @staticmethod
@@ -503,6 +511,14 @@ class GroupedPooledEmbeddingsLookup(
             ) in embedding_kernel.named_parameters_by_table():
                 yield (table_name, tbe_slice)
 
+    def flush(self) -> None:
+        for emb_module in self._emb_modules:
+            emb_module.flush()
+
+    def purge(self) -> None:
+        for emb_module in self._emb_modules:
+            emb_module.purge()
+
 
 class MetaInferGroupedEmbeddingsLookup(
     BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tensor], TBEToRegisterMixIn
@@ -626,6 +642,14 @@ class MetaInferGroupedEmbeddingsLookup(
         )
         for emb_module in self._emb_modules:
             yield from emb_module.named_buffers(prefix, recurse)
+
+    def flush(self) -> None:
+        # not implemented
+        pass
+
+    def purge(self) -> None:
+        # not implemented
+        pass
 
 
 class MetaInferGroupedPooledEmbeddingsLookup(
@@ -770,6 +794,14 @@ class MetaInferGroupedPooledEmbeddingsLookup(
         )
         for emb_module in self._emb_modules:
             yield from emb_module.named_buffers(prefix, recurse)
+
+    def flush(self) -> None:
+        # not implemented
+        pass
+
+    def purge(self) -> None:
+        # not implemented
+        pass
 
 
 class InferGroupedLookupMixin(ABC):


### PR DESCRIPTION
Summary:
The reason for doing both at the same time is to also enable the unit test.

What this diff does: 
* call flushing before state_dict
* call reset_cache_states after load_state_dict

Problem previous is that when we call sharded_ebc.state_dict(), it won't recursively call lookup.state_dict(). So no flushing was called.


todo: add unit test_load_state_dict for ec

Differential Revision: D53199744


