### PR TITLE
Metric State Vectorization

### DIFF
--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -39,6 +39,18 @@ def get_calibration_states(
     }
 
 
+# We create _fused implementation separate because bucket metrics use `get_calibration_states`
+def get_calibration_states_fused(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
+) -> torch.Tensor:
+    return torch.stack(
+        [
+            torch.sum(predictions * weights, dim=-1),
+            torch.sum(labels * weights, dim=-1),
+        ]
+    )
+
+
 class CalibrationMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for Calibration, which is the
@@ -50,16 +62,10 @@ class CalibrationMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        state_names = [CALIBRATION_NUM, CALIBRATION_DENOM]
         self._add_state(
-            CALIBRATION_NUM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
-            CALIBRATION_DENOM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -78,12 +84,10 @@ class CalibrationMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CalibrationMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-        for state_name, state_value in get_calibration_states(
-            labels, predictions, weights
-        ).items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+        states = get_calibration_states_fused(labels, predictions, weights)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -91,8 +95,8 @@ class CalibrationMetricComputation(RecMetricComputation):
                 name=MetricName.CALIBRATION,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_calibration(
-                    cast(torch.Tensor, self.calibration_num),
-                    cast(torch.Tensor, self.calibration_denom),
+                    self.get_state(CALIBRATION_NUM),
+                    self.get_state(CALIBRATION_DENOM),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -28,11 +28,10 @@ def compute_ctr(ctr_num: torch.Tensor, ctr_denom: torch.Tensor) -> torch.Tensor:
 
 def get_ctr_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> Dict[str, torch.Tensor]:
-    return {
-        CTR_NUM: torch.sum(labels * weights, dim=-1),
-        CTR_DENOM: torch.sum(weights, dim=-1),
-    }
+) -> torch.Tensor:
+    return torch.stack(
+        [torch.sum(labels * weights, dim=-1), torch.sum(weights, dim=-1)]
+    )  # ctr_num, ctr_denom
 
 
 class CTRMetricComputation(RecMetricComputation):
@@ -46,16 +45,10 @@ class CTRMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        state_names = [CTR_NUM, CTR_DENOM]
         self._add_state(
-            CTR_NUM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
-            CTR_DENOM,
-            torch.zeros(self._n_tasks, dtype=torch.double),
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks)),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -74,12 +67,10 @@ class CTRMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CTRMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-        for state_name, state_value in get_ctr_states(
-            labels, predictions, weights
-        ).items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+        states = get_ctr_states(labels, predictions, weights)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -87,8 +78,8 @@ class CTRMetricComputation(RecMetricComputation):
                 name=MetricName.CTR,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_ctr(
-                    cast(torch.Tensor, self.ctr_num),
-                    cast(torch.Tensor, self.ctr_denom),
+                    self.get_state(CTR_NUM),
+                    self.get_state(CTR_DENOM),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -48,11 +48,13 @@ def compute_error_sum(
 
 def get_mse_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> Dict[str, torch.Tensor]:
-    return {
-        "error_sum": compute_error_sum(labels, predictions, weights),
-        "weighted_num_samples": torch.sum(weights, dim=-1),
-    }
+) -> torch.Tensor:
+    return torch.stack(
+        [
+            compute_error_sum(labels, predictions, weights),  # error_sum
+            torch.sum(weights, dim=-1),  # weighted_num_samples
+        ],
+    )
 
 
 class MSEMetricComputation(RecMetricComputation):
@@ -65,16 +67,10 @@ class MSEMetricComputation(RecMetricComputation):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        state_names = ["error_sum", "weighted_num_samples"]
         self._add_state(
-            "error_sum",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
-            "weighted_num_samples",
-            torch.zeros(self._n_tasks, dtype=torch.double),
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -92,12 +88,11 @@ class MSEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for MSEMetricComputation update"
             )
-        states = get_mse_states(labels, predictions, weights)
         num_samples = predictions.shape[-1]
-        for state_name, state_value in states.items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+        states = get_mse_states(labels, predictions, weights)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         return [
@@ -105,16 +100,16 @@ class MSEMetricComputation(RecMetricComputation):
                 name=MetricName.MSE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_mse(
-                    cast(torch.Tensor, self.error_sum),
-                    cast(torch.Tensor, self.weighted_num_samples),
+                    self.get_state(ERROR_SUM),
+                    self.get_state(WEIGHTED_NUM_SAMPES),
                 ),
             ),
             MetricComputationReport(
                 name=MetricName.RMSE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_rmse(
-                    cast(torch.Tensor, self.error_sum),
-                    cast(torch.Tensor, self.weighted_num_samples),
+                    self.get_state(ERROR_SUM),
+                    self.get_state(WEIGHTED_NUM_SAMPES),
                 ),
             ),
             MetricComputationReport(

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -94,6 +94,25 @@ def get_ne_states(
     }
 
 
+def get_ne_states_fused(
+    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
+) -> torch.Tensor:
+    cross_entropy = compute_cross_entropy(
+        labels,
+        predictions,
+        weights,
+        eta,
+    )
+    return torch.stack(
+        [
+            torch.sum(cross_entropy, dim=-1),  # state "cross_entropy_sum"
+            torch.sum(weights, dim=-1),  # state "weighted_num_samples"
+            torch.sum(weights * labels, dim=-1),  # state "pos_labels"
+            torch.sum(weights * (1.0 - labels), dim=-1),  # state "neg_labels"
+        ]
+    )
+
+
 class NEMetricComputation(RecMetricComputation):
     r"""
     This class implements the RecMetricComputation for NE, i.e. Normalized Entropy.
@@ -117,30 +136,15 @@ class NEMetricComputation(RecMetricComputation):
             allow_missing_label_with_zero_weight
         )
         super().__init__(*args, **kwargs)
-        self._add_state(
+        state_names = [
             "cross_entropy_sum",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "weighted_num_samples",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "pos_labels",
-            torch.zeros(self._n_tasks, dtype=torch.double),
-            add_window_state=True,
-            dist_reduce_fx="sum",
-            persistent=True,
-        )
-        self._add_state(
             "neg_labels",
-            torch.zeros(self._n_tasks, dtype=torch.double),
+        ]
+        self._add_state(
+            state_names,
+            torch.zeros((len(state_names), self._n_tasks), dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
             persistent=True,
@@ -159,13 +163,12 @@ class NEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for NEMetricComputation update"
             )
-        states = get_ne_states(labels, predictions, weights, self.eta)
-        num_samples = predictions.shape[-1]
 
-        for state_name, state_value in states.items():
-            state = getattr(self, state_name)
-            state += state_value
-            self._aggregate_window_state(state_name, state_value, num_samples)
+        num_samples = predictions.shape[-1]
+        states = get_ne_states_fused(labels, predictions, weights, self.eta)
+        state = getattr(self, self._fused_name)
+        state += states
+        self._aggregate_window_state(self._fused_name, states, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
         reports = [
@@ -173,10 +176,10 @@ class NEMetricComputation(RecMetricComputation):
                 name=MetricName.NE,
                 metric_prefix=MetricPrefix.LIFETIME,
                 value=compute_ne(
-                    cast(torch.Tensor, self.cross_entropy_sum),
-                    cast(torch.Tensor, self.weighted_num_samples),
-                    cast(torch.Tensor, self.pos_labels),
-                    cast(torch.Tensor, self.neg_labels),
+                    self.get_state("cross_entropy_sum"),
+                    self.get_state("weighted_num_samples"),
+                    self.get_state("pos_labels"),
+                    self.get_state("neg_labels"),
                     self.eta,
                     self._allow_missing_label_with_zero_weight,
                 ),
@@ -200,9 +203,9 @@ class NEMetricComputation(RecMetricComputation):
                     name=MetricName.LOG_LOSS,
                     metric_prefix=MetricPrefix.LIFETIME,
                     value=compute_logloss(
-                        cast(torch.Tensor, self.cross_entropy_sum),
-                        cast(torch.Tensor, self.pos_labels),
-                        cast(torch.Tensor, self.neg_labels),
+                        self.get_state("cross_entropy_sum"),
+                        self.get_state("pos_labels"),
+                        self.get_state("neg_labels"),
                         self.eta,
                     ),
                 ),

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -13,6 +13,7 @@ import abc
 import itertools
 import math
 from collections import defaultdict, deque
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -147,6 +148,9 @@ class RecMetricComputation(Metric, abc.ABC):
         self._window_size = window_size
         self._compute_on_all_ranks = compute_on_all_ranks
         self._should_validate_update = should_validate_update
+        self._fused_map: Dict[str, int] = {}
+        self._window_fused_map: Dict[str, int] = {}
+        self._fused_name = "_fused_states"
         if self._window_size > 0:
             self._batch_window_buffers = {}
         else:
@@ -160,15 +164,40 @@ class RecMetricComputation(Metric, abc.ABC):
                 persistent=True,
             )
 
+        self._register_load_state_dict_pre_hook(
+            self._pre_load_state_dict_hook, with_module=True
+        )
+
     @staticmethod
     def get_window_state_name(state_name: str) -> str:
         return f"window_{state_name}"
 
+    def get_fused_state_name(self) -> str:
+        return self._fused_name
+
+    def get_fused_window_state_name(self) -> str:
+        return self.get_window_state_name(self.get_fused_state_name())
+
     def get_window_state(self, state_name: str) -> torch.Tensor:
-        return getattr(self, self.get_window_state_name(state_name))
+        if state_name in self._fused_map:
+            fused_window_states = getattr(self, self.get_fused_window_state_name())
+            return fused_window_states[self._fused_map[state_name]]
+        else:
+            return getattr(self, self.get_window_state_name(state_name))
+
+    def get_state(self, state_name: str) -> torch.Tensor:
+        if state_name in self._fused_map:
+            fused_states = getattr(self, self._fused_name)
+            return fused_states[self._fused_map[state_name]]
+        else:
+            return getattr(self, state_name)
 
     def _add_state(
-        self, name: str, default: DefaultValueT, add_window_state: bool, **kwargs: Any
+        self,
+        name: Union[str, List[str]],
+        default: torch.Tensor,
+        add_window_state: bool,
+        **kwargs: Any,
     ) -> None:
         """
         name (str): the name of this state. The state will be accessible
@@ -187,24 +216,33 @@ class RecMetricComputation(Metric, abc.ABC):
         persistent (bool): set this to True if you want to save/checkpoint the
             metric and this state is required to compute the checkpointed metric.
         """
-        # pyre-fixme[6]: Expected `Union[List[typing.Any], torch.Tensor]` for 2nd
-        #  param but got `DefaultValueT`.
-        super().add_state(name, default, **kwargs)
+        if isinstance(name, List):
+            super().add_state(self._fused_name, default, **kwargs)
+        else:
+            super().add_state(name, default, **kwargs)
+
         if add_window_state:
             if self._batch_window_buffers is None:
                 raise RuntimeError(
                     "Users is adding a window state while window metric is disabled."
                 )
             kwargs["persistent"] = False
-            window_state_name = self.get_window_state_name(name)
+            if isinstance(name, List):
+                window_state_name = self.get_window_state_name(self._fused_name)
+            else:
+                window_state_name = self.get_window_state_name(name)
             # Avoid pyre error
             assert isinstance(default, torch.Tensor)
             super().add_state(window_state_name, default.detach().clone(), **kwargs)
 
+            # pyre-fixme[16]: `Optional` has no attribute `__setitem__`.
             self._batch_window_buffers[window_state_name] = WindowBuffer(
                 max_size=self._window_size,
                 max_buffer_count=MAX_BUFFER_COUNT,
             )
+
+        if isinstance(name, List):
+            self._fused_map.update({s: i for i, s in enumerate(name)})
 
     def _aggregate_window_state(
         self, state_name: str, state: torch.Tensor, num_samples: int
@@ -264,6 +302,51 @@ class RecMetricComputation(Metric, abc.ABC):
                 )
                 for name in self._batch_window_buffers
             }
+
+    def state_dict(
+        self,
+        destination: Optional[Dict[str, Any]] = None,
+        prefix: str = "",
+        keep_vars: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        r"""Registers metric states to be part of the state dict separately, unflattens fused states such
+        that it is backwards compatible with checkpointing.
+        """
+        state_dict = {}
+        if destination is not None:
+            state_dict = super().state_dict(
+                destination=destination, prefix=prefix, keep_vars=keep_vars
+            )
+            # For checkpointing comptability with unfused state, unflatten the fused state
+            if state_dict is not None:
+                key = prefix + self._fused_name
+                if key in state_dict:
+                    del state_dict[key]  # we don't need fused state in state dict
+                    for state_name in self._fused_map:
+                        curr = self.get_state(state_name)
+                        if not keep_vars:
+                            curr = curr.detach()
+                        state_dict[prefix + state_name] = deepcopy(curr)
+
+        return state_dict
+
+    @staticmethod
+    def _pre_load_state_dict_hook(
+        self: torch.nn.Module, state_dict: Dict[str, Any], prefix: str, *args: Any
+    ) -> None:
+        r"""Hook to load the state dict from the checkpoint.
+        We take checkpointed values and turn them into fused state for performance.
+        """
+        states_list = []
+        for state_name in cast(RecMetricComputation, self)._fused_map:
+            name = prefix + state_name
+            if name in state_dict:
+                state_val = state_dict.pop(name)
+                setattr(self, state_name, state_val)
+                states_list.append(state_val)
+
+        fused_state = torch.stack(states_list, dim=0)
+        setattr(self, cast(RecMetricComputation, self)._fused_name, fused_state)
 
 
 class RecMetric(nn.Module, abc.ABC):

--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -94,11 +94,11 @@ class TestGPU(unittest.TestCase):
         ne_computation = ne._metrics_computations[0]
         # test RecMetricComputation._add_window_state
         torch.allclose(
-            ne_computation.window_cross_entropy_sum,
+            ne_computation.get_window_state("cross_entropy_sum"),
             torch.tensor([0.0], dtype=torch.double, device=device),
         )
         torch.allclose(
-            ne_computation.window_weighted_num_samples,
+            ne_computation.get_window_state("weighted_num_samples"),
             torch.tensor([[0.0]], dtype=torch.double, device=device),
         )
 
@@ -126,13 +126,11 @@ class TestGPU(unittest.TestCase):
                 )
             else:
                 self.assertEqual(
-                    ne_computation.window_cross_entropy_sum.size(), torch.Size([1])
+                    ne_computation.get_window_state("cross_entropy_sum").size(),
+                    torch.Size([1]),
                 )
+                fused_state_name = ne_computation.get_fused_window_state_name()
                 self.assertEqual(
-                    len(
-                        ne_computation._batch_window_buffers[
-                            "window_cross_entropy_sum"
-                        ].buffers
-                    ),
+                    len(ne_computation._batch_window_buffers[fused_state_name].buffers),
                     3,
                 )


### PR DESCRIPTION
Summary:
Fusing states for each metric to reduce computation overhead. this will help **every** model that uses RecMetrics. By fusing state we no longer all gather per state, we see metrics go from N all_gather's to 1. N being number of states held by metric. This can be generally helpful for metrics that may require many states to be computed.

Backward compat remains for metrics that are not vectorized. As well as checkpointing from snapshots before this diff.

Differential Revision: D49957177
