### PR TITLE
Remove recat tensor compute

### DIFF
--- a/torchrec/sparse/tests/keyed_jagged_tensor_benchmark.py
+++ b/torchrec/sparse/tests/keyed_jagged_tensor_benchmark.py
@@ -138,7 +138,6 @@ def gen_dist_split_input(
         num_splits=num_workers,
         device=device,
         batch_size_per_rank=batch_size_per_rank,
-        use_tensor_compute=False,
     )
 
     return (kjt_lengths, kjt_values, batch_size_per_rank, recat)


### PR DESCRIPTION
Summary:
PT2 can compile without recat tensor compute.
Removing not to have second path.

Reviewed By: TroyGarden

Differential Revision: D58160116


