### PR TITLE
Fix Sigmoid PT2 test to mimic AIMP PT2 and refactor torchbind class register

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -735,8 +735,14 @@ class ShardedEmbeddingCollection(
                             table_name
                         ]
                         local_shards_wrapper = v._local_tensor
-                        shards_wrapper["local_tensors"].extend(local_shards_wrapper.local_shards())  # pyre-ignore[16]
-                        shards_wrapper["local_offsets"].extend(local_shards_wrapper.local_offsets())  # pyre-ignore[16]
+                        shards_wrapper["local_tensors"].extend(
+                            # pyre-ignore[16]
+                            local_shards_wrapper.local_shards()
+                        )
+                        shards_wrapper["local_offsets"].extend(
+                            # pyre-ignore[16]
+                            local_shards_wrapper.local_offsets()
+                        )
                         shards_wrapper["global_size"] = v.size()
                         shards_wrapper["global_stride"] = v.stride()
                         shards_wrapper["placements"] = v.placements

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -77,7 +77,8 @@ def get_state_dict(
     key_to_local_shards: Dict[str, List[Shard]] = defaultdict(list)
     key_to_global_metadata: Dict[str, ShardedTensorMetadata] = {}
     key_to_dtensor_metadata: Dict[str, DTensorMetadata] = {}
-    key_to_local_tensor_shards: Dict[str, List[Any]] = defaultdict(list)  # pyre-ignore[33]
+    # pyre-ignore[33]
+    key_to_local_tensor_shards: Dict[str, List[Any]] = defaultdict(list)
 
     def get_key_from_embedding_table(embedding_table: ShardedEmbeddingTable) -> str:
         return prefix + f"{embedding_table.name}.weight"

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -107,9 +107,10 @@ def _load_state_dict(
                         dst_local_shard.tensor.detach().copy_(src_local_shard.tensor)
                 elif isinstance(dst_param, DTensor):
                     assert isinstance(src_param, DTensor)
-                    assert len(dst_param.to_local().local_chunks) == len(  # pyre-ignore[16]
-                        src_param.to_local().local_chunks
-                    )
+                    assert len(
+                        # pyre-ignore[16]
+                        dst_param.to_local().local_chunks
+                    ) == len(src_param.to_local().local_chunks)
                     for i, (dst_local_shard, src_local_shard) in enumerate(
                         zip(
                             dst_param.to_local().local_shards(),  # pyre-ignore[16]

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -844,8 +844,14 @@ class ShardedEmbeddingBagCollection(
                             table_name
                         ]
                         local_shards_wrapper = v._local_tensor
-                        shards_wrapper["local_tensors"].extend(local_shards_wrapper.local_shards())  # pyre-ignore[16]
-                        shards_wrapper["local_offsets"].extend(local_shards_wrapper.local_offsets())  # pyre-ignore[16]
+                        shards_wrapper["local_tensors"].extend(
+                            # pyre-ignore[16]
+                            local_shards_wrapper.local_shards()
+                        )
+                        shards_wrapper["local_offsets"].extend(
+                            # pyre-ignore[16]
+                            local_shards_wrapper.local_offsets()
+                        )
                         shards_wrapper["global_size"] = v.size()
                         shards_wrapper["global_stride"] = v.stride()
                         shards_wrapper["placements"] = v.placements

--- a/torchrec/distributed/shards_wrapper.py
+++ b/torchrec/distributed/shards_wrapper.py
@@ -24,7 +24,7 @@ from torch.distributed.checkpoint.planner import (
     WriteItemType,
 )
 
-aten = torch.ops.aten  # pyre-ignore[5]: Globally accessible variable `aten` has no type specified.
+aten = torch.ops.aten  # pyre-ignore[5]
 
 
 class LocalShardsWrapper(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
@@ -95,9 +95,7 @@ class LocalShardsWrapper(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new
         }
 
         if func in dispatcher:
-            return dispatcher[func](  # pyre-ignore [29] - `Variable[_VT]` is not a function.
-                args, kwargs
-            )
+            return dispatcher[func](args, kwargs)  # pyre-ignore [29]
         else:
             raise NotImplementedError(
                 f"{func} is not supported for LocalShardsWrapper!"

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -213,7 +213,8 @@ def copy_state_dict(
         if isinstance(global_tensor, ShardedTensor):
             global_tensor = global_tensor.local_shards()[0].tensor
         if isinstance(global_tensor, DTensor):
-            global_tensor = global_tensor.to_local().local_shards()[0]  # pyre-ignore[16]
+            # pyre-ignore[16]
+            global_tensor = global_tensor.to_local().local_shards()[0]
 
         if isinstance(tensor, ShardedTensor):
             for local_shard in tensor.local_shards():
@@ -237,7 +238,8 @@ def copy_state_dict(
                 local_shard.tensor.copy_(t)
         elif isinstance(tensor, DTensor):
             shard_offsets = tensor.to_local().local_offsets()  # pyre-ignore[16]
-            for i, local_shard in enumerate(tensor.to_local().local_shards()):  # pyre-ignore[16]
+            # pyre-ignore[16]
+            for i, local_shard in enumerate(tensor.to_local().local_shards()):
                 assert global_tensor.ndim == local_shard.ndim
                 t = global_tensor.detach()
                 local_shape = local_shard.shape


### PR DESCRIPTION
Summary:
Fix PT2 sigmoid test with updated non-strict export mode and mimic AIMP PT2 path: https://fburl.com/code/y84jsrwo.

Given use of registering torchbind classes in multiple files when fixing this diff, put registration/deregistration in utils file.

Differential Revision: D59117177
