### PR TITLE
adapt MCModules to operate on global ids

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -205,6 +205,7 @@ def bucketize_kjt_before_all2all(
     output_permute: bool = False,
     bucketize_pos: bool = False,
     block_bucketize_row_pos: Optional[List[torch.Tensor]] = None,
+    keep_original_indices: bool = False,
 ) -> Tuple[KeyedJaggedTensor, Optional[torch.Tensor]]:
     """
     Bucketizes the `values` in KeyedJaggedTensor into `num_buckets` buckets,
@@ -221,6 +222,7 @@ def bucketize_kjt_before_all2all(
         bucketize_pos (bool): output the changed position of the bucketized values or
             not.
         block_bucketize_row_pos (Optional[List[torch.Tensor]]): The offsets of shard size for each feature.
+        keep_original_indices (bool): whether to keep the original indices or not.
 
     Returns:
         Tuple[KeyedJaggedTensor, Optional[torch.Tensor]]: the bucketized `KeyedJaggedTensor` and the optional permute mapping from the unbucketized values to bucketized value.
@@ -249,8 +251,8 @@ def bucketize_kjt_before_all2all(
         batch_size_per_feature=_fx_wrap_batch_size_per_feature(kjt),
         max_B=_fx_wrap_max_B(kjt),
         block_bucketize_pos=block_bucketize_row_pos,  # each tensor should have the same dtype as kjt.lengths()
+        keep_orig_idx=keep_original_indices,
     )
-
     return (
         KeyedJaggedTensor(
             # duplicate keys will be resolved by AllToAll

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -282,6 +282,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         is_sequence: bool = False,
         has_feature_processor: bool = False,
         need_pos: bool = False,
+        keep_original_indices: bool = False,
     ) -> None:
         super().__init__()
         self._world_size: int = pg.size()
@@ -306,6 +307,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         self._has_feature_processor = has_feature_processor
         self._need_pos = need_pos
         self.unbucketize_permute_tensor: Optional[torch.Tensor] = None
+        self._keep_original_indices = keep_original_indices
 
     def forward(
         self,
@@ -336,6 +338,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
                 if sparse_features.weights_or_none() is None
                 else self._need_pos
             ),
+            keep_original_indices=self._keep_original_indices,
         )
 
         return self._dist(bucketized_features)

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -879,7 +879,12 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         )
         self.register_buffer(
             "_mch_remapped_ids_mapping",
-            torch.arange(self._zch_size, dtype=torch.int64, device=self.device),
+            torch.arange(
+                start=self._output_global_offset,
+                end=self._output_global_offset + self._zch_size,
+                dtype=torch.int64,
+                device=self.device,
+            ),
         )
 
         self._evicted_emb_indices: torch.Tensor = torch.empty((1,), device=self.device)
@@ -1161,7 +1166,9 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
                 searched_indices[matching_indices]
             ]
             # default embedding for non-matching ids
-            remapped_ids[~matching_indices] = self._zch_size - 1
+            remapped_ids[~matching_indices] = (
+                self._output_global_offset + self._zch_size - 1
+            )
 
             remapped_features[name] = JaggedTensor(
                 values=remapped_ids,


### PR DESCRIPTION
Summary: MC Modules (which effectively remap from input space into a table.num_embeddings) originally were working on local id ranges (due to RW block bucketization kernel behavior).  This leverages recent work on kernel to switch to global id space which allows eas(ier) resharding logic.

Differential Revision: D61344283
