### PR TITLE
Fix FeatureProcessor device only to meta when exporting

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -411,7 +411,7 @@ class ShardedQuantFeatureProcessedEmbeddingBagCollection(
                 # Generic copy, for example initailized on cpu but -> sharding as meta
                 self.feature_processors_per_rank.append(
                     copy.deepcopy(feature_processor)
-                    if device_type == feature_processor_device
+                    if device_type == "meta"
                     else copy_to_device(
                         feature_processor,
                         feature_processor_device,

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -2019,6 +2019,8 @@ class InferShardingsTest(unittest.TestCase):
             if isinstance(input, torch.Tensor):
                 inputs[i] = input.to(torch.device("meta"))
 
+        # move dense params also to meta
+        sharded_model.to("meta")
         sharded_model(*inputs)
         # Don't care about the output since we are sharding on meta
 

--- a/torchrec/modules/feature_processor_.py
+++ b/torchrec/modules/feature_processor_.py
@@ -201,3 +201,12 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection, CopyMixIn):
             self.position_weights_dict[key] = self.position_weights[key]
 
         return self
+
+    # Override to make sure position_weights and position_weights_dict are in sync
+    # pyre-ignore [2]
+    def _apply(self, *args, **kwargs) -> nn.Module:
+        super()._apply(*args, **kwargs)
+        for k, param in self.position_weights.items():
+            self.position_weights_dict[k] = param
+
+        return self


### PR DESCRIPTION
Summary:
D56021085 - This fixed copying FP parameters to meta device when sharding model on meta
Weird thing is though that FP parameters are not sparse parameters, they are dense. Therefore, maybe they shouldn’t be on meta device.
https://fburl.com/code/xuv9s5k2 - AIMP assumes only sparse params are on meta device

However, FP sets the weights for the KJT, for example: https://fburl.com/code/qjazm3p9
This means that if the model is sharded on meta and the input KJTs are also on meta device, the FP can set the weights on device cpu if the parameters of the FP are on CPU.

Differential Revision: D56492970
