### PR TITLE
Fix the runtime error in lowering

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -121,12 +121,15 @@ def embeddings_cat_empty_rank_handle(
 def embeddings_cat_empty_rank_handle_inference(
     embeddings: List[torch.Tensor],
     dim: int = 0,
-    device: Optional[torch.device] = None,
+    device: Optional[str] = None,
     dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     if len(embeddings) == 0:
         # return a dummy empty tensor when grouped_configs is empty
-        return torch.empty([0], dtype=dtype, device=device)
+        dev: Optional[torch.device] = (
+            torch.device(device) if device is not None else None
+        )
+        return torch.empty([0], dtype=dtype, device=dev)
     elif len(embeddings) == 1:
         return embeddings[0]
     else:
@@ -582,7 +585,7 @@ class MetaInferGroupedEmbeddingsLookup(
         ]
 
         self.grouped_configs = grouped_configs
-        self.device: Optional[torch.device] = device
+        self.device: Optional[str] = str(device) if device is not None else None
         self.output_dtype: torch.dtype = (
             fused_params["output_dtype"].as_dtype()
             if fused_params and "output_dtype" in fused_params
@@ -711,7 +714,7 @@ class MetaInferGroupedPooledEmbeddingsLookup(
 
         self.grouped_configs = grouped_configs
         self._feature_processor = feature_processor
-        self.device: Optional[torch.device] = device
+        self.device: Optional[str] = str(device) if device is not None else None
         self.output_dtype: torch.dtype = (
             fused_params["output_dtype"].as_dtype()
             if fused_params and "output_dtype" in fused_params


### PR DESCRIPTION
Summary:
We saw a runtime error during lowering:
```
embeddings_cat_empty_rank_handle_inference = _torch_package_1_torchrec_distributed_embedding_lookup_embeddings_cat_empty_rank_handle_inference([getitem_6], dim = 1, device = device(type='meta', index=0), dtype = torch.float32);  getitem_6 = None
                                                                                                                                                                                  ~~~~~~ <--- HERE
    embeddings_cat_empty_rank_handle_inference_1 = _torch_package_1_torchrec_distributed_embedding_lookup_embeddings_cat_empty_rank_handle_inference([getitem_5], dim = 1, device = device(type='meta', index=1), dtype = torch.float32);  getitem_5 = None
    offsets = keyed_jagged_tensor.offsets()
RuntimeError: isString() INTERNAL ASSERT FAILED at "buck-out/v2/gen/fbcode/fb8f97d711df971f/caffe2/__ATen-core-headers__/buck-headers/ATen/core/ivalue_inl.h":2362, please report a bug to PyTorch. Expected String but got Int
```
The error looks like the graph module failed to inherit the type and construct the `device` correctly.

This diff fixed the issue.

Differential Revision: D55218723


