### PR TITLE
Fix torch.export stuckness with APS full model export

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -988,7 +988,12 @@ def _maybe_compute_length_per_key(
     values: Optional[torch.Tensor],
 ) -> List[int]:
     if length_per_key is None:
-        if len(keys) and values is not None and values.is_meta:
+        if (
+            len(keys)
+            and values is not None
+            and values.is_meta
+            and not is_non_strict_exporting()
+        ):
             # create dummy lengths per key when on meta device
             total_length = values.numel()
             _length = [total_length // len(keys)] * len(keys)


### PR DESCRIPTION
Summary: Resolve torch.export stuckness in exporting full model IG CTR for PT2 full stack inference workstream: https://docs.google.com/document/d/14LUIir04SkiagOchVpiOrXg-Pqqg5MiG9ArYNzWwyik/edit

Differential Revision: D61560171
