### PR TITLE
Only allow table_wise in fp-ebc for mtia

### DIFF
--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -205,6 +205,9 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         return FeatureProcessedEmbeddingBagCollection
 
     def sharding_types(self, compute_device_type: str) -> List[str]:
+        if compute_device_type in {"mtia"}:
+            return [ShardingType.TABLE_WISE.value]
+
         # No row wise because position weighted FP and RW don't play well together.
         types = [
             ShardingType.DATA_PARALLEL.value,


### PR DESCRIPTION
Summary: Follow ebc/ec to only allow table_wise in fp-ebc for mtia.

Reviewed By: gnahzg

Differential Revision: D53778749


