### PR TITLE
Add VLE serialization and deserialization

### DIFF
--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -379,7 +379,7 @@ def register_custom_op(
                 for dim in dims
             ]
 
-        schema_string = f"{op_name}(Tensor?[] values, int batch_size) -> Tensor[]"
+        schema_string = f"{op_name}(Tensor?[] values, SymInt batch_size) -> Tensor[]"
         operator_registry_state.op_registry_schema[op_name] = schema_string
         # Register schema
         lib.define(schema_string)


### PR DESCRIPTION
Summary:
# context
* `VariableLengthEmbeddingArch` (VLE) inherits from `PooledEmbeddingArch` (PEA) with a few modifications
* we want to apply the same custom-op treatment for the VLE module in the serialization and deserialization
* reference to PEA custom_op: D56942421

# changes
1. add `VLEMetadata` in ir_types.thrift to support metadata for ThriftSerializer. It stores less paramters than that for PEA.
2. add `VLEThriftSerializer`
3. add `Optional` for in the PEA's `_non_strict_exporting_forward` function
4. call `_non_strict_exporting_forward` in VLE for non-strict export
5. changed the custom_op schema from `int batch_size` to `SymInt batch_size` so that the custom_op can take dynamic batch_size

Reviewed By: PaulZhang12

Differential Revision: D57825514


