### PR TITLE
Add index_per_key() accessor in KeyedJaggedTensor class

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1678,6 +1678,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             self._lengths_offset_per_key = _cumsum(self.stride_per_key())
         return self._lengths_offset_per_key
 
+    def index_per_key(self) -> Dict[str, int]:
+        return self._key_indices()
+
     def split(self, segments: List[int]) -> List["KeyedJaggedTensor"]:
         split_list: List[KeyedJaggedTensor] = []
         start = 0


### PR DESCRIPTION
Summary:
As title. We need to access this field.
Split this one out from the UserEmbeddingCache diff to make it easier for github PR since this file is open sourced.

Differential Revision: D54658774


