### PR TITLE
Use mark_unbacked for KJT.values

### DIFF
--- a/torchrec/pt2/utils.py
+++ b/torchrec/pt2/utils.py
@@ -44,7 +44,7 @@ def kjt_for_pt2_tracing(
         # We can mark static lengths dimension as we have fixed batch_size, but using VB path for tracing
         torch._dynamo.decorators.mark_static(lengths, 0)
         values = kjt.values().long()
-        torch._dynamo.decorators.mark_dynamic(values, 0)
+        torch._dynamo.decorators.mark_unbacked(values, 0)
 
         return KeyedJaggedTensor(
             keys=kjt.keys(),
@@ -71,7 +71,7 @@ def kjt_for_pt2_tracing(
     stride = kjt.stride()
 
     values = kjt.values().long()
-    torch._dynamo.decorators.mark_dynamic(values, 0)
+    torch._dynamo.decorators.mark_unbacked(values, 0)
 
     return KeyedJaggedTensor(
         keys=kjt.keys(),


### PR DESCRIPTION
Summary: Using dynamo mark_unbacked for values, to avoid specialization on 0,1 size during compilation.

Differential Revision: D58866248
