### PR TITLE
Prefetch Support

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -327,7 +327,10 @@ class ShardedEmbeddingModule(
         self._output_dists: List[nn.Module] = []
 
     def prefetch(
-        self, dist_input: KJTList, forward_stream: Optional[torch.cuda.Stream] = None
+        self,
+        dist_input: KJTList,
+        forward_stream: Optional[torch.cuda.Stream] = None,
+        ctx: Optional[ShrdCtx] = None,
     ) -> None:
         """
         Prefetch input features for each lookup module.


### PR DESCRIPTION
Summary:
Extend existing TorchRec module api's to support ITEP custom reindex logic before calling into underlying EBC.

Core library: pass module context to prefetch calls.

Differential Revision: D57233457


