### PR TITLE
Add device argument in the deserialization function

### DIFF
--- a/torchrec/ir/types.py
+++ b/torchrec/ir/types.py
@@ -10,7 +10,9 @@
 #!/usr/bin/env python3
 
 import abc
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
+
+import torch
 
 from torch import nn
 
@@ -38,7 +40,12 @@ class SerializerInterface(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    # pyre-ignore [2]: Parameter `input` must have a type other than `Any`.
-    def deserialize(cls, input: Any, typename: str) -> nn.Module:
+    def deserialize(
+        cls,
+        # pyre-ignore [2]: Parameter `input` must have a type other than `Any`.
+        input: Any,
+        typename: str,
+        device: Optional[torch.device] = None,
+    ) -> nn.Module:
         # Take the bytes in the buffer and regenerate the eager embedding module
         pass

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -9,7 +9,7 @@
 
 #!/usr/bin/env python3
 
-from typing import List, Tuple, Type
+from typing import List, Optional, Tuple, Type
 
 import torch
 
@@ -45,6 +45,7 @@ def serialize_embedding_modules(
 def deserialize_embedding_modules(
     ep: ExportedProgram,
     serializer_cls: Type[SerializerInterface] = DEFAULT_SERIALIZER_CLS,
+    device: Optional[torch.device] = None,
 ) -> nn.Module:
     """
     Takes ExportedProgram (IR) and looks for ir_metadata buffer.
@@ -72,7 +73,9 @@ def deserialize_embedding_modules(
                 )
 
             deserialized_module = serializer_cls.deserialize(
-                serialized_module, module_type_dict[fqn]
+                serialized_module,
+                module_type_dict[fqn],
+                device,
             )
             fqn_to_new_module[fqn] = deserialized_module
 


### PR DESCRIPTION
Summary:
# context
* current deserialization on the serialized embedding modules (from torch.export) will place the modules on the default device
* we would like to add more control over the desrialization function so that we can specify on which device we would like the deserialized modules be
* the rationale behind this is that we often want the deserialized module on a **meta** device, and then shard the module (basically replace the module with a sharded version).
* by doing this it can save the cost of creating an actual deserialized module on a CPU or GPU device.

# changes
1. we added an optional argument `device` to the `SerializerInterface` class, so that all the serializer should follow the same sematics
2. the default value is `None`, and we are expecting **this default value would always lead to the same behavior** as prior to this change
3. modified the `deserialize` function for `EBCJsonSerializer`, and confirmed that if the given `device` argument is `None`, the logic should be the same as before
4. modified the `deserialize` function for `PEAThriftSerializer`, and confirmed that the`__init__` function for `PositionWeightedModulePEA` and `PooledEmbeddingArch` both have default for `device=None`
5. modified the `deserialize` function for `EBCThriftSerializer`, and confirmed that the`__init__` function for `EmbeddingBagCollection` has default for `device=None`
5. modified the `deserialize` function for `EBCThriftSerializer`, and confirmed that the`__init__` function for `EmbeddingBagCollection` has default for `device=None`

# reference
1. [code search](https://fburl.com/code/1jyxadpi) for the `SerializerInterface`
{F1649407030}

Differential Revision: D57808349


