### PR TITLE
[detailed][pt2] KJT custom op for 1d lengths input

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1956,15 +1956,15 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 self.weights_or_none(),
             )
         else:
-
             (
                 permuted_lengths,
                 permuted_values,
                 permuted_weights,
-            ) = torch.ops.fbgemm.permute_2D_sparse_data(
+            ) = torch.ops.fbgemm.permute_2D_sparse_data_input1D(
                 indices_tensor,
-                self.lengths().view(len(self._keys), -1),
+                self.lengths(),
                 self.values(),
+                self.stride(),
                 self.weights_or_none(),
                 permuted_length_per_key_sum,
             )
@@ -1977,7 +1977,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             keys=permuted_keys,
             values=permuted_values,
             weights=permuted_weights,
-            lengths=permuted_lengths.view(-1),
+            lengths=permuted_lengths,
             offsets=None,
             stride=stride,
             stride_per_key_per_rank=optional_permuted_stride_per_key_per_rank,
@@ -2343,14 +2343,14 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                             lengths,
                             values,
                             weights,
-                        ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                        ) = torch.ops.fbgemm.permute_2D_sparse_data_input1D(
                             torch.jit._unwrap_optional(recat),
-                            lengths.view(-1, stride),
+                            lengths,
                             values,
+                            stride,
                             weights,
                             values.numel(),
                         )
-                        lengths = lengths.view(-1)
                     else:  # variable batch size per rank
                         (
                             lengths,

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -1316,7 +1316,6 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             keys=keys,
             lengths=lengths,
         )
-
         indices = [1, 0, 2]
         permuted_jag_tensor = jag_tensor.permute(indices)
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2774

## 1. Context

`fbgemm::permute_2D_sparse_data` is the workhorse behind KJT (`KeyedJaggedTensor`) key permutation, and it requires a **2-D `[T, B]` lengths tensor** — `TORCH_CHECK(lengths.dim() == 2)` is the first thing the CPU implementation asserts. A KJT, however, stores its lengths as a **flat 1-D buffer of `T * B`** elements. Every caller therefore has to sandwich the op between two reshapes:

```python
permuted_lengths, permuted_values, permuted_weights = torch.ops.fbgemm.permute_2D_sparse_data(
    permute, lengths.view(-1, stride), values, weights, permuted_lengths_sum
)
permuted_lengths = permuted_lengths.view(-1)
```

That sandwich is the problem for PT2. `stride` is the batch size, which under dynamic-shape compilation is symbolic, so the compiler sees `reshape → opaque custom op → reshape` and has to relate the symbolic dimensions across an op boundary it cannot see through. The reshapes are what generate the guards and the shape-reasoning burden, not the permute itself.

This diff adds `permute_2D_sparse_data_input1D`, which **moves both views inside the operator**. The traced graph then contains a single custom-op node that takes the flat lengths and an explicit `SymInt stride`, and whose output shapes are described by one fake kernel — nothing for the compiler to reason through.

Reference: D58948987.

## 2. Op contract

```
permute_2D_sparse_data_input1D(
    Tensor permute,               # [T'], destination-to-source key mapping
    Tensor lengths,               # [T * B], FLAT (this is the change)
    Tensor values,
    SymInt stride,                # B, the batch size that delinearises `lengths`
    Tensor? weights = None,
    SymInt? permuted_lengths_sum = None
) -> (Tensor, Tensor, Tensor?)    # permuted_lengths is [T' * B], also FLAT
```

Semantically identical to `permute_2D_sparse_data`; only the lengths layout at the op boundary differs.

## 3. Algorithm design

### 3.1 A zero-cost wrapper, not a reimplementation

Both the CPU and CUDA implementations are three lines that delegate to the existing 2-D op:

```cpp
auto [permuted_lengths, permuted_indices, permuted_weights] =
    permute_2D_sparse_data_cpu(          // (or _cuda)
        permute, lengths.view({-1, stride}), indices, weights, permuted_lengths_sum);
return {permuted_lengths.view(-1), permuted_indices, permuted_weights};
```

This is deliberate. The permute kernels — the two-phase lengths-permute-plus-prefix-sum and the indices/weights gather — are already tuned and shared; forking them for a layout difference that is pure tensor metadata would double the maintenance surface for zero throughput gain.

`view` is used rather than `reshape`, so both conversions are **metadata-only**: no allocation, no copy, no kernel. The runtime cost of the wrapper is two `TensorImpl` constructions. The precondition is that `lengths` be contiguous, which holds for KJT's flat lengths buffer by construction.

The value of the wrapper is entirely at the *op boundary*: the reshape now happens on the C++ side of a `torch.library` op, so it is invisible to Dynamo and never becomes a graph node.

### 3.2 What the delegated 2-D op actually does

Worth recording, since the new op inherits its cost model and its `permuted_lengths_sum` argument:

1. `T = permute.numel()`, `B = lengths.size(1)`. `permute` maps each *output* key slot to an *input* key slot, so `T` may differ from the input key count — keys can be dropped or repeated.
2. **Phase 1** — `_permute_2D_lengths_kernel` writes `permuted_lengths[T, B]` and, in the same sweep, the input offsets and a per-thread cumulative sum of the output offsets. Fusing the scan into the lengths permute is what avoids a separate prefix-sum pass.
3. **Output sizing** — if the caller passes `permuted_lengths_sum`, it is used directly; otherwise the total is read out of the phase-1 cumsum. Passing it is the fast path: it lets the output be allocated without waiting on phase 1, and on the PT2 path it keeps the output shape *static* (see 3.3).
4. **Phase 2** — `_permute_2D_indices_weights_kernel` gathers values (and optionally weights) from input offsets to output offsets.

Cost: `O(T * B)` for the lengths phase, `O(sum(permuted_lengths))` for the gather. The wrapper adds `O(1)`.

### 3.3 Fake (meta) kernel — the actual PT2 payload

`permute_2D_sparse_data_input1D_meta` is where the compile-time shape contract lives:

1. `torch._check(lengths.dim() == 1, ...)` — encodes the 1-D precondition into the trace, so a mis-shaped input fails at trace time with a readable message instead of inside the C++ `TORCH_CHECK`.
2. `permuted_lengths = lengths.new_empty([T * B])` with `T = permute.numel()`, `B = stride`. Note the output is declared **1-D** — the meta kernel describes the flattened result, matching what the wrapper returns, so the compiler never sees the intermediate `[T, B]` shape at all.
3. The values output is genuinely **data-dependent** (its size is the sum of the permuted lengths), so the kernel branches:
   - `permuted_lengths_sum` provided → use it, and the output gets a **static** shape. This is why callers should pass it whenever they can compute it.
   - otherwise → `torch.library.get_ctx().new_dynamic_size()`, declaring an unbacked symbolic size rather than guessing.
4. `permuted_weights` mirrors `permuted_indices`' size when weights are present, and is `None` otherwise — the optional output's presence is a function of the input's presence, which is statically decidable.

### 3.4 Autograd design: the op is its own backward

The forward is a permutation-gather, so its gradient is the scatter by the **inverse permutation** — which is the same gather with the permute inverted. That makes the backward a self-call:

```python
inv_permute = torch.ops.fbgemm.invert_permute(ctx.permute)
... = torch.ops.fbgemm.permute_2D_sparse_data_input1D(
        inv_permute, ctx.permuted_lengths, grad_values, ctx.stride, grad_weights, None)
```

Two details make this correct:

- The lengths passed to the backward are `ctx.permuted_lengths`, the *forward's output* lengths — because `grad_values` arrives laid out in the permuted order, so that is the jagged structure the inverse gather must read.
- `permuted_lengths_sum` is passed as `None`. The backward's output size is the *input's* total, which the context does not carry, so it is recomputed rather than assumed.

`setup_context` saves only `permute`, `permuted_lengths`, and `stride` — the three things the backward needs — and deliberately not `values` or `weights`, which a gather's gradient never reads. The returned 6-tuple aligns with the 6 forward inputs, with `None` in the `permute`, `stride`, and `permuted_lengths_sum` slots.

**These two functions are authored but not registered in this diff.** Only `impl_abstract` is wired up for `permute_2D_sparse_data_input1D`; the corresponding `impl_autograd(...)` call — which the 2-D variant has — is not added. The op is therefore forward-only in practice here, consistent with the original note that backward/autograd was untested. Wiring it is a one-line follow-up once there is opcheck coverage.

## 4. Registration surface

| Library | Key | Implementation |
|---|---|---|
| `fbgemm::` | `CPU` | `permute_2D_sparse_data_input1D_cpu` |
| `fbgemm::` | `CUDA` | `permute_2D_sparse_data_input1D_cuda` (via `FBGEMM_OP_DISPATCH`) |
| `fbgemm::` | `Meta` | `permute_2D_sparse_data_input1D_meta` (via `register_fake`) |
| `fb::` | `CPU` | `permute_2D_sparse_data_input1D_cpu` (mirror for the sparsenn op set) |

Two intentional asymmetries:

1. **`SymInt stride` in `fbgemm::` vs `int stride` in `fb::`.** The `fbgemm::` schema is the PT2-facing one; declaring `stride` as `SymInt` is what lets the batch size stay symbolic through tracing instead of burning in a constant. The `fb::` mirror is CPU/eager only and does not need it.
2. **No `PT2_COMPLIANT_TAG`** on the new op, unlike `permute_2D_sparse_data`. The tag asserts full PT2 compliance including autograd and opcheck coverage; withholding it until 3.4 is registered and tested keeps the claim honest rather than advertising compliance the op does not yet have.

The `fb::` CUDA key is not registered in this diff — CUDA is reachable through `fbgemm::` only.

## 5. Analysis

1. **BC.** Purely additive. `permute_2D_sparse_data` is untouched in schema, implementation, and registration; existing callers are unaffected. Adoption in `jagged_tensor.py` is intentionally left out of this diff (see the open question in the original notes about whether the KJT call site should switch directly).
2. **Contiguity.** The wrapper uses `view`, which fails loudly on a non-contiguous `lengths` rather than silently copying. Given the caller was already doing the same `view` in Python, this preserves existing behaviour exactly.
3. **Where the win is.** Runtime cost is unchanged — same kernels, same passes. The gain is compile-time: one graph node with a declared fake kernel instead of a reshape/op/reshape triple whose symbolic dimensions the compiler must relate across an opaque boundary.
4. **`permuted_lengths_sum` matters more under PT2 than eager.** In eager it saves a sync; under `torch.compile` it is the difference between a static output shape and an unbacked symbolic size that propagates downstream.
5. **Test coverage.** Validated through the TorchRec KJT permute tests (`test_permute`, `test_permute_duplicates`, `test_permute_w_weights`) on both CPU and GPU. Backward is not covered, matching 3.4.

## 6. Changes

1. **`fbgemm_gpu/src/sparse_ops/sparse_ops_cpu.cpp`**: adds `permute_2D_sparse_data_input1D_cpu` (the delegating wrapper), the `fbgemm::` schema with `SymInt stride`, and the CPU dispatch entry.
2. **`fbgemm_gpu/src/sparse_ops/sparse_permute_2d.cu`**: adds `permute_2D_sparse_data_input1D_cuda` and its `FBGEMM_OP_DISPATCH` CUDA registration.
3. **`fbgemm_gpu/include/fbgemm_gpu/sparse_ops.h`**: declares both new entry points.
4. **`fbgemm_gpu/fbgemm_gpu/sparse_ops.py`**: adds `permute_2D_sparse_data_input1D_meta` (registered via `impl_abstract`) plus the `_setup_context` / `_backward` pair described in 3.4 (defined, not yet registered).
5. **`caffe2/torch/fb/sparsenn/sparsenn_operators.cpp`**: adds the `fb::` schema mirror and its CPU implementation binding.

Differential Revision: D58956327


