### PR TITLE
Fix CPU Unit Test CI on OSS

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -132,7 +132,7 @@ class TestPt2(unittest.TestCase):
 
             if test_pt2_ir_export:
                 pt2_ir = torch.export.export(EM, inputs, {}, strict=False)
-                pt2_ir_output = pt2_ir(*inputs)
+                pt2_ir_output = pt2_ir.module()(*inputs)
                 assert_close(eager_output, pt2_ir_output)
 
     def test_kjt_split(self) -> None:


### PR DESCRIPTION
Summary:
{F1467318350}

CPU Unit Test CI for OSS failing on call to PT2 ExportedProgram: https://github.com/pytorch/torchrec/actions/runs/8233905334/job/22514441384. OSS CI expects .module() instead of directly calling forward

Differential Revision: D54751106


