### PR TITLE
add l2_cache_size config path from model config

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -1156,6 +1156,10 @@ class KeyValueEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor], FusedOptimizer
             **ssd_tbe_params,
         ).to(device)
 
+        logger.info(
+            f"tbe_unique_id:{self._emb_module.tbe_unique_id} => table name to count dict:{self.table_name_to_count}"
+        )
+
         self._optim: KeyValueEmbeddingFusedOptimizer = KeyValueEmbeddingFusedOptimizer(
             config,
             self._emb_module,

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -610,6 +610,7 @@ class KeyValueParams:
     gather_ssd_cache_stats: Optional[bool] = None
     stats_reporter_config: Optional[TBEStatsReporterConfig] = None
     use_passed_in_path: bool = True
+    l2_cache_size: Optional[int] = None
 
     # Parameter Server (PS) Attributes
     ps_hosts: Optional[Tuple[Tuple[str, int], ...]] = None
@@ -623,13 +624,15 @@ class KeyValueParams:
                 self.ssd_storage_directory,
                 self.ssd_rocksdb_write_buffer_size,
                 self.ssd_rocksdb_shards,
-                self.gather_ssd_cache_stats,
-                self.stats_reporter_config,
                 # Parameter Server (PS) Attributes
                 self.ps_hosts,
                 self.ps_client_thread_num,
                 self.ps_max_key_per_request,
                 self.ps_max_local_index_length,
+                # tbe attributes
+                self.gather_ssd_cache_stats,
+                self.stats_reporter_config,
+                self.l2_cache_size,
             )
         )
 


### PR DESCRIPTION
Summary: support l2 cache size as a config passed from model side

Differential Revision: D61418000
