### PR TITLE
Use weights_only for load

### DIFF
--- a/examples/retrieval/two_tower_retrieval.py
+++ b/examples/retrieval/two_tower_retrieval.py
@@ -136,7 +136,7 @@ def infer(
             # pyre-ignore[16]
             faiss.read_index(f"{load_dir}/faiss.index"),
         )
-        two_tower_sd = torch.load(f"{load_dir}/model.pt")
+        two_tower_sd = torch.load(f"{load_dir}/model.pt", weights_only=True)
         retrieval_sd = convert_TwoTower_to_TwoTowerRetrieval(
             two_tower_sd,
             [f"t_{two_tower_column_names[0]}"],

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -238,7 +238,7 @@ class TestKeyedOptimizer(unittest.TestCase):
         bytesIO = io.BytesIO()
         torch.save(opt, bytesIO)
         bytesIO.seek(0)
-        reload_opt = torch.load(bytesIO, weights_only=True)
+        reload_opt = torch.load(bytesIO, weights_only=False)
 
         for k in reload_opt.state_dict():
             self.assertEqual(

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -238,7 +238,7 @@ class TestKeyedOptimizer(unittest.TestCase):
         bytesIO = io.BytesIO()
         torch.save(opt, bytesIO)
         bytesIO.seek(0)
-        reload_opt = torch.load(bytesIO)
+        reload_opt = torch.load(bytesIO, weights_only=True)
 
         for k in reload_opt.state_dict():
             self.assertEqual(
@@ -274,7 +274,7 @@ class TestCombinedOptimizer(unittest.TestCase):
         bytesIO = io.BytesIO()
         torch.save(combined_optimizer, bytesIO)
         bytesIO.seek(0)
-        reload_combined_optimizer = torch.load(bytesIO)
+        reload_combined_optimizer = torch.load(bytesIO, weights_only=True)
 
         for k in reload_combined_optimizer.state_dict():
             self.assertEqual(

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -274,7 +274,7 @@ class TestCombinedOptimizer(unittest.TestCase):
         bytesIO = io.BytesIO()
         torch.save(combined_optimizer, bytesIO)
         bytesIO.seek(0)
-        reload_combined_optimizer = torch.load(bytesIO, weights_only=True)
+        reload_combined_optimizer = torch.load(bytesIO, weights_only=False)
 
         for k in reload_combined_optimizer.state_dict():
             self.assertEqual(


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/