### PR TITLE
support non contiguous sharding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ torchmetrics==1.0.3
 torchx
 tqdm
 usort
+
+# for tests
+# https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3
+expecttest

--- a/torchrec/distributed/collective_utils.py
+++ b/torchrec/distributed/collective_utils.py
@@ -51,7 +51,7 @@ def invoke_on_rank_and_broadcast_result(
 
         id = invoke_on_rank_and_broadcast_result(pg, 0, allocate_id)
     """
-    if pg.rank() == rank:
+    if dist.get_rank() == rank:
         res = func(*args, **kwargs)
         object_list = [res]
     else:

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -900,7 +900,7 @@ class InferGroupedPooledEmbeddingsLookup(
 ):
     def __init__(
         self,
-        grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
+        grouped_configs_per_rank: Dict[int, List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
@@ -940,7 +940,7 @@ class InferGroupedEmbeddingsLookup(
 ):
     def __init__(
         self,
-        grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
+        grouped_configs_per_rank: Dict[int, List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,
@@ -972,7 +972,7 @@ class InferCPUGroupedEmbeddingsLookup(
 ):
     def __init__(
         self,
-        grouped_configs_per_rank: List[List[GroupedEmbeddingConfig]],
+        grouped_configs_per_rank: Dict[int, List[GroupedEmbeddingConfig]],
         world_size: int,
         fused_params: Optional[Dict[str, Any]] = None,
         device: Optional[torch.device] = None,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from functools import partial
 from typing import (
     Any,
-    Callable,
     cast,
     Dict,
     Iterator,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -210,7 +210,20 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         pg: Optional[dist.ProcessGroup] = None,
     ) -> ShardingPlan:
         """
-        Call self.plan(...) on rank 0 and broadcast
+        Call self.plan(...) on group rank 0 and broadcast
+
+        If the pg is a WORLD pg, then group rank 0 == global rank 0,
+        and there's no conversion needed.
+
+        However when pg is a group pg, say the below case:
+
+        [
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+        ]
+
+        The broadcast in the 2nd group is esssentially
+        from group rank 0 (global rank 4).
         """
         if pg is None:
             assert dist.is_initialized(), (
@@ -224,13 +237,15 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             sharders = get_default_sharders()
         return invoke_on_rank_and_broadcast_result(
             pg,
-            0,
+            # Convert from group rank 0 to WORLD
+            # See https://github.com/pytorch/pytorch/blob/b5bef9bbfd3aa963645d915c0452f5e342b60039/torch/distributed/distributed_c10d.py#L2117
+            dist.get_global_rank(pg, 0),
             self.plan,
             module,
             sharders,
         )
 
-    def plan(
+    def plan(  # noqa: C901
         self,
         module: nn.Module,
         sharders: List[ModuleSharder[nn.Module]],

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -16,7 +16,6 @@ from typing import cast, Dict, List, Optional, Set, Tuple, Union
 import torch
 
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-
 from torchrec.distributed.planner.types import (
     Enumerator,
     Perf,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -186,6 +186,7 @@ class Topology:
         inter_host_bw: float = CROSS_NODE_BANDWIDTH,
         bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER,
         custom_topology_data: Optional[CustomTopologyData] = None,
+        device_ranks: Optional[List[int]] = None,
     ) -> None:
         """
         Representation of a network of devices in a cluster.
@@ -206,7 +207,13 @@ class Topology:
         ddr_cap = ddr_cap if ddr_cap else DDR_CAP
 
         self._devices: List[DeviceHardware] = []
-        for rank in range(world_size):
+        self._device_ranks: List[int] = (
+            device_ranks if device_ranks is not None else list(range(world_size))
+        )
+        assert (
+            len(self._device_ranks) == world_size
+        ), f"Mismatched {world_size=} and device_ranks={len(self._device_ranks)}. Device ranks input: {device_ranks}"
+        for rank in self._device_ranks:
             self._devices.append(
                 DeviceHardware(
                     rank=rank,
@@ -232,6 +239,10 @@ class Topology:
     @property
     def devices(self) -> List[DeviceHardware]:
         return self._devices
+
+    @property
+    def device_ranks(self) -> List[int]:
+        return self._device_ranks
 
     @property
     def world_size(self) -> int:

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -769,7 +769,6 @@ def shard_qebc(
             assert ps.sharding_type == sharding_type.value
             assert ps.sharding_spec is not None
             sharding_spec: ShardingSpec = ps.sharding_spec
-            # pyre-ignore
             assert len(sharding_spec.shards) == len(expected_shards[i])
             for shard, ((offset_r, offset_c, size_r, size_c), placement) in zip(
                 sharding_spec.shards, expected_shards[i]
@@ -819,7 +818,6 @@ def shard_qec(
             assert ps.sharding_type == sharding_type.value
             assert ps.sharding_spec is not None
             sharding_spec: ShardingSpec = ps.sharding_spec
-            # pyre-ignore
             assert len(sharding_spec.shards) == len(expected_shards[i])
             for shard, ((offset_r, offset_c, size_r, size_c), placement) in zip(
                 sharding_spec.shards, expected_shards[i]

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -46,6 +46,7 @@ from torchrec.distributed.types import (
     ShardingPlan,
     ShardingType,
 )
+from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import BaseEmbeddingConfig, EmbeddingBagConfig
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
 from torchrec.optim.optimizers import in_backward_optimizer_filter
@@ -347,11 +348,9 @@ def sharding_single_rank_test(
                 ):
                     sharding_spec = parameter_sharding.sharding_spec
                     if sharding_spec is not None:
-                        # pyre-ignore
                         for shard in sharding_spec.shards:
-                            placement = shard.placement
-                            rank: Optional[int] = placement.rank()
-                            assert rank is not None
+                            placement = none_throws(shard.placement)
+                            rank = none_throws(placement.rank())
                             shard.placement = torch.distributed._remote_device(
                                 f"rank:{rank}/cuda:{rank}"
                             )


### PR DESCRIPTION
Summary:
More of an RFC diff.
depends on https://github.com/pytorch/torchrec/pull/1837 (see diagram there)

The high level idea is we want to disagg the dense and sparse tower placement in rec model distributed training.

Let's say we have 2 DGX hosts with 16 GPUs.

## Today:

We flat shard DMP/FSDP onto the 16 GPUs. A2A/AG/RS would be world size of 16.
This poses challenge on scalability as the model would quickly be comm bound above 128 GPUs.

## After:

We allow for logical segregated placement.
E.g. for the same 16 GPUs, we can do 1:3 split and place sparse onto 4, and dense onto 12.

To leverage intra nvswitch connect, we can do

```
[
  [0 | 1 2 3],
  [4 | 5 6 7],
[
  [8 | 9 10 11],
  [12 | 13 14 15],
]
```

placement.

That way, the world size becomes 4 and 12 respectively. And across them we use P2P comm.

Differential Revision: D55577262


