### PR TITLE
migrate to FBGEMM version of Permute Pooled Embs module

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -25,6 +25,7 @@ from typing import (
 )
 
 import torch
+from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
 from torch import nn, Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
@@ -66,7 +67,6 @@ from torchrec.distributed.utils import (
     convert_to_fbgemm_types,
     merge_fused_params,
     optimizer_type_to_emb_opt_type,
-    PermutePooledEmbeddings,
 )
 from torchrec.modules.embedding_configs import (
     EmbeddingBagConfig,

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -11,7 +11,6 @@ import copy
 import logging
 
 from collections import OrderedDict
-from itertools import accumulate
 from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
 
 import torch
@@ -30,22 +29,6 @@ from torchrec.types import CopyMixIn
 
 logger: logging.Logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
-
-try:
-    torch.ops.load_library(
-        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_cpu"
-    )
-    torch.ops.load_library(
-        "//deeplearning/fbgemm/fbgemm_gpu:permute_pooled_embedding_ops_gpu"
-    )
-except OSError:
-    pass
-
-# OSS
-try:
-    pass
-except ImportError:
-    pass
 
 """
 torch.package safe functions from pyre_extensions. However, pyre_extensions is
@@ -456,45 +439,3 @@ def init_parameters(module: nn.Module, device: torch.device) -> None:
                     m.reset_parameters()
 
             module.apply(maybe_reset_parameters)
-
-
-# TODO remove and use FBGEMM version once changes are in the package
-class PermutePooledEmbeddings:
-    def __init__(
-        self,
-        embs_dims: List[int],
-        permute: List[int],
-        device: Optional[torch.device] = None,
-    ) -> None:
-        logging.info("Using Permute Pooled Embeddings")
-        self._offset_dim_list: torch.Tensor = torch.tensor(
-            [0] + list(accumulate(embs_dims)), device=device, dtype=torch.int64
-        )
-
-        self._permute: torch.Tensor = torch.tensor(
-            permute, device=device, dtype=torch.int64
-        )
-
-        inv_permute: List[int] = [0] * len(permute)
-        for i, p in enumerate(permute):
-            inv_permute[p] = i
-
-        self._inv_permute: torch.Tensor = torch.tensor(
-            inv_permute, device=device, dtype=torch.int64
-        )
-
-        inv_embs_dims = [embs_dims[i] for i in permute]
-
-        self._inv_offset_dim_list: torch.Tensor = torch.tensor(
-            [0] + list(accumulate(inv_embs_dims)), device=device, dtype=torch.int64
-        )
-
-    def __call__(self, pooled_embs: torch.Tensor) -> torch.Tensor:
-        result = torch.ops.fbgemm.permute_pooled_embs_auto_grad(
-            pooled_embs,
-            self._offset_dim_list.to(device=pooled_embs.device),
-            self._permute.to(device=pooled_embs.device),
-            self._inv_offset_dim_list.to(device=pooled_embs.device),
-            self._inv_permute.to(device=pooled_embs.device),
-        )
-        return result


### PR DESCRIPTION
Summary:
migrate to use fbgemm directory version, as it is in pkg already
removes logging for traceability purposes later

Differential Revision: D55154971


