### PR TITLE
MCH module + Q/SQ EC Test / Bug Fixes

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -676,7 +676,7 @@ class KJTOneToAll(nn.Module):
                 "cpu" if device is None else device.type
             )  # TODO: replace hardcoded cpu with DEFAULT_DEVICE_TYPE in torchrec.distributed.types when torch package issue resolved
         else:
-            # If no device is provided, use "cuda".
+            # BUG: device will default to cuda if cpu specified
             self._device_type: str = (
                 device.type
                 if device is not None and device.type in {"meta", "cuda", "mtia"}

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -319,7 +319,7 @@ def bucketize_kjt_inference(
             num_buckets=num_buckets,
             block_sizes=block_sizes_new_type,
             bucketize_pos=bucketize_pos,
-            block_bucketize_pos=block_bucketize_row_pos,  # each tensor should have the same dtype as kjt.lengths()
+            block_bucketize_pos=block_bucketize_row_pos,
         )
     else:
         (


### PR DESCRIPTION
Summary:
Initial to do Prod strategy is use unsharded MCH module in front of Q / SQ EC.  General seems ok, but biggest issue:

[2] uneven sharding flag was not respected for rw sequence GPU case, easy fix cc: gnahzg
[3] get_propogate device is bit unf/messy, will cleanup in followup task, but found edgecase wrt cpu path cc: gnahzg

Differential Revision: D61572421
