### PR TITLE
Improve perf of _block_bucketize_sparse_features_cuda_kernel2 - for pooled emb

### DIFF
--- a/torchrec/distributed/tests/test_utils.py
+++ b/torchrec/distributed/tests/test_utils.py
@@ -346,7 +346,9 @@ class KJTBucketizeTest(unittest.TestCase):
 
         self.assertTrue(
             keyed_jagged_tensor_equals(
-                block_bucketized_kjt, expected_block_bucketized_kjt
+                block_bucketized_kjt,
+                expected_block_bucketized_kjt,
+                is_pooled_features=True,
             )
         )
 
@@ -439,7 +441,9 @@ class KJTBucketizeTest(unittest.TestCase):
 
         self.assertTrue(
             keyed_jagged_tensor_equals(
-                block_bucketized_kjt, expected_block_bucketized_kjt
+                block_bucketized_kjt,
+                expected_block_bucketized_kjt,
+                is_pooled_features=True,
             )
         )
 

--- a/torchrec/sparse/test_utils/__init__.py
+++ b/torchrec/sparse/test_utils/__init__.py
@@ -7,41 +7,81 @@
 
 # pyre-strict
 
+import math
 from typing import Optional
 
 import torch
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
-def keyed_jagged_tensor_equals(
-    kjt1: Optional[KeyedJaggedTensor], kjt2: Optional[KeyedJaggedTensor]
+def _tensor_eq_or_none(
+    t1: Optional[torch.Tensor],
+    t2: Optional[torch.Tensor],
+    out_of_order: bool = False,
+    length: Optional[torch.Tensor] = None,
 ) -> bool:
-    def _tensor_eq_or_none(
-        t1: Optional[torch.Tensor], t2: Optional[torch.Tensor]
-    ) -> bool:
-        if t1 is None and t2 is None:
-            return True
-        elif t1 is None and t2 is not None:
-            return False
-        elif t1 is not None and t2 is None:
-            return False
-        else:
-            assert t1 is not None
-            assert t2 is not None
-            return torch.equal(t1, t2) and t1.dtype == t2.dtype
+    if t1 is None and t2 is None:
+        return True
+    elif t1 is None and t2 is not None:
+        return False
+    elif t1 is not None and t2 is None:
+        return False
 
+    assert t1 is not None
+    assert t2 is not None
+
+    if t1.dtype != t2.dtype:
+        return False
+
+    if not out_of_order:
+        return torch.equal(t1, t2)
+
+    assert length is not None
+    is_int = not torch.is_floating_point(t1)
+    vals_1 = t1.tolist()
+    vals_2 = t2.tolist()
+    current_offset = 0
+    for i in length.tolist():
+        if i == 0:
+            continue
+        sorted_vals_1 = sorted(vals_1[current_offset : current_offset + i])
+        sorted_vals_2 = sorted(vals_2[current_offset : current_offset + i])
+        if is_int:
+            if sorted_vals_1 != sorted_vals_2:
+                return False
+        else:
+            for left, right in zip(
+                sorted_vals_1,
+                sorted_vals_2,
+            ):
+                if not math.isclose(left, right):
+                    return False
+        current_offset += i
+    return True
+
+
+def keyed_jagged_tensor_equals(
+    kjt1: Optional[KeyedJaggedTensor],
+    kjt2: Optional[KeyedJaggedTensor],
+    is_pooled_features: bool = False,
+) -> bool:
     if kjt1 is None and kjt2 is None:
         return True
     elif kjt1 is None and kjt2 is not None:
         return False
     elif kjt1 is not None and kjt2 is None:
         return False
-    else:
-        assert kjt1 is not None
-        assert kjt2 is not None
-        return (
-            kjt1.keys() == kjt2.keys()
-            and _tensor_eq_or_none(kjt1.lengths(), kjt2.lengths())
-            and _tensor_eq_or_none(kjt1.values(), kjt2.values())
-            and _tensor_eq_or_none(kjt1._weights, kjt2._weights)
-        )
+
+    assert kjt1 is not None
+    assert kjt2 is not None
+    if not (
+        kjt1.keys() == kjt2.keys()
+        and _tensor_eq_or_none(kjt1.lengths(), kjt2.lengths())
+    ):
+        return False
+
+    return _tensor_eq_or_none(
+        kjt1.values(), kjt2.values(), is_pooled_features, kjt1.lengths()
+    ) and _tensor_eq_or_none(
+        kjt1._weights, kjt2._weights, is_pooled_features, kjt1.lengths()
+    )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2346

This diffs tries to parallelize _block_bucketize_sparse_features_cuda_kernel2 more (the kernel that bucketize the data vector) based on the assumption that the order of id in an id list feature does not matter given that they will be pooled. 
w/o the change:
```
INFO:root:Start to benchmark ...
INFO:2024-02-20 12:28:34 463824:476125 DynoConfigLoader.cpp:61] Setting communication fabric enabled = 0
INFO:root:uneven_block_bucketize_sparse_features forward: torch.int64, 1574639424 bytes read/write, 50.14653396606445 ms, 31.400762913456834 GB/s
INFO:root:Start to benchmark ...
INFO:root:even_block_bucketize_sparse_features forward: torch.int64, 1574639424 bytes read/write, 38.90265655517578 ms, 40.476398360268355 GB/s
```
With the change:
```
INFO:2024-02-20 12:30:07 507530:516345 DynoConfigLoader.cpp:61] Setting communication fabric enabled = 0
INFO:root:uneven_block_bucketize_sparse_features forward: torch.int64, 1181149568 bytes read/write, 5.501140117645264 ms, 214.70995879770197 GB/s
INFO:root:Start to benchmark ...
INFO:root:even_block_bucketize_sparse_features forward: torch.int64, 1181149568 bytes read/write, 5.078537464141846 ms, 232.57671649363064 GB/s
[albertchen@devgpu020]~/fbsource/fbcode% buck run mode/opt //deeplearning/fbgemm/fbgemm_gpu:sparse_ops_benchmark -c fbcode.enable_gpu_sections=true -- block-bucketize-sparse-features-bench --row-size=10000 --element-num=49186232 --batch-size=2500 --device cuda
```

**Kernel perf improves by more than 5 times.**

Before https://fburl.com/perfdoctor/4bh0qu3x
 {F1460471239} 

After https://fburl.com/perfdoctor/2cnb3s0p
 {F1460471412} 

It is 6 times faster

Differential Revision: D53961140


