### PR TITLE
Dim bucket for key value kernel

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -425,6 +425,10 @@ def _prefetch_and_cached(
     Return if this embedding use hbm as cache. In this case we might want to use
     bucketizer to group by dimension for memory efficiency.
     """
+    if table.compute_kernel in {
+        EmbeddingComputeKernel.KEY_VALUE,
+    }:
+        return True
 
     return (
         table.compute_kernel


### PR DESCRIPTION
Summary:
Enforce emb dim bucketizing for key_value compute kernel.

Reasons:
* mixed dimension support unclear (FBGEMM / PS)
* More efficient use of cache space.

Open to come back to this issue in the future.

Reviewed By: sryap

Differential Revision: D58681352
