### PR TITLE
update DTensor namespace for non public APIs in TorchRec

### DIFF
--- a/torchrec/distributed/tests/test_shards_wrapper.py
+++ b/torchrec/distributed/tests/test_shards_wrapper.py
@@ -11,9 +11,8 @@ import unittest
 from typing import List, Optional, Union
 
 import torch
-from hypothesis import settings, Verbosity
 from torch import distributed as dist
-from torch.distributed._tensor._shards_wrapper import LocalShardsWrapper
+from torchrec.distributed.shards_wrapper import LocalShardsWrapper
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,


### PR DESCRIPTION
Summary: Fix OSS CI for `_shards_wrapper` distributed tensor namespace has changed from _tensor to tensor.

Differential Revision: D61483729
