### PR TITLE
Deshim //folly:dynamic to //folly/json:dynamic in torchrec

### DIFF
--- a/torchrec/inference/server.cpp
+++ b/torchrec/inference/server.cpp
@@ -12,7 +12,7 @@
 
 #include <folly/futures/Future.h>
 #include <folly/io/IOBuf.h>
-#include <folly/json.h>
+#include <folly/json/json.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <grpc++/grpc++.h>


### PR DESCRIPTION
Summary:
The following headers were shimmed in //folly:dynamic and were modded:
  - folly/DynamicConverter.h -> folly/json/DynamicConverter.h
  - folly/dynamic.h -> folly/json/dynamic.h
  - folly/dynamic-inl.h -> folly/json/dynamic-inl.h
  - folly/json.h -> folly/json/json.h

`arc lint` was applied

Reviewed By: bcardosolopes

Differential Revision: D53837597


