### PR TITLE
KJT methods test coverage with pt2 checks refactoring

### DIFF
--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List
+
+import torch
+
+
+try:
+    if torch.jit.is_scripting():
+        raise Exception()
+
+    from torch.compiler import (
+        is_compiling as is_compiler_compiling,
+        is_dynamo_compiling as is_torchdynamo_compiling,
+    )
+
+    def is_non_strict_exporting() -> bool:
+        return not is_torchdynamo_compiling() and is_compiler_compiling()
+
+except Exception:
+    # BC for torch versions without compiler and torch deploy path
+    def is_torchdynamo_compiling() -> bool:  # type: ignore[misc]
+        return False
+
+    def is_non_strict_exporting() -> bool:
+        return False
+
+
+def pt2_checks_tensor_slice(
+    tensor: torch.Tensor, start_offset: int, end_offset: int, dim: int = 0
+) -> None:
+    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+        return
+
+    torch._check_is_size(start_offset)
+    torch._check_is_size(end_offset)
+    torch._check_is_size(end_offset - start_offset)
+    torch._check(start_offset <= tensor.size(dim))
+    torch._check(end_offset <= tensor.size(dim))
+    torch._check(end_offset >= start_offset)
+
+
+def pt2_checks_all_is_size(list: List[int]) -> List[int]:
+    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+        return list
+
+    for i in list:
+        torch._check_is_size(i)
+    return list

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -16,10 +16,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 from torch.autograd.profiler import record_function
 from torch.fx._pytree import register_pytree_flatten_spec, TreeSpec
-
-from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
 from torch.utils._pytree import GetAttrKey, KeyEntry, register_pytree_node
-
+from torchrec.pt2.checks import pt2_checks_all_is_size, pt2_checks_tensor_slice
 from torchrec.streamable import Pipelineable
 
 try:
@@ -851,15 +849,19 @@ def _use_segment_sum_csr(stride_per_key: List[int]) -> bool:
 def _length_per_key_from_stride_per_key(
     lengths: torch.Tensor, stride_per_key: List[int]
 ) -> List[int]:
+    ret: List[int] = []
     if _use_segment_sum_csr(stride_per_key):
         stride_per_key_offsets = _to_offsets(
             _pin_and_move(
                 torch.tensor(stride_per_key, dtype=torch.int32), lengths.device
             )
         )
-        return torch.ops.fbgemm.segment_sum_csr(
-            1, stride_per_key_offsets, lengths
-        ).tolist()
+        ret = torch.jit.annotate(
+            List[int],
+            torch.ops.fbgemm.segment_sum_csr(
+                1, stride_per_key_offsets, lengths
+            ).tolist(),
+        )
     else:
         tensor_list: List[torch.Tensor] = [
             torch.sum(chunk).view(1) for chunk in torch.split(lengths, stride_per_key)
@@ -867,7 +869,10 @@ def _length_per_key_from_stride_per_key(
         if len(tensor_list) == 0:
             return []
 
-        return torch.cat(tensor_list).tolist()
+        ret = torch.jit.annotate(List[int], torch.cat(tensor_list).tolist())
+
+    pt2_checks_all_is_size(ret)
+    return ret
 
 
 def _maybe_compute_length_per_key(
@@ -1440,11 +1445,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         if torch.jit.is_scripting() or not is_torchdynamo_compiling():
             return
 
-        for s in self._stride_per_key:
-            torch._check_is_size(s)
+        pt2_checks_all_is_size(self._stride_per_key)
         for s in self._stride_per_key_per_rank:
-            for _s in s:
-                torch._check_is_size(_s)
+            pt2_checks_all_is_size(s)
 
     @staticmethod
     def from_offsets_sync(
@@ -1891,14 +1894,14 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                         )
                     )
                 else:
-                    if not torch.jit.is_scripting() and is_torchdynamo_compiling():
-                        # Checks for dynamo dynamic shapes tracing
-                        torch._check_is_size(start_offset)
-                        torch._check_is_size(end_offset)
-                        torch._check_is_size(end_offset - start_offset)
-                        torch._check(start_offset <= self._values.size(0))
-                        torch._check(end_offset <= self._values.size(0))
-                        torch._check(end_offset >= start_offset)
+                    pt2_checks_tensor_slice(self._values, start_offset, end_offset)
+
+                    lengths_offset_per_key: List[int] = self.lengths_offset_per_key()
+                    pt2_checks_tensor_slice(
+                        self.lengths(),
+                        lengths_offset_per_key[start],
+                        lengths_offset_per_key[end],
+                    )
 
                     split_list.append(
                         KeyedJaggedTensor(
@@ -1910,9 +1913,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                                 else self.weights()[start_offset:end_offset]
                             ),
                             lengths=self.lengths()[
-                                self.lengths_offset_per_key()[
-                                    start
-                                ] : self.lengths_offset_per_key()[end]
+                                lengths_offset_per_key[start] : lengths_offset_per_key[
+                                    end
+                                ]
                             ],
                             offsets=None,
                             stride=stride,
@@ -2093,6 +2096,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 offsets=None,
             )
         else:
+            pt2_checks_tensor_slice(self._values, start_offset, end_offset)
+
             return JaggedTensor(
                 values=self._values[start_offset:end_offset],
                 weights=(


### PR DESCRIPTION
Summary:
Adding dynamo coverage for KJT methods:
- permute
- split
- regroup_as_dict
- getitem
- todict


split and getitem tests need additional checks (similar to pre slice check).

Extracted those checks into pt2/utils, pt2_checks_tensor_slice.

Differential Revision: D57220897


