### PR TITLE
Embedding grouper will group by local instead of global dimension

### DIFF
--- a/torchrec/distributed/embedding_dim_bucketer.py
+++ b/torchrec/distributed/embedding_dim_bucketer.py
@@ -104,7 +104,7 @@ class EmbDimBucketer:
         bucket_id = 0
 
         for table in embedding_tables:
-            dim_in_bytes = self.dim_in_bytes(table.embedding_dim, table.data_type)
+            dim_in_bytes = self.dim_in_bytes(table.local_cols, table.data_type)
             buckets[dim_in_bytes] = bucket_id
 
         self.num_buckets = 1
@@ -119,7 +119,7 @@ class EmbDimBucketer:
         bucket_id = -1
 
         for table in embedding_tables:
-            dim_in_bytes = self.dim_in_bytes(table.embedding_dim, table.data_type)
+            dim_in_bytes = self.dim_in_bytes(table.local_cols, table.data_type)
             if dim_in_bytes not in buckets.keys():
                 bucket_id += 1
                 buckets[dim_in_bytes] = bucket_id
@@ -137,7 +137,7 @@ class EmbDimBucketer:
         bucket_id = -1
 
         for table in embedding_tables:
-            dim_in_bytes = self.dim_in_bytes(table.embedding_dim, table.data_type)
+            dim_in_bytes = self.dim_in_bytes(table.local_cols, table.data_type)
             cl_dim = dim_in_bytes // self.cacheline
             if cl_dim not in cl_buckets.keys():
                 bucket_id += 1

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -285,7 +285,7 @@ def group_tables(
                 table.has_feature_processor,
                 tuple(sorted(group_fused_params.items())),
                 _get_compute_kernel_type(table.compute_kernel),
-                emb_dim_bucketer.get_bucket(table.embedding_dim, table.data_type),
+                emb_dim_bucketer.get_bucket(table.local_cols, table.data_type),
             )
             # micromanage the order of we traverse the groups to ensure backwards compatibility
             if grouping_key not in groups:

--- a/torchrec/distributed/tests/test_emb_dim_bucketer.py
+++ b/torchrec/distributed/tests/test_emb_dim_bucketer.py
@@ -36,11 +36,15 @@ class TestEmbDimBucketer(unittest.TestCase):
         buckets = random.sample(range(1024), num_buckets)
 
         for i in range(num_tables):
+            local_cols = buckets[i % num_buckets]
+            local_rows = random.randint(100, 500000)
             embeddings.append(
                 ShardedEmbeddingTable(
                     name=f"table_{i}",
-                    embedding_dim=buckets[i % num_buckets],
-                    num_embeddings=random.randint(100, 500000),
+                    local_cols=local_cols,
+                    local_rows=local_rows,
+                    embedding_dim=local_cols * random.randint(1, 20),
+                    num_embeddings=local_rows * random.randint(1, 20),
                     data_type=DataType.FP16,
                     compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING,
                 )
@@ -51,11 +55,15 @@ class TestEmbDimBucketer(unittest.TestCase):
         num_tables = 47
         embeddings: List[ShardedEmbeddingTable] = []
         for i in range(num_tables):
+            local_cols = 16
+            local_rows = random.randint(100, 500000)
             embeddings.append(
                 ShardedEmbeddingTable(
                     name=f"table_{i}",
-                    embedding_dim=16,
-                    num_embeddings=random.randint(100, 500000),
+                    local_cols=local_cols,
+                    local_rows=local_rows,
+                    embedding_dim=local_cols * random.randint(1, 20),
+                    num_embeddings=local_rows * random.randint(1, 20),
                     data_type=DataType.FP16,
                 )
             )


### PR DESCRIPTION
Summary:
## Context
In TorchRec sharder, embedding tables (EmbeddingBag, VBE, or other form) will all eventually get fused and grouped into some TableBatchedEmbedding, which is the only entrance for table local lookup within GPU.

Within each TBE, all offloaded embeddings with HBM cache (location=UVM_CACHING) will maintain a monolith space in GPU for cache purposes. For simplicity, this space is determined by the widest table (with max dimension). Therefore, if two tables with very different dimensions are grouped together, it may waste lots of HBM.

In practice, we only group tables with very similar dimension together for memory efficiency.

## Problem to Solve
The grouping algorithm is buggy, and will group by pre-sharded dimension. This is wrong as the actual TBE decides the cache space by "actual hosted dimension", which is post-sharded dimension (aka local dimension).

This diff fixed it.

Differential Revision: D55171232


