### PR TITLE
TorchRec MX4 padding support

### DIFF
--- a/torchrec/distributed/fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/fbgemm_qcomm_codec.py
@@ -197,14 +197,14 @@ def get_qcomm_codecs_registry(
         qcomm_config_copy = copy.deepcopy(qcomms_config)
         # TODO: On H100, FP8 types might be natively supported, in which case we should check for that arch type and not fallback.
         if comm_op == CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER:
-            if qcomm_config_copy.forward_precision == CommType.FP8:
+            if qcomm_config_copy.forward_precision in [CommType.FP8, CommType.MX4]:
                 logger.warning(
-                    "FP8 is not supported for reduce scatter's forward - falling back to FP16"
+                    "FP8/MX4 is not supported for reduce scatter's forward - falling back to FP16"
                 )
                 qcomm_config_copy.forward_precision = CommType.FP16
-            if qcomm_config_copy.backward_precision == CommType.FP8:
+            if qcomm_config_copy.backward_precision in [CommType.FP8, CommType.MX4]:
                 logger.warning(
-                    "FP8 is not supported for reduce scatter's backward - falling back to BF16"
+                    "FP8/MX4 is not supported for reduce scatter's backward - falling back to BF16"
                 )
                 qcomm_config_copy.backward_precision = CommType.BF16
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -224,6 +224,18 @@ class QuantizedCommCodec(Generic[QuantizationContext]):
         """
         ...
 
+    def padded_size(
+        self,
+        input_tensor: torch.Tensor,
+        dim_per_rank: List[int],
+        my_rank: int,
+        qcomm_ctx: QuantizationContext,
+    ) -> Tuple[int, int]:
+        """
+        Return (padded_dim_sum, padding_size) of the input tensor for quantization.
+        """
+        ...
+
 
 class NoOpQuantizedCommCodec(Generic[QuantizationContext]):
     """
@@ -256,6 +268,18 @@ class NoOpQuantizedCommCodec(Generic[QuantizationContext]):
 
     def create_context(self) -> Optional[QuantizationContext]:
         return None
+
+    def padded_size(
+        self,
+        input_tensor: torch.Tensor,
+        dim_per_rank: List[int],
+        my_rank: int,
+        qcomm_ctx: QuantizationContext,
+    ) -> Tuple[int, int]:
+        dim_sum = (
+            input_tensor.shape[0] if input_tensor.dim() == 1 else input_tensor.shape[1]
+        )
+        return dim_sum, 0
 
 
 @dataclass
@@ -343,7 +367,7 @@ class LazyAwaitable(Awaitable[W], metaclass=_LazyAwaitableMeta):
     Some caveats:
 
     * This works with Pytorch functions, but not any generic method, if
-      you would like to do arbitary python operations, you need to
+      you would like to do arbitrary python operations, you need to
       implement the corresponding magic methods
 
     * In the case that one function have two or more arguments are LazyAwaitable,


### PR DESCRIPTION
Summary: rowwise padding is needed to fix NE of Ads ranking models for AlltoAll communication with MX4.

Differential Revision: D61928939


