### PR TITLE
respect context manager's device in EmbeddingBagCollection

### DIFF
--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -176,8 +176,22 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         config = EmbeddingBagConfig(
             name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
         )
+
+        # test with device from input
         ebc = EmbeddingBagCollection(tables=[config], device=torch.device("meta"))
         self.assertEqual(torch.device("meta"), ebc.embedding_bags["t1"].weight.device)
+        self.assertEqual(torch.device("meta"), ebc.device)
+
+        # test with device from context manager
+        with torch.device("meta"):
+            ebc = EmbeddingBagCollection(tables=[config])
+        self.assertEqual(torch.device("meta"), ebc.embedding_bags["t1"].weight.device)
+        self.assertEqual(torch.device("meta"), ebc.device)
+
+        # test default device is cpu
+        ebc = EmbeddingBagCollection(tables=[config])
+        self.assertEqual(torch.device("cpu"), ebc.embedding_bags["t1"].weight.device)
+        self.assertEqual(torch.device("cpu"), ebc.device)
 
 
 class EmbeddingCollectionTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
`EmbeddingBagCollection` module does not respect context manager's device, this diff fixes the issue by:
* removing fallback to CPU if `device` input is not provided to `EmbeddingBagCollection`
* using the device from `EmbeddingBag` child module as the device for `EmbeddingBagCollection`
* If `device` is provided as input it is prioritized over manager's device

Before - context manager device not respected
```
conf = EmbeddingBagConfig(name="t1", embedding_dim=3, num_embeddings=15, feature_names=["f1"])
with torch.device("meta"):
    model = EmbeddingBagCollection([conf])
    print("devices:", [p.device for p in model.parameters()])

>>> devices: [device(type='cpu')]
```

After - respects context manager device
```
with torch.device("meta"):
    model = EmbeddingBagCollection([conf])
    print("devices:", [p.device for p in model.parameters()])

>>> devices: [device(type='meta')]
```

Differential Revision: D54493437


