### PR TITLE
option to output DTensor in state dict through fused_params

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -901,9 +901,9 @@ class EmbeddingSharding(abc.ABC, Generic[C, F, T, W], FeatureShardingMixIn):
     """
 
     def __init__(
-        self, qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None
+        self,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
-
         self._qcomm_codecs_registry = qcomm_codecs_registry
 
     @property


### PR DESCRIPTION
Summary:
Users can optionally receive DTensor in state dict as opposed to ShardedTensor through fused_param setting, default is false.
```
fused_params: {"output_dtensor": True}
```

This diff only enable it for RW, these paths will be added for subsequent sharding schemes in their respective diff such as for CW/TWCW: D57063512

Differential Revision: D60932501
