### PR TITLE
attempt to write specialized reshape code for 1d <-> 2d

### DIFF
--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -353,7 +353,9 @@ def _test_compile_rank_fn(
             torch._dynamo.config.capture_scalar_outputs = True
             torch._dynamo.config.capture_dynamic_output_shape_ops = True
             opt_fn = torch.compile(
-                dmp, backend=torch_compile_backend, fullgraph=True, dynamic=True
+                dmp,
+                backend=torch_compile_backend,
+                fullgraph=True,
             )
             compile_out = opt_fn(kjt_for_pt2_tracing(kjt, convert_to_vb=convert_to_vb))
             torch.testing.assert_close(eager_out, compile_out)
@@ -401,6 +403,13 @@ class TestPt2Train(MultiProcessTestBase):
                     ShardingType.COLUMN_WISE.value,
                     _InputType.SINGLE_BATCH,
                     _ConvertToVariableBatch.TRUE,
+                    "eager",
+                ),
+                (
+                    _ModelType.EBC,
+                    ShardingType.TABLE_WISE.value,
+                    _InputType.SINGLE_BATCH,
+                    _ConvertToVariableBatch.FALSE,
                     "eager",
                 ),
             ]

--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -11,6 +11,8 @@ from typing import List
 
 import torch
 
+from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+
 USE_TORCHDYNAMO_COMPILING_PATH: bool = False
 
 
@@ -74,3 +76,19 @@ def pt2_checks_all_is_size(list: List[int]) -> List[int]:
     for i in list:
         torch._check_is_size(i)
     return list
+
+
+def pt2_check_size_nonzero(x: torch.Tensor) -> torch.Tensor:
+    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+        return x
+
+    for i in range(x.dim()):
+        torch._check(x.size(i) > 0)
+    return x
+
+
+def pt2_guard_size_oblivious(x: bool) -> bool:
+    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+        return x
+
+    return guard_size_oblivious(x)


### PR DESCRIPTION
Summary:
This diff contains torchrec changes that, together with a separate PyTorch PR, will ensure that uniform batch test with view conversions work in the existing torchrec tests.

I am deliberately not including the changes in test_pt2_multiprocess.py that I used to test locally on my devserver. I will let the torchrec team decide if they want those changes in this diff or they prefer to do it themselves in a separate diff.

Differential Revision: D58200241


