### PR TITLE
delete oss references to caffe2.fb

### DIFF
--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -15,7 +15,6 @@ from typing import List
 import hypothesis.strategies as st
 
 import torch
-from caffe2.torch.fb.model_transform.splitting.split_dispatcher import SplitDispatchMode
 from hypothesis import given, settings
 from torchrec import EmbeddingBagConfig, EmbeddingCollection, EmbeddingConfig
 from torchrec.distributed.embedding_types import ShardingType


### PR DESCRIPTION
Summary:
clean up following D56017483

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D56043391


