### PR TITLE
fix is_weighted by using config

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -22,7 +22,6 @@ FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS: str = (
     "__register_quant_state_dict_split_scale_bias"
 )
 FUSED_PARAM_TBE_ROW_ALIGNMENT: str = "__register_tbe_row_alignment"
-FUSED_PARAM_IS_WEIGHTED: str = "__register_tbe_is_weighted"
 FUSED_PARAM_BOUNDS_CHECK_MODE: str = "__register_tbe_bounds_check_mode"
 
 
@@ -60,13 +59,6 @@ def get_fused_param_tbe_row_alignment(
         return fused_params[FUSED_PARAM_TBE_ROW_ALIGNMENT]
 
 
-def is_fused_param_weighted(fused_params: Optional[Dict[str, Any]]) -> Optional[bool]:
-    if fused_params is None or FUSED_PARAM_IS_WEIGHTED not in fused_params:
-        return None
-    else:
-        return fused_params[FUSED_PARAM_IS_WEIGHTED]
-
-
 def fused_param_bounds_check_mode(
     fused_params: Optional[Dict[str, Any]]
 ) -> Optional[BoundsCheckMode]:
@@ -99,8 +91,6 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS)
     if FUSED_PARAM_TBE_ROW_ALIGNMENT in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_TBE_ROW_ALIGNMENT)
-    if FUSED_PARAM_IS_WEIGHTED in fused_params_for_tbe:
-        fused_params_for_tbe.pop(FUSED_PARAM_IS_WEIGHTED)
     if FUSED_PARAM_BOUNDS_CHECK_MODE in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_BOUNDS_CHECK_MODE)
 

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -35,7 +35,6 @@ from torchrec.distributed.fused_params import (
     fused_param_bounds_check_mode,
     is_fused_param_quant_state_dict_split_scale_bias,
     is_fused_param_register_tbe,
-    is_fused_param_weighted,
     tbe_fused_params,
     TBEToRegisterMixIn,
 )
@@ -192,7 +191,7 @@ class QuantBatchedEmbeddingBag(
                 managed.append(EmbeddingLocation.HOST)
         self._config: GroupedEmbeddingConfig = config
         self._emb_module_registered: bool = is_fused_param_register_tbe(fused_params)
-        self._is_weighted: Optional[bool] = is_fused_param_weighted(fused_params)
+        self._is_weighted: Optional[bool] = config.is_weighted
         self._quant_state_dict_split_scale_bias: bool = (
             is_fused_param_quant_state_dict_split_scale_bias(fused_params)
         )

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -32,7 +32,6 @@ from torchrec.distributed.embeddingbag import (
     create_sharding_infos_by_sharding,
 )
 from torchrec.distributed.fused_params import (
-    FUSED_PARAM_IS_WEIGHTED,
     FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS,
     FUSED_PARAM_REGISTER_TBE_BOOL,
     get_tbes_to_register_from_iterable,
@@ -352,8 +351,6 @@ class QuantEmbeddingBagCollectionSharder(
             fused_params[FUSED_PARAM_REGISTER_TBE_BOOL] = getattr(
                 module, FUSED_PARAM_REGISTER_TBE_BOOL, False
             )
-        if FUSED_PARAM_IS_WEIGHTED not in fused_params:
-            fused_params[FUSED_PARAM_IS_WEIGHTED] = module.is_weighted()
 
         return ShardedQuantEmbeddingBagCollection(
             module, params, env, fused_params, device=device


### PR DESCRIPTION
Summary: The first fused parameter will override the other tbes. Fixing by using config.is_weighted

Reviewed By: hlin09

Differential Revision: D56847642
