### PR TITLE
default _use_segment_sum_csr for dynamo

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -727,6 +727,10 @@ def _use_segment_sum_csr(stride_per_key: List[int]) -> bool:
     per segment that match performance between the kernel and PyTorch solution, to
     determine the threshold of when to use `segment_sum_csr`.
     """
+    if is_torchdynamo_compiling():
+        # dynamo symbolic shapes can not pass this condition without concrete stride values
+        return False
+
     elements_per_segment = sum(stride_per_key) / len(stride_per_key)
     segment_threshold = int(
         1.39771


### PR DESCRIPTION
Summary:
Constanting heuristic for dynamo for now.
Dynamo can not pass it without concrete values of the batch compile time.

Differential Revision: D54966335


