### PR TITLE
Disable non-VB inductor test, until new fbgemm op is not in sigrid release

### DIFF
--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -534,7 +534,8 @@ class TestPt2Train(MultiProcessTestBase):
                     ShardingType.TABLE_WISE.value,
                     _InputType.SINGLE_BATCH,
                     _ConvertToVariableBatch.FALSE,
-                    "inductor",
+                    # TODO: Revert to "inductor" once D59031938 is relanded, waits sigrid predictor push on ~7/2/2024 for fbgemm op to be in (D58956327)
+                    "eager",
                     _TestConfig(),
                 ),
                 (
@@ -542,7 +543,8 @@ class TestPt2Train(MultiProcessTestBase):
                     ShardingType.COLUMN_WISE.value,
                     _InputType.SINGLE_BATCH,
                     _ConvertToVariableBatch.FALSE,
-                    "inductor",
+                    # TODO: Revert to "inductor" once D59031938 is relanded, waits sigrid predictor push on ~7/2/2024 for fbgemm op to be in (D58956327)
+                    "eager",
                     _TestConfig(),
                 ),
             ]


### PR DESCRIPTION
Summary:
D59031938 was reverted, due to sigrid predictor package release wait (should happen next week 07/01)

Until then disabling inductor tests, to not have them failing on main.

Differential Revision: D59076371
