### PR TITLE
Always return .int() conversion from unwrap_kjt

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -15,6 +15,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.distributed.types import BoundsCheckMode
 
 FUSED_PARAM_REGISTER_TBE_BOOL: str = "__register_tbes_in_named_modules"
 FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
@@ -22,6 +23,7 @@ FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
 )
 FUSED_PARAM_TBE_ROW_ALIGNMENT: str = "__register_tbe_row_alignment"
 FUSED_PARAM_IS_WEIGHTED: str = "__register_tbe_is_weighted"
+FUSED_PARAM_BOUNDS_CHECK_MODE: str = "__register_tbe_bounds_check_mode"
 
 
 class TBEToRegisterMixIn:
@@ -65,6 +67,15 @@ def is_fused_param_weighted(fused_params: Optional[Dict[str, Any]]) -> Optional[
         return fused_params[FUSED_PARAM_IS_WEIGHTED]
 
 
+def fused_param_bounds_check_mode(
+    fused_params: Optional[Dict[str, Any]]
+) -> Optional[BoundsCheckMode]:
+    if fused_params is None or FUSED_PARAM_BOUNDS_CHECK_MODE not in fused_params:
+        return None
+    else:
+        return fused_params[FUSED_PARAM_BOUNDS_CHECK_MODE]
+
+
 def is_fused_param_quant_state_dict_split_scale_bias(
     fused_params: Optional[Dict[str, Any]]
 ) -> bool:
@@ -90,5 +101,7 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_TBE_ROW_ALIGNMENT)
     if FUSED_PARAM_IS_WEIGHTED in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_IS_WEIGHTED)
+    if FUSED_PARAM_BOUNDS_CHECK_MODE in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_BOUNDS_CHECK_MODE)
 
     return fused_params_for_tbe

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -151,14 +151,12 @@ def _get_runtime_device(
 def _unwrap_kjt(
     features: KeyedJaggedTensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    if features.device().type == "cuda":
-        return (
-            features.values().int(),
-            features.offsets().int(),
-            features.weights_or_none(),
-        )
-    else:
-        return features.values(), features.offsets(), features.weights_or_none()
+    # Here it should always follow cuda path, runtime device cannot be meta
+    return (
+        features.values().int(),
+        features.offsets().int(),
+        features.weights_or_none(),
+    )
 
 
 @torch.fx.wrap

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -21,6 +21,7 @@ from torch.fx.passes.split_utils import getattr_recursive
 from torchrec import distributed as trec_dist, inference as trec_infer
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fused_params import (
+    FUSED_PARAM_BOUNDS_CHECK_MODE,
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
     FUSED_PARAM_REGISTER_TBE_BOOL,
 )
@@ -36,7 +37,12 @@ from torchrec.distributed.quant_embeddingbag import (
     QuantFeatureProcessedEmbeddingBagCollectionSharder,
 )
 from torchrec.distributed.shard import _shard_modules
-from torchrec.distributed.types import ModuleSharder, ShardingPlan, ShardingType
+from torchrec.distributed.types import (
+    BoundsCheckMode,
+    ModuleSharder,
+    ShardingPlan,
+    ShardingType,
+)
 
 from torchrec.modules.embedding_configs import QuantConfig
 from torchrec.modules.embedding_modules import (
@@ -375,6 +381,7 @@ def shard_quant_model(
     _fused_param: Dict[str, Any] = {
         FUSED_PARAM_REGISTER_TBE_BOOL: True,
         FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: True,
+        FUSED_PARAM_BOUNDS_CHECK_MODE: BoundsCheckMode.NONE,
     }
 
     _sharders: List[ModuleSharder[torch.nn.Module]] = [


### PR DESCRIPTION
Summary: With _unwrap_kjt_for_cpu, and recording the runtime_device in QuantEmbeddingBag, the conditional for  the input device in _unwrap_kjt is no longer needed, as this path should always record the cuda device impl (as features will either be on cuda or meta)

Differential Revision: D56765511
