### PR TITLE
KJT skip pin_memory for dynamo

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -37,6 +37,14 @@ except Exception:
 
 
 def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+    if is_torchdynamo_compiling():
+        # TODO(ivankobzarev): Dynamo trace with pin_memory once FakeTensor supports it.
+        return (
+            tensor
+            if device.type == "cpu"
+            else tensor.to(device=device, non_blocking=True)
+        )
+
     return (
         tensor
         if device.type == "cpu"


### PR DESCRIPTION
Summary:
FakeTensor does not support pin_memory for now.
Skipping it in dynamo trace.

Differential Revision: D54555514


