### PR TITLE
add dense kernel for all sharding types

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -401,7 +401,9 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         sharding_type: str,
         compute_device_type: str,
     ) -> List[str]:
-        ret: List[str] = []
+        ret = [
+            EmbeddingComputeKernel.DENSE.value,
+        ]
         if sharding_type != ShardingType.DATA_PARALLEL.value:
             ret += [
                 EmbeddingComputeKernel.FUSED.value,
@@ -411,11 +413,6 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.FUSED_UVM.value,
                     EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                 ]
-        else:
-            # TODO re-enable model parallel and dense
-            ret += [
-                EmbeddingComputeKernel.DENSE.value,
-            ]
         return ret
 
     @property


### PR DESCRIPTION
Summary:
Allow to use dense kernel for all kinds of sharding types.

More details: https://github.com/pytorch/torchrec/issues/1614#issuecomment-1980378724