### PR TITLE
Call finish_checkpoint_resume to flush optimizer step

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -494,6 +494,9 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
         # pyre-ignore [16]
         self._emb_module.set_learning_rate(self.param_groups[0]["lr"])
 
+    def set_optimizer_step(self, step: int) -> None:
+        self._emb_module.set_optimizer_step(step)
+
 
 def _gen_named_parameters_by_table_ssd(
     emb_module: SSDTableBatchedEmbeddingBags,

--- a/torchrec/optim/keyed.py
+++ b/torchrec/optim/keyed.py
@@ -388,6 +388,12 @@ class CombinedOptimizer(KeyedOptimizer):
         for _, opt in self._optims:
             opt.save_param_groups(save)
 
+    def set_optimizer_step(self, step: int) -> None:
+        for _, opt in self._optims:
+            if hasattr(opt, "set_optimizer_step"):
+                # pyre-ignore [16]: Undefined attribute [16]: `KeyedOptimizer` has no attribute `set_optimizer_step`.
+                opt.set_optimizer_step(step)
+
 
 class KeyedOptimizerWrapper(KeyedOptimizer):
     """


### PR DESCRIPTION
Summary: `iter` number is a critical counter in computing how much decay is needed together with `prev_iter`. However, `iter` is not checkpointed since it is not in `split_optimizer_state`. Instead, it relies on external calls of `set_optimizer_step` to flush the counter, which relies on explict calls of `finish_checkpoint_resume` to trigger `flush_state` in `FullSyncOptimizer`. This chain of actions is not properly set up in existing code, which causes the issue that after a preemption, `iter` gets reset to zero.

Differential Revision: D60155781
