### PR TITLE
pass table names to TBE for EC as well

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -604,6 +604,7 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
                 pooling_mode=PoolingMode.NONE,
                 weights_precision=weights_precision,
                 device=device,
+                table_names=[t.name for t in config.embedding_tables],
                 **fused_params,
             )
         )


### PR DESCRIPTION
Summary: followup to D54442088, which passed table names to EBC but not EC (blame is on me, totally forgot about that)

Differential Revision: D56076712


