### PR TITLE
bump pre-commit and formatting versioning to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -8,9 +8,9 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/omnilib/ufmt
-    rev: v1.3.2
+    rev: v2.5.1
     hooks:
       - id: ufmt
         additional_dependencies:
-          - black == 22.3.0
-          - usort == 1.0.2
+          - black == 24.2.0
+          - usort == 1.0.8.post1


### PR DESCRIPTION
Summary:
internal versioning of black has been updated causing out of sync issues with oss formatting versions, i.e. https://github.com/pytorch/torchrec/actions/runs/8147399095/job/22268020763

updated black versioning changes
https://github.com/pytorch/torchrec/commit/9a217b50128a049e01ff2b66f375a63410bce87b
https://github.com/pytorch/torchrec/commit/4e41029116bca69b81371cd94ad1a9cb251b1cce

Differential Revision: D54510840


