### PR TITLE
Sync .pyre_configuration.external files for those that got out of sync with last upgrade

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -480,7 +480,9 @@ def transform_module(
 
             sharded_module = _shard_modules(
                 module=copied_module,
-                # pyre-ignore [6]
+                # pyre-fixme[6]: For 2nd argument expected
+                #  `Optional[List[ModuleSharder[Module]]]` but got
+                #  `List[ModuleSharder[Variable[T (bound to Module)]]]`.
                 sharders=[sharder],
                 device=device,
                 plan=plan,
@@ -489,13 +491,14 @@ def transform_module(
 
     if compile_mode == CompileMode.FX_SCRIPT:
         return fx_script_module(
-            # pyre-ignore [6]
+            # pyre-fixme[6]: For 1st argument expected `Module` but got
+            #  `Optional[Module]`.
             sharded_module
             if not benchmark_unsharded_module
             else module
         )
     else:
-        # pyre-ignore [7]
+        # pyre-fixme[7]: Expected `Module` but got `Optional[Module]`.
         return sharded_module if not benchmark_unsharded_module else module
 
 

--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -101,7 +101,9 @@ def _test_sharding(  # noqa C901
             # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
             #  `Optional[ProcessGroup]`.
             env=ShardingEnv.from_process_group(ctx.pg),
-            # pyre-ignore
+            # pyre-fixme[6]: For 4th argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[EmbeddingCollectionSharder]`.
             sharders=[sharder],
             device=ctx.device,
         )

--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -668,7 +668,8 @@ class ShardedInferenceKeyedJaggedTensorPool(
         raise NotImplementedError("Inference does not support update")
 
     def _update_preproc(self, values: KeyedJaggedTensor) -> KeyedJaggedTensor:
-        # pyre-fixme[7]: Expected `Tensor` but got implicit return value of `None`.
+        # pyre-fixme[7]: Expected `KeyedJaggedTensor` but got implicit return value
+        #  of `None`.
         pass
 
 

--- a/torchrec/distributed/object_pool.py
+++ b/torchrec/distributed/object_pool.py
@@ -132,13 +132,15 @@ class ShardedObjectPool(
         # pyre-ignore[2]
         **kwargs,
     ) -> Awaitable[Awaitable[torch.Tensor]]:
-        # pyre-ignore
+        # pyre-fixme[7]: Expected `Awaitable[Awaitable[Tensor]]` but got implicit
+        #  return value of `None`.
         pass
 
     def compute(self, ctx: ShrdCtx, dist_input: torch.Tensor) -> DistOut:
-        # pyre-ignore
+        # pyre-fixme[7]: Expected `DistOut` but got implicit return value of `None`.
         pass
 
     def output_dist(self, ctx: ShrdCtx, output: DistOut) -> LazyAwaitable[Out]:
-        # pyre-ignore
+        # pyre-fixme[7]: Expected `LazyAwaitable[Variable[Out]]` but got implicit
+        #  return value of `None`.
         pass

--- a/torchrec/distributed/shards_wrapper.py
+++ b/torchrec/distributed/shards_wrapper.py
@@ -27,7 +27,9 @@ from torch.distributed.checkpoint.planner import (
 aten = torch.ops.aten  # pyre-ignore[5]
 
 
-class LocalShardsWrapper(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
+# pyre-fixme[13]: Attribute `_local_shards` is never initialized.
+# pyre-fixme[13]: Attribute `_storage_meta` is never initialized.
+class LocalShardsWrapper(torch.Tensor):
     """
     A wrapper class to hold local shards of a DTensor.
     This class is used largely for checkpointing purposes and implicity subtypes

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -862,7 +862,8 @@ def shard_qebc(
     quant_model_copy = copy.deepcopy(mi.quant_model)
     sharded_model = _shard_modules(
         module=quant_model_copy,
-        # pyre-ignore
+        # pyre-fixme[6]: For 2nd argument expected
+        #  `Optional[List[ModuleSharder[Module]]]` but got `List[TestQuantEBCSharder]`.
         sharders=[sharder],
         device=device,
         plan=plan,
@@ -912,7 +913,8 @@ def shard_qec(
     quant_model_copy = copy.deepcopy(mi.quant_model)
     sharded_model = _shard_modules(
         module=quant_model_copy,
-        # pyre-ignore
+        # pyre-fixme[6]: For 2nd argument expected
+        #  `Optional[List[ModuleSharder[Module]]]` but got `List[TestQuantECSharder]`.
         sharders=[sharder],
         device=device,
         plan=plan,

--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -110,7 +110,9 @@ class InferHeteroShardingsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=non_sharded_model,
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[QuantEmbeddingCollectionSharder]`.
             sharders=[sharder],
             device=torch.device(sharding_device),
             plan=plan,
@@ -201,7 +203,9 @@ class InferHeteroShardingsTest(unittest.TestCase):
         }
         sharded_model = _shard_modules(
             module=non_sharded_model,
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[QuantEmbeddingBagCollectionSharder]`.
             sharders=[sharder],
             device=torch.device("cpu"),
             plan=plan,

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -2025,7 +2025,9 @@ class InferShardingsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=quant_model,
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[QuantFeatureProcessedEmbeddingBagCollectionSharder]`.
             sharders=[sharder],
             device=local_device,
             plan=plan,
@@ -2180,7 +2182,9 @@ class InferShardingsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=quant_model,
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[QuantFeatureProcessedEmbeddingBagCollectionSharder]`.
             sharders=[sharder],
             # shard on meta to simulate device movement from cpu -> meta QFPEBC
             device=torch.device("meta"),

--- a/torchrec/distributed/tests/test_infer_utils.py
+++ b/torchrec/distributed/tests/test_infer_utils.py
@@ -103,7 +103,9 @@ class UtilsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=quant_model[0],
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[TestQuantEBCSharder]`.
             sharders=[sharder],
             device=device,
             plan=plan,
@@ -178,7 +180,9 @@ class UtilsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=quant_model[0],
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[TestQuantECSharder]`.
             sharders=[sharder],
             device=device,
             plan=plan,
@@ -256,7 +260,9 @@ class UtilsTest(unittest.TestCase):
 
         sharded_model = _shard_modules(
             module=quant_model[0],
-            # pyre-ignore
+            # pyre-fixme[6]: For 2nd argument expected
+            #  `Optional[List[ModuleSharder[Module]]]` but got
+            #  `List[TestQuantEBCSharder]`.
             sharders=[sharder],
             device=device,
             plan=plan,

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -44,7 +44,8 @@ try:
     # other metaclasses (i.e. AwaitableMeta) for customized
     # behaviors, as Generic is non-trival metaclass in
     # python 3.6 and below
-    from typing import GenericMeta  # pyre-ignore: python 3.6
+    # pyre-fixme[21]: Could not find name `GenericMeta` in `typing` (stubbed).
+    from typing import GenericMeta
 except ImportError:
     # In python 3.7+, GenericMeta doesn't exist as it's no
     # longer a non-trival metaclass,


### PR DESCRIPTION
Summary:
This downgrades the .pyre_configurations in the following projects to keep their internal and external configurations synced.
- beanmachine/beanmachine/ppl
- tools/sapp
- torchrec
- torchx

The versions were chosen to match the most recent Pyre version in [pyre-check-nightly](https://pypi.org/project/pyre-check-nightly/#history).

Differential Revision: D61211101
