### PR TITLE
serialize warmup deply sessions

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -85,6 +85,7 @@ class GPUExecutor {
   std::function<void()> warmupFn_;
 
   std::mutex warmUpMutex_;
+  std::mutex warmUpAcquireSessionMutex_;
   std::condition_variable warmUpCV_;
   int warmUpCounter_{0};
 


### PR DESCRIPTION
Summary:
https://fb.workplace.com/groups/inferenceusers/posts/25761311556824116/

we cannot warmup the deploy session in parallel, added a mutex to serialize it

Reviewed By: 842974287

Differential Revision: D53291886


