### PR TITLE
Dynamo doesn't support to(..., non_blocking=True)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -63,8 +63,8 @@ except Exception:
 
 def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     if is_torchdynamo_compiling():
-        # TODO(ivankobzarev): Dynamo trace with pin_memory once FakeTensor supports it
-        return tensor.to(device=device, non_blocking=True)
+        # TODO: remove once FakeTensor supports pin_memory() and to(..., non_blocking=True)
+        return tensor.to(device=device)
 
     return (
         tensor.pin_memory().to(device=device, non_blocking=True)


### PR DESCRIPTION
Summary:
as per title.

Also internal workstreams are registering is_torchdynamo_compiling() as True in some workstreams, seems like a seperate bug.

Reviewed By: IvanKobzarev

Differential Revision:
D57190750

Privacy Context Container: 1203980333745195


