### PR TITLE
enable is_weighted for quant emb kernel

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -21,6 +21,7 @@ FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
     "__register_quant_state_dict_split_scale_bias"
 )
 FUSED_PARAM_TBE_ROW_ALIGNMENT: str = "__register_tbe_row_alignment"
+FUSED_PARAM_IS_WEIGHTED: str = "__register_tbe_is_weighted"
 
 
 class TBEToRegisterMixIn:
@@ -57,6 +58,13 @@ def get_fused_param_tbe_row_alignment(
         return fused_params[FUSED_PARAM_TBE_ROW_ALIGNMENT]
 
 
+def is_fused_param_weighted(fused_params: Optional[Dict[str, Any]]) -> Optional[bool]:
+    if fused_params is None or FUSED_PARAM_IS_WEIGHTED not in fused_params:
+        return None
+    else:
+        return fused_params[FUSED_PARAM_IS_WEIGHTED]
+
+
 def is_fused_param_quant_state_dict_split_scale_bias(
     fused_params: Optional[Dict[str, Any]]
 ) -> bool:
@@ -80,5 +88,7 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS)
     if FUSED_PARAM_TBE_ROW_ALIGNMENT in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_TBE_ROW_ALIGNMENT)
+    if FUSED_PARAM_IS_WEIGHTED in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_IS_WEIGHTED)
 
     return fused_params_for_tbe

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -32,6 +32,7 @@ from torchrec.distributed.embeddingbag import (
     create_sharding_infos_by_sharding,
 )
 from torchrec.distributed.fused_params import (
+    FUSED_PARAM_IS_WEIGHTED,
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
     FUSED_PARAM_REGISTER_TBE_BOOL,
     get_tbes_to_register_from_iterable,
@@ -351,6 +352,8 @@ class QuantEmbeddingBagCollectionSharder(
             fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = getattr(
                 module, FUSED_PARAM_REGISTER_TBE_BOOL, False
             )
+        if FUSED_PARAM_IS_WEIGHTED not in fused_params:
+            fused_params[FUSED_PARAM_IS_WEIGHTED] = module.is_weighted()
 
         return ShardedQuantEmbeddingBagCollection(
             module, params, env, fused_params, device=device


### PR DESCRIPTION
Summary: pass is_weighted to quant emb kernel, so we can statically determine tbe module invoking

Reviewed By: gnahzg

Differential Revision: D55567522


