### PR TITLE
Add VBE KJT support to EmbeddingCollection

### DIFF
--- a/torchrec/distributed/tests/test_sequence_model.py
+++ b/torchrec/distributed/tests/test_sequence_model.py
@@ -305,6 +305,7 @@ class TestEmbeddingCollectionSharder(EmbeddingCollectionSharder):
         kernel_type: str,
         qcomms_config: Optional[QCommsConfig] = None,
         fused_params: Optional[Dict[str, Any]] = None,
+        use_index_dedup: bool = False,
     ) -> None:
         self._sharding_type = sharding_type
         self._kernel_type = kernel_type
@@ -321,6 +322,7 @@ class TestEmbeddingCollectionSharder(EmbeddingCollectionSharder):
         super().__init__(
             fused_params=fused_params,
             qcomm_codecs_registry=qcomm_codecs_registry,
+            use_index_dedup=use_index_dedup,
         )
 
     """


### PR DESCRIPTION
Summary:
- pad lengths to final batch size so that EC with index dedup will be compatible with VBE kjt.
- expands reindexed embeddings with vbe inverse indices
- long term solution is to fix seq TBE to not need lengths/batch size info, just length per key

Differential Revision: D51600051


