### PR TITLE
Remove get_tbe_specs_from_sqebc import from __init__.py

### DIFF
--- a/torchrec/distributed/__init__.py
+++ b/torchrec/distributed/__init__.py
@@ -35,7 +35,6 @@ These include:
 """
 
 from torchrec.distributed.comm import get_local_rank, get_local_size  # noqa
-from torchrec.distributed.infer_utils import get_tbe_specs_from_sqebc  # noqa
 from torchrec.distributed.model_parallel import DistributedModelParallel  # noqa
 from torchrec.distributed.train_pipeline import (  # noqa
     DataLoadingThread,


### PR DESCRIPTION
Summary: The import in `torchrec/distributed/__init__.py` was added in D54486851 , but it caused HPC server to crash with SIGSEGV during shutdown in our unit test, potentially caused by circular dependency.

Reviewed By: s4ayub

Differential Revision: D54990905


