### PR TITLE
GMPP breakage fix

### DIFF
--- a/torchrec/distributed/__init__.py
+++ b/torchrec/distributed/__init__.py
@@ -36,7 +36,6 @@ These include:
 
 from torchrec.distributed.comm import get_local_rank, get_local_size  # noqa
 from torchrec.distributed.model_parallel import DistributedModelParallel  # noqa
-from torchrec.distributed.shard import shard, shard_modules  # noqa
 from torchrec.distributed.train_pipeline import (  # noqa
     DataLoadingThread,
     EvalPipelineSparseDist,


### PR DESCRIPTION
Summary: So traced issues with changes back to 5 month old introduction to __init__.py.   LSS never add anything to __init__.py due to design flaw with torch.package importer logic.

Differential Revision: D61839464
