### PR TITLE
Prototype for uneven sharding autoplanner support

### DIFF
--- a/torchrec/distributed/planner/__init__.py
+++ b/torchrec/distributed/planner/__init__.py
@@ -21,6 +21,9 @@ The features includes:
     - automatically building and selecting an optimized sharding plan.
 """
 
-from torchrec.distributed.planner.planners import EmbeddingShardingPlanner  # noqa
+from torchrec.distributed.planner.planners import (  # noqa
+    EmbeddingShardingPlanner,
+    HeteroEmbeddingShardingPlanner,  # noqa
+)
 from torchrec.distributed.planner.types import ParameterConstraints, Topology  # noqa
 from torchrec.distributed.planner.utils import bytes_to_gb, sharder_name  # noqa

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -453,7 +453,9 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             }
         self._topology_groups: Dict[str, Topology] = topology_groups
         self._batch_size: int = batch_size if batch_size else BATCH_SIZE
-        self._constraints = constraints
+        self._constraints: Dict[str, ParameterConstraints] = (
+            constraints if constraints else {}
+        )
         # pyre-ignore
         self._enumerators: Dict[str, Enumerator] = (
             enumerators
@@ -584,17 +586,27 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
                 sharders=sharders,
             )
 
+            # If no device_group is assigned in the constraints, use the current device group
+            # TODO: Create a util function to assign device_group according to empirical rules to cuda or cpu
+            for sharding_option in search_space:
+                if sharding_option.name not in self._constraints:
+                    self._constraints[sharding_option.name] = ParameterConstraints(
+                        device_group=group
+                    )
+                elif not self._constraints[sharding_option.name].device_group:
+                    self._constraints[sharding_option.name].device_group = group
+
             # filter by device group
             search_space = [
-                s_o
-                for s_o in search_space
-                # pyre-ignore [16]
-                if self._constraints[s_o.name].device_group == group
+                sharding_option
+                for sharding_option in search_space
+                if self._constraints[sharding_option.name].device_group == group
             ]
 
             if not search_space:
                 # No shardable parameters
-                return ShardingPlan({})
+                best_plans.append(ShardingPlan({}))
+                continue
 
             proposal_cache: Dict[
                 Tuple[int, ...],

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -141,6 +141,34 @@ class DeviceHardware:
     perf: Perf
 
 
+class CustomTopologyData:
+    """
+    Custom device data for individual device in a topology.
+    """
+
+    supported_fields = ["ddr_cap", "hbm_cap"]
+
+    def __init__(
+        self,
+        data: Dict[str, List[int]],
+        world_size: int,
+    ) -> None:
+        assert all(
+            key in self.supported_fields for key in data.keys()
+        ), f"{data.keys()} not supported in CustomTopologyData"
+        assert all(
+            len(v) == world_size for v in data.values()
+        ), f"{data.values()} must be positive"
+        self._data = data
+        self._world_size = world_size
+
+    def get_data(self, key: str) -> List[int]:
+        assert (
+            key in self.supported_fields
+        ), f"{key} not supported in CustomTopologyData"
+        return self._data[key]
+
+
 class Topology:
     def __init__(
         self,
@@ -154,6 +182,7 @@ class Topology:
         intra_host_bw: float = INTRA_NODE_BANDWIDTH,
         inter_host_bw: float = CROSS_NODE_BANDWIDTH,
         bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER,
+        custom_topology_data: Optional[CustomTopologyData] = None,
     ) -> None:
         """
         Representation of a network of devices in a cluster.

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -168,6 +168,9 @@ class CustomTopologyData:
         ), f"{key} not supported in CustomTopologyData"
         return self._data[key]
 
+    def has_data(self, key: str) -> bool:
+        return key in self._data
+
 
 class Topology:
     def __init__(
@@ -220,6 +223,7 @@ class Topology:
         self._intra_host_bw = intra_host_bw
         self._inter_host_bw = inter_host_bw
         self._bwd_compute_multiplier = bwd_compute_multiplier
+        self._custom_topology_data = custom_topology_data
 
     @property
     def compute_device(self) -> str:

--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import Callable, Dict, List, Optional, Type, Union
+from typing import Callable, cast, Dict, List, Optional, Type, Union
 
 import torch
 import torch.distributed as dist
@@ -15,7 +15,11 @@ from torch import nn
 from torch.distributed._composable.contract import contract
 from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.model_parallel import get_default_sharders
-from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner import (
+    EmbeddingShardingPlanner,
+    HeteroEmbeddingShardingPlanner,
+    Topology,
+)
 from torchrec.distributed.sharding_plan import (
     get_module_to_default_sharders,
     ParameterShardingGenerator,
@@ -223,21 +227,33 @@ def _shard_modules(  # noqa: C901
     }
 
     if plan is None:
-        assert isinstance(
-            env, ShardingEnv
-        ), "Currently hybrid sharding only support use manual sharding plan"
-        planner = EmbeddingShardingPlanner(
-            topology=Topology(
-                local_world_size=get_local_size(env.world_size),
-                world_size=env.world_size,
-                compute_device=device.type,
+        if isinstance(env, dict) and len(env) > 1:  # use heterogenous sharding
+            planner = HeteroEmbeddingShardingPlanner(
+                topology_groups={
+                    group: Topology(
+                        local_world_size=get_local_size(cur_env.world_size),
+                        world_size=cur_env.world_size,
+                        compute_device=group,
+                    )
+                    for group, cur_env in env.items()
+                }
             )
-        )
-        pg = env.process_group
-        if pg is not None:
-            plan = planner.collective_plan(module, sharders, pg)
-        else:
+            # For heterogenous sharding, only generate the plan, no broadcast
             plan = planner.plan(module, sharders)
+        else:
+            env = cast(ShardingEnv, env)
+            planner = EmbeddingShardingPlanner(
+                topology=Topology(
+                    local_world_size=get_local_size(env.world_size),
+                    world_size=env.world_size,
+                    compute_device=device.type,
+                )
+            )
+            pg = env.process_group
+            if pg is not None:
+                plan = planner.collective_plan(module, sharders, pg)
+            else:
+                plan = planner.plan(module, sharders)
 
     if type(module) in sharder_map:
         # If the top level module is itself a shardable module, return the sharded variant.

--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -10,12 +10,14 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import List
 
 import torch
 from torchrec import EmbeddingBagConfig, EmbeddingCollection, EmbeddingConfig
+from torchrec.distributed.embedding_types import ShardingType
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.planner.planners import HeteroEmbeddingShardingPlanner
-from torchrec.distributed.planner.types import Topology
+from torchrec.distributed.planner.types import CustomTopologyData, Topology
 from torchrec.distributed.quant_embedding import (
     QuantEmbeddingCollectionSharder,
     ShardedQuantEmbeddingCollection,
@@ -338,4 +340,101 @@ class InferHeteroShardingsTest(unittest.TestCase):
                 shard_model._module_kjt_input[0]._lookups[0]._embedding_lookups_per_rank
             ),
             env_dict["cpu"].world_size,
+        )
+
+    def test_cpu_gpu_uneven_sharding_shard_modules(self) -> None:
+        num_embeddings = 1000
+        emb_dim = 16
+        tables = [
+            EmbeddingConfig(
+                num_embeddings=num_embeddings,
+                embedding_dim=emb_dim,
+                name=f"table_{i}",
+                feature_names=[f"feature_{i}"],
+            )
+            for i in range(3)
+        ]
+        model = KJTInputWrapper(
+            module_kjt_input=torch.nn.Sequential(
+                EmbeddingCollection(
+                    tables=tables,
+                    device=torch.device("cpu"),
+                )
+            )
+        )
+        non_sharded_model = quantize(
+            model,
+            inplace=False,
+            quant_state_dict_split_scale_bias=True,
+            weight_dtype=torch.qint8,
+        )
+        sharder = QuantEmbeddingCollectionSharder()
+        ddr_caps = [500, 100, 100]
+        topo_cpu = Topology(
+            world_size=3,
+            compute_device="cpu",
+            custom_topology_data=CustomTopologyData(
+                data={"ddr_cap": ddr_caps}, world_size=3
+            ),
+        )
+        topo_gpu = Topology(world_size=2, compute_device="cuda")
+        topo_groups = {
+            "cpu": topo_cpu,
+            "cuda": topo_gpu,
+        }
+        constraints = {
+            "table_0": ParameterConstraints(
+                device_group="cpu", sharding_types=[ShardingType.ROW_WISE.value]
+            ),
+            "table_1": ParameterConstraints(
+                device_group="cuda", sharding_types=[ShardingType.TABLE_WISE.value]
+            ),
+            "table_2": ParameterConstraints(
+                device_group="cuda", sharding_types=[ShardingType.TABLE_WISE.value]
+            ),
+        }
+        planner = HeteroEmbeddingShardingPlanner(
+            topology_groups=topo_groups, constraints=constraints
+        )
+        module_plan = planner.plan(
+            non_sharded_model,
+            # pyre-ignore
+            sharders=[sharder],
+        )
+
+        self.assertTrue(
+            # pyre-ignore
+            module_plan.plan["_module_kjt_input.0"]["table_0"]
+            .sharding_spec.shards[0]
+            .placement.device()
+            .type,
+            "cpu",
+        )
+        expected_row_sizes: List[int] = []
+        total_ddr_cap = sum(ddr_caps)
+        expected_row_sizes.append(int(num_embeddings * (ddr_caps[0] / total_ddr_cap)))
+        expected_row_sizes.append(int(num_embeddings * (ddr_caps[1] / total_ddr_cap)))
+        expected_row_sizes.append(num_embeddings - sum(expected_row_sizes))
+
+        for i in range(len(ddr_caps)):
+            self.assertEqual(
+                module_plan.plan["_module_kjt_input.0"]["table_0"]
+                .sharding_spec.shards[i]
+                .shard_sizes[0],
+                expected_row_sizes[i],
+            )
+
+        self.assertTrue(
+            module_plan.plan["_module_kjt_input.0"]["table_1"]
+            .sharding_spec.shards[0]
+            .placement.device()
+            .type,
+            "cuda",
+        )
+        self.assertTrue(
+            module_plan.plan["_module_kjt_input.0"]["table_2"]
+            .sharding_spec.shards[0]
+            .placement.device()
+            .type,
+            "cuda",
         )


### PR DESCRIPTION
Summary:
Support uneven sharding for heterogenous topology, currently only support row-wise.
Rows are enumerated in in propotion of the device size provided.

Differential Revision: D55801230


