### PR TITLE
In unflattened model case, modify to_copy nodes in DMP to be on appropriate device

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -19,6 +19,7 @@ from torch.distributed.algorithms.ddp_comm_hooks import (
     default_hooks as ddp_default_hooks,
 )
 from torch.distributed.fsdp import FullyShardedDataParallel
+from torch.export import UnflattenedModule
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
@@ -38,6 +39,7 @@ from torchrec.distributed.utils import (
     filter_state_dict,
     sharded_model_copy,
 )
+from torchrec.ir.utils import move_to_copy_nodes_to_device
 from torchrec.optim.fused import FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
 
@@ -270,6 +272,9 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
         if init_data_parallel:
             self.init_data_parallel()
+
+        if isinstance(self.module, UnflattenedModule):
+            move_to_copy_nodes_to_device(self.module, self.device)
 
     @property
     def module(self) -> nn.Module:


### PR DESCRIPTION
Summary: When torch.exporting, device specializations can occur: https://fb.workplace.com/groups/1075192433118967/posts/1474166129888260/?comment_id=1474191496552390&reply_comment_id=1474683806503159 such as here: https://fburl.com/code/94ta7omp. Currently, the best solution is to do another pass of the graph and modify the device accordingly when environments change, in this case DMP for distributed training

Differential Revision: D60532584
