### PR TITLE
Adds threading support in torchrec train pipeline.

### DIFF
--- a/torchrec/distributed/__init__.py
+++ b/torchrec/distributed/__init__.py
@@ -35,6 +35,8 @@ These include:
 from torchrec.distributed.comm import get_local_rank, get_local_size  # noqa
 from torchrec.distributed.model_parallel import DistributedModelParallel  # noqa
 from torchrec.distributed.train_pipeline import (  # noqa
+    DataLoadingThread,
+    EvalPipelineSparseDist,
     PrefetchTrainPipelineSparseDist,
     TrainPipeline,
     TrainPipelineBase,


### PR DESCRIPTION
Summary:
Motivation
- In training, we have mostly been focused on optimizing for better GPU utilization. For models that are not GPU bound, we often observe that CPU ops taking nontrivial amount of time. With existing pipelines, these operations are executed in the main thread. Depending on the complexity of the model input, they can take tens of milliseconds in our traces.
- There are certain applications that are latency sensitive. While the multi-stage pipelines we have improve throughput greatly, they hurt latency by buffering multiple batches in the pipeline.

In this change we add the capability to load data and copy it to gpu in a background thread. This helps reduce the iteration latency for the models we mentioned above, and minimizes the number of batches in the pipeline.

In this diff, we are adding a new eval (forwardonly) sparse-data-dist pipeline with threading enabled.

Reviewed By: dstaay-fb

Differential Revision: D53453429

