### PR TITLE
Benchmark subprocess sleep for multiprocessing queue fix

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -16,6 +16,7 @@ import gc
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 
 from enum import Enum
@@ -686,6 +687,9 @@ def init_module_and_run_benchmark(
 
         if queue is not None:
             queue.put(res)
+
+            while not queue.empty():
+                time.sleep(1)
 
     return res
 


### PR DESCRIPTION
Summary: This is extremely hacky, but it works. Without the time.sleep, the subprocesses will exit before the main process reads everything from the queue, causing FileNotFoundError with multiprocessing. This is flaky with smaller world sizes but seems to reproduce everytime with world size 8

Differential Revision: D55142200


