### PR TITLE
add bag reverse mapping for block_bucketize kernel

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -141,6 +141,7 @@ def bucketize_kjt_before_all2all(
         bucketized_weights,
         pos,
         unbucketize_permute,
+        _,
     ) = torch.ops.fbgemm.block_bucketize_sparse_features(
         kjt.lengths().view(-1),
         kjt.values(),


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2477

* we add the per indices bucketize bag reverse index return for inference batching needs.

Differential Revision: D55492793


