### PR TITLE
Small syntactic changes for dynamo compatibility

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -81,17 +81,20 @@ def _get_recat(
         if local_split == 0:
             return None
 
-        recat: List[int] = []
+        feature_order: List[int] = []
+        for x in range(num_splits // stagger):
+            for y in range(stagger):
+                feature_order.append(x + num_splits // stagger * y)
 
-        feature_order: List[int] = [
-            x + num_splits // stagger * y
-            for x in range(num_splits // stagger)
-            for y in range(stagger)
-        ]
+        recat: torch.Tensor = torch.empty(
+            local_split * len(feature_order), dtype=torch.int32
+        )
 
+        _i = 0
         for i in range(local_split):
             for j in feature_order:  # range(num_splits):
-                recat.append(i + j * local_split)
+                recat[_i] = i + j * local_split
+                _i += 1
 
         # variable batch size
         if batch_size_per_rank is not None and any(

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -856,12 +856,13 @@ class ShardedEmbeddingBagCollection(
     ) -> LazyAwaitable[KeyedTensor]:
         batch_size_per_feature_pre_a2a = []
         awaitables = []
-        for lookup, dist, sharding_context, features in zip(
-            self._lookups,
-            self._output_dists,
-            ctx.sharding_contexts,
-            input,
-        ):
+
+        # No usage of zip for dynamo
+        for i in range(len(self._lookups)):
+            lookup = self._lookups[i]
+            dist = self._output_dists[i]
+            sharding_context = ctx.sharding_contexts[i]
+            features = input[i]
             awaitables.append(dist(lookup(features), sharding_context))
             if sharding_context:
                 batch_size_per_feature_pre_a2a.extend(


### PR DESCRIPTION
Summary:
Dynamo has some gaps in support of generators, list comprehension etc.
Avoiding them for now with syntactic changes

Previous diff was reverted because recat was created on the target device from the start.
Then with per-item manipulations it was writing directly to device (which broke freya training as it looks like freya does not support per-item changes).

In this diff recat is created on "cpu", the same as List[int] in original version.

Differential Revision: D54192498


