### PR TITLE
Fix dynamic embedding bugs that may lead to segmentation faults

### DIFF
--- a/contrib/dynamic_embedding/src/tde/ps.cpp
+++ b/contrib/dynamic_embedding/src/tde/ps.cpp
@@ -25,9 +25,12 @@ c10::intrusive_ptr<FetchHandle> PS::Fetch(
   if (cache_ids_to_fetch_or_evict_.empty()) {
     return c10::make_intrusive<FetchHandle>(time, c10::intrusive_ptr<PS>());
   }
-  fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
-  c10::intrusive_ptr<Notification> notification =
-      fetch_notifications_.back().second;
+  c10::intrusive_ptr<Notification> notification;
+  {
+    std::unique_lock<std::mutex> lock_fetch(fetch_notifications_mutex_);
+    fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
+    notification=fetch_notifications_.back().second;
+  } 
   uint32_t num_os_ids = os_ids_.size();
   io_.Pull(
       table_name_,
@@ -122,6 +125,9 @@ void PS::Evict(torch::Tensor ids_to_evict) {
     torch::Tensor data = torch::cat(all_tensors, 0).cpu();
     TORCH_CHECK(data.numel() == data_size * col_size_);
 
+    // to prevent the original data from being prematurely recycled
+    auto data_shared_ptr = std::make_shared<torch::Tensor>(data);
+
     offsets[0] = 0;
     for (uint32_t j = 0; j < all_tensors.size(); ++j) {
       offsets[j + 1] =
@@ -136,22 +142,30 @@ void PS::Evict(torch::Tensor ids_to_evict) {
         col_ids,
         os_ids_,
         tcb::span{
-            reinterpret_cast<uint8_t*>(data.data_ptr<float>()),
+            reinterpret_cast<uint8_t*>(data_shared_ptr->data_ptr<float>()),
             data_size * sizeof(float)},
         tcb::span{offsets.data(), offsets_size},
-        [&notification] { notification.Done(); });
+        [&notification, data_shared_ptr] { notification.Done(); });
   }
   notification.Wait();
 }
 
 void PS::SyncFetch(int64_t time) {
-  while (!fetch_notifications_.empty()) {
-    auto& [t, notification] = fetch_notifications_.front();
-    if (t != time && time >= 0) {
+  std::unique_lock<std::mutex> lock(
+      fetch_notifications_mutex_, std::defer_lock);
+
+  while (true) {
+    lock.lock();
+    if (fetch_notifications_.empty() ||
+        fetch_notifications_.front().first != time && time >= 0) {
+      lock.unlock();
       break;
     }
-    notification->Wait();
+    auto notification = fetch_notifications_.front().second;
     fetch_notifications_.pop_front();
+    lock.unlock();
+
+    notification->Wait();
   }
 }
 

--- a/contrib/dynamic_embedding/src/tde/ps.h
+++ b/contrib/dynamic_embedding/src/tde/ps.h
@@ -99,6 +99,7 @@ class PS : public torch::CustomClassHolder {
   void Filter(const torch::Tensor& tensor);
 
   std::mutex mu_;
+  std::mutex fetch_notifications_mutex_;
   std::string table_name_;
   c10::intrusive_ptr<LocalShardList> shards_;
   int64_t col_size_;

--- a/torchrec/csrc/dynamic_embedding/ps.cpp
+++ b/torchrec/csrc/dynamic_embedding/ps.cpp
@@ -25,9 +25,12 @@ c10::intrusive_ptr<FetchHandle> PS::fetch(
     return c10::make_intrusive<FetchHandle>(time, c10::intrusive_ptr<PS>());
   }
 
-  fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
-  c10::intrusive_ptr<Notification> notification =
-      fetch_notifications_.back().second;
+  c10::intrusive_ptr<Notification> notification;
+  {
+    std::unique_lock<std::mutex> lock_fetch(fetch_notifications_mutex_);
+    fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
+    notification=fetch_notifications_.back().second;
+  } 
   // Does not support multiple col ids at the moment.
   std::vector<int64_t> col_ids{0};
   uint32_t num_os_ids = os_ids_.size();
@@ -128,13 +131,21 @@ void PS::evict(torch::Tensor ids_to_evict) {
 }
 
 void PS::synchronize_fetch(int64_t time) {
-  while (!fetch_notifications_.empty()) {
-    auto& [t, notification] = fetch_notifications_.front();
-    if (t != time && time >= 0) {
+  std::unique_lock<std::mutex> lock(
+      fetch_notifications_mutex_, std::defer_lock);
+
+  while (true) {
+    lock.lock();
+    if (fetch_notifications_.empty() ||
+        fetch_notifications_.front().first != time && time >= 0) {
+      lock.unlock();
       break;
     }
-    notification->wait();
+    auto notification = fetch_notifications_.front().second;
     fetch_notifications_.pop_front();
+    lock.unlock();
+
+    notification->wait();
   }
 }
 

--- a/torchrec/csrc/dynamic_embedding/ps.h
+++ b/torchrec/csrc/dynamic_embedding/ps.h
@@ -142,6 +142,7 @@ class PS : public torch::CustomClassHolder {
 
   // We need a mutex because the evict and fetch may happen in different thread.
   std::mutex mu_;
+  std::mutex fetch_notifications_mutex_;
   std::string table_name_;
   c10::intrusive_ptr<LocalShardList> shards_;
   int64_t col_size_;


### PR DESCRIPTION
Hi TorchRec Team,

We've recently been trying to use the dynamic embedding feature in torchrec contrib, but we  have encountered a few challenges. The process may result in a segmentation fault. After debugging, we've identified two potential problems.

1） fetch_notifications_ is not thread-safe.
2）Tensor data might be recycled during pushing operations.

For the first issue, the fetch_notifications_ variable is accessed in both the pull and sync fetch functions. As these functions are called in different threads, there might be a thread safety issue.

For the second issue, the tensor generated by concat in the push function is a temporary variable. The subsequent call to io.push is asynchronous and does not copy the data. Therefore, the data might have been recycled by the time it is executed asynchronously, leading to access to invalid data.

In light of these findings, we have undertaken some corrective measures to address these issues. We appreciate your attention to this Pull Request and eagerly await your valuable feedback.

Thank you for your time and consideration.