### PR TITLE
enable VBE in PEA

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -299,7 +299,6 @@ def get_inputs(
                 average_batch_size=batch_size,
                 world_size=world_size,
                 num_float_features=0,
-                # pyre-ignore
                 tables=tables,
             )
         else:

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -121,6 +121,7 @@ class VariableBatchModelInputCallable(Protocol):
         world_size: int,
         num_float_features: int,
         tables: Union[List[EmbeddingTableConfig], List[EmbeddingBagConfig]],
+        weighted_tables: Union[List[EmbeddingTableConfig], List[EmbeddingBagConfig]],
         pooling_avg: int = 10,
         global_constant_batch: bool = False,
     ) -> Tuple["ModelInput", List["ModelInput"]]: ...
@@ -181,6 +182,7 @@ def gen_model_and_input(
                 world_size=world_size,
                 num_float_features=num_float_features,
                 tables=tables,
+                weighted_tables=weighted_tables or [],
                 global_constant_batch=global_constant_batch,
             )
             if generate == ModelInput.generate_variable_batch_input
@@ -273,10 +275,10 @@ def sharding_single_rank_test(
     apply_optimizer_in_backward_config: Optional[
         Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
     ] = None,
-    variable_batch_size: bool = False,
+    variable_batch_size: bool = False,  # variable batch per rank
     batch_size: int = 4,
     feature_processor_modules: Optional[Dict[str, torch.nn.Module]] = None,
-    variable_batch_per_feature: bool = False,
+    variable_batch_per_feature: bool = False,  # VBE
     global_constant_batch: bool = False,
 ) -> None:
 

--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -356,7 +356,6 @@ def _test_compile_rank_fn(
                     average_batch_size=batch_size,
                     world_size=world_size,
                     num_float_features=num_float_features,
-                    # pyre-ignore
                     tables=mi.tables,
                 )
             else:


### PR DESCRIPTION
Summary:
* adds VBE support to PEA
  * supports VBE with weighted features (id score list)
  * note that this support requires inverse indices to be passed in via KJT (this can be changed)
  * note that VBE output of PEA is not by group and is by feature i.e. output is dict of feature name to tensor (this can be changed, but matches current VLE behavior)
* refactors output awaitable to be shared with VLE arch
* refactors VBE format test input generation
* note this refactors usage of keyed jagged index select function as for weights it only takes in float dtype, so if it's non float weight dtype it will be cast to float for permute then back to original dtype

Differential Revision: D60188967
