### PR TITLE
Embedding grouper distinguish between prefetched vs non-prefetched table

### DIFF
--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -23,6 +23,7 @@ from torchrec.distributed.embedding_sharding import (
     _get_compute_kernel_type,
     _get_grouping_fused_params,
     _get_weighted_avg_cache_load_factor,
+    _use_hbm_as_cache,
     group_tables,
 )
 
@@ -394,18 +395,24 @@ class TestGroupTablesPerRank(unittest.TestCase):
         if distinct_key == "compute_kernel" and _get_compute_kernel_type(
             compute_kernels[0]
         ) == _get_compute_kernel_type(compute_kernels[1]):
-            self.assertEqual(
-                _get_table_names_by_groups(tables),
-                [["table_0", "table_1"]],
-            )
+            # Typically, a table with same group of kernel (e.g. FUSED vs FUSED_UVM)
+            # would be grouped together. But if one of them are related to CACHE,
+            # we'll group them separately because we don't want to add the burden of
+            # prefetch()
+            if _use_hbm_as_cache(tables[0]) != _use_hbm_as_cache(tables[1]):
+                self.assertEqual(
+                    sorted(_get_table_names_by_groups(tables)),
+                    [["table_0"], ["table_1"]],
+                )
+            else:
+                self.assertEqual(
+                    _get_table_names_by_groups(tables),
+                    [["table_0", "table_1"]],
+                )
             return
 
-        # emb dim bucketizier only in use when computer kernel is uvm caching
-        # and prefetch pipeline is True
-        if (
-            distinct_key == "local_dim"
-            and compute_kernels[0] != EmbeddingComputeKernel.FUSED_UVM_CACHING
-        ):
+        # emb dim bucketizier only in use when computer kernel is caching
+        if distinct_key == "local_dim" and _use_hbm_as_cache(tables[0]):
             self.assertEqual(
                 _get_table_names_by_groups(tables),
                 [["table_0", "table_1"]],


### PR DESCRIPTION
Summary:
If `prefetch_pipeline` is as fused parameter, training pipeline will try to call `prefetch()` in a separate stream one batch ahead of time. This process, is unfortunately consuming lots of extra memory. Practically it consumes 8~9x the size of input tensor at peak.

Therefore, we wish to minimize the input tensor size to `prefetch()` call as much as possible. To achieve that, we don't want to mix tables that require prefetch and doesn't to be grouped to the same TBE.

This diff will not change behavior for any jobs without cached embedding offloading.

For embedding-offloaded jobs, this diff will slightly decrease the performance of TBE lookup as it result in more TBEs (and subsequently more kernels in forward and backward). but greatly increase the memory efficiency.

Differential Revision: D55901328


