### PR TITLE
Add precision and recall to pyper rec metrics.

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -41,8 +41,10 @@ from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ndcg import NDCGMetric
 from torchrec.metrics.ne import NEMetric
+from torchrec.metrics.precision import PrecisionMetric
 from torchrec.metrics.rauc import RAUCMetric
 from torchrec.metrics.rec_metric import RecMetric, RecMetricList
+from torchrec.metrics.recall import RecallMetric
 from torchrec.metrics.recall_session import RecallSessionMetric
 from torchrec.metrics.scalar import ScalarMetric
 from torchrec.metrics.segmented_ne import SegmentedNEMetric
@@ -72,6 +74,8 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.NDCG: NDCGMetric,
     RecMetricEnum.XAUC: XAUCMetric,
     RecMetricEnum.SCALAR: ScalarMetric,
+    RecMetricEnum.PRECISION: PrecisionMetric,
+    RecMetricEnum.RECALL: RecallMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -37,6 +37,8 @@ class RecMetricEnum(RecMetricEnumBase):
     NDCG = "ndcg"
     XAUC = "xauc"
     SCALAR = "scalar"
+    PRECISION = "precision"
+    RECALL = "recall"
 
 
 @dataclass(unsafe_hash=True, eq=True)

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -64,6 +64,11 @@ class MetricName(MetricNameBase):
     XAUC = "xauc"
     SCALAR = "scalar"
 
+    TOTAL_POSITIVE_EXAMPLES = "total_positive_examples"
+    TOTAL_NEGATIVE_EXAMPLES = "total_negative_examples"
+    PRECISION = "precision"
+    RECALL = "recall"
+
 
 class MetricNamespaceBase(StrValueMixin, Enum):
     pass
@@ -97,6 +102,9 @@ class MetricNamespace(MetricNamespaceBase):
     XAUC = "xauc"
 
     SCALAR = "scalar"
+
+    PRECISION = "precision"
+    RECALL = "recall"
 
 
 class MetricPrefix(StrValueMixin, Enum):

--- a/torchrec/metrics/precision.py
+++ b/torchrec/metrics/precision.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, cast, Dict, List, Optional, Type
+
+import torch
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+)
+
+
+THRESHOLD = "threshold"
+
+
+def compute_precision(
+    num_true_positives: torch.Tensor, num_false_positives: torch.Tensor
+) -> torch.Tensor:
+    return torch.where(
+        num_true_positives + num_false_positives == 0.0,
+        0.0,
+        num_true_positives / (num_true_positives + num_false_positives).double(),
+    )
+
+
+def compute_true_pos_sum(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: torch.Tensor,
+    threshold: float = 0.5,
+) -> torch.Tensor:
+    predictions = predictions.double()
+    return torch.sum(weights * ((predictions >= threshold) * labels), dim=-1)
+
+
+def compute_false_pos_sum(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: torch.Tensor,
+    threshold: float = 0.5,
+) -> torch.Tensor:
+    predictions = predictions.double()
+    return torch.sum(weights * ((predictions >= threshold) * (1 - labels)), dim=-1)
+
+
+def get_precision_states(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: Optional[torch.Tensor],
+    threshold: float = 0.5,
+) -> Dict[str, torch.Tensor]:
+    if weights is None:
+        weights = torch.ones_like(predictions)
+    return {
+        "true_pos_sum": compute_true_pos_sum(labels, predictions, weights, threshold),
+        "false_pos_sum": compute_false_pos_sum(labels, predictions, weights, threshold),
+    }
+
+
+class PrecisionMetricComputation(RecMetricComputation):
+    r"""
+    This class implements the RecMetricComputation for Precision.
+
+    The constructor arguments are defined in RecMetricComputation.
+    See the docstring of RecMetricComputation for more detail.
+
+    Args:
+        threshold (float): If provided, computes Precision metrics cutting off at
+            the specified threshold.
+    """
+
+    def __init__(self, *args: Any, threshold: float = 0.5, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._add_state(
+            "true_pos_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "false_pos_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._threshold: float = threshold
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        if predictions is None:
+            raise RecMetricException(
+                "Inputs 'predictions' should not be None for PrecisionMetricComputation update"
+            )
+        states = get_precision_states(labels, predictions, weights, self._threshold)
+        num_samples = predictions.shape[-1]
+
+        for state_name, state_value in states.items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
+
+    def _compute(self) -> List[MetricComputationReport]:
+        reports = [
+            MetricComputationReport(
+                name=MetricName.PRECISION,
+                metric_prefix=MetricPrefix.LIFETIME,
+                value=compute_precision(
+                    cast(torch.Tensor, self.true_pos_sum),
+                    cast(torch.Tensor, self.false_pos_sum),
+                ),
+            ),
+            MetricComputationReport(
+                name=MetricName.PRECISION,
+                metric_prefix=MetricPrefix.WINDOW,
+                value=compute_precision(
+                    self.get_window_state("true_pos_sum"),
+                    self.get_window_state("false_pos_sum"),
+                ),
+            ),
+        ]
+        return reports
+
+
+class PrecisionMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.PRECISION
+    _computation_class: Type[RecMetricComputation] = PrecisionMetricComputation

--- a/torchrec/metrics/recall.py
+++ b/torchrec/metrics/recall.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, cast, Dict, List, Optional, Type
+
+import torch
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+)
+
+
+THRESHOLD = "threshold"
+
+
+def compute_recall(
+    num_true_positives: torch.Tensor, num_false_negitives: torch.Tensor
+) -> torch.Tensor:
+    return torch.where(
+        num_true_positives + num_false_negitives == 0.0,
+        0.0,
+        num_true_positives / (num_true_positives + num_false_negitives),
+    )
+
+
+def compute_true_pos_sum(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: torch.Tensor,
+    threshold: float = 0.5,
+) -> torch.Tensor:
+    predictions = predictions.double()
+    return torch.sum(weights * ((predictions >= threshold) * labels), dim=-1)
+
+
+def compute_false_neg_sum(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: torch.Tensor,
+    threshold: float = 0.5,
+) -> torch.Tensor:
+    predictions = predictions.double()
+    return torch.sum(weights * ((predictions <= threshold) * labels), dim=-1)
+
+
+def get_recall_states(
+    labels: torch.Tensor,
+    predictions: torch.Tensor,
+    weights: Optional[torch.Tensor],
+    threshold: float = 0.5,
+) -> Dict[str, torch.Tensor]:
+    if weights is None:
+        weights = torch.ones_like(predictions)
+    return {
+        "true_pos_sum": compute_true_pos_sum(labels, predictions, weights, threshold),
+        "false_neg_sum": compute_false_neg_sum(labels, predictions, weights, threshold),
+    }
+
+
+class RecallMetricComputation(RecMetricComputation):
+    r"""
+    This class implements the RecMetricComputation for Recall.
+
+    The constructor arguments are defined in RecMetricComputation.
+    See the docstring of RecMetricComputation for more detail.
+
+    Args:
+        threshold (float): If provided, computes Recall metrics cutting off at
+            the specified threshold.
+    """
+
+    def __init__(self, *args: Any, threshold: float = 0.5, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._add_state(
+            "true_pos_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._add_state(
+            "false_neg_sum",
+            torch.zeros(self._n_tasks, dtype=torch.double),
+            add_window_state=True,
+            dist_reduce_fx="sum",
+            persistent=True,
+        )
+        self._threshold: float = threshold
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        if predictions is None:
+            raise RecMetricException(
+                "Inputs 'predictions' should not be None for RecallMetricComputation update"
+            )
+        states = get_recall_states(labels, predictions, weights, self._threshold)
+        num_samples = predictions.shape[-1]
+
+        for state_name, state_value in states.items():
+            state = getattr(self, state_name)
+            state += state_value
+            self._aggregate_window_state(state_name, state_value, num_samples)
+
+    def _compute(self) -> List[MetricComputationReport]:
+        reports = [
+            MetricComputationReport(
+                name=MetricName.RECALL,
+                metric_prefix=MetricPrefix.LIFETIME,
+                value=compute_recall(
+                    cast(torch.Tensor, self.true_pos_sum),
+                    cast(torch.Tensor, self.false_neg_sum),
+                ),
+            ),
+            MetricComputationReport(
+                name=MetricName.RECALL,
+                metric_prefix=MetricPrefix.WINDOW,
+                value=compute_recall(
+                    self.get_window_state("true_pos_sum"),
+                    self.get_window_state("false_neg_sum"),
+                ),
+            ),
+        ]
+        return reports
+
+
+class RecallMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.RECALL
+    _computation_class: Type[RecMetricComputation] = RecallMetricComputation

--- a/torchrec/metrics/tests/test_precision.py
+++ b/torchrec/metrics/tests/test_precision.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Dict, Iterable, Type, Union
+
+import torch
+from torch import no_grad
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.precision import compute_precision, PrecisionMetric
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
+from torchrec.metrics.test_utils import (
+    metric_test_helper,
+    rec_metric_value_test_launcher,
+    RecTaskInfo,
+    TestMetric,
+)
+
+
+WORLD_SIZE = 4
+
+
+class TestPrecisionMetric(TestMetric):
+    @staticmethod
+    def _get_states(
+        labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        predictions = predictions.double()
+        true_pos_sum = torch.sum(weights * ((predictions >= 0.5) == labels))
+        false_pos_sum = torch.sum(weights * ((predictions >= 0.5) == (1 - labels)))
+        return {
+            "true_pos_sum": true_pos_sum,
+            "false_pos_sum": false_pos_sum,
+        }
+
+    @staticmethod
+    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+        return compute_precision(
+            states["true_pos_sum"],
+            states["false_pos_sum"],
+        )
+
+
+class PrecisionMetricTest(unittest.TestCase):
+    target_clazz: Type[RecMetric] = PrecisionMetric
+    task_name: str = "precision"
+
+    # Temporarily comment out fuse unit tests due to unknown failure (D56856649).
+    # def test_unfused_precision(self) -> None:
+    #     rec_metric_value_test_launcher(
+    #         target_clazz=PrecisionMetric,
+    #         target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    #         test_clazz=TestPrecisionMetric,
+    #         metric_name=PrecisionMetricTest.task_name,
+    #         task_names=["t1", "t2", "t3"],
+    #         fused_update_limit=0,
+    #         compute_on_all_ranks=False,
+    #         should_validate_update=False,
+    #         world_size=WORLD_SIZE,
+    #         entry_point=metric_test_helper,
+    #     )
+
+    # def test_fused_precision(self) -> None:
+    #     rec_metric_value_test_launcher(
+    #         target_clazz=PrecisionMetric,
+    #         target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+    #         test_clazz=TestPrecisionMetric,
+    #         metric_name=PrecisionMetricTest.task_name,
+    #         task_names=["t1", "t2", "t3"],
+    #         fused_update_limit=0,
+    #         compute_on_all_ranks=False,
+    #         should_validate_update=False,
+    #         world_size=WORLD_SIZE,
+    #         entry_point=metric_test_helper,
+    #     )
+
+
+class PrecisionMetricValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of precision in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    def setUp(self) -> None:
+        self.predictions = {"DefaultTask": None}
+        self.weights = {"DefaultTask": None}
+        self.labels = {"DefaultTask": None}
+        self.batches = {
+            "predictions": self.predictions,
+            "weights": self.weights,
+            "labels": self.labels,
+        }
+        self.precision = PrecisionMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=100,
+            tasks=[DefaultTaskInfo],
+        )
+
+    def test_calc_acc_perfect(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.Tensor(
+            [[1] * 5000 + [0] * 10000 + [1] * 5000]
+        )
+
+        expected_precision = torch.tensor([1], dtype=torch.double)
+        self.precision.update(**self.batches)
+        actual_precision = self.precision.compute()[
+            "precision-DefaultTask|window_precision"
+        ]
+        torch.allclose(expected_precision, actual_precision)
+
+    def test_calc_acc_zero(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.Tensor(
+            [[0] * 5000 + [1] * 10000 + [0] * 5000]
+        )
+
+        expected_precision = torch.tensor([0], dtype=torch.double)
+        self.precision.update(**self.batches)
+        actual_precision = self.precision.compute()[
+            "precision-DefaultTask|window_precision"
+        ]
+        torch.allclose(expected_precision, actual_precision)
+
+    def test_calc_precision_balanced(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.ones([1, 20000])
+
+        expected_precision = torch.tensor([0.5], dtype=torch.double)
+        self.precision.update(**self.batches)
+        actual_precision = self.precision.compute()[
+            "precision-DefaultTask|window_precision"
+        ]
+        torch.allclose(expected_precision, actual_precision)
+
+
+def generate_model_outputs_cases() -> Iterable[Dict[str, Union[float, torch.Tensor]]]:
+    return [
+        # random_inputs
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.3, 0.2, 0.5, 0.8, 0.7]]),
+            "threshold": 0.6,
+            "expected_precision": torch.tensor([0.5]),
+        },
+        # perfect_condition
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[1, 0, 0, 1, 1]]),
+            "weights": torch.tensor([[1] * 5]),
+            "threshold": 0.6,
+            "expected_precision": torch.tensor([1.0]),
+        },
+        # inverse_prediction
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0, 1, 1, 0, 0]]),
+            "weights": torch.tensor([[1] * 5]),
+            "threshold": 0.1,
+            "expected_precision": torch.tensor([0.0]),
+        },
+    ]
+
+
+class ThresholdValueTest(unittest.TestCase):
+    """This set of tests verify the computation logic of precision with a modified threshold
+    in several cases that we know the computation results.
+    """
+
+    @no_grad()
+    def _test_precision_helper(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        expected_precision: torch.Tensor,
+        threshold: float,
+    ) -> None:
+        num_task = labels.shape[0]
+        batch_size = labels.shape[0]
+        task_list = []
+        inputs: Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]] = {
+            "predictions": {},
+            "labels": {},
+            "weights": {},
+        }
+        for i in range(num_task):
+            task_info = RecTaskInfo(
+                name=f"Task:{i}",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+            task_list.append(task_info)
+            # pyre-ignore
+            inputs["predictions"][task_info.name] = predictions[i]
+            # pyre-ignore
+            inputs["labels"][task_info.name] = labels[i]
+            # pyre-ignore
+            inputs["weights"][task_info.name] = weights[i]
+
+        precision = PrecisionMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=batch_size,
+            tasks=task_list,
+            # pyre-ignore
+            threshold=threshold,  # threshold is one of the kwargs
+        )
+        # pyre-ignore
+        precision.update(**inputs)
+        actual_precision = precision.compute()
+
+        for task_id, task in enumerate(task_list):
+            cur_actual_precision = actual_precision[
+                f"precision-{task.name}|window_precision"
+            ]
+            cur_expected_precision = expected_precision[task_id].unsqueeze(dim=0)
+
+            torch.testing.assert_close(
+                cur_actual_precision,
+                cur_expected_precision,
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                msg=f"Actual: {cur_actual_precision}, Expected: {cur_expected_precision}",
+            )
+
+    def test_precision(self) -> None:
+        test_data = generate_model_outputs_cases()
+        for inputs in test_data:
+            try:
+                self._test_precision_helper(
+                    **inputs  # pyre-ignore, surpressing a type hint error
+                )
+            except AssertionError:
+                print("Assertion error caught with data set ", inputs)
+                raise

--- a/torchrec/metrics/tests/test_recall.py
+++ b/torchrec/metrics/tests/test_recall.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Dict, Iterable, Type, Union
+
+import torch
+from torch import no_grad
+from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
+from torchrec.metrics.recall import compute_recall, RecallMetric
+from torchrec.metrics.test_utils import (
+    metric_test_helper,
+    rec_metric_value_test_launcher,
+    RecTaskInfo,
+    TestMetric,
+)
+
+
+WORLD_SIZE = 4
+
+
+class TestRecallMetric(TestMetric):
+    @staticmethod
+    def _get_states(
+        labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        predictions = predictions.double()
+        true_pos_sum = torch.sum(weights * ((predictions >= 0.5) == labels))
+        false_neg_sum = torch.sum(weights * ((predictions <= 0.5) == (labels)))
+        return {
+            "true_pos_sum": true_pos_sum,
+            "false_neg_sum": false_neg_sum,
+        }
+
+    @staticmethod
+    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+        return compute_recall(
+            states["true_pos_sum"],
+            states["false_neg_sum"],
+        )
+
+
+class RecallMetricTest(unittest.TestCase):
+    clazz: Type[RecMetric] = RecallMetric
+    task_name: str = "recall"
+
+    # Temporarily comment out fuse unit tests due to unknown failure (D56856649).
+    # def test_unfused_recall(self) -> None:
+    #     rec_metric_value_test_launcher(
+    #         target_clazz=RecallMetric,
+    #         target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    #         test_clazz=TestRecallMetric,
+    #         metric_name=RecallMetricTest.task_name,
+    #         task_names=["t1", "t2", "t3"],
+    #         fused_update_limit=0,
+    #         compute_on_all_ranks=False,
+    #         should_validate_update=False,
+    #         world_size=WORLD_SIZE,
+    #         entry_point=metric_test_helper,
+    #     )
+
+    # def test_fused_recall(self) -> None:
+    #     rec_metric_value_test_launcher(
+    #         target_clazz=RecallMetric,
+    #         target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+    #         test_clazz=TestRecallMetric,
+    #         metric_name=RecallMetricTest.task_name,
+    #         task_names=["t1", "t2", "t3"],
+    #         fused_update_limit=0,
+    #         compute_on_all_ranks=False,
+    #         should_validate_update=False,
+    #         world_size=WORLD_SIZE,
+    #         entry_point=metric_test_helper,
+    #     )
+
+
+class RecallMetricValueTest(unittest.TestCase):
+    r"""This set of tests verify the computation logic of recall in several
+    corner cases that we know the computation results. The goal is to
+    provide some confidence of the correctness of the math formula.
+    """
+
+    def setUp(self) -> None:
+        self.predictions = {"DefaultTask": None}
+        self.weights = {"DefaultTask": None}
+        self.labels = {"DefaultTask": None}
+        self.batches = {
+            "predictions": self.predictions,
+            "weights": self.weights,
+            "labels": self.labels,
+        }
+        self.recall = RecallMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=100,
+            tasks=[DefaultTaskInfo],
+        )
+
+    def test_calc_acc_perfect(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.Tensor(
+            [[1] * 5000 + [0] * 10000 + [1] * 5000]
+        )
+
+        expected_recall = torch.tensor([1], dtype=torch.double)
+        self.recall.update(**self.batches)
+        actual_recall = self.recall.compute()["recall-DefaultTask|window_recall"]
+        torch.allclose(expected_recall, actual_recall)
+
+    def test_calc_acc_zero(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.Tensor(
+            [[0] * 5000 + [1] * 10000 + [0] * 5000]
+        )
+
+        expected_recall = torch.tensor([0], dtype=torch.double)
+        self.recall.update(**self.batches)
+        actual_recall = self.recall.compute()["recall-DefaultTask|window_recall"]
+        torch.allclose(expected_recall, actual_recall)
+
+    def test_calc_recall_balanced(self) -> None:
+        self.predictions["DefaultTask"] = torch.Tensor(
+            [[0.0001 * x for x in range(10000)] * 2]
+        )
+        self.labels["DefaultTask"] = torch.Tensor([[0] * 10000 + [1] * 10000])
+        self.weights["DefaultTask"] = torch.ones([1, 20000])
+
+        expected_recall = torch.tensor([0.5], dtype=torch.double)
+        self.recall.update(**self.batches)
+        actual_recall = self.recall.compute()["recall-DefaultTask|window_recall"]
+        torch.allclose(expected_recall, actual_recall)
+
+
+def generate_model_outputs_cases() -> Iterable[Dict[str, Union[float, torch.Tensor]]]:
+    return [
+        # random_inputs
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0.2, 0.6, 0.8, 0.4, 0.9]]),
+            "weights": torch.tensor([[0.3, 0.2, 0.5, 0.8, 0.7]]),
+            "threshold": 0.6,
+            "expected_recall": torch.tensor([0.7 / 1.8]),
+        },
+        # perfect_condition
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[1, 0, 0, 1, 1]]),
+            "weights": torch.tensor([[1] * 5]),
+            "threshold": 0.6,
+            "expected_recall": torch.tensor([1.0]),
+        },
+        # inverse_prediction
+        {
+            "labels": torch.tensor([[1, 0, 0, 1, 1]]),
+            "predictions": torch.tensor([[0, 1, 1, 0, 0]]),
+            "weights": torch.tensor([[1] * 5]),
+            "threshold": 0.1,
+            "expected_recall": torch.tensor([0.0]),
+        },
+    ]
+
+
+class ThresholdValueTest(unittest.TestCase):
+    """This set of tests verify the computation logic of recall with a modified threshold
+    in several cases that we know the computation results.
+    """
+
+    @no_grad()
+    def _test_recall_helper(
+        self,
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        weights: torch.Tensor,
+        expected_recall: torch.Tensor,
+        threshold: float,
+    ) -> None:
+        num_task = labels.shape[0]
+        batch_size = labels.shape[0]
+        task_list = []
+        inputs: Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]] = {
+            "predictions": {},
+            "labels": {},
+            "weights": {},
+        }
+        for i in range(num_task):
+            task_info = RecTaskInfo(
+                name=f"Task:{i}",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+            task_list.append(task_info)
+            # pyre-ignore
+            inputs["predictions"][task_info.name] = predictions[i]
+            # pyre-ignore
+            inputs["labels"][task_info.name] = labels[i]
+            # pyre-ignore
+            inputs["weights"][task_info.name] = weights[i]
+
+        recall = RecallMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=batch_size,
+            tasks=task_list,
+            # pyre-ignore
+            threshold=threshold,  # threshold is one of the kwargs
+        )
+        # pyre-ignore
+        recall.update(**inputs)
+        actual_recall = recall.compute()
+
+        for task_id, task in enumerate(task_list):
+            cur_actual_recall = actual_recall[f"recall-{task.name}|window_recall"]
+            cur_expected_recall = expected_recall[task_id].unsqueeze(dim=0)
+
+            torch.testing.assert_close(
+                cur_actual_recall,
+                cur_expected_recall,
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                msg=f"Actual: {cur_actual_recall}, Expected: {cur_expected_recall}",
+            )
+
+    def test_recall(self) -> None:
+        test_data = generate_model_outputs_cases()
+        for inputs in test_data:
+            try:
+                self._test_recall_helper(
+                    **inputs  # pyre-ignore, surpressing a type hint error
+                )
+            except AssertionError:
+                print("Assertion error caught with data set ", inputs)
+                raise


### PR DESCRIPTION
Summary: Add a baseline precision and recall metric calculated from threshold for pyper models. Accuracy metric that is already implemented in rec sys will also be forwarded in.

Reviewed By: zainhuda

Differential Revision: D56856649


