### PR TITLE
Introduce Serializer in TorchRec for torch.export PEA

### DIFF
--- a/torchrec/ir/types.py
+++ b/torchrec/ir/types.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import abc
+from typing import Any
+
+from torch import nn
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+
+class SerializerInterface(abc.ABC):
+    """
+    Interface for Serializer classes for torch.export IR.
+    """
+
+    @classmethod
+    @property
+    def module_to_serializer_cls(cls):
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def serialize(
+        cls,
+        module: nn.Module,
+    ) -> Any:
+        # Take the eager embedding module and generate bytes in buffer
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def deserialize(cls, input: Any) -> nn.Module:
+        # Take the bytes in the buffer and regenerate the eager embedding module
+        pass
+
+
+class EBCJsonSerializer(SerializerInterface):
+    @classmethod
+    def serialize(
+        cls,
+        module: nn.Module,
+    ) -> str:
+        # TODO: Add support for EBC with dataclass
+        pass
+
+    @classmethod
+    def deserialize(cls, input: str) -> nn.Module:
+        # TODO: Add support for EBC with dataclass
+        pass
+
+
+class JsonSerializer(SerializerInterface):
+    module_to_serializer_cls = {
+        EmbeddingBagCollection: EBCJsonSerializer,
+    }
+
+    @classmethod
+    def serialize(
+        cls,
+        module: nn.Module,
+    ) -> str:
+        # TODO: Add support for dataclass
+        pass
+
+    @classmethod
+    def deserialize(cls, input: str) -> nn.Module:
+        # TODO: Add support for dataclass
+        pass

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+from typing import Type
+
+from torch import nn
+from torchrec.ir.types import JsonSerializer, SerializerInterface
+
+
+DEFAULT_SERIALIZER_CLS = JsonSerializer
+
+
+def serialize_embedding_modules(
+    model: nn.Module,
+    serializer_cls: Type[SerializerInterface] = DEFAULT_SERIALIZER_CLS,
+) -> nn.Module:
+    for _, module in model.named_modules():
+        if type(module) in serializer_cls.module_to_serializer_cls:
+            serialized_module = serializer_cls.serialize(module)
+            module.register_buffer("ir_metadata", serialized_module, persistent=False)
+
+    return model
+
+
+def deserialize_embedding_modules(
+    model: nn.Module,
+    serializer_cls: Type[SerializerInterface] = DEFAULT_SERIALIZER_CLS,
+) -> nn.Module:
+    fqn_to_new_module = {}
+    for name, module in model.named_modules():
+        if "ir_metadata" in dict(module.named_buffers()):
+            serialized_module = dict(module.named_buffers())["ir_metadata"]
+            deserialized_module = serializer_cls.deserialize(serialized_module)
+            fqn_to_new_module[name] = deserialized_module
+
+    for fqn, new_module in fqn_to_new_module.items():
+        setattr(model, fqn, new_module)
+
+    return model


### PR DESCRIPTION
Summary: Adding a serializer class to support thrift serialization of PEA configs for regenerating the eager module after torch.export through saving the metadata as a bytes buffer in the module.

Differential Revision: D55661704


