### PR TITLE
Changed `LazyAwaitable.__torch_function__` to clasmethod

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -371,8 +371,9 @@ class LazyAwaitable(Awaitable[W], metaclass=_LazyAwaitableMeta):
         else:
             return obj
 
+    @classmethod
     # pyre-ignore [2, 3]
-    def __torch_function__(self, func, types, args=(), kwargs=None):
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
         """
         The LazyAwaitable type has a `__torch_function__` implementation.
         This means when this type is seens as an argument to a PyTorch


### PR DESCRIPTION
Summary: This avoids the deprecation warning causing a lot of log spam.

Reviewed By: idning, yjhao, wanchaol

Differential Revision: D60775821
