### PR TITLE
switch variable batch pt2 compile test back to inductor

### DIFF
--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -518,8 +518,7 @@ class TestPt2Train(MultiProcessTestBase):
                     ShardingType.TABLE_WISE.value,
                     _InputType.SINGLE_BATCH,
                     _ConvertToVariableBatch.TRUE,
-                    # TODO: Revert to "inductor" once https://github.com/pytorch/pytorch/pull/130431 is landed
-                    "eager",
+                    "inductor",
                     _TestConfig(),
                 ),
                 (
@@ -527,8 +526,7 @@ class TestPt2Train(MultiProcessTestBase):
                     ShardingType.COLUMN_WISE.value,
                     _InputType.SINGLE_BATCH,
                     _ConvertToVariableBatch.TRUE,
-                    # TODO: Revert to "inductor" once https://github.com/pytorch/pytorch/pull/130431 is landed
-                    "eager",
+                    "inductor",
                     _TestConfig(),
                 ),
                 (


### PR DESCRIPTION
Summary:
to handle concatenating multiple 1d VBE embeddings, we introduce some conditional logic in GroupedEmbeddingLookup. this broke the pt2 multiprocess test, which was fixed in https://github.com/pytorch/pytorch/pull/130431.

to bypass we ran the test in eager mode, but this diff switches it back to inductor.

Reviewed By: iamzainhuda

Differential Revision: D59722240
