### PR TITLE
Get rid of self attributes for InferCPURwSparseFeaturesDist

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -921,13 +921,21 @@ class ShardedQuantEcInputDist(torch.nn.Module):
             for i in range(len(self._input_dists)):
                 input_dist = self._input_dists[i]
                 input_dist_result = input_dist(features_by_sharding[i])
-                ret.append(input_dist_result)
-                unbucketize_permute_tensor.append(
-                    input_dist.unbucketize_permute_tensor
-                    if isinstance(input_dist, InferRwSparseFeaturesDist)
-                    or isinstance(input_dist, InferCPURwSparseFeaturesDist)
-                    else None
-                )
+                # TODO: clean up the logic here
+                # Should avoid getting self attributes from input_dists
+                # Intead, use return value to change any LHS
+                if isinstance(input_dist, InferCPURwSparseFeaturesDist):
+                    ret.append(input_dist_result.features)
+                    unbucketize_permute_tensor.append(
+                        input_dist_result.unbucketize_permute_tensor
+                    )
+                else:
+                    ret.append(input_dist_result)
+                    unbucketize_permute_tensor.append(
+                        input_dist.unbucketize_permute_tensor
+                        if isinstance(input_dist, InferRwSparseFeaturesDist)
+                        else None
+                    )
 
             return (
                 ret,


### PR DESCRIPTION
Summary:
Currently self attribute in class got assigned during module inference caused rw_sharding.py lots of issue when adding leaf module. We cannot exclude a full module as leaf.

For instance, the unbucketize tensor is an attribute of input dist module, which we update during runtime inside the forward pass: rw_sharding.py
By treating the entire input dist as leaf, the fx tracer didn’t know this information and assume the unbucketize tensor is a static attribute.


An easy repro is N5341011

Differential Revision: D57176524


