### PR TITLE
Add ability to specify pipelineable preproc modules to ignore during SDD model rewrite

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -93,12 +93,14 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
         self,
         model_type: Type[nn.Module] = TestSparseNN,
         enable_fsdp: bool = False,
+        preproc_module: Optional[nn.Module] = None,
     ) -> nn.Module:
         unsharded_model = model_type(
             tables=self.tables,
             weighted_tables=self.weighted_tables,
             dense_device=self.device,
             sparse_device=torch.device("meta"),
+            preproc_module=preproc_module,
         )
         if enable_fsdp:
             unsharded_model.over.dhn_arch.linear0 = FSDP(

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -8,14 +8,94 @@
 # pyre-strict
 
 import unittest
+from unittest.mock import MagicMock
 
 import torch
-from torchrec.distributed.train_pipeline.utils import _get_node_args
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.test_model import ModelInput, TestNegSamplingModule
+
+from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import (
+    TrainPipelineSparseDistTestBase,
+)
+from torchrec.distributed.train_pipeline.utils import (
+    _get_node_args,
+    _rewrite_model,
+    PipelinedForward,
+    TrainPipelineContext,
+)
+from torchrec.distributed.types import ShardingType
 
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
-class TestTrainPipelineUtils(unittest.TestCase):
+class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_rewrite_model(self) -> None:
+        sharding_type = ShardingType.TABLE_WISE.value
+        kernel_type = EmbeddingComputeKernel.FUSED.value
+        fused_params = {}
+
+        extra_input = ModelInput.generate(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            batch_size=10,
+            world_size=1,
+            num_float_features=10,
+            randomize_indices=False,
+        )[0].to(self.device)
+
+        preproc_module = TestNegSamplingModule(
+            extra_input=extra_input,
+        )
+        model = self._setup_model(preproc_module=preproc_module)
+
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, fused_params
+        )
+
+        # Try to rewrite model without ignored_preproc_modules defined, EBC forwards not overwritten to PipelinedForward due to KJT modification
+        _rewrite_model(
+            model=sharded_model,
+            batch=None,
+            context=TrainPipelineContext(),
+            dist_stream=None,
+        )
+        self.assertNotIsInstance(
+            sharded_model.module.sparse.ebc.forward, PipelinedForward
+        )
+        self.assertNotIsInstance(
+            sharded_model.module.sparse.weighted_ebc.forward, PipelinedForward
+        )
+
+        # Now provide preproc module explicitly
+        _rewrite_model(
+            model=sharded_model,
+            batch=None,
+            context=TrainPipelineContext(),
+            dist_stream=None,
+            pipeline_preproc=True,
+        )
+        self.assertIsInstance(sharded_model.module.sparse.ebc.forward, PipelinedForward)
+        self.assertIsInstance(
+            sharded_model.module.sparse.weighted_ebc.forward, PipelinedForward
+        )
+        self.assertEqual(
+            sharded_model.module.sparse.ebc.forward._args[0].preproc_modules[0],
+            sharded_model.module.preproc_module,
+        )
+        self.assertEqual(
+            sharded_model.module.sparse.weighted_ebc.forward._args[0].preproc_modules[
+                0
+            ],
+            sharded_model.module.preproc_module,
+        )
+
+
+class TestUtils(unittest.TestCase):
     def test_get_node_args_helper_call_module_kjt(self) -> None:
         graph = torch.fx.Graph()
         kjt_args = []
@@ -42,7 +122,9 @@ class TestTrainPipelineUtils(unittest.TestCase):
         )
 
         num_found = 0
-        _, num_found = _get_node_args(kjt_node)
+        _, num_found = _get_node_args(
+            MagicMock(), kjt_node, set(), TrainPipelineContext(), False
+        )
 
         # Weights is call_module node, so we should only find 2 args unmodified
         self.assertEqual(num_found, len(kjt_args) - 1)


### PR DESCRIPTION
Summary:
Make torchrec automatically pipeline any modules that don't have trainable params during sparse data dist pipelining.

tldr; with some traversal logic changes, TorchRec sparse data dist pipeline can support arbitrary input transformations at input dist stage as long as they are composed of either nn.Module calls or currently supported ops (mainly getattr and getitem)

Differential Revision: D57944338
