### PR TITLE
Create BoundsCheckMode fused_param for inference

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -15,6 +15,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.distributed.types import BoundsCheckMode
 
 FUSED_PARAM_REGISTER_TBE_BOOL: str = "__register_tbes_in_named_modules"
 FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
@@ -22,6 +23,7 @@ FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
 )
 FUSED_PARAM_TBE_ROW_ALIGNMENT: str = "__register_tbe_row_alignment"
 FUSED_PARAM_IS_WEIGHTED: str = "__register_tbe_is_weighted"
+FUSED_PARAM_BOUNDS_CHECK_MODE: str = "__register_tbe_bounds_check_mode"
 
 
 class TBEToRegisterMixIn:
@@ -65,6 +67,15 @@ def is_fused_param_weighted(fused_params: Optional[Dict[str, Any]]) -> Optional[
         return fused_params[FUSED_PARAM_IS_WEIGHTED]
 
 
+def fused_param_bounds_check_mode(
+    fused_params: Optional[Dict[str, Any]]
+) -> Optional[BoundsCheckMode]:
+    if fused_params is None or FUSED_PARAM_BOUNDS_CHECK_MODE not in fused_params:
+        return None
+    else:
+        return fused_params[FUSED_PARAM_BOUNDS_CHECK_MODE]
+
+
 def is_fused_param_quant_state_dict_split_scale_bias(
     fused_params: Optional[Dict[str, Any]]
 ) -> bool:
@@ -90,5 +101,7 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_TBE_ROW_ALIGNMENT)
     if FUSED_PARAM_IS_WEIGHTED in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_IS_WEIGHTED)
+    if FUSED_PARAM_BOUNDS_CHECK_MODE in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_BOUNDS_CHECK_MODE)
 
     return fused_params_for_tbe

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -21,6 +21,7 @@ from torch.fx.passes.split_utils import getattr_recursive
 from torchrec import distributed as trec_dist, inference as trec_infer
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fused_params import (
+    FUSED_PARAM_BOUNDS_CHECK_MODE,
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
     FUSED_PARAM_REGISTER_TBE_BOOL,
 )
@@ -36,7 +37,12 @@ from torchrec.distributed.quant_embeddingbag import (
     QuantFeatureProcessedEmbeddingBagCollectionSharder,
 )
 from torchrec.distributed.shard import _shard_modules
-from torchrec.distributed.types import ModuleSharder, ShardingPlan, ShardingType
+from torchrec.distributed.types import (
+    BoundsCheckMode,
+    ModuleSharder,
+    ShardingPlan,
+    ShardingType,
+)
 
 from torchrec.modules.embedding_configs import QuantConfig
 from torchrec.modules.embedding_modules import (
@@ -375,6 +381,7 @@ def shard_quant_model(
     _fused_param: Dict[str, Any] = {
         FUSED_PARAM_REGISTER_TBE_BOOL: True,
         FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: True,
+        FUSED_PARAM_BOUNDS_CHECK_MODE: BoundsCheckMode.NONE,
     }
 
     _sharders: List[ModuleSharder[torch.nn.Module]] = [

--- a/torchrec/inference/tests/generate_test_packages.py
+++ b/torchrec/inference/tests/generate_test_packages.py
@@ -18,10 +18,27 @@ from typing import Optional, Tuple
 import torch
 from torch.package import PackageExporter
 
-try:
-    from .test_modules import Nested, Simple
-except ImportError:
-    from test_modules import Nested, Simple  # pyre-ignore
+
+class Simple(torch.nn.Module):
+    def __init__(self, N: int, M: int) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(N, M))
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = self.weight + input
+        return output
+
+    def set_weight(self, weight: torch.Tensor) -> None:
+        self.weight[:] = torch.nn.Parameter(weight)
+
+
+class Nested(torch.nn.Module):
+    def __init__(self, N: int, M: int) -> None:
+        super().__init__()
+        self.simple = Simple(N, M)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return self.simple(input)
 
 
 def save(

--- a/torchrec/inference/tests/test_modules.py
+++ b/torchrec/inference/tests/test_modules.py
@@ -11,26 +11,36 @@
 #!/usr/bin/env python3
 # @nolint
 
-import torch
+import unittest
+
+from torchrec.distributed.test_utils.infer_utils import TorchTypesModelInputWrapper
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.inference.modules import quantize_inference_model, shard_quant_model
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
-class Simple(torch.nn.Module):
-    def __init__(self, N: int, M: int) -> None:
-        super().__init__()
-        self.weight = torch.nn.Parameter(torch.ones(N, M))
+class EagerModelProcessingTests(unittest.TestCase):
+    def test_quantize_shard_cuda(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=10,
+                embedding_dim=4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(10)
+        ]
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = self.weight + input
-        return output
+        model = TorchTypesModelInputWrapper(
+            TestSparseNN(
+                tables=tables,
+            )
+        )
 
-    def set_weight(self, weight: torch.Tensor) -> None:
-        self.weight[:] = torch.nn.Parameter(weight)
+        table_fqns = ["table_" + str(i) for i in range(10)]
 
+        quantized_model = quantize_inference_model(model)
+        sharded_model, _ = shard_quant_model(quantized_model, table_fqns)
 
-class Nested(torch.nn.Module):
-    def __init__(self, N: int, M: int) -> None:
-        super().__init__()
-        self.simple = Simple(N, M)
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return self.simple(input)
+        sharded_qebc = sharded_model._module.sparse.ebc
+        self.assertEqual(len(sharded_qebc.tbes), 1)


### PR DESCRIPTION
Summary: Introduce BoundsCheckMode fused_param for TBE BoundsCheckMode. There is no reason really to run bounds_check_indices during inference use case (AIMP has it off by default: https://fburl.com/code/q8zhundg), and it causes issues with the PT2 IR (bounds_check_indices is a mutating op)

Differential Revision: D56743992
