### PR TITLE
make model.model_metrics.qps_metric.warmup_steps can be passed through config

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -463,6 +463,7 @@ def generate_metric_module(
             batch_size=batch_size,
             world_size=world_size,
             window_seconds=metrics_config.throughput_metric.window_size,
+            warmup_steps=metrics_config.throughput_metric.warmup_steps,
         )
     else:
         throughput_metric = None

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -80,6 +80,7 @@ class RecComputeMode(Enum):
 
 _DEFAULT_WINDOW_SIZE = 10_000_000
 _DEFAULT_THROUGHPUT_WINDOW_SECONDS = 100
+_DEFAULT_THROUGHPUT_WARMUP_STEPS = 100
 
 
 @dataclass
@@ -113,6 +114,7 @@ class StateMetricEnum(StrValueMixin, Enum):
 @dataclass
 class ThroughputDef:
     window_size: int = _DEFAULT_THROUGHPUT_WINDOW_SECONDS
+    warmup_steps: int = _DEFAULT_THROUGHPUT_WARMUP_STEPS
 
 
 @dataclass


### PR DESCRIPTION
Summary:
`ThroughputMetric` already support warm_steps, however it's default to always 100.
Thsi diff is to make qps_metric.warmup_steps configurable so that it can be control through model yaml file or command argument, for example,

```
buck2 run mode/{opt,amd-gpu} //aps_models/ads/icvr:icvr_launcher -- mode=local_ctr_cvr_cmf_rep_1000x_v1_no_atom +model.model_metrics.qps_metric.warmup_steps=1
```

Reviewed By: Yuzhen11

Differential Revision: D60388121
