### PR TITLE
Integrate heterogenous auto planner to TGIF DI

### DIFF
--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -104,11 +104,6 @@ def calculate_shard_sizes_and_offsets(
 
     (rows, columns) = tensor.shape
 
-    if device_memory_sizes is not None:
-        assert (
-            sharding_type == ShardingType.ROW_WISE.value
-        ), "Currently only support uneven sharding for row_wise sharding"
-
     if sharding_type == ShardingType.DATA_PARALLEL.value:
         return [[rows, columns]] * world_size, [[0, 0]] * world_size
     elif sharding_type == ShardingType.TABLE_WISE.value:


### PR DESCRIPTION
Summary:
As titled

Integrate TorchRec autoplanner for uneven sharding through option use_trec_hetero_auto_planner. The autoplanner would only be used when user explicitly set so.

Continue testing would be done before we fully migrate to use TorchRec Hetero Autoplanner. Aiming for timeline end of H1 2024

Differential Revision: D56203531


