### PR TITLE
Add imbalance stats for total perf, hbm and ddr

### DIFF
--- a/torchrec/distributed/planner/tests/test_stats.py
+++ b/torchrec/distributed/planner/tests/test_stats.py
@@ -7,15 +7,30 @@
 
 # pyre-strict
 
+import math
 import unittest
 from typing import List
 
+import hypothesis.strategies as st
+
 import torch
+from hypothesis import given, settings
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.planners import EmbeddingShardingPlanner
-from torchrec.distributed.planner.stats import EmbeddingStats, NoopEmbeddingStats
+from torchrec.distributed.planner.stats import (
+    _calc_max_chi_divergence,
+    _calc_max_kl_divergence,
+    _chi_divergence,
+    _kl_divergence,
+    _normalize_float,
+    _normalize_int,
+    _total_distance,
+    _total_variation,
+    EmbeddingStats,
+    NoopEmbeddingStats,
+)
 from torchrec.distributed.planner.types import Topology
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.types import ModuleSharder, ShardingType
@@ -86,3 +101,77 @@ class TestEmbeddingStats(unittest.TestCase):
             if top_hbm_usage_keyword in row:
                 top_hbm_mem_usage = float(row.split(" ")[6])
         self.assertIsNotNone(top_hbm_mem_usage)
+
+    def test_normalize_float(self) -> None:
+        p = [2.0, 2.0]
+        self.assertEqual(_normalize_float(p), [0.5, 0.5])
+
+    def test_normalize_int(self) -> None:
+        p = [2, 2]
+        self.assertEqual(_normalize_int(p), [0.5, 0.5])
+
+    def test_total_variation(self) -> None:
+        p_1 = [0.5, 0.5]
+        self.assertEqual(_total_variation(p_1), 0.0)
+
+        p_2 = [0.0, 1.0]
+        self.assertEqual(_total_variation(p_2), 0.5)
+
+    def test_total_distance(self) -> None:
+        p_1 = [0.5, 0.5]
+        self.assertEqual(_total_distance(p_1), 0.0)
+
+        p_2 = [0.0, 1.0]
+        self.assertEqual(_total_distance(p_2), 1.0)
+
+    def test_chi_divergence(self) -> None:
+        p_1 = [0.5, 0.5]
+        self.assertEqual(_chi_divergence(p_1), 0.0)
+
+        p_2 = [0.0, 1.0]
+        self.assertEqual(_chi_divergence(p_2), 1.0)
+
+    def test_kl_divergence(self) -> None:
+        p_1 = [0.5, 0.5]
+        self.assertEqual(_kl_divergence(p_1), 0.0)
+
+        p_2 = [0.1, 0.9]
+        self.assertAlmostEqual(_kl_divergence(p_2), 0.368, 3)
+
+    # pyre-ignore
+    @given(
+        N=st.integers(min_value=10, max_value=200),
+    )
+    @settings(max_examples=4, deadline=None)
+    def test_kl_divergence_upper_bound(self, N: int) -> None:
+        # Generate most imbalanced distribution
+        normalized_p = [
+            1.0,
+        ] + [
+            0.0
+        ] * (N - 1)
+        N = len(normalized_p)
+        self.assertEqual(_kl_divergence(normalized_p), _calc_max_kl_divergence(N))
+
+    # pyre-ignore
+    @given(
+        N=st.integers(min_value=10, max_value=200),
+        alpha=st.floats(min_value=1.0, max_value=5.0),
+    )
+    @settings(max_examples=4, deadline=None)
+    def test_chi_divergence_upper_bound(self, N: int, alpha: float) -> None:
+        # Generate most imbalanced distribution
+        normalized_p = [
+            1.0,
+        ] + [
+            0.0
+        ] * (N - 1)
+        N = len(normalized_p)
+
+        self.assertTrue(
+            math.isclose(
+                _chi_divergence(normalized_p, alpha),
+                _calc_max_chi_divergence(N, alpha),
+                abs_tol=1e-10,
+            )
+        )


### PR DESCRIPTION
Summary:
Add and log 4 ways to measure imbalance of generated sharding plan.

Suppose we have $k$ gpus. Let $s$ be a vector where the $i^{th}$ component is the total size currently allocated to the $i^{th}$ device.

First we normalize vector $s$ such that sum of elements in $p$ equals 1. We can view this as a probability distribution, and to get a measure of imbalance, we can measure its deviation from uniform distribution $p$ using one of the following ways:

- total variations
- total distance
- chi divergence
- KL divergence

Differential Revision: D57465383


