### PR TITLE
fix pt2 test bug

### DIFF
--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -766,7 +766,6 @@ class TestPt2Train(MultiProcessTestBase):
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires one GPU",
     )
-    @settings(verbosity=Verbosity.verbose, deadline=None)
     def test_compile_multiprocess_fake_pg(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:
# context
to fix OSS CPU test bug
```
FAILED torchrec/distributed/tests/test_pt2_multiprocess.py::TestPt2Train::test_compile_multiprocess_fake_pg - hypothesis.errors.InvalidArgument: Using `settings` on a test without `given` is completely pointless.
```

Differential Revision: D50747500
