### PR TITLE
Enable pt2_checks check_is_size for non-strict-export

### DIFF
--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -55,10 +55,14 @@ except Exception:
         return False
 
 
+def is_pt2_compiling() -> bool:
+    return is_torchdynamo_compiling() or is_compiler_compiling()
+
+
 def pt2_checks_tensor_slice(
     tensor: torch.Tensor, start_offset: int, end_offset: int, dim: int = 0
 ) -> None:
-    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+    if torch.jit.is_scripting() or not is_pt2_compiling():
         return
 
     torch._check_is_size(start_offset)
@@ -70,7 +74,7 @@ def pt2_checks_tensor_slice(
 
 
 def pt2_checks_all_is_size(list: List[int]) -> List[int]:
-    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+    if torch.jit.is_scripting() or not is_pt2_compiling():
         return list
 
     for i in list:
@@ -79,7 +83,7 @@ def pt2_checks_all_is_size(list: List[int]) -> List[int]:
 
 
 def pt2_check_size_nonzero(x: torch.Tensor) -> torch.Tensor:
-    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+    if torch.jit.is_scripting() or not is_pt2_compiling():
         return x
 
     for i in range(x.dim()):
@@ -88,7 +92,7 @@ def pt2_check_size_nonzero(x: torch.Tensor) -> torch.Tensor:
 
 
 def pt2_guard_size_oblivious(x: bool) -> bool:
-    if torch.jit.is_scripting() or not is_torchdynamo_compiling():
+    if torch.jit.is_scripting() or not is_pt2_compiling():
         return x
 
     return guard_size_oblivious(x)

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -890,6 +890,8 @@ def _maybe_compute_length_per_key(
         else:
             _length: List[int] = []
         length_per_key = _length
+        pt2_checks_all_is_size(length_per_key)
+
     return length_per_key
 
 


### PR DESCRIPTION
Summary:
pt2/checks/_check_is_size were not enabled for non-strict-export
But we need them for data dep conditions.

Fixes test_kjt_permute for non-strict-export

Reviewed By: TroyGarden

Differential Revision: D58533186
