### PR TITLE
remove _embedding_collection alias in mc_embedding that causes extra ckpt storage

### DIFF
--- a/torchrec/distributed/mc_embedding.py
+++ b/torchrec/distributed/mc_embedding.py
@@ -9,7 +9,7 @@
 
 #!/usr/bin/env python3
 
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, cast, Dict, List, Optional, Type
 
 import torch
 
@@ -87,9 +87,10 @@ class ShardedManagedCollisionEmbeddingCollection(
             device,
         )
 
-        # For consistency with embeddingbag
-        # pyre-ignore [8]
-        self._embedding_collection: ShardedEmbeddingCollection = self._embedding_module
+    # For consistency with embeddingbag
+    @property
+    def _embedding_collection(self) -> ShardedEmbeddingCollection:
+        return cast(ShardedEmbeddingCollection, self._embedding_module)
 
     def create_context(
         self,

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -9,7 +9,7 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Type
+from typing import Any, cast, Dict, Optional, Type
 
 import torch
 from torchrec.distributed.embedding_types import KJTList
@@ -72,11 +72,10 @@ class ShardedManagedCollisionEmbeddingBagCollection(
             device,
         )
 
-        # For backwards compat, some references still to self._embedding_bag_collection
-        # pyre-ignore [8]
-        self._embedding_bag_collection: ShardedEmbeddingBagCollection = (
-            self._embedding_module
-        )
+    # For backwards compat, some references still to self._embedding_bag_collection
+    @property
+    def _embedding_bag_collection(self) -> ShardedEmbeddingBagCollection:
+        return cast(ShardedEmbeddingBagCollection, self._embedding_module)
 
     def create_context(
         self,

--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 
-from typing import Dict, Optional, Tuple, Union
+from typing import cast, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -110,8 +110,10 @@ class ManagedCollisionEmbeddingCollection(BaseManagedCollisionEmbeddingCollectio
             embedding_collection, managed_collision_collection, return_remapped_features
         )
 
-        # For consistency with embedding bag collection
-        self._embedding_collection: EmbeddingCollection = embedding_collection
+    # For consistency with embedding bag collection
+    @property
+    def _embedding_collection(self) -> EmbeddingCollection:
+        return cast(EmbeddingCollection, self._embedding_module)
 
 
 class ManagedCollisionEmbeddingBagCollection(BaseManagedCollisionEmbeddingCollection):
@@ -141,7 +143,7 @@ class ManagedCollisionEmbeddingBagCollection(BaseManagedCollisionEmbeddingCollec
             return_remapped_features,
         )
 
-        # For backwards compat, as references existed in tests
-        self._embedding_bag_collection: EmbeddingBagCollection = (
-            embedding_bag_collection
-        )
+    # For backwards compat, as references existed in tests
+    @property
+    def _embedding_bag_collection(self) -> EmbeddingBagCollection:
+        return cast(EmbeddingBagCollection, self._embedding_module)


### PR DESCRIPTION
Summary: the alias will make checkpoint create extra files to store the values (although having the same value). checked the code and dstaay-fb it is not necessary. The _embedding_collection style is mainly used when parent is sparse_arch, which does not seem to be our case either. so removing it.

Differential Revision: D61149486
