### PR TITLE
fix CI for test_shards_wrapper

### DIFF
--- a/torchrec/distributed/tests/test_shards_wrapper.py
+++ b/torchrec/distributed/tests/test_shards_wrapper.py
@@ -106,7 +106,6 @@ class LocalShardsWrapperDistributedTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
     @unittest.skip("Need to fix circular import errors with Torch")
     def test_shards_wrapper_all_gather_into_tensor(self) -> None:
         world_size = 2
@@ -138,7 +137,6 @@ class LocalShardsWrapperDistributedTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
     @unittest.skip("Need to fix circular import errors with Torch")
     def test_shards_wrapper_all_gather(self) -> None:
         world_size = 2
@@ -168,7 +166,6 @@ class LocalShardsWrapperDistributedTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
     @unittest.skip("Need to fix circular import errors with Torch")
     def test_shards_wrapper_all_gather_object(self) -> None:
         world_size = 2


### PR DESCRIPTION
Summary:
Fixing:

```
FAILED torchrec/distributed/tests/test_shards_wrapper.py::LocalShardsWrapperDistributedTest::test_shards_wrapper_all_gather - hypothesis.errors.InvalidArgument: Using `settings` on a test without `given` is completely pointless.
FAILED torchrec/distributed/tests/test_shards_wrapper.py::LocalShardsWrapperDistributedTest::test_shards_wrapper_all_gather_into_tensor - hypothesis.errors.InvalidArgument: Using `settings` on a test without `given` is completely pointless.
FAILED torchrec/distributed/tests/test_shards_wrapper.py::LocalShardsWrapperDistributedTest::test_shards_wrapper_all_gather_object - hypothesis.errors.InvalidArgument: Using `settings` on a test without `given` is completely pointless.
ERROR torchrec/distributed/tests/test_shards_wrapper.py::test_all_gather_into_tensor
ERROR torchrec/distributed/tests/test_shards_wrapper.py::test_all_gather
ERROR torchrec/distributed/tests/test_shards_wrapper.py::test_all_gather_object

Differential Revision: D59017357
