### PR TITLE
Make sure unweighted emb lookup executes before fp emb lookup

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -291,6 +291,9 @@ def group_tables(
             if grouping_key not in groups:
                 grouping_keys.append(grouping_key)
             groups[grouping_key].append(table)
+        grouping_keys.sort(
+            key=lambda x: x[2]
+        )  # put tables without feature processor in the front
 
         for grouping_key in grouping_keys:
             (


### PR DESCRIPTION
Summary: Sort group keys in embedding_sharding so keys(lookups) with has_feature_processor=True executes first.

Differential Revision: D55045404


