### PR TITLE
add annotation to data loader next_batch

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -283,7 +283,8 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         if self._dataloader_exhausted:
             batch = None
         else:
-            batch = next(dataloader_iter, None)
+            with record_function("## next_batch ##"):
+                batch = next(dataloader_iter, None)
             if batch is None:
                 self._dataloader_exhausted = True
         return batch
@@ -700,7 +701,8 @@ class StagedTrainPipeline(TrainPipeline[In, Optional[StageOut]]):
         if self._dataloader_exhausted:
             batch = None
         else:
-            batch = next(dataloader_iter, None)
+            with record_function("## next_batch ##"):
+                batch = next(dataloader_iter, None)
             if batch is None:
                 self._dataloader_exhausted = True
         return batch


### PR DESCRIPTION
Summary:
The data loader batch fetching logic isn't regular kernel related so profiler wouldn't show the actual e2e time.

This would show a label instead of just leaving it blank.

Differential Revision: D55858614


