### PR TITLE
Fix device hardcoding in graph

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -742,11 +742,10 @@ class MetaInferGroupedPooledEmbeddingsLookup(
                 torch.empty(
                     [0],
                     dtype=self.output_dtype,
-                    device=self.device,
                 ),
                 sparse_features.stride(),
                 0,
-            )
+            ).to(sparse_features.device())
 
         embeddings: List[torch.Tensor] = []
         features_by_group = (


### PR DESCRIPTION
Summary: Using self.device hardcodes the device into the fx graph when traced, especially as the function is not fx wrapped. Having the device depend on the input device fixes this issue

Differential Revision: D58090380


