### PR TITLE
Replace `constraints` with `dynamic_shapes` in apf

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2066,6 +2066,32 @@ register_pytree_node(
 register_pytree_flatten_spec(KeyedJaggedTensor, _kjt_flatten_spec)
 
 
+def flatten_kjt_list(
+    kjt_arr: List[KeyedJaggedTensor],
+) -> Tuple[List[Optional[torch.Tensor]], List[List[str]]]:
+    _flattened_data = []
+    _flattened_context = []
+    for t in kjt_arr:
+        _values, _context = _kjt_flatten(t)
+        _flattened_data.extend(_values)
+        _flattened_context.append(_context)
+    return _flattened_data, _flattened_context
+
+
+def unflatten_kjt_list(
+    values: List[Optional[torch.Tensor]], contexts: List[List[str]]
+) -> List[KeyedJaggedTensor]:
+    num_kjt_fields = len(KeyedJaggedTensor._fields)
+    length = len(values)
+    return [
+        _kjt_unflatten(
+            values[j * num_kjt_fields : (j + 1) * num_kjt_fields],
+            contexts[j],
+        )
+        for j in range(length // num_kjt_fields)
+    ]
+
+
 def _maybe_compute_offset_per_key_kt(
     length_per_key: List[int],
     offset_per_key: Optional[List[int]],


### PR DESCRIPTION
Summary: `constraints` argument for `torch.export` has been deprecated in favor of the `dynamic_shapes` argument. This PR updates the use of the deprecated API in `apf`. In addition, this diff registers `DefaultRecTrainInput` as a pytree node to make it work with `torch.export.dynamic_shapes.process_dynamic_shapes()`.

Differential Revision: D53697239


