### PR TITLE
add autodep rule for torchrec/inference/Batching.h

### DIFF
--- a/torchrec/inference/src/Batching.cpp
+++ b/torchrec/inference/src/Batching.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "torchrec/inference/Batching.h"
+#include "torchrec/inference/Batching.h" // @manual
 
 #include <c10/core/ScalarType.h>
 #include <folly/Range.h>


### PR DESCRIPTION
Summary: Allow autodeps to auto add `fbcode//torchrec/inference:batching` to the buck target when we imported `torchrec/inference/Batching.h`

Reviewed By: houseroad

Differential Revision: D54284062


