### PR TITLE
Prevent excess buffer allocation

### DIFF
--- a/torchrec/modules/itep_modules.py
+++ b/torchrec/modules/itep_modules.py
@@ -204,6 +204,9 @@ class GenericITEPModule(nn.Module):
 
                 emb_tables: List[ShardedEmbeddingTable] = emb._config.embedding_tables
                 for table in emb_tables:
+                    # Skip if table was already added previously (if multiple shards assigned to same rank)
+                    if table.name in self.table_name_to_idx:
+                        continue
 
                     (
                         pruned_hash_size,


### PR DESCRIPTION
Summary: Ads a check if features have allready been assigned a buffer in GenericITEPModule. This way, if multiple column shards of the same feature are assigned to the same rank, ITEP will only have one buffer per feature_name, instead of per shard of each feature name.

Differential Revision: D58823158
