### PR TITLE
[KT.regroup Ops][3/N] implementation of fbgemm op - kt_regroup_arguments

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -175,7 +175,7 @@ def permute_multi_embedding(
     keyed_tensors: List["KeyedTensor"], groups: List[List["str"]]
 ) -> List[torch.Tensor]:
     keys, lengths, values = _desugar_keyed_tensors(keyed_tensors)
-    permutes, in_shape, out_shape, out_lengths = _kt_regroup_permutes(
+    permutes, in_shape, out_shape, out_lengths = torch.ops.fbgemm.kt_regroup_arguments(
         values[0], keys, lengths, groups
     )
     permuted_values = torch.ops.fbgemm.permute_multi_embedding(
@@ -264,7 +264,7 @@ def _remap_to_groups(
     return permute, inv_permute, offsets, inv_offsets, splits
 
 
-def _kt_regroup_permutes(
+def _kt_regroup_arguments(
     value: torch.Tensor,
     keys: List[List[str]],
     key_lengths: List[List[int]],


### PR DESCRIPTION
Summary:
# context
* learned from previous benchmark/trace analysis, that the CPU runtime (~2.0 ms) is still comparable with the GPU runtime (~2.2 ms)
|Operator|CPU runtime|GPU runtime|
|---|---|---|
|**native-pytorch**|3.9 ms|3.1 ms|
|**[prod] permute_pooled_embs**|2.1 ms|4.9 ms|
|**[new] permute_multi_embedding**|2.0 ms|2.2 ms|
* after a closer look, it takes ~1.1 ms in the meta arguments preparation/calculation, particularly, the `_multi_remap_to_groups`
 {F1713121552}
* in order to further improve the CPU runtime performance, we are moving the meta argument preparation into the C++ domain (inside the operator)

# details
* the new operator `kt_regroup_permutes` directly takes input from python/pytorch domain as:
**1.** feature/key list: `List[List[str]]`
**2.** feature/key lengths: `List[List[int]]`
**3.** permute feature/key list: `List[List[str]]`. 
* use `torch.ops.fbgemm.kt_regroup_permutes` to do the same work as `_kt_regroup_permutes`
* in the new op `keyed_tensor_regroup`, first calls the `generate_keyed_tensor_permutes` to get the proper arguments
* then call the `permute_multi_embedding` op for the actual operation.

Differential Revision: D58649553


