### PR TITLE
Remove unused exception parameter from titan/yada/tests/messenger/MarkReadApplicatorTest.cpp

### DIFF
--- a/torchrec/inference/server.cpp
+++ b/torchrec/inference/server.cpp
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
   torch::jit::script::Module module;
   try {
     module = torch::jit::load(argv[1]);
-  } catch (const c10::Error& e) {
+  } catch (const c10::Error&) {
     std::cerr << "Error loading model\n";
     return -1;
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D58830686
