### PR TITLE
refactor single gpu model parallel tests

### DIFF
--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -397,6 +397,7 @@ def data_parallel() -> ParameterShardingGenerator:
 def table_wise(
     rank: int,
     device: Optional[str] = None,
+    compute_kernel: Optional[str] = None,
 ) -> ParameterShardingGenerator:
     """
     Returns a generator of ParameterShardingPlan for `ShardingType::TABLE_WISE` for construct_module_sharding_plan.
@@ -404,6 +405,7 @@ def table_wise(
     Args:
     rank (int): rank to place table when doing table wise
     device (Optional[str]): device to place table when doing table_wise sharding
+    compute_kernel (Optional[str]): embedding compute kernel to use for the table
 
     Example::
 
@@ -441,7 +443,7 @@ def table_wise(
             device_type,
             sharder,
             placements=([placement_helper(device, rank)] if device else None),
-            compute_kernel=(EmbeddingComputeKernel.QUANT.value if device else None),
+            compute_kernel=compute_kernel,
         )
 
     return _parameter_sharding_generator

--- a/torchrec/distributed/tests/test_fp_embeddingbag.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag.py
@@ -38,7 +38,8 @@ from torchrec.distributed.test_utils.multi_process import (
 from torchrec.distributed.test_utils.test_sharding import copy_state_dict
 from torchrec.distributed.tests.test_fp_embeddingbag_utils import (
     create_module_and_freeze,
-    get_configs_and_kjt_inputs,
+    get_configs,
+    get_kjt_inputs,
 )
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -236,7 +237,8 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         hypothesis.assume(not xor(use_dmp, use_fp_collection))
 
         WORLD_SIZE = 2
-        embedding_bag_config, kjt_input_per_rank = get_configs_and_kjt_inputs()
+        embedding_bag_config = get_configs()
+        kjt_input_per_rank = get_kjt_inputs()
 
         self._run_multi_process_test(
             callable=_test_sharding,
@@ -264,7 +266,7 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
     def test_sharding_fp_ebc_from_meta(
         self, use_fp_collection: bool, backend: str
     ) -> None:
-        embedding_bag_config, kjt_input_per_rank = get_configs_and_kjt_inputs()
+        embedding_bag_config = get_configs()
         self._run_multi_process_test(
             callable=_test_sharding_from_meta,
             world_size=2,

--- a/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
@@ -153,36 +153,20 @@ class TestFPEBCSharder(FeatureProcessedEmbeddingBagCollectionSharder):
         return [self._kernel_type]
 
 
-def get_configs_and_kjt_inputs() -> (
-    Tuple[List[EmbeddingBagConfig], List[KeyedJaggedTensor]]
-):
-    embedding_bag_config = [
+def get_configs() -> List[EmbeddingBagConfig]:
+    dims = [3 * 16, 8, 8, 3 * 16]
+    return [
         EmbeddingBagConfig(
-            name="table_0",
-            feature_names=["feature_0"],
-            embedding_dim=3 * 16,
+            name=f"table_{i}",
+            feature_names=[f"feature_{i}"],
+            embedding_dim=dim,
             num_embeddings=16,
-        ),
-        EmbeddingBagConfig(
-            name="table_1",
-            feature_names=["feature_1"],
-            embedding_dim=8,
-            num_embeddings=16,
-        ),
-        EmbeddingBagConfig(
-            name="table_2",
-            feature_names=["feature_2"],
-            embedding_dim=8,
-            num_embeddings=16,
-        ),
-        EmbeddingBagConfig(
-            name="table_3",
-            feature_names=["feature_3"],
-            embedding_dim=3 * 16,
-            num_embeddings=16,
-        ),
+        )
+        for i, dim in enumerate(dims)
     ]
 
+
+def get_kjt_inputs() -> List[KeyedJaggedTensor]:
     # Rank 0
     #             instance 0   instance 1  instance 2
     # "feature_0"   [0, 1]       None        [2]
@@ -235,5 +219,4 @@ def get_configs_and_kjt_inputs() -> (
             ),
         ),
     ]
-
-    return embedding_bag_config, kjt_input_per_rank
+    return kjt_input_per_rank

--- a/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
@@ -28,6 +28,8 @@ from torchrec.modules.feature_processor_ import (
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
+DEFAULT_MAX_FEATURE_LENGTH = 12
+
 
 class SparseArch(nn.Module):
     def __init__(
@@ -35,8 +37,20 @@ class SparseArch(nn.Module):
         tables: List[EmbeddingBagConfig],
         use_fp_collection: bool,
         device: torch.device,
+        max_feature_lengths: Optional[List[int]] = None,
     ) -> None:
         super().__init__()
+
+        feature_names = [
+            feature_name for table in tables for feature_name in table.feature_names
+        ]
+
+        if max_feature_lengths is None:
+            max_feature_lengths = [DEFAULT_MAX_FEATURE_LENGTH] * len(feature_names)
+
+        assert len(max_feature_lengths) == len(
+            feature_names
+        ), "Expect max_feature_lengths to have the same number of items as feature_names"
 
         self._fp_ebc: FeatureProcessedEmbeddingBagCollection = (
             FeatureProcessedEmbeddingBagCollection(
@@ -49,20 +63,19 @@ class SparseArch(nn.Module):
                     cast(
                         Dict[str, FeatureProcessor],
                         {
-                            "feature_0": PositionWeightedModule(max_feature_length=10),
-                            "feature_1": PositionWeightedModule(max_feature_length=10),
-                            "feature_2": PositionWeightedModule(max_feature_length=12),
-                            "feature_3": PositionWeightedModule(max_feature_length=12),
+                            feature_name: PositionWeightedModule(
+                                max_feature_length=max_feature_length
+                            )
+                            for feature_name, max_feature_length in zip(
+                                feature_names, max_feature_lengths
+                            )
                         },
                     )
                     if not use_fp_collection
                     else PositionWeightedModuleCollection(
-                        max_feature_lengths={
-                            "feature_0": 10,
-                            "feature_1": 10,
-                            "feature_2": 12,
-                            "feature_3": 12,
-                        }
+                        max_feature_lengths=dict(
+                            zip(feature_names, max_feature_lengths)
+                        ),
                     )
                 ),
             ).to(device)
@@ -85,9 +98,10 @@ def create_module_and_freeze(
     tables: List[EmbeddingBagConfig],
     use_fp_collection: bool,
     device: torch.device,
+    max_feature_lengths: Optional[List[int]] = None,
 ) -> SparseArch:
 
-    sparse_arch = SparseArch(tables, use_fp_collection, device)
+    sparse_arch = SparseArch(tables, use_fp_collection, device, max_feature_lengths)
 
     torch.manual_seed(0)
     for param in sparse_arch.parameters():

--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -16,6 +16,7 @@ import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings
 from torchrec import EmbeddingBagConfig, EmbeddingCollection, EmbeddingConfig
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.planner.planners import HeteroEmbeddingShardingPlanner
 from torchrec.distributed.planner.types import Topology
@@ -71,12 +72,17 @@ class InferHeteroShardingsTest(unittest.TestCase):
             weight_dtype=torch.qint8,
         )
         sharder = QuantEmbeddingCollectionSharder()
+        compute_kernel = EmbeddingComputeKernel.QUANT.value
         module_plan = construct_module_sharding_plan(
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(([20, 10, 100], "cpu")),
-                "table_1": table_wise(rank=0, device="cuda"),
-                "table_2": table_wise(rank=1, device="cuda"),
+                "table_1": table_wise(
+                    rank=0, device="cuda", compute_kernel=compute_kernel
+                ),
+                "table_2": table_wise(
+                    rank=1, device="cuda", compute_kernel=compute_kernel
+                ),
             },
             # pyre-ignore
             sharder=sharder,
@@ -165,12 +171,17 @@ class InferHeteroShardingsTest(unittest.TestCase):
             weight_dtype=torch.qint8,
         )
         sharder = QuantEmbeddingBagCollectionSharder()
+        compute_kernel = EmbeddingComputeKernel.QUANT.value
         module_plan = construct_module_sharding_plan(
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(([20, 10, 100], "cpu")),
-                "table_1": table_wise(rank=0, device="cuda"),
-                "table_2": table_wise(rank=1, device="cuda"),
+                "table_1": table_wise(
+                    rank=0, device="cuda", compute_kernel=compute_kernel
+                ),
+                "table_2": table_wise(
+                    rank=1, device="cuda", compute_kernel=compute_kernel
+                ),
             },
             # pyre-ignore
             sharder=sharder,

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -68,6 +68,7 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
         self,
         num_batches: int = 5,
         batch_size: int = 1,
+        max_feature_lengths: Optional[List[int]] = None,
     ) -> List[ModelInput]:
         return [
             ModelInput.generate(
@@ -76,6 +77,7 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
                 batch_size=batch_size,
                 world_size=1,
                 num_float_features=10,
+                max_feature_lengths=max_feature_lengths,
             )[0]
             for i in range(num_batches)
         ]


### PR DESCRIPTION
Summary:
Adding
* _create_tables
* _create_model
* generate_batch

which allow all 3 current use case to reuse the same `_generate_dmps_and_batch`

Motivation is to reuse mode code in upcoming SSD TBE tests.

Differential Revision: D58259588
