### PR TITLE
Add feature pools to torchrec OSS

### DIFF
--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+#!/usr/bin/env python3
+
+from typing import cast, Dict, List, Optional, Tuple, Type, Union
+
+import torch
+from torchrec.distributed.object_pool import ShardedObjectPool
+from torchrec.distributed.sharding.rw_kjt_pool_sharding import (
+    InferRwKeyedJaggedTensorPoolOutputDist,
+    InferRwKeyedJaggedTensorPoolSharding,
+    KeyedJaggedTensorPoolRwReplicatedSharding,
+    KeyedJaggedTensorPoolRwSharding,
+)
+from torchrec.distributed.sharding.rw_pool_sharding import InferRwObjectPoolInputDist
+from torchrec.distributed.tensor_sharding import ObjectPoolShardingContext
+
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ModuleSharder,
+    ObjectPoolShardingPlan,
+    ObjectPoolShardingType,
+    ShardingEnv,
+)
+from torchrec.modules.keyed_jagged_tensor_pool import KeyedJaggedTensorPool
+from torchrec.modules.object_pool_lookups import (
+    KeyedJaggedTensorPoolLookup,
+    TensorJaggedIndexSelectLookup,
+    UVMCachingInt32Lookup,
+    UVMCachingInt64Lookup,
+)
+from torchrec.modules.utils import deterministic_dedup, jagged_index_select_with_empty
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+class KeyedJaggedTensorPoolAwaitable(LazyAwaitable[KeyedJaggedTensor]):
+    def __init__(
+        self,
+        awaitable: Awaitable[JaggedTensor],
+        keys: List[str],
+        device: torch.device,
+        unbucketize_permute: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._awaitable = awaitable
+        self._unbucketize_permute = unbucketize_permute
+        self._keys = keys
+        self._device = device
+
+    def _wait_impl(self) -> KeyedJaggedTensor:
+        # we could un-permute, but perhaps unnecessary for caching use case.
+        jt = self._awaitable.wait()
+
+        # if we have an empty found, we should not perform any lookups and just
+        # return an empty KJT.
+        if jt.lengths().size()[0] == 0:
+            return KeyedJaggedTensor.empty(
+                is_weighted=jt.weights_or_none() is not None,
+                device=self._device,
+                values_dtype=jt.values().dtype,
+                lengths_dtype=jt.lengths().dtype,
+                weights_dtype=getattr(jt.weights_or_none(), "dtype", None),
+            )
+
+        """
+        We need to permute the row order KJT based on the unbucketize permute tensor
+        to respect the original order that it came in.
+        """
+
+        unbucketize_id_permute = (
+            torch.arange(jt.lengths().shape[0], device=self._device)
+            .view(-1, len(self._keys))[self._unbucketize_permute]
+            .flatten()
+        )
+
+        """
+        Since the all to all will return to us in a row manner format, we need to regroup
+        using jaggeed index_select to key order.
+        For example, we will receive 0,2,3,4,5,6,7. But we need it to be in [0,2,5,6,3,4,7] order.
+
+        F1      F2
+        [0,2] . [3,4]
+        [5,6]   [7]
+
+        Can remove if we can write efficient kernel that can return in feature order. This would also
+        require splits to be transposed and flattened, to be put in feature order.
+        """
+
+        row_major_to_feature_major_permute = (
+            torch.arange(jt.lengths().shape[0], device=self._device)
+            .view(-1, len(self._keys))
+            .t()
+            .flatten()
+        )
+        """
+            The below is equivalent to doing
+            reorder_v = jagged_index_select(values, unbucketize_id_permute)
+            reorder_v = jagged_index_select(reorder_v, row_major_to_feature_major_permute)
+        """
+
+        indices = unbucketize_id_permute[row_major_to_feature_major_permute]
+        reorder_l = jt.lengths()[indices]
+        reorder_o = torch.ops.fbgemm.asynchronous_inclusive_cumsum(reorder_l)
+        reorder_v = jagged_index_select_with_empty(
+            jt.values().unsqueeze(-1), indices, jt.offsets()[1:], reorder_o
+        )
+
+        reorder_w = (
+            jagged_index_select_with_empty(
+                jt.weights().unsqueeze(-1),
+                indices,
+                jt.offsets()[1:],
+                reorder_o,
+            )
+            if jt.weights_or_none() is not None
+            else None
+        )
+
+        return KeyedJaggedTensor(
+            keys=self._keys,
+            values=reorder_v.flatten(),
+            weights=reorder_w.flatten() if reorder_w is not None else None,
+            lengths=reorder_l,
+        )
+
+
+class ShardedKeyedJaggedTensorPool(
+    ShardedObjectPool[
+        KeyedJaggedTensor,  # Out
+        JaggedTensor,  # DistOut
+        ObjectPoolShardingContext,  # Ctx
+    ]
+):
+    """
+    Sharded implementation of `KeyedJaggedTensorPool`
+
+    When dealing with a large pool that cannot fit in a single device memory
+    (i.e. HBM / UVM / CPU etc), this module handles sharding the pool row-wise, including
+    orchestrating the communication between ranks for distributed lookup and update.
+
+    Args:
+        pool_size (int): total number of batches that can be stored in the pool
+        values_dtype (torch.dtype): dtype of the KJT values in the pool
+        feature_max_lengths (Dict[str,int]): Mapping from feature name in KJT
+            to the maximum size of the jagged slices for the feature.
+        is_weighted (bool): whether KJT values have weights that need to be stored.
+        sharding_env (ShardingEnv): sharding environment (e.g. world_size, ranks, etc)
+        sharding_plan (ObjectPoolShardingPlan): info about sharding strategy
+        device (Optional[torch.device]): default device
+        enable_uvm (bool): if set to true, the pool will be allocated on UVM
+
+    Example::
+        # Example on 2 GPUs
+        # on rank 0, update ids [2,0] with values
+        # ids   f1       f2
+        # 2     [1]      [2, 3]
+        # 0     [4,5]    [6]
+        sharded_keyed_jagged_tensor_pool.update(
+            ids=torch.Tensor([2,0],dtype=torch.int,device="cuda:0")
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1","f2"],
+                values=torch.Tensor([1,2,3,4,5,6],device="cuda:0"),
+                lengths=torch.Tensor([1,2,2,1],device="cuda:0")
+            )
+        )
+
+        # on rank 1, update ids [1,3] with values
+        # ids   f1           f2
+        # 1     [7,8]        []
+        # 3     [9,10,11]    [12]
+        sharded_keyed_jagged_tensor_pool.update(
+            ids=torch.Tensor([1,3],dtype=torch.int,device="cuda:1")
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1","f2"],
+                values=torch.Tensor([7,8,9,10,11,12],device="cuda:1"),
+                lengths=torch.Tensor([2,0,3,1],device="cuda:1")
+            )
+        )
+
+        # At this point the global state is:
+        # ids   f1      f2
+        # 0    [2,3]    [6]         <- rank 0
+        # 1    [7,8]    [9,10,11]   <- rank 0
+        # 2    [1]      [4,5]       <- rank 1
+        # 3    []       [12]        <- rank 1
+
+    """
+
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_env: ShardingEnv,
+        sharding_plan: ObjectPoolShardingPlan,
+        device: Optional[torch.device] = None,
+        # TODO add quantized comms codec registry
+        enable_uvm: bool = False,
+    ) -> None:
+
+        super().__init__()
+        self._pool_size = pool_size
+        self._values_dtype = values_dtype
+        self._sharding_env = sharding_env
+        self._device: torch.device = device or torch.device("cuda")
+        self._is_weighted = is_weighted
+        self._sharding_plan = sharding_plan
+        self._feature_max_lengths = feature_max_lengths
+        self.register_buffer(
+            "_feature_max_lengths_t",
+            torch.tensor(
+                list(feature_max_lengths.values()),
+                dtype=torch.int32,
+                device=self._device,
+            ),
+            persistent=False,
+        )
+        self._features: List[str] = list(feature_max_lengths.keys())
+        self._enable_uvm = enable_uvm
+
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._permute_feature = None
+        if sharding_plan.sharding_type == ObjectPoolShardingType.ROW_WISE:
+            self._sharding: KeyedJaggedTensorPoolRwSharding = (
+                KeyedJaggedTensorPoolRwSharding(
+                    env=self._sharding_env,
+                    device=self._device,
+                    pool_size=self._pool_size,
+                    num_features=len(feature_max_lengths),
+                )
+            )
+        elif sharding_plan.sharding_type == ObjectPoolShardingType.REPLICATED_ROW_WISE:
+            self._sharding: KeyedJaggedTensorPoolRwReplicatedSharding = (
+                KeyedJaggedTensorPoolRwReplicatedSharding(
+                    env=self._sharding_env,
+                    device=self._device,
+                    pool_size=self._pool_size,
+                    num_features=len(feature_max_lengths),
+                )
+            )
+
+        else:
+            raise NotImplementedError(
+                f"Sharding type {self._sharding_plan.sharding_type} is not implemented"
+            )
+
+        # pyre-ignore
+        self._lookup: KeyedJaggedTensorPoolLookup = None
+        if self._enable_uvm:
+            if values_dtype == torch.int64:
+                self._lookup = UVMCachingInt64Lookup(
+                    self._sharding.local_pool_size,
+                    feature_max_lengths,
+                    is_weighted,
+                    self._device,
+                )
+            if values_dtype == torch.int32:
+                self._lookup = UVMCachingInt32Lookup(
+                    self._sharding.local_pool_size,
+                    feature_max_lengths,
+                    is_weighted,
+                    self._device,
+                )
+        else:
+            self._lookup = TensorJaggedIndexSelectLookup(
+                self._sharding.local_pool_size,
+                values_dtype,
+                feature_max_lengths,
+                is_weighted,
+                self._device,
+            )
+        if self._lookup is None:
+            raise ValueError(
+                f"Cannot create lookup for {self._enable_uvm=} {self._values_dtype}"
+            )
+
+        for fqn, tensor in self._lookup.states_to_register():
+            self.register_buffer(
+                fqn,
+                tensor,
+            )
+
+        # pyre-ignore
+        self._lookup_ids_dist_impl = self._sharding.create_lookup_ids_dist()
+        # pyre-ignore
+        self._lookup_values_dist_impl = self._sharding.create_lookup_values_dist()
+        # pyre-ignore
+        self._update_ids_dist_impl = self._sharding.create_update_ids_dist()
+        # pyre-ignore
+        self._update_values_dist_impl = self._sharding.create_update_values_dist()
+
+        self._initialize_torch_state(self._lookup, sharding_plan.sharding_type)
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def feature_max_lengths(self) -> Dict[str, int]:
+        return self._feature_max_lengths
+
+    @property
+    def values_dtype(self) -> torch.dtype:
+        return self._values_dtype
+
+    @property
+    def is_weighted(self) -> bool:
+        return self._is_weighted
+
+    @property
+    def device(self) -> torch.device:
+        torch._assert(self._device is not None, "self._device should already be set")
+        return self._device
+
+    def _initialize_torch_state(
+        self, lookup: KeyedJaggedTensorPoolLookup, sharding_type: ObjectPoolShardingType
+    ) -> None:
+        for fqn, tensor in self._sharding.get_sharded_states_to_register(self._lookup):
+            self.register_buffer(fqn, tensor)
+        # somewhat hacky. ideally, we should be able to invoke this method on
+        # any update to the lookup's key_lengths field.
+        lengths, offsets = lookup._infer_jagged_lengths_inclusive_offsets()
+        lookup._lengths = lengths
+        lookup._offsets = offsets
+
+    def _lookup_ids_dist(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        return self._lookup_ids_dist_impl(ctx=ctx, ids=ids)
+
+    def _update_preproc(self, values: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        """
+        1. Permute/filter KJT keys to be the same as in feature_max_lengths
+        2. Ensure the max_lengths of input is within the feature_max_lengths
+        """
+        if self._permute_feature is None:
+            self._permute_feature = []
+            for feature in self._feature_max_lengths.keys():
+                for j, kjt_feature in enumerate(values.keys()):
+                    if feature == kjt_feature:
+                        self._permute_feature.append(j)
+
+        valid_input = values.permute(self._permute_feature)
+        # can disable below check if expensive
+        max_elements, _max_indices = (
+            valid_input.lengths()
+            .reshape(len(self._feature_max_lengths.keys()), -1)
+            .max(dim=1)
+        )
+
+        assert torch.all(
+            max_elements <= self._feature_max_lengths_t
+        ).item(), "input KJT has a feature that exceeds specified max lengths"
+
+        return valid_input
+
+    def _update_local(
+        self,
+        ctx: ObjectPoolShardingContext,
+        ids: torch.Tensor,
+        values: JaggedTensor,
+    ) -> None:
+        if ids.size(0) == 0:
+            return
+        jt = values
+        deduped_ids, dedup_permutation = deterministic_dedup(ids)
+
+        device = ids.device
+        arange_idx = torch.arange(len(jt.lengths()), device=device)
+        value_dedup_permute = (arange_idx.view(-1, len(self._feature_max_lengths)))[
+            dedup_permutation, :
+        ].flatten()
+
+        deduped_lengths = jt.lengths()[value_dedup_permute]
+        deduped_offsets = torch.ops.fbgemm.asynchronous_inclusive_cumsum(
+            deduped_lengths
+        )
+        deduped_values = jagged_index_select_with_empty(
+            jt.values().unsqueeze(-1),
+            value_dedup_permute,
+            jt.offsets()[1:],
+            deduped_offsets,
+        )
+
+        deduped_values, deduped_lengths = (
+            deduped_values.flatten(),
+            deduped_lengths.flatten(),
+        )
+
+        deduped_weights = None
+        if jt.weights_or_none() is not None:
+            deduped_weights = jagged_index_select_with_empty(
+                jt.weights().unsqueeze(-1),
+                value_dedup_permute,
+                jt.offsets()[1:],
+                deduped_offsets,
+            )
+            deduped_weights = deduped_weights.flatten()
+
+        self._lookup.update(
+            deduped_ids,
+            JaggedTensor(
+                values=deduped_values,
+                lengths=deduped_lengths,
+                weights=deduped_weights,
+            ),
+        )
+
+    def _lookup_local(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> JaggedTensor:
+        return self._lookup.lookup(ids)
+
+    def _lookup_values_dist(
+        self,
+        ctx: ObjectPoolShardingContext,
+        values: JaggedTensor,
+    ) -> LazyAwaitable[KeyedJaggedTensor]:
+        return KeyedJaggedTensorPoolAwaitable(
+            awaitable=self._lookup_values_dist_impl(ctx, values),
+            unbucketize_permute=ctx.unbucketize_permute,
+            keys=self._features,
+            device=self._device,
+        )
+
+    def _update_ids_dist(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        return self._update_ids_dist_impl(ctx=ctx, ids=ids)
+
+    def _update_values_dist(
+        self, ctx: ObjectPoolShardingContext, values: KeyedJaggedTensor
+    ) -> Awaitable[JaggedTensor]:
+        return self._update_values_dist_impl(values, ctx)
+
+    def create_context(self) -> ObjectPoolShardingContext:
+        return cast(ObjectPoolShardingContext, self._sharding.create_context())
+
+
+@torch.fx.wrap
+def _get_reorder_values_lengths_weights(
+    keys: List[str],
+    jt: JaggedTensor,
+    # not actually optional, just making torchscript type happy.
+    unbucketize_permute: Optional[torch.Tensor],
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    unbucketize_id_permute = (
+        torch.arange(jt.lengths().shape[0], device=device)
+        .view(-1, len(keys))[unbucketize_permute]
+        .flatten()
+    )
+    row_major_to_feature_major_permute = (
+        torch.arange(jt.lengths().shape[0], device=device)
+        .view(-1, len(keys))
+        .t()
+        .flatten()
+    )
+    indices = unbucketize_id_permute[row_major_to_feature_major_permute]
+    reorder_l = jt.lengths()[indices]
+    reorder_o = torch.ops.fbgemm.asynchronous_inclusive_cumsum(reorder_l)
+    reorder_v = jagged_index_select_with_empty(
+        jt.values().unsqueeze(-1), indices, jt.offsets()[1:], reorder_o
+    )
+    reorder_w = (
+        jagged_index_select_with_empty(
+            jt.weights().unsqueeze(-1),
+            indices,
+            jt.offsets()[1:],
+            reorder_o,
+        ).flatten()
+        if jt.weights_or_none() is not None
+        else None
+    )
+
+    return (reorder_v.flatten(), reorder_l.flatten(), reorder_w)
+
+
+class ShardedInferenceKeyedJaggedTensorPool(
+    ShardedObjectPool[KeyedJaggedTensor, List[torch.Tensor], ObjectPoolShardingContext],
+):
+    _local_kjt_pool_shards: torch.nn.ModuleList
+    _world_size: int
+    _device: torch.device
+
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_env: ShardingEnv,
+        sharding_plan: ObjectPoolShardingPlan,
+        module: KeyedJaggedTensorPool,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+
+        self._pool_size = pool_size
+        self._values_dtype = values_dtype
+        self._sharding_env = sharding_env
+        self._world_size = self._sharding_env.world_size
+        self._device = device or torch.device("cuda")
+        self._sharding_plan = sharding_plan
+
+        self._is_weighted = is_weighted
+        self._feature_max_lengths = feature_max_lengths
+
+        torch._assert(
+            self._sharding_plan.inference, "Plan needs to have inference enabled"
+        )
+
+        if self._sharding_plan.sharding_type == ObjectPoolShardingType.ROW_WISE:
+            # pyre-fixme[4]: Attribute must be annotated.
+            self._sharding = InferRwKeyedJaggedTensorPoolSharding(
+                env=self._sharding_env,
+                device=self._device,
+                pool_size=self._pool_size,
+            )
+        else:
+            raise NotImplementedError(
+                f"Sharding type {self._sharding_plan.sharding_type} is not implemented"
+            )
+
+        self._local_kjt_pool_shards = torch.nn.ModuleList()
+        offset = 0
+        for rank, this_rank_size in zip(
+            range(self._world_size), self._sharding.local_pool_size_per_rank
+        ):
+            shard_device = (
+                torch.device("cpu")
+                if device == torch.device("cpu")
+                else torch.device("cuda", rank)
+            )
+            self._local_kjt_pool_shards.append(
+                TensorJaggedIndexSelectLookup(
+                    this_rank_size,
+                    self._values_dtype,
+                    feature_max_lengths,
+                    self._is_weighted,
+                    shard_device,
+                )
+            )
+            if module._device != torch.device("meta"):
+                self._local_kjt_pool_shards[rank]._values.copy_(
+                    module.values[offset : offset + this_rank_size]
+                )
+                self._local_kjt_pool_shards[rank]._key_lengths.copy_(
+                    module.key_lengths[offset : offset + this_rank_size]
+                )
+                jagged_lengths, jagged_offsets = self._local_kjt_pool_shards[
+                    rank
+                ]._infer_jagged_lengths_inclusive_offsets()
+                self._local_kjt_pool_shards[rank]._jagged_lengths = jagged_lengths
+                self._local_kjt_pool_shards[rank]._jagged_offsets = jagged_offsets
+            offset += this_rank_size
+
+        # TODO: move these to class type declarations
+        #   this can be somewhat tricky w/ torchscript since these are
+        #   abstract classes.
+        self._lookup_ids_dist_impl: InferRwObjectPoolInputDist = torch.jit.annotate(
+            InferRwObjectPoolInputDist,
+            self._sharding.create_lookup_ids_dist(),
+        )
+
+        self._lookup_values_dist_impl: InferRwKeyedJaggedTensorPoolOutputDist = (
+            torch.jit.annotate(
+                InferRwKeyedJaggedTensorPoolOutputDist,
+                self._sharding.create_lookup_values_dist(),
+            )
+        )
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._values_dtype
+
+    @property
+    def device(self) -> torch.device:
+        torch._assert(self._device is not None, "self._device should already be set")
+        return self._device
+
+    def create_context(self) -> ObjectPoolShardingContext:
+        raise NotImplementedError("create_context() is not implemented")
+
+    # pyre-ignore
+    def _lookup_ids_dist(
+        self,
+        ids: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
+        return self._lookup_ids_dist_impl(ids)
+
+    # pyre-ignore
+    def _lookup_local(
+        self,
+        dist_input: List[torch.Tensor],
+    ) -> List[JaggedTensor]:
+        ret = torch.jit.annotate(List[JaggedTensor], [])
+        for i, shard in enumerate(self._local_kjt_pool_shards):
+            ret.append(shard(dist_input[i]))
+        return ret
+
+    # pyre-ignore
+    def _lookup_values_dist(
+        self,
+        lookups: List[JaggedTensor],
+    ) -> JaggedTensor:
+        return self._lookup_values_dist_impl(lookups)
+
+    # pyre-ignore
+    def forward(self, ids: torch.Tensor) -> KeyedJaggedTensor:
+        dist_input, unbucketize_permute = self._lookup_ids_dist(ids)
+        lookup = self._lookup_local(dist_input)
+        # Here we are playing a trick to workaround a fx tracing issue,
+        # as proxy is not iteratable.
+        lookup_list = []
+        for i in range(self._world_size):
+            lookup_list.append(lookup[i])
+
+        jt = self._lookup_values_dist(lookup_list)
+        keys = list(self._feature_max_lengths.keys())
+        reorder_v, reorder_l, reorder_w = _get_reorder_values_lengths_weights(
+            keys, jt, unbucketize_permute, self._device
+        )
+
+        ret = KeyedJaggedTensor.from_lengths_sync(
+            keys=keys,
+            values=reorder_v,
+            weights=reorder_w,
+            lengths=reorder_l,
+        )
+        return ret
+
+    # pyre-ignore
+    def _update_ids_dist(
+        self,
+        ctx: ObjectPoolShardingContext,
+        ids: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError("Inference does not currently support update")
+
+    # pyre-ignore
+    def _update_values_dist(self, ctx: ObjectPoolShardingContext, values: torch.Tensor):
+        raise NotImplementedError("Inference does not currently support update")
+
+    def _update_local(
+        self,
+        ctx: ObjectPoolShardingContext,
+        ids: torch.Tensor,
+        values: List[torch.Tensor],
+    ) -> None:
+        raise NotImplementedError("Inference does not support update")
+
+    def _update_preproc(self, values: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        # pyre-fixme[7]: Expected `Tensor` but got implicit return value of `None`.
+        pass
+
+
+class KeyedJaggedTensorPoolSharder(ModuleSharder[KeyedJaggedTensorPool]):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def shard(
+        self,
+        module: KeyedJaggedTensorPool,
+        plan: ObjectPoolShardingPlan,
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> Union[ShardedKeyedJaggedTensorPool, ShardedInferenceKeyedJaggedTensorPool]:
+        if plan.inference:
+            return ShardedInferenceKeyedJaggedTensorPool(
+                pool_size=module.pool_size,
+                feature_max_lengths=module.feature_max_lengths,
+                values_dtype=module.values_dtype,
+                is_weighted=module.is_weighted,
+                sharding_env=env,
+                sharding_plan=plan,
+                module=module,
+                device=device,
+            )
+        return ShardedKeyedJaggedTensorPool(
+            module.pool_size,
+            module.feature_max_lengths,
+            module.values_dtype,
+            module.is_weighted,
+            sharding_plan=plan,
+            sharding_env=env,
+            device=device,
+            enable_uvm=module._enable_uvm,
+        )
+
+    @property
+    def module_type(self) -> Type[KeyedJaggedTensorPool]:
+        return KeyedJaggedTensorPool

--- a/torchrec/distributed/object_pool.py
+++ b/torchrec/distributed/object_pool.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from abc import abstractmethod
+from typing import Generic
+
+import torch
+from torch._prims_common import is_integer_dtype
+from torchrec.distributed.types import (
+    Awaitable,
+    DistOut,
+    LazyAwaitable,
+    Out,
+    ShardedModule,
+    ShrdCtx,
+)
+from torchrec.modules.object_pool import ObjectPool
+
+
+class ShardedObjectPool(
+    Generic[Out, DistOut, ShrdCtx],
+    ObjectPool[Out],
+    ShardedModule[torch.Tensor, DistOut, Out, ShrdCtx],
+):
+    """
+    An abstract distributed K-V store supports update and lookup on torch.Tensor and KeyedJaggedTensor.
+
+    To use the update() function, users need to implement _update_preproc(), _ids_dist(), _update_local(), update_value_dist()
+    To use the lookup() function, users need to implement _ids_dist(), _lookup_local(), lookup_value_dist()
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @abstractmethod
+    def _update_preproc(self, values: Out) -> Out:
+        """
+        Sanity check and preproc input values
+        """
+        ...
+
+    @abstractmethod
+    def _update_ids_dist(
+        self, ctx: ShrdCtx, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]: ...
+
+    @abstractmethod
+    def _update_local(
+        self, ctx: ShrdCtx, ids: torch.Tensor, values: DistOut
+    ) -> None: ...
+
+    @abstractmethod
+    def _update_values_dist(self, ctx: ShrdCtx, values: Out) -> Awaitable[DistOut]: ...
+
+    @abstractmethod
+    def _lookup_ids_dist(
+        self, ctx: ShrdCtx, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]: ...
+
+    @abstractmethod
+    def _lookup_local(self, ctx: ShrdCtx, ids: torch.Tensor) -> DistOut: ...
+
+    @abstractmethod
+    def _lookup_values_dist(
+        self, ctx: ShrdCtx, values: DistOut
+    ) -> LazyAwaitable[Out]: ...
+
+    @abstractmethod
+    def create_context(self) -> ShrdCtx:
+        pass
+
+    # pyre-ignore override *input/**kwargs
+    def forward(self, ids: torch.Tensor) -> LazyAwaitable[Out]:
+        """
+        Perform distributed lookup on the pool using `ids`
+
+        It comprises 3 stages:
+
+        1) IDs received at each rank must be distributed via all2all to the correct ranks.
+        2) Each rank receives the correct IDs, and looks up the values locally
+        3) Each rank distributes the values from local lookup to other ranks. Note that this step depends on IDs dist because we need to know the batch dimension of tensors to send to all other ranks.
+
+        Refer to docstring for `ShardedTensorPool` and `ShardedKeyedJaggedTensorPool` for examples.
+        """
+        torch._assert(is_integer_dtype(ids.dtype), "ids type must be int")
+
+        ctx = self.create_context()
+        id_dist = self._lookup_ids_dist(ctx, ids).wait().wait()
+        local_lookup = self._lookup_local(ctx, id_dist)
+        dist_values = self._lookup_values_dist(ctx, local_lookup)
+        return dist_values
+
+    def lookup(self, ids: torch.Tensor) -> LazyAwaitable[Out]:
+        return self.forward(ids)
+
+    def update(self, ids: torch.Tensor, values: Out) -> None:
+        """
+        Perform distributed update on the pool mapping `ids` to `values`
+
+        Args:
+            ids (torch.Tensor): 1D tensor containing ids to be updated
+            values (torch.Tensor): tensor where first dim must equal number of ids
+
+        It comprises 4 stages:
+
+        1) Optional preproc stage for the values tensor received
+        2) Distribute IDs to correct ranks
+        3) Distribute value tensor/KJT to correct ranks
+        4) Each rank will now have the IDs to update and the corresponding values tensor/KJT, and can update locally
+
+        Refer to docstring for `ShardedTensorPool` and `ShardedKeyedJaggedTensorPool` for examples.
+        """
+        torch._assert(is_integer_dtype(ids.dtype), "ids type must be int")
+        values = self._update_preproc(values=values)
+        ctx = self.create_context()
+        dist_ids = self._update_ids_dist(ctx=ctx, ids=ids).wait().wait()
+        dist_values = self._update_values_dist(ctx=ctx, values=values).wait()
+        self._update_local(ctx=ctx, ids=dist_ids, values=dist_values)
+
+    # These below aren't used, instead we have lookup_ids_dist/lookup_local/lookup_values_dist, and corresponding update
+    def input_dist(
+        self,
+        ctx: ShrdCtx,
+        # pyre-ignore[2]
+        *input,
+        # pyre-ignore[2]
+        **kwargs,
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        # pyre-ignore
+        pass
+
+    def compute(self, ctx: ShrdCtx, dist_input: torch.Tensor) -> DistOut:
+        # pyre-ignore
+        pass
+
+    def output_dist(self, ctx: ShrdCtx, output: DistOut) -> LazyAwaitable[Out]:
+        # pyre-ignore
+        pass

--- a/torchrec/distributed/sharding/rw_kjt_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_kjt_pool_sharding.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Iterable, List, Tuple
+
+import torch
+import torch.distributed as dist
+
+from torch.distributed._shard.sharded_tensor import Shard, ShardMetadata
+
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from torchrec.distributed.comm import (
+    get_local_rank,
+    get_local_size,
+    intra_and_cross_node_pg,
+)
+from torchrec.distributed.dist_data import JaggedTensorAllToAll
+from torchrec.distributed.sharding.rw_pool_sharding import (
+    InferRwObjectPoolInputDist,
+    RwObjectPoolIDsDist,
+)
+from torchrec.distributed.tensor_sharding import (
+    InferObjectPoolSharding,
+    ObjectPoolReplicatedRwShardingContext,
+    ObjectPoolRwShardingContext,
+    ObjectPoolSharding,
+)
+from torchrec.distributed.types import Awaitable, ShardingEnv
+from torchrec.modules.object_pool_lookups import KeyedJaggedTensorPoolLookup
+from torchrec.modules.utils import jagged_index_select_with_empty
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+class RwKeyedJaggedTensorPoolLookupValuesDist(torch.nn.Module):
+    """
+    Module to distribute KeyedJaggedTensor to all ranks after local pool lookup
+
+    Args:
+        num_features (int): number of features in KeyedJaggedTensor to be distributed
+        env (ShardingEnv): Sharding environment with info such as rank and world size
+
+    Example:
+        dist = RwKeyedJaggedTensorPoolLookupValuesDist(num_features=2, env=env)
+
+        # on rank 0, sends 1 and receives 2 batches
+        ctx = ObjectPoolRwShardingContext(num_ids_each_rank_to_send=1, num_ids_each_rank_to_receive=2)
+        jt = JaggedTensor(values=[2,3,2], lengths=[2,1])
+
+        # on rank 1, sends 2 and receives 1 batches
+        ctx = ObjectPoolRwShardingContext(num_ids_each_rank_to_send=2, num_ids_each_rank_to_receive=1)
+        jt = JaggedTensor(values=[1,1,5,2,8], lengths=[2,2,1])
+
+        rank0_out = dist(ctx, jt).wait()
+
+        # rank0_out is
+        # JaggedTensor(values=[2,3,1,1,5,2], lengths=[2,2,2])
+
+        rank1_out = dist(ctx, jt).wait()
+        # rank1_out is
+        # JaggedTensor(values=[2,8], lengths=[1,1])
+
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        env: ShardingEnv,
+    ) -> None:
+        super().__init__()
+        self._sharding_env = env
+        self._num_features = num_features
+
+    def forward(
+        self,
+        ctx: ObjectPoolRwShardingContext,
+        jagged_tensor: JaggedTensor,
+    ) -> Awaitable[JaggedTensor]:
+        """
+        Sends JaggedTensor to relevant `ProcessGroup` ranks.
+
+        Args:
+            ctx (ObjectPoolRwShardingContext): Context for RW sharding, containing
+                number of items to send and receive from each rank.
+            jagged_tensor (JaggedTensor): JaggedTensor to distribute. This JT is
+                constructed from flattening a KeyedJaggedTensor.
+
+        Returns:
+            Awaitable[JaggedTensor]: awaitable of `JaggedTensor`
+        """
+        return JaggedTensorAllToAll(
+            jt=jagged_tensor,
+            # pyre-ignore
+            num_items_to_send=ctx.num_ids_each_rank_to_send * self._num_features,
+            # pyre-ignore
+            num_items_to_receive=ctx.num_ids_each_rank_to_receive * self._num_features,
+            # pyre-ignore
+            pg=self._sharding_env.process_group,
+        )
+
+
+class RwKeyedJaggedTensorPoolUpdateValuesDist(torch.nn.Module):
+    """
+    Module to distribute updated KeyedJaggedTensor to all ranks after local pool update
+
+    Args:
+        num_features (int): number of features in KeyedJaggedTensor to be distributed
+        env (ShardingEnv): Sharding environment with info such as rank and world size
+        device (torch.device): Device on which to allocate tensors
+        num_replicas (int): number of times KJT should be replicated across ranks in case
+            of replicated row-wise sharding. Defaults to 1 (no replica).
+
+    Example:
+        keys=['A','B']
+        dist = RwKeyedJaggedTensorPoolUpdateValuesDist(num_features=len(keys), env=env)
+        ctx = ObjectPoolRwShardingContext(
+            num_ids_each_rank_to_send=1,
+            num_ids_each_rank_to_receive=1,
+        )
+        awaitable = dist(rank0_input, ctx)
+
+        # where:
+        # rank0_input is KeyedJaggedTensor holding
+
+        #         0           1
+        # 'A'    [A.V0]       None
+        # 'B'    None         [B.V0]
+
+        # rank1_input is KeyedJaggedTensor holding
+
+        #         0           1
+        # 'A'     [A.V3]      [A.V4]
+        # 'B'     None        [B.V2]
+
+        rank0_output = awaitable.wait()
+
+        # where:
+        # rank0_output is JaggedTensor holding
+
+        values = [A.V0, A.V3]
+        lengths = [1,0,1,0]
+
+        # rank1_output is JaggedTensor holding
+
+        values = [B.V0, A.V4, B.V2]
+        lengths = [0,1,1,1]
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        env: ShardingEnv,
+        device: torch.device,
+        num_replicas: int = 1,
+    ) -> None:
+        super().__init__()
+        self._env = env
+        self._num_features = num_features
+        self._num_replicas = num_replicas
+        self._device = device
+
+    def forward(
+        self,
+        values: KeyedJaggedTensor,
+        ctx: ObjectPoolRwShardingContext,
+    ) -> Awaitable[JaggedTensor]:
+        """
+        Sends tensor to relevant `ProcessGroup` ranks.
+
+        Args:
+            values (KeyedJaggedTensor): KJT to distribute
+            ctx (ObjectPoolRwShardingContext): Context for RW sharding, containing
+                indices along batch dimension to permute KJT before A2A, as well as
+                number of items to send and receive from each rank.
+
+        Returns:
+            Awaitable[JaggedTensor]: awaitable of `JaggedTensor` from which KJT can be
+            reconstructed.
+
+        """
+
+        kjt = values
+        permute_idx = ctx.unbucketize_permute
+
+        # Below code lets us select values out from a KJT in a row manner format for example
+        # KJT
+        # f1 [0,1] [2,3]
+        # f2 [3,4,5] [6]
+        # the values come in as 0,1,2,3,4,5,6, however, we need it in feature order e.g.
+        # 0,1,3,4,5,2,3,6 to more efficiently to the all to alls
+        # we can use jagged index select to these, e.g. we need the indices to come in order of
+        # 0,2,1,3.
+        # this can be done by first chunking viewing as [[0,1][2,3]],
+        # then taking a transpose and flatten => [0,2,1,3]
+
+        arange_idx = torch.arange(
+            kjt.stride() * self._num_features, device=self._device
+        )
+        jagged_idx = arange_idx.view(self._num_features, -1).t()
+        jt_lengths_in_order_for_a2a = jagged_idx[permute_idx].flatten()
+
+        lengths_to_send = kjt.lengths()[jt_lengths_in_order_for_a2a]
+        kjt_values_to_send_offsets = torch.ops.fbgemm.asynchronous_inclusive_cumsum(
+            lengths_to_send
+        )
+        kjt_values_to_send = jagged_index_select_with_empty(
+            kjt.values().unsqueeze(-1),
+            jt_lengths_in_order_for_a2a,
+            kjt.offsets()[1:],
+            kjt_values_to_send_offsets,
+        )
+        kjt_values_to_send = kjt_values_to_send.flatten()
+
+        kjt_weights_to_send = None
+        if kjt.weights_or_none() is not None:
+            kjt_weights_to_send = jagged_index_select_with_empty(
+                kjt.weights().unsqueeze(-1),
+                jt_lengths_in_order_for_a2a,
+                kjt.offsets()[1:],
+                kjt_values_to_send_offsets,
+            )
+
+        if self._num_replicas > 1:
+            kjt_values_to_send = kjt_values_to_send.repeat(self._num_replicas)
+            lengths_to_send = lengths_to_send.flatten().repeat(self._num_replicas)
+            if kjt_weights_to_send is not None:
+                kjt_weights_to_send = kjt_weights_to_send.repeat(self._num_replicas)
+
+        jt_all_to_all = JaggedTensorAllToAll(
+            JaggedTensor(
+                values=kjt_values_to_send,
+                lengths=lengths_to_send,
+                weights=kjt_weights_to_send,
+            ),
+            # pyre-ignore
+            num_items_to_send=ctx.num_ids_each_rank_to_send * self._num_features,
+            # pyre-ignore
+            num_items_to_receive=ctx.num_ids_each_rank_to_receive * self._num_features,
+            # pyre-ignore
+            pg=self._env.process_group,
+        )
+
+        return jt_all_to_all
+
+
+class KeyedJaggedTensorPoolRwSharding(ObjectPoolSharding):
+    def __init__(
+        self,
+        env: ShardingEnv,
+        device: torch.device,
+        pool_size: int,
+        num_features: int,
+    ) -> None:
+        self._env = env
+        # pyre-ignore
+        self._pg: dist.ProcessGroup = self._env.process_group
+        self._world_size: int = self._env.world_size
+        self._rank: int = self._env.rank
+        self._device = device
+        self._pool_size = pool_size
+
+        self._block_size: int = (
+            pool_size + self._env.world_size - 1
+        ) // self._env.world_size
+
+        self.local_pool_size: int = (
+            self._block_size
+            if self._env.rank != self._env.world_size - 1
+            else pool_size - self._block_size * (self._env.world_size - 1)
+        )
+
+        self._block_size_t: torch.Tensor = torch.tensor(
+            [
+                self._block_size,
+            ],
+            dtype=torch.long,
+            device=self._device,
+        )
+        self._num_features = num_features
+
+    def create_update_ids_dist(
+        self,
+    ) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(self._pg, is_update=True)
+
+    def create_update_values_dist(
+        self,
+    ) -> RwKeyedJaggedTensorPoolUpdateValuesDist:
+        return RwKeyedJaggedTensorPoolUpdateValuesDist(
+            num_features=self._num_features,
+            env=self._env,
+            device=self._device,
+        )
+
+    def create_lookup_ids_dist(
+        self,
+    ) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(self._pg, is_update=False)
+
+    def create_lookup_values_dist(self) -> RwKeyedJaggedTensorPoolLookupValuesDist:
+        return RwKeyedJaggedTensorPoolLookupValuesDist(
+            num_features=self._num_features, env=self._env
+        )
+
+    def get_sharded_states_to_register(
+        self, lookup: KeyedJaggedTensorPoolLookup
+    ) -> Iterable[Tuple[str, torch.Tensor]]:
+        for fqn, tensor in lookup.states_to_register():
+            yield fqn, ShardedTensor._init_from_local_shards(
+                [
+                    Shard(
+                        tensor=tensor,
+                        metadata=ShardMetadata(
+                            shard_offsets=[
+                                self._env.rank * self._block_size,
+                                0,
+                            ],
+                            shard_sizes=[
+                                tensor.shape[0],
+                                tensor.shape[1],
+                            ],
+                            placement=f"rank:{self._env.rank}/{str(tensor.device)}",
+                        ),
+                    )
+                ],
+                torch.Size([self._pool_size, tensor.shape[1]]),
+                process_group=self._env.process_group,
+            )
+
+    def create_context(self) -> ObjectPoolRwShardingContext:
+        return ObjectPoolRwShardingContext(block_size=self._block_size_t)
+
+
+@torch.fx.wrap
+def _cat_if_multiple(tensor_list: List[torch.Tensor]) -> torch.Tensor:
+    if len(tensor_list) == 1:
+        return tensor_list[0].flatten()
+    else:
+        return torch.cat([x.flatten() for x in tensor_list])
+
+
+class InferRwKeyedJaggedTensorPoolOutputDist(torch.nn.Module):
+    """
+    Redistributes jaggd tensors in RW fashion with an AlltoOne operation.
+
+    Inference assumes that this is called on a single rank, but jagged tensors are placed
+    on different devices.
+
+    Args:
+        env (ShardingEnv): Sharding environment with info such as rank and world size
+        device (torch.device): device on which the tensors will be communicated to.
+
+    Example:
+        device_cpu = torch.device("cpu")
+        dist = InferRwKeyedJaggedTensorPoolOutputDist(env, device_cpu)
+        jagged_tensors = [
+            JaggedTensor(values=torch.tensor([1,2,3]), lengths=torch.tensor([1,1,1]), device=torch.device("rank:0/cuda:0")),
+            JaggedTensor(values=torch.tensor([5,5,5]), lengths=torch.tensor([2,1]), device=torch.device("rank:1/cuda:0")),
+        ]
+        jt = dist(jagged_tensors)
+
+        # jt has values [1,2,3,5,5,5] and lengths [1,1,1,2,1]
+    """
+
+    def __init__(
+        self,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self._sharding_env = env
+        self._device = device
+
+    def forward(
+        self,
+        jagged_tensors: List[JaggedTensor],
+    ) -> JaggedTensor:
+        """
+        Performs AlltoOne operation on list of jagged tensors placed on different
+        devices and returns merged jagged tensor.
+
+        Args:
+            jagged_tensors (List[JaggedTensor]): List of jagged tensors placed on
+             different ranks
+
+        Returns: JaggedTensor
+        """
+        lengths = [jt.lengths() for jt in jagged_tensors]
+        values = [jt.values() for jt in jagged_tensors]
+        values = _cat_if_multiple(
+            torch.ops.fbgemm.all_to_one_device(
+                [v.reshape(-1, v.shape[0]) for v in values], self._device
+            )
+        )
+        lengths = _cat_if_multiple(
+            torch.ops.fbgemm.all_to_one_device(
+                [x.reshape(-1, x.shape[0]) for x in lengths],
+                self._device,
+            )
+        )
+
+        return JaggedTensor(values=values, lengths=lengths)
+
+
+class InferRwKeyedJaggedTensorPoolSharding(InferObjectPoolSharding):
+    def __init__(
+        self,
+        pool_size: int,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        super().__init__(pool_size, env, device)
+
+    def create_lookup_ids_dist(self) -> InferRwObjectPoolInputDist:
+        return InferRwObjectPoolInputDist(
+            self._env, device=self._device, block_size=self._block_size_t
+        )
+
+    def create_lookup_values_dist(self) -> InferRwKeyedJaggedTensorPoolOutputDist:
+        return InferRwKeyedJaggedTensorPoolOutputDist(
+            env=self._env, device=self._device
+        )
+
+
+class KeyedJaggedTensorPoolRwReplicatedSharding(ObjectPoolSharding):
+    def __init__(
+        self,
+        env: ShardingEnv,
+        device: torch.device,
+        pool_size: int,
+        num_features: int,
+    ) -> None:
+        self._env = env
+        # pyre-ignore
+        self._pg: dist.ProcessGroup = self._env.process_group
+        self._world_size: int = self._env.world_size
+        self._rank: int = self._env.rank
+        self._device = device
+        self._local_world_size: int = get_local_size(self._world_size)
+
+        self._pool_size = pool_size
+
+        self._num_features = num_features
+
+        intra_pg, _cross_pg = intra_and_cross_node_pg(
+            device, backend=dist.get_backend(self._pg)
+        )
+
+        # pyre-ignore
+        self._intra_pg: dist.ProcessGroup = intra_pg
+
+        self._local_rank: int = get_local_rank(self._world_size)
+
+        self._block_size: int = (
+            pool_size + self._local_world_size - 1
+        ) // self._local_world_size
+
+        self.local_pool_size: int = (
+            self._block_size
+            if self._local_rank != self._local_world_size - 1
+            else pool_size - self._block_size * (self._local_world_size - 1)
+        )
+
+        self._block_size_t: torch.Tensor = torch.tensor(
+            [
+                self._block_size,
+            ],
+            dtype=torch.long,
+            device=self._device,
+        )
+
+        self._local_env = ShardingEnv(
+            world_size=dist.get_world_size(self._intra_pg),
+            rank=dist.get_rank(self._intra_pg),
+            pg=self._intra_pg,
+        )
+
+        self._num_replicas: int = self._world_size // self._local_world_size
+
+    def create_update_ids_dist(
+        self,
+    ) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(
+            self._pg,
+            is_update=True,
+            bucketize_world_size=self._intra_pg.size(),
+            num_replicas=self._num_replicas,
+        )
+
+    def create_update_values_dist(
+        self,
+    ) -> RwKeyedJaggedTensorPoolUpdateValuesDist:
+        return RwKeyedJaggedTensorPoolUpdateValuesDist(
+            num_features=self._num_features,
+            env=self._env,
+            num_replicas=self._num_replicas,
+            device=self._device,
+        )
+
+    def create_lookup_ids_dist(
+        self,
+    ) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(self._intra_pg, is_update=False)
+
+    def create_lookup_values_dist(
+        self,
+    ) -> RwKeyedJaggedTensorPoolLookupValuesDist:
+        return RwKeyedJaggedTensorPoolLookupValuesDist(
+            num_features=self._num_features, env=self._local_env
+        )
+
+    def get_sharded_states_to_register(
+        self, lookup: KeyedJaggedTensorPoolLookup
+    ) -> Iterable[Tuple[str, torch.Tensor]]:
+        for fqn, tensor in lookup.states_to_register():
+            yield fqn, ShardedTensor._init_from_local_shards(
+                [
+                    Shard(
+                        tensor=tensor,
+                        metadata=ShardMetadata(
+                            shard_offsets=[
+                                self._local_env.rank * self._block_size,
+                                0,
+                            ],
+                            shard_sizes=[
+                                tensor.shape[0],
+                                tensor.shape[1],
+                            ],
+                            placement=f"rank:{self._local_env.rank}/{str(tensor.device)}",
+                        ),
+                    )
+                ],
+                torch.Size([self._pool_size, tensor.shape[1]]),
+                process_group=self._local_env.process_group,
+            )
+
+    def create_context(self) -> ObjectPoolReplicatedRwShardingContext:
+        return ObjectPoolReplicatedRwShardingContext(block_size=self._block_size_t)

--- a/torchrec/distributed/sharding/rw_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_pool_sharding.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.dist_data import TensorAllToAll
+from torchrec.distributed.tensor_sharding import ObjectPoolRwShardingContext
+from torchrec.distributed.types import Awaitable, ShardingEnv
+
+NUM_THREADS_BUCKETIZE = 32
+
+
+class RwObjectPoolIDsDist(torch.nn.Module):
+    """
+    Redistribute torch.Tensor values containing IDs for sharded object pools
+
+    Args:
+        pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
+        is_update (bool): Boolean indicating whether this is an update or not. Defaults
+            to False.
+
+            During update, number of values to send to each rank is determined by the
+            number of IDs in each bucket, while no. of values to receive from each rank is
+            determined by the no. of IDs for the current rank to be sent by all
+            other ranks.
+
+            During lookup, we first receive IDs to lookup from other ranks before
+            distributing the looked up values, so the no. of values to send to each rank
+            is collected from other ranks after IDs All2All. Conversely, no. of values
+            to receive from each rank is determined by the number of IDs in each bucket.
+            This is opposite of what happens during an update, so the code is shared.
+
+        bucketize_world_size (Optional[int]): Number of buckets to bucketize IDs into.
+            Defaults to `None` in which case the world size of the ProcessGroup is used.
+
+        num_replicas (int): number of replicas of objects (tensor/KJT) to keep across
+        ranks in case of replicated RW sharding. Defaults to 1.
+
+    Example:
+        dist = RwObjectPoolIDsDist(pg=pg, is_update=True, bucketize_world_size=2)
+        ids = torch.Tensor([0,2,1,4,5])
+        out = dist(ctx,ids).wait().wait()
+
+        # values 2 and 1 need to be swapped
+        ctx.unbucketize_permute == torch.tensor([0,2,1,3,4])
+        ctx.num_ids_each_rank_to_send = torch.tensor([2,3])
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        is_update: bool = True,
+        bucketize_world_size: Optional[int] = None,
+        num_replicas: int = 1,
+    ) -> None:
+        super().__init__()
+        self._world_size: int = pg.size()
+        self._dist = TensorAllToAll(pg=pg)
+        self._is_update: bool = is_update
+
+        self._num_replicas = num_replicas
+        self._bucketize_world_size: int = bucketize_world_size or pg.size()
+
+    def forward(
+        self,
+        ctx: ObjectPoolRwShardingContext,
+        ids: torch.Tensor,
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        """
+        Bucketizes IDs into `world_size` buckets and distributes them to other ranks.
+
+        Args:
+            ctx (Optional[EmbeddingShardingContext]): shared context from
+                RW sharding operation. Number of ids to receive and send per rank
+                is stored in this context
+            ids (torch.Tensor): 1D tensor containing ids to be distributed
+
+        Returns:
+            Awaitable[Awaitable[torch.Tensor]]: awaitable of tensor awaitable.
+
+        """
+
+        num_ids = ids.shape[0]
+        num_threads = NUM_THREADS_BUCKETIZE
+        quot, rem = divmod(num_ids, num_threads)
+        lengths = [quot] * num_threads
+        for i in range(rem):
+            lengths[i] += 1
+        lengths = torch.tensor(lengths, device=ids.device, dtype=torch.int)
+
+        (
+            bucketized_lengths,
+            bucketized_indices,
+            _bucketized_weights,
+            _bucketize_permute,
+            unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+            lengths=lengths,
+            indices=ids,
+            bucketize_pos=False,
+            sequence=True,
+            # pyre-ignore
+            block_sizes=ctx.block_size.to(ids.dtype),
+            my_size=self._bucketize_world_size,
+            weights=None,
+        )
+
+        bucketized_lengths = (
+            bucketized_lengths.reshape(self._bucketize_world_size, -1).sum(dim=1).int()
+        )
+
+        ctx.ids_before_input_dist = ids
+        ctx.unbucketize_permute = unbucketize_permute
+        # not needed, see if we can remove
+        ctx.bucketize_permute = None
+
+        if self._num_replicas > 1:
+            bucketized_indices = bucketized_indices.repeat(self._num_replicas)
+            bucketized_lengths = bucketized_lengths.repeat(self._num_replicas)
+
+        await_dist_ids = self._dist(
+            input=bucketized_indices,
+            splits=bucketized_lengths,
+        )
+
+        if self._is_update:
+            ctx.num_ids_each_rank_to_send = bucketized_lengths
+            ctx.num_ids_each_rank_to_receive = await_dist_ids._output_splits
+        else:
+            ctx.num_ids_each_rank_to_send = await_dist_ids._output_splits
+            ctx.num_ids_each_rank_to_receive = bucketized_lengths
+
+        return await_dist_ids
+
+
+@torch.fx.wrap
+def _get_bucketize_shape(ids: torch.Tensor, device: torch.device) -> torch.Tensor:
+    return torch.tensor([ids.size(dim=0)], device=device, dtype=torch.long)
+
+
+@torch.fx.wrap
+def _get_unbucketize_permute_index(
+    unbucketize_permute: Optional[torch.Tensor],
+) -> torch.Tensor:
+    assert unbucketize_permute is not None, "unbucketize permute must not be None"
+    _, index = unbucketize_permute.sort()
+    return index
+
+
+class InferRwObjectPoolInputDist(torch.nn.Module):
+    """
+    Redistribute torch.Tensor values containing IDs for sharded object pools for inference
+
+    Args:
+        env (ShardingEnv): Sharding environment containing rank, world size, etc
+        device (torch.device): device on which the tensors will be communicated to during
+            lookup and update
+        block_size (torch.Tensor): tensor containing block sizes for each rank.
+            e.g. if block_size=torch.tensor(100), then IDs 0-99 will be assigned to rank
+            0, 100-199 to rank 1, and so on.
+
+    Example:
+        device = torch.device("cpu")
+        dist = InferRwObjectPoolInputDist(env=env, device=device, block_size=torch.tensor(100))
+        ids = torch.Tensor([0,99,100,111])
+        list_ids, permute = dist.lookup(ids)
+
+        # list_ids == [torch.Tensor([0,99], device="cpu"), torch.Tensor([100,111], device="cpu)])]
+    """
+
+    _world_size: int
+    _device: torch.device
+    _block_size: torch.Tensor
+
+    def __init__(
+        self,
+        env: ShardingEnv,
+        device: torch.device,
+        block_size: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._world_size = env.world_size
+        self._device = device
+        self._block_size = block_size
+
+    def forward(
+        self,
+        ids: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
+        """
+        Bucketizes ids tensor into a list of tensors each containing ids
+        for the corresponding rank. Places each tensor on the appropriate device.
+
+        Args:
+            ids (torch.Tensor): Tensor with ids
+
+        Returns:
+           Tuple[List[torch.Tensor], torch.Tensor]: Tuple containing list of ids tensors
+            for each rank given the bucket sizes, and the tensor containing indices
+            to permute the ids to get the original order before bucketization.
+        """
+        (
+            bucketized_lengths,
+            bucketized_indices,
+            _bucketized_weights,
+            _bucketize_permute,
+            unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+            _get_bucketize_shape(ids, ids.device),
+            ids.long(),
+            bucketize_pos=False,
+            sequence=True,
+            block_sizes=self._block_size.long(),
+            my_size=self._world_size,
+            weights=None,
+        )
+
+        id_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(bucketized_lengths)
+        dist_ids = []
+        for rank in range(self._world_size):
+            offset = id_offsets[rank]
+            next_offset = id_offsets[rank + 1]
+            ids_for_rank = bucketized_indices[offset:next_offset]
+            dist_ids.append(
+                ids_for_rank
+                if self._device == torch.device("cpu")
+                else ids_for_rank.to(torch.device(f"cuda:{rank}"), non_blocking=True)
+            )
+
+        assert unbucketize_permute is not None, "unbucketize permute must not be None"
+        return dist_ids, unbucketize_permute
+
+    def update(
+        self,
+        ids: torch.Tensor,
+        values: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor], torch.Tensor]:
+        """
+        Split the values into same buckets are IDs and place on the appropriate device
+        for inference.
+
+        Args:
+            ids (torch.Tensor): Tensor with ids
+            values (torch.Tensor): Tensor with values
+
+        Returns:
+           Tuple[List[torch.Tensor], List[torch.Tensor] torch.Tensor]: Tuple containing
+            list of ids tensors, list of values tensors, and a tensor containing indices
+            to permute the ids to get the original order before bucketization.
+        """
+        (
+            bucketized_lengths,
+            bucketized_indices,
+            _bucketized_weights,
+            _bucketize_permute,
+            unbucketize_permute,
+        ) = torch.ops.fbgemm.block_bucketize_sparse_features(
+            _get_bucketize_shape(ids, ids.device),
+            ids.long(),
+            bucketize_pos=False,
+            sequence=True,
+            block_sizes=self._block_size.long(),
+            my_size=self._world_size,
+            weights=None,
+        )
+
+        id_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(bucketized_lengths)
+
+        index = _get_unbucketize_permute_index(unbucketize_permute)
+        unbucketize_values = values[index]
+        dist_ids = []
+        dist_values = []
+        for rank in range(self._world_size):
+            offset = id_offsets[rank]
+            next_offset = id_offsets[rank + 1]
+            ids_for_rank = bucketized_indices[offset:next_offset]
+            values_for_rank = unbucketize_values[offset:next_offset]
+            dist_ids.append(
+                ids_for_rank
+                if self._device == torch.device("cpu")
+                else ids_for_rank.to(torch.device(f"cuda:{rank}"), non_blocking=True)
+            )
+            dist_values.append(
+                values_for_rank
+                if self._device == torch.device("cpu")
+                else values_for_rank.to(torch.device(f"cuda:{rank}"), non_blocking=True)
+            )
+
+        return dist_ids, dist_values, unbucketize_permute

--- a/torchrec/distributed/sharding/rw_tensor_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_tensor_pool_sharding.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from torch.distributed._shard.sharded_tensor import Shard, ShardMetadata
+
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from torchrec.distributed.dist_data import TensorValuesAllToAll
+from torchrec.distributed.sharding.rw_pool_sharding import (
+    InferRwObjectPoolInputDist,
+    RwObjectPoolIDsDist,
+)
+from torchrec.distributed.tensor_sharding import (
+    InferObjectPoolSharding,
+    ObjectPoolRwShardingContext,
+    ObjectPoolSharding,
+    TensorPoolRwShardingContext,
+)
+from torchrec.distributed.types import LazyAwaitable, ShardingEnv
+from torchrec.modules.object_pool_lookups import TensorPoolLookup
+
+
+class RwTensorPoolValuesDist(torch.nn.Module):
+    """
+    Module to distribute torch.Tensor to all ranks after local pool lookup
+
+    Args:
+        pg (dist.ProcessGroup): ProcessGroup for AlltoAll communication.
+        is_update (bool): Boolean indicating whether this is an update or not.
+
+    Example:
+        dist = RwTensorPoolLookupValuesDist(pg)
+        # rank 0
+        rank0_ctx = TensorPoolRwShardingContext(
+            num_ids_each_rank_to_send=2,
+            num_ids_each_rank_to_receive=3,
+        )
+        rank0_values = torch.tensor([2,3,4,5])
+
+        # rank 1
+        rank0_ctx = TensorPoolRwShardingContext(
+            num_ids_each_rank_to_send=3,
+            num_ids_each_rank_to_receive=2,
+        )
+        rank1_values = torch.tensor([1,1,1,3,4])
+
+        rank0_out = dist(rank0_ctx, rank0_values).wait()
+        # rank0_out has values [2,3,1,1,1]
+
+        rank1_out = dist(rank1_ctx, rank1_values).wait()
+        # rank1_out has values [4,5,3,4]
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        is_update: bool,
+    ) -> None:
+        super().__init__()
+        self._pg = pg
+        self._dist = TensorValuesAllToAll(pg=pg)
+        self._is_update = is_update
+
+    def forward(
+        self,
+        ctx: TensorPoolRwShardingContext,
+        values: torch.Tensor,
+    ) -> LazyAwaitable[torch.Tensor]:
+        """
+        Redistributes local tensor values after tensor pool lookup.
+        Will only permute values when updating.
+
+        Args:
+            ctx (TensorPoolRwShardingContext): Context for RW sharding, containing
+                number of items to send and receive from each rank.
+            values (torch.Tensor): tensor to distribute.
+
+        Returns:
+            LazyAwaitable[torch.Tensor]: Lazy awaitable of tensor
+        """
+
+        if self._is_update:
+            with torch.no_grad():
+                assert hasattr(ctx, "unbucketize_permute")
+                bucketize_permute = torch.ops.fbgemm.invert_permute(
+                    ctx.unbucketize_permute
+                )
+                values = values[bucketize_permute]
+
+        return self._dist(
+            input=values,
+            input_splits=ctx.num_ids_each_rank_to_send,
+            output_splits=ctx.num_ids_each_rank_to_receive,
+        )
+
+
+class TensorPoolRwSharding(ObjectPoolSharding):
+    def __init__(
+        self,
+        pool_size: int,
+        dim: int,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        self._env = env
+        # pyre-ignore
+        self._pg: dist.ProcessGroup = self._env.process_group
+        self._world_size: int = self._env.world_size
+        self._rank: int = self._env.rank
+        self._device = device
+        self._pool_size = pool_size
+        self._dim = dim
+
+        self._block_size: int = (
+            pool_size + self._env.world_size - 1
+        ) // self._env.world_size
+
+        self.local_pool_size: int = (
+            self._block_size
+            if self._env.rank != self._env.world_size - 1
+            else pool_size - self._block_size * (self._env.world_size - 1)
+        )
+
+        self._block_size_t: torch.Tensor = torch.tensor(
+            [
+                self._block_size,
+            ],
+            dtype=torch.long,
+            device=self._device,
+        )
+
+    def create_update_ids_dist(
+        self,
+    ) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(self._pg, is_update=True)
+
+    def create_update_values_dist(
+        self,
+    ) -> RwTensorPoolValuesDist:
+        """
+        used in embedding A2A in update()
+        """
+        return RwTensorPoolValuesDist(self._pg, is_update=True)
+
+    def create_lookup_ids_dist(self) -> RwObjectPoolIDsDist:
+        return RwObjectPoolIDsDist(self._pg, is_update=False)
+
+    def create_lookup_values_dist(
+        self,
+    ) -> RwTensorPoolValuesDist:
+        """
+        used in embedding A2A in lookup()
+        """
+        return RwTensorPoolValuesDist(self._pg, is_update=False)
+
+    def get_sharded_states_to_register(
+        self, lookup: TensorPoolLookup
+    ) -> Iterable[Tuple[str, torch.Tensor]]:
+        for fqn, tensor in lookup.states_to_register():
+            yield fqn, ShardedTensor._init_from_local_shards(
+                [
+                    Shard(
+                        tensor=tensor,
+                        metadata=ShardMetadata(
+                            shard_offsets=[
+                                self._env.rank * self._block_size,
+                                0,
+                            ],
+                            shard_sizes=[
+                                tensor.shape[0],
+                                tensor.shape[1],
+                            ],
+                            placement=f"rank:{self._env.rank}/{str(tensor.device)}",
+                        ),
+                    )
+                ],
+                torch.Size([self._pool_size, tensor.shape[1]]),
+                process_group=self._env.process_group,
+            )
+
+    def create_context(self) -> ObjectPoolRwShardingContext:
+        return ObjectPoolRwShardingContext(block_size=self._block_size_t)
+
+
+class InferRwTensorPoolOutputDist(torch.nn.Module):
+    """
+    Collects local tensor values after tensor pool lookup
+    to one device during inference.
+
+    Args:
+        env (ShardingEnv): Sharding environment
+        device (torch.device): device to collect onto
+
+    Example:
+        device = torch.device("cpu")
+        dist = InferRwTensorPoolOutputDist(env, device)
+        lookups = [
+            torch.Tensor([1,2,3], device="rank0:cuda:0"),
+            torch.Tensor([4,5,6], device="rank1:cuda:0"),
+        ]
+        vals = dist(lookups)
+        # tensors merged and on CPU
+        vals = torch.Tensor([1,2,3,4,5,6], device=device)
+    """
+
+    def __init__(
+        self,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self._device: Optional[torch.device] = device
+        self._world_size: int = env.world_size
+        self._cat_dim = 0
+        self._placeholder: torch.Tensor = torch.ones(1, device=device)
+
+    def forward(
+        self,
+        lookups: List[torch.Tensor],
+    ) -> torch.Tensor:
+        """
+        Merge lookup values tensor on different devices onto a single device and rank
+
+        Args:
+            lookups (List[torch.Tensor]): List of tensors placed on possibly different
+            devices / ranks.
+
+        Returns:
+            torch.Tensor: Merged tensor on the requested device
+        """
+        torch._assert(len(lookups) == self._world_size, "lookups size not world size")
+
+        non_cat_size = lookups[0].size(1 - self._cat_dim)
+        return torch.ops.fbgemm.merge_pooled_embeddings(
+            lookups,
+            non_cat_size,
+            # syntax for torchscript
+            self._placeholder.device,
+            self._cat_dim,
+        )
+
+
+class InferRwTensorPoolSharding(InferObjectPoolSharding):
+    def __init__(
+        self,
+        pool_size: int,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        super().__init__(pool_size, env, device)
+
+    def create_lookup_ids_dist(self) -> InferRwObjectPoolInputDist:
+        return InferRwObjectPoolInputDist(
+            self._env, device=self._device, block_size=self._block_size_t
+        )
+
+    def create_lookup_values_dist(
+        self,
+    ) -> InferRwTensorPoolOutputDist:
+        return InferRwTensorPoolOutputDist(env=self._env, device=self._device)

--- a/torchrec/distributed/tensor_pool.py
+++ b/torchrec/distributed/tensor_pool.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Optional, Tuple, Type, Union
+
+import torch
+from torchrec.distributed.object_pool import ShardedObjectPool
+from torchrec.distributed.sharding.rw_pool_sharding import (
+    InferRwObjectPoolInputDist,
+    RwObjectPoolIDsDist,
+)
+from torchrec.distributed.sharding.rw_tensor_pool_sharding import (
+    InferRwTensorPoolOutputDist,
+    InferRwTensorPoolSharding,
+    RwTensorPoolValuesDist,
+    TensorPoolRwSharding,
+)
+from torchrec.distributed.tensor_sharding import ObjectPoolShardingContext
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ModuleSharder,
+    ObjectPoolShardingPlan,
+    ObjectPoolShardingType,
+    ShardingEnv,
+)
+from torchrec.modules.object_pool_lookups import TensorLookup, TensorPoolLookup
+from torchrec.modules.tensor_pool import TensorPool
+from torchrec.modules.utils import deterministic_dedup
+
+
+class TensorPoolAwaitable(LazyAwaitable[torch.Tensor]):
+    def __init__(
+        self,
+        awaitable: Awaitable[torch.Tensor],
+        unbucketize_permute: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._awaitable = awaitable
+        self._unbucketize_permute = unbucketize_permute
+
+    def _wait_impl(self) -> torch.Tensor:
+        tensor = self._awaitable.wait()
+
+        return tensor[self._unbucketize_permute]
+
+
+class ShardedTensorPool(
+    ShardedObjectPool[torch.Tensor, torch.Tensor, ObjectPoolShardingContext]
+):
+    """
+    Sharded implementation of `TensorPool`
+
+    When dealing with large pool of tensors that cannot fit in a single device memory
+    (i.e. HBM / UVM / CPU etc), this module handles sharding the pool row-wise, including
+    orchestrating the communication between ranks for distributed lookup and update.
+
+    Args:
+        env (ShardingEnv): sharding environment (e.g. world_size, ranks, etc)
+        pool_size (int): total number of rows of tensors in the pool
+        dim (int): dimension that each tensor in the pool
+        dtype (torch.dtype): dtype of the tensors in the pool
+        sharding_plan (ObjectPoolShardingPlan): info about sharding strategy
+        device (Optional[torch.device]): default device
+        enable_uvm (bool): if set to true, the pool will be allocated on UVM
+
+    Example::
+        # Example on 2 GPUs
+
+        # rank 0
+        sharded_keyed_jagged_tensor_pool.update(
+            ids=torch.Tensor([2,0],dtype=torch.int,device="cuda:0")
+            values=torch.Tensor([
+                [1,2,3],
+                [4,5,6],
+            ],dtype=torch.int,device="cuda:0")
+        )
+
+        # on rank 1
+        sharded_keyed_jagged_tensor_pool.update(
+            ids=torch.Tensor([1,3],dtype=torch.int,device="cuda:1")
+            values=torch.Tensor([
+                [7,8,9],
+                [10,11,12],
+            ],dtype=torch.int,device="cuda:1")
+        )
+
+        # At this point the global state is:
+        # ids   tensor
+        # 0     [1,2,3]         <- rank 0
+        # 1     [7,8,9]         <- rank 1
+        # 2     [4,5,6]         <- rank 0
+        # 3     [10,11,12]      <- rank 1
+
+    """
+
+    def __init__(
+        self,
+        env: ShardingEnv,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        sharding_plan: ObjectPoolShardingPlan,
+        device: Optional[torch.device] = None,
+        enable_uvm: bool = False,
+    ) -> None:
+        super().__init__()
+
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._world_size = env.world_size
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._rank = env.rank
+        self._pool_size = pool_size
+        self._sharding_env = env
+        self._dim: int = dim
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._device = device if device is not None else torch.device("meta")
+        self._dtype = dtype
+        self._sharding_plan = sharding_plan
+        self._enable_uvm = enable_uvm
+
+        if sharding_plan.sharding_type == ObjectPoolShardingType.ROW_WISE:
+            self._sharding: TensorPoolRwSharding = TensorPoolRwSharding(
+                env=self._sharding_env,
+                device=self._device,
+                pool_size=self._pool_size,
+                dim=dim,
+            )
+        else:
+            raise NotImplementedError(
+                f"Sharding type {self._sharding_plan.sharding_type} is not implemented"
+            )
+
+        self._lookup: TensorPoolLookup = TensorLookup(
+            self._sharding.local_pool_size,
+            self._dim,
+            self._dtype,
+            self._device,
+            self._enable_uvm,
+        )
+
+        self._lookup_ids_dist_impl: RwObjectPoolIDsDist = (
+            self._sharding.create_lookup_ids_dist()
+        )
+        self._lookup_values_dist_impl: RwTensorPoolValuesDist = (
+            self._sharding.create_lookup_values_dist()
+        )
+
+        self._update_ids_dist_impl: RwObjectPoolIDsDist = (
+            self._sharding.create_update_ids_dist()
+        )
+        self._update_values_dist_impl: RwTensorPoolValuesDist = (
+            self._sharding.create_update_values_dist()
+        )
+
+        self._initialize_torch_state()
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        torch._assert(self._device is not None, "self._device should already be set")
+        return self._device
+
+    def _update_preproc(self, values: torch.Tensor) -> torch.Tensor:
+        assert values.dtype == self.dtype
+        assert values.size(1) == self._dim
+        assert values.device.type == self._device.type
+        return values
+
+    def _update_ids_dist(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        return self._update_ids_dist_impl(ctx=ctx, ids=ids)
+
+    def _update_values_dist(
+        self, ctx: ObjectPoolShardingContext, values: torch.Tensor
+    ) -> LazyAwaitable[torch.Tensor]:
+        return self._update_values_dist_impl(ctx=ctx, values=values)
+
+    def _update_local(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor, values: torch.Tensor
+    ) -> None:
+        deduped_ids, dedup_permutation = deterministic_dedup(ids)
+
+        self._lookup.update(
+            deduped_ids,
+            values[dedup_permutation],
+        )
+
+    def _lookup_ids_dist(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> Awaitable[Awaitable[torch.Tensor]]:
+        return self._lookup_ids_dist_impl(ctx=ctx, ids=ids)
+
+    def _lookup_local(
+        self, ctx: ObjectPoolShardingContext, ids: torch.Tensor
+    ) -> torch.Tensor:
+        return self._lookup.lookup(ids)
+
+    def _lookup_values_dist(
+        self,
+        ctx: ObjectPoolShardingContext,
+        values: torch.Tensor,
+    ) -> LazyAwaitable[torch.Tensor]:
+        return TensorPoolAwaitable(
+            awaitable=self._lookup_values_dist_impl(ctx, values),
+            unbucketize_permute=ctx.unbucketize_permute,
+        )
+
+    def create_context(self) -> ObjectPoolShardingContext:
+        return self._sharding.create_context()
+
+    def _initialize_torch_state(self) -> None:
+        for fqn, tensor in self._sharding.get_sharded_states_to_register(self._lookup):
+            self.register_buffer(fqn, tensor)
+
+
+@torch.fx.wrap
+def update(
+    shard: torch.nn.Parameter, rank_ids: torch.Tensor, values: torch.Tensor
+) -> torch.Tensor:
+    if values.device != shard.device:
+        values = values.to(shard.device)
+    shard[rank_ids] = values
+    return torch.empty(0)
+
+
+class LocalShardPool(torch.nn.Module):
+    """
+    Module containing a single shard of a tensor pool as a parameter.
+
+    Used to lookup and update the pool during inference.
+
+    Args:
+        shard (torch.Tensor): Subset of the tensor pool.
+
+    Example:
+        # shard containing 2 rows from tensor pool with dim=3
+        shard = torch.tensor([
+            [1,2,3],
+            [4,5,6],
+        ])
+        pool = LocalShardPool(shard)
+        out = pool(torch.tensor([0]))
+        # out is tensor([1,2,3]) i.e. first row of the shard
+    """
+
+    def __init__(
+        self,
+        shard: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._shard: torch.nn.Parameter = torch.nn.Parameter(
+            shard,
+            requires_grad=False,
+        )
+
+    def forward(self, rank_ids: torch.Tensor) -> torch.Tensor:
+        """
+        Lookup the rows in the shard corresponding to the given rank ids.
+
+        Args:
+            rank_ids (torch.Tensor): Tensor of rank ids to lookup.
+
+        Returns:
+            torch.Tensor: Tensor of values corresponding to the given rank ids.
+        """
+        return self._shard[rank_ids]
+
+    def update(self, rank_ids: torch.Tensor, values: torch.Tensor) -> None:
+        _ = update(self._shard, rank_ids, values)
+
+
+class ShardedInferenceTensorPool(
+    ShardedObjectPool[torch.Tensor, List[torch.Tensor], ObjectPoolShardingContext],
+):
+    _local_shard_pools: torch.nn.ModuleList
+    _world_size: int
+    _device: torch.device
+    _rank: int
+
+    def __init__(
+        self,
+        env: ShardingEnv,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        plan: ObjectPoolShardingPlan,
+        module: TensorPool,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+
+        self._pool_size = pool_size
+        self._dtype = dtype
+        self._sharding_env = env
+        self._world_size = env.world_size
+        self._device = device or torch.device("cuda")
+        self._sharding_plan = plan
+
+        self._rank = env.rank
+        self._dim = dim
+
+        torch._assert(
+            self._sharding_plan.inference, "Plan needs to have inference enabled"
+        )
+
+        if self._sharding_plan.sharding_type == ObjectPoolShardingType.ROW_WISE:
+            # pyre-fixme[4]: Attribute must be annotated.
+            self._sharding = InferRwTensorPoolSharding(
+                env=self._sharding_env,
+                device=self._device,
+                pool_size=self._pool_size,
+            )
+        else:
+            raise NotImplementedError(
+                f"Sharding type {self._sharding_plan.sharding_type} is not implemented"
+            )
+
+        self._local_shard_pools: torch.nn.ModuleList = torch.nn.ModuleList()
+        offset = 0
+        for rank, this_rank_size in zip(
+            range(
+                self._world_size,
+            ),
+            self._sharding.local_pool_size_per_rank,
+        ):
+            shard_device = (
+                torch.device("cpu")
+                if device == torch.device("cpu")
+                else torch.device("cuda", rank)
+            )
+            self._local_shard_pools.append(
+                LocalShardPool(
+                    torch.empty(
+                        (
+                            this_rank_size,
+                            self._dim,
+                        ),
+                        dtype=self._dtype,
+                        device=shard_device,
+                        requires_grad=False,
+                    ),
+                )
+            )
+
+            if module._pool.device != torch.device("meta"):
+                local_shard = module._pool[offset : offset + this_rank_size]
+                self._local_shard_pools[rank]._shard.copy_(local_shard)
+
+            offset += this_rank_size
+
+        self._lookup_ids_dist_impl: InferRwObjectPoolInputDist = (
+            self._sharding.create_lookup_ids_dist()
+        )
+        self._lookup_values_dist_impl: InferRwTensorPoolOutputDist = (
+            self._sharding.create_lookup_values_dist()
+        )
+
+    # TODO use DTensor that works with Inference Publishing. Right now ShardedTensor doesn't fit this shoe.
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        torch._assert(self._device is not None, "self._device should already be set")
+        return self._device
+
+    def create_context(self) -> ObjectPoolShardingContext:
+        raise NotImplementedError("create_context() is not implemented")
+
+    # pyre-ignore
+    def _lookup_ids_dist(
+        self,
+        ids: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], torch.Tensor]:
+        return self._lookup_ids_dist_impl(ids)
+
+    # pyre-ignore
+    def _update_ids_dist(
+        self,
+        ids: torch.Tensor,
+        values: torch.Tensor,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor], torch.Tensor]:
+        return self._lookup_ids_dist_impl.update(ids, values)
+
+    # pyre-ignore
+    def _lookup_local(
+        self,
+        dist_input: List[torch.Tensor],
+    ) -> List[torch.Tensor]:
+        ret = []
+        for i, shard in enumerate(self._local_shard_pools):
+            ret.append(shard(dist_input[i]))
+        return ret
+
+    # pyre-ignore
+    def _lookup_values_dist(
+        self,
+        lookups: List[torch.Tensor],
+    ) -> torch.Tensor:
+        return self._lookup_values_dist_impl(lookups)
+
+    # pyre-ignore
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        dist_input, unbucketize_permute = self._lookup_ids_dist(ids)
+        lookup = self._lookup_local(dist_input)
+
+        # Here we are playing a trick to workaround a fx tracing issue,
+        # as proxy is not iteratable.
+        lookup_list = []
+        for i in range(self._world_size):
+            lookup_list.append(lookup[i])
+
+        output = self._lookup_values_dist(lookup_list)
+
+        return output[unbucketize_permute].view(-1, self._dim)
+
+    # pyre-ignore
+    def _update_values_dist(self, ctx: ObjectPoolShardingContext, values: torch.Tensor):
+        raise NotImplementedError("Inference does not support update")
+
+    # pyre-ignore
+    def _update_local(
+        self,
+        dist_input: List[torch.Tensor],
+        dist_values: List[torch.Tensor],
+    ) -> None:
+        for i, shard in enumerate(self._local_shard_pools):
+            ids = dist_input[i]
+            values = dist_values[i]
+            deduped_ids, dedup_permutation = deterministic_dedup(ids)
+            shard.update(deduped_ids, values[dedup_permutation])
+
+    def _update_preproc(self, values: torch.Tensor) -> torch.Tensor:
+        # pyre-fixme[7]: Expected `Tensor` but got implicit return value of `None`.
+        pass
+
+    def update(self, ids: torch.Tensor, values: torch.Tensor) -> None:
+        dist_input, dist_values, unbucketize_permute = self._update_ids_dist(
+            ids, values
+        )
+        self._update_local(dist_input, dist_values)
+
+
+class TensorPoolSharder(ModuleSharder[TensorPool]):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def shard(
+        self,
+        module: TensorPool,
+        plan: ObjectPoolShardingPlan,
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+    ) -> Union[ShardedTensorPool, ShardedInferenceTensorPool]:
+        if plan.inference:
+            return ShardedInferenceTensorPool(
+                env=env,
+                pool_size=module.pool_size,
+                dim=module.dim,
+                dtype=module.dtype,
+                plan=plan,
+                device=device,
+                module=module,
+            )
+        return ShardedTensorPool(
+            env=env,
+            pool_size=module.pool_size,
+            dim=module.dim,
+            dtype=module.dtype,
+            sharding_plan=plan,
+            device=device,
+            enable_uvm=module._enable_uvm,
+        )
+
+    @property
+    def module_type(self) -> Type[TensorPool]:
+        return TensorPool

--- a/torchrec/distributed/tensor_sharding.py
+++ b/torchrec/distributed/tensor_sharding.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+#!/usr/bin/env python3
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import cast, Iterable, List, Optional, Tuple
+
+import torch
+from torch import distributed as dist
+from torchrec.distributed.types import Multistreamable, ShardingEnv
+
+
+@dataclass
+class ObjectPoolShardingContext(Multistreamable):
+    ids_before_input_dist: Optional[torch.Tensor] = None
+    num_ids_each_rank_to_receive: Optional[torch.Tensor] = None
+    num_ids_each_rank_to_send: Optional[torch.Tensor] = None
+    bucketize_permute: Optional[torch.Tensor] = None
+    unbucketize_permute: Optional[torch.Tensor] = None
+
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        stream_casted = cast(torch._C.Stream, stream)
+        if self.ids_before_input_dist is not None:
+            self.ids_before_input_dist.record_stream(stream_casted)
+        if self.num_ids_each_rank_to_receive is not None:
+            self.num_ids_each_rank_to_receive.record_stream(stream_casted)
+        if self.num_ids_each_rank_to_send is not None:
+            self.num_ids_each_rank_to_send.record_stream(stream_casted)
+        if self.bucketize_permute is not None:
+            self.bucketize_permute.record_stream(stream_casted)
+        if self.unbucketize_permute is not None:
+            self.unbucketize_permute.record_stream(stream_casted)
+
+
+@dataclass
+class RwShardingContext(Multistreamable):
+    block_size: Optional[torch.Tensor] = None
+
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        stream_casted = cast(torch._C.Stream, stream)
+        if self.block_size is not None:
+            self.block_size.record_stream(stream_casted)
+
+
+@dataclass
+class ObjectPoolRwShardingContext(ObjectPoolShardingContext, RwShardingContext):
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        super().record_stream(stream)
+
+
+@dataclass
+class ObjectPoolReplicatedRwShardingContext(ObjectPoolRwShardingContext):
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        super().record_stream(stream)
+
+
+@dataclass
+class TensorPoolRwShardingContext(ObjectPoolRwShardingContext):
+    """
+    Placeholder for additional sharding context for TensorPool
+    """
+
+    def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
+        super().record_stream(stream)
+
+
+class ObjectPoolSharding(ABC):
+    @abstractmethod
+    def create_update_ids_dist(self) -> torch.nn.Module:
+        pass
+
+    @abstractmethod
+    def create_update_values_dist(self) -> torch.nn.Module:
+        pass
+
+    @abstractmethod
+    def create_lookup_ids_dist(self) -> torch.nn.Module:
+        pass
+
+    @abstractmethod
+    def create_lookup_values_dist(self) -> torch.nn.Module:
+        pass
+
+    @abstractmethod
+    def get_sharded_states_to_register(self) -> Iterable[Tuple[str, torch.Tensor]]:
+        pass
+
+    @abstractmethod
+    def create_context(self) -> ObjectPoolShardingContext:
+        pass
+
+
+class InferObjectPoolSharding(ABC):
+    def __init__(
+        self,
+        pool_size: int,
+        env: ShardingEnv,
+        device: torch.device,
+    ) -> None:
+        self._pool_size = pool_size
+        self._env = env
+        # pyre-ignore
+        self._pg: dist.ProcessGroup = self._env.process_group
+        self._world_size: int = self._env.world_size
+        self._rank: int = self._env.rank
+        self._device = device
+
+        self._block_size: int = (
+            pool_size + self._env.world_size - 1
+        ) // self._env.world_size
+        self._last_block_size: int = self._pool_size - self._block_size * (
+            self._world_size - 1
+        )
+        self.local_pool_size_per_rank: List[int] = [self._block_size] * (
+            self._world_size - 1
+        ) + [self._last_block_size]
+
+        self._block_size_t: torch.Tensor = torch.tensor(
+            [self._block_size], device=self._device, dtype=torch.long
+        )
+
+    @abstractmethod
+    def create_lookup_ids_dist(self) -> torch.nn.Module:
+        pass
+
+    @abstractmethod
+    def create_lookup_values_dist(self) -> torch.nn.Module:
+        pass

--- a/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
@@ -1,0 +1,834 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from typing import cast, Dict, List
+
+import torch
+from hypothesis import given, settings, strategies as st
+from torchrec.distributed.keyed_jagged_tensor_pool import (
+    KeyedJaggedTensorPoolSharder,
+    ShardedInferenceKeyedJaggedTensorPool,
+    ShardedKeyedJaggedTensorPool,
+)
+from torchrec.distributed.shard import _shard_modules
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ObjectPoolShardingPlan,
+    ObjectPoolShardingType,
+    ShardingEnv,
+    ShardingPlan,
+)
+from torchrec.modules.keyed_jagged_tensor_pool import KeyedJaggedTensorPool
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
+    @staticmethod
+    def _test_sharded_keyed_jagged_tensor_pool(
+        rank: int,
+        world_size: int,
+        backend: str,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_plan: ObjectPoolShardingPlan,
+        input_per_rank: List[torch.Tensor],
+        enable_uvm: bool = False,
+    ) -> None:
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            input_per_rank = [id.to(ctx.device) for id in input_per_rank]
+            keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+                pool_size=pool_size,
+                feature_max_lengths=feature_max_lengths,
+                values_dtype=values_dtype,
+                is_weighted=is_weighted,
+                device=torch.device("meta"),
+                enable_uvm=enable_uvm,
+            )
+
+            # pyre-ignore
+            sharded_keyed_jagged_tensor_pool: (
+                ShardedKeyedJaggedTensorPool
+            ) = KeyedJaggedTensorPoolSharder().shard(
+                keyed_jagged_tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                #  got `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            # rank 0
+            #         0      1
+            # "f1"   [1]     [3,3]
+            # "f2"   [11]    [13,13,13]
+
+            # rank 1
+            #         0       1
+            # "f1"   [2,2]    [4]
+            # "f2"   [12,12]  [14,14,14,14]
+            values = KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1", "f2"],
+                values=torch.tensor(
+                    (
+                        [1, 3, 3, 11, 13, 13, 13]
+                        if ctx.rank == 0
+                        else [2, 2, 4, 12, 12, 14, 14, 14, 14]
+                    ),
+                    dtype=values_dtype,
+                    device=ctx.device,
+                ),
+                lengths=torch.tensor(
+                    [1, 2, 1, 3] if ctx.rank == 0 else [2, 1, 2, 4],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+            )
+
+            sharded_keyed_jagged_tensor_pool.update(
+                ids=torch.tensor(
+                    [2, 0] if ctx.rank == 0 else [1, 3],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+                values=values,
+            )
+
+            # init global state is
+            # 4         8
+            # f1       f2
+            # [3,3] .  [13,13,13]
+            # [2,2] .  [12,12]
+            # [1] .    [11]
+            # [4]      [14,14,14,14]
+
+            kjt = sharded_keyed_jagged_tensor_pool.lookup(input_per_rank[ctx.rank])
+
+            # expected values
+            # rank 0: KeyedJaggedTensor({
+            #     "f1": [[1], [3, 3]],
+            #     "f2": [[11], [13, 13, 13]]
+            # })
+
+            # rank 1: KeyedJaggedTensor({
+            #     "f1": [[2, 2], [4], [3, 3], [1]],
+            #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+            # })
+
+            torch.testing.assert_close(
+                kjt.values().cpu(),
+                torch.tensor(
+                    (
+                        [1, 3, 3, 11, 13, 13, 13]
+                        if ctx.rank == 0
+                        else [2, 2, 4, 3, 3, 1, 12, 12, 14, 14, 14, 14, 13, 13, 13, 11]
+                    ),
+                    dtype=values_dtype,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+            torch.testing.assert_close(
+                kjt.lengths().cpu(),
+                torch.tensor(
+                    [1, 2, 1, 3] if ctx.rank == 0 else [2, 1, 2, 1, 2, 4, 3, 1],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    # pyre-ignore
+    @given(
+        enable_uvm=st.booleans(),
+        values_dtype=st.sampled_from([torch.int32, torch.int64]),
+    )
+    @settings(max_examples=4, deadline=None)
+    def test_sharded_keyed_jagged_tensor_pool_rw(
+        self, enable_uvm: bool, values_dtype: torch.dtype
+    ) -> None:
+        input_per_rank = [
+            torch.tensor([2, 0], dtype=torch.int),
+            torch.tensor([1, 3, 0, 2], dtype=torch.int),
+        ]
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+
+        self._run_multi_process_test(
+            callable=self._test_sharded_keyed_jagged_tensor_pool,
+            world_size=2,
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=values_dtype,
+            is_weighted=False,
+            input_per_rank=input_per_rank,
+            sharding_plan=ObjectPoolShardingPlan(
+                sharding_type=ObjectPoolShardingType.ROW_WISE
+            ),
+            backend="nccl",
+            enable_uvm=enable_uvm,
+        )
+
+    @staticmethod
+    def _test_input_permute(
+        rank: int,
+        world_size: int,
+        backend: str,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_plan: ObjectPoolShardingPlan,
+        input_per_rank: List[torch.Tensor],
+    ) -> None:
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            input_per_rank = [id.to(ctx.device) for id in input_per_rank]
+            keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+                pool_size=pool_size,
+                feature_max_lengths=feature_max_lengths,
+                values_dtype=values_dtype,
+                is_weighted=is_weighted,
+                device=torch.device("meta"),
+            )
+
+            # pyre-ignore
+            sharded_keyed_jagged_tensor_pool: (
+                ShardedKeyedJaggedTensorPool
+            ) = KeyedJaggedTensorPoolSharder().shard(
+                keyed_jagged_tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                #  got `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            sharded_keyed_jagged_tensor_pool.update(
+                ids=torch.tensor(
+                    [2, 0] if ctx.rank == 0 else [1, 3],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+                values=KeyedJaggedTensor.from_lengths_sync(
+                    keys=["f3", "f2", "f1"],
+                    values=torch.tensor(
+                        (
+                            [21, 11, 13, 13, 13, 1, 3, 3]
+                            if ctx.rank == 0
+                            else [22, 22, 24, 12, 12, 14, 14, 14, 14, 2, 2, 4]
+                        ),
+                        dtype=values_dtype,
+                        device=ctx.device,
+                    ),
+                    lengths=torch.tensor(
+                        [1, 0, 1, 3, 1, 2] if ctx.rank == 0 else [2, 1, 2, 4, 2, 1],
+                        dtype=torch.int,
+                        device=ctx.device,
+                    ),
+                ),
+            )
+
+            # init global state is
+            # 4         8
+            # f1       f2
+            # [3,3] .  [13,13,13]
+            # [2,2] .  [12,12]
+            # [1] .    [11]
+            # [4]      [14,14,14,14]
+
+            kjt = sharded_keyed_jagged_tensor_pool(input_per_rank[ctx.rank])
+
+            # expected values
+            # rank 0: KeyedJaggedTensor({
+            #     "f1": [[1], [3, 3]],
+            #     "f2": [[11], [13, 13, 13]]
+            # })
+
+            # rank 1: KeyedJaggedTensor({
+            #     "f1": [[2, 2], [4], [3, 3], [1]],
+            #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+            # })
+
+            torch.testing.assert_close(
+                kjt.values().cpu(),
+                torch.tensor(
+                    (
+                        [1, 3, 3, 11, 13, 13, 13]
+                        if ctx.rank == 0
+                        else [2, 2, 4, 3, 3, 1, 12, 12, 14, 14, 14, 14, 13, 13, 13, 11]
+                    ),
+                    dtype=values_dtype,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+            torch.testing.assert_close(
+                kjt.lengths().cpu(),
+                torch.tensor(
+                    [1, 2, 1, 3] if ctx.rank == 0 else [2, 1, 2, 1, 2, 4, 3, 1],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_input_permute(
+        self,
+    ) -> None:
+        input_per_rank = [
+            torch.tensor([2, 0], dtype=torch.int),
+            torch.tensor([1, 3, 0, 2], dtype=torch.int),
+        ]
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+
+        self._run_multi_process_test(
+            callable=self._test_input_permute,
+            world_size=2,
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=torch.int64,
+            is_weighted=False,
+            input_per_rank=input_per_rank,
+            sharding_plan=ObjectPoolShardingPlan(
+                sharding_type=ObjectPoolShardingType.ROW_WISE
+            ),
+            backend="nccl",
+        )
+
+    @staticmethod
+    def _test_sharded_KJT_pool_input_conflict(
+        rank: int,
+        world_size: int,
+        backend: str,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_plan: ObjectPoolShardingPlan,
+        input_per_rank: List[torch.Tensor],
+    ) -> None:
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            input_per_rank = [id.to(ctx.device) for id in input_per_rank]
+            keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+                pool_size=pool_size,
+                feature_max_lengths=feature_max_lengths,
+                values_dtype=values_dtype,
+                is_weighted=is_weighted,
+                device=torch.device("meta"),
+            )
+
+            # pyre-ignore
+            sharded_keyed_jagged_tensor_pool: (
+                ShardedKeyedJaggedTensorPool
+            ) = KeyedJaggedTensorPoolSharder().shard(
+                keyed_jagged_tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                #  got `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            # rank 0 input:
+            # ids   f1      f2
+            # 2     1       11
+            # 1     3, 3    13, 13, 13
+
+            # rank 1 input:
+            # ids   f1      f2
+            # 1     2, 2    12, 12
+            # 3     4       14, 14, 14, 14
+
+            sharded_keyed_jagged_tensor_pool.update(
+                ids=torch.tensor(
+                    [2, 1] if ctx.rank == 0 else [1, 3],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+                values=KeyedJaggedTensor.from_lengths_sync(
+                    keys=["f1", "f2"],
+                    values=torch.tensor(
+                        (
+                            [1, 3, 3, 11, 13, 13, 13]
+                            if ctx.rank == 0
+                            else [2, 2, 4, 12, 12, 14, 14, 14, 14]
+                        ),
+                        dtype=values_dtype,
+                        device=ctx.device,
+                    ),
+                    lengths=torch.tensor(
+                        [1, 2, 1, 3] if ctx.rank == 0 else [2, 1, 2, 4],
+                        dtype=torch.int,
+                        device=ctx.device,
+                    ),
+                ),
+            )
+
+            kjt = sharded_keyed_jagged_tensor_pool(input_per_rank[ctx.rank])
+            # expected values
+            # rank 0: KeyedJaggedTensor({
+            #     "f1": [[1], [3, 3]],
+            #     "f2": [[11], [13, 13, 13]]
+            # })
+
+            # rank 1: KeyedJaggedTensor({
+            #     "f1": [[2, 2], [4], [3, 3], [1]],
+            #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+            # })
+
+            torch.testing.assert_close(
+                kjt.values().cpu(),
+                torch.tensor(
+                    (
+                        [1, 11]
+                        if ctx.rank == 0
+                        else [2, 2, 4, 1, 12, 12, 14, 14, 14, 14, 11]
+                    ),
+                    dtype=values_dtype,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+            torch.testing.assert_close(
+                kjt.lengths().cpu(),
+                torch.tensor(
+                    [1, 0, 1, 0] if ctx.rank == 0 else [2, 1, 0, 1, 2, 4, 0, 1],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharded_KJT_pool_input_conflict(
+        self,
+    ) -> None:
+        input_per_rank = [
+            torch.tensor([2, 0], dtype=torch.int),
+            torch.tensor([1, 3, 0, 2], dtype=torch.int),
+        ]
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+
+        self._run_multi_process_test(
+            callable=self._test_sharded_KJT_pool_input_conflict,
+            world_size=2,
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=torch.int64,
+            is_weighted=False,
+            input_per_rank=input_per_rank,
+            sharding_plan=ObjectPoolShardingPlan(
+                sharding_type=ObjectPoolShardingType.ROW_WISE
+            ),
+            backend="nccl",
+        )
+
+    @staticmethod
+    def _test_sharded_KJT_pool_input_empty(
+        rank: int,
+        world_size: int,
+        backend: str,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_plan: ObjectPoolShardingPlan,
+        input_per_rank: List[torch.Tensor],
+    ) -> None:
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            input_per_rank = [id.to(ctx.device) for id in input_per_rank]
+            keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+                pool_size=pool_size,
+                feature_max_lengths=feature_max_lengths,
+                values_dtype=values_dtype,
+                is_weighted=is_weighted,
+                device=torch.device("meta"),
+            )
+
+            # pyre-ignore
+            sharded_keyed_jagged_tensor_pool: (
+                ShardedKeyedJaggedTensorPool
+            ) = KeyedJaggedTensorPoolSharder().shard(
+                keyed_jagged_tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                #  got `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            # rank 0 input:
+            # ids   f1      f2
+            # 2     1       11
+            # 1     3, 3    13, 13, 13
+
+            # rank 1 input:
+            # ids   f1      f2
+            # 1     2, 2    12, 12
+            # 3     4       14, 14, 14, 14
+
+            sharded_keyed_jagged_tensor_pool.update(
+                ids=torch.tensor(
+                    [2, 1] if ctx.rank == 0 else [1, 3],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+                values=KeyedJaggedTensor.from_lengths_sync(
+                    keys=["f1", "f2"],
+                    values=torch.tensor(
+                        (
+                            [1, 3, 3, 11, 13, 13, 13]
+                            if ctx.rank == 0
+                            else [2, 2, 4, 12, 12, 14, 14, 14, 14]
+                        ),
+                        dtype=values_dtype,
+                        device=ctx.device,
+                    ),
+                    lengths=torch.tensor(
+                        [1, 2, 1, 3] if ctx.rank == 0 else [2, 1, 2, 4],
+                        dtype=torch.int,
+                        device=ctx.device,
+                    ),
+                ),
+            )
+
+            kjt = sharded_keyed_jagged_tensor_pool(input_per_rank[ctx.rank])
+            # expected values
+            # rank 0: KeyedJaggedTensor({
+            #     "f1": [[1], [3, 3]],
+            #     "f2": [[11], [13, 13, 13]]
+            # })
+
+            # rank 1: KeyedJaggedTensor({
+            #     "f1": [[2, 2], [4], [3, 3], [1]],
+            #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+            # })
+
+            torch.testing.assert_close(
+                kjt.values().cpu(),
+                torch.tensor(
+                    [1, 11] if ctx.rank == 0 else [],
+                    dtype=values_dtype,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+            torch.testing.assert_close(
+                kjt.lengths().cpu(),
+                torch.tensor(
+                    [1, 0, 1, 0] if ctx.rank == 0 else [],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharded_KJT_pool_input_empty(self) -> None:
+        input_per_rank = [
+            torch.tensor([2, 0], dtype=torch.int),
+            torch.tensor([], dtype=torch.int),
+        ]
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        self._run_multi_process_test(
+            callable=self._test_sharded_KJT_pool_input_empty,
+            world_size=2,
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=torch.int64,
+            is_weighted=False,
+            input_per_rank=input_per_rank,
+            sharding_plan=ObjectPoolShardingPlan(
+                sharding_type=ObjectPoolShardingType.ROW_WISE
+            ),
+            backend="nccl",
+        )
+
+    @staticmethod
+    def _test_sharded_keyed_jagged_tensor_pool_replicated_rw(
+        rank: int,
+        world_size: int,
+        local_world_size: int,
+        backend: str,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype,
+        is_weighted: bool,
+        sharding_plan: ObjectPoolShardingPlan,
+    ) -> None:
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=local_world_size
+        ) as ctx:
+            keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+                pool_size=pool_size,
+                feature_max_lengths=feature_max_lengths,
+                values_dtype=values_dtype,
+                is_weighted=is_weighted,
+                device=torch.device("meta"),
+            )
+
+            # pyre-ignore
+            sharded_keyed_jagged_tensor_pool: (
+                ShardedKeyedJaggedTensorPool
+            ) = KeyedJaggedTensorPoolSharder().shard(
+                keyed_jagged_tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                #  got `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            # init global state is
+            # 4         8
+            # f1       f2
+            # [3,3] .  [13,13,13]
+            # [2,2] .  [12,12]
+            # [1] .    [11]
+            # [4]      [14,14,14,14]
+
+            ids = [[1], [0], [2], [3]]
+
+            values_and_lengths = [
+                ([2, 2, 12, 12], [2, 2]),
+                ([3, 3, 13, 13, 13], [2, 3]),
+                ([1, 11], [1, 1]),
+                ([4, 14, 14, 14, 14], [1, 4]),
+            ]
+
+            sharded_keyed_jagged_tensor_pool.update(
+                ids=torch.tensor(
+                    ids[ctx.rank],
+                    dtype=torch.int,
+                    device=ctx.device,
+                ),
+                values=KeyedJaggedTensor.from_lengths_sync(
+                    keys=["f1", "f2"],
+                    values=torch.tensor(
+                        values_and_lengths[ctx.rank][0],
+                        dtype=values_dtype,
+                        device=ctx.device,
+                    ),
+                    lengths=torch.tensor(
+                        values_and_lengths[ctx.rank][1],
+                        dtype=torch.int,
+                        device=ctx.device,
+                    ),
+                ),
+            )
+
+            lookup_per_rank = [[0, 1, 2, 3], [0, 2], [3, 1], [0]]
+
+            kjt = sharded_keyed_jagged_tensor_pool.lookup(
+                torch.tensor(
+                    lookup_per_rank[ctx.rank], device=ctx.device, dtype=torch.int32
+                )
+            ).wait()
+
+            # expected values
+            # rank 0:
+            # kjt KeyedJaggedTensor({
+            #   "f1": [[3, 3], [2, 2], [1], [4]],
+            #   "f2": [[13, 13, 13], [12, 12], [11], [14, 14, 14, 14]]
+            # })
+            # rank 1:
+            # kjt KeyedJaggedTensor({
+            #   "f1": [[3, 3], [1]],
+            #   "f2": [[13, 13, 13], [11]]
+            # })
+            # rank 2:
+            # kjt KeyedJaggedTensor({
+            #   "f1": [[4], [2, 2]],
+            #   "f2": [[14, 14, 14, 14], [12, 12]]
+            # })
+            # rank 3:
+            # kjt KeyedJaggedTensor({
+            #   "f1": [[3, 3]],
+            #   "f2": [[13, 13, 13]]
+            # })
+
+            expected_values_and_lengths = [
+                (
+                    [3, 3, 2, 2, 1, 4, 13, 13, 13, 12, 12, 11, 14, 14, 14, 14],
+                    [2, 2, 1, 1, 3, 2, 1, 4],
+                ),
+                ([3, 3, 1, 13, 13, 13, 11], [2, 1, 3, 1]),
+                ([4, 2, 2, 14, 14, 14, 14, 12, 12], [1, 2, 4, 2]),
+                ([3, 3, 13, 13, 13], [2, 3]),
+            ]
+
+            torch.testing.assert_close(
+                kjt.values(),
+                torch.tensor(
+                    expected_values_and_lengths[ctx.rank][0],
+                    dtype=kjt.values().dtype,
+                    device=kjt.values().device,
+                ),
+            )
+
+            torch.testing.assert_close(
+                kjt.lengths(),
+                torch.tensor(
+                    expected_values_and_lengths[ctx.rank][1],
+                    dtype=kjt.lengths().dtype,
+                    device=kjt.lengths().device,
+                ),
+            )
+
+            assert list(sharded_keyed_jagged_tensor_pool.state_dict().keys()) == [
+                "values",
+                "key_lengths",
+            ]
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharded_keyed_jagged_tensor_pool_replicated_rw(
+        self,
+    ) -> None:
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+
+        self._run_multi_process_test(
+            callable=self._test_sharded_keyed_jagged_tensor_pool_replicated_rw,
+            world_size=4,
+            local_world_size=4,
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=torch.int64,
+            is_weighted=False,
+            sharding_plan=ObjectPoolShardingPlan(
+                sharding_type=ObjectPoolShardingType.REPLICATED_ROW_WISE
+            ),
+            backend="nccl",
+        )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    def test_sharded_kjt_pool_inference(self) -> None:
+        world_size = 2
+        pool_size = 4
+        device = torch.device("cpu")
+        cuda_device = torch.device("cuda:0")
+
+        # init global state is
+        # 4         8
+        # f1       f2
+        # [3,3] .  [13,13,13]
+        # [2,2] .  [12,12]
+        # [1] .    [11]
+        # [4]      [14,14,14,14]
+
+        kjt_pool_orig = KeyedJaggedTensorPool(
+            pool_size=pool_size,
+            feature_max_lengths={"f1": 2, "f2": 4},
+            values_dtype=torch.int,
+            is_weighted=False,
+            device=torch.device("cpu"),
+        )
+        kjt_pool_orig.update(
+            ids=torch.tensor([0, 1, 2, 3], dtype=torch.int, device=device),
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1", "f2"],
+                values=torch.tensor(
+                    [3, 3, 2, 2, 1, 4, 13, 13, 13, 12, 12, 11, 14, 14, 14, 14],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+                lengths=torch.tensor(
+                    [2, 2, 1, 1, 3, 2, 1, 4],
+                    dtype=torch.int,
+                    device=torch.device("cpu"),
+                ),
+            ),
+        )
+
+        sharded_inference_kjt_pool = _shard_modules(
+            kjt_pool_orig,
+            plan=ShardingPlan(
+                plan={
+                    "": ObjectPoolShardingPlan(
+                        ObjectPoolShardingType.ROW_WISE, inference=True
+                    ),
+                }
+            ),
+            device=cuda_device,
+            env=ShardingEnv.from_local(world_size=world_size, rank=0),
+            sharders=[
+                cast(ModuleSharder[torch.nn.Module], KeyedJaggedTensorPoolSharder())
+            ],
+        )
+        self.assertIsInstance(
+            sharded_inference_kjt_pool, ShardedInferenceKeyedJaggedTensorPool
+        )
+
+        self.assertEqual(sharded_inference_kjt_pool.dtype, torch.int)
+
+        from torchrec.fx.tracer import symbolic_trace
+
+        sharded_inference_kjt_pool_gm: torch.fx.GraphModule = symbolic_trace(
+            sharded_inference_kjt_pool
+        )
+        sharded_inference_kjt_pool_gm_script = torch.jit.script(
+            sharded_inference_kjt_pool_gm
+        )  # noqa
+
+        input_cases = [[0, 1, 2, 3], [0, 2, 1, 3]]
+        for input in input_cases:
+            input = torch.tensor(input, dtype=torch.int64)
+            ref = kjt_pool_orig.lookup(input)
+            val = sharded_inference_kjt_pool.lookup(input.to(cuda_device))
+
+            torch.testing.assert_close(ref.values().cpu(), val.values().cpu())
+            torch.testing.assert_close(ref.length_per_key(), val.length_per_key())
+
+            val_gm_script = sharded_inference_kjt_pool_gm_script(input.to(cuda_device))
+            torch.testing.assert_close(ref.values().cpu(), val_gm_script.values().cpu())
+            torch.testing.assert_close(
+                ref.length_per_key(), val_gm_script.length_per_key()
+            )
+
+        assert hasattr(sharded_inference_kjt_pool_gm_script, "_local_kjt_pool_shards")
+        assert hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "0")
+        assert hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "1")

--- a/torchrec/distributed/tests/test_tensor_pool.py
+++ b/torchrec/distributed/tests/test_tensor_pool.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+from hypothesis import given, settings, strategies as st
+from torchrec.distributed.tensor_pool import TensorPoolSharder
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import (
+    ObjectPoolShardingPlan,
+    ObjectPoolShardingType,
+    ShardedTensor,
+    ShardingEnv,
+)
+from torchrec.modules.tensor_pool import TensorPool
+
+
+class TestShardedTensorPool(MultiProcessTestBase):
+    @staticmethod
+    def _test_sharded_tensor_pool(
+        rank: int, world_size: int, enable_uvm: bool = False
+    ) -> None:
+
+        pool_size = 5
+        dim = 4
+        backend = "nccl"
+        dtype = torch.float32
+        sharding_plan = ObjectPoolShardingPlan(
+            sharding_type=ObjectPoolShardingType.ROW_WISE
+        )
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            torch.use_deterministic_algorithms(False)
+            tensor_pool = TensorPool(
+                pool_size=pool_size,
+                dim=dim,
+                dtype=dtype,
+                enable_uvm=enable_uvm,
+            )
+
+            sharded_tensor_pool = TensorPoolSharder().shard(
+                module=tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+                #  `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            if ctx.rank == 0:
+                ids = [4, 1]
+                values = [[0.1, 0.2, 0.3, 0.4], [0.4, 0.5, 0.6, 0.7]]
+
+            else:
+                ids = [3, 0]
+                values = [[0.11, 0.21, 0.31, 1.0], [0.41, 0.51, 0.61, 2.0]]
+
+            ids = torch.tensor(ids, dtype=torch.int, device=ctx.device)
+            values = torch.tensor(values, dtype=torch.float, device=ctx.device)
+
+            sharded_tensor_pool.update(
+                ids=ids,
+                values=values,
+            )
+
+            lookup_ids = torch.tensor([0, 1, 2, 3], dtype=torch.int, device=ctx.device)
+
+            values = sharded_tensor_pool.lookup(ids=lookup_ids).wait()
+            torch.testing.assert_close(
+                values.cpu(),
+                torch.tensor(
+                    [
+                        [0.41, 0.51, 0.61, 2.0],
+                        [0.4, 0.5, 0.6, 0.7],
+                        [0.0, 0.0, 0.0, 0.0],
+                        [0.11, 0.21, 0.31, 1.0],
+                    ],
+                    device=torch.device("cpu"),
+                ),
+            )
+
+            state_dict = sharded_tensor_pool.state_dict()
+            ut = unittest.TestCase()
+            ut.assertIn("_pool", state_dict)
+            sharded_pool_state = state_dict["_pool"]
+            ut.assertIsInstance(sharded_pool_state, ShardedTensor)
+            pool_state = (
+                torch.empty(size=sharded_pool_state.size(), device=ctx.device)
+                if ctx.rank == 0
+                else None
+            )
+            sharded_pool_state.gather(out=pool_state)
+            if ctx.rank == 0:
+                torch.testing.assert_close(
+                    pool_state,
+                    torch.tensor(
+                        [
+                            [0.41, 0.51, 0.61, 2.0],
+                            [0.4, 0.5, 0.6, 0.7],
+                            [0.0, 0.0, 0.0, 0.0],
+                            [0.11, 0.21, 0.31, 1.0],
+                            [0.1000, 0.2000, 0.3000, 0.4000],
+                        ],
+                        device=ctx.device,
+                    ),
+                )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-ignore
+    @given(
+        enable_uvm=st.booleans(),
+    )
+    @settings(deadline=None)
+    def test_sharded_tensor_pool(self, enable_uvm: bool) -> None:
+        world_size = 2
+        self._run_multi_process_test(
+            callable=self._test_sharded_tensor_pool,
+            world_size=world_size,
+            enable_uvm=enable_uvm,
+        )
+
+    @staticmethod
+    def _test_sharded_tensor_pool_conflict_update(
+        rank: int,
+        world_size: int,
+    ) -> None:
+
+        pool_size = 5
+        dim = 3
+        backend = "nccl"
+        dtype = torch.float32
+        sharding_plan = ObjectPoolShardingPlan(
+            sharding_type=ObjectPoolShardingType.ROW_WISE
+        )
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            torch.use_deterministic_algorithms(False)
+            tensor_pool = TensorPool(
+                pool_size=pool_size,
+                dim=dim,
+                dtype=dtype,
+            )
+
+            sharded_tensor_pool = TensorPoolSharder().shard(
+                module=tensor_pool,
+                plan=sharding_plan,
+                device=ctx.device,
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+                #  `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+            )
+
+            if ctx.rank == 0:
+                ids = [4, 1]
+                values = [0.1, 0.2, 0.3], [0.4, 0.5, 0.6]
+
+            else:
+                ids = [3, 1]
+                values = [0.11, 0.21, 0.31], [0.41, 0.51, 0.61]
+
+            ids = torch.tensor(ids, dtype=torch.int, device=ctx.device)
+            values = torch.tensor(values, dtype=torch.float, device=ctx.device)
+
+            sharded_tensor_pool.update(
+                ids=ids,
+                values=values,
+            )
+
+            lookup_ids = torch.tensor([0, 1, 2, 3], dtype=torch.int, device=ctx.device)
+
+            values = sharded_tensor_pool(ids=lookup_ids).wait()
+            torch.testing.assert_close(
+                values.cpu(),
+                torch.tensor(
+                    [
+                        [0.0, 0.0, 0.0],
+                        [0.41, 0.51, 0.61],
+                        [0.0, 0.0, 0.0],
+                        [0.11, 0.21, 0.31],
+                    ],
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_sharded_tensor_pool_conflict_update(
+        self,
+    ) -> None:
+        world_size = 2
+        self._run_multi_process_test(
+            callable=self._test_sharded_tensor_pool_conflict_update,
+            world_size=world_size,
+        )

--- a/torchrec/distributed/tests/test_tensor_pool_rw_sharding.py
+++ b/torchrec/distributed/tests/test_tensor_pool_rw_sharding.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+from torchrec.distributed.sharding.rw_tensor_pool_sharding import TensorPoolRwSharding
+from torchrec.distributed.tensor_sharding import TensorPoolRwShardingContext
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import ShardingEnv
+
+
+class TestTensorPoolRwSharding(MultiProcessTestBase):
+    @staticmethod
+    def _test_update(
+        rank: int,
+        world_size: int,
+    ) -> None:
+        backend = "nccl"
+        dtype = torch.float32
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+            #  `Optional[ProcessGroup]`.
+            sharding_env = ShardingEnv.from_process_group(ctx.pg)
+            if ctx.rank == 0:
+                ids = [4, 1]
+                values = [0.1, 0.2, 0.3], [0.4, 0.5, 0.6]
+
+            else:
+                ids = [3, 0]
+                values = [0.11, 0.21, 0.31], [0.41, 0.51, 0.61]
+
+            ids = torch.tensor(ids, dtype=torch.int, device=ctx.device)
+            values = torch.tensor(values, dtype=torch.float, device=ctx.device)
+
+            block_size = torch.tensor([3], dtype=torch.int, device=ctx.device)
+            update_ctx = TensorPoolRwShardingContext(block_size=block_size)
+            rw_sharding = TensorPoolRwSharding(
+                env=sharding_env, device=ctx.device, dim=3, pool_size=4
+            )
+            input_dist = rw_sharding.create_lookup_ids_dist()
+            update_values_dist = rw_sharding.create_update_values_dist()
+            dist_ids = input_dist(ctx=update_ctx, ids=ids).wait().wait()
+
+            torch.testing.assert_close(
+                dist_ids.cpu(),
+                torch.tensor(
+                    [1, 0],
+                    device=torch.device("cpu"),
+                    dtype=torch.int,
+                ),
+            )
+
+            dist_values = update_values_dist(ctx=update_ctx, values=values).wait()
+            if rank == 0:
+                torch.testing.assert_close(
+                    dist_values.cpu(),
+                    torch.tensor(
+                        [[0.4, 0.5, 0.6], [0.41, 0.51, 0.61]],
+                        device=torch.device("cpu"),
+                        dtype=dtype,
+                    ),
+                )
+            else:
+                torch.testing.assert_close(
+                    dist_values.cpu(),
+                    torch.tensor(
+                        [[0.1, 0.2, 0.3], [0.11, 0.21, 0.31]],
+                        device=torch.device("cpu"),
+                        dtype=dtype,
+                    ),
+                )
+
+    @staticmethod
+    def _test_lookup(
+        rank: int,
+        world_size: int,
+    ) -> None:
+        backend = "nccl"
+        dtype = torch.float32
+        with MultiProcessContext(
+            rank, world_size, backend, local_size=world_size
+        ) as ctx:
+            # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+            #  `Optional[ProcessGroup]`.
+            sharding_env = ShardingEnv.from_process_group(ctx.pg)
+
+            block_size = torch.tensor([3], dtype=torch.int, device=ctx.device)
+            lookup_ctx = TensorPoolRwShardingContext(block_size=block_size)
+            rw_sharding = TensorPoolRwSharding(
+                env=sharding_env, device=ctx.device, dim=3, pool_size=5
+            )
+            input_dist = rw_sharding.create_lookup_ids_dist()
+            lookup_values_dist = rw_sharding.create_lookup_values_dist()
+
+            ids = torch.tensor([0, 1, 2, 3], dtype=torch.int, device=ctx.device)
+            dist_ids = input_dist(ctx=lookup_ctx, ids=ids).wait().wait()
+            if rank == 0:
+                torch.testing.assert_close(
+                    dist_ids.cpu(),
+                    torch.tensor(
+                        [0, 1, 2, 0, 1, 2],
+                        dtype=torch.int,
+                        device=torch.device("cpu"),
+                    ),
+                )
+            else:
+                torch.testing.assert_close(
+                    dist_ids.cpu(),
+                    torch.tensor(
+                        [0, 0],
+                        dtype=torch.int,
+                        device=torch.device("cpu"),
+                    ),
+                )
+
+            # assume the _local_pool on rank 0 is
+            # [
+            # [0.41, 0.51, 0.61],
+            # [0.4, 0.5, 0.6],
+            # [0.0, 0.0, 0.0],
+            # ]
+
+            # on rank 1 is
+            # [
+            # [0.11, 0.21, 0.31],
+            # [0.1, 0.2, 0.3],
+            # ]
+
+            if rank == 0:
+                lookup_values = torch.tensor(
+                    [
+                        [0.41, 0.51, 0.61],
+                        [0.4, 0.5, 0.6],
+                        [0.0, 0.0, 0.0],
+                        [0.41, 0.51, 0.61],
+                        [0.4, 0.5, 0.6],
+                        [0.0, 0.0, 0.0],
+                    ],
+                    dtype=dtype,
+                    device=ctx.device,
+                )
+
+            else:
+                lookup_values = torch.tensor(
+                    [
+                        [0.11, 0.21, 0.31],
+                        [0.11, 0.21, 0.31],
+                    ],
+                    dtype=dtype,
+                    device=ctx.device,
+                )
+
+            dist_output_values = lookup_values_dist(
+                ctx=lookup_ctx, values=lookup_values
+            ).wait()
+
+            torch.testing.assert_close(
+                dist_output_values.cpu(),
+                torch.tensor(
+                    [
+                        [0.41, 0.51, 0.61],
+                        [0.4, 0.5, 0.6],
+                        [0.0, 0.0, 0.0],
+                        [0.11, 0.21, 0.31],
+                    ],
+                    device=torch.device("cpu"),
+                ),
+            )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_update(
+        self,
+    ) -> None:
+        world_size = 2
+        self._run_multi_process_test(callable=self._test_update, world_size=world_size)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_lookup(
+        self,
+    ) -> None:
+        world_size = 2
+        self._run_multi_process_test(callable=self._test_lookup, world_size=world_size)

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -984,3 +984,20 @@ def rank_device(device_type: str, rank: int) -> torch.device:
         return torch.device("cpu")
 
     return torch.device(f"{device_type}:{rank}")
+
+
+class ObjectPoolShardingType(Enum):
+    """
+    Sharding type for object pool
+    """
+
+    ROW_WISE = "row_wise"
+    # across nodes, state will be replicated. On lookup, all2alls will happen intranode.
+    # State is synced via update a2a being global internode.
+    REPLICATED_ROW_WISE = "replicated_row_wise"
+
+
+@dataclass
+class ObjectPoolShardingPlan(ModuleShardingPlan):
+    sharding_type: ObjectPoolShardingType
+    inference: bool = False

--- a/torchrec/modules/keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/keyed_jagged_tensor_pool.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, List, Optional
+
+import torch
+from torchrec.modules.object_pool import ObjectPool
+from torchrec.modules.object_pool_lookups import (
+    KeyedJaggedTensorPoolLookup,
+    TensorJaggedIndexSelectLookup,
+    UVMCachingInt64Lookup,
+)
+from torchrec.modules.utils import deterministic_dedup, jagged_index_select_with_empty
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+@torch.fx.wrap
+def _fx_assert_device(ids: torch.Tensor, device: torch.device) -> None:
+    assert ids.device == device
+    assert ids.dtype in [torch.int32, torch.int64]
+
+
+@torch.fx.wrap
+def _fx_wrap_lookup(
+    ids: torch.Tensor,
+    keys: List[str],
+    feature_max_lengths: Dict[str, int],
+    is_weighted: bool,
+    values_dtype: torch.dtype,
+    device: torch.device,
+    lookup: TensorJaggedIndexSelectLookup,  # This type enforement is a hack to make it work with torch.jit.script
+    weigth_dtype: Optional[torch.dtype] = None,
+) -> KeyedJaggedTensor:
+    jt_lookup: JaggedTensor = lookup.lookup(ids)
+
+    row_major_to_feature_major_permute = (
+        torch.arange((ids.shape[0] * len(feature_max_lengths)), device=device)
+        .view(-1, len(feature_max_lengths))
+        .t()
+        .flatten()
+    )
+
+    lengths = jt_lookup.lengths().flatten()[row_major_to_feature_major_permute]
+    output_offsets = torch.ops.fbgemm.asynchronous_inclusive_cumsum(lengths)
+    values = jagged_index_select_with_empty(
+        jt_lookup.values().flatten().unsqueeze(-1),
+        row_major_to_feature_major_permute,
+        jt_lookup.offsets().flatten()[1:],
+        output_offsets,
+    )
+    values, lengths = values.flatten(), lengths.flatten()
+
+    weights = torch.jit.annotate(Optional[torch.Tensor], None)
+    if jt_lookup.weights_or_none() is not None:
+        weights = jagged_index_select_with_empty(
+            jt_lookup.weights().flatten().unsqueeze(-1),
+            row_major_to_feature_major_permute,
+            jt_lookup.offsets().flatten()[1:],
+            output_offsets,
+        )
+        weights = weights.flatten()
+
+    return KeyedJaggedTensor.from_lengths_sync(
+        keys=keys,
+        values=values,
+        lengths=lengths,
+        weights=weights,
+    )
+
+
+class KeyedJaggedTensorPool(ObjectPool[KeyedJaggedTensor]):
+    """
+    KeyedJaggedTensorPool represents a collection of KeyedJaggedTensor (KJT)
+    with an index over the batch (non-jagged) dimension. For example, if a KJT
+    has 2 features "Feature0" and "Feature1" with stride of 2 (i.e. batch dim = 2),
+    KeyedJaggedTensorPool allows associating an index with batch 0 of "Feature0" and
+    "Feature1". Example:
+
+    #              "Feature0"  "Feature1" < dim_0
+    #  batch_0      [V0,V1]       None    <-- associated with index 2
+    #  batch_1       [V3]         [V4]    <-- associated with index 0
+    #    ^
+    #  dim_1
+
+    This is useful when one needs to associate entity IDs to sparse features with
+    jagged dimension, for example during hard negative sampling.
+
+    Args:
+        pool_size (int): total number of batches that can be stored in the pool
+        feature_max_lengths (Dict[str,int]): Mapping from feature name in KJT
+            to the maximum size of the jagged slices for the feature.
+        is_weighted (bool): whether KJT values have weights that need to be stored.
+        device (Optional[torch.device]): default device
+        enable_uvm (bool): if set to true, the pool will be allocated on UVM
+
+    Call Args:
+        ids: 1D torch.Tensor of ids to look up
+
+    Returns:
+        KeyedJaggedTensor with uniform stride of ids.size(0)
+
+    Example::
+
+        feature_max_lengths = {"feature0": 2, "feature1": 3}
+
+        kjt_pool = KeyedJaggedTensorPool(
+            pool_size=10,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=torch.float,
+        )
+
+        # Update
+        kjt_pool.update(
+            ids=torch.tensor([1,0,2]), # Assign different indices along batch dim
+            values=kjt,
+        )
+
+        # Lookup
+        lookup_kjt = kjt_pool.lookup(ids=torch.Tensor([2,0]))
+
+        print(lookup_kjt)
+        # KeyedJaggedTensor({
+        #     "feature0": [[v2], [v0, v1]]
+        #     "feature1": [[v5,v6,v7], [v4]]
+        # })
+
+    """
+
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        values_dtype: torch.dtype = torch.int64,
+        is_weighted: bool = False,
+        device: Optional[torch.device] = None,
+        enable_uvm: bool = False,
+    ) -> None:
+        super().__init__()
+        self._pool_size = pool_size
+        self._feature_max_lengths: Dict[str, int] = feature_max_lengths
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._total_lengths = sum(self._feature_max_lengths.values())
+        self._values_dtype = values_dtype
+        self._is_weighted = is_weighted
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._device = device if device is not None else torch.device("meta")
+        self._enable_uvm = enable_uvm
+
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._permute_feature = None
+        self.register_buffer(
+            "_feature_max_lengths_t",
+            torch.tensor(
+                list(feature_max_lengths.values()),
+                dtype=torch.int32,
+                device=self._device,
+            ),
+            persistent=False,
+        )
+
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._keys = list(self._feature_max_lengths.keys())
+        # pyre-ignore
+        self._lookup: KeyedJaggedTensorPoolLookup = None
+        if self._enable_uvm and values_dtype == torch.int64:
+            self._lookup = UVMCachingInt64Lookup(
+                pool_size, feature_max_lengths, is_weighted, self._device
+            )
+        else:
+            self._lookup = TensorJaggedIndexSelectLookup(
+                pool_size,
+                values_dtype,
+                feature_max_lengths,
+                is_weighted,
+                self._device,
+            )
+
+        if self._lookup is None:
+            raise ValueError(
+                f"Cannot create lookup for {self._enable_uvm=} {self._values_dtype}"
+            )
+
+        for fqn, tensor in self._lookup.states_to_register():
+            self.register_buffer(
+                fqn,
+                tensor,
+            )
+
+    def _load_from_state_dict(
+        self,
+        state_dict: Dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: Dict[str, Any],
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ) -> None:
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            True,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+        self._lookup._values = state_dict[prefix + "values"]
+        self._lookup._key_lengths = state_dict[prefix + "key_lengths"]
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def feature_max_lengths(self) -> Dict[str, int]:
+        return self._feature_max_lengths
+
+    @property
+    def values_dtype(self) -> torch.dtype:
+        return self._values_dtype
+
+    @property
+    def is_weighted(self) -> bool:
+        return self._is_weighted
+
+    def lookup(self, ids: torch.Tensor) -> KeyedJaggedTensor:
+        _fx_assert_device(ids, self._device)
+        return _fx_wrap_lookup(
+            ids,
+            self._keys,
+            self._feature_max_lengths,
+            self._is_weighted,
+            self._values_dtype,
+            self._device,
+            self._lookup,
+            self._weights.dtype if self._is_weighted else None,
+        )
+
+    def _update_preproc(self, values: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        """
+        2 steps:
+        1. Permute/filter KJT keys to be the same as in feature_max_lengths
+        2. Ensure the max_lengths of input is within the feature_max_lengths
+        """
+        if self._permute_feature is None:
+            self._permute_feature = []
+            for feature in self._feature_max_lengths.keys():
+                for j, kjt_feature in enumerate(values.keys()):
+                    if feature == kjt_feature:
+                        self._permute_feature.append(j)
+
+        valid_input = values.permute(self._permute_feature)
+        max_elements, _max_indices = (
+            valid_input.lengths().reshape(len(self._keys), -1).max(dim=1)
+        )
+
+        assert torch.all(
+            max_elements <= self._feature_max_lengths_t
+        ).item(), "input KJT has a feature that exceeds specified max lengths"
+
+        return valid_input
+
+    def update(self, ids: torch.Tensor, values: KeyedJaggedTensor) -> None:
+        _fx_assert_device(ids, self._device)
+
+        kjt = self._update_preproc(values)
+        assert kjt.values().dtype == self._values_dtype
+
+        # If duplicate ids are passed in for update, only the last one is kept
+        deduped_ids, dedup_permutation = deterministic_dedup(ids)
+        arange_idx = torch.arange(
+            values.stride() * len(self._keys), device=self._device
+        )
+        feature_major_to_row_major_permute = (arange_idx.view(len(self._keys), -1).t())[
+            dedup_permutation, :
+        ].flatten()
+
+        row_major_lengths = kjt.lengths()[feature_major_to_row_major_permute]
+        row_major_offsets = torch.ops.fbgemm.asynchronous_inclusive_cumsum(
+            row_major_lengths
+        )
+        row_major_values = jagged_index_select_with_empty(
+            kjt.values().unsqueeze(-1),
+            feature_major_to_row_major_permute,
+            kjt.offsets()[1:],
+            row_major_offsets,
+        )
+
+        row_major_values = row_major_values.flatten()
+
+        row_major_lengths = row_major_lengths.flatten()
+
+        row_major_weights = None
+        if self._is_weighted:
+            row_major_weights = jagged_index_select_with_empty(
+                kjt.weights().unsqueeze(-1),
+                feature_major_to_row_major_permute,
+                kjt.offsets()[1:],
+                row_major_offsets,
+            )
+            row_major_weights = row_major_weights.flatten()
+
+        self._lookup.update(
+            deduped_ids,
+            JaggedTensor(
+                values=row_major_values,
+                lengths=row_major_lengths.flatten(),
+                weights=row_major_weights,
+            ),
+        )

--- a/torchrec/modules/object_pool.py
+++ b/torchrec/modules/object_pool.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+from typing import Generic, TypeVar
+
+import torch
+
+T = TypeVar("T")
+
+
+class ObjectPool(abc.ABC, torch.nn.Module, Generic[T]):
+    """
+    Interface for TensorPool and KeyedJaggedTensorPool
+
+    Defines methods for lookup, update and obtaining pool size
+    """
+
+    @abc.abstractmethod
+    def lookup(self, ids: torch.Tensor) -> T:
+        pass
+
+    @abc.abstractmethod
+    def update(self, ids: torch.Tensor, values: T) -> None:
+        pass
+
+    @abc.abstractproperty
+    def pool_size(self) -> int:
+        pass

--- a/torchrec/modules/object_pool_lookups.py
+++ b/torchrec/modules/object_pool_lookups.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import abc
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import torch
+
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    EmbeddingLocation,
+    PoolingMode,
+    SparseType,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+from torch.autograd.profiler import record_function
+from torchrec.modules.utils import jagged_index_select_with_empty
+from torchrec.sparse.jagged_tensor import JaggedTensor
+
+
+torch.fx.wrap("jagged_index_select_with_empty")
+
+
+class KeyedJaggedTensorPoolLookup(abc.ABC, torch.nn.Module):
+    """
+    Abstract base class for KeyedJaggedTensor pool lookups
+
+    Implementations of this class should define methods for
+     - lookup using ids
+     - update values associated with ids
+     - returning states that should be saved
+        and loaded in state_dict()
+
+    Args:
+        pool_size (int): size of the pool
+        feature_max_lengths (Dict[str,int]): Dict mapping feature name to max length that
+            its values can have for any given batch. The underlying storage representation
+            for the KJT pool is currently a padded 2D tensor, so this information is
+            needed.
+        is_weighted (bool): Boolean indicating whether or not the KJTs will have weights
+            that need to be stored separately.
+        device (torch.device): device that KJTs should be placed on
+
+    Example:
+        Other classes should inherit from this class and implement the
+        abstract methods.
+    """
+
+    _pool_size: int
+    _feature_max_lengths: Dict[str, int]
+    _is_weighted: bool
+    _total_lengths: int
+    _total_lengths_t: torch.Tensor
+    _key_lengths: torch.Tensor
+    _jagged_lengths: torch.Tensor
+    _jagged_offsets: torch.Tensor
+    _device: torch.device
+
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        is_weighted: bool,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self._pool_size = pool_size
+        self._feature_max_lengths = feature_max_lengths
+        self._device = device
+        self._total_lengths = sum(self._feature_max_lengths.values())
+        self._total_lengths_t = torch.tensor(
+            [self._total_lengths], device=device, dtype=torch.int32
+        )
+        self._is_weighted = is_weighted
+
+        self._key_lengths = torch.zeros(
+            (self._pool_size, len(self._feature_max_lengths)),
+            dtype=torch.int32,
+            device=self._device,
+        )
+
+        lengths, offsets = self._infer_jagged_lengths_inclusive_offsets()
+        self._jagged_lengths = lengths
+        self._jagged_offsets = offsets
+
+    def _infer_jagged_lengths_inclusive_offsets(
+        self,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        lengths_sum = self._key_lengths.sum(dim=1)
+        padded_lengths = self._total_lengths_t - lengths_sum
+        jagged_lengths = torch.stack([lengths_sum, padded_lengths], dim=1).flatten()
+        return (
+            jagged_lengths,
+            torch.ops.fbgemm.asynchronous_inclusive_cumsum(jagged_lengths),
+        )
+
+    def _load_from_state_dict(
+        self,
+        state_dict: Dict[str, torch.Tensor],
+        prefix: str,
+        local_metadata: Dict[str, Any],
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ) -> None:
+        """
+        Override _load_from_state_dict in torch.nn.Module.
+        """
+        torch.nn.Module._load_from_state_dict(
+            self,
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+        lengths, offsets = self._infer_jagged_lengths_inclusive_offsets()
+        self._jagged_lengths = lengths
+        self._jagged_offsets = offsets
+
+    @abc.abstractmethod
+    def lookup(self, ids: torch.Tensor) -> JaggedTensor:
+        pass
+
+    @abc.abstractmethod
+    def update(self, ids: torch.Tensor, values: JaggedTensor) -> None:
+        # assume that at this point there are no duplicate ids, and all preproc is done by KJTPool
+        pass
+
+    def forward(self, ids: torch.Tensor) -> JaggedTensor:
+        """
+        Forward performs a lookup using the given ids
+
+        Args:
+            ids (torch.Tensor): Tensor of IDs to lookup
+
+        Returns:
+            JaggedTensor: JaggedTensor containing the merged
+                values, lengths and weights associated with the ids
+                for all the features of the KJT pool.
+        """
+        return self.lookup(ids)
+
+    @abc.abstractmethod
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        pass
+
+
+class TensorJaggedIndexSelectLookup(KeyedJaggedTensorPoolLookup):
+    _values_dtype: torch.dtype
+    _values: torch.Tensor
+    _weights: torch.Tensor
+
+    def __init__(
+        self,
+        pool_size: int,
+        values_dtype: torch.dtype,
+        feature_max_lengths: Dict[str, int],
+        is_weighted: bool,
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            device=device,
+            is_weighted=is_weighted,
+        )
+
+        self._values_dtype = values_dtype
+
+        self._values = torch.zeros(
+            (self._pool_size, self._total_lengths),
+            dtype=self._values_dtype,
+            device=self._device,
+        )
+
+        if self._is_weighted:
+            self._weights = torch.zeros(
+                (self._pool_size, self._total_lengths),
+                dtype=torch.float,
+                device=self._device,
+            )
+        else:
+            # to appease torchscript
+            self._weights = torch.empty((0,), dtype=torch.float, device=self._device)
+
+    def lookup(self, ids: torch.Tensor) -> JaggedTensor:
+        """
+        Example:
+        memory layout is
+        values = [
+            [1], [2, 2], 0, 0, 0,0
+            [11,11],[12,12,12],0,0
+        ]
+        lengths = [
+            1,2
+            2,3
+        ]
+
+        We can consider this as a jagged tensor with
+        [
+            [1,2,2], [0,0,0,0],
+            [11,11,12,12,12],[0,0]
+        ]
+        where we can combine all values together, and all padded values together.
+        The index to select into is then 2*ids (doubled because of padding index).
+
+        jagged_index_select will let us retrieve
+        [1,2,2,11,11,12,12,12], that we can then massage into
+        [
+            [1], [2,2]
+            [11,11] [12,12,12]
+        ]
+
+        Later (not in this method), we turn this into appropriate KJT format,
+        using jagged index select to transpose into
+        [
+            [1] [11, 11]
+            [2,2] [12,12,12]
+        ]
+        """
+
+        with record_function("## KJTPool Lookup ##"):
+            key_lengths_for_ids = self._key_lengths[ids]
+            lookup_indices = 2 * ids
+            lengths = self._jagged_lengths[lookup_indices]
+            offsets = torch.ops.fbgemm.asynchronous_inclusive_cumsum(lengths)
+            values = jagged_index_select_with_empty(
+                self._values.flatten().unsqueeze(-1),
+                lookup_indices,
+                self._jagged_offsets,
+                offsets,
+            )
+            weights = torch.jit.annotate(Optional[torch.Tensor], None)
+            if self._is_weighted:
+                weights = jagged_index_select_with_empty(
+                    self._weights.flatten().unsqueeze(-1),
+                    lookup_indices,
+                    self._jagged_offsets,
+                    offsets,
+                )
+
+        return JaggedTensor(
+            values=values, weights=weights, lengths=key_lengths_for_ids.flatten()
+        )
+
+    def update(self, ids: torch.Tensor, values: JaggedTensor) -> None:
+
+        with record_function("## TensorPool update ##"):
+            key_lengths = (
+                # pyre-ignore
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .sum(axis=1)
+            )
+            key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
+
+            padded_values = torch.ops.fbgemm.jagged_to_padded_dense(
+                values.values(),
+                [key_offsets],
+                [self._total_lengths],
+                0,
+            )
+
+            self._values[ids] = padded_values.to(self._values.dtype)
+            self._key_lengths[ids] = (
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .to(self._key_lengths.dtype)
+            )
+
+            if values.weights_or_none() is not None:
+                padded_weights = torch.ops.fbgemm.jagged_to_padded_dense(
+                    values.weights(),
+                    [key_offsets],
+                    [self._total_lengths],
+                    0,
+                )
+                self._weights[ids] = padded_weights
+
+            lengths, offsets = self._infer_jagged_lengths_inclusive_offsets()
+            self._jagged_lengths = lengths
+            self._jagged_offsets = offsets
+
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield "values", self._values
+        yield "key_lengths", self._key_lengths
+        if self._is_weighted:
+            yield "weights", self._weights
+
+
+class UVMCachingInt64Lookup(KeyedJaggedTensorPoolLookup):
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        is_weighted: bool,
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            device=device,
+            is_weighted=is_weighted,
+        )
+
+        # memory layout will be
+        # [f1 upper bits][f2 upper bits][upper bits paddings][f1 lower bits][f2 lower bits][lower bits paddings]
+
+        # TBE requires dim to be divisible by 4
+        self._bit_dims: int = ((self._total_lengths + 4 - 1) // 4) * 4
+
+        self._bit_dims_t: torch.Tensor = torch.tensor(
+            [self._bit_dims], dtype=torch.int32, device=self._device
+        )
+
+        self._tbe = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    pool_size,
+                    2 * self._bit_dims,
+                    EmbeddingLocation.MANAGED,
+                    ComputeDevice.CUDA,
+                ),
+            ],
+            pooling_mode=PoolingMode.NONE,
+            device=device,
+        )
+        self._tbe_state: torch.Tensor = (
+            self._tbe.split_embedding_weights()[0].flatten().view(pool_size, -1)
+        )
+
+        if self._is_weighted:
+            # pyre-ignore
+            self._tbe_weights = SplitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=[
+                    (
+                        pool_size,
+                        self._bit_dims,
+                        (
+                            EmbeddingLocation.MANAGED_CACHING
+                            if device != torch.device("meta")
+                            else EmbeddingLocation.MANAGED
+                        ),
+                        ComputeDevice.CUDA,
+                    ),
+                ],
+                pooling_mode=PoolingMode.NONE,
+                device=device,
+            )
+            self._tbe_weights_state: torch.Tensor = (
+                self._tbe_weights.split_embedding_weights()[0]
+                .flatten()
+                .view(pool_size, -1)
+            )
+
+    def lookup(self, ids: torch.Tensor) -> JaggedTensor:
+        with record_function("## UVMCachingInt64Lookup lookup ##"):
+            output = self._tbe(
+                indices=ids,
+                offsets=torch.tensor([0, ids.shape[0]], device=self._device),
+            )
+
+            output_int_split = output.view(torch.int32).split(
+                [self._bit_dims, self._bit_dims], dim=1
+            )
+            output_int_upper = output_int_split[0].to(torch.int64) << 32
+            output_int_lower = output_int_split[1].to(torch.int64) & 0xFFFFFFFF
+
+            kjt_dense_values = output_int_upper | output_int_lower
+
+            key_lengths_for_ids = self._key_lengths[ids]
+            lengths_sum = key_lengths_for_ids.sum(dim=1)
+
+            padded_lengths = self._bit_dims_t - lengths_sum
+            # TODO: pre-compute this on class init
+            jagged_lengths = torch.stack(
+                [
+                    lengths_sum,
+                    padded_lengths,
+                ],
+                dim=1,
+            ).flatten()
+
+            lookup_indices = torch.arange(0, ids.shape[0] * 2, 2, device=self._device)
+            output_lengths = jagged_lengths[lookup_indices]
+            values = jagged_index_select_with_empty(
+                kjt_dense_values.flatten().unsqueeze(-1),
+                lookup_indices,
+                torch.ops.fbgemm.asynchronous_inclusive_cumsum(jagged_lengths),
+                torch.ops.fbgemm.asynchronous_inclusive_cumsum(output_lengths),
+            )
+
+        return JaggedTensor(
+            values=values.flatten(),
+            lengths=key_lengths_for_ids.flatten(),
+        )
+
+    def update(self, ids: torch.Tensor, values: JaggedTensor) -> None:
+        with record_function("## UVMCachingInt64Lookup update ##"):
+            key_lengths = (
+                # pyre-ignore
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .sum(axis=1)
+            )
+            key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
+            padded_values = torch.ops.fbgemm.jagged_to_padded_dense(
+                values.values(),
+                [key_offsets],
+                [self._bit_dims],
+                0,
+            )
+
+            values_upper_bits = (padded_values >> 32).to(torch.int32)
+            values_lower_bits = (padded_values & 0xFFFFFFFF).to(torch.int32)
+
+            state = torch.cat([values_upper_bits, values_lower_bits], dim=1).view(
+                torch.float32
+            )
+
+            self._tbe_state[ids] = state
+
+            self._key_lengths[ids] = (
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .to(self._key_lengths.dtype)
+            )
+
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield "values_upper_and_lower_bits", self._tbe_state
+        if self._is_weighted:
+            yield "weights", self._tbe_weights_state
+
+
+class UVMCachingInt32Lookup(KeyedJaggedTensorPoolLookup):
+    def __init__(
+        self,
+        pool_size: int,
+        feature_max_lengths: Dict[str, int],
+        is_weighted: bool,
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            device=device,
+            is_weighted=is_weighted,
+        )
+
+        # memory layout will be
+        # f1        f2
+        # [f1 bits] [f2 bits] padding
+        # TBE requires dim to be divisible by 4.
+        self._bit_dims: int = ((self._total_lengths + 4 - 1) // 4) * 4
+        self._bit_dims_t: torch.Tensor = torch.tensor(
+            [self._bit_dims], dtype=torch.int32, device=self._device
+        )
+
+        self._tbe = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    pool_size,
+                    self._bit_dims,
+                    (
+                        EmbeddingLocation.MANAGED_CACHING
+                        if self._device.type != "meta"
+                        else EmbeddingLocation.DEVICE
+                    ),
+                    ComputeDevice.CUDA,
+                ),
+            ],
+            pooling_mode=PoolingMode.NONE,
+            device=device,
+        )
+
+        self._tbe_state: torch.Tensor = (
+            self._tbe.split_embedding_weights()[0].flatten().view(pool_size, -1)
+        )
+
+        if self._is_weighted:
+            # pyre-ignore
+            self._tbe_weights = SplitTableBatchedEmbeddingBagsCodegen(
+                embedding_specs=[
+                    (
+                        pool_size,
+                        self._bit_dims,
+                        (
+                            EmbeddingLocation.MANAGED_CACHING
+                            if self._device.type != "meta"
+                            else EmbeddingLocation.DEVICE
+                        ),
+                        ComputeDevice.CUDA,
+                    ),
+                ],
+                pooling_mode=PoolingMode.NONE,
+                device=device,
+            )
+            self._tbe_weights_state: torch.Tensor = (
+                self._tbe_weights.split_embedding_weights()[0]
+                .flatten()
+                .view(pool_size, -1)
+            )
+
+    def lookup(self, ids: torch.Tensor) -> JaggedTensor:
+        with record_function("## UVMCachingInt32Lookup lookup ##"):
+            output = self._tbe(
+                indices=ids,
+                offsets=torch.tensor([0, ids.shape[0]], device=self._device),
+            )
+
+            kjt_dense_values = output.view(torch.int32)
+
+            key_lengths_for_ids = self._key_lengths[ids]
+            lengths_sum = key_lengths_for_ids.sum(dim=1)
+
+            padded_lengths = self._bit_dims_t - lengths_sum
+            jagged_lengths = torch.stack(
+                [
+                    lengths_sum,
+                    padded_lengths,
+                ],
+                dim=1,
+            ).flatten()
+
+            lookup_ids = 2 * torch.arange(ids.shape[0], device=self._device)
+            output_lengths = jagged_lengths[lookup_ids]
+            values = jagged_index_select_with_empty(
+                kjt_dense_values.flatten().unsqueeze(-1),
+                lookup_ids,
+                torch.ops.fbgemm.asynchronous_inclusive_cumsum(jagged_lengths),
+                torch.ops.fbgemm.asynchronous_inclusive_cumsum(output_lengths),
+            )
+
+        return JaggedTensor(
+            values=values.flatten(),
+            lengths=key_lengths_for_ids.flatten(),
+        )
+
+    def update(self, ids: torch.Tensor, values: JaggedTensor) -> None:
+        with record_function("## UVMCachingInt32Lookup update##"):
+            key_lengths = (
+                # pyre-ignore
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .sum(axis=1)
+            )
+            key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
+            state = torch.ops.fbgemm.jagged_to_padded_dense(
+                values.values(),
+                [key_offsets],
+                [self._bit_dims],
+                0,
+            ).view(torch.float32)
+
+            self._tbe_state[ids] = state
+
+            self._key_lengths[ids] = (
+                values.lengths()
+                .view(-1, len(self._feature_max_lengths))
+                .to(self._key_lengths.dtype)
+            )
+
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield "values", self._tbe_state
+        if self._is_weighted:
+            yield "weights", self._tbe_weights_state
+
+
+class TensorPoolLookup(abc.ABC, torch.nn.Module):
+    """
+    Abstract base class for tensor pool lookups
+
+    Implementations of this class should define methods for
+     - lookup using ids
+     - update values associated with ids
+     - returning states that should be saved
+        and loaded in state_dict()
+     - setting state from loaded values
+
+    Args:
+        pool_size (int): size of the pool
+        dim (int): dimension of the tensors in the pool
+        dtype (torch.dtype): dtype of the tensors in the pool
+        device (torch.device): device of the tensors in the pool
+
+    Example:
+        Other classes should inherit this base class and implement the
+        abstract methods.
+    """
+
+    def __init__(
+        self,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self._pool_size = pool_size
+        self._dim = dim
+        self._dtype = dtype
+        self._device = device
+
+    @abc.abstractmethod
+    def lookup(self, ids: torch.Tensor) -> torch.Tensor:
+        pass
+
+    @abc.abstractmethod
+    def update(self, ids: torch.Tensor, values: torch.Tensor) -> None:
+        # assume that at this point there are no duplicate ids, and all preproc is done by TensorPool
+        pass
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        """
+        Forward performs a lookup using the given ids
+
+        Args:
+            ids (torch.Tensor): Tensor of IDs to lookup
+
+        Returns:
+            torch.Tensor: Tensor of values associated with the given ids
+        """
+        return self.lookup(ids)
+
+    @abc.abstractmethod
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        pass
+
+    @abc.abstractmethod
+    def set_state(self, loaded_values: torch.Tensor) -> None:
+        pass
+
+
+class TensorLookup(TensorPoolLookup):
+    def __init__(
+        self,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        enable_uvm: bool = False,
+    ) -> None:
+        super().__init__(
+            pool_size=pool_size,
+            dim=dim,
+            dtype=dtype,
+            device=device,
+        )
+
+        self._enable_uvm = enable_uvm
+        self._pool: torch.Tensor = (
+            torch.zeros(
+                (self._pool_size, self._dim),
+                out=torch.ops.fbgemm.new_unified_tensor(
+                    torch.zeros(
+                        (self._pool_size, self._dim),
+                        device=device,
+                        dtype=dtype,
+                    ),
+                    [self._pool_size * self._dim],
+                    False,
+                ),
+            )
+            if self._enable_uvm
+            else torch.zeros(
+                (self._pool_size, self._dim),
+                dtype=self._dtype,
+                device=self._device,
+            )
+        )
+
+    def lookup(self, ids: torch.Tensor) -> torch.Tensor:
+        torch._assert(
+            ids.device.type == self._device.type,
+            "ids.device.type does not match self._device.type",
+        )
+        with record_function("## TensorPool Lookup ##"):
+            ret = self._pool[ids]
+        return ret
+
+    def update(self, ids: torch.Tensor, values: torch.Tensor) -> None:
+        with record_function("## TensorPool update ##"):
+            self._pool[ids] = values
+
+    def set_state(self, loaded_values: torch.Tensor) -> None:
+        self._pool.copy_(loaded_values)
+
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield "_pool", self._pool
+
+
+class UVMCachingFloatLookup(TensorPoolLookup):
+    def __init__(
+        self,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+
+        super().__init__(
+            pool_size=pool_size,
+            dim=dim,
+            dtype=dtype,
+            device=device,
+        )
+
+        sparse_type = SparseType.from_dtype(self._dtype)
+
+        self._tbe = SplitTableBatchedEmbeddingBagsCodegen(
+            embedding_specs=[
+                (
+                    self._pool_size,
+                    self._dim,
+                    (
+                        EmbeddingLocation.MANAGED_CACHING
+                        if self._device.type != "meta"
+                        else EmbeddingLocation.DEVICE
+                    ),
+                    ComputeDevice.CUDA,
+                ),
+            ],
+            pooling_mode=PoolingMode.NONE,
+            device=device,
+            weights_precision=sparse_type,
+            output_dtype=sparse_type,
+        )
+
+        self._tbe_state: torch.Tensor = (
+            self._tbe.split_embedding_weights()[0].flatten().view(pool_size, -1)
+        )
+
+    def lookup(self, ids: torch.Tensor) -> torch.Tensor:
+        torch._assert(
+            ids.device.type == self._device.type,
+            "ids.device.type does not match self._device.type",
+        )
+        with record_function("## UVMCachingFloatLookup lookup ##"):
+            output = self._tbe(
+                indices=ids,
+                offsets=torch.tensor([0, ids.shape[0]], device=self._device),
+            )
+        return output
+
+    def update(self, ids: torch.Tensor, values: torch.Tensor) -> None:
+        with record_function("## UVMCachingFloatLookup update ##"):
+            self._tbe_state[ids] = values
+
+    def states_to_register(self) -> Iterator[Tuple[str, torch.Tensor]]:
+        yield "_pool", self._tbe_state
+
+    def set_state(self, loaded_values: torch.Tensor) -> None:
+        self._tbe_state.copy_(loaded_values)

--- a/torchrec/modules/tensor_pool.py
+++ b/torchrec/modules/tensor_pool.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional
+
+import torch
+from torchrec.modules.object_pool import ObjectPool
+from torchrec.modules.utils import deterministic_dedup
+
+
+@torch.fx.wrap
+def _fx_assert_device(ids: torch.Tensor, device: torch.device) -> None:
+    assert ids.device == device
+    assert ids.dtype in [torch.int32, torch.int64]
+
+
+@torch.fx.wrap
+def _fx_assert_pool_size(ids: torch.Tensor, pool_size: int) -> None:
+    assert torch.all(ids < pool_size).item()
+
+
+class TensorPool(ObjectPool[torch.Tensor]):
+    """
+    TensorPool represents a collection of torch.Tensor with uniform dimension.
+    It is effectively a 2D tensor of size [pool_size, dim], where each [1,dim] row
+    tensor is associated with an unique index which can be set up with update().
+    Each row tensor making up the tensor pool can be quried by its index with lookup().
+
+    Args:
+        pool_size (int): total number of rows of tensors in the pool
+        dim (int): dimension that each tensor in the pool
+        dtype (torch.dtype): dtype of the tensors in the pool
+        device (Optional[torch.device]): default device
+        loaded_values (Optional[torch.Tensor]): pre-defined values to initialize the pool
+        enable_uvm (bool): if set to true, the pool will be allocated on UVM
+
+    Call Args:
+        ids: 1D torch.Tensor of ids to look up
+
+    Returns:
+        torch.Tensor of shape [ids.size(0), dim]
+
+    Example::
+
+        dense_pool = TensorPool(
+            pool_size=10,
+            dim=2,
+            dtype=torch.float
+        )
+
+        # Update
+        ids = torch.Tensor([1, 9])
+        update_values = torch.Tensor([[1.0, 2.0],[3.0,4.0]])
+        dense_pool.update(ids=ids, values=update_values)
+
+        # Lookup
+        lookup_values = dense_pool.lookup(ids=ids)
+
+        print(lookup_values)
+        # tensor([[1., 2.],
+        #        [3., 4.]])
+    """
+
+    def __init__(
+        self,
+        pool_size: int,
+        dim: int,
+        dtype: torch.dtype,
+        device: Optional[torch.device] = None,
+        loaded_values: Optional[torch.Tensor] = None,
+        enable_uvm: bool = False,
+    ) -> None:
+        super().__init__()
+        self._pool_size = pool_size
+        self._dtype = dtype
+        # pyre-fixme[4]: Attribute must be annotated.
+        self._device = device if device is not None else torch.device("meta")
+        self._dim = dim
+        self._enable_uvm = enable_uvm
+        # TODO enable multiple lookup on unsharded module
+
+        self.register_buffer(
+            "_pool",
+            torch.zeros(
+                (self._pool_size, self._dim),
+                dtype=self._dtype,
+                device=self._device,
+            ),
+        )
+        if loaded_values is not None:
+            self._pool = loaded_values
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        torch._assert(self._device is not None, "self._device should already be set")
+        return self._device
+
+    @property
+    def pool(self) -> torch.Tensor:
+        return self._pool
+
+    def lookup(self, ids: torch.Tensor) -> torch.Tensor:
+        _fx_assert_device(ids, self._device)
+        _fx_assert_pool_size(ids, self._pool_size)
+        return self._pool[ids]
+
+    def update(self, ids: torch.Tensor, values: torch.Tensor) -> None:
+        assert values.dim() == 2
+        assert values.size(1) == self._dim
+        assert values.dtype == self._dtype
+        assert values.device == self._device, f"{values.device} != {self._device}"
+        _fx_assert_device(ids, self._device)
+        _fx_assert_pool_size(ids, self._pool_size)
+
+        # If duplicate ids are passed in for update, only the last one is kept
+        deduped_ids, dedup_permutation = deterministic_dedup(ids)
+        self._pool[deduped_ids] = values[dedup_permutation]
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        return self.lookup(ids)

--- a/torchrec/modules/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/tests/test_keyed_jagged_tensor_pool.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import unittest
+
+import torch
+from torchrec.modules.keyed_jagged_tensor_pool import KeyedJaggedTensorPool
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class KeyedJaggedTensorPoolTest(unittest.TestCase):
+    def test_update_lookup(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        values_dtype = torch.int64
+
+        keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=values_dtype,
+            device=device,
+        )
+
+        # init global state is
+        # 4         8
+        # f1       f2
+        # [3,3] .  [13,13,13]
+        # [2,2] .  [12,12]
+        # [1] .    [11]
+        # [4]      [14,14,14,14]
+
+        keyed_jagged_tensor_pool.update(
+            ids=torch.tensor([2, 0, 1, 3], device=device),
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1", "f2"],
+                values=torch.tensor(
+                    [1, 3, 3, 2, 2, 4, 11, 13, 13, 13, 12, 12, 14, 14, 14, 14],
+                    dtype=values_dtype,
+                    device=device,
+                ),
+                lengths=torch.tensor(
+                    [1, 2, 2, 1, 1, 3, 2, 4], dtype=torch.int, device=device
+                ),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([2, 0], device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [[1], [3, 3]],
+        #     "f2": [[11], [13, 13, 13]]
+        # })
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor(
+                [1, 3, 3, 11, 13, 13, 13],
+                dtype=values_dtype,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor(
+                [1, 2, 1, 3],
+                dtype=torch.int,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([1, 3, 0, 2], device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [[2, 2], [4], [3, 3], [1]],
+        #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+        # })
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor(
+                [2, 2, 4, 3, 3, 1, 12, 12, 14, 14, 14, 14, 13, 13, 13, 11],
+                dtype=values_dtype,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor(
+                [2, 1, 2, 1, 2, 4, 3, 1],
+                dtype=torch.int,
+                device=torch.device("cpu"),
+            ),
+        )
+
+    def test_input_permute(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        values_dtype = torch.int32
+
+        keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=values_dtype,
+            device=device,
+        )
+
+        # init global state is
+        # 4         8
+        # f1       f2               f3
+        # [3,3] .  [13,13,13]       [23]
+        # [2,2] .  [12,12]          [22, 22, 22]
+        # [1] .    [11]             [21, 21]
+        # [4]      [14,14,14,14]    []
+
+        keyed_jagged_tensor_pool.update(
+            ids=torch.tensor([2, 0, 1, 3], device=device),
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f2", "f3", "f1"],
+                values=torch.tensor(
+                    [
+                        11,
+                        13,
+                        13,
+                        13,
+                        12,
+                        12,
+                        14,
+                        14,
+                        14,
+                        14,
+                        21,
+                        21,
+                        23,
+                        22,
+                        22,
+                        22,
+                        1,
+                        3,
+                        3,
+                        2,
+                        2,
+                        4,
+                    ],
+                    dtype=values_dtype,
+                    device=device,
+                ),
+                lengths=torch.tensor(
+                    [1, 3, 2, 4, 2, 1, 3, 0, 1, 2, 2, 1], dtype=torch.int, device=device
+                ),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([2, 0], device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [[1], [3, 3]],
+        #     "f2": [[11], [13, 13, 13]]
+        # })
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor(
+                [1, 3, 3, 11, 13, 13, 13],
+                dtype=values_dtype,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor(
+                [1, 2, 1, 3],
+                dtype=torch.int,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([1, 3, 0, 2], device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [[2, 2], [4], [3, 3], [1]],
+        #     "f2": [[12, 12], [14, 14, 14, 14], [13, 13, 13], [11]]
+        # })
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor(
+                [2, 2, 4, 3, 3, 1, 12, 12, 14, 14, 14, 14, 13, 13, 13, 11],
+                dtype=values_dtype,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor(
+                [2, 1, 2, 1, 2, 4, 3, 1],
+                dtype=torch.int,
+                device=torch.device("cpu"),
+            ),
+        )
+
+    def test_conflict(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        values_dtype = torch.int32
+
+        keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=values_dtype,
+            device=device,
+        )
+
+        # input is
+        # ids    f1       f2
+        # 2      [1]      [11]
+        # 0      [3,3] .  [13,13,13]
+        # 2      [2,2]    [12,12]
+        # 3      [4]      [14,14,14,14]
+
+        keyed_jagged_tensor_pool.update(
+            ids=torch.tensor([2, 0, 2, 3], device=device),
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1", "f2"],
+                values=torch.tensor(
+                    [1, 3, 3, 2, 2, 4, 11, 13, 13, 13, 12, 12, 14, 14, 14, 14],
+                    dtype=values_dtype,
+                    device=device,
+                ),
+                lengths=torch.tensor(
+                    [1, 2, 2, 1, 1, 3, 2, 4], dtype=torch.int, device=device
+                ),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([2, 0], device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [[2,2], [3, 3]],
+        #     "f2": [[12, 12], [13, 13, 13]]
+        # })
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor(
+                [2, 2, 3, 3, 12, 12, 13, 13, 13],
+                dtype=values_dtype,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor(
+                [2, 2, 2, 3],
+                dtype=torch.int,
+                device=torch.device("cpu"),
+            ),
+        )
+
+    def test_empty_lookup(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        values_dtype = torch.int32
+
+        keyed_jagged_tensor_pool = KeyedJaggedTensorPool(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            values_dtype=values_dtype,
+            device=device,
+        )
+
+        # init global state is
+        # 4         8
+        # f1       f2
+        # [3,3] .  [13,13,13]
+        # [2,2] .  [12,12]
+        # [1] .    [11]
+        # [4]      [14,14,14,14]
+
+        ids = torch.tensor([2, 0, 1, 3], device=device)
+        keyed_jagged_tensor_pool.update(
+            ids=ids,
+            values=KeyedJaggedTensor.from_lengths_sync(
+                keys=["f1", "f2"],
+                values=torch.tensor(
+                    [1, 3, 3, 2, 2, 4, 11, 13, 13, 13, 12, 12, 14, 14, 14, 14],
+                    dtype=values_dtype,
+                    device=device,
+                ),
+                lengths=torch.tensor(
+                    [1, 2, 2, 1, 1, 3, 2, 4], dtype=torch.int, device=device
+                ),
+            ),
+        )
+
+        kjt = keyed_jagged_tensor_pool.lookup(
+            ids=torch.tensor([], dtype=ids.dtype, device=device),
+        )
+
+        # expected values
+        # KeyedJaggedTensor({
+        #     "f1": [],
+        #     "f2": [],
+        # })
+
+        self.assertEqual(kjt.keys(), ["f1", "f2"])
+
+        torch.testing.assert_close(
+            kjt.values().cpu(),
+            torch.tensor([], dtype=values_dtype, device=torch.device("cpu")),
+        )
+
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.tensor([], dtype=torch.int, device=torch.device("cpu")),
+        )

--- a/torchrec/modules/tests/test_kjt_pool_lookup.py
+++ b/torchrec/modules/tests/test_kjt_pool_lookup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import unittest
+
+import torch
+from torchrec.modules.object_pool_lookups import UVMCachingInt64Lookup
+from torchrec.sparse.jagged_tensor import JaggedTensor
+
+
+class KeyedJaggedTensorPoolLookupTest(unittest.TestCase):
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_uvm_caching_int64_lookup(
+        self,
+    ) -> None:
+        device = torch.device("cuda:0")
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        lookup = UVMCachingInt64Lookup(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            is_weighted=False,
+            device=device,
+        )
+        ids = torch.tensor([0, 1, 2, 3], device=device)
+        jt_values = torch.tensor(
+            [1, 3, 3, 2, 2, 4, 11, 13, 13, 13, 12, 12, 14, 14, 14, 14],
+            dtype=torch.int64,
+            device=device,
+        )
+        jt_lengths = torch.tensor(
+            [1, 2, 2, 1, 1, 3, 2, 4], dtype=torch.int, device=device
+        )
+
+        lookup.update(
+            ids=ids,
+            values=JaggedTensor(
+                jt_values,
+                lengths=jt_lengths,
+            ),
+        )
+
+        torch.testing.assert_close(lookup.lookup(ids).values(), jt_values)
+
+        INT64_VALUE_SHIFT = int(3e9)
+        lookup.update(
+            ids=ids,
+            values=JaggedTensor(
+                jt_values + INT64_VALUE_SHIFT,
+                lengths=jt_lengths,
+            ),
+        )
+
+        torch.testing.assert_close(
+            lookup.lookup(ids).values(), jt_values + INT64_VALUE_SHIFT
+        )

--- a/torchrec/modules/tests/test_tensor_pool.py
+++ b/torchrec/modules/tests/test_tensor_pool.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import unittest
+
+import torch
+
+from torchrec.modules.tensor_pool import TensorPool
+
+
+class TensorPoolTest(unittest.TestCase):
+    def test_update_lookup(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+        pool_size = 10
+        dim = 3
+        batch_size = 5
+        dense_pool = TensorPool(
+            pool_size=pool_size,
+            dim=dim,
+            dtype=torch.float,
+            device=device,
+        )
+        update_ids = [1, 9, 4, 2, 6]
+        ids_to_row = {1: 0, 9: 1, 4: 2, 2: 3, 6: 4}
+        ids = torch.tensor(update_ids, dtype=torch.int, device=device)
+        reference_values = torch.rand(
+            (batch_size, dim), dtype=torch.float, device=device
+        )
+        dense_pool.update(ids=ids, values=reference_values)
+
+        lookup_ids = torch.randint(
+            low=0, high=pool_size, size=(batch_size,), dtype=torch.int, device=device
+        )
+        lookup_values = dense_pool.lookup(ids=lookup_ids)
+        for i in range(batch_size):
+            if lookup_ids[i] in update_ids:
+                # pyre-ignore
+                lookup_id: int = lookup_ids[i].int().item()
+                torch.testing.assert_close(
+                    reference_values[ids_to_row[lookup_id]],
+                    lookup_values[i],
+                )
+            else:
+                torch.testing.assert_close(
+                    lookup_values[i],
+                    torch.zeros(3, dtype=torch.float, device=device),
+                    msg=f"{dense_pool._pool[lookup_ids[i]]}",
+                )
+
+        torch.testing.assert_close(dense_pool.pool_size, pool_size)
+
+    def test_conflict(
+        self,
+    ) -> None:
+        device = (
+            torch.device("cpu")
+            if not torch.cuda.is_available()
+            else torch.device("cuda:0")
+        )
+        pool_size = 10
+        dim = 3
+        batch_size = 5
+        dense_pool = TensorPool(
+            pool_size=pool_size,
+            dim=dim,
+            dtype=torch.float,
+            device=device,
+        )
+        update_ids = [1, 9, 4, 1, 6]
+        ids_to_row = {9: 1, 4: 2, 1: 3, 6: 4}  # The first 1 is deduped and removed
+        ids = torch.tensor(update_ids, dtype=torch.int, device=device)
+        reference_values = torch.rand(
+            (batch_size, dim), dtype=torch.float, device=device
+        )
+        dense_pool.update(ids=ids, values=reference_values)
+
+        lookup_ids = torch.randint(
+            low=0, high=pool_size, size=(batch_size,), dtype=torch.int, device=device
+        )
+        lookup_values = dense_pool.lookup(ids=lookup_ids)
+        for i in range(batch_size):
+            if lookup_ids[i] in update_ids:
+                # pyre-ignore
+                lookup_id: int = lookup_ids[i].int().item()
+                torch.testing.assert_close(
+                    reference_values[ids_to_row[lookup_id]],
+                    lookup_values[i],
+                )
+            else:
+                torch.testing.assert_close(
+                    lookup_values[i],
+                    torch.zeros(3, dtype=torch.float, device=device),
+                    msg=f"{dense_pool._pool[lookup_ids[i]]}",
+                )
+
+        torch.testing.assert_close(dense_pool.pool_size, pool_size)


### PR DESCRIPTION
Summary:
We are adding new TorchRec modules for fast, scalable and efficient indexing of tensors:  TensorPool and KeyedJaggedTensorPool for dense and sparse tensors respectively.

The proposed modules provide abstractions for reading and writing large tensor and KeyedJaggedTensor values, with support for sharding and flexible data emplacement (e.g. HBM, UVM, CPU, etc). They expose APIs to update and look up values based on arbitrary indices, and support sharding to distribute the tensors across multiple devices, abstracting away the collective communications for distributed lookup and updates.

# Motivation
When working with recommender systems, there is often a need to transform or augment the model’s feature inputs in various ways. For example, when training retrieval/candidate generation models, it is common to extend the training data with negative samples. In the context of video recommendation, negative samples might be the IDs of videos that the user did not click on (i.e. **hard negative samples**). Retrieval models are then trained to produce a list of positive samples as candidates for further ranking downstream.

In such cases, it may not be practical to store all the necessary features in the batched data. For example, during candidate generation, extracting features for a large corpus of candidate items may be prohibitively expensive. Instead, auxiliary features can be stored in memory and indexed to efficiently lookup features when needed to augment the given samples during training or inference.

These modules can also be used to implement a distributed cache for embeddings that supports index-based lookup and updates.

Note: this is joint work from various technical contributors (in no particular order): @xing-liu @strisunshinewentingwang @murphymatt @Michael-JY-He @YLGH @jiayisuse @gnahzg @yanxia @hongweitian @SeanXiaohengMao @cz171

Reviewed By: joshuadeng

Differential Revision: D58355479
