### PR TITLE
Add Regression AUC (RAUC) metrics

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -39,6 +39,7 @@ from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ndcg import NDCGMetric
 from torchrec.metrics.ne import NEMetric
+from torchrec.metrics.rauc import RAUCMetric
 from torchrec.metrics.rec_metric import RecMetric, RecMetricList
 from torchrec.metrics.recall_session import RecallSessionMetric
 from torchrec.metrics.scalar import ScalarMetric
@@ -58,6 +59,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.CALIBRATION: CalibrationMetric,
     RecMetricEnum.AUC: AUCMetric,
     RecMetricEnum.AUPRC: AUPRCMetric,
+    RecMetricEnum.RAUC: RAUCMetric,
     RecMetricEnum.MSE: MSEMetric,
     RecMetricEnum.MAE: MAEMetric,
     RecMetricEnum.MULTICLASS_RECALL: MulticlassRecallMetric,

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -23,6 +23,7 @@ class RecMetricEnum(RecMetricEnumBase):
     CTR = "ctr"
     AUC = "auc"
     AUPRC = "auprc"
+    RAUC = "rauc"
     CALIBRATION = "calibration"
     MSE = "mse"
     MAE = "mae"

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -49,8 +49,10 @@ class MetricName(MetricNameBase):
     RMSE = "rmse"
     AUC = "auc"
     AUPRC = "auprc"
+    RAUC = "rauc"
     GROUPED_AUC = "grouped_auc"
     GROUPED_AUPRC = "grouped_auprc"
+    GROUPED_RAUC = "grouped_rauc"
     RECALL_SESSION_LEVEL = "recall_session_level"
     MULTICLASS_RECALL = "multiclass_recall"
     WEIGHTED_AVG = "weighted_avg"
@@ -76,6 +78,7 @@ class MetricNamespace(MetricNamespaceBase):
     MSE = "mse"
     AUC = "auc"
     AUPRC = "auprc"
+    RAUC = "rauc"
     MAE = "mae"
     ACCURACY = "accuracy"
 

--- a/torchrec/metrics/rauc.py
+++ b/torchrec/metrics/rauc.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type
+
+import torch
+import torch.distributed as dist
+from torchmetrics.utilities.distributed import gather_all_tensors
+from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+)
+
+PREDICTIONS = "predictions"
+LABELS = "labels"
+WEIGHTS = "weights"
+GROUPING_KEYS = "grouping_keys"
+REQUIRED_INPUTS = "required_inputs"
+
+
+def _concat_if_needed(
+    predictions: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    This check exists because of how the state is organized due to quirks in RecMetrics.
+    Since we do not do tensor concatenatation in the compute or update call, there are cases (in non-distributed settings)
+    where the tensors from updates are not concatted into a single tensor. Which is determined by the length of the list.
+    """
+    preds_t, labels_t, weights_t = None, None, None
+    if len(predictions) > 1:
+        preds_t = torch.cat(predictions, dim=-1)
+        labels_t = torch.cat(labels, dim=-1)
+        weights_t = torch.cat(weights, dim=-1)
+    else:
+        preds_t = predictions[0]
+        labels_t = labels[0]
+        weights_t = weights[0]
+
+    return preds_t, labels_t, weights_t
+
+
+def count_reverse_pairs_divide_and_conquer(input: List[float]) -> float:
+
+    n = len(input)
+    total_inversions = divide(input, 0, len(input) - 1)
+
+    return total_inversions / (n * (n - 1) / 2)
+
+
+def divide(input: List[float], low: int, high: int) -> int:
+    if low >= high:
+        return 0
+
+    mid = low + (high - low) // 2
+
+    left_inversions = divide(input, low, mid)
+    right_inversions = divide(input, mid + 1, high)
+    merge_inversions = conquer_and_count(input, low, mid, high)
+
+    return left_inversions + right_inversions + merge_inversions
+
+
+def conquer_and_count(
+    input: List[float], left_index: int, mid_index: int, right_index: int
+) -> int:
+    left = input[left_index : mid_index + 1]
+    right = input[mid_index + 1 : right_index + 1]
+
+    i, j, k, inversions = 0, 0, left_index, 0
+
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            input[k] = left[i]
+            i += 1
+        else:
+            input[k] = right[j]
+            j += 1
+            count = (mid_index + 1) - (left_index + i)
+            inversions += count
+        k += 1
+
+    while i < len(left):
+        input[k] = left[i]
+        i += 1
+        k += 1
+
+    while j < len(right):
+        input[k] = right[j]
+        j += 1
+        k += 1
+
+    return inversions
+
+
+def _compute_rauc_helper(
+    predictions: torch.Tensor,
+    labels: torch.Tensor,
+    weights: torch.Tensor,
+) -> torch.Tensor:
+
+    array = [
+        x
+        for x, _ in sorted(
+            zip(labels.tolist(), predictions.tolist()), key=lambda x: (x[1], x[0])
+        )
+    ]
+
+    return torch.tensor(1 - count_reverse_pairs_divide_and_conquer(array))
+
+
+def compute_rauc(
+    n_tasks: int,
+    predictions: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
+) -> torch.Tensor:
+    """
+    Computes RAUC (Regression AUC) for regression tasks.
+
+    Args:
+        predictions (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
+        labels (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
+        weights (List[torch.Tensor]): tensor of size (n_tasks, n_examples).
+    """
+
+    preds_t, labels_t, weights_t = _concat_if_needed(predictions, labels, weights)
+    raucs = []
+    for predictions_i, labels_i, weights_i in zip(preds_t, labels_t, weights_t):
+        rauc = _compute_rauc_helper(predictions_i, labels_i, weights_i)
+        raucs.append(rauc.view(1))
+    return torch.cat(raucs)
+
+
+def compute_rauc_per_group(
+    n_tasks: int,
+    predictions: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
+    grouping_keys: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Computes RAUC (Regression AUC) for regression tasks for groups of predictions/labels.
+    Args:
+        n_tasks (int): number of tasks
+        predictions (List[torch.Tensor]): tensor of size (n_tasks, n_examples)
+        labels (List[torch.Tensor]: tensor of size (n_tasks, n_examples)
+        weights (List[torch.Tensor]): tensor of size (n_tasks, n_examples)
+        grouping_keys (torch.Tensor): tensor of size (n_examples,)
+
+    Returns:
+        torch.Tensor: tensor of size (n_tasks,), average of RAUCs per group.
+    """
+    preds_t, labels_t, weights_t = _concat_if_needed(predictions, labels, weights)
+    raucs = []
+    if grouping_keys.numel() != 0 and grouping_keys[0] == -1:
+        # we added padding  as the first elements during init to avoid floating point exception in sync()
+        # removing the paddings to avoid numerical errors.
+        grouping_keys = grouping_keys[1:]
+
+    # get unique group indices
+    group_indices = torch.unique(grouping_keys)
+
+    for (predictions_i, labels_i, weights_i) in zip(preds_t, labels_t, weights_t):
+        # Loop over each group
+        rauc_groups_sum = torch.tensor([0], dtype=torch.float32)
+        for group_idx in group_indices:
+            # get predictions, labels, and weights for this group
+            group_mask = grouping_keys == group_idx
+            grouped_predictions = predictions_i[group_mask]
+            grouped_labels = labels_i[group_mask]
+            grouped_weights = weights_i[group_mask]
+
+            rauc = _compute_rauc_helper(
+                grouped_predictions, grouped_labels, grouped_weights
+            )
+            rauc_groups_sum = rauc_groups_sum.to(rauc.device)
+            rauc_groups_sum += rauc.view(1)
+        avg_rauc = (
+            rauc_groups_sum / len(group_indices)
+            if len(group_indices) > 0
+            else torch.tensor([0.5], dtype=torch.float32)
+        )
+        raucs.append(avg_rauc)
+    return torch.cat(raucs)
+
+
+def _state_reduction(state: List[torch.Tensor], dim: int = 1) -> List[torch.Tensor]:
+    return [torch.cat(state, dim=dim)]
+
+
+# pyre-ignore
+_grouping_keys_state_reduction = partial(_state_reduction, dim=0)
+
+
+class RAUCMetricComputation(RecMetricComputation):
+    r"""
+    This class implements the RecMetricComputation for RAUC, i.e. Regression AUC.
+
+    The constructor arguments are defined in RecMetricComputation.
+    See the docstring of RecMetricComputation for more detail.
+    Args:
+        grouped_rauc (bool): If True, computes RAUC per group and returns average RAUC across all groups.
+            The `grouping_keys` is provided during state updates along with predictions, labels, weights.
+            This feature is currently not enabled for `fused_update_limit`.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        grouped_rauc: bool = False,
+        fused_update_limit: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if grouped_rauc and fused_update_limit > 0:
+            raise RecMetricException(
+                "Grouped RAUC and Fused Update Limit cannot be enabled together yet."
+            )
+
+        self._grouped_rauc: bool = grouped_rauc
+        self._num_samples: int = 0
+        self._add_state(
+            PREDICTIONS,
+            [],
+            add_window_state=False,
+            dist_reduce_fx=_state_reduction,
+            persistent=False,
+        )
+        self._add_state(
+            LABELS,
+            [],
+            add_window_state=False,
+            dist_reduce_fx=_state_reduction,
+            persistent=False,
+        )
+        self._add_state(
+            WEIGHTS,
+            [],
+            add_window_state=False,
+            dist_reduce_fx=_state_reduction,
+            persistent=False,
+        )
+        if self._grouped_rauc:
+            self._add_state(
+                GROUPING_KEYS,
+                [],
+                add_window_state=False,
+                dist_reduce_fx=_grouping_keys_state_reduction,
+                persistent=False,
+            )
+        self._init_states()
+
+    # The states values are set to empty lists in __init__() and reset(), and then we
+    # add a size (self._n_tasks, 1) tensor to each of the list as the initial values
+    # This is to bypass the limitation of state aggregation in TorchMetrics sync() when
+    # we try to checkpoint the states before update()
+    # The reason for using lists here is to avoid automatically stacking the tensors from
+    # all the trainers into one tensor in sync()
+    # The reason for using non-empty tensors as the first elements is to avoid the
+    # floating point exception thrown in sync() for aggregating empty tensors
+    def _init_states(self) -> None:
+        if len(getattr(self, PREDICTIONS)) > 0:
+            return
+        self._num_samples = 0
+        getattr(self, PREDICTIONS).append(
+            torch.zeros((self._n_tasks, 1), dtype=torch.float, device=self.device)
+        )
+        getattr(self, LABELS).append(
+            torch.zeros((self._n_tasks, 1), dtype=torch.float, device=self.device)
+        )
+        getattr(self, WEIGHTS).append(
+            torch.zeros((self._n_tasks, 1), dtype=torch.float, device=self.device)
+        )
+        if self._grouped_rauc:
+            getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Args:
+            predictions (torch.Tensor): tensor of size (n_task, n_examples)
+            labels (torch.Tensor): tensor of size (n_task, n_examples)
+            weights (torch.Tensor): tensor of size (n_task, n_examples)
+            grouping_key (torch.Tensor): Optional tensor of size (1, n_examples) that specifies the groups of
+                    predictions/labels per batch. If provided, the RAUC metric also
+                    computes RAUC per group and returns the average RAUC across all groups.
+        """
+        if predictions is None or weights is None:
+            raise RecMetricException(
+                "Inputs 'predictions' and 'weights' should not be None for RAUCMetricComputation update"
+            )
+        predictions = predictions.float()
+        labels = labels.float()
+        weights = weights.float()
+        batch_size = predictions.size(-1)
+        start_index = max(self._num_samples + batch_size - self._window_size, 0)
+
+        # Using `self.predictions =` will cause Pyre errors.
+        w_preds = getattr(self, PREDICTIONS)
+        w_labels = getattr(self, LABELS)
+        w_weights = getattr(self, WEIGHTS)
+
+        # remove init states
+        if self._num_samples == 0:
+            for lst in [w_preds, w_labels, w_weights]:
+                lst.pop(0)
+
+        w_preds.append(predictions)
+        w_labels.append(labels)
+        w_weights.append(weights)
+
+        self._num_samples += batch_size
+
+        while self._num_samples > self._window_size:
+            diff = self._num_samples - self._window_size
+            if diff > w_preds[0].size(-1):
+                self._num_samples -= w_preds[0].size(-1)
+                # Remove the first element from predictions, labels, and weights
+                for lst in [w_preds, w_labels, w_weights]:
+                    lst.pop(0)
+            else:
+                # Update the first element of predictions, labels, and weights
+                # Off by one potentially - keeping legacy behaviour
+                for lst in [w_preds, w_labels, w_weights]:
+                    lst[0] = lst[0][:, diff:]
+                    # if empty tensor, remove it
+                    if torch.numel(lst[0]) == 0:
+                        lst.pop(0)
+                self._num_samples -= diff
+
+        if self._grouped_rauc:
+            if REQUIRED_INPUTS not in kwargs or (
+                (grouping_keys := kwargs[REQUIRED_INPUTS].get(GROUPING_KEYS)) is None
+            ):
+                raise RecMetricException(
+                    f"Input '{GROUPING_KEYS}' are required for RAUCMetricComputation grouped update"
+                )
+            getattr(self, GROUPING_KEYS)[0] = torch.cat(
+                [
+                    cast(torch.Tensor, getattr(self, GROUPING_KEYS)[0])[start_index:],
+                    grouping_keys.squeeze(),
+                ],
+                dim=0,
+            )
+
+    def _compute(self) -> List[MetricComputationReport]:
+        reports = []
+        reports.append(
+            MetricComputationReport(
+                name=MetricName.RAUC,
+                metric_prefix=MetricPrefix.WINDOW,
+                value=compute_rauc(
+                    self._n_tasks,
+                    cast(List[torch.Tensor], getattr(self, PREDICTIONS)),
+                    cast(List[torch.Tensor], getattr(self, LABELS)),
+                    cast(List[torch.Tensor], getattr(self, WEIGHTS)),
+                ),
+            )
+        )
+
+        if self._grouped_rauc:
+            reports.append(
+                MetricComputationReport(
+                    name=MetricName.GROUPED_RAUC,
+                    metric_prefix=MetricPrefix.WINDOW,
+                    value=compute_rauc_per_group(
+                        self._n_tasks,
+                        cast(List[torch.Tensor], getattr(self, PREDICTIONS)),
+                        cast(List[torch.Tensor], getattr(self, LABELS)),
+                        cast(List[torch.Tensor], getattr(self, WEIGHTS)),
+                        cast(torch.Tensor, getattr(self, GROUPING_KEYS))[0],
+                    ),
+                )
+            )
+        return reports
+
+    def _sync_dist(
+        self,
+        dist_sync_fn: Callable = gather_all_tensors,  # pyre-ignore[24]
+        process_group: Optional[Any] = None,  # pyre-ignore[2]
+    ) -> None:
+        """
+        This function is overridden from torchmetric.Metric, since for RAUC we want to concat the tensors
+        right before the allgather collective is called. It directly changes the attributes/states, which
+        is ok because end of function sets the attributes to reduced values
+        """
+        for attr in self._reductions:  # pragma: no cover
+            val = getattr(self, attr)
+            if isinstance(val, list) and len(val) > 1:
+                setattr(self, attr, [torch.cat(val, dim=-1)])
+        super()._sync_dist(dist_sync_fn, process_group)
+
+    def reset(self) -> None:
+        super().reset()
+        self._init_states()
+
+
+class RAUCMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.RAUC
+    _computation_class: Type[RecMetricComputation] = RAUCMetricComputation
+
+    def __init__(
+        self,
+        world_size: int,
+        my_rank: int,
+        batch_size: int,
+        tasks: List[RecTaskInfo],
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        window_size: int = 100,
+        fused_update_limit: int = 0,
+        compute_on_all_ranks: bool = False,
+        should_validate_update: bool = False,
+        process_group: Optional[dist.ProcessGroup] = None,
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        super().__init__(
+            world_size=world_size,
+            my_rank=my_rank,
+            batch_size=batch_size,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            window_size=window_size,
+            fused_update_limit=fused_update_limit,
+            compute_on_all_ranks=compute_on_all_ranks,
+            should_validate_update=should_validate_update,
+            process_group=process_group,
+            **kwargs,
+        )
+        if kwargs.get("grouped_rauc"):
+            self._required_inputs.add(GROUPING_KEYS)

--- a/torchrec/metrics/tests/test_rauc.py
+++ b/torchrec/metrics/tests/test_rauc.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict, Iterable, List, Optional, Type, Union
+
+import torch
+from torch import no_grad
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.rauc import RAUCMetric
+from torchrec.metrics.rec_metric import (
+    RecComputeMode,
+    RecMetric,
+    RecMetricException,
+    RecTaskInfo,
+)
+from torchrec.metrics.test_utils import (
+    metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
+    rec_metric_value_test_launcher,
+    sync_test_helper,
+    TestMetric,
+)
+
+
+def compute_rauc(
+    predictions: torch.Tensor, labels: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+
+    n = len(predictions)
+    cnt = 0.0
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            if (labels[i] - labels[j]) * (predictions[i] - predictions[j]) >= 0:
+                cnt += 1
+
+    return torch.tensor(cnt / (n * (n - 1) / 2))
+
+
+class TestRAUCMetric(TestMetric):
+    def __init__(
+        self,
+        world_size: int,
+        rec_tasks: List[RecTaskInfo],
+    ) -> None:
+        super().__init__(
+            world_size,
+            rec_tasks,
+            compute_lifetime_metric=False,
+            local_compute_lifetime_metric=False,
+        )
+
+    @staticmethod
+    def _aggregate(
+        states: Dict[str, torch.Tensor], new_states: Dict[str, torch.Tensor]
+    ) -> None:
+        for k, v in new_states.items():
+            if k not in states:
+                states[k] = v.float().detach().clone()
+            else:
+                states[k] = torch.cat([states[k], v.float()])
+
+    @staticmethod
+    def _get_states(
+        labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        return {
+            "predictions": predictions,
+            "weights": weights,
+            "labels": labels,
+        }
+
+    @staticmethod
+    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+        return compute_rauc(states["predictions"], states["labels"], states["weights"])
+
+
+WORLD_SIZE = 4
+
+
+class RAUCMetricTest(unittest.TestCase):
+    clazz: Type[RecMetric] = RAUCMetric
+    task_name: str = "rauc"
+
+    def test_unfused_rauc(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=RAUCMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestRAUCMetric,
+            metric_name=RAUCMetricTest.task_name,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=metric_test_helper,
+        )
+
+    def test_fused_rauc(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=RAUCMetric,
+            target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            test_clazz=TestRAUCMetric,
+            metric_name=RAUCMetricTest.task_name,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=metric_test_helper,
+        )
+
+
+class RAUCGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = RAUCMetric
+    task_name: str = "rauc"
+
+    def test_sync_rauc(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=RAUCMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestRAUCMetric,
+            metric_name=RAUCGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
+        )
+
+
+class RAUCMetricValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of RAUC in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    def setUp(self) -> None:
+        self.predictions = {"DefaultTask": None}
+        self.weights = {"DefaultTask": None}
+        self.labels = {"DefaultTask": None}
+        self.batches = {
+            "predictions": self.predictions,
+            "weights": self.weights,
+            "labels": self.labels,
+        }
+        self.rauc = RAUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=100,
+            tasks=[DefaultTaskInfo],
+        )
+
+    def test_calc_rauc_perfect(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(100)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(100)] * 2]
+        )
+        self.weights["DefaultTask"] = torch.Tensor([[1] * 50 + [0] * 100 + [1] * 50])
+
+        expected_rauc = torch.tensor([1], dtype=torch.float)
+        self.rauc.update(**self.batches)
+        actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
+        assert torch.allclose(expected_rauc, actual_rauc)
+
+    def test_calc_rauc_zero(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(100)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor(
+            [[-0.0001 * x for x in range(100)] * 2]
+        )
+        self.weights["DefaultTask"] = torch.Tensor([[0] * 50 + [1] * 100 + [0] * 50])
+
+        expected_rauc = torch.tensor([0], dtype=torch.float)
+        self.rauc.update(**self.batches)
+        actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
+        assert torch.allclose(expected_rauc, actual_rauc)
+
+    def test_calc_rauc_random(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor([[1, 2, 3, 4]])
+        self.labels["DefaultTask"] = torch.Tensor([[2, 1, 4, 3]])
+        self.weights["DefaultTask"] = torch.Tensor([[1, 1, 1, 1]])
+
+        expected_rauc = torch.tensor([2.0 / 3], dtype=torch.float)
+        self.rauc.update(**self.batches)
+        actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
+        assert torch.allclose(expected_rauc, actual_rauc)
+
+    def test_window_size_rauc(self) -> None:
+        # for determinisitc batches
+        torch.manual_seed(0)
+
+        rauc = RAUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=5,
+            window_size=100,
+            tasks=[DefaultTaskInfo],
+        )
+
+        # init states, so we expect 3 (state tensors) * 4 bytes (float)
+        self.assertEqual(sum(rauc.get_memory_usage().values()), 12)
+
+        # bs = 5
+        self.labels["DefaultTask"] = torch.rand(5)
+        self.predictions["DefaultTask"] = torch.rand(5)
+        self.weights["DefaultTask"] = torch.rand(5)
+
+        for _ in range(1000):
+            rauc.update(**self.batches)
+
+        # check memory, window size is 100, so we have upperbound of memory to expect
+        # so with a 100 window size / tensors of size 5 = 20 tensors (per state) * 3 states * 20 bytes per tensor of size 5 = 1200 bytes
+        self.assertEqual(sum(rauc.get_memory_usage().values()), 1200)
+        # with bs 5, we expect 20 tensors per state, so 60 tensors
+        self.assertEqual(len(rauc.get_memory_usage().values()), 60)
+
+        assert torch.allclose(
+            rauc.compute()["rauc-DefaultTask|window_rauc"],
+            torch.tensor([0.5152], dtype=torch.float),
+            atol=1e-4,
+        )
+
+        # test rauc memory usage with window size equal to incoming batch
+        rauc = RAUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=100,
+            window_size=100,
+            tasks=[DefaultTaskInfo],
+        )
+
+        self.labels["DefaultTask"] = torch.rand(100)
+        self.predictions["DefaultTask"] = torch.rand(100)
+        self.weights["DefaultTask"] = torch.rand(100)
+
+        for _ in range(10):
+            rauc.update(**self.batches)
+
+        # passing in batch size == window size, we expect for each state just one tensor of size 400, sum to 1200 as previous
+        self.assertEqual(sum(rauc.get_memory_usage().values()), 1200)
+        self.assertEqual(len(rauc.get_memory_usage().values()), 3)
+
+        assert torch.allclose(
+            rauc.compute()["rauc-DefaultTask|window_rauc"],
+            torch.tensor([0.5508], dtype=torch.float),
+            atol=1e-4,
+        )
+
+
+def generate_model_outputs_cases() -> Iterable[Dict[str, torch._tensor.Tensor]]:
+    return [
+        # random_inputs
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.13, 0.2, 0.5, 0.8, 0.75]]),
+            "grouping_keys": torch.tensor([0, 1, 0, 1, 1]),
+            "expected_rauc": torch.tensor([0.3333]),
+        },
+        # perfect_condition
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[1, 0, 0, 1, 1]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([1, 1, 0, 0, 1]),
+            "expected_rauc": torch.tensor([1.0]),
+        },
+        # inverse_prediction
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0, 1, 1, 0, 0]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([0, 1, 0, 1, 1]),
+            "expected_rauc": torch.tensor([0.1667]),
+        },
+        # all_scores_the_same
+        {
+            "labels": torch.tensor([[1, 0, 1, 0, 1, 0]]),
+            "predictions": torch.tensor([[0.5] * 6]),
+            "weights": torch.tensor([[1] * 6]),
+            "grouping_keys": torch.tensor([1, 1, 1, 0, 0, 0]),
+            "expected_rauc": torch.tensor([1.0]),
+        },
+        # one_class_in_input
+        {
+            "labels": torch.tensor([[1, 1, 1, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[1] * 5]),
+            "grouping_keys": torch.tensor([1, 0, 0, 1, 0]),
+            "expected_rauc": torch.tensor([1.0]),
+        },
+        # one_group
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.13, 0.2, 0.5, 0.8, 0.75]]),
+            "grouping_keys": torch.tensor([1, 1, 1, 1, 1]),
+            "expected_rauc": torch.tensor([0.6]),
+        },
+        # two tasks
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 0], [1, 1, 1, 1, 0]]),
+            "predictions": torch.tensor(
+                [
+                    [0.2281, 0.1051, 0.4885, 0.7740, 0.3097],
+                    [0.4658, 0.3445, 0.6048, 0.6587, 0.5088],
+                ]
+            ),
+            "weights": torch.tensor(
+                [
+                    [0.6334, 0.6937, 0.6631, 0.5078, 0.3570],
+                    [0.2637, 0.2479, 0.2697, 0.6500, 0.7583],
+                ]
+            ),
+            "grouping_keys": torch.tensor([0, 1, 0, 0, 1]),
+            "expected_rauc": torch.tensor([0.8333, 0.5]),
+        },
+    ]
+
+
+class GroupedRAUCValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of RAUC in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    @no_grad()
+    def _test_grouped_rauc_helper(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        expected_rauc: torch.Tensor,
+        grouping_keys: Optional[torch.Tensor] = None,
+    ) -> None:
+        num_task = labels.shape[0]
+        batch_size = labels.shape[0]
+        task_list = []
+        inputs: Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]] = {
+            "predictions": {},
+            "labels": {},
+            "weights": {},
+        }
+        if grouping_keys is not None:
+            inputs["required_inputs"] = {"grouping_keys": grouping_keys}
+        for i in range(num_task):
+            task_info = RecTaskInfo(
+                name=f"Task:{i}",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+            task_list.append(task_info)
+            # pyre-ignore
+            inputs["predictions"][task_info.name] = predictions[i]
+            # pyre-ignore
+            inputs["labels"][task_info.name] = labels[i]
+            # pyre-ignore
+            inputs["weights"][task_info.name] = weights[i]
+
+        rauc = RAUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=batch_size,
+            tasks=task_list,
+            # pyre-ignore
+            grouped_rauc=True,
+        )
+        # pyre-ignore
+        rauc.update(**inputs)
+        actual_rauc = rauc.compute()
+
+        for task_id, task in enumerate(task_list):
+            cur_actual_rauc = actual_rauc[f"rauc-{task.name}|window_grouped_rauc"]
+            cur_expected_rauc = expected_rauc[task_id].unsqueeze(dim=0)
+
+            torch.testing.assert_close(
+                cur_actual_rauc,
+                cur_expected_rauc,
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                msg=f"Actual: {cur_actual_rauc}, Expected: {cur_expected_rauc}",
+            )
+
+    def test_grouped_rauc(self) -> None:
+        test_data = generate_model_outputs_cases()
+        for inputs in test_data:
+            try:
+                self._test_grouped_rauc_helper(**inputs)
+            except AssertionError:
+                print("Assertion error caught with data set ", inputs)
+                raise
+
+    def test_misconfigured_grouped_rauc(self) -> None:
+        with self.assertRaises(RecMetricException):
+            self._test_grouped_rauc_helper(
+                **{
+                    "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+                    "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+                    "weights": torch.tensor([[0.13, 0.2, 0.5, 0.8, 0.75]]),
+                    # no provided grouping_keys
+                    "expected_rauc": torch.tensor([0.2419]),
+                },
+            )
+
+    def test_required_input_for_grouped_Rauc(self) -> None:
+        rauc = RAUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[
+                RecTaskInfo(
+                    name="Task:0",
+                    label_name="label",
+                    prediction_name="prediction",
+                    weight_name="weight",
+                )
+            ],
+            # pyre-ignore
+            grouped_rauc=True,
+        )
+
+        self.assertIn("grouping_keys", rauc.get_required_inputs())


### PR DESCRIPTION
Summary:
Implement regression AUC metrics. Regression AUC is an extension of classification AUC. See Section 4.1.1 in https://arxiv.org/ftp/arxiv/papers/1205/1205.2618.pdf for related discussions.

On a high level, regression AUC is an extension of the traditional AUC for classification through the probabilistic interpretation: the area under the curve is equal to the probability that a classifier will rank a randomly chosen positive instance higher than a randomly chosen negative one.

We utilize merge sort to optimize time complexity to O(nlog(n)).

#TODO:
- need more test cases.
- grouped_rauc is not verified.

f535371503

 {F1461111882}

Reviewed By: zainhuda

Differential Revision: D53377225
