### PR TITLE
[detailed][ops] switch to new op for KeyedTensor.regroup

### DIFF
--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -352,6 +352,59 @@ class TestJsonSerializer(unittest.TestCase):
                     continue
                 assert param.device.type == device.type, f"{name} should be on {device}"
 
+    # pyre-ignore
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "this test needs a GPU machine to run",
+    )
+    def test_deserialize_device_kt_regroup(self) -> None:
+        class Model(nn.Module):
+            def __init__(self, ebc):
+                super().__init__()
+                self.ebc = ebc
+
+            def forward(
+                self,
+                features: KeyedJaggedTensor,
+            ) -> List[torch.Tensor]:
+                kt = self.ebc(features)
+                return KeyedTensor.regroup([kt], [[key] for key in kt.keys()])
+
+        model = self.generate_model()
+        model = Model(model.ebc1)
+        id_list_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([0, 1, 2, 3, 2, 3]),
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 6]),
+        )
+        eager_out = model(id_list_features)
+
+        # Serialize EBC
+        model, sparse_fqns = encapsulate_ir_modules(model, JsonSerializer)
+        ep = torch.export.export(
+            model,
+            (id_list_features,),
+            {},
+            strict=False,
+            # Allows KJT to not be unflattened and run a forward on unflattened EP
+            preserve_module_call_signature=(tuple(sparse_fqns)),
+        )
+        unflatten_model = torch.export.unflatten(ep)
+        deserialized_model = decapsulate_ir_modules(
+            unflatten_model, JsonSerializer, torch.device("cuda")
+        )
+        device = torch.device("cuda")
+        deserialized_model.to(device)
+        id_list_features = id_list_features.to(device)
+
+        deserialized_model.load_state_dict(model.state_dict())
+        # Run forward on deserialized model
+        deserialized_out = deserialized_model(id_list_features)
+
+        for i, tensor in enumerate(deserialized_out):
+            assert eager_out[i].shape == tensor.shape
+            assert torch.allclose(eager_out[i].to(tensor), tensor)
+
     def test_compound_module(self) -> None:
         tb1_config = EmbeddingBagConfig(
             name="t1",

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2753,11 +2753,7 @@ class KeyedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def regroup(
         keyed_tensors: List["KeyedTensor"], groups: List[List[str]]
     ) -> List[torch.Tensor]:
-        # Fast path, one-to-one correspondence between keyed_tensors and groups
-        if _all_keys_used_once(keyed_tensors, groups) is True:
-            return _fbgemm_permute_pooled_embs(keyed_tensors, groups)
-        else:  # Fallback to slow path otherwise
-            return _regroup_keyed_tensors(keyed_tensors, groups)
+        return permute_multi_embedding(keyed_tensors, groups)
 
     @staticmethod
     def regroup_as_dict(


### PR DESCRIPTION
# Enable New Op for `KeyedTensor.regroup` method
## TL;DR
We have developed a new operator, fbgemm.regroup_keyed_tensor, which supports multi-tensor input and output with CUDA acceleration and autograd support. This new operator is designed to replace the existing fbgemm.permute_pooled_embedding operator, which only supports single-tensor permute.
Major performance improvements include:
1. Reduced GPU runtime by 60%, CPU runtime by 40%, and GPU memory by 30% (measured by local benchmarks, #2159)
2. Improved overall training QPS by 0.5% in production environments (measured with IG-CTR, D43405610))
3. Improved eager model inference QPS by ~3% (measured with ins-mtml-ctr, D61227366)
Major functionality enablements include:
1. Support duplicate features in the output mapping
2. Dispatch registration with major backends (CUDA, CPU, Meta, Autograd)
3. PT2 compiler can trace through the operator for dynamic shape with SymInt
4. PT2 IR can export KTRegroup module with TorchRec serializer

The development of this operator was a ground-up effort that navigated numerous challenges and issues, making it an exemplary case study for future operator development endeavors. 

## Background
KeyedTensor (KT) permute operation is needed in most of the recommendation models who use TorchRec’s EBC (EmbeddingBagCollection) modules, where the embeddings are packed in a contiguous format but very often are not in orders/shapes that can be directly fed to the downstream dense modules (shown below).
<img width="1600" height="566" alt="image" src="https://github.com/user-attachments/assets/0912373a-8b75-4a60-84cc-f0841811f169" />

## Problem Statement
Previously the permute operator (fbgemm.permute_pooled_embs_auto_grad) only works on a single tensor: takes only one tensor as input and outputs a tensor with the same shape. However, in most TorchRec use cases, there are multiple input tensors (from multiple EBCs) and multiple tensors are needed for the downstream modules, as a workaround, a torch.concat function has to be used before the permute operator, and a torch.split function has to be used afterwards (shown below). 
There are three major drawbacks of this workaround approach: 
1. The data are effectively stored in 2D (batch x feature_dim) so both torch.concat and torch.split need non-trivial GPU compute resources.
2. Extra memory allocation for the temporary tensor holding the concatenated data and permuted data.
3. The existing permute operator can’t handle duplicate data slice (feature), and it has to fall back to native pytorch implementation (much slower) if duplication exists.
<img width="1600" height="330" alt="image" src="https://github.com/user-attachments/assets/87653de2-1eaf-4450-b0e9-ba664928bc2f" />

## Achievement
1. Core functionality improvement: we developed, and iterated (see below) on a new regroup operator (fbgemm.regroup_keyed_tensor) that takes multiple KTs as input, directly outputs KTs with desired key orders without using extra GPU memory, and supports duplicates in the regroup mapping (in both forward and backward). 
2. Performance wins: we thoroughly analyzed the local perf benchmark, studied the perf impact, and launched to production.
    1. (Local benchmark: #2159): in a typical use case, CPU runtime reduces 40% from 1.8 ms to 1.1 ms, GPU runtime reduces 60% from 4.9 ms to 2.0 ms, and GPU memory reduces 33% from 1.5 K to 1.0 K 
    2. (Training in production: D43405610): measured with an ads foundation model training (FB-FM-v2), the new regroup operator showed 1ms runtime saving per batch, and the overall training QPS improved by 0.5%. 
    3. Please note that this is a global change benefiting all APS models that use ebc_sparse_arch, besides, the new regroup operator should have higher overall QPS improvement in common models, because the foundation model is much more complicated thus the regroup operation has relatively lower overall impact.
    4. TorchRec/KJT Inference in production: The KTRegroup module contributed a large portion of QPS boosts helping mitigation of previously QPS regression, and finally bringing overall QPS gain in Eager Model Processing.

## This PR
* the new op `permute_multi_embedding` outperforms the original op `_fbgemm_permute_pooled_embs`
* this diff makes the move to switch to the new op
* more results: #2159, [traces](https://drive.google.com/drive/folders/1DEYozPihmij2zRAyG9AMxaIbcjTPWRVU?usp=drive_link)
* previous prod
<img width="3252" height="1400" alt="image" src="https://github.com/user-attachments/assets/4dd763e1-b35a-46d7-9070-d8cab4b88ff5" />

* new prod
<img width="3204" height="1398" alt="image" src="https://github.com/user-attachments/assets/74050aa8-deaa-414b-aafc-74cfa57a466c" />

* metrics

|Operator|CPU runtime|GPU runtime|GPU memory|notes|
|---|---|---|---|---|
|**[fallback] pytorch generic**|3.9 ms|3.2 ms|1.0 K|CPU-bounded, allow duplicates|
|**[previous prod] permute_pooled_embs**|1.9 ms|4.9 ms|1.5 K|GPU-boudned, does **NOT** allow duplicates, PT2 non-compatible `pin_and_move`|
|**[new prod] permute_multi_embedding**|1.0 ms|2.0 ms|1.0 K|both CPU and GPU runtime/memory improved, **ALLOW** duplicates, PT2 friendly|

NOTE: the new op takes in `List[List[str]]` and `List[List[int]]`, it currently does not support dynamic_shape and produces error like the following: 
>     1) SerializeError: Failed serializing node kt_regroup_permutes in graph: %kt_regroup_permutes : [num_users=3] = call_function[target=torch.ops.fbgemm.kt_regroup_permutes.default](args = (%ir_custom_op, [[f1], [f2]], [[3], [5]], [[f1], [f2]]), kwargs = {})
...
Caused by SerializeError: Unsupported list/tuple argument type: [<class 'torch.fx.immutable_collections.immutable_list'>, <class 'torch.fx.immutable_collections.immutable_list'>]

Differential Revision: D55277833


