### PR TITLE
[detailed][pt2] support dynamic dim for variable lengths in KJT

### DIFF
--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -150,8 +150,11 @@ def mark_dynamic_kjt(
     if kjt._weights is not None:
         shapes_collection[kjt._weights] = (vlen,)
     if variable_length:
-        batch_size = _get_dim(batch_size, "batch_size", max=4294967295)
-        llen = len(kjt.keys()) * batch_size
+        if batch_size is None:
+            llen = _get_dim(None, "llen", max=4294967295)
+        else:
+            batch_size = _get_dim(batch_size, "batch_size", max=4294967295)
+            llen = len(kjt.keys()) * batch_size
         olen = llen + 1
         if kjt._lengths is not None:
             shapes_collection[kjt._lengths] = (llen,)


### PR DESCRIPTION
# PT2 IR Dynamic Shape Issue in TorchRec - Why and How
## TL;DR
This note explains why we have dynamic shape issues in TorchRec modules, and how we tackled them. Now we have resolved most (if not all) of the IR-related dynamic shape problems in TorchRec.
The fundamental reason is that the torch compiler is not smart enough to handle complex correlations among the dynamic shapes, and 0s and 1s need special handling during range inference.

## Dynamic Shape Basics
In PT2 IR (used it exchangeably with torch.export in this note) the program/model will be traced under the assumption that all input shapes are static, except for those explicitly marked as dynamic dimensions. [[reference](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export.html)]
During the PT2 (dynamo) tracing, the output tensors' shapes can often be derived from the input shapes. For example, `torch.concat` produces an output tensor of (32, s0+s1) given two input tensors of shapes (32, s0), (32, s1), where s1 and s2 are dynamic dimensions. And the compiler needs this information to build the graph.
<img width="1424" height="638" alt="image" src="https://github.com/user-attachments/assets/28799b0f-c20d-4e7e-83e7-71c10ff8f8d5" />

## Keyed Jagged Tensor
Let’s first start with a jagged tensor (JT, [code](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L560)), which is the condensed sparse representation of a batch of feature values. For example, we have a collection of books labeled from 0 - 1,000,000. In a batch of 3 users, #1 user read book 1,3,5, #2 user read book 2, 4, while #3 user liked book 6 so much and read it twice. From the picture below, we can see a JT consists of the following fields: values, weights (optional), lengths, offsets.

A keyed jagged tensor (KJT, [code](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L1723)) is a natural extension of multiple jagged tensors. Continuing with the previous example, for the same users, we have another feature, say which songs a user has listened to. #1 and #2 user listened song 1 five times, #3 user has never listened to any song from our list.
<img width="1600" height="379" alt="image" src="https://github.com/user-attachments/assets/685f3aa0-949e-4095-99a9-e53654e03d83" />

From the above example, we can see that the values and weights have the same size, while the offsets tensor has one more element than the lengths tensor. A very important assumption is that in a KJT all the features (keys) have the same batch_size (number of users): therefore, lengths’ size = batch_size x feature_count. The exception is that in a variable batch case, each feature has its own batch_size, so we keep another list called `length_per_key`.

## Embedding Module
EmbeddingBagCollection (EBC, [code](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/modules/embedding_modules.py#L97)) is a typical TorchRec embedding module that supports functions like variable batch and sharding, and we’ll focus on this module in the following discussion. The EBC represents a collection of [embedding bags](https://pytorch.org/docs/stable/generated/torch.nn.EmbeddingBag.html), each embedding bag is essentially a lookup table that produces an embedding for each is: id (int) ⇒ embedding (1d tensor), with dim to denote the size of the embedding tensor. The followed pooling operation merges the id list into a single embedding, as shown below:
<img width="1600" height="712" alt="image" src="https://github.com/user-attachments/assets/c8e24198-dd32-41ce-a0f5-ee31c75ebfcd" />

## Dynamic Dim Complexity
The compiler will always check the range of a dynamic dim, because many operators often have different behaviors over 0, 1, -1, and other numbers, and the compiler should be able to infer which logic branch to put into the graph.

* derived dynamic shape
The first error we encountered was can’t infer the `batch_size` from the KJT’s offsets size:
```
torch/fx/experimental/symbolic_shapes.py:5004] eval Eq(((s2 - 1)//2), 3) [guard added] (_ops.py:1060 in __call__), for more info run with TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED="Eq(((s2 - 1)//2), 3)"
```
Our first solution is to develop a utility function mark_dynamic_kjt (#2058) to mark the batch_size = s0, and use derived dynamic dim for others, lengths = (s0 * keys,), and offsets = (s0 * keys + 1,). So that we can preserve the correlation among the lengths, offsets, and batch_size.

* range conflict
The second error came very soon after we used derived dynamic dim, that the compiler failed to resolve the valid ranges for the derived dynamic dim. For example, if s0 (batch_size) has a valid range of [2, sys_max-1], then lengths (s0 * keys, ) and offsets (s0 * keys + 1, ) would definitely be out of the sys_max. [P1461452943](https://www.internalfb.com/intern/paste/P1461452943)
```
 - Not all values of llen4 = L['args'][0][0].event_id_list_features_seqs['fb_page_new']._lengths.size()[0] in the specified range 4 <= llen4 <= 4294967295 satisfy the generated guard 8 <= L['args'][0][0].event_id_list_features_seqs['fb_page_new']._lengths.size()[0] and L['args'][0][0].event_id_list_features_seqs['fb_page_new']._lengths.size()[0] <= 4294967295
Suggested fixes:
  llen4 = Dim('llen4', min=8, max=4294967295)
  llen2 = Dim('llen2', min=8, max=4294967295)
  llen3 = Dim('llen3', min=10, max=4294967295)
  llen1 = Dim('llen1', min=24, max=4294967295)
  dim_fb_page_new_timestamps = Dim('dim_fb_page_new_timestamps', max=1073741823)
  dim_fb_page_setsuna_timestamps = Dim('dim_fb_page_setsuna_timestamps', max=1073741823)
  dim_marketplace_timestamps = Dim('dim_marketplace_timestamps', max=858993459)
  dim_user_conv_ads_event_timestamps = Dim('dim_user_conv_ads_event_timestamps', max=357913941)
```
Max range calculation wasn’t so bad, we just changed the dynamic dim’s max range as sys_max // keys (#2195). It worked for some models including the FB-FM local-default.

* variable batch in sequential feature
The sequential features use variable batches, the output batch_size are harder to derive from lengths or offsets but require other parameters. Other than that, several KJTs share the same set of keys, and additional correlations to make the range calculation way too complicated.
In theory, the user should be responsible for correctly marking all the dynamic dimensions with their ranges, however, this is almost impossible, especially considering the feature count is easily over 1,000.

* final solution
Since all the complexity comes from the fact that the batch_size used in the output pooled embedding tensor is derived from the input KJT’s dynamic shapes, a natural wonder is that can we harmlessly break the correlation between the input KJT and the output embeddings?
So far the answer is still yes. We assign an unbacked dynamic dim to for the output embeddings’ batch_size, and let the downstream operations treat it as a brand new dynamic dim. (#2022).
We are safe to do this because the values, lengths, and offsets are only related to the downstream components by the embeddings, whose dimensions are determined by the embedding tables and the only dynamic dim is the batch_size. So we can just mark the lengths in KJT as a random dynamic dim.

## Zero-Size Dynamic Dim
The compiler doesn’t like zero-size dynamic dim, and the minimum is hence set to 2. Usually in a KJT the lengths, and offsets won’t have such a problem but the values could be empty theoretically.
```
[rank0]:   - Not all values of vlen5 = L['args'][0][0].event_id_list_features_seqs['marketplace']._values.size()[0] in the specified range are valid because vlen5 was inferred to be a constant (0).
[rank0]: Suggested fixes:
[rank0]:   vlen5 = 0
```
There are actually 3 places in PT2 IR flow where the zero-size tensor could cause a problem:
1. In torch.export, a sample_input is needed to trace the model and generate the IR graph
2. run the IR module with zero-size tensor (in test)
3. run the unflattened module with zero-size tensor (in real training)
There was a time that we thought this issue was rooted in the torch compiler and almost impossible to resolve in torch.export due to violating some fundamental dynamic dim assumptions, and we only hope it won’t happen in the real training time with fingers crossed.
Fortunately we realize that we can alter the input KJT values to be non-empty without changing its behavior in the torch export process (this is only true within the torch.export. where a dummy custom op is used to represent the embedding modules).

Basically, in the mark_kjt_dynamic utility function, we check the sample_input (KJT) values size. and reset it to ones(2,0) if it’s empty. In this case, the lengths should be all zeros. By doing this, the compiler can trace through the model and export the correct IR (#2250).

The exported program can take in normal inputs (non-zero tensor KJT) without an issue. However, it still throws an error if the input KJT has zero-size values. So does the unflattened model, which will be used in real training.
```
(Pdb) ep.module()(features_0)
*** RuntimeError: Expected input id_list_features__values.shape[0] = 0 to be of the form s0, where s0 is an integer
```

## Takeaways
1. By overcoming the two major dynamic shape issues, TorchRec should be fully compatible with dynamic shape in PT2 IR. As circumstantial evidence, we haven’t seen any dynamic-shape issue during testing all the major models in the APS IR workstream.
2. Breaking the correlation between input and output could be a shortcut to resolve the complications in torch compiler’s dynamic dimension inference.
3. Zero-size tensor issue could use a workaround combining with a custom-op swapping in torch export.

Differential Revision: D59194969
