### PR TITLE
[detailed][pt2] torch.export/IR - support serialization of compound module

### DIFF
--- a/torchrec/ir/types.py
+++ b/torchrec/ir/types.py
@@ -10,7 +10,7 @@
 #!/usr/bin/env python3
 
 import abc
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -24,28 +24,25 @@ class SerializerInterface(abc.ABC):
 
     @classmethod
     @property
-    # pyre-ignore [3]: Returning `None` but type `Any` is specified.
-    def module_to_serializer_cls(cls) -> Dict[str, Type[Any]]:
+    def module_to_serializer_cls(cls) -> Dict[str, Any]:
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
-    # pyre-ignore [3]: Returning `None` but type `Any` is specified.
     def serialize(
         cls,
         module: nn.Module,
-    ) -> Any:
+    ) -> Tuple[torch.Tensor, List[str]]:
         # Take the eager embedding module and generate bytes in buffer
-        pass
+        raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
     def deserialize(
         cls,
-        # pyre-ignore [2]: Parameter `input` must have a type other than `Any`.
-        input: Any,
-        typename: str,
+        input: torch.Tensor,
         device: Optional[torch.device] = None,
+        unflatten: Optional[nn.Module] = None,
     ) -> nn.Module:
         # Take the bytes in the buffer and regenerate the eager embedding module
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
# TorchRec Composable Serializer Design
## Context
1. We are working with APS/APF on the module serialization, our goal is to restore the correct TorchRec (embedding) modules after deserialization. 
    1. serialization: model ⇒ IR using torch.export.export
    2. deserialization: IR ⇒ model’ using torch.export.unflatten
2. High-level idea is that:
    1. TorchRec serializer writes the necessary (serialized) information for the embedding module into a named buffer, and asks the IR export to keep it. 
    2. TorchRec serializer retrieves that information from the named_buffer and replaces the unflattened module with the corresponding embedding modules.

## Baseline
1. The current TorchRec serializer class keeps a map (emb_module ⇒ serializer), and has a dedicated serializer for each supported embedding module.
2. The serializer implements two APIs:
    1. nn.module ⇒ torch.Tensor (serialized bytes)
    2. torch.Tensor ⇒ nn.module
3. The serialization function iterates through the named modules for the target model:
    1. when it’s a supported TorchRec module, it calls the corresponding serializer
    2. get the serialized data, and put into a named buffer under the module
4. The deserialization function iterates through the named modules for the unflattened model (which has the same fully qualified name and hierarchy):
    1. when the module contains the specific named buffer, it calls the corresponding TorchRec serializer
    2. the serializer generates a new TorchRec module, which is used to replace the unflattened module

## Issue
1. The aforementioned approach works just fine for simple embedding modules like EBC, where the serialization and deserialization is straightforward: 
    2. it extracts all the embedding bag configurations and serializes the parameters
    3. it constructs a new EBC with embedding bag configurations from the parameters
4. We just need to implement a corresponding serializer when expanding our support for the new embedding module.
5. However, we have some composite modules like fpEBC, which consists of an EBC and feature processors (FPs), and makes the situation complicated:
    1. we want to re-use the serialization/deserialization logic for the EBC
    2. there are different FPs, which require different initialization parameters
    3. we don’t want to differentiate fpEBC based on its FPs
<img width="515" height="241" alt="image" src="https://github.com/user-attachments/assets/c1fc8618-a005-4201-bc5e-50cd6b219c5a" />

## Proposal
1. High-level idea: slightly change the serializer API, feed in the children modules in deserialization
2. Each serializer can focus on its own level of serialization/deserialization
3. Easily expand to complicated/nested module/model serialization
4. Composite module serialization is simply as:
```
   def deserialize(  # simplified Pseudo code
       input: torch.Tensor,
       children: Dict[str, nn.Module] = {},  # proposed change
   ) -> nn.Module:
       raw_bytes = input.numpy().tobytes()
       metadata = FPEBCMetadata(**json.loads(raw_bytes.decode()))
       feature_processors: dict[str, FeatureProcessor] = {}
       for feature in metadata.feature_list:
           fp = children[f"_feature_processors.{feature}"]  # fp is available
           assert isinstance(fp, FeatureProcessor)
           feature_processors[feature] = fp
       ebc = children["_embedding_bag_collection"]  # ebc is available
       assert isinstance(ebc, EmbeddingBagCollection)
       return FeatureProcessedEmbeddingBagCollection(
           ebc,
           feature_processors,
       )
```

## Details
Serializer side needs:
1. Implement serializer for each type of FP, this step is the similar to EBC serializer
2. In the FP_EBC serializer
    1. the serialization API only needs to store minimum data, such as the feature list (to preserve the feature order)
    2. in the deserialization API only needs to gather the child EBC module FPs (which are available from the API input arguments), and construct an FP_EBC

Serialization function needs:
1. In TorchRec serialization function, the logic is the same: iterating over all the modules and running the serializer for each supported module.

Deserialization function needs:
1. The traversal algorithm needs to upgrade:
2. deserialize a module if it’s supported and does NOT require child modules
3. defer the deserialization of a supported module until all its required children are available (deserialized)
    1. continue on deserializing its children until the next module is not a child
    2. feed the child modules and corresponding relative module names to resume the deserialization
4. implementation: [utils.py](https://fburl.com/code/y3s9wlxk), see more in the [stack](https://www.internalfb.com/diff/D58221182)
5. alternative implementation does not require complex traversal algorithm, just recursive function calls: [utils.py](https://fburl.com/code/wlbn6xeg)

## Trade-offs
Alternative
1. In the deserialization function, we can just handle the special case of FP_EBC
    1. we know an FP_EBC only has one EBC and FPs
    2. Feature processors can come as Dict[str, FP] or FeatureProcessorCollection (1 module)
2. Serialize FPs + EBC separately
    1. Metadata to serialize into FPEBC module is FPEBCMetadata, which is just FP metadata + EBC metadata
    2. Reuse EBC serializer for EBC metadata
    3. In FPEBC serializer class, serialize the FP part
        1. If dictionary, each FP contains the metadata for it’s own construction
        2. If FeatureProcessorCollection, serialize as part of module
        3. This means we require distinctive feature processor serializers, which we would need in the composable serializer anyway no? Like one for PositionWeightedModule, one for IDSNamedBucketize, etc.
    4. Write the FPEBCMetadata bytes as “ir_metadata” buffer to the FPEBC. That means, the underlying EBC class does not have the “ir_metadata” buffer!
        1. Deserialize encounters this here: https://fburl.com/code/a3qh1xqv 
    5. That means all necessary functionality will be required to be implemented by FPEBCserializer, no changes to public apis

Cons
1. code complexity: the traversal function?
2. changed the public APIs
    1. serializer APIs are changed (now needs the children modules)
    2. but the entrypoint is the serialization/deserialization util functions

Pros
1. One serializer only focuses on serialization of its own unique data, decoupled from other serializer classes.
2. Easily expanded to external use-case, example: [test_serializer.py](https://fburl.com/code/phkoc5ko)
2. Can apply to other modules, considering PEA with FP, currently we only support one type of FP for the PEA, and the PEA isn’t going to be deprecated very soon
3. FP_EBC’s FP part actually has two versions, one is ModuleDict of FPs and the other is a FP collection. It’s easily handled by the FP_EBC serializer with the composable approach.

## This PR
* after discussion with dstaay-fb, a rule of thumb: serializer APIs better to be symmetric
* `SerializerInterface.serialize` takes a target module (nn.Module, usually sparse), returns a tensor (serialized binary, will be put to a buffer), and a list of child_fqns, which require further serialization
* `SerializerInterface.deserialize` takes the binary data (tensor from buffer), a device flag, and the unflattened module (for its child modules), returns the deserialized module
* the main APIs for external usage are the `serialize_embedding_modules` and `_deserialize_embedding_modules`
* the former walks through the input module, finds the sparse (sub)modules, stores sparse modules metadata in buffer
* the later walks through the input module (unflattened from ep), finds the stored metadata from the buffer, and restore the sparse modules.

Differential Revision: D58933792


