### PR TITLE
test_comm test inductor

### DIFF
--- a/torchrec/distributed/tests/test_comm.py
+++ b/torchrec/distributed/tests/test_comm.py
@@ -138,7 +138,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -263,7 +263,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -378,7 +378,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -454,7 +454,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -541,7 +541,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -618,7 +618,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)
@@ -683,7 +683,7 @@ class TestAllToAll(unittest.TestCase):
     )
     # pyre-ignore
     @given(
-        torch_compile_args=st.sampled_from([None, ("eager", True)]),
+        torch_compile_args=st.sampled_from([None, ("inductor", True)]),
         specify_pg=st.sampled_from([True]),
     )
     @settings(deadline=None)


### PR DESCRIPTION
Summary: Start testing inductor backend for collective ops instead of just eager

Differential Revision: D57558437


