### PR TITLE
TBE logging - populate TBE contents

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -893,6 +893,7 @@ class BatchedFusedEmbeddingBag(
                 pooling_mode=self._pooling,
                 weights_precision=weights_precision,
                 device=device,
+                table_names=[t.name for t in config.embedding_tables],
                 **fused_params,
             )
         )


### PR DESCRIPTION
Summary:
Populate table names for D54181313.

Split into a separate diff to fix github export (otherwise diff
straddles fbgemm and torchrec).

Differential Revision: D54442088


