### PR TITLE
fix tensor clone warning in throughput metrics

### DIFF
--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -172,9 +172,7 @@ class ThroughputMetric(nn.Module):
             if not math.isclose(lifetime_throughput.item(), 0):
                 ret.update(
                     {
-                        self._lifetime_throughput_key: torch.tensor(
-                            lifetime_throughput, dtype=torch.double
-                        ),
+                        self._lifetime_throughput_key: lifetime_throughput.clone().detach(),
                         self._window_throughput_key: torch.tensor(
                             window_throughput, dtype=torch.double
                         ),


### PR DESCRIPTION
Summary:
get rid of some user warning logs.

It's generally preferred to clone via clone().detach() due to

1. efficiency over large tensor copies (not applicable here)
2. dtype / device preservation
3. detach from computation graph, as opposed to initalize tensor as leaf node

and likely some other reasons i'm forgetting.

Differential Revision: D59492531
