### PR TITLE
Simplify custom op naming for meta functionalization of sparse modules

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -217,7 +217,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
             features.offsets_or_none(),
         ]  # if want to include the weights: `+ [bag.weight for bag in self.embedding_bags.values()]`
         dims = [sum(self._lengths_per_embedding)]
-        ebc_op = register_custom_op(self, dims)
+        ebc_op = register_custom_op(type(self).__name__, dims)
         outputs = ebc_op(arg_list, batch_size)
         return KeyedTensor(
             keys=self._embedding_names,


### PR DESCRIPTION
Summary: Registering custom ops for meta functionalization with ids can lead to hash collisions, resulting in wrong dimensions for a sparse module. This diff replaces custom op naming to just the dimension that is returned, alongside the module type, to ensure that the right dimensions are always returned and simplify the custom op naming logic significantly.

Differential Revision: D57108438


