### PR TITLE
add expecttest dependency to allow for pytorch core testing utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ torchmetrics==1.0.3
 torchx
 tqdm
 usort
+
+# for tests
+# https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3
+expecttest


### PR DESCRIPTION
This is to allow for usage of from torch.testing._internal.common_distributed import spawn_threads_and_init_comms
aka threaded pg for lightweight "distributed" tests.
That avoids heavier process based tests when unnecessary.

Differential Revision: D56960671


