### PR TITLE
Automatic Training Benchmark and World Size 8

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -683,7 +683,7 @@ def benchmark_module(
     compile_modes: List[CompileMode],
     tables: Union[List[EmbeddingBagConfig], List[EmbeddingConfig]],
     warmup_iters: int = 20,
-    bench_iters: int = 2000,
+    bench_iters: int = 500,
     prof_iters: int = 20,
     batch_size: int = 2048,
     world_size: int = 2,


### PR DESCRIPTION
Summary:
Introduce automatic torchrec training benchmark. This is a followup of automatic_qebc which is the torchrec inference benchmark. 

https://docs.google.com/document/d/1JxB45lFkzA0t29OuriG6AQdalLl2k7lS8AESfNtV07M/edit?usp=sharing shows how powerful this benchmark can be in detecting regressions, along with showing the massive difference with using world_size 8 versus 2 in regression detection.

Differential Revision: D54547431


