### PR TITLE
fix embedding dim for int8 output

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -602,9 +602,8 @@ class MetaInferGroupedEmbeddingsLookup(
             )
         )
         for i in range(len(self._emb_modules)):
-            embeddings.append(
-                self._emb_modules[i].forward(features_by_group[i]).view(-1)
-            )
+            # 2d embedding by nature
+            embeddings.append(self._emb_modules[i].forward(features_by_group[i]))
 
         return embeddings_cat_empty_rank_handle_inference(
             embeddings, device=self.device, dtype=self.output_dtype

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -673,11 +673,8 @@ class ShardedQuantEmbeddingCollection(
     ) -> List[List[torch.Tensor]]:
         ret: List[List[torch.Tensor]] = []
 
-        for lookup, features, sharding_type in zip(
-            self._lookups, dist_input, self._sharding_type_to_sharding.keys()
-        ):
-            embedding_dim = self._embedding_dim_for_sharding_type(sharding_type)
-            ret.append([o.view(-1, embedding_dim) for o in lookup.forward(features)])
+        for lookup, features in zip(self._lookups, dist_input):
+            ret.append(lookup.forward(features))
         return ret
 
     # pyre-ignore


### PR DESCRIPTION
Summary: * in trec, we introduced flattening and reshape operations while tensors shapes will be honored by tbe allocation directly.

Differential Revision: D54885770


