### PR TITLE
Register serialized name to KJT/JT

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -636,7 +636,11 @@ def _jt_flatten_spec(t: JaggedTensor, spec: TreeSpec) -> List[Optional[torch.Ten
 
 
 register_pytree_node(
-    JaggedTensor, _jt_flatten, _jt_unflatten, flatten_with_keys_fn=_jt_flatten_with_keys
+    JaggedTensor,
+    _jt_flatten,
+    _jt_unflatten,
+    flatten_with_keys_fn=_jt_flatten_with_keys,
+    serialized_type_name="torchrec.sparse.jagged_tensor.JaggedTensor",
 )
 register_pytree_flatten_spec(JaggedTensor, _jt_flatten_spec)
 
@@ -2093,6 +2097,7 @@ register_pytree_node(
     _kjt_flatten,
     _kjt_unflatten,
     flatten_with_keys_fn=_kjt_flatten_with_keys,
+    serialized_type_name="torchrec.sparse.jagged_tensor.KeyedJaggedTensor",
 )
 register_pytree_flatten_spec(KeyedJaggedTensor, _kjt_flatten_spec)
 


### PR DESCRIPTION
Summary:
Trying to reland D51312977. Hopefully this wont break any torch
packages as D53139358 recently did a similar change where called
`register_pytree_node` with an extra new argument, `flatten_with_keys_fn`,
which was added recently in D52547850.

Differential Revision: D53857843


