### PR TITLE
KJT permute torch export support

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -163,6 +163,7 @@ class TestPt2(unittest.TestCase):
             kjt.keys(),
             (kjt._values, kjt._lengths, indices),
             test_aot_inductor=False,
+            test_pt2_ir_export=True,
         )
 
     def test_kjt_length_per_key(self) -> None:


### PR DESCRIPTION
Summary: Support non-strict torch export for KJT permute method used by Sharded TorchRec Modules

Differential Revision: D55040353


