### PR TITLE
fx wrap entrypoint of EmbeddingBagCollection

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -230,6 +230,13 @@ def _update_embedding_configs(
         )
 
 
+@torch.fx.wrap
+def features_to_dict(
+    features: KeyedJaggedTensor,
+) -> Dict[str, JaggedTensor]:
+    return features.to_dict()
+
+
 class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin):
     """
     EmbeddingBagCollection represents a collection of pooled embeddings (EmbeddingBags).
@@ -452,7 +459,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
             KeyedTensor
         """
 
-        feature_dict = features.to_dict()
+        feature_dict = features_to_dict(features)
         embeddings = []
 
         # TODO ideally we can accept KJTs with any feature order. However, this will require an order check + permute, which will break torch.script.


### PR DESCRIPTION
Summary: We want to tag the part before tbe in ebc to INPUT_DIST net, in order to make the graph structure after splitting similar to sharded ebc. Using fx wrap to tag the entrypoint of ebc and we will use this in the splitting tag rules.

Reviewed By: 842974287

Differential Revision: D55023624


