### PR TITLE
add configs for 1) client thread num 2) max key per request 3) max local index length 4) ps hosts & ports

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -848,6 +848,14 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
         fused_params = config.fused_params or {}
         if "cache_precision" not in fused_params:
             fused_params["cache_precision"] = weights_precision
+        if "ps_hosts" in fused_params:
+            fused_params.pop("ps_hosts")
+        if "ps_max_key_per_request" in fused_params:
+            fused_params.pop("ps_max_key_per_request")
+        if "ps_client_thread_num" in fused_params:
+            fused_params.pop("ps_client_thread_num")
+        if "ps_max_local_index_length" in fused_params:
+            fused_params.pop("ps_max_local_index_length")
 
         self._emb_module: SplitTableBatchedEmbeddingBagsCodegen = (
             SplitTableBatchedEmbeddingBagsCodegen(
@@ -1276,6 +1284,14 @@ class BatchedFusedEmbeddingBag(
         fused_params = config.fused_params or {}
         if "cache_precision" not in fused_params:
             fused_params["cache_precision"] = weights_precision
+        if "ps_hosts" in fused_params:
+            fused_params.pop("ps_hosts")
+        if "ps_max_key_per_request" in fused_params:
+            fused_params.pop("ps_max_key_per_request")
+        if "ps_client_thread_num" in fused_params:
+            fused_params.pop("ps_client_thread_num")
+        if "ps_max_local_index_length" in fused_params:
+            fused_params.pop("ps_max_local_index_length")
 
         self._emb_module: SplitTableBatchedEmbeddingBagsCodegen = (
             SplitTableBatchedEmbeddingBagsCodegen(


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2727

In this diff, we added the APi to enable 1) client thread num and 2) max key per request 3) max local index length 4) ps hosts & ports in Parameter Server to be configurable in model config

Reviewed By: emlin

Differential Revision: D58372476
