### PR TITLE
reshard support

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -205,6 +205,7 @@ def bucketize_kjt_before_all2all(
     output_permute: bool = False,
     bucketize_pos: bool = False,
     block_bucketize_row_pos: Optional[List[torch.Tensor]] = None,
+    keep_original_indices: bool = False,
 ) -> Tuple[KeyedJaggedTensor, Optional[torch.Tensor]]:
     """
     Bucketizes the `values` in KeyedJaggedTensor into `num_buckets` buckets,
@@ -221,6 +222,7 @@ def bucketize_kjt_before_all2all(
         bucketize_pos (bool): output the changed position of the bucketized values or
             not.
         block_bucketize_row_pos (Optional[List[torch.Tensor]]): The offsets of shard size for each feature.
+        keep_original_indices (bool): whether to keep the original indices or not.
 
     Returns:
         Tuple[KeyedJaggedTensor, Optional[torch.Tensor]]: the bucketized `KeyedJaggedTensor` and the optional permute mapping from the unbucketized values to bucketized value.
@@ -249,8 +251,8 @@ def bucketize_kjt_before_all2all(
         batch_size_per_feature=_fx_wrap_batch_size_per_feature(kjt),
         max_B=_fx_wrap_max_B(kjt),
         block_bucketize_pos=block_bucketize_row_pos,  # each tensor should have the same dtype as kjt.lengths()
+        keep_orig_idx=keep_original_indices,
     )
-
     return (
         KeyedJaggedTensor(
             # duplicate keys will be resolved by AllToAll

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -282,6 +282,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         is_sequence: bool = False,
         has_feature_processor: bool = False,
         need_pos: bool = False,
+        keep_original_indices: bool = False,
     ) -> None:
         super().__init__()
         self._world_size: int = pg.size()
@@ -306,6 +307,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         self._has_feature_processor = has_feature_processor
         self._need_pos = need_pos
         self.unbucketize_permute_tensor: Optional[torch.Tensor] = None
+        self._keep_original_indices = keep_original_indices
 
     def forward(
         self,
@@ -336,6 +338,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
                 if sparse_features.weights_or_none() is None
                 else self._need_pos
             ),
+            keep_original_indices=self._keep_original_indices,
         )
 
         return self._dist(bucketized_features)

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -28,7 +28,12 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ShardedTensor,
+    ShardingEnv,
+    ShardingPlan,
+)
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.embedding_modules import EmbeddingCollection
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
@@ -254,7 +259,7 @@ def _test_sharding_and_remapping(  # noqa C901
                 tensor = sharded_tensor.local_shards()[0].tensor.cpu()
                 assert torch.equal(
                     tensor, final_state_per_rank[ctx.rank][postfix]
-                ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {initial_state_per_rank[rank][postfix]}"
+                ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {final_state_per_rank[rank][postfix]}"
 
         remapped_ids = [remapped_ids1, remapped_ids2]
         for key in kjt_input.keys():
@@ -265,6 +270,176 @@ def _test_sharding_and_remapping(  # noqa C901
                 ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
 
         # TODO: validate embedding rows, and eviction
+
+
+def _test_sharding_and_resharding(  # noqa C901
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    kjt_out_per_iter_per_rank: List[List[KeyedJaggedTensor]],
+    initial_state_per_rank: List[Dict[str, torch.Tensor]],
+    final_state_per_rank: List[Dict[str, torch.Tensor]],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+
+        kjt_input = kjt_input_per_rank[rank].to(ctx.device)
+        kjt_out_per_iter = [
+            kjt[rank].to(ctx.device) for kjt in kjt_out_per_iter_per_rank
+        ]
+        return_remapped: bool = True
+        sparse_arch = SparseArch(
+            tables,
+            torch.device("meta"),
+            return_remapped=return_remapped,
+        )
+
+        apply_optimizer_in_backward(
+            RowWiseAdagrad,
+            [
+                sparse_arch._mc_ec._embedding_collection.embeddings["table_0"].weight,
+                sparse_arch._mc_ec._embedding_collection.embeddings["table_1"].weight,
+            ],
+            {"lr": 0.01},
+        )
+        module_sharding_plan = construct_module_sharding_plan(
+            sparse_arch._mc_ec,
+            per_param_sharding={"table_0": row_wise(), "table_1": row_wise()},
+            local_size=local_size,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+            sharder=sharder,
+        )
+
+        sharded_sparse_arch = _shard_modules(
+            module=copy.deepcopy(sparse_arch),
+            plan=ShardingPlan({"_mc_ec": module_sharding_plan}),
+            # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+            #  `Optional[ProcessGroup]`.
+            env=ShardingEnv.from_process_group(ctx.pg),
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        assert isinstance(
+            sharded_sparse_arch._mc_ec, ShardedManagedCollisionEmbeddingCollection
+        )
+        assert isinstance(
+            sharded_sparse_arch._mc_ec._embedding_collection,
+            ShardedEmbeddingCollection,
+        )
+        assert (
+            sharded_sparse_arch._mc_ec._embedding_collection._has_uninitialized_input_dist
+            is False
+        )
+        assert (
+            not hasattr(
+                sharded_sparse_arch._mc_ec._embedding_collection, "_input_dists"
+            )
+            or len(sharded_sparse_arch._mc_ec._embedding_collection._input_dists) == 0
+        )
+
+        assert isinstance(
+            sharded_sparse_arch._mc_ec._managed_collision_collection,
+            ShardedManagedCollisionCollection,
+        )
+        # sharded model
+        # each rank gets a subbatch
+        loss1, remapped_ids1 = sharded_sparse_arch(kjt_input)
+        loss1.backward()
+        loss2, remapped_ids2 = sharded_sparse_arch(kjt_input)
+        loss2.backward()
+        remapped_ids = [remapped_ids1, remapped_ids2]
+        for key in kjt_input.keys():
+            for i, kjt_out in enumerate(kjt_out_per_iter[:2]):  # first two iterations
+                assert torch.equal(
+                    remapped_ids[i][key].values(),
+                    kjt_out[key].values(),
+                ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+
+        state_dict = sharded_sparse_arch.state_dict()
+        cpu_state_dict = {}
+        for key, tensor in state_dict.items():
+            if isinstance(tensor, ShardedTensor):
+                tensor = tensor.local_shards()[0].tensor
+            cpu_state_dict[key] = tensor.to("cpu")
+        gather_list = [None, None] if ctx.rank == 0 else None
+        torch.distributed.gather_object(cpu_state_dict, gather_list)
+
+    if rank == 0:
+        with MultiProcessContext(rank, 1, backend, 1) as ctx:
+            kjt_input = kjt_input_per_rank[rank].to(ctx.device)
+            sparse_arch = SparseArch(
+                tables,
+                torch.device("meta"),
+                return_remapped=return_remapped,
+            )
+
+            apply_optimizer_in_backward(
+                RowWiseAdagrad,
+                [
+                    sparse_arch._mc_ec._embedding_collection.embeddings[
+                        "table_0"
+                    ].weight,
+                    sparse_arch._mc_ec._embedding_collection.embeddings[
+                        "table_1"
+                    ].weight,
+                ],
+                {"lr": 0.01},
+            )
+            module_sharding_plan = construct_module_sharding_plan(
+                sparse_arch._mc_ec,
+                per_param_sharding={"table_0": row_wise(), "table_1": row_wise()},
+                local_size=1,
+                world_size=1,
+                device_type="cuda" if torch.cuda.is_available() else "cpu",
+                sharder=sharder,
+            )
+
+            sharded_sparse_arch = _shard_modules(
+                module=copy.deepcopy(sparse_arch),
+                plan=ShardingPlan({"_mc_ec": module_sharding_plan}),
+                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but got
+                #  `Optional[ProcessGroup]`.
+                env=ShardingEnv.from_process_group(ctx.pg),
+                sharders=[sharder],
+                device=ctx.device,
+            )
+            state_dict = sharded_sparse_arch.state_dict()
+
+            for key in state_dict.keys():
+                if isinstance(state_dict[key], ShardedTensor):
+                    replacement_tensor = torch.cat(
+                        # pyre-ignore [16]
+                        [gather_list[0][key], gather_list[1][key]],
+                        dim=0,
+                    ).to(ctx.device)
+                    state_dict[key].local_shards()[0].tensor.copy_(replacement_tensor)
+                else:
+                    state_dict[key] = gather_list[0][key].to(ctx.device)
+
+            sharded_sparse_arch.load_state_dict(state_dict)
+            loss3, remapped_ids3 = sharded_sparse_arch(kjt_input)
+            final_state_dict = sharded_sparse_arch.state_dict()
+            for key, sharded_tensor in final_state_dict.items():
+                postfix = ".".join(key.split(".")[-2:])
+                if postfix in final_state_per_rank[ctx.rank]:
+                    tensor = sharded_tensor.local_shards()[0].tensor.cpu()
+                    assert torch.equal(
+                        tensor, final_state_per_rank[ctx.rank][postfix]
+                    ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {final_state_per_rank[rank][postfix]}"
+
+            remapped_ids = [remapped_ids3]
+            for key in kjt_input.keys():
+                for i, kjt_out in enumerate(kjt_out_per_iter[-1:]):  # last iteration
+                    assert torch.equal(
+                        remapped_ids[i][key].values(),
+                        kjt_out[key].values(),
+                    ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
 
 
 @skip_if_asan_class
@@ -331,6 +506,180 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
             callable=_test_sharding,
             world_size=WORLD_SIZE,
             tables=embedding_config,
+            sharder=ManagedCollisionEmbeddingCollectionSharder(),
+            backend=backend,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    # pyre-ignore
+    @given(backend=st.sampled_from(["nccl"]))
+    @settings(deadline=None)
+    def test_sharding_zch_mc_ec_reshard(self, backend: str) -> None:
+
+        WORLD_SIZE = 2
+
+        embedding_config = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+            EmbeddingConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=32,
+            ),
+        ]
+
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [1000, 2000, 1001, 2000, 2001, 2002],
+                ),
+                lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                weights=None,
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [
+                        1000,
+                        1002,
+                        1004,
+                        2000,
+                        2002,
+                        2004,
+                    ],
+                ),
+                lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                weights=None,
+            ),
+        ]
+
+        kjt_out_per_iter_per_rank: List[List[KeyedJaggedTensor]] = []
+        kjt_out_per_iter_per_rank.append(
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor(
+                        [7, 15, 7, 31, 31, 31],
+                    ),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                    weights=None,
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor(
+                        [7, 7, 7, 31, 31, 31],
+                    ),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                    weights=None,
+                ),
+            ]
+        )
+        # TODO: cleanup sorting so more dedugable/logical initial fill
+
+        kjt_out_per_iter_per_rank.append(
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor(
+                        [3, 14, 4, 27, 29, 28],
+                    ),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                    weights=None,
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor(
+                        [3, 5, 6, 27, 28, 30],
+                    ),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                    weights=None,
+                ),
+            ]
+        )
+
+        kjt_out_per_iter_per_rank.append(
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor(
+                        [3, 14, 4, 27, 29, 28],
+                    ),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1]),
+                    weights=None,
+                ),
+                KeyedJaggedTensor.empty(),
+            ]
+        )
+
+        max_int = torch.iinfo(torch.int64).max
+
+        final_state_per_rank = [
+            {
+                "table_0._mch_sorted_raw_ids": torch.LongTensor(
+                    [1000, 1001, 1002, 1004, 2000] + [max_int] * (16 - 5)
+                ),
+                "table_1._mch_sorted_raw_ids": torch.LongTensor(
+                    [2000, 2001, 2002, 2004] + [max_int] * (32 - 4)
+                ),
+                "table_0._mch_remapped_ids_mapping": torch.LongTensor(
+                    [3, 4, 5, 6, 14, 0, 1, 2, 7, 8, 9, 10, 11, 12, 13, 15],
+                ),
+                "table_1._mch_remapped_ids_mapping": torch.LongTensor(
+                    [
+                        27,
+                        29,
+                        28,
+                        30,
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26,
+                        31,
+                    ],
+                ),
+            },
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_sharding_and_resharding,
+            world_size=WORLD_SIZE,
+            tables=embedding_config,
+            kjt_input_per_rank=kjt_input_per_rank,
+            kjt_out_per_iter_per_rank=kjt_out_per_iter_per_rank,
+            initial_state_per_rank=None,
+            final_state_per_rank=final_state_per_rank,
             sharder=ManagedCollisionEmbeddingCollectionSharder(),
             backend=backend,
         )

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -879,7 +879,12 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         )
         self.register_buffer(
             "_mch_remapped_ids_mapping",
-            torch.arange(self._zch_size, dtype=torch.int64, device=self.device),
+            torch.arange(
+                start=self._output_global_offset,
+                end=self._output_global_offset + self._zch_size,
+                dtype=torch.int64,
+                device=self.device,
+            ),
         )
 
         self._evicted_emb_indices: torch.Tensor = torch.empty((1,), device=self.device)
@@ -1161,7 +1166,9 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
                 searched_indices[matching_indices]
             ]
             # default embedding for non-matching ids
-            remapped_ids[~matching_indices] = self._zch_size - 1
+            remapped_ids[~matching_indices] = (
+                self._output_global_offset + self._zch_size - 1
+            )
 
             remapped_features[name] = JaggedTensor(
                 values=remapped_ids,


### PR DESCRIPTION
Summary:
ZCH modules can support limited resharding, specifically, it must align along existing boundaries from last training.  Ie. [50, 50, 50, 50] -> [100, 100], but [34, 34, 33] is not valid.

This diff adds that logic to existing TREC MC modules.

Differential Revision: D61213903
