### PR TITLE
remove unused splits_cumsum field from KJTSplitsAllToAllMeta

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -485,7 +485,6 @@ class KJTSplitsAllToAllMeta:
     keys: List[str]
     device: torch.device
     stagger: int
-    splits_cumsum: List[int]
 
 
 class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):


### PR DESCRIPTION
Summary: tsia

Reviewed By: zainhuda

Differential Revision: D54432182


