### PR TITLE
Bug fix for local run in TensorAllToAllValuesAwaitable

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -1558,7 +1558,7 @@ class TensorAllToAllValuesAwaitable(Awaitable[torch.Tensor]):
 
         self._dist_values: torch.Tensor
         if self._workers == 1:
-            self._dist_values = input_splits
+            self._dist_values = input
             return
         else:
             if input.dim() > 1:


### PR DESCRIPTION
Summary: bug fix when local workers is 1. we should take in variable ids instead of one with splits

Reviewed By: sarckk

Differential Revision: D59491275
