### PR TITLE
fix device type from gpu to cuda

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -409,7 +409,7 @@ class ShardedEmbeddingCollection(
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
                     device_ids=[device]
-                    if self._device and self._device.type == "gpu"
+                    if self._device and self._device.type == "cuda"
                     else None,
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -499,7 +499,7 @@ class ShardedEmbeddingBagCollection(
                 self._lookups[index] = DistributedDataParallel(
                     module=lookup,
                     device_ids=[device]
-                    if self._device and (self._device.type in {"gpu", "mtia"})
+                    if self._device and (self._device.type in {"cuda", "mtia"})
                     else None,
                     process_group=env.process_group,
                     gradient_as_bucket_view=True,


### PR DESCRIPTION
Summary: gpu is an invalid device type. fix it to use cuda

Differential Revision: D53531123


