### PR TITLE
Fast FBGEMM path KT.regroup_as

### DIFF
--- a/torchrec/sparse/tests/test_jagged_tensor_gpu.py
+++ b/torchrec/sparse/tests/test_jagged_tensor_gpu.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+import torch
+from torchrec.sparse.jagged_tensor import _regroup_keyed_tensors, KeyedTensor
+from torchrec.sparse.tests.utils import build_groups, build_kts
+from torchrec.test_utils import skip_if_asan_class
+
+
+@skip_if_asan_class
+class TestKeyedTensorGPU(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.device = torch.cuda.current_device()
+
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "Not enough GPUs, this test requires at least one GPUs",
+    )
+    def test_regroup_backward_skips_and_duplicates(self) -> None:
+        kts = build_kts(
+            dense_features=20,
+            sparse_features=20,
+            dim_dense=64,
+            dim_sparse=128,
+            batch_size=128,
+            device=self.device,
+            run_backward=True,
+        )
+        groups = build_groups(kts=kts, num_groups=2, skips=True, duplicates=True)
+        labels = torch.randint(0, 1, (128,), device=self.device).float()
+
+        tensor_groups = KeyedTensor.regroup(kts, groups)
+        pred0 = tensor_groups[0].sum(dim=1).mul(tensor_groups[1].sum(dim=1))
+        loss = torch.nn.functional.l1_loss(pred0, labels).sum()
+        actual_kt_0_grad = torch.autograd.grad(
+            loss, kts[0].values(), retain_graph=True
+        )[0]
+        actual_kt_1_grad = torch.autograd.grad(
+            loss, kts[1].values(), retain_graph=True
+        )[0]
+
+        # clear grads are return
+        kts[0].values().grad = None
+        kts[1].values().grad = None
+
+        tensor_groups = _regroup_keyed_tensors(kts, groups)
+        pred1 = tensor_groups[0].sum(dim=1).mul(tensor_groups[1].sum(dim=1))
+        loss = torch.nn.functional.l1_loss(pred1, labels).sum()
+        expected_kt_0_grad = torch.autograd.grad(
+            loss, kts[0].values(), retain_graph=True
+        )[0]
+        expected_kt_1_grad = torch.autograd.grad(
+            loss, kts[1].values(), retain_graph=True
+        )[0]
+
+        torch.allclose(actual_kt_0_grad, expected_kt_0_grad)
+        torch.allclose(actual_kt_1_grad, expected_kt_1_grad)
+
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "Not enough GPUs, this test requires at least one GPUs",
+    )
+    def test_regroup_backward(self) -> None:
+        kts = build_kts(
+            dense_features=20,
+            sparse_features=20,
+            dim_dense=64,
+            dim_sparse=128,
+            batch_size=128,
+            device=self.device,
+            run_backward=True,
+        )
+        groups = build_groups(kts=kts, num_groups=2, skips=False, duplicates=False)
+        labels = torch.randint(0, 1, (128,), device=self.device).float()
+
+        tensor_groups = KeyedTensor.regroup(kts, groups)
+        pred0 = tensor_groups[0].sum(dim=1).mul(tensor_groups[1].sum(dim=1))
+        loss = torch.nn.functional.l1_loss(pred0, labels).sum()
+        actual_kt_0_grad = torch.autograd.grad(
+            loss, kts[0].values(), retain_graph=True
+        )[0]
+        actual_kt_1_grad = torch.autograd.grad(
+            loss, kts[1].values(), retain_graph=True
+        )[0]
+
+        # clear grads are return
+        kts[0].values().grad = None
+        kts[1].values().grad = None
+
+        tensor_groups = _regroup_keyed_tensors(kts, groups)
+        pred1 = tensor_groups[0].sum(dim=1).mul(tensor_groups[1].sum(dim=1))
+        loss = torch.nn.functional.l1_loss(pred1, labels).sum()
+        expected_kt_0_grad = torch.autograd.grad(
+            loss, kts[0].values(), retain_graph=True
+        )[0]
+        expected_kt_1_grad = torch.autograd.grad(
+            loss, kts[1].values(), retain_graph=True
+        )[0]
+
+        torch.allclose(actual_kt_0_grad, expected_kt_0_grad)
+        torch.allclose(actual_kt_1_grad, expected_kt_1_grad)

--- a/torchrec/sparse/tests/utils.py
+++ b/torchrec/sparse/tests/utils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+from typing import List
+
+import torch
+from torchrec.sparse.jagged_tensor import KeyedTensor
+
+
+def build_kts(
+    dense_features: int,
+    sparse_features: int,
+    dim_dense: int,
+    dim_sparse: int,
+    batch_size: int,
+    device: torch.device,
+    run_backward: bool,
+) -> List[KeyedTensor]:
+    key_dim = 1
+    dense_embs = [
+        torch.randn(batch_size, dim_dense, device=device, requires_grad=run_backward)
+        for i in range(dense_features)
+    ]
+    dense_keys = [f"dense_{i}" for i in range(dense_features)]
+    dense_kt = KeyedTensor.from_tensor_list(dense_keys, dense_embs, key_dim)
+
+    sparse_embs = [
+        torch.randn(batch_size, dim_sparse, device=device, requires_grad=run_backward)
+        for i in range(sparse_features)
+    ]
+    sparse_keys = [f"sparse_{i}" for i in range(sparse_features)]
+    sparse_kt = KeyedTensor.from_tensor_list(sparse_keys, sparse_embs, key_dim)
+    return [dense_kt, sparse_kt]
+
+
+def build_groups(
+    kts: List[KeyedTensor],
+    num_groups: int,
+    skips: bool = False,
+    duplicates: bool = False,
+) -> List[List[str]]:
+    all_keys = []
+    for kt in kts:
+        all_keys.extend(kt.keys())
+    allocation = [random.randint(0, num_groups - 1) for _ in range(len(all_keys))]
+    groups = [[] for _ in range(num_groups)]
+    for i, key in enumerate(allocation):
+        groups[key].append(all_keys[i])
+    if skips:
+        for group in groups:
+            if len(group) > 1:
+                group.pop(random.randint(0, len(group) - 1))
+    if duplicates:
+        for group in groups:
+            group.append(random.choice(all_keys))
+    return groups


### PR DESCRIPTION
Summary:
Use custom FBGEMM kernel when possible for inference/training.  ~0-75% runtime speedup.

Benchmark Results [Forward]
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 80       | device: cuda     | Runtime (P90):   0.4 ms | Memory (P90):  24.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 80       | device: cuda     | Runtime (P90):   0.4 ms | Memory (P90):  36.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 160      | device: cuda     | Runtime (P90):   0.8 ms | Memory (P90):  48.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 160      | device: cuda     | Runtime (P90):   0.6 ms | Memory (P90):  72.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 320      | device: cuda     | Runtime (P90):   1.9 ms | Memory (P90):  96.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 320      | device: cuda     | Runtime (P90):   0.7 ms | Memory (P90): 144.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 640      | device: cuda     | Runtime (P90):   4.6 ms | Memory (P90): 192.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 640      | device: cuda     | Runtime (P90):   1.3 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 1280     | device: cuda     | Runtime (P90):  13.2 ms | Memory (P90): 384.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 1280     | device: cuda     | Runtime (P90):   2.2 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 80       | device: cuda     | Runtime (P90):   0.3 ms | Memory (P90):  48.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 80       | device: cuda     | Runtime (P90):   0.4 ms | Memory (P90):  72.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 160      | device: cuda     | Runtime (P90):   0.8 ms | Memory (P90):  96.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 160      | device: cuda     | Runtime (P90):   0.6 ms | Memory (P90): 144.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 320      | device: cuda     | Runtime (P90):   1.8 ms | Memory (P90): 192.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 320      | device: cuda     | Runtime (P90):   0.9 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 640      | device: cuda     | Runtime (P90):   4.1 ms | Memory (P90): 384.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 640      | device: cuda     | Runtime (P90):   1.6 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 1280     | device: cuda     | Runtime (P90):  12.8 ms | Memory (P90): 768.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 1280     | device: cuda     | Runtime (P90):   3.1 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 80       | device: cuda     | Runtime (P90):   0.4 ms | Memory (P90):  96.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 80       | device: cuda     | Runtime (P90):   0.5 ms | Memory (P90): 144.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 160      | device: cuda     | Runtime (P90):   0.7 ms | Memory (P90): 192.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 160      | device: cuda     | Runtime (P90):   0.8 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 320      | device: cuda     | Runtime (P90):   1.6 ms | Memory (P90): 384.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 320      | device: cuda     | Runtime (P90):   1.4 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 640      | device: cuda     | Runtime (P90):   4.8 ms | Memory (P90): 768.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 640      | device: cuda     | Runtime (P90):   2.8 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 1280     | device: cuda     | Runtime (P90):  12.5 ms | Memory (P90): 1536.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 1280     | device: cuda     | Runtime (P90):   5.6 ms | Memory (P90): 2304.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 80       | device: cuda     | Runtime (P90):   0.4 ms | Memory (P90): 192.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 80       | device: cuda     | Runtime (P90):   0.8 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 160      | device: cuda     | Runtime (P90):   0.9 ms | Memory (P90): 384.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 160      | device: cuda     | Runtime (P90):   1.4 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 320      | device: cuda     | Runtime (P90):   1.7 ms | Memory (P90): 768.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 320      | device: cuda     | Runtime (P90):   2.8 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 640      | device: cuda     | Runtime (P90):   4.1 ms | Memory (P90): 1536.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 640      | device: cuda     | Runtime (P90):   5.6 ms | Memory (P90): 2304.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 1280     | device: cuda     | Runtime (P90):  12.2 ms | Memory (P90): 3072.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 1280     | device: cuda     | Runtime (P90):  11.1 ms | Memory (P90): 4608.0

Benchmark Results [Fowrard + Backward]
  [prod] KeyedTensor.regroup          | B: 512      | F: 80       | device: cuda     | Runtime (P90):   2.2 ms | Memory (P90):  72.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 160      | device: cuda     | Runtime (P90):   4.7 ms | Memory (P90): 144.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 160      | device: cuda     | Runtime (P90):   3.4 ms | Memory (P90): 144.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 320      | device: cuda     | Runtime (P90):   9.0 ms | Memory (P90): 288.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 320      | device: cuda     | Runtime (P90):   6.5 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 640      | device: cuda     | Runtime (P90):  19.9 ms | Memory (P90): 576.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 640      | device: cuda     | Runtime (P90):  11.4 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 512      | F: 1280     | device: cuda     | Runtime (P90):  46.7 ms | Memory (P90): 1152.0
  [prod] KeyedTensor.regroup          | B: 512      | F: 1280     | device: cuda     | Runtime (P90):  23.1 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 80       | device: cuda     | Runtime (P90):   2.6 ms | Memory (P90): 144.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 80       | device: cuda     | Runtime (P90):   2.5 ms | Memory (P90): 144.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 160      | device: cuda     | Runtime (P90):   4.5 ms | Memory (P90): 288.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 160      | device: cuda     | Runtime (P90):   3.9 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 320      | device: cuda     | Runtime (P90):   8.8 ms | Memory (P90): 576.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 320      | device: cuda     | Runtime (P90):   6.7 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 640      | device: cuda     | Runtime (P90):  18.7 ms | Memory (P90): 1152.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 640      | device: cuda     | Runtime (P90):  12.2 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 1024     | F: 1280     | device: cuda     | Runtime (P90):  42.8 ms | Memory (P90): 2304.0
  [prod] KeyedTensor.regroup          | B: 1024     | F: 1280     | device: cuda     | Runtime (P90):  23.1 ms | Memory (P90): 2304.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 80       | device: cuda     | Runtime (P90):   2.5 ms | Memory (P90): 288.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 80       | device: cuda     | Runtime (P90):   2.4 ms | Memory (P90): 288.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 160      | device: cuda     | Runtime (P90):   4.5 ms | Memory (P90): 576.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 160      | device: cuda     | Runtime (P90):   4.2 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 320      | device: cuda     | Runtime (P90):   8.9 ms | Memory (P90): 1152.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 320      | device: cuda     | Runtime (P90):   7.7 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 640      | device: cuda     | Runtime (P90):  19.2 ms | Memory (P90): 2304.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 640      | device: cuda     | Runtime (P90):  12.9 ms | Memory (P90): 2304.0
  [fallback] _regroup_keyed_tenors    | B: 2048     | F: 1280     | device: cuda     | Runtime (P90):  45.1 ms | Memory (P90): 4608.0
  [prod] KeyedTensor.regroup          | B: 2048     | F: 1280     | device: cuda     | Runtime (P90):  26.4 ms | Memory (P90): 4608.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 80       | device: cuda     | Runtime (P90):   2.4 ms | Memory (P90): 576.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 80       | device: cuda     | Runtime (P90):   2.7 ms | Memory (P90): 576.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 160      | device: cuda     | Runtime (P90):   4.4 ms | Memory (P90): 1152.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 160      | device: cuda     | Runtime (P90):   4.4 ms | Memory (P90): 1152.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 320      | device: cuda     | Runtime (P90):   8.4 ms | Memory (P90): 2304.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 320      | device: cuda     | Runtime (P90):   8.1 ms | Memory (P90): 2304.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 640      | device: cuda     | Runtime (P90):  28.0 ms | Memory (P90): 4608.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 640      | device: cuda     | Runtime (P90):  15.6 ms | Memory (P90): 4608.0
  [fallback] _regroup_keyed_tenors    | B: 4096     | F: 1280     | device: cuda     | Runtime (P90):  43.2 ms | Memory (P90): 9216.0
  [prod] KeyedTensor.regroup          | B: 4096     | F: 1280     | device: cuda     | Runtime (P90):  31.2 ms | Memory (P90): 9216.0

Differential Revision: D56392296


