### PR TITLE
Cast tensor dtype to long in _unwrap_kjt_for_cpu

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -161,7 +161,11 @@ def _unwrap_kjt(
 def _unwrap_kjt_for_cpu(
     features: KeyedJaggedTensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    return features.values(), features.offsets(), features.weights_or_none()
+    return (
+        features.values().long(),
+        features.offsets().long(),
+        features.weights_or_none(),
+    )
 
 
 @torch.fx.wrap


### PR DESCRIPTION
Summary: Follow up for: D60489592. The tensor dtype for indices could be casted to int32 by Preproc (e.g.: IGRankingTRPTrainPreproc) before lookup, this causes TBE lookup error in fbgemm kernel: https://fburl.com/everpaste/sqdb7rmt.

Differential Revision: D60535441
