### PR TITLE
Support empty tensor list

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -163,6 +163,21 @@ def _all_keys_used_once(
 
 
 @torch.fx.wrap
+def _regroup(
+    keyed_tensors: List["KeyedTensor"],
+    groups: List[List[str]],
+) -> List[torch.Tensor]:
+    if len(keyed_tensors) == 0:
+        return []
+
+    # Fast path, one-to-one correspondence between keyed_tensors and groups
+    if _all_keys_used_once(keyed_tensors, groups) is True:
+        return _fbgemm_permute_pooled_embs(keyed_tensors, groups)
+    else:  # Fallback to slow path otherwise
+        return _regroup_keyed_tensors(keyed_tensors, groups)
+
+
+@torch.fx.wrap
 def _fbgemm_permute_pooled_embs(
     keyed_tensors: List["KeyedTensor"], groups: List[List["str"]]
 ) -> List[torch.Tensor]:
@@ -2577,11 +2592,10 @@ class KeyedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def regroup(
         keyed_tensors: List["KeyedTensor"], groups: List[List[str]]
     ) -> List[torch.Tensor]:
-        # Fast path, one-to-one correspondence between keyed_tensors and groups
-        if _all_keys_used_once(keyed_tensors, groups) is True:
-            return _fbgemm_permute_pooled_embs(keyed_tensors, groups)
-        else:  # Fallback to slow path otherwise
-            return _regroup_keyed_tensors(keyed_tensors, groups)
+        return _regroup(
+            keyed_tensors=keyed_tensors,
+            groups=groups,
+        )
 
     @staticmethod
     def regroup_as_dict(

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -2150,6 +2150,17 @@ class TestKeyedTensor(unittest.TestCase):
         for key in keys:
             self.assertTrue(torch.equal(kt[key], d[key]))
 
+    def test_regroup_empty_list(self) -> None:
+        keyed_tensors = []
+        groups = []
+
+        grouped_tensors = KeyedTensor.regroup(
+            keyed_tensors=keyed_tensors,
+            groups=groups,
+        )
+
+        self.assertEqual([], grouped_tensors)
+
     def test_regroup_single_kt(self) -> None:
         tensor_list = [torch.randn(2, 3) for i in range(5)]
         key_dim = 1


### PR DESCRIPTION
Summary:
When we configure empty sparse feature list, the embedding lookup results could be an empty list.

This is for unblocking the experiment in D57450566 (leaving only dense features in APS models)

Reviewed By: joshuadeng

Differential Revision: D57500720


