### PR TITLE
Add uvm to allowed compute kernel for zch

### DIFF
--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -267,6 +267,7 @@ class BaseManagedCollisionEmbeddingCollectionSharder(BaseEmbeddingSharder[M]):
         return [
             EmbeddingComputeKernel.FUSED.value,
             EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            EmbeddingComputeKernel.FUSED_UVM.value,
         ]
 
     def sharding_types(self, compute_device_type: str) -> List[str]:

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -782,7 +782,10 @@ class TestEnumerators(unittest.TestCase):
 
         self.assertEqual(
             set(allowed_compute_kernels),
-            {EmbeddingComputeKernel.FUSED.value},
+            {
+                EmbeddingComputeKernel.FUSED.value,
+                EmbeddingComputeKernel.FUSED_UVM.value,
+            },
         )
 
     def test_filter_compute_kernels_mch_ebc_no_available(self) -> None:


### PR DESCRIPTION
Summary: Allow zch to use uvm.

Differential Revision: D53598269


