### PR TITLE
Use at least one cache sets per TBE

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -112,7 +112,9 @@ def _populate_ssd_tbe_params(config: GroupedEmbeddingConfig) -> Dict[str, Any]:
             cache_load_factor = 0.2
 
         local_rows_sum: int = sum(table.local_rows for table in config.embedding_tables)
-        ssd_tbe_params["cache_sets"] = int(cache_load_factor * local_rows_sum / ASSOC)
+        ssd_tbe_params["cache_sets"] = max(
+            int(cache_load_factor * local_rows_sum / ASSOC), 1
+        )
 
     # populate init min and max
     if (


### PR DESCRIPTION
Summary:
I added assertion to check for cache sets > 0, since it would fail without error when cache sets = 0.

Fixing in this diff to use at least one cache sets, so we don't have to worry about rounding error anymore.

Example:
table size is 30.
Which means cache sets is int(30 * 0.2 / 32) = 0

Differential Revision: D58626864
