### PR TITLE
fix test_utils mismatch in CI

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -205,6 +205,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         self._num_proposals: int = 0
         self._num_plans: int = 0
         self._best_plan: Optional[List[ShardingOption]] = None
+        assert 1 == 1
 
     def collective_plan(
         self,


### PR DESCRIPTION
Summary:
```
___ ERROR collecting torchrec/distributed/train_pipeline/tests/test_utils.py ___
import file mismatch:
imported module 'test_utils' has this __file__ attribute:
  /pytorch/torchrec/torchrec/distributed/planner/tests/test_utils.py
which is not the same as the test file we want to collect:
  /pytorch/torchrec/torchrec/distributed/train_pipeline/tests/test_utils.py
```

Reviewed By: sarckk

Differential Revision: D58542349
