### PR TITLE
skip empty rank lookup

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -1050,7 +1050,7 @@ class EmbeddingsAllToOne(nn.Module):
         Returns:
             Awaitable[torch.Tensor]: awaitable of the merged embeddings.
         """
-        assert len(tensors) == self._world_size
+        assert len(tensors) <= self._world_size
 
         is_target_device_cpu: bool = self._device.type == "cpu"
 

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -825,11 +825,15 @@ def shard_qebc(
     expected_shards: Optional[List[List[Tuple[Tuple[int, int, int, int], str]]]] = None,
     plan: Optional[ShardingPlan] = None,
     ebc_fqn: str = "_module.sparse.ebc",
+    shard_score_ebc: bool = False,
 ) -> torch.nn.Module:
     sharder = TestQuantEBCSharder(
         sharding_type=sharding_type.value,
         kernel_type=EmbeddingComputeKernel.QUANT.value,
-        shardable_params=[table.name for table in mi.tables],
+        shardable_params=(
+            [table.name for table in mi.tables]
+            + ([table.name for table in mi.weighted_tables] if shard_score_ebc else [])
+        ),
     )
     if not plan:
         # pyre-ignore


### PR DESCRIPTION
Summary: We have observe issue when run in predictor side with empty ranks (rank with TBEs). In this diff, we try to skip the creation of lookup for empty rank to remove all invalid operations for empty rank.

Differential Revision: D61020328
