### PR TITLE
If output_dtype is passed in fused_params, use it in planner

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -34,6 +34,7 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingType,
 )
+from torchrec.modules.embedding_configs import DataType
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
 
 
@@ -128,6 +129,7 @@ class EmbeddingEnumerator(Enumerator):
                     stochastic_rounding,
                     bounds_check_mode,
                     feature_names,
+                    output_dtype,
                 ) = _extract_constraints_for_param(self._constraints, name)
 
                 sharding_options_per_table: List[ShardingOption] = []
@@ -177,6 +179,7 @@ class EmbeddingEnumerator(Enumerator):
                                 dependency=dependency,
                                 is_pooled=is_pooled,
                                 feature_names=feature_names,
+                                output_dtype=output_dtype,
                             )
                         )
                 if not sharding_options_per_table:
@@ -274,6 +277,7 @@ def _extract_constraints_for_param(
     Optional[bool],
     Optional[BoundsCheckMode],
     Optional[List[str]],
+    Optional[DataType],
 ]:
     input_lengths = [POOLING_FACTOR]
     col_wise_shard_dim = None
@@ -282,6 +286,7 @@ def _extract_constraints_for_param(
     stochastic_rounding = None
     bounds_check_mode = None
     feature_names = None
+    output_dtype = None
 
     if constraints and constraints.get(name):
         input_lengths = constraints[name].pooling_factors
@@ -291,6 +296,7 @@ def _extract_constraints_for_param(
         stochastic_rounding = constraints[name].stochastic_rounding
         bounds_check_mode = constraints[name].bounds_check_mode
         feature_names = constraints[name].feature_names
+        output_dtype = constraints[name].output_dtype
 
     return (
         input_lengths,
@@ -300,6 +306,7 @@ def _extract_constraints_for_param(
         stochastic_rounding,
         bounds_check_mode,
         feature_names,
+        output_dtype,
     )
 
 

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -101,6 +101,7 @@ def _to_sharding_plan(
             enforce_hbm=sharding_option.enforce_hbm,
             stochastic_rounding=sharding_option.stochastic_rounding,
             bounds_check_mode=sharding_option.bounds_check_mode,
+            output_dtype=sharding_option.output_dtype,
         )
         plan[sharding_option.path] = module_plan
     return ShardingPlan(plan)

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -42,6 +42,7 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingType,
 )
+from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
 
 from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
 
@@ -159,6 +160,15 @@ class EmbeddingPerfEstimator(ShardEstimator):
                     else False
                 )
 
+            # hardcoded as 8 bytes
+            # input indices can be of int32, but in TBE they get converted to int64 anyway
+            input_data_type_size = BIGINT_DTYPE
+            output_data_type_size: float = (
+                DATA_TYPE_NUM_BITS[sharding_option.output_dtype] / 8
+                if sharding_option.output_dtype
+                else sharding_option.tensor.element_size()
+            )
+
             expected_cache_fetches = 0
             if (
                 caching_ratio is not None
@@ -185,8 +195,9 @@ class EmbeddingPerfEstimator(ShardEstimator):
                 world_size=self._topology.world_size,
                 local_world_size=self._topology.local_world_size,
                 input_lengths=sharding_option.input_lengths,
-                input_data_type_size=BIGINT_DTYPE,
+                input_data_type_size=input_data_type_size,
                 table_data_type_size=table_data_type_size,
+                output_data_type_size=output_data_type_size,
                 fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
                 bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
                 fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
@@ -221,6 +232,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         input_lengths: List[float],
         input_data_type_size: float,
         table_data_type_size: float,
+        output_data_type_size: float,
         fwd_a2a_comm_data_type_size: float,
         bwd_a2a_comm_data_type_size: float,
         fwd_sr_comm_data_type_size: float,
@@ -255,6 +267,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
             input_data_type_size (float): the data type size of the distributed
                 data_parallel input.
             table_data_type_size (float): the data type size of the table.
+            output_data_type_size (float): the data type size of the output embeddings.
             fwd_comm_data_type_size (float): the data type size of the distributed
                 data_parallel input during forward communication.
             bwd_comm_data_type_size (float): the data type size of the distributed
@@ -306,6 +319,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
                     emb_dim=emb_dim,
                     input_data_type_size=input_data_type_size,
                     table_data_type_size=table_data_type_size,
+                    output_data_type_size=output_data_type_size,
                     fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
                     bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
                     num_poolings=num_poolings,
@@ -328,6 +342,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
                     emb_dim=emb_dim,
                     input_data_type_size=input_data_type_size,
                     table_data_type_size=table_data_type_size,
+                    output_data_type_size=output_data_type_size,
                     fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
                     bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
                     fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
@@ -351,6 +366,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
                     emb_dim=emb_dim,
                     input_data_type_size=input_data_type_size,
                     table_data_type_size=table_data_type_size,
+                    output_data_type_size=output_data_type_size,
                     fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
                     bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
                     fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
@@ -375,6 +391,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
                     emb_dim=emb_dim,
                     input_data_type_size=input_data_type_size,
                     table_data_type_size=table_data_type_size,
+                    output_data_type_size=output_data_type_size,
                     num_poolings=num_poolings,
                     device_bw=device_bw,
                     inter_host_bw=inter_host_bw,
@@ -412,6 +429,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         emb_dim: int,
         input_data_type_size: float,
         table_data_type_size: float,
+        output_data_type_size: float,
         fwd_a2a_comm_data_type_size: float,
         bwd_a2a_comm_data_type_size: float,
         num_poolings: List[float],
@@ -505,6 +523,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         emb_dim: int,
         input_data_type_size: float,
         table_data_type_size: float,
+        output_data_type_size: float,
         fwd_a2a_comm_data_type_size: float,
         bwd_a2a_comm_data_type_size: float,
         fwd_sr_comm_data_type_size: float,
@@ -593,6 +612,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         emb_dim: int,
         input_data_type_size: float,
         table_data_type_size: float,
+        output_data_type_size: float,
         fwd_a2a_comm_data_type_size: float,
         bwd_a2a_comm_data_type_size: float,
         fwd_sr_comm_data_type_size: float,
@@ -689,6 +709,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         emb_dim: int,
         input_data_type_size: float,
         table_data_type_size: float,
+        output_data_type_size: float,
         num_poolings: List[float],
         device_bw: float,
         inter_host_bw: float,
@@ -859,6 +880,16 @@ class EmbeddingStorageEstimator(ShardEstimator):
                 else [sharding_option.batch_size] * sharding_option.num_inputs
             )
 
+            # hardcoded as 8 bytes
+            # input indices can be of int32, but in TBE they get converted to int64 anyway
+            input_data_type_size = BIGINT_DTYPE
+
+            output_data_type_size: float = (
+                DATA_TYPE_NUM_BITS[sharding_option.output_dtype] / 8
+                if sharding_option.output_dtype
+                else sharding_option.tensor.element_size()
+            )
+
             shard_storages = calculate_shard_storages(
                 sharder=sharder,
                 sharding_type=sharding_option.sharding_type,
@@ -873,6 +904,8 @@ class EmbeddingStorageEstimator(ShardEstimator):
                 num_poolings=num_poolings,
                 caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
                 is_pooled=sharding_option.is_pooled,
+                input_data_type_size=input_data_type_size,
+                output_data_type_size=output_data_type_size,
             )
 
             for shard, storage in zip(sharding_option.shards, shard_storages):
@@ -893,6 +926,8 @@ def calculate_shard_storages(
     num_poolings: List[float],
     caching_ratio: float,
     is_pooled: bool,
+    input_data_type_size: float,
+    output_data_type_size: float,
 ) -> List[Storage]:
     """
     Calculates estimated storage sizes for each sharded tensor, comprised of input,
@@ -915,14 +950,12 @@ def calculate_shard_storages(
         caching_ratio (float): ratio of HBM to DDR memory for UVM caching.
         is_pooled (bool): True if embedding output is pooled (ie. `EmbeddingBag`), False
             if unpooled/sequential (ie. `Embedding`).
+        input_data_type_size (int): number of bytes of input data type.
+        output_data_type_size (int): number of bytes of output data type.
 
     Returns:
         List[Storage]: storage object for each device in topology.
     """
-
-    input_data_type_size = BIGINT_DTYPE
-    output_data_type_size = tensor.element_size()
-
     input_sizes, output_sizes = _calculate_shard_io_sizes(
         sharding_type=sharding_type,
         batch_sizes=batch_sizes,
@@ -1002,8 +1035,8 @@ def _calculate_shard_io_sizes(
     input_lengths: List[float],
     emb_dim: int,
     shard_sizes: List[List[int]],
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
@@ -1077,8 +1110,8 @@ def _calculate_dp_shard_io_sizes(
     input_lengths: List[float],
     emb_dim: int,
     num_shards: int,
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
@@ -1104,8 +1137,8 @@ def _calculate_tw_shard_io_sizes(
     world_size: int,
     input_lengths: List[float],
     emb_dim: int,
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
@@ -1131,8 +1164,8 @@ def _calculate_cw_shard_io_sizes(
     world_size: int,
     input_lengths: List[float],
     shard_sizes: List[List[int]],
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
@@ -1163,8 +1196,8 @@ def _calculate_rw_shard_io_sizes(
     world_size: int,
     input_lengths: List[float],
     shard_sizes: List[List[int]],
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
@@ -1206,8 +1239,8 @@ def _calculate_twrw_shard_io_sizes(
     local_world_size: int,
     input_lengths: List[float],
     shard_sizes: List[List[int]],
-    input_data_type_size: int,
-    output_data_type_size: int,
+    input_data_type_size: float,
+    output_data_type_size: float,
     num_poolings: List[float],
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -32,6 +32,7 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingPlan,
 )
+from torchrec.modules.embedding_configs import DataType
 from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
 
@@ -291,6 +292,7 @@ class ShardingOption:
         dependency: Optional[str] = None,
         is_pooled: Optional[bool] = None,
         feature_names: Optional[List[str]] = None,
+        output_dtype: Optional[DataType] = None,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -311,6 +313,7 @@ class ShardingOption:
         self._is_pooled = is_pooled
         self.is_weighted: Optional[bool] = None
         self.feature_names: Optional[List[str]] = feature_names
+        self.output_dtype: Optional[DataType] = output_dtype
 
     @property
     def tensor(self) -> torch.Tensor:
@@ -441,6 +444,7 @@ class ParameterConstraints:
     stochastic_rounding: Optional[bool] = None
     bounds_check_mode: Optional[BoundsCheckMode] = None
     feature_names: Optional[List[str]] = None
+    output_dtype: Optional[DataType] = None
 
 
 class PlannerErrorType(Enum):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -511,6 +511,7 @@ class ParameterSharding:
         enforce_hbm (Optional[bool]): whether to use HBM.
         stochastic_rounding (Optional[bool]): whether to use stochastic rounding.
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
+        output_dtype (Optional[DataType]): output dtype.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -529,6 +530,7 @@ class ParameterSharding:
     enforce_hbm: Optional[bool] = None
     stochastic_rounding: Optional[bool] = None
     bounds_check_mode: Optional[BoundsCheckMode] = None
+    output_dtype: Optional[DataType] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -390,6 +390,9 @@ def add_params_from_parameter_sharding(
     if parameter_sharding.bounds_check_mode is not None:
         fused_params["bounds_check_mode"] = parameter_sharding.bounds_check_mode
 
+    if parameter_sharding.output_dtype is not None:
+        fused_params["output_dtype"] = parameter_sharding.output_dtype
+
     # print warning if sharding_type is data_parallel or kernel is dense
     if parameter_sharding.sharding_type == ShardingType.DATA_PARALLEL.value:
         logger.warning(


### PR DESCRIPTION
Summary:
Allow passing output_dtype through ParameterConstraints.

The params passed in ParameterConstraints always override the params passed through sharder.fused_params.

Currently, this is only used for storage estimation.

We also add the path in perf estimation. Reasoning is that right now perf estimators don't differentiate read and write. In a subsequent diff, we will explore updating perf estimates with this new info.

Reviewed By: damianr99

Differential Revision: D54399193


