### PR TITLE
c10::optional -> std::optional in torchrec/inference/include/torchrec/inference/GPUExecutor.h +4

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -58,7 +58,7 @@ class GPUExecutor {
       std::shared_ptr<IGPUExecutorObserver>
           observer, // shared_ptr because used in completion executor callback
       std::function<void()> warmupFn = {},
-      c10::optional<size_t> numThreadsPerGPU = c10::nullopt,
+      std::optional<size_t> numThreadsPerGPU = c10::nullopt,
       std::unique_ptr<GCConfig> gcConfig = std::make_unique<GCConfig>());
   GPUExecutor(GPUExecutor&& executor) noexcept = default;
   GPUExecutor& operator=(GPUExecutor&& executor) noexcept = default;

--- a/torchrec/inference/include/torchrec/inference/Validation.h
+++ b/torchrec/inference/include/torchrec/inference/Validation.h
@@ -20,7 +20,7 @@ namespace torchrec {
 bool validateSparseFeatures(
     at::Tensor& values,
     at::Tensor& lengths,
-    c10::optional<at::Tensor> maybeWeights = c10::nullopt);
+    std::optional<at::Tensor> maybeWeights = c10::nullopt);
 
 // Returns whether dense features are valid.
 // Currently validates:

--- a/torchrec/inference/src/GPUExecutor.cpp
+++ b/torchrec/inference/src/GPUExecutor.cpp
@@ -77,7 +77,7 @@ GPUExecutor::GPUExecutor(
     std::chrono::milliseconds queueTimeout,
     std::shared_ptr<IGPUExecutorObserver> observer,
     std::function<void()> warmupFn,
-    c10::optional<size_t> numThreadsPerGPU,
+    std::optional<size_t> numThreadsPerGPU,
     std::unique_ptr<GCConfig> gcConfig)
     : manager_(manager),
       model_(std::move(model)),

--- a/torchrec/inference/src/Validation.cpp
+++ b/torchrec/inference/src/Validation.cpp
@@ -14,7 +14,7 @@ namespace torchrec {
 bool validateSparseFeatures(
     at::Tensor& values,
     at::Tensor& lengths,
-    c10::optional<at::Tensor> maybeWeights) {
+    std::optional<at::Tensor> maybeWeights) {
   auto flatLengths = lengths.view(-1);
 
   // validate sum of lengths equals number of values/weights


### PR DESCRIPTION
Summary:
Generated with
```
fbgs -f '.*\.(cpp|cxx|cc|h|hpp|cu|cuh)$' c10::optional -l | perl -pe 's/^fbsource.fbcode.//' | grep -v executorch | xargs -n 50 perl -pi -e 's/c10::optional/std::optional/'
```

 - If you approve of this diff, please use the "Accept & Ship" button :-)

(4 files modified.)

Reviewed By: palmje

Differential Revision: D57631092


