### PR TITLE
Fix device issue with regroup module

### DIFF
--- a/torchrec/modules/regroup.py
+++ b/torchrec/modules/regroup.py
@@ -52,7 +52,6 @@ def module_init(module: "KTRegroupAsDict", keyed_tensors: List[KeyedTensor]) -> 
     assert all(
         kt.device() == keyed_tensors[0].device() for kt in keyed_tensors
     ), "All inputs should be on the same device."
-    module.device = keyed_tensors[0].device()
     assert all(
         kt.key_dim() == keyed_tensors[0].key_dim() for kt in keyed_tensors
     ), "All inputs should have the same key_dim"
@@ -63,6 +62,56 @@ def module_init(module: "KTRegroupAsDict", keyed_tensors: List[KeyedTensor]) -> 
     else:
         module._init_regroup(keyed_tensors)
     module._is_inited = True
+
+
+class PermuteMultiEmbedding(torch.nn.Module):
+    """
+    Module to handle cached tensors and running FBGEMM
+    op for KT. This separate module allows fx tracing through
+    all the logic in KTRegroupAsDict while keeping what's necessary
+    for exposing set_device and allowing tensors to be moved to
+    the appropriate device during model processing.
+
+    Args:
+        groups (List[List[str]]): Groups from KTRegroupAsDict
+
+    """
+
+    def __init__(self, groups: List[List[str]]) -> None:
+        super().__init__()
+        self._groups = groups
+        self.register_buffer("_permutes", torch.empty(0), persistent=False)
+        self.register_buffer("_in_shapes", torch.empty(0), persistent=False)
+        self.register_buffer("_out_shapes", torch.empty(0), persistent=False)
+        self._out_lengths: Optional[List[int]] = None
+
+    def init_tensors(
+        self,
+        permute: torch.Tensor,
+        in_shapes: torch.Tensor,
+        out_shapes: torch.Tensor,
+        out_lengths: List[int],
+    ) -> None:
+        # no need to pin_memory() or to(..., non_blocking=True) since occurs only once
+        self._permutes = permute
+        self._in_shapes = in_shapes
+        self._out_shapes = out_shapes
+        self._out_lengths = out_lengths
+
+    @torch.jit.export
+    def set_device(self, device: str) -> None:
+        self._permutes = self._permutes.to(device)
+        self._in_shapes = self._in_shapes.to(device)
+        self._out_shapes = self._out_shapes.to(device)
+
+    def forward(self, values: List[torch.Tensor]) -> List[torch.Tensor]:
+        return torch.ops.fbgemm.permute_multi_embedding(
+            values,
+            self._permutes,
+            self._in_shapes,
+            self._out_shapes,
+            self._out_lengths,
+        )
 
 
 class KTRegroupAsDict(torch.nn.Module):
@@ -97,26 +146,27 @@ class KTRegroupAsDict(torch.nn.Module):
         self._is_inited = False
 
         # cached values populated on first forward call
-        self.device: Optional[torch.device] = None
         self._dim: int = 1
         self._use_fbgemm_regroup: bool = False
         self._splits: List[int] = []
         self._idx_key_pairs: List[Tuple[int, str]] = []
-        self.register_buffer("_permutes", torch.empty(0), persistent=False)
-        self.register_buffer("_in_shapes", torch.empty(0), persistent=False)
-        self.register_buffer("_out_shapes", torch.empty(0), persistent=False)
-        self._out_lengths: Optional[List[int]] = None
+        self._permute_pooled_embs_impl = PermuteMultiEmbedding(groups)
 
     def _init_fbgemm_regroup(self, kts: List[KeyedTensor]) -> None:
         self._use_fbgemm_regroup = True
         keys, lengths, values = _desugar_keyed_tensors(kts)
-        self._permutes, self._in_shapes, self._out_shapes, self._out_lengths = (
-            _kt_regroup_arguments(
-                values[0],
-                keys,
-                lengths,
-                self._groups,
-            )
+        permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
+            values[0],
+            keys,
+            lengths,
+            self._groups,
+        )
+        # no need to pin_memory() or to(..., non_blocking=True) since occurs only once
+        self._permute_pooled_embs_impl.init_tensors(
+            permutes,
+            in_shapes,
+            out_shapes,
+            out_lengths,
         )
 
     def _init_regroup(self, kts: List[KeyedTensor]) -> None:
@@ -152,13 +202,7 @@ class KTRegroupAsDict(torch.nn.Module):
 
         if self._use_fbgemm_regroup:
             values = _get_kts_values(keyed_tensors)
-            permuted_values = torch.ops.fbgemm.permute_multi_embedding(
-                values,
-                self._permutes,
-                self._in_shapes,
-                self._out_shapes,
-                self._out_lengths,
-            )
+            permuted_values = self._permute_pooled_embs_impl(values)
         else:
             permuted_values = _permuted_values(
                 keyed_tensors, self._idx_key_pairs, self._dim


### PR DESCRIPTION
Summary:
When using the new RegroupAsDict module with cached tensors, ex. self._permutes, they aren't properly moved to the right devices during the model processing pipeline. This is due to the fact that the module is not a leaf module and does not have a `set_device` method.

This diff creates a submodule `PermutePooledEmbeddings` that just handles the fbgemm logic and holds the cached tensors (for moving to the right device), along with adding this module to the leaf modules for AIMP.

Differential Revision: D60062406
