### PR TITLE
remove is_non_strict_exporting from modules.utils

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -18,7 +18,8 @@ from torchrec.modules.embedding_configs import (
     EmbeddingConfig,
     pooling_type_to_str,
 )
-from torchrec.modules.utils import is_non_strict_exporting, register_custom_op
+from torchrec.modules.utils import register_custom_op
+from torchrec.pt2.checks import is_non_strict_exporting
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -26,24 +26,6 @@ from torchrec.streamable import Multistreamable
 lib = torch.library.Library("custom", "FRAGMENT")
 
 
-try:
-    if torch.jit.is_scripting():
-        raise Exception()
-
-    from torch.compiler import (
-        is_compiling as is_compiler_compiling,
-        is_dynamo_compiling as is_torchdynamo_compiling,
-    )
-
-    def is_non_strict_exporting() -> bool:
-        return not is_torchdynamo_compiling() and is_compiler_compiling()
-
-except Exception:
-
-    def is_non_strict_exporting() -> bool:
-        return False
-
-
 class OpRegistryState:
     """
     State of operator registry.


### PR DESCRIPTION
Summary:
# context
* don't need to keep multiple copies of `is_non_strict_exporting`
* it's best place is under pt2.checks

Differential Revision: D58756127


