### PR TITLE
Implement budget shrinkage when bin-packing difficult proposals.

### DIFF
--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -199,6 +199,13 @@ class LuusJaakolaSearch:
         self.fright: Optional[float] = None
         self.d: float = self.right - self.left
 
+    def shrink_right(self, B: float) -> None:
+        "Shrink right boundary given [B,infinity) -> infinity"
+        self.right = B
+        self.fright = math.inf
+        self.d = self.right - self.left
+        self.x = self.clamp(self.x)
+
     def clamp(self, x: float) -> float:
         "Clamp x into range [left, right]"
         if x < self.left:


### PR DESCRIPTION
Summary:
Some proposals are much more difficult for the bin-packer than others.
e.g. for APF mast_ctr_cvr_conso_cmf_pipeline, with 0.88 storage reservation:

```
buck2 run mode/opt aps_models/ads/common/utils:sharding_planner_util_run[inplace] -- \
    --mode=mast_ctr_cvr_conso_cmf_pipeline \
    --world_size=128 \
    --batch_size=1024 \
    --hbm_mem_gb=80 \
    --embedding_location=UVM_CACHING \
    --auto_tuning_stats_file=manifold://intaik/flat/stats_2024-01-30_254b64e645a747f4024f8faf95a815c3_1a1381a2b29f6931fb7cbcc1f3a3ebb3_5d06dfdf1f616f69c9622f1a1e88ef55_65536_131072_262144.json \
    --pipeline_type=prefetch-sparse-dist \
    --storage_reservation_policy=FixedPercentage \
    --storage_reservation_percentage=0.88
```

and using the scaleup proposer, we see the partitioner has 1TB of
available budget (10% of total HBM), but attempts to use it all fail
to partition, so we end up falling back to the min-working-set
non-scaled plan.

```
EmbeddingOffloadScaleupProposer - cache scale up budget=1076.78 GB, exploring [152.02, 1228.8] GB
EmbeddingOffloadScaleupProposer - proposed size=152.02 GB, score=59.371404015505505
EmbeddingOffloadScaleupProposer - proposed size=1102.03 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1132.72 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=989.15 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=776.23 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=962.52 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=535.53 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1024.85 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=444.16 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1097.76 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1132.72 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1098.68 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1132.72 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=908.05 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=1056.36 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=801.69 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=740.11 GB, score=None
```

This diff introduces an optimization where we shrink the search space
as we discover non-partitionable proposals, which allows us to focus
the search into more productive areas.

We know the partitioner costs are non-smooth in general (why we
switched away from simple binary-search). This diff uses a narrower
assumption, if a scaleup proposal using X GB fails to partition, any
proposal larger than this will also fail.

With shrinkage, we discover an optimal plan using 213GB.
```
EmbeddingOffloadScaleupProposer - cache scale up budget=1076.78 GB, exploring [152.02, 1228.8] GB
EmbeddingOffloadScaleupProposer - proposed size=152.02 GB, score=59.371404015505505
EmbeddingOffloadScaleupProposer - proposed size=1102.03 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=879.47 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=728.05 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=461.63 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=245.85 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=233.26 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=197.23 GB, score=58.653459490303476
EmbeddingOffloadScaleupProposer - proposed size=215.92 GB, score=None
EmbeddingOffloadScaleupProposer - proposed size=167.79 GB, score=59.158962621812364
EmbeddingOffloadScaleupProposer - proposed size=189.74 GB, score=58.77705761067111
EmbeddingOffloadScaleupProposer - proposed size=171.28 GB, score=59.10331765634908
EmbeddingOffloadScaleupProposer - proposed size=167.77 GB, score=59.158962621812364
EmbeddingOffloadScaleupProposer - proposed size=179.19 GB, score=58.95720474703581
EmbeddingOffloadScaleupProposer - proposed size=158.81 GB, score=59.28707837441257
EmbeddingOffloadScaleupProposer - proposed size=203.26 GB, score=58.561385218983325
EmbeddingOffloadScaleupProposer - proposed size=213.36 GB, score=58.42813341117671
```

Differential Revision: D54431752


