### PR TITLE
Revert D58137460: Multisect successfully blamed "D58137460: [FBGEMM][MTIA] Support MTIA in DenseTableBatchedEmbeddingBagsCodegen" for one test failure

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -929,20 +929,16 @@ class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
         weights_precision = data_type_to_sparse_type(config.data_type)
         fused_params = config.fused_params or {}
         output_dtype = fused_params.get("output_dtype", SparseType.FP32)
-        use_cpu: bool = (
-            device is None
-            or device.type == "cpu"
-            or (not (torch.cuda.is_available() or torch.mtia.is_available()))
-        )
         self._emb_module: DenseTableBatchedEmbeddingBagsCodegen = (
             DenseTableBatchedEmbeddingBagsCodegen(
                 list(zip(self._local_rows, self._local_cols)),
                 feature_table_map=self._feature_table_map,
                 pooling_mode=PoolingMode.NONE,
-                use_cpu=use_cpu,
+                use_cpu=device is None
+                or device.type == "cpu"
+                or not torch.cuda.is_available(),
                 weights_precision=weights_precision,
                 output_dtype=output_dtype,
-                use_mtia=device is not None and device.type == "mtia",
             )
         )
         self._param_per_table: Dict[str, TableBatchedEmbeddingSlice] = dict(
@@ -1362,20 +1358,16 @@ class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
         weights_precision = data_type_to_sparse_type(config.data_type)
         fused_params = config.fused_params or {}
         output_dtype = fused_params.get("output_dtype", SparseType.FP32)
-        use_cpu: bool = (
-            device is None
-            or device.type == "cpu"
-            or (not (torch.cuda.is_available() or torch.mtia.is_available()))
-        )
         self._emb_module: DenseTableBatchedEmbeddingBagsCodegen = (
             DenseTableBatchedEmbeddingBagsCodegen(
                 list(zip(self._local_rows, self._local_cols)),
                 feature_table_map=self._feature_table_map,
                 pooling_mode=self._pooling,
-                use_cpu=use_cpu,
+                use_cpu=device is None
+                or device.type == "cpu"
+                or not torch.cuda.is_available(),
                 weights_precision=weights_precision,
                 output_dtype=output_dtype,
-                use_mtia=device is not None and device.type == "mtia",
             )
         )
         self._param_per_table: Dict[str, TableBatchedEmbeddingSlice] = dict(


### PR DESCRIPTION
Summary:
This diff reverts D58137460
D58137460: [FBGEMM][MTIA] Support MTIA in DenseTableBatchedEmbeddingBagsCodegen by gnahzg causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_cot_integration_test#test](https://www.internalfb.com/intern/test/281475108054087/)

Here's the Multisect link:
https://www.internalfb.com/multisect/5409932
Here are the tasks that are relevant to this breakage:
T191381073: 500+ tests unhealthy for minimal_viable_ai

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Reviewed By: gnahzg, yumin829928

Differential Revision: D58449527
