### PR TITLE
Make train pipeline account for detached arg from torch.export serialization solution

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -563,6 +563,26 @@ def _get_node_args_helper(
                 # pyre-fixme[16]
                 and child_node.target.__name__ == "KeyedJaggedTensor"
             ):
+                call_module_found = False
+                for arg_node in child_node.args:
+                    if (
+                        isinstance(arg_node, torch.fx.Node)
+                        and arg_node.op == "call_module"
+                    ):
+                        call_module_found = True
+                        break
+
+                for arg_node in child_node.kwargs.values():
+                    if (
+                        isinstance(arg_node, torch.fx.Node)
+                        and arg_node.op == "call_module"
+                    ):
+                        call_module_found = True
+                        break
+
+                if call_module_found:
+                    break
+
                 if "values" in child_node.kwargs:
                     arg = child_node.kwargs["values"]
                 else:


### PR DESCRIPTION
Summary:
With the torchrec serialization solution, previous modifications on the KJT might not be properly recorded. https://www.internalfb.com/phabricator/paste/view/P1399383958 is an example of a model where this bug surfaced.

This is due to the fact that in TorchRec serialization for the PT2 IR, the sparse arch is first compiled as part of the IR and then module swapped back to the original eager module say in the trainer. In order to do this, we preserve the module call signature of the sparse arch, making the inputs as KJTs instead of flattened values, lengths, weights.

However, in the train pipeline, this was not accounted for. If the input node was a KJT, only the values was looked at to see if it was modified, not the weights. This change now checks all the args for the KJT to see if they are a call_module (result of some other module output). If that is the case, there is no way this KJT is unmodified and should not be counted.

Differential Revision: D58272814
