### PR TITLE
register custom_op for fpEBC

### DIFF
--- a/torchrec/ir/schema.py
+++ b/torchrec/ir/schema.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from torchrec.modules.embedding_configs import DataType, PoolingType
 
@@ -32,3 +32,19 @@ class EBCMetadata:
     tables: List[EmbeddingBagConfigMetadata]
     is_weighted: bool
     device: Optional[str]
+
+
+@dataclass
+class FPEBCMetadata:
+    is_fp_collection: bool
+    features: List[str]
+
+
+@dataclass
+class PositionWeightedModuleMetadata:
+    max_feature_length: int
+
+
+@dataclass
+class PositionWeightedModuleCollectionMetadata:
+    max_feature_lengths: List[Tuple[str, int]]

--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -227,7 +227,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         self.assertEqual(torch.device("cpu"), ebc.embedding_bags["t1"].weight.device)
         self.assertEqual(torch.device("cpu"), ebc.device)
 
-    def test_exporting(self) -> None:
+    def test_ir_export(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -294,6 +294,13 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
             sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
             2,
             "Shoulde be exact 2 EmbeddingBagCollection nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(
+            output.size(), exported.size(), "Output should match exported output"
         )
 
 

--- a/torchrec/modules/tests/test_fp_embedding_modules.py
+++ b/torchrec/modules/tests/test_fp_embedding_modules.py
@@ -21,22 +21,12 @@ from torchrec.modules.feature_processor_ import (
     PositionWeightedModuleCollection,
 )
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
 
 class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
-    def test_position_weighted_module_ebc(self) -> None:
-        #     0       1        2  <-- batch
-        # 0   [0,1] None    [2]
-        # 1   [3]    [4]    [5,6,7]
-        # ^
-        # feature
-        features = KeyedJaggedTensor.from_offsets_sync(
-            keys=["f1", "f2"],
-            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
-        )
 
+    def generate_fp_ebc(self) -> FeatureProcessedEmbeddingBagCollection:
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -52,8 +42,21 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             "f1": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=10)),
             "f2": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=5)),
         }
+        return FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
 
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
+    def test_position_weighted_module_ebc(self) -> None:
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        )
+
+        fp_ebc = self.generate_fp_ebc()
 
         pooled_embeddings = fp_ebc(features)
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
@@ -86,6 +89,53 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
         )
 
+        fp_ebc = self.generate_fp_ebc()
+
+        pooled_embeddings = fp_ebc(features)
+        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
+        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
+        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
+
+    def test_ir_export(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self, fp_ebc) -> None:
+                super().__init__()
+                self._fp_ebc = fp_ebc
+
+            def forward(self, features: KeyedJaggedTensor) -> KeyedTensor:
+                return self._fp_ebc(features)
+
+        m = MyModule(self.generate_fp_ebc())
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
+        )
+        ep = torch.export.export(
+            m,
+            (features,),
+            {},
+            strict=False,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("_embedding_bag") for n in ep.graph.nodes),
+            0,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
+            1,
+            "Shoulde be exact 1 EBC nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(output.keys(), exported.keys())
+        self.assertEqual(output.values().size(), exported.values().size())
+
+
+class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCase):
+    def generate_fp_ebc(self) -> FeatureProcessedEmbeddingBagCollection:
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -97,20 +147,11 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             ],
             is_weighted=True,
         )
-        feature_processors = {
-            "f1": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=10)),
-            "f2": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=5)),
-        }
 
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
+        return FeatureProcessedEmbeddingBagCollection(
+            ebc, PositionWeightedModuleCollection({"f1": 10, "f2": 10})
+        )
 
-        pooled_embeddings = fp_ebc(features)
-        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
-        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
-        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
-
-
-class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCase):
     def test_position_weighted_collection_module_ebc(self) -> None:
         #     0       1        2  <-- batch
         # 0   [0,1] None    [2]
@@ -123,21 +164,7 @@ class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCa
             offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
         )
 
-        ebc = EmbeddingBagCollection(
-            tables=[
-                EmbeddingBagConfig(
-                    name="t1", embedding_dim=8, num_embeddings=16, feature_names=["f1"]
-                ),
-                EmbeddingBagConfig(
-                    name="t2", embedding_dim=8, num_embeddings=16, feature_names=["f2"]
-                ),
-            ],
-            is_weighted=True,
-        )
-
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(
-            ebc, PositionWeightedModuleCollection({"f1": 10, "f2": 10})
-        )
+        fp_ebc = self.generate_fp_ebc()
 
         pooled_embeddings = fp_ebc(features)
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
@@ -155,3 +182,40 @@ class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCa
             pooled_embeddings_gm_script.offset_per_key(),
             pooled_embeddings.offset_per_key(),
         )
+
+    def test_ir_export(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self, fp_ebc) -> None:
+                super().__init__()
+                self._fp_ebc = fp_ebc
+
+            def forward(self, features: KeyedJaggedTensor) -> KeyedTensor:
+                return self._fp_ebc(features)
+
+        m = MyModule(self.generate_fp_ebc())
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
+        )
+        ep = torch.export.export(
+            m,
+            (features,),
+            {},
+            strict=False,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("_embedding_bag") for n in ep.graph.nodes),
+            0,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
+            1,
+            "Shoulde be exact 1 EBC nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(output.keys(), exported.keys())
+        self.assertEqual(output.values().size(), exported.values().size())


### PR DESCRIPTION
Summary:
# context
* convert `FeatureProcessedEmbeddingBagCollection` to custom op in IR export
* add serialization and deserialization function for FPEBC
* add an API for the `FeatureProcessorInterface` to export necessary paramters for create an instance
* use this API (`get_init_kwargs`) in the serialize and deserialize functions to flatten and unflatten the feature processor

# details
1. Added `FPEBCMetadata` schema for FP_EBC, use a `fp_json` string to store the necessary paramters
2. Added `FPEBCJsonSerializer`, converted the init_kwargs to json string and store in the `fp_json` field in the metadata
3. Added a fqn check for `serialized_fqns`, so that when a higher-level module is serialized, the lower-level module can be skipped (it's already included in the higher-level module)
4. Added an API called `get_init_kwargs` for `FeatureProcessorsCollection` and `FeatureProcessor`, and use a `FeatureProcessorNameMap` to map the classname to the feature processor class
5. Added `_non_strict_exporting_forward` function for FPEBC so that in non_strict IR export it goes to the custom_op logic

Differential Revision: D57829276


