### PR TITLE
Add utils to torchrec.modules.__init__

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -19,12 +19,25 @@ from torchrec.modules.embedding_configs import (
     pooling_type_to_str,
 )
 from torchrec.modules.utils import register_custom_op
-from torchrec.sparse.jagged_tensor import (
-    is_non_strict_exporting,
-    JaggedTensor,
-    KeyedJaggedTensor,
-    KeyedTensor,
-)
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
+
+
+try:
+    if torch.jit.is_scripting():
+        raise Exception()
+
+    from torch.compiler import (
+        is_compiling as is_compiler_compiling,
+        is_dynamo_compiling as is_torchdynamo_compiling,
+    )
+
+    def is_non_strict_exporting() -> bool:
+        return not is_torchdynamo_compiling() and is_compiler_compiling()
+
+except Exception:
+
+    def is_non_strict_exporting() -> bool:
+        return False
 
 
 @torch.fx.wrap


### PR DESCRIPTION
Summary:
# context
* An ImportError was reported
```
ImportError: cannot import name 'register_custom_op' from 'torchrec.modules.utils'
```
* it's due to previously introduced function at D56443608

Differential Revision: D56578871
