### PR TITLE
Add clippy support for IG Models

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -52,6 +52,7 @@ class OptimType(Enum):
     SHAMPOO_V2 = "SHAMPOO_V2"
     LION = "LION"
     ADAMW = "ADAMW"
+    SHAMPOO_V2_MRS = "SHAMPOO_V2_MRS"
 
 
 @unique


### PR DESCRIPTION
Summary: Add clippy wrapper to shampoo_wrapper. I added shampoo_pt2_compile_config as an input as the main difference from the ads distributed wrapped.

Differential Revision: D60599611
