### PR TITLE
Add Scalar Metric to TorchRec

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -41,6 +41,7 @@ from torchrec.metrics.ndcg import NDCGMetric
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.rec_metric import RecMetric, RecMetricList
 from torchrec.metrics.recall_session import RecallSessionMetric
+from torchrec.metrics.scalar import ScalarMetric
 from torchrec.metrics.segmented_ne import SegmentedNEMetric
 from torchrec.metrics.throughput import ThroughputMetric
 from torchrec.metrics.tower_qps import TowerQPSMetric
@@ -66,6 +67,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.ACCURACY: AccuracyMetric,
     RecMetricEnum.NDCG: NDCGMetric,
     RecMetricEnum.XAUC: XAUCMetric,
+    RecMetricEnum.SCALAR: ScalarMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -33,6 +33,7 @@ class RecMetricEnum(RecMetricEnumBase):
     ACCURACY = "accuracy"
     NDCG = "ndcg"
     XAUC = "xauc"
+    SCALAR = "scalar"
 
 
 @dataclass(unsafe_hash=True, eq=True)

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -58,6 +58,7 @@ class MetricName(MetricNameBase):
     ACCURACY = "accuracy"
     NDCG = "ndcg"
     XAUC = "xauc"
+    SCALAR = "scalar"
 
 
 class MetricNamespaceBase(StrValueMixin, Enum):
@@ -89,6 +90,8 @@ class MetricNamespace(MetricNamespaceBase):
     TOWER_QPS = "qps"
     NDCG = "ndcg"
     XAUC = "xauc"
+
+    SCALAR = "scalar"
 
 
 class MetricPrefix(StrValueMixin, Enum):

--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+)
+
+
+class ScalarMetricComputation(RecMetricComputation):
+    """
+    Metric that logs whatever value is given as the label.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._add_state(
+            "labels",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="mean",
+            persistent=True,
+        )
+        self._add_state(
+            "window_count",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="mean",
+            persistent=True,
+        )
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        num_samples = labels.shape[0]
+
+        states = {
+            "labels": labels.mean(dim=-1),
+            "window_count": torch.tensor([1.0]).to(
+                labels.device
+            ),  # put window count on the correct device
+        }
+        for state_name, state_value in states.items():
+            setattr(self, state_name, state_value)
+            self._aggregate_window_state(state_name, state_value, num_samples)
+
+    def _compute(self) -> List[MetricComputationReport]:
+        return [
+            MetricComputationReport(
+                name=MetricName.SCALAR,
+                metric_prefix=MetricPrefix.LIFETIME,
+                value=self.labels,
+            ),
+            MetricComputationReport(
+                name=MetricName.SCALAR,
+                metric_prefix=MetricPrefix.WINDOW,
+                # return the mean of the window state
+                value=self.get_window_state("labels")
+                / self.get_window_state("window_count"),
+            ),
+        ]
+
+
+class ScalarMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.SCALAR
+    _computation_class: Type[RecMetricComputation] = ScalarMetricComputation

--- a/torchrec/metrics/tests/test_scalar.py
+++ b/torchrec/metrics/tests/test_scalar.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.scalar import ScalarMetric
+
+
+WORLD_SIZE = 4
+BATCH_SIZE = 10
+
+
+class ScalarMetricTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scalar = ScalarMetric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+        )
+
+    def test_scalar(self) -> None:
+        """
+        Test scalar metric passes through each tensor as is
+        """
+        metric_to_log = torch.tensor([0.1])
+
+        self.scalar.update(
+            labels={DefaultTaskInfo.name: metric_to_log},
+            predictions={DefaultTaskInfo.name: metric_to_log},
+            weights={DefaultTaskInfo.name: metric_to_log},
+        )
+        metric = self.scalar.compute()
+        actual_metric = metric[f"scalar-{DefaultTaskInfo.name}|lifetime_scalar"]
+
+        torch.testing.assert_close(
+            actual_metric,
+            metric_to_log,
+            atol=1e-4,
+            rtol=1e-4,
+            check_dtype=False,
+            equal_nan=True,
+            msg=f"Actual: {actual_metric}, Expected: {metric_to_log}",
+        )
+
+        # Pass through second tensor with different value
+        # check we get the value back with no averaging or any differences
+
+        metric_to_log = torch.tensor([0.9])
+
+        self.scalar.update(
+            labels={DefaultTaskInfo.name: metric_to_log},
+            predictions={DefaultTaskInfo.name: metric_to_log},
+            weights={DefaultTaskInfo.name: metric_to_log},
+        )
+        metric = self.scalar.compute()
+        actual_metric = metric[f"scalar-{DefaultTaskInfo.name}|lifetime_scalar"]
+
+        torch.testing.assert_close(
+            actual_metric,
+            metric_to_log,
+            atol=1e-4,
+            rtol=1e-4,
+            check_dtype=False,
+            equal_nan=True,
+            msg=f"Actual: {actual_metric}, Expected: {metric_to_log}",
+        )
+
+    def test_scalar_window(self) -> None:
+        """
+        Test windowing of scalar metric gives average of previously reported values.
+        """
+        metric_to_log = torch.tensor([0.1])
+
+        self.scalar.update(
+            labels={DefaultTaskInfo.name: metric_to_log},
+            predictions={DefaultTaskInfo.name: metric_to_log},
+            weights={DefaultTaskInfo.name: metric_to_log},
+        )
+
+        metric_to_log = torch.tensor([0.9])
+
+        self.scalar.update(
+            labels={DefaultTaskInfo.name: metric_to_log},
+            predictions={DefaultTaskInfo.name: metric_to_log},
+            weights={DefaultTaskInfo.name: metric_to_log},
+        )
+
+        metric = self.scalar.compute()
+
+        actual_window_metric = metric[f"scalar-{DefaultTaskInfo.name}|window_scalar"]
+
+        expected_window_metric = torch.tensor([0.5])
+
+        torch.testing.assert_close(
+            actual_window_metric,
+            expected_window_metric,
+            atol=1e-4,
+            rtol=1e-4,
+            check_dtype=False,
+            equal_nan=True,
+            msg=f"Actual: {actual_window_metric}, Expected: {expected_window_metric}",
+        )


### PR DESCRIPTION
Summary:
Add new metric called ScalarMetric, which logs the tensor passed in as the label to tensorboard.

This will help users of APS log custom scalers in production runs

Differential Revision: D53499300


