### PR TITLE
Use gpu_library_selector for permute_pooled_embedding_ops_gpu

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -35,20 +35,9 @@ try:
     torch.ops.load_library(
         "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_cpu"
     )
-    try:
-        if torch.version.hip:
-            torch.ops.load_library(
-                "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu_hip"
-            )
-        else:
-            torch.ops.load_library(
-                "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu_cuda"
-            )
-    except OSError:
-        # For backward compatibility
-        torch.ops.load_library(
-            "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
-        )
+    torch.ops.load_library(
+        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
+    )
 except OSError:
     pass
 


### PR DESCRIPTION
Summary: Using gpu_library_selector can avoid divergence in the usercode

Differential Revision: D54986292


