### PR TITLE
Support min/max carry over for eager mode from_float method

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -338,7 +338,9 @@ class QuantBatchedEmbeddingBag(
         ]
 
     @classmethod
-    def from_float(cls, module: BaseEmbedding) -> "QuantBatchedEmbeddingBag":
+    def from_float(
+        cls, module: BaseEmbedding, use_precomputed_fake_quant: bool = False
+    ) -> "QuantBatchedEmbeddingBag":
         assert hasattr(
             module, "qconfig"
         ), "BaseEmbedding input float module must have qconfig defined"
@@ -490,7 +492,9 @@ class QuantBatchedEmbedding(
                 yield append_prefix(prefix, f"{config.name}.weight_qbias"), weight_qbias
 
     @classmethod
-    def from_float(cls, module: BaseEmbedding) -> "QuantBatchedEmbedding":
+    def from_float(
+        cls, module: BaseEmbedding, use_precomputed_fake_quant: bool = False
+    ) -> "QuantBatchedEmbedding":
         assert hasattr(
             module, "qconfig"
         ), "BaseEmbedding input float module must have qconfig defined"

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -514,7 +514,9 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
 
     @classmethod
     def from_float(
-        cls, module: OriginalEmbeddingBagCollection
+        cls,
+        module: OriginalEmbeddingBagCollection,
+        use_precomputed_fake_quant: bool = False,
     ) -> "EmbeddingBagCollection":
         assert hasattr(
             module, "qconfig"
@@ -617,7 +619,9 @@ class FeatureProcessedEmbeddingBagCollection(EmbeddingBagCollection):
     @classmethod
     # pyre-ignore
     def from_float(
-        cls, module: OriginalFeatureProcessedEmbeddingBagCollection
+        cls,
+        module: OriginalFeatureProcessedEmbeddingBagCollection,
+        use_precomputed_fake_quant: bool = False,
     ) -> "FeatureProcessedEmbeddingBagCollection":
         fp_ebc = module
         ebc = module._embedding_bag_collection
@@ -903,7 +907,11 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         return feature_embeddings
 
     @classmethod
-    def from_float(cls, module: OriginalEmbeddingCollection) -> "EmbeddingCollection":
+    def from_float(
+        cls,
+        module: OriginalEmbeddingCollection,
+        use_precomputed_fake_quant: bool = False,
+    ) -> "EmbeddingCollection":
         assert hasattr(
             module, "qconfig"
         ), "EmbeddingCollection input float module must have qconfig defined"


### PR DESCRIPTION
Summary:
After QAT is completed or given pre-tuned weight observer via tunable PTQ algorithm, it should not over-write again with a given weight, at least for static QAT never.

Dynamic QAT also does not require to re-run weight observer again by design.

This is a fix

Differential Revision: D57747749


