### PR TITLE
ScaleUpProposer will try to promote an offloaded table if it's larger than HBM-only

### DIFF
--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -10,6 +10,8 @@
 import unittest
 from typing import cast
 
+from unittest.mock import Mock, patch
+
 import torch
 import torchrec.optim as trec_optim
 
@@ -27,6 +29,8 @@ from torchrec.distributed.planner.shard_estimators import (
     _calculate_storage_specific_sizes,
     EmbeddingOffloadStats,
     EmbeddingPerfEstimator,
+    EmbeddingStorageEstimator,
+    PipelineAwareMode,
 )
 from torchrec.distributed.planner.types import ParameterConstraints, Perf, Topology
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
@@ -561,6 +565,197 @@ class TestEmbeddingStorageEstimator(unittest.TestCase):
             )
 
             self.assertEqual(estimates, expected_storage)
+
+    @patch(
+        "torchrec.distributed.planner.shard_estimators._calculate_shard_io_sizes",
+        return_value=([1024], [3333]),
+    )
+    @patch(
+        "torchrec.distributed.planner.shard_estimators._calculate_storage_specific_sizes",
+        return_value=[100],
+    )
+    def test_pipelined_noprefetch_storage(self, p1: Mock, p2: Mock) -> None:
+        for mode in list(PipelineAwareMode):
+            topology = Topology(world_size=2, compute_device="cuda")
+            estimator = EmbeddingStorageEstimator(
+                topology=topology, pipeline_aware_mode=mode
+            )
+            tables = [
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=10,
+                    name="table_0",
+                    feature_names=["feature_0"],
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=10,
+                    name="table_1",
+                    feature_names=["feature_1"],
+                ),
+            ]
+            constraints = {
+                "table_0": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED_UVM_CACHING.value],
+                    sharding_types=[ShardingType.TABLE_WISE.value],
+                    cache_params=CacheParams(
+                        load_factor=0.1,
+                    ),
+                ),
+                # simulate promoting a uvm caching table to HBM during scaleup.
+                "table_1": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED.value],
+                    sharding_types=[ShardingType.TABLE_WISE.value],
+                    cache_params=CacheParams(
+                        load_factor=None,
+                    ),
+                ),
+            }
+            enumerator = EmbeddingEnumerator(
+                topology=topology,
+                batch_size=BATCH_SIZE,
+                estimator=estimator,
+                constraints=constraints,
+            )
+
+            model = TestSparseNN(tables=tables, weighted_tables=[])
+            sharding_options = enumerator.enumerate(
+                module=model,
+                sharders=[
+                    cast(
+                        ModuleSharder[torch.nn.Module],
+                        EmbeddingBagCollectionSharder(
+                            fused_params={
+                                "cache_load_factor": 0.2,
+                            }
+                        ),
+                    )
+                ],
+            )
+
+            if mode == PipelineAwareMode.ALL:
+                expected_storage = {
+                    ("table_0", "fused_uvm_caching", "table_wise"): [(100 + 3333, 100)],
+                    ("table_1", "fused", "table_wise"): [(100 + 3333, 100)],
+                }
+            else:
+                expected_storage = {
+                    ("table_0", "fused_uvm_caching", "table_wise"): [
+                        (100 + 3333 + 1024, 100)
+                    ],
+                    ("table_1", "fused", "table_wise"): [(100 + 3333 + 1024, 100)],
+                }
+            actual_storage = {
+                (
+                    sharding_option.name,
+                    sharding_option.compute_kernel,
+                    sharding_option.sharding_type,
+                ): [
+                    (shard.storage.hbm, shard.storage.ddr)
+                    for shard in sharding_option.shards
+                    if shard.storage is not None
+                ]
+                for sharding_option in sharding_options
+            }
+            self.assertEqual(expected_storage, actual_storage)
+
+    @patch(
+        "torchrec.distributed.planner.shard_estimators._calculate_shard_io_sizes",
+        return_value=([1024], [2333]),
+    )
+    @patch(
+        "torchrec.distributed.planner.shard_estimators._calculate_storage_specific_sizes",
+        return_value=[100],
+    )
+    def test_pipelined_prefetch_storage(self, p1: Mock, p2: Mock) -> None:
+        for mode in list(PipelineAwareMode):
+            topology = Topology(world_size=2, compute_device="cuda")
+            estimator = EmbeddingStorageEstimator(
+                topology=topology, pipeline_aware_mode=mode
+            )
+            tables = [
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=10,
+                    name="table_0",
+                    feature_names=["feature_0"],
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=10,
+                    name="table_1",
+                    feature_names=["feature_1"],
+                ),
+            ]
+            constraints = {
+                "table_0": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED_UVM_CACHING.value],
+                    sharding_types=[ShardingType.TABLE_WISE.value],
+                    cache_params=CacheParams(
+                        load_factor=0.1,
+                        prefetch_pipeline=True,
+                    ),
+                ),
+                # simulate promoting a uvm caching table to HBM during scaleup.
+                "table_1": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED.value],
+                    sharding_types=[ShardingType.TABLE_WISE.value],
+                    cache_params=CacheParams(
+                        load_factor=None,
+                        prefetch_pipeline=True,
+                    ),
+                ),
+            }
+            enumerator = EmbeddingEnumerator(
+                topology=topology,
+                batch_size=BATCH_SIZE,
+                estimator=estimator,
+                constraints=constraints,
+            )
+
+            model = TestSparseNN(tables=tables, weighted_tables=[])
+            sharding_options = enumerator.enumerate(
+                module=model,
+                sharders=[
+                    cast(
+                        ModuleSharder[torch.nn.Module],
+                        EmbeddingBagCollectionSharder(
+                            fused_params={
+                                "cache_load_factor": 0.2,
+                                "prefetch_pipeline": True,
+                            }
+                        ),
+                    )
+                ],
+            )
+
+            if mode == PipelineAwareMode.NONE:
+                expected_storage = {
+                    ("table_0", "fused_uvm_caching", "table_wise"): [
+                        (100 + 2333 + 1024, 100)
+                    ],
+                    ("table_1", "fused", "table_wise"): [(100 + 2333 + 1024, 100)],
+                }
+            else:
+                expected_storage = {
+                    ("table_0", "fused_uvm_caching", "table_wise"): [
+                        (100 + 1024 * 11, 100)
+                    ],
+                    ("table_1", "fused", "table_wise"): [(100 + 1024 * 4, 100)],
+                }
+            actual_storage = {
+                (
+                    sharding_option.name,
+                    sharding_option.compute_kernel,
+                    sharding_option.sharding_type,
+                ): [
+                    (shard.storage.hbm, shard.storage.ddr)
+                    for shard in sharding_option.shards
+                    if shard.storage is not None
+                ]
+                for sharding_option in sharding_options
+            }
+            self.assertEqual(expected_storage, actual_storage)
 
     def test_default_output_sizes(self) -> None:
         topology = Topology(world_size=2, compute_device="cuda")


### PR DESCRIPTION
Summary: Checked https://github.com/pytorch/torchrec/pull/1924?fbclid=IwAR0e8LHTP5IwRSLcDyOll7pavxaxTEczaOtexLR3A6kVUuWJ9BqKwBPhBg8 for context. Basically, under some specific case, a table could use even more hbm when offloaded and prefetched. in this case, we'd rather not offload them.

Differential Revision: D56505315


