### PR TITLE
Fix bug in criteo.py that caused NaN issues

### DIFF
--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -258,7 +258,7 @@ class BinaryCriteoUtils:
         del labels
 
         # Log is expensive to compute at runtime.
-        dense_np -= (dense_np.min() - 2)
+        dense_np -= dense_np.min() - 2
         dense_np = np.log(dense_np, dtype=np.float32)
 
         # To be consistent with dense and sparse.

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -258,7 +258,7 @@ class BinaryCriteoUtils:
         del labels
 
         # Log is expensive to compute at runtime.
-        dense_np += 3
+        dense_np -= (dense_np.min() - 2)
         dense_np = np.log(dense_np, dtype=np.float32)
 
         # To be consistent with dense and sparse.


### PR DESCRIPTION
The original script simply added 3 to the target value before taking the log. This led to the issue that in data preprocessing, if there was a value of -3, it would result in a value of -inf. This problem was mentioned in the issue https://github.com/facebookresearch/dlrm/issues/363#issue-1963837683. I changed the preprocessing operation to dense_np -= dense_np.min() - 2 in the tsv_to_npys function, and correctly handled the Criteo Kaggle dataset.