### PR TITLE
Add num positive and negative examples to torch metrics

### DIFF
--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -63,6 +63,8 @@ class MetricName(MetricNameBase):
     NDCG = "ndcg"
     XAUC = "xauc"
     SCALAR = "scalar"
+    TOTAL_POSITIVE_EXAMPLES = "total_positive_examples"
+    TOTAL_NEGATIVE_EXAMPLES = "total_negative_examples"
 
 
 class MetricNamespaceBase(StrValueMixin, Enum):


### PR DESCRIPTION
Summary: This adds num positive and num negative examples in addition to total num examples in the QPS computation for torch metrics.

Reviewed By: wilson100hong

Differential Revision: D56376508
