### PR TITLE
Deepcopy FP module even if on meta device

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 from typing import Any, Dict, List, Optional, Type
 
 import torch
@@ -409,7 +410,7 @@ class ShardedQuantFeatureProcessedEmbeddingBagCollection(
         self.feature_processors_per_rank: nn.ModuleList = torch.nn.ModuleList()
         for i in range(env.world_size):
             self.feature_processors_per_rank.append(
-                feature_processor
+                copy.deepcopy(feature_processor)
                 if device_type == "meta"
                 else copy_to_device(
                     feature_processor,


### PR DESCRIPTION
Summary:
When we fx trace, even if there are 2 FP modules (because 2 cards), since it was sharded on meta, the ranks just have a reference to the FP on rank 0

and for whatever reason, FX eliminates the FP on rank 1 and it just shows the one on rank 0

do a deepcopy even when on meta device so each rank explicitly has their own copy, fx will persist it

Reviewed By: lequytra, tissue3

Differential Revision: D53294788


