### PR TITLE
fix a test issue

### DIFF
--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -383,7 +383,6 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
     def test_copy_mixin(self) -> None:
         device = torch.device("cuda:0")
         device_1 = torch.device("cuda:1")


### PR DESCRIPTION
Summary:
to fix a broken test: https://github.com/pytorch/torchrec/actions/runs/9295841173/job/25613611044
```
=========================== short test summary info ============================
FAILED torchrec/distributed/tests/test_quant_model_parallel.py::QuantModelParallelModelCopyTest::test_copy_mixin - hypothesis.errors.InvalidArgument: Using `settings` on a test without `given` is completely pointless.
===== 1 failed, 569 passed, 226 skipped, 195 warnings in 257.76s (0:04:17) =====
```

Reviewed By: gnahzg

Differential Revision: D57972148


