### PR TITLE
Fix ph_key issue with trec pipeline

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -774,7 +774,8 @@ def _get_node_args_helper(
                     # pyre-ignore[16]
                     ph_key: str = child_node.ph_key
                     # example: ph_key = 'event_id_list_features_seqs[marketplace]'
-                    ph_keys = ph_key.split("[")
+                    ph_key = ph_key.replace("[", ".")
+                    ph_keys = ph_key.split(".")
                     for key in ph_keys:
                         if "]" in key:
                             arg_info.input_attrs.append(key[:-1])


### PR DESCRIPTION
Summary:
Fix ph_key issue by:
1. make ph_key for TrainModelInput to be model_input.id_list_features["defalut"]
2. handles parsing in trec utils.

Differential Revision: D62160686
