### PR TITLE
Fix scalar torchrec metric to be not persistent

### DIFF
--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -29,14 +29,14 @@ class ScalarMetricComputation(RecMetricComputation):
             torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="mean",
-            persistent=True,
+            persistent=False,
         )
         self._add_state(
             "window_count",
             torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="mean",
-            persistent=True,
+            persistent=False,
         )
 
     def update(


### PR DESCRIPTION
Summary:
As title.

Scalar metric does not need to be persistent, and can continue to log tensor values after being pre-empted or started from checkpoint without issue.

Differential Revision: D53780853


