### PR TITLE
Not dynamo trace through conditions

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -1009,7 +1009,11 @@ def reduce_scatter_v_pooled(
         [ip_split if d == 0 else input_size[d] for d in range(len(input_size))]
         for ip_split in input_splits
     ]
-    equal_splits = all(ip_split == input_splits[0] for ip_split in input_splits)
+
+    equal_splits = False
+    if not torch.compiler.is_dynamo_compiling():
+        # We can not check during tracing equality of splits -> fallback on general
+        equal_splits = all(ip_split == input_splits[0] for ip_split in input_splits)
 
     rsvi = ReduceScatterVInfo(
         input_sizes=input_sizes,


### PR DESCRIPTION
Summary:
Eager behavior of those changes should not change.

For dynamo tracing is hard to pass through conditions on shapes and checks like all batch_size == s.

Simplifying those checks for dynamo:

 - fallback to variable batch size in jagged tensor
 - comm_op use reduce_scatter_v for dynamo if we can not check that the splits are all equal.

Differential Revision: D55132251


