### PR TITLE
More aggressive memory freeing from TrainPipelineContext

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
+++ b/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
@@ -297,7 +297,7 @@ def runner(
             )
             if rank == 0:
                 print(
-                    f"  {pipeline_clazz.__name__: <{35}} | Runtime (P90): {result.runtime_percentile(90)/1000:5.1f} s | Memory (P90): {result.max_mem_percentile(90)/1000:5.1f} GB"
+                    f"  {pipeline_clazz.__name__: <{35}} | Runtime (P90): {result.runtime_percentile(90)/1000:5.3f} s | Memory (P90): {result.max_mem_percentile(90)/1000:5.3f} GB"
                 )
 
 

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -378,6 +378,8 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 for names, awaitable in context.fused_splits_awaitables:
                     for name, request in zip(names, awaitable.wait()):
                         context.input_dist_tensors_requests[name] = request
+        context.input_dist_splits_requests.clear()
+        context.fused_splits_awaitables.clear()
 
     def _copy_batch_to_gpu(self, dataloader_iter: Iterator[In]) -> Optional[In]:
         """


### PR DESCRIPTION
Summary:
As users highlighted, TrainPipeline refactoring introduced memory regression ~2% due to more context management for code readability.  This results in higher peak memory (takes longer for a context to drop out of refcount)

relatively easy to get a lot more aggressive about releasing memory stored in TrainPipelineContext.

Differential Revision:
D57123339

Privacy Context Container: 1203980333745195


