### PR TITLE
Wrap DP tables with DDP after reset parameters

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -17,7 +17,7 @@ from itertools import accumulate
 from typing import Any, cast, Dict, List, MutableMapping, Optional, Type, Union
 
 import torch
-from torch import nn
+from torch import distributed as dist, nn
 from torch.autograd.profiler import record_function
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.embedding_sharding import (
@@ -609,6 +609,11 @@ class ShardedEmbeddingCollection(
             param = self.embeddings[f"{table_config.name}"].weight
             # pyre-ignore
             table_config.init_fn(param)
+
+            sharding_type = self.module_sharding_plan[table_config.name].sharding_type
+            if sharding_type == ShardingType.DATA_PARALLEL.value:
+                pg = self._env.process_group
+                dist.broadcast(param, src=0, group=pg)
 
     def _generate_permute_indices_per_feature(
         self,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -28,7 +28,7 @@ from typing import (
 
 import torch
 from fbgemm_gpu.permute_pooled_embedding_modules import PermutePooledEmbeddings
-from torch import nn, Tensor
+from torch import distributed as dist, nn, Tensor
 from torch.autograd.profiler import record_function
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
@@ -727,6 +727,11 @@ class ShardedEmbeddingBagCollection(
             param = self.embedding_bags[f"{table_config.name}"].weight
             # pyre-ignore
             table_config.init_fn(param)
+
+            sharding_type = self.module_sharding_plan[table_config.name].sharding_type
+            if sharding_type == ShardingType.DATA_PARALLEL.value:
+                pg = self._env.process_group
+                dist.broadcast(param, src=0, group=pg)
 
     def _create_input_dist(
         self,


### PR DESCRIPTION
Summary:
# Problem

Problem is once we wrap DP tables with DDP, the parameters are the same, but not synced. So if we reset the parameters in the table without using the same manual seed, it could cause the DP table parameters to be different. 

In other words, DP tables would be initialized differently.

# Fix

There are a few ways to fix it. This is the way we believe to be least invasive and follow the spirit of the api.

What we do:
1. Delay the DDP wrapping to reset_parameters
2. rewrap everytime we call reset_parameters

Differential Revision: D55227979


