### PR TITLE
Don't skip_torchrec when using torchrec PT2 pipeline

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -248,6 +248,7 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
                 torch._dynamo.config.force_unspec_int_unbacked_size_like_on_torchrec_kjt = (
                     True
                 )
+                torch._dynamo.config.skip_torchrec = False
 
                 # Importing only before compilation to not slow-done train_pipelines import
                 torch.ops.import_module("fbgemm_gpu.sparse_ops")


### PR DESCRIPTION
Summary: We introduced `torch._dynamo.config.skip_torchrec` to control whether tracing into torchrec paths. PT2 pipeline is mainly used for torchrec PT2 compilation, so it should set `skip_torchrec` to False by default

Differential Revision: D61219995
