### PR TITLE
[detailed][pt2] torch.export - refactor using encapsulate and decapsulate

### DIFF
--- a/torchrec/ir/schema.py
+++ b/torchrec/ir/schema.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from torchrec.modules.embedding_configs import DataType, PoolingType
 
@@ -32,3 +32,19 @@ class EBCMetadata:
     tables: List[EmbeddingBagConfigMetadata]
     is_weighted: bool
     device: Optional[str]
+
+
+@dataclass
+class FPEBCMetadata:
+    is_fp_collection: bool
+    features: List[str]
+
+
+@dataclass
+class PositionWeightedModuleMetadata:
+    max_feature_length: int
+
+
+@dataclass
+class PositionWeightedModuleCollectionMetadata:
+    max_feature_lengths: List[Tuple[str, int]]

--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -25,10 +25,13 @@ from torchrec.ir.utils import (
 
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.modules.feature_processor_ import PositionWeightedModuleCollection
+from torchrec.modules.feature_processor_ import (
+    PositionWeightedModule,
+    PositionWeightedModuleCollection,
+)
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 from torchrec.modules.utils import operator_registry_state
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class CompoundModule(nn.Module):
@@ -90,16 +93,18 @@ class CompoundModuleSerializer(JsonSerializer):
 
 
 class TestJsonSerializer(unittest.TestCase):
+    # in the model we have 5 duplicated EBCs, 1 fpEBC with fpCollection, and 1 fpEBC with fpDict
     def generate_model(self) -> nn.Module:
         class Model(nn.Module):
-            def __init__(self, ebc, fpebc):
+            def __init__(self, ebc, fpebc1, fpebc2):
                 super().__init__()
                 self.ebc1 = ebc
                 self.ebc2 = copy.deepcopy(ebc)
                 self.ebc3 = copy.deepcopy(ebc)
                 self.ebc4 = copy.deepcopy(ebc)
                 self.ebc5 = copy.deepcopy(ebc)
-                self.fpebc = fpebc
+                self.fpebc1 = fpebc1
+                self.fpebc2 = fpebc2
 
             def forward(
                 self,
@@ -111,22 +116,17 @@ class TestJsonSerializer(unittest.TestCase):
                 kt4 = self.ebc4(features)
                 kt5 = self.ebc5(features)
 
-                fpebc_res = self.fpebc(features)
+                fpebc1_res = self.fpebc1(features)
+                fpebc2_res = self.fpebc2(features)
                 ebc_kt_vals = [kt.values() for kt in [kt1, kt2, kt3, kt4, kt5]]
-                sparse_arch_vals = sum(ebc_kt_vals)
-                sparse_arch_res = KeyedTensor(
-                    keys=kt1.keys(),
-                    values=sparse_arch_vals,
-                    length_per_key=kt1.length_per_key(),
-                )
 
-                return KeyedTensor.regroup(
-                    [sparse_arch_res, fpebc_res], [["f1"], ["f2", "f3"]]
+                return (
+                    ebc_kt_vals + list(fpebc1_res.values()) + list(fpebc2_res.values())
                 )
 
         tb1_config = EmbeddingBagConfig(
             name="t1",
-            embedding_dim=4,
+            embedding_dim=3,
             num_embeddings=10,
             feature_names=["f1"],
         )
@@ -138,7 +138,7 @@ class TestJsonSerializer(unittest.TestCase):
         )
         tb3_config = EmbeddingBagConfig(
             name="t3",
-            embedding_dim=4,
+            embedding_dim=5,
             num_embeddings=10,
             feature_names=["f3"],
         )
@@ -149,7 +149,7 @@ class TestJsonSerializer(unittest.TestCase):
         )
         max_feature_lengths = {"f1": 100, "f2": 100}
 
-        fpebc = FeatureProcessedEmbeddingBagCollection(
+        fpebc1 = FeatureProcessedEmbeddingBagCollection(
             EmbeddingBagCollection(
                 tables=[tb1_config, tb2_config],
                 is_weighted=True,
@@ -158,8 +158,18 @@ class TestJsonSerializer(unittest.TestCase):
                 max_feature_lengths=max_feature_lengths,
             ),
         )
+        fpebc2 = FeatureProcessedEmbeddingBagCollection(
+            EmbeddingBagCollection(
+                tables=[tb1_config, tb3_config],
+                is_weighted=True,
+            ),
+            {
+                "f1": PositionWeightedModule(max_feature_length=10),
+                "f3": PositionWeightedModule(max_feature_length=20),
+            },
+        )
 
-        model = Model(ebc, fpebc)
+        model = Model(ebc, fpebc1, fpebc2)
 
         return model
 
@@ -190,12 +200,16 @@ class TestJsonSerializer(unittest.TestCase):
         for i, tensor in enumerate(ep_output):
             self.assertEqual(eager_out[i].shape, tensor.shape)
 
-        # Only 2 custom op registered, as dimensions of ebc are same
-        self.assertEqual(len(operator_registry_state.op_registry_schema), 2)
+        # Should have 3 custom op registered, as dimensions of ebc are same,
+        # and two fpEBCs have different dims
+        self.assertEqual(len(operator_registry_state.op_registry_schema), 3)
 
         total_dim_ebc = sum(model.ebc1._lengths_per_embedding)
-        total_dim_fpebc = sum(
-            model.fpebc._embedding_bag_collection._lengths_per_embedding
+        total_dim_fpebc1 = sum(
+            model.fpebc1._embedding_bag_collection._lengths_per_embedding
+        )
+        total_dim_fpebc2 = sum(
+            model.fpebc2._embedding_bag_collection._lengths_per_embedding
         )
         # Check if custom op is registered with the correct name
         # EmbeddingBagCollection type and total dim
@@ -204,35 +218,63 @@ class TestJsonSerializer(unittest.TestCase):
             in operator_registry_state.op_registry_schema
         )
         self.assertTrue(
-            f"EmbeddingBagCollection_{total_dim_fpebc}"
+            f"EmbeddingBagCollection_{total_dim_fpebc1}"
+            in operator_registry_state.op_registry_schema
+        )
+        self.assertTrue(
+            f"EmbeddingBagCollection_{total_dim_fpebc2}"
             in operator_registry_state.op_registry_schema
         )
 
         # Deserialize EBC
         deserialized_model = deserialize_embedding_modules(ep, JsonSerializer)
 
+        # check EBC config
         for i in range(5):
             ebc_name = f"ebc{i + 1}"
-            assert isinstance(
+            self.assertIsInstance(
                 getattr(deserialized_model, ebc_name), EmbeddingBagCollection
             )
 
-            for deserialized_config, org_config in zip(
+            for deserialized, orginal in zip(
                 getattr(deserialized_model, ebc_name).embedding_bag_configs(),
                 getattr(model, ebc_name).embedding_bag_configs(),
             ):
-                assert deserialized_config.name == org_config.name
-                assert deserialized_config.embedding_dim == org_config.embedding_dim
-                assert deserialized_config.num_embeddings, org_config.num_embeddings
-                assert deserialized_config.feature_names, org_config.feature_names
+                self.assertEqual(deserialized.name, orginal.name)
+                self.assertEqual(deserialized.embedding_dim, orginal.embedding_dim)
+                self.assertEqual(deserialized.num_embeddings, orginal.num_embeddings)
+                self.assertEqual(deserialized.feature_names, orginal.feature_names)
+
+        # check FPEBC config
+        for i in range(2):
+            fpebc_name = f"fpebc{i + 1}"
+            assert isinstance(
+                getattr(deserialized_model, fpebc_name),
+                FeatureProcessedEmbeddingBagCollection,
+            )
+
+            for deserialized, orginal in zip(
+                getattr(
+                    deserialized_model, fpebc_name
+                )._embedding_bag_collection.embedding_bag_configs(),
+                getattr(
+                    model, fpebc_name
+                )._embedding_bag_collection.embedding_bag_configs(),
+            ):
+                self.assertEqual(deserialized.name, orginal.name)
+                self.assertEqual(deserialized.embedding_dim, orginal.embedding_dim)
+                self.assertEqual(deserialized.num_embeddings, orginal.num_embeddings)
+                self.assertEqual(deserialized.feature_names, orginal.feature_names)
 
         deserialized_model.load_state_dict(model.state_dict())
-        # Run forward on deserialized model
+
+        # Run forward on deserialized model and compare the output
         deserialized_out = deserialized_model(id_list_features)
 
-        for i, tensor in enumerate(deserialized_out):
-            assert eager_out[i].shape == tensor.shape
-            assert torch.allclose(eager_out[i], tensor)
+        self.assertEqual(len(deserialized_out), len(eager_out))
+        for deserialized, orginal in zip(deserialized_out, eager_out):
+            self.assertEqual(deserialized.shape, orginal.shape)
+            self.assertTrue(torch.allclose(deserialized, orginal))
 
     def test_dynamic_shape_ebc(self) -> None:
         model = self.generate_model()
@@ -259,7 +301,7 @@ class TestJsonSerializer(unittest.TestCase):
             dynamic_shapes=collection.dynamic_shapes(model, (feature1,)),
             strict=False,
             # Allows KJT to not be unflattened and run a forward on unflattened EP
-            preserve_module_call_signature=(tuple(sparse_fqns)),
+            preserve_module_call_signature=tuple(sparse_fqns),
         )
 
         # Run forward on ExportedProgram
@@ -271,8 +313,8 @@ class TestJsonSerializer(unittest.TestCase):
 
         # Deserialize EBC
         deserialized_model = deserialize_embedding_modules(ep, JsonSerializer)
-
         deserialized_model.load_state_dict(model.state_dict())
+
         # Run forward on deserialized model
         deserialized_out = deserialized_model(feature2)
 

--- a/torchrec/ir/types.py
+++ b/torchrec/ir/types.py
@@ -47,3 +47,18 @@ class SerializerInterface(abc.ABC):
     ) -> nn.Module:
         # Take the bytes in the buffer and regenerate the eager embedding module
         raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def encapsulate_module(cls, module: nn.Module) -> List[str]:
+        # Take the eager embedding module and encapsulate the module, including serialization
+        # and meta_forward-swapping, then returns a list of children (fqns) which needs further encapsulation
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def decapsulate_module(
+        cls, module: nn.Module, device: Optional[torch.device] = None
+    ) -> nn.Module:
+        # Take the eager embedding module and decapsulate it by removing serialization and meta_forward-swapping
+        raise NotImplementedError

--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -227,7 +227,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         self.assertEqual(torch.device("cpu"), ebc.embedding_bags["t1"].weight.device)
         self.assertEqual(torch.device("cpu"), ebc.device)
 
-    def test_exporting(self) -> None:
+    def test_ir_export(self) -> None:
         class MyModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -294,6 +294,13 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
             sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
             2,
             "Shoulde be exact 2 EmbeddingBagCollection nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(
+            output.size(), exported.size(), "Output should match exported output"
         )
 
 

--- a/torchrec/modules/tests/test_fp_embedding_modules.py
+++ b/torchrec/modules/tests/test_fp_embedding_modules.py
@@ -21,22 +21,12 @@ from torchrec.modules.feature_processor_ import (
     PositionWeightedModuleCollection,
 )
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
 
 class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
-    def test_position_weighted_module_ebc(self) -> None:
-        #     0       1        2  <-- batch
-        # 0   [0,1] None    [2]
-        # 1   [3]    [4]    [5,6,7]
-        # ^
-        # feature
-        features = KeyedJaggedTensor.from_offsets_sync(
-            keys=["f1", "f2"],
-            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
-        )
 
+    def generate_fp_ebc(self) -> FeatureProcessedEmbeddingBagCollection:
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -52,8 +42,21 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             "f1": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=10)),
             "f2": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=5)),
         }
+        return FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
 
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
+    def test_position_weighted_module_ebc(self) -> None:
+        #     0       1        2  <-- batch
+        # 0   [0,1] None    [2]
+        # 1   [3]    [4]    [5,6,7]
+        # ^
+        # feature
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+        )
+
+        fp_ebc = self.generate_fp_ebc()
 
         pooled_embeddings = fp_ebc(features)
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
@@ -86,6 +89,53 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
         )
 
+        fp_ebc = self.generate_fp_ebc()
+
+        pooled_embeddings = fp_ebc(features)
+        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
+        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
+        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
+
+    def test_ir_export(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self, fp_ebc) -> None:
+                super().__init__()
+                self._fp_ebc = fp_ebc
+
+            def forward(self, features: KeyedJaggedTensor) -> KeyedTensor:
+                return self._fp_ebc(features)
+
+        m = MyModule(self.generate_fp_ebc())
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
+        )
+        ep = torch.export.export(
+            m,
+            (features,),
+            {},
+            strict=False,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("_embedding_bag") for n in ep.graph.nodes),
+            0,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
+            1,
+            "Shoulde be exact 1 EBC nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(output.keys(), exported.keys())
+        self.assertEqual(output.values().size(), exported.values().size())
+
+
+class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCase):
+    def generate_fp_ebc(self) -> FeatureProcessedEmbeddingBagCollection:
         ebc = EmbeddingBagCollection(
             tables=[
                 EmbeddingBagConfig(
@@ -97,20 +147,11 @@ class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
             ],
             is_weighted=True,
         )
-        feature_processors = {
-            "f1": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=10)),
-            "f2": cast(FeatureProcessor, PositionWeightedModule(max_feature_length=5)),
-        }
 
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(ebc, feature_processors)
+        return FeatureProcessedEmbeddingBagCollection(
+            ebc, PositionWeightedModuleCollection({"f1": 10, "f2": 10})
+        )
 
-        pooled_embeddings = fp_ebc(features)
-        self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
-        self.assertEqual(pooled_embeddings.values().size(), (3, 16))
-        self.assertEqual(pooled_embeddings.offset_per_key(), [0, 8, 16])
-
-
-class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCase):
     def test_position_weighted_collection_module_ebc(self) -> None:
         #     0       1        2  <-- batch
         # 0   [0,1] None    [2]
@@ -123,21 +164,7 @@ class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCa
             offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
         )
 
-        ebc = EmbeddingBagCollection(
-            tables=[
-                EmbeddingBagConfig(
-                    name="t1", embedding_dim=8, num_embeddings=16, feature_names=["f1"]
-                ),
-                EmbeddingBagConfig(
-                    name="t2", embedding_dim=8, num_embeddings=16, feature_names=["f2"]
-                ),
-            ],
-            is_weighted=True,
-        )
-
-        fp_ebc = FeatureProcessedEmbeddingBagCollection(
-            ebc, PositionWeightedModuleCollection({"f1": 10, "f2": 10})
-        )
+        fp_ebc = self.generate_fp_ebc()
 
         pooled_embeddings = fp_ebc(features)
         self.assertEqual(pooled_embeddings.keys(), ["f1", "f2"])
@@ -155,3 +182,40 @@ class PositionWeightedModuleCollectionEmbeddingBagCollectionTest(unittest.TestCa
             pooled_embeddings_gm_script.offset_per_key(),
             pooled_embeddings.offset_per_key(),
         )
+
+    def test_ir_export(self) -> None:
+        class MyModule(torch.nn.Module):
+            def __init__(self, fp_ebc) -> None:
+                super().__init__()
+                self._fp_ebc = fp_ebc
+
+            def forward(self, features: KeyedJaggedTensor) -> KeyedTensor:
+                return self._fp_ebc(features)
+
+        m = MyModule(self.generate_fp_ebc())
+        features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8, 9, 9, 9]),
+        )
+        ep = torch.export.export(
+            m,
+            (features,),
+            {},
+            strict=False,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("_embedding_bag") for n in ep.graph.nodes),
+            0,
+        )
+        self.assertEqual(
+            sum(n.name.startswith("embedding_bag_collection") for n in ep.graph.nodes),
+            1,
+            "Shoulde be exact 1 EBC nodes in the exported graph",
+        )
+
+        # export_program's module should produce the same output shape
+        output = m(features)
+        exported = ep.module()(features)
+        self.assertEqual(output.keys(), exported.keys())
+        self.assertEqual(output.values().size(), exported.values().size())


### PR DESCRIPTION
## context
1. we plan to consolidate the non_strict_forward into the TorchRec IR serializer, and this diff is to implement the new set of APIs for testing and migration.
    1. current TorchRec IR APIs are serialize_embedding_modules and deserialize_embedding_modules. 
    2. the new set of APIs are named encapsulate_ir_modules and decapsulate_ir_modules. 
    3. two sets of APIs basically take in the same arguments.
2. the major differences are that:
    1. in the new encapsulate_ir_modules, the TorchRec (embedding) modules' forward functions are replaced by a ir_meta_forward via the corresponding serializer. While in the old API flow the non_strict_forward is embedded within the TorchRec module and hidden behind a is_non_strict_export flag. 
    2. in the new decapsulate_ir_modules, it takes in the unflatten_module which is unflattened by torch.export.unflatten. While in the old API, it takes in the ExportedProgram and run the torch.export.unflatten function inside the TorchRec IR's deserialize_embedding_modules function, which introduced extra coupling.
3. This diff does NOT affect the original APIs.
4. Embedding modules including EBC, PEA, VLE, fpEBC have been tested with dynamic shape support.

## details
* schema
<img width="3724" height="2072" alt="image" src="https://github.com/user-attachments/assets/d866ac24-c3ab-4d0e-bd1d-4e8f5ee45e07" />

<img width="3680" height="1796" alt="image" src="https://github.com/user-attachments/assets/eeb09c14-347e-43a3-9457-f6a9eec5e472" />

* static ir_custom_op definition, **dynamic shape is supported**
```
@torch.library.custom_op("torchrec::ir_custom_op", mutates_args={})
def ir_custom_op_impl(
    tensors: List[Optional[torch.Tensor]], batch_size: int, dim: int
) -> torch.Tensor: # when multiple output tensor is needed, we can simply do a torch.split
    device = None
    for t in tensors:
        if t is not None:
            device = t.device
            break
    logger.info(f"torch.ops.torchrec.ir_custom_op -> ({batch_size}, {dim})")
    return torch.empty(batch_size, dim, device=device)
```
* The previous custom_op is unified into a static operator named ir_custom_op, which does not require registering on the fly. So there is no need to call a helper function register_custom_ops_for_nodes when unflatten an exported IR artifact.
* It decouples the non_strict_export_forward function in each TorchRec module, and avoids the complexity in the original module's forward logic as below, and the non_strict_export flag in torch.export.export is no longer a necessary flag.
```
    def forward(
        self,
        id_list_features: KeyedJaggedTensor,
        id_score_list_features: Optional[KeyedJaggedTensor] = None,
    ) -> Dict[str, torch.Tensor]:
        if is_non_strict_exporting() and not torch.jit.is_scripting():
            return self._non_strict_exporting_forward(  # <---- this create a shortcut to the original forward function
                id_list_features, id_score_list_features
            )
        ... # the actual forward function
```

Differential Revision: D59019375
