### PR TITLE
Limit search space to budgets reachable by scaleup.

### DIFF
--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -605,7 +605,7 @@ class TestProposers(unittest.TestCase):
         self.assertEqual(proposals, 16)
         self.assertNotEqual(initial_mem, best_plan, "couldn't find a better plan")
         # goal is 7.9, we get very close
-        self.assertEqual(best_plan, 7.960684550926089 * GB)
+        self.assertEqual(best_plan, 7.9028974287211895 * GB)
 
     def test_proposers_to_proposals_list(self) -> None:
         def make_mock_proposal(name: str) -> List[ShardingOption]:

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -199,6 +199,13 @@ class LuusJaakolaSearch:
         self.fright: Optional[float] = None
         self.d: float = self.right - self.left
 
+    def shrink_right(self, B: float) -> None:
+        "Shrink right boundary given [B,infinity) -> infinity"
+        self.right = B
+        self.fright = math.inf
+        self.d = self.right - self.left
+        self.x = self.clamp(self.x)
+
     def clamp(self, x: float) -> float:
         "Clamp x into range [left, right]"
         if x < self.left:


### PR DESCRIPTION
Summary:
When available scaleup budget is larger then the amount of memory to
promote all eligible scaleup tables to HBM, limit the search space to
this ceiling, else we'll consume some of our limited search iterations
exploring the same ceiling.

Reviewed By: henrylhtsang

Differential Revision: D54704900


