### PR TITLE
edgecase, pin memory requires both cuda + cpu

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -63,17 +63,13 @@ except Exception:
 
 def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     if is_torchdynamo_compiling():
-        # TODO(ivankobzarev): Dynamo trace with pin_memory once FakeTensor supports it.
-        return (
-            tensor
-            if device.type == "cpu"
-            else tensor.to(device=device, non_blocking=True)
-        )
+        # TODO(ivankobzarev): Dynamo trace with pin_memory once FakeTensor supports it
+        return tensor.to(device=device, non_blocking=True)
 
     return (
-        tensor
-        if device.type == "cpu"
-        else tensor.pin_memory().to(device=device, non_blocking=True)
+        tensor.pin_memory().to(device=device, non_blocking=True)
+        if device.type == "cuda" and tensor.device.type == "cpu"
+        else tensor.to(device=device, non_blocking=True)
     )
 
 


### PR DESCRIPTION
Summary:
Some broken tests point to edge case:

pin_memory requires tensor be on cpu and target device be cuda.   Some tests happen to run on "meta" devices which exposed cases we call a cpu tensor, looking to move to "meta" w/o cuda available.

Really we need to check (1) its a cpu tensor, and (2) we want to move to a cuda device before leverage "pin_memory()" optimziation.

Differential Revision: D57089961


