### PR TITLE
Non-strict export fix in split and hardening test framework

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1865,6 +1865,11 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                     _lengths = torch.narrow(
                         self.lengths(), 0, lengths_start, lengths_sz
                     )
+
+                    if self.weights_or_none() is not None:
+                        torch._check(start_offset + sz <= self.weights().size(0))
+                        torch._check(start_offset <= self.weights().size(0))
+
                     split_list.append(
                         KeyedJaggedTensor(
                             keys=keys,
@@ -2062,6 +2067,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             torch._check_is_size(sz)
             torch._check(start_offset <= self.values().size(0))
             torch._check(sz <= self.values().size(0))
+
+            if self.weights_or_none() is not None:
+                torch._check(start_offset <= self.weights().size(0))
+                torch._check(sz <= self.weights().size(0))
 
             return JaggedTensor(
                 values=torch.narrow(


### PR DESCRIPTION
Summary: As there are more instances of KJT/TorchRec data types used in PT2 IR, more edge cases are popping up. This diff fixes a bug and hardens the test framework by introducing weights for the KJT for all tests alongside ***simulating dynamic shapes for values and weights***.

Differential Revision: D57163211


