### PR TITLE
Fix pyre error in jagged benchmark

### DIFF
--- a/torchrec/sparse/tests/jagged_tensor_benchmark.py
+++ b/torchrec/sparse/tests/jagged_tensor_benchmark.py
@@ -46,7 +46,9 @@ def bench(
     results = timeit.repeat(
         lambda: fn(input_data[0], input_data[1]), number=10, repeat=10
     )
-    print(f"{name} {np.median(results)*1000:.1f}us")
+
+    p_50 = np.percentile(np.asarray(results), 50)
+    print(f"{name} {p_50*1000:.1f}us")
 
 
 @click.command()


### PR DESCRIPTION
Summary:
Address OSS error by explicitly convert to numpy array and also using p50 for the median
{F1461949323}

Differential Revision: D54268961


