### PR TITLE
introduce LocalShardsWrapper for DTensor

### DIFF
--- a/torchrec/distributed/tensor_configs.py
+++ b/torchrec/distributed/tensor_configs.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Tuple
+
+import torch
+from torch.distributed.checkpoint.metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    TensorProperties,
+    TensorStorageMetadata,
+)
+from torch.distributed.checkpoint.planner import (
+    TensorWriteData,
+    WriteItem,
+    WriteItemType,
+)
+
+aten = torch.ops.aten  # pyre-ignore[5]: Globally accessible variable `aten` has no type specified.
+
+
+class LocalShardsWrapper(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
+    __slots__ = ["_local_shards", "_storage_meta"]
+    _local_shards: List[torch.Tensor]
+    _storage_meta: TensorStorageMetadata
+
+    @staticmethod
+    def __new__(
+        cls, local_shards: List[torch.Tensor], local_offsets: List[Tuple[int, ...]]
+    ) -> "LocalShardsWrapper":
+        assert len(local_shards) > 0
+        assert len(local_shards) == len(local_offsets)
+        assert all(
+            tensor.device == local_shards[0].device for tensor in local_shards[1:]
+        )
+
+        # we calculate the total tensor size by "concat" on second tensor dimension
+        cat_tensor_shape = list(local_shards[0].size())
+        if len(local_shards) > 1:  # column-wise sharding
+            for shard in local_shards[1:]:
+                cat_tensor_shape[1] += shard.size()[1]
+
+        wrapper_properties = TensorProperties.create_from_tensor(local_shards[0])
+        wrapper_shape = torch.Size(cat_tensor_shape)
+        chunks_meta = [
+            ChunkStorageMetadata(
+                offsets=torch.Size(offset),
+                sizes=shard.size(),
+            )
+            for shard, offset in zip(local_shards, local_offsets)
+        ]
+
+        r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+            cls,
+            torch.Size(cat_tensor_shape),
+        )
+        r._local_shards = local_shards
+        r._storage_meta = TensorStorageMetadata(
+            properties=wrapper_properties,
+            size=wrapper_shape,
+            chunks=chunks_meta,
+        )
+
+        return r
+
+    # necessary for ops dispatching from this subclass to its local shards
+    @classmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+
+        dispatcher = {
+            torch.ops._c10d_functional.all_gather_into_tensor.default: cls.handle_all_gather_into_tensor,
+            torch.ops._c10d_functional.wait_tensor.default: cls.handle_wait_tensor,
+            aten._to_copy.default: cls.handle_to_copy,
+            aten.view.default: cls.handle_view,
+            aten.equal.default: cls.handle_equal,
+            aten.detach.default: cls.handle_detach,
+            aten.clone.default: cls.handle_clone,
+        }
+
+        if func in dispatcher:
+            return dispatcher[func](args, kwargs)
+        else:
+            raise NotImplementedError(
+                f"{func} is not supported for LocalShardsWrapper!"
+            )
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_all_gather_into_tensor(args, kwargs):
+        dim = args[0].local_sizes()[0][1]
+        cat_tensor = torch.cat(
+            [t.view(-1) for t in args[0].local_shards()], dim=0
+        ).view(-1, dim)
+        return torch.ops._c10d_functional.all_gather_into_tensor.default(
+            cat_tensor, *args[1:], **kwargs
+        )
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_wait_tensor(args, kwargs):
+        return torch.ops._c10d_functional.wait_tensor(args[0])
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_to_copy(args, kwargs):
+        res_shards_list = [
+            aten._to_copy.default(shard, *args[1:], **kwargs)
+            for shard in args[0].local_shards()
+        ]
+        return LocalShardsWrapper(res_shards_list, args[0].local_offsets())
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_view(args, kwargs):
+        # TODO, do we need to change the shape of associated offsets?
+        res_shards_list = [
+            aten.view.default(shard, args[1], **kwargs)
+            for shard in args[0].local_shards()
+        ]
+        return LocalShardsWrapper(res_shards_list, args[0].local_offsets())
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_equal(args, kwargs):
+        """
+        LocalShardsWrapper equal impl also checks for equality of storage metadata
+        and the order of shards
+        """
+        a, b = args[0], args[1]
+        if len(a.local_shards()) != len(b.local_shards()):
+            return False
+        if not all(
+            aten.equal.default(x, y) for x, y in zip(a.local_shards(), b.local_shards())
+        ):
+            return False
+        if not a.storage_metadata() == b.storage_metadata():
+            return False
+        return True
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_detach(args, kwargs):
+        self_ls = args[0]
+        deatched_local_shards = [
+            aten.detach.default(shard) for shard in self_ls.local_shards()
+        ]
+        self_ls._local_shards = deatched_local_shards
+        self_ls._storage_meta.properties.requires_grad = False
+        return self_ls
+
+    @staticmethod
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def handle_clone(args, kwargs):
+        self_ls = args[0]
+        desired_memory_format = kwargs.get("memory_format", None)
+        if desired_memory_format and desired_memory_format != torch.preserve_format:
+            raise NotImplementedError(
+                f"{desired_memory_format} is not supported for LocalShardsWrapper!"
+            )
+        cloned_local_shards = [
+            shard.clone(memory_format=desired_memory_format)
+            for shard in self_ls._local_shards
+        ]
+        return LocalShardsWrapper(cloned_local_shards, self_ls.local_offsets())
+
+    @property
+    def device(self) -> torch._C.device:
+        return self._local_shards[0].device
+
+    @property
+    def is_meta(self) -> bool:
+        return self._local_shards[0].is_meta
+
+    # pyre-ignore[14]
+    def is_pinned(self) -> bool:
+        return self._storage_meta.properties.pin_memory
+
+    # pyre-ignore[14]
+    def requires_grad_(self, requires_grad: bool = True) -> "LocalShardsWrapper":
+        self._storage_meta.properties.requires_grad = requires_grad
+        [shard.requires_grad_(requires_grad) for shard in self._local_shards]
+        return self
+
+    def local_shards(self) -> List[torch.Tensor]:
+        """
+        Returns a list of :class:`torch.Tensor' corresponding to the
+        local shards for this rank. Returns an empty list if the current rank
+        does not host any shards for this Tensor.
+        """
+        return self._local_shards
+
+    def local_sizes(self) -> List[torch.Size]:
+        """
+        Returns a list of :class:`torch.Size' corresponding to the
+        local sizes for the shards on this rank. Returns an empty list if the current rank
+        does not host any shards for this Tensor.
+        """
+        return [chunk.sizes for chunk in self._storage_meta.chunks]
+
+    def local_offsets(self) -> List[torch.Size]:
+        """
+        Returns a list of :class:`torch.Size' corresponding to the
+        local offsets for the shards on this rank. Returns an empty list if the current rank
+        does not host any shards for this Tensor.
+        """
+        return [chunk.offsets for chunk in self._storage_meta.chunks]
+
+    @property
+    def local_chunks(self) -> List[ChunkStorageMetadata]:
+        """
+        Returns a :class:`List[ChunkStorageMetadata]` object corresponding to the
+        metadata for each tensor shard
+        """
+        return self._storage_meta.chunks
+
+    def local_shards_sizes_offsets(
+        self,
+    ) -> List[Tuple[torch.Tensor, torch.Size, torch.Size]]:
+        """
+        Returns a :class:`List[Tuple[torch.Tensor, torch.Size, torch.Size]]` object corresponding to the
+        metadata for each tensor shard
+        """
+        return [
+            (tensor, chunk.sizes, chunk.offsets)
+            for tensor, chunk in zip(self._local_shards, self._storage_meta.chunks)
+        ]
+
+    def storage_metadata(self) -> TensorStorageMetadata:
+        """
+        Returns a :class:`TensorStorageMetadata` object corresponding to the
+        metadata for the local tensor on current rank
+        """
+        return self._storage_meta
+
+    def _create_write_items(self, fqn, size) -> List[WriteItem]:
+        """
+        For compatibility with DCP, we support creation of WriteItems
+        such that they can be saved properly.
+        """
+        return [
+            WriteItem(
+                index=MetadataIndex(fqn, chunks.offsets),
+                type=WriteItemType.SHARD,
+                tensor_data=TensorWriteData(
+                    chunk=ChunkStorageMetadata(
+                        offsets=chunks.offsets,
+                        sizes=chunks.sizes,
+                    ),
+                    properties=self._storage_meta.properties,
+                    size=size,
+                ),
+            )
+            for tensor, chunks in zip(self.local_shards(), self.local_chunks)
+        ]
+
+    def __hash__(self):
+        return id(self)
+
+    # pyre-fixme[14]: `__repr__` overrides method defined in `torch._tensor.Tensor` inconsistently.
+    # pyre-fixme[3]: Return type must be annotated.
+    def __repr__(self):
+        return f"LocalShardsWrapper:{self._local_shards} {self._storage_meta}"
+
+    def __str__(self) -> str:
+        return f"LocalShardsWrapper:{self._local_shards} {self._storage_meta}"

--- a/torchrec/distributed/tests/test_tensor_configs.py
+++ b/torchrec/distributed/tests/test_tensor_configs.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List, Optional, Union
+
+import torch
+from hypothesis import settings, Verbosity
+from torch import distributed as dist
+from torchrec.distributed.tensor_configs import LocalShardsWrapper
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.test_utils import seed_and_log, skip_if_asan_class
+
+
+def test_all_gather_into_tensor(
+    rank: int,
+    world_size: int,
+    backend: str,
+    expected_result: Union[torch.Tensor, List[torch.Tensor]],
+    shards_wrapper: List[LocalShardsWrapper],
+    local_size: Optional[int] = None,
+    async_op: bool = False,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        local_shards_wrapper = shards_wrapper[ctx.rank]
+        output_tensor = torch.empty((8, 5), device=torch.device(f"cuda:{ctx.rank}"))
+        res = dist.all_gather_into_tensor(
+            output_tensor, local_shards_wrapper, group=ctx.pg, async_op=async_op
+        )
+        if async_op:
+            res.wait()
+        torch.testing.assert_close(
+            output_tensor.cpu(),
+            expected_result,
+        )
+
+
+def test_all_gather(
+    rank: int,
+    world_size: int,
+    backend: str,
+    expected_result: Union[torch.Tensor, List[torch.Tensor]],
+    shards_wrapper: List[LocalShardsWrapper],
+    local_size: Optional[int] = None,
+    async_op: bool = False,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        local_shards_wrapper = shards_wrapper[ctx.rank]
+        tensor_list = [
+            torch.zeros((4, 5), dtype=torch.float32, device=f"cuda:{rank}")
+            for _ in range(2)
+        ]
+        res = dist.distributed_c10d.all_gather(
+            tensor_list,
+            local_shards_wrapper,
+            async_op=True,
+        )
+        if async_op:
+            res.wait()
+        for tensor, expected in zip(tensor_list, expected_result):
+            torch.testing.assert_close(
+                tensor.cpu(),
+                expected.cpu(),
+            )
+
+
+def test_all_gather_object(
+    rank: int,
+    world_size: int,
+    backend: str,
+    expected_result: Union[torch.Tensor, List[torch.Tensor]],
+    shards_wrapper: List[LocalShardsWrapper],
+    local_size: Optional[int] = None,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        local_shards_wrapper = shards_wrapper[ctx.rank]
+        output = [None] * world_size
+        dist.distributed_c10d.all_gather_object(
+            output,
+            local_shards_wrapper,
+        )
+        for i in range(world_size):
+            torch.testing.assert_close(
+                output[i]._local_shards[0],  # pyre-ignore[16]
+                shards_wrapper[i]._local_shards[0],
+            )
+
+
+@skip_if_asan_class
+class LocalShardsWrapperDistributedTest(MultiProcessTestBase):
+    @seed_and_log
+    def setUp(self, backend: str = "nccl") -> None:
+        super().setUp()
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @unittest.skip("Need to fix circular import errors with Torch")
+    def test_shards_wrapper_all_gather_into_tensor(self) -> None:
+        world_size = 2
+        backend = "nccl"
+        shards_0 = [torch.rand((4, 5), device=torch.device("cuda:0"))]
+        shards_1 = [torch.rand((4, 5), device=torch.device("cuda:1"))]
+        expected_result = torch.cat(
+            [torch.cat(shards_0, dim=0).cpu(), torch.cat(shards_1, dim=0).cpu()], dim=0
+        )
+        offsets = [(0, 0)]
+
+        # shards wrapper for rank 0 and rank 1, offsets don't matter
+        ls_0 = LocalShardsWrapper(local_shards=shards_0, local_offsets=offsets)
+        ls_1 = LocalShardsWrapper(local_shards=shards_1, local_offsets=offsets)
+
+        self._run_multi_process_test(
+            callable=test_all_gather_into_tensor,
+            shards_wrapper=[
+                ls_0,
+                ls_1,
+            ],
+            expected_result=expected_result,
+            world_size=world_size,
+            backend=backend,
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @unittest.skip("Need to fix circular import errors with Torch")
+    def test_shards_wrapper_all_gather(self) -> None:
+        world_size = 2
+        backend = "nccl"
+        shards_0 = [torch.rand((4, 5), device=torch.device("cuda:0"))]
+        shards_1 = [torch.zeros((4, 5), device=torch.device("cuda:1"))]
+        expected_result = [shards_0[0], shards_1[0]]
+        offsets = [(0, 0)]
+
+        # shards wrapper for rank 0 and rank 1, offsets don't matter
+        ls_0 = LocalShardsWrapper(local_shards=shards_0, local_offsets=offsets)
+        ls_1 = LocalShardsWrapper(local_shards=shards_1, local_offsets=offsets)
+
+        self._run_multi_process_test(
+            callable=test_all_gather,
+            shards_wrapper=[
+                ls_0,
+                ls_1,
+            ],
+            expected_result=expected_result,
+            world_size=world_size,
+            backend=backend,
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @settings(verbosity=Verbosity.verbose, deadline=None)
+    @unittest.skip("Need to fix circular import errors with Torch")
+    def test_shards_wrapper_all_gather_object(self) -> None:
+        world_size = 2
+        backend = "nccl"
+        shards_0 = [torch.rand((4, 5), device=torch.device("cuda:0"))]
+        shards_1 = [torch.zeros((4, 5), device=torch.device("cuda:1"))]
+        expected_result = [shards_0[0], shards_1[0]]
+        offsets = [(0, 0)]
+
+        # shards wrapper for rank 0 and rank 1, offsets don't matter
+        ls_0 = LocalShardsWrapper(local_shards=shards_0, local_offsets=offsets)
+        ls_1 = LocalShardsWrapper(local_shards=shards_1, local_offsets=offsets)
+
+        self._run_multi_process_test(
+            callable=test_all_gather_object,
+            shards_wrapper=[
+                ls_0,
+                ls_1,
+            ],
+            expected_result=expected_result,
+            world_size=world_size,
+            backend=backend,
+        )


### PR DESCRIPTION
Summary:
This diff introduces LocalShardsWrapper which is crucial to migrating from using ShardedTensor to DTensor in TRec state dict representation. As well as any changes needed in PT-D and ModelStore to support this.

It allows us to extend DTensor to support multiple shards on a rank as well as empty shards on a rank as needed by TRec sharding logic.

This diff also extends the support for LocalShardsWrapper to be used in conjunction with DTensor in checkpointing cases (ModelStore and DCP)

See D54375878 for how it is used.

**LocalShardsWrapper supports the following torch ops:**
+ torch.ops._c10d_functional.all_gather_into_tensor.default
+ aten._to_copy.default
+ aten.view.default
+ aten.equal.default
+ aten.detach.default

With extensibility to add more as required by use cases.

See https://docs.google.com/document/d/16Ptl50mGFJW2cljdF2HQ6FwsiA0scwbAbjx_4dhabJw/edit?usp=drivesdk for more info regarding design and approach.

NOTE: This version of LocalShardsWrapper does not support empty shards, that is added in the next diff enabling CW. D57063512

Reviewed By: XilunWu

Differential Revision: D57688538


