### PR TITLE
[detailed] benchmark on SplitTBE module with different emb-dim

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_split_table_batched_embeddings.py
+++ b/torchrec/distributed/benchmark/benchmark_split_table_batched_embeddings.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import click
+
+import torch
+
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
+
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+    BoundsCheckMode,
+    EmbeddingLocation,
+    PoolingMode,
+)
+from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
+    ComputeDevice,
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
+from torchrec.distributed.benchmark.benchmark_utils import benchmark_func
+from torchrec.distributed.test_utils.test_model import ModelInput
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+@click.command()
+@click.option("--num-embeddings", default=100_000)
+@click.option("--embedding-dim", default=128)
+@click.option("--num-tables", default=4)
+@click.option("--batch-size", default=262144)
+@click.option("--bag-size", default=10)
+def main(
+    num_embeddings: int,
+    embedding_dim: int,
+    num_tables: int,
+    batch_size: int,
+    bag_size: int,
+) -> None:
+    if embedding_dim == 0:
+        for embedding_dim in [4, 4, 8, 16, 32, 64, 128, 256, 512, 1024]:
+            op_bench(num_embeddings, embedding_dim, num_tables, batch_size, bag_size)
+    else:
+        op_bench(num_embeddings, embedding_dim, num_tables, batch_size, bag_size)
+
+
+def op_bench(
+    num_embeddings: int,
+    embedding_dim: int,
+    num_tables: int,
+    batch_size: int,
+    bag_size: int,
+) -> None:
+    emb = SplitTableBatchedEmbeddingBagsCodegen(
+        [
+            (
+                num_embeddings,
+                embedding_dim,
+                EmbeddingLocation.DEVICE,
+                (
+                    ComputeDevice.CUDA
+                    if torch.cuda.is_available()
+                    else ComputeDevice.CPU
+                ),
+            )
+        ]
+        * num_tables,
+        optimizer=OptimType.EXACT_ADAGRAD,
+        learning_rate=0.1,
+        eps=0.1,
+        weights_precision=SparseType.FP32,
+        stochastic_rounding=False,
+        output_dtype=SparseType.FP32,
+        pooling_mode=PoolingMode.SUM,
+        bounds_check_mode=BoundsCheckMode.NONE,
+    )
+
+    def _func_to_benchmark(
+        kjt: KeyedJaggedTensor,
+        model: torch.nn.Module,
+    ) -> torch.Tensor:
+        return model.forward(kjt.values(), kjt.offsets())
+
+    # breakpoint()  # import fbvscode; fbvscode.set_trace()
+    tables = [
+        EmbeddingBagConfig(
+            num_embeddings=num_embeddings,
+            embedding_dim=embedding_dim,
+            name="table_0",
+            feature_names=["feature_0"],
+        )
+    ]
+    inputs = ModelInput.generate(
+        tables=tables,
+        weighted_tables=[],
+        batch_size=batch_size,
+        world_size=1,
+        num_float_features=0,
+        pooling_avg=10,
+        device=torch.device("cuda"),
+    )[0].idlist_features
+
+    result = benchmark_func(
+        name=f"SplitTableBatchedEmbeddingBagsCodegen-{num_embeddings}-{embedding_dim}-{num_tables}-{batch_size}-{bag_size}",
+        bench_inputs=inputs,  # pyre-ignore
+        prof_inputs=inputs,  # pyre-ignore
+        num_benchmarks=10,
+        num_profiles=10,
+        profile_dir=".",
+        world_size=1,
+        func_to_benchmark=_func_to_benchmark,
+        benchmark_func_kwargs={"model": emb},
+        rank=0,
+        pre_gpu_load=3,
+    )
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
# context
* benchmark results w/ small batch_size
```
SplitTableBatchedEmbeddingBagsCodegen-1000-16-4-1024-10 | Runtime (P90): 0.289728 ms | Memory (P90): 1 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-32-4-1024-10 | Runtime (P90): 0.304992 ms | Memory (P90): 1 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-64-4-1024-10 | Runtime (P90): 0.315392 ms | Memory (P90): 3 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-128-4-1024-10 | Runtime (P90): 0.295552 ms | Memory (P90): 5 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-256-4-1024-10 | Runtime (P90): 0.30096 ms | Memory (P90): 9 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-512-4-1024-10 | Runtime (P90): 0.317056 ms | Memory (P90): 18 MB
SplitTableBatchedEmbeddingBagsCodegen-1000-1024-4-1024-10 | Runtime (P90): 0.31792 ms | Memory (P90): 36 MB
```
* benchmark results w/ large batch_size
```
SplitTableBatchedEmbeddingBagsCodegen-100000-16-16-131072-10 | Runtime (P90): 0.587584 ms | Memory (P90): 0.31 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-32-16-131072-10 | Runtime (P90): 0.722624 ms | Memory (P90): 0.51 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-64-16-131072-10 | Runtime (P90): 1.29395 ms | Memory (P90): 0.92 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-128-16-131072-10 | Runtime (P90): 2.73472 ms | Memory (P90): 1.7 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-256-16-131072-10 | Runtime (P90): 6.5608 ms | Memory (P90): 3.4 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-512-16-131072-10 | Runtime (P90): 14.8527 ms | Memory (P90): 6.6 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-1024-16-131072-10 | Runtime (P90): 31.055 ms | Memory (P90): 13 GB
```

# traces
* [trace files](https://fburl.com/gdrive/t8qaitoi)
* batch_size - 128
<img width="3142" height="592" alt="image" src="https://github.com/user-attachments/assets/93933f9e-9de8-408f-9e40-69504f5d779c" />

* batch_size - 32
<img width="3400" height="508" alt="image" src="https://github.com/user-attachments/assets/cb50647f-fccf-41fb-96ce-f00e8ad150fd" />

* dim-64: 0.30ms
<img width="2340" height="1044" alt="image" src="https://github.com/user-attachments/assets/e717b80b-2cdc-450e-b388-18c688e959f9" />

* dim-32: 0.16ms
<img width="1930" height="1120" alt="image" src="https://github.com/user-attachments/assets/a612cedb-4f6f-42b5-9d3e-946413189bbd" />

* dim-16: 0.15ms
<img width="2316" height="1118" alt="image" src="https://github.com/user-attachments/assets/c17ce8d6-4e7f-4e33-aa6f-c35478437dbd" />

* dim-8: 0.12ms
<img width="2166" height="1154" alt="image" src="https://github.com/user-attachments/assets/cb8c3a5d-c88c-43d4-a7be-be5742bf6bb1" />

* dim-4: 0.12ms
<img width="2160" height="1108" alt="image" src="https://github.com/user-attachments/assets/038633ac-934d-420f-b874-86f2fb0a463d" />


# discussions
* the kernel contains two major parts run on GPU: 1) a lightweighted `direct_copy_kernel_cuda`, and 2) a heavy-lifting `split_embedding_codegen_forward_unweighted_kernel`. 
* details of the `direct_copy_kernel_cuda`
<img width="3152" height="1834" alt="image" src="https://github.com/user-attachments/assets/b13fd92d-2192-4daa-a26c-2760f69827e5" />

* the cpu runtime for launching these two GPU kernels (~3.8ms from the traces), which is the bottleneck of this operator.

# conclusions
* for the heavy-lifting kernel, there is a plateau value (minimum) regarding to the embedding dimension, which is at 32.
* after applying pre-benchmark gpu load, runtime is only determined by the heavy-lifting kernel:
```
SplitTableBatchedEmbeddingBagsCodegen-100000-4-4-262144-10 | Runtime (P90): 0.121216 ms | Memory (P90): 7.5 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-8-4-262144-10 | Runtime (P90): 0.134432 ms | Memory (P90): 7.5 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-16-4-262144-10 | Runtime (P90): 0.160608 ms | Memory (P90): 7.5 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-32-4-262144-10 | Runtime (P90): 0.174016 ms | Memory (P90): 7.6 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-64-4-262144-10 | Runtime (P90): 0.310464 ms | Memory (P90): 7.7 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-128-4-262144-10 | Runtime (P90): 0.647872 ms | Memory (P90): 7.9 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-256-4-262144-10 | Runtime (P90): 1.45062 ms | Memory (P90): 8.3 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-512-4-262144-10 | Runtime (P90): 3.33741 ms | Memory (P90): 9 GB
SplitTableBatchedEmbeddingBagsCodegen-100000-1024-4-262144-10 | Runtime (P90): 7.01872 ms | Memory (P90): 11 GB
```
* spreadsheets
<img width="2576" height="768" alt="image" src="https://github.com/user-attachments/assets/551b6060-cc42-4a0b-9b85-a4dbcf6dfd88" />

  | num_embeddings | embedding_dim | num_tables | batch_size | bag_size | gpu runtime |   | gpu memory |   | speed
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
SplitTableBatchedEmbeddingBagsCodegen-100000-4-4-262144-10 | 100000 | 4 | 4 | 262144 | 10 | 0.120768 | ms | 3.1 | GB | 33.12135665
SplitTableBatchedEmbeddingBagsCodegen-100000-8-4-262144-10 | 100000 | 8 | 4 | 262144 | 10 | 0.134432 | ms | 3.1 | GB | 59.50964056
SplitTableBatchedEmbeddingBagsCodegen-100000-12-4-262144-10 | 100000 | 12 | 4 | 262144 | 10 | 0.149088 | ms | 3.1 | GB | 80.4893754
SplitTableBatchedEmbeddingBagsCodegen-100000-16-4-262144-10 | 100000 | 16 | 4 | 262144 | 10 | 0.161056 | ms | 3.1 | GB | 99.34432744
SplitTableBatchedEmbeddingBagsCodegen-100000-24-4-262144-10 | 100000 | 24 | 4 | 262144 | 10 | 0.174336 | ms | 3.2 | GB | 137.6651982
SplitTableBatchedEmbeddingBagsCodegen-100000-32-4-262144-10 | 100000 | 32 | 4 | 262144 | 10 | 0.17536 | ms | 3.2 | GB | 182.4817518
SplitTableBatchedEmbeddingBagsCodegen-100000-40-4-262144-10 | 100000 | 40 | 4 | 262144 | 10 | 0.290784 | ms | 3.2 | GB | 137.5591504
SplitTableBatchedEmbeddingBagsCodegen-100000-48-4-262144-10 | 100000 | 48 | 4 | 262144 | 10 | 0.303456 | ms | 3.2 | GB | 158.1777918
SplitTableBatchedEmbeddingBagsCodegen-100000-56-4-262144-10 | 100000 | 56 | 4 | 262144 | 10 | 0.32368 | ms | 3.3 | GB | 173.0103806
SplitTableBatchedEmbeddingBagsCodegen-100000-64-4-262144-10 | 100000 | 64 | 4 | 262144 | 10 | 0.31184 | ms | 3.3 | GB | 205.2334531
SplitTableBatchedEmbeddingBagsCodegen-100000-72-4-262144-10 | 100000 | 72 | 4 | 262144 | 10 | 0.538304 | ms | 3.3 | GB | 133.7534181
SplitTableBatchedEmbeddingBagsCodegen-100000-80-4-262144-10 | 100000 | 80 | 4 | 262144 | 10 | 0.55024 | ms | 3.3 | GB | 145.3911021
SplitTableBatchedEmbeddingBagsCodegen-100000-88-4-262144-10 | 100000 | 88 | 4 | 262144 | 10 | 0.577824 | ms | 3.4 | GB | 152.2955087
SplitTableBatchedEmbeddingBagsCodegen-100000-96-4-262144-10 | 100000 | 96 | 4 | 262144 | 10 | 0.578432 | ms | 3.4 | GB | 165.9659217
SplitTableBatchedEmbeddingBagsCodegen-100000-104-4-262144-10 | 100000 | 104 | 4 | 262144 | 10 | 0.627168 | ms | 3.4 | GB | 165.824787
SplitTableBatchedEmbeddingBagsCodegen-100000-112-4-262144-10 | 100000 | 112 | 4 | 262144 | 10 | 0.64256 | ms | 3.4 | GB | 174.3027888
SplitTableBatchedEmbeddingBagsCodegen-100000-120-4-262144-10 | 100000 | 120 | 4 | 262144 | 10 | 0.685216 | ms | 3.5 | GB | 175.1272591
SplitTableBatchedEmbeddingBagsCodegen-100000-128-4-262144-10 | 100000 | 128 | 4 | 262144 | 10 | 0.649856 | ms | 3.5 | GB | 196.9667126
SplitTableBatchedEmbeddingBagsCodegen-100000-256-4-262144-10 | 100000 | 256 | 4 | 262144 | 10 | 1.44794 | ms | 3.9 | GB | 176.8029062
SplitTableBatchedEmbeddingBagsCodegen-100000-512-4-262144-10 | 100000 | 512 | 4 | 262144 | 10 | 3.3343 | ms | 4.7 | GB | 153.5554689
SplitTableBatchedEmbeddingBagsCodegen-100000-1024-4-262144-10 | 100000 | 1024 | 4 | 262144 | 10 | 7.01322 | ms | 6.2 | GB | 146.009964


Differential Revision: D62254614
