### PR TITLE
add GPU sync tests

### DIFF
--- a/torchrec/metrics/test_utils/__init__.py
+++ b/torchrec/metrics/test_utils/__init__.py
@@ -365,7 +365,7 @@ def rec_metric_gpu_sync_test_launcher(
     entry_point: Callable[..., None],
     batch_size: int = BATCH_SIZE,
     batch_window_size: int = BATCH_WINDOW_SIZE,
-    **kwargs: Any,
+    **kwargs: Dict[str, Any],
 ) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         lc = get_launch_config(
@@ -385,6 +385,7 @@ def rec_metric_gpu_sync_test_launcher(
             should_validate_update,
             batch_size,
             batch_window_size,
+            kwargs.get("n_classes", None),
         )
 
 
@@ -402,6 +403,7 @@ def sync_test_helper(
     batch_window_size: int = BATCH_WINDOW_SIZE,
     n_classes: Optional[int] = None,
     zero_weights: bool = False,
+    **kwargs: Dict[str, Any],
 ) -> None:
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
@@ -413,6 +415,10 @@ def sync_test_helper(
 
     tasks = gen_test_tasks(task_names)
 
+    if n_classes:
+        # pyre-ignore[6]: Incompatible parameter type
+        kwargs["number_of_classes"] = n_classes
+
     auc = target_clazz(
         world_size=world_size,
         batch_size=batch_size,
@@ -420,6 +426,8 @@ def sync_test_helper(
         compute_on_all_ranks=compute_on_all_ranks,
         tasks=tasks,
         window_size=batch_window_size * world_size,
+        # pyre-ignore[6]: Incompatible parameter type
+        **kwargs,
     )
 
     weight_value: Optional[torch.Tensor] = None
@@ -466,10 +474,17 @@ def sync_test_helper(
     res = auc.compute()
 
     if rank == 0:
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"{metric_name}-{task_names[0]}|window_{metric_name}"],
-        )
+        # Serving Calibration uses Calibration naming inconsistently
+        if metric_name == "serving_calibration":
+            assert torch.allclose(
+                test_metrics[1][task_names[0]],
+                res[f"{metric_name}-{task_names[0]}|window_calibration"],
+            )
+        else:
+            assert torch.allclose(
+                test_metrics[1][task_names[0]],
+                res[f"{metric_name}-{task_names[0]}|window_{metric_name}"],
+            )
 
     # we also test the case where other rank has more tensors than rank 0
     auc.reset()
@@ -489,10 +504,17 @@ def sync_test_helper(
     res = auc.compute()
 
     if rank == 0:
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"{metric_name}-{task_names[0]}|window_{metric_name}"],
-        )
+        # Serving Calibration uses Calibration naming inconsistently
+        if metric_name == "serving_calibration":
+            assert torch.allclose(
+                test_metrics[1][task_names[0]],
+                res[f"{metric_name}-{task_names[0]}|window_calibration"],
+            )
+        else:
+            assert torch.allclose(
+                test_metrics[1][task_names[0]],
+                res[f"{metric_name}-{task_names[0]}|window_{metric_name}"],
+            )
 
     dist.destroy_process_group()
 

--- a/torchrec/metrics/tests/test_accuracy.py
+++ b/torchrec/metrics/tests/test_accuracy.py
@@ -17,8 +17,10 @@ from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
     RecTaskInfo,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -251,3 +253,24 @@ class ThresholdValueTest(unittest.TestCase):
             except AssertionError:
                 print("Assertion error caught with data set ", inputs)
                 raise
+
+
+class AccuracyGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = AccuracyMetric
+    task_name: str = "accuracy"
+
+    def test_sync_accuracy(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=AccuracyMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestAccuracyMetric,
+            metric_name=AccuracyGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
+        )

--- a/torchrec/metrics/tests/test_auprc.py
+++ b/torchrec/metrics/tests/test_auprc.py
@@ -23,7 +23,9 @@ from torchrec.metrics.rec_metric import (
 )
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -346,3 +348,24 @@ class GroupedAUPRCValueTest(unittest.TestCase):
         )
 
         self.assertIn("grouping_keys", auprc.get_required_inputs())
+
+
+class AUPRCGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = AUPRCMetric
+    task_name: str = "auprc"
+
+    def test_sync_auprc(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=AUPRCMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestAUPRCMetric,
+            metric_name=AUPRCGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
+        )

--- a/torchrec/metrics/tests/test_calibration.py
+++ b/torchrec/metrics/tests/test_calibration.py
@@ -15,7 +15,9 @@ from torchrec.metrics.calibration import CalibrationMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -76,4 +78,25 @@ class CalibrationMetricTest(unittest.TestCase):
             should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=metric_test_helper,
+        )
+
+
+class CalibrationGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = CalibrationMetric
+    task_name: str = "calibration"
+
+    def test_sync_calibration(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=CalibrationMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestCalibrationMetric,
+            metric_name=CalibrationGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
         )

--- a/torchrec/metrics/tests/test_ctr.py
+++ b/torchrec/metrics/tests/test_ctr.py
@@ -15,7 +15,9 @@ from torchrec.metrics.ctr import CTRMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -70,4 +72,25 @@ class CTRMetricTest(unittest.TestCase):
             should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=metric_test_helper,
+        )
+
+
+class CTRGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = CTRMetric
+    task_name: str = "ctr"
+
+    def test_sync_ctr(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=CTRMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestCTRMetric,
+            metric_name=CTRGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
         )

--- a/torchrec/metrics/tests/test_mae.py
+++ b/torchrec/metrics/tests/test_mae.py
@@ -15,7 +15,9 @@ from torchrec.metrics.mae import compute_mae, MAEMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -73,4 +75,25 @@ class MAEMetricTest(unittest.TestCase):
             should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=metric_test_helper,
+        )
+
+
+class MAEGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = MAEMetric
+    task_name: str = "mae"
+
+    def test_sync_mae(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=MAEMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestMAEMetric,
+            metric_name=MAEGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
         )

--- a/torchrec/metrics/tests/test_mse.py
+++ b/torchrec/metrics/tests/test_mse.py
@@ -15,7 +15,9 @@ from torchrec.metrics.mse import compute_mse, compute_rmse, MSEMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -122,4 +124,25 @@ class MSEMetricTest(unittest.TestCase):
             should_validate_update=False,
             world_size=WORLD_SIZE,
             entry_point=metric_test_helper,
+        )
+
+
+class MSEGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = MSEMetric
+    task_name: str = "mse"
+
+    def test_sync_mse(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=MSEMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestMSEMetric,
+            metric_name=MSEGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
         )

--- a/torchrec/metrics/tests/test_multiclass_recall.py
+++ b/torchrec/metrics/tests/test_multiclass_recall.py
@@ -19,7 +19,9 @@ from torchrec.metrics.multiclass_recall import (
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -111,5 +113,28 @@ class MulticlassRecallMetricTest(unittest.TestCase):
             world_size=WORLD_SIZE,
             entry_point=metric_test_helper,
             batch_window_size=10,
+            n_classes=N_CLASSES,
+        )
+
+
+class MulticlassRecallGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = MulticlassRecallMetric
+    task_name: str = "multiclass_recall"
+
+    def test_sync_multiclass_recall(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=MulticlassRecallMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestMulticlassRecallMetric,
+            metric_name=MulticlassRecallGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
+            # pyre-ignore[6] Incompatible parameter type
             n_classes=N_CLASSES,
         )

--- a/torchrec/metrics/tests/test_ndcg.py
+++ b/torchrec/metrics/tests/test_ndcg.py
@@ -10,12 +10,13 @@
 import unittest
 
 from dataclasses import replace
-from typing import Dict
+from typing import Any, Dict, List
 
 import torch
 from torchrec.metrics.metrics_config import DefaultTaskInfo
 
 from torchrec.metrics.ndcg import NDCGMetric, SESSION_KEY
+from torchrec.metrics.test_utils import RecTaskInfo
 
 
 WORLD_SIZE = 4
@@ -99,14 +100,13 @@ def get_test_case_negative_task() -> Dict[str, torch.Tensor]:
     }
 
 
-"""
-predictions = [0.1, 0.5, 0.3, 0.4, 0.2, 0.1] * weights = [1, 0, 0, 1, 0, 0] => [0.1, 0, 0, 0.4, 0.0, 0.0]
-labels = [1, 0, 1, 1, 0, 1] * weights = [1, 0, 1, 1, 0, 1] => [1, 0, 0, 1, 0, 0]
-    => NDCG going to be perfect for both sessions (trivially).
-"""
-
-
 def get_test_case_scale_by_weights_tensor() -> Dict[str, torch.Tensor]:
+    """
+    For this test case,
+    predictions * weights = [0.1, 0, 0, 0.4, 0.0, 0.0]
+    labels * weights = [1, 0, 0, 1, 0, 0]
+    So NDCG going to be perfect for both sessions.
+    """
     return {
         "predictions": torch.tensor([[0.1, 0.5, 0.3, 0.4, 0.2, 0.1]]),
         "session_ids": torch.tensor([[1, 1, 1, 2, 2, 2]]),
@@ -118,97 +118,63 @@ def get_test_case_scale_by_weights_tensor() -> Dict[str, torch.Tensor]:
 
 
 class NDCGMetricValueTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.non_exponential_ndcg = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyre-ignore
-            exponential_gain=False,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
+    def generate_metric(
+        self,
+        world_size: int,
+        my_rank: int,
+        batch_size: int,
+        tasks: List[RecTaskInfo] = [DefaultTaskInfo],
+        exponential_gain: bool = False,
+        session_key: str = SESSION_KEY,
+        k: int = -1,
+        remove_single_length_sessions: bool = False,
+        scale_by_weights_tensor: bool = False,
+        report_ndcg_as_decreasing_curve: bool = True,
+        **kwargs: Dict[str, Any],
+    ) -> NDCGMetric:
+        return NDCGMetric(
+            world_size=world_size,
+            my_rank=my_rank,
+            batch_size=batch_size,
+            tasks=tasks,
+            # pyre-ignore[6]
+            session_key=session_key,
+            # pyre-ignore[6]
+            exponential_gain=exponential_gain,
+            # pyre-ignore[6]
+            remove_single_length_sessions=remove_single_length_sessions,
+            # pyre-ignore[6]
+            scale_by_weights_tensor=scale_by_weights_tensor,
+            # pyre-ignore[6]
+            report_ndcg_as_decreasing_curve=report_ndcg_as_decreasing_curve,
+            # pyre-ignore[6]
+            k=k,
+            # pyre-ignore[6]
+            **kwargs,
         )
 
-        self.exponential_ndcg = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyre-ignore
-            exponential_gain=True,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
-        )
-
-        self.ndcg_at_k = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyre-ignore
-            exponential_gain=False,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
-            # pyre-ignore[6]: In call `NDCGMetric.__init__`, for argument `k`, expected `Dict[str, typing.Any]` but got `int`
-            k=2,
-        )
-
-        self.ndcg_remove_single_length_sessions = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyre-ignore
-            exponential_gain=False,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
-            # pyre-ignore[6]: In call `NDCGMetric.__init__`, for argument `remove_single_length_sessions`, expected `Dict[str, typing.Any]` but got `bool`
-            remove_single_length_sessions=True,
-        )
-
-        TempTaskInfo = replace(DefaultTaskInfo, is_negative_task=True)
-        self.ndcg_apply_negative_task_mask = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[TempTaskInfo],
-            # pyre-ignore
-            exponential_gain=False,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
-        )
-
-        self.ndcg_report_as_increasing_and_scale_by_weights_tensor = NDCGMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyre-ignore
-            exponential_gain=False,  # exponential_gain is one of the kwargs
-            # pyre-ignore
-            session_key=SESSION_KEY,  # session_key is one of the kwargs
-            # pyre-ignore[6]: In call `NDCGMetric.__init__`, for argument `remove_single_length_sessions`, expected `Dict[str, typing.Any]` but got `bool`
-            remove_single_length_sessions=True,
-            # pyre-ignore[6]: In call `NDCGMetric.__init__`, for argument `scale_by_weights_tensor`, expected `Dict[str, typing.Any]` but got `bool`
-            scale_by_weights_tensor=True,
-            # pyre-ignore[6]: In call `NDCGMetric.__init__`, for argument `report_ndcg_as_decreasing_curve`, expected `Dict[str, typing.Any]` but got `bool`
-            report_ndcg_as_decreasing_curve=False,
-        )
-
-    def test_single_session(self) -> None:
+    def test_single_session_non_exp(self) -> None:
         """
         Test single session in a update.
         """
         model_output = get_test_case_multiple_sessions_within_batch()
-        self.non_exponential_ndcg.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.non_exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -221,14 +187,28 @@ class NDCGMetricValueTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
-        self.exponential_ndcg.update(
+    def test_single_session_exp(self) -> None:
+        """
+        Test single session in a update for exponential metric.
+        """
+        model_output = get_test_case_multiple_sessions_within_batch()
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=True,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_exp"]
 
         torch.testing.assert_close(
@@ -241,19 +221,28 @@ class NDCGMetricValueTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
-    def test_multiple_sessions(self) -> None:
+    def test_multiple_sessions_non_exp(self) -> None:
         """
         Test multiple sessions in a single update.
         """
         model_output = get_test_case_multiple_sessions_within_batch()
-        self.non_exponential_ndcg.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.non_exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -266,14 +255,25 @@ class NDCGMetricValueTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
-        self.exponential_ndcg.update(
+    def test_multiple_sessions_exp(self) -> None:
+        model_output = get_test_case_multiple_sessions_within_batch()
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=True,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_exp"]
 
         torch.testing.assert_close(
@@ -291,14 +291,23 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test sessions where all labels are 0.
         """
         model_output = get_test_case_all_labels_zero()
-        self.non_exponential_ndcg.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.non_exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -311,14 +320,28 @@ class NDCGMetricValueTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
-        self.exponential_ndcg.update(
+    def test_negative_sessions_exp(self) -> None:
+        """
+        Test sessions where all labels are 0, for exponential gain.
+        """
+        model_output = get_test_case_all_labels_zero()
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=True,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_exp"]
 
         torch.testing.assert_close(
@@ -336,14 +359,23 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test another multiple sessions in a single update.
         """
         model_output = get_test_case_another_multiple_sessions_within_batch()
-        self.non_exponential_ndcg.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.non_exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -356,14 +388,28 @@ class NDCGMetricValueTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
-        self.exponential_ndcg.update(
+    def test_another_multiple_sessions_exp(self) -> None:
+        """
+        Test another multiple sessions in a single update, for exponential gain.
+        """
+        model_output = get_test_case_another_multiple_sessions_within_batch()
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=True,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.exponential_ndcg.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_exp"]
 
         torch.testing.assert_close(
@@ -381,14 +427,23 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test NDCG @ K.
         """
         model_output = get_test_case_at_k()
-        self.ndcg_at_k.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+            k=2,
+        )
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.ndcg_at_k.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -406,14 +461,24 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test NDCG with removing single length sessions.
         """
         model_output = get_test_case_remove_single_length_sessions()
-        self.ndcg_remove_single_length_sessions.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+            remove_single_length_sessions=True,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
-        metric = self.ndcg_remove_single_length_sessions.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -431,15 +496,26 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test NDCG with apply negative task mask.
         """
         model_output = get_test_case_negative_task()
-        self.ndcg_apply_negative_task_mask.update(
+        TempTaskInfo = replace(DefaultTaskInfo, is_negative_task=True)
+
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[TempTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
 
-        metric = self.ndcg_apply_negative_task_mask.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(
@@ -457,15 +533,27 @@ class NDCGMetricValueTest(unittest.TestCase):
         Test NDCG with reporting as increasing NDCG and scaling by weights tensor correctly.
         """
         model_output = get_test_case_scale_by_weights_tensor()
-        self.ndcg_report_as_increasing_and_scale_by_weights_tensor.update(
+        metric = self.generate_metric(
+            world_size=WORLD_SIZE,
+            my_rank=0,
+            batch_size=BATCH_SIZE,
+            tasks=[DefaultTaskInfo],
+            exponential_gain=False,
+            session_key=SESSION_KEY,
+            remove_single_length_sessions=True,
+            scale_by_weights_tensor=True,
+            report_ndcg_as_decreasing_curve=False,
+        )
+
+        metric.update(
             predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
             labels={DefaultTaskInfo.name: model_output["labels"][0]},
             weights={DefaultTaskInfo.name: model_output["weights"][0]},
             required_inputs={SESSION_KEY: model_output["session_ids"][0]},
         )
 
-        metric = self.ndcg_report_as_increasing_and_scale_by_weights_tensor.compute()
-        actual_metric = metric[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
+        output = metric.compute()
+        actual_metric = output[f"ndcg-{DefaultTaskInfo.name}|lifetime_ndcg"]
         expected_metric = model_output["expected_ndcg_non_exp"]
 
         torch.testing.assert_close(

--- a/torchrec/metrics/tests/test_ne_positive.py
+++ b/torchrec/metrics/tests/test_ne_positive.py
@@ -29,7 +29,8 @@ def generate_model_output() -> Dict[str, torch._tensor.Tensor]:
 
 
 class NEPositiveValueTest(unittest.TestCase):
-    r"""This set of tests verify the computation logic of AUC in several
+    """
+    This set of tests verify the computation logic of AUC in several
     corner cases that we know the computation results. The goal is to
     provide some confidence of the correctness of the math formula.
     """

--- a/torchrec/metrics/tests/test_recall.py
+++ b/torchrec/metrics/tests/test_recall.py
@@ -17,8 +17,10 @@ from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
 from torchrec.metrics.recall import compute_recall, RecallMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
     RecTaskInfo,
+    sync_test_helper,
     TestMetric,
 )
 
@@ -32,8 +34,8 @@ class TestRecallMetric(TestMetric):
         labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
     ) -> Dict[str, torch.Tensor]:
         predictions = predictions.double()
-        true_pos_sum = torch.sum(weights * ((predictions >= 0.5) == labels))
-        false_neg_sum = torch.sum(weights * ((predictions <= 0.5) == (labels)))
+        true_pos_sum = torch.sum(weights * ((predictions >= 0.5) * labels))
+        false_neg_sum = torch.sum(weights * ((predictions <= 0.5) * (labels)))
         return {
             "true_pos_sum": true_pos_sum,
             "false_neg_sum": false_neg_sum,
@@ -51,34 +53,33 @@ class RecallMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = RecallMetric
     task_name: str = "recall"
 
-    # Temporarily comment out fuse unit tests due to unknown failure (D56856649).
-    # def test_unfused_recall(self) -> None:
-    #     rec_metric_value_test_launcher(
-    #         target_clazz=RecallMetric,
-    #         target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-    #         test_clazz=TestRecallMetric,
-    #         metric_name=RecallMetricTest.task_name,
-    #         task_names=["t1", "t2", "t3"],
-    #         fused_update_limit=0,
-    #         compute_on_all_ranks=False,
-    #         should_validate_update=False,
-    #         world_size=WORLD_SIZE,
-    #         entry_point=metric_test_helper,
-    #     )
+    def test_unfused_recall(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=RecallMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestRecallMetric,
+            metric_name=RecallMetricTest.task_name,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=metric_test_helper,
+        )
 
-    # def test_fused_recall(self) -> None:
-    #     rec_metric_value_test_launcher(
-    #         target_clazz=RecallMetric,
-    #         target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
-    #         test_clazz=TestRecallMetric,
-    #         metric_name=RecallMetricTest.task_name,
-    #         task_names=["t1", "t2", "t3"],
-    #         fused_update_limit=0,
-    #         compute_on_all_ranks=False,
-    #         should_validate_update=False,
-    #         world_size=WORLD_SIZE,
-    #         entry_point=metric_test_helper,
-    #     )
+    def test_fused_recall(self) -> None:
+        rec_metric_value_test_launcher(
+            target_clazz=RecallMetric,
+            target_compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            test_clazz=TestRecallMetric,
+            metric_name=RecallMetricTest.task_name,
+            task_names=["t1", "t2", "t3"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=WORLD_SIZE,
+            entry_point=metric_test_helper,
+        )
 
 
 class RecallMetricValueTest(unittest.TestCase):
@@ -245,3 +246,24 @@ class ThresholdValueTest(unittest.TestCase):
             except AssertionError:
                 print("Assertion error caught with data set ", inputs)
                 raise
+
+
+class RecallGPUSyncTest(unittest.TestCase):
+    clazz: Type[RecMetric] = RecallMetric
+    task_name: str = "recall"
+
+    def test_sync_recall(self) -> None:
+        rec_metric_gpu_sync_test_launcher(
+            target_clazz=RecallMetric,
+            target_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            test_clazz=TestRecallMetric,
+            metric_name=RecallGPUSyncTest.task_name,
+            task_names=["t1"],
+            fused_update_limit=0,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            world_size=2,
+            batch_size=5,
+            batch_window_size=20,
+            entry_point=sync_test_helper,
+        )

--- a/torchrec/metrics/tests/test_segmented_ne.py
+++ b/torchrec/metrics/tests/test_segmented_ne.py
@@ -17,7 +17,8 @@ from torchrec.metrics.segmented_ne import SegmentedNEMetric
 
 
 class SegementedNEValueTest(unittest.TestCase):
-    r"""This set of tests verify the computation logic of AUC in several
+    """
+    This set of tests verify the computation logic of AUC in several
     corner cases that we know the computation results. The goal is to
     provide some confidence of the correctness of the math formula.
     """


### PR DESCRIPTION
Summary: 
**TLDR: Significant clean up of recmetrics tests and fixing long standing testing issues with particular metrics. Because RecMetrics is community sourced, the quality of metric and test implementations can have high variance which leads to SEVs later on due to the high surface area RecMetrics operates on.**

Added GPU sync tests to simulate gathering metric states on to rank 0 and computing. Tests don't cover this case before, which has resulted in SEVs in the past as users aren't aware of how RecMetrics collects and computes metrics.

Added numerical value tests, most metrics are do not have this which can result in issues down the line if metrics need to be changed/accommodate future changes. Also we've found inconsistencies sometimes from other methods, so always good to check here. We compare each metric to a reference implementation from literature to ensure the values are as expected.

Fixed and cleaned up some tests, particularly enforcing a standard of quality that can be referenced for future metric implementations and tests.

Reviewed By: henrylhtsang

Differential Revision: D59173140
