### PR TITLE
fix cpu test issue "CMake Error: Unknown argument: -v"

### DIFF
--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -83,4 +83,4 @@ jobs:
             -DBUILD_REDIS_IO=ON \
             -DCMAKE_PREFIX_PATH=/opt/conda/envs/build_binary/lib/python${{ matrix.python-version }}/site-packages/torch/share/cmake ..
         conda run -n build_binary make -j
-        conda run -n build_binary ctest -v .
+        conda run -n build_binary ctest -V .


### PR DESCRIPTION
Summary:
# context
* TorchRec CPU Unit Test is failing: [test](https://github.com/pytorch/torchrec/actions/runs/9785198706)
```
+ conda run -n build_binary ctest -v .
+ local cmd=run
+ case "$cmd" in
+ __conda_exe run -n build_binary ctest -v .
+ /opt/conda/bin/conda run -n build_binary ctest -v .
CMake Error: Unknown argument: -v
CMake Error: Run 'ctest --help' for all supported options.

ERROR conda.cli.main_run:execute(47): `conda run ctest -v .` failed. (See above for error)
```
* this is because the cmake synatx has changed from "-v" to "-V"
* there is a recent CMAKE version bump
```
CMake Deprecation Warning at aten/src/ATen/native/quantized/cpu/qnnpack/deps/clog/CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```

Differential Revision: D56152144
