### PR TITLE
Allow passing feature names through ParameterConstraints and ShardingOption

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -125,6 +125,7 @@ class EmbeddingEnumerator(Enumerator):
                     enforce_hbm,
                     stochastic_rounding,
                     bounds_check_mode,
+                    feature_names,
                 ) = _extract_constraints_for_param(self._constraints, name)
 
                 sharding_options_per_table: List[ShardingOption] = []
@@ -172,6 +173,7 @@ class EmbeddingEnumerator(Enumerator):
                                 bounds_check_mode=bounds_check_mode,
                                 dependency=dependency,
                                 is_pooled=is_pooled,
+                                feature_names=feature_names,
                             )
                         )
                 if not sharding_options_per_table:
@@ -265,6 +267,7 @@ def _extract_constraints_for_param(
     Optional[bool],
     Optional[bool],
     Optional[BoundsCheckMode],
+    Optional[List[str]],
 ]:
     input_lengths = [POOLING_FACTOR]
     col_wise_shard_dim = None
@@ -272,6 +275,7 @@ def _extract_constraints_for_param(
     enforce_hbm = None
     stochastic_rounding = None
     bounds_check_mode = None
+    feature_names = None
 
     if constraints and constraints.get(name):
         input_lengths = constraints[name].pooling_factors
@@ -280,6 +284,7 @@ def _extract_constraints_for_param(
         enforce_hbm = constraints[name].enforce_hbm
         stochastic_rounding = constraints[name].stochastic_rounding
         bounds_check_mode = constraints[name].bounds_check_mode
+        feature_names = constraints[name].feature_names
 
     return (
         input_lengths,
@@ -288,6 +293,7 @@ def _extract_constraints_for_param(
         enforce_hbm,
         stochastic_rounding,
         bounds_check_mode,
+        feature_names,
     )
 
 

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -288,6 +288,7 @@ class ShardingOption:
         bounds_check_mode: Optional[BoundsCheckMode] = None,
         dependency: Optional[str] = None,
         is_pooled: Optional[bool] = None,
+        feature_names: Optional[List[str]] = None,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -307,6 +308,7 @@ class ShardingOption:
         self.dependency = dependency
         self._is_pooled = is_pooled
         self.is_weighted: Optional[bool] = None
+        self.feature_names: Optional[List[str]] = feature_names
 
     @property
     def tensor(self) -> torch.Tensor:
@@ -436,6 +438,7 @@ class ParameterConstraints:
     enforce_hbm: Optional[bool] = None
     stochastic_rounding: Optional[bool] = None
     bounds_check_mode: Optional[BoundsCheckMode] = None
+    feature_names: Optional[List[str]] = None
 
 
 class PlannerErrorType(Enum):


### PR DESCRIPTION
Summary:
Allow users to pass in feature_names. Preferably, it should be same as table.feature_names.

In the case when no constraints are passed in, the feature_names will be None. 

Another option is to force extract feature names from BaseEmbeddingConfig, but that seems to be against the convention.

Differential Revision: D53454672


