### PR TITLE
Add test case for BC Unit test

### DIFF
--- a/torchrec/schema/test_schema_utils.py
+++ b/torchrec/schema/test_schema_utils.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import inspect
+
+import unittest
+from typing import Any, Dict, Tuple
+
+from .utils import is_signature_compatible
+
+
+def stable_test_func(
+    a: int, b: float, *, c: int, d: float = 1.0, **kwargs: Dict[str, Any]
+) -> int:
+    return a
+
+
+def stable_test_func_basic(
+    a: int,
+    b: float,
+    c: bool = True,
+    d: float = 1.0,
+) -> bool:
+    return c
+
+
+class TestUtils(unittest.TestCase):
+    def test_is_not_backwards_compatible(self) -> None:
+        ## stable_test_func tests
+        def test_func_positional_arg_removed(
+            a: int, *, c: int, d: float = 1.0, **kwargs: Dict[str, Any]
+        ) -> int:
+            return a
+
+        def test_func_positional_arg_added(
+            a: int,
+            b: float,
+            z: float,
+            *,
+            c: int,
+            d: float = 1.0,
+            **kwargs: Dict[str, Any],
+        ) -> int:
+            return a
+
+        def test_func_keyword_arg_removed(
+            a: int, b: float, *, d: float = 1.0, **kwargs: Dict[str, Any]
+        ) -> int:
+            return a
+
+        def test_func_var_kwargs_removed(
+            a: int, b: float, z: float, *, d: float = 1.0
+        ) -> int:
+            return a
+
+        def test_func_var_args_removed(
+            a: int, b: float, z: float, d: float = 1.0, **kwargs: Dict[str, Any]
+        ) -> int:
+            return a
+
+        # stable_test_func_basic tests
+        def test_func_basic_keyword_or_pos_arg_shifted(
+            a: int,
+            b: float,
+            d: float = 1.0,
+            c: bool = True,
+        ) -> bool:
+            return c
+
+        def test_func_basic_add_arg_in_middle(
+            a: int,
+            b: float,
+            d: float = 1.0,
+            z: float = 1.0,
+            c: bool = True,
+        ) -> bool:
+            return c
+
+        def test_func_basic_default_arg_changed(
+            a: int,
+            b: float,
+            c: bool = True,
+            d: float = 2.0,
+        ) -> bool:
+            return c
+
+        def test_func_basic_default_arg_removed(
+            a: int,
+            b: float,
+            c: bool,
+            d: float = 1.0,
+        ) -> bool:
+            return c
+
+        def test_func_basic_arg_type_change(
+            a: int,
+            b: bool,
+            c: bool = True,
+            d: float = 1.0,
+        ) -> bool:
+            return c
+
+        def test_func_basic_return_type_changed(
+            a: int,
+            b: float,
+            c: bool = True,
+            d: float = 1.0,
+        ) -> int:
+            return a
+
+        local_funcs = locals()
+        for name, func in local_funcs.items():
+            if name.startswith("test_func_basic"):
+                self.assertFalse(
+                    is_signature_compatible(
+                        inspect.signature(stable_test_func_basic),
+                        inspect.signature(func),
+                    ),
+                    f"{name} is backwards compatible with stable_test_func_basic when it shouldn't be.",
+                )
+            elif name.startswith("test_func"):
+                self.assertFalse(
+                    is_signature_compatible(
+                        inspect.signature(stable_test_func), inspect.signature(func)
+                    ),
+                    f"{name} is not backwards compatible with stable_test_func when it shouldn't be.",
+                )
+            else:
+                continue
+
+    def test_is_backwards_compatible(self) -> None:
+        # stable_test_func tests
+        def test_func_keyword_arg_added(
+            a: int,
+            b: float,
+            *,
+            c: int,
+            d: float = 1.0,
+            e: float = 1.0,
+            **kwargs: Dict[str, Any],
+        ) -> int:
+            return a
+
+        def test_func_keyword_arg_shifted(
+            a: int, b: float, *, d: float = 1.0, c: int, **kwargs: Dict[str, Any]
+        ) -> int:
+            return a
+
+        # stable_test_func_basic tests
+        def test_func_basic_add_arg_at_end(
+            a: int,
+            b: float,
+            c: bool = True,
+            d: float = 1.0,
+            e: float = 1.0,
+        ) -> bool:
+            return c
+
+        def test_func_basic_add_var_args_at_end(
+            a: int,
+            b: float,
+            c: bool = True,
+            d: float = 1.0,
+            *args: Tuple[Any],
+        ) -> bool:
+            return c
+
+        def test_func_basic_add_var_kwargs_at_end(
+            a: int,
+            b: float,
+            c: bool = True,
+            d: float = 1.0,
+            **kwargs: Dict[str, Any],
+        ) -> bool:
+            return c
+
+        local_funcs = locals()
+        for name, func in local_funcs.items():
+            if name.startswith("test_func_basic"):
+                self.assertTrue(
+                    is_signature_compatible(
+                        inspect.signature(stable_test_func_basic),
+                        inspect.signature(func),
+                    ),
+                    f"{name} is supposed to be backwards compatible with stable_test_func_basic",
+                )
+            elif name.startswith("test_func"):
+                self.assertTrue(
+                    is_signature_compatible(
+                        inspect.signature(stable_test_func), inspect.signature(func)
+                    ),
+                    f"{name} is supposed to be backwards compatible with stable_test_func",
+                )
+            else:
+                continue

--- a/torchrec/schema/test_schema_utils.py
+++ b/torchrec/schema/test_schema_utils.py
@@ -147,6 +147,17 @@ class TestUtils(unittest.TestCase):
         ) -> int:
             return a
 
+        def test_func_keyword_arg_added_in_middle(
+            a: int,
+            b: float,
+            *,
+            c: int,
+            e: float = 1.0,
+            d: float = 1.0,
+            **kwargs: Dict[str, Any],
+        ) -> int:
+            return a
+
         def test_func_keyword_arg_shifted(
             a: int, b: float, *, d: float = 1.0, c: int, **kwargs: Dict[str, Any]
         ) -> int:

--- a/torchrec/schema/utils.py
+++ b/torchrec/schema/utils.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import inspect
+
+
+def is_signature_compatible(
+    expected_signature: inspect.Signature,
+    current_signature: inspect.Signature,
+) -> bool:
+    """Check if two signatures are compatible.
+
+    Args:
+        sig1: The first signature.
+        sig2: The second signature.
+        ignore_types: Whether to ignore types when checking compatibility.
+        ignore_names: Whether to ignore names when checking compatibility.
+
+    Returns:
+        True if the signatures are compatible, False otherwise.
+
+    """
+
+    # If current signature has less parameters than expected signature
+    # BC is automatically broken, no need to check further
+    if len(expected_signature.parameters) > len(current_signature.parameters):
+        return False
+
+    # Check order of positional arguments
+    expected_args = list(expected_signature.parameters.values())
+    current_args = list(current_signature.parameters.values())
+
+    expected_keyword_only_args = set()
+    current_keyword_only_args = set()
+
+    for i in range(len(expected_args)):
+        expected_arg = expected_args[i]
+        current_arg = current_args[i]
+
+        # If the kinds of arguments are different, BC is broken
+        # unless current arg is a keyword argument
+        if expected_arg.kind != current_arg.kind:
+            if expected_arg.kind == expected_arg.VAR_KEYWORD:
+                # Any arg can be inserted before **kwargs and still maintain BC
+                continue
+            else:
+                return False
+
+        # Potential positional arguments need to have the same name
+        # keyword only arguments can be mixed up
+        if expected_arg.kind == expected_arg.POSITIONAL_OR_KEYWORD:
+            if expected_arg.name != current_arg.name:
+                return False
+
+            # Positional arguments need to have the same type annotation
+            # TODO: Account for Union Types?
+            if expected_arg.annotation != current_arg.annotation:
+                return False
+
+            # Positional arguments need to have the same default value
+            if expected_arg.default != current_arg.default:
+                return False
+        elif expected_arg.kind == expected_arg.KEYWORD_ONLY:
+            # Store the names of all keyword only arguments
+            # to check if all expected keyword only arguments
+            # are present in current signature
+            expected_keyword_only_args.add(expected_arg.name)
+            current_keyword_only_args.add(current_arg.name)
+
+    # All kwargs in expected signature must be present in current signature
+    for kwarg in expected_keyword_only_args:
+        if kwarg not in current_keyword_only_args:
+            return False
+
+    # TODO: Account for Union Types?
+    if current_signature.return_annotation != expected_signature.return_annotation:
+        return False
+    return True

--- a/torchrec/schema/utils.py
+++ b/torchrec/schema/utils.py
@@ -36,12 +36,23 @@ def is_signature_compatible(
     expected_args = list(expected_signature.parameters.values())
     current_args = list(current_signature.parameters.values())
 
+    # Store the names of all keyword only arguments
+    # to check if all expected keyword only arguments
+    # are present in current signature
     expected_keyword_only_args = set()
     current_keyword_only_args = set()
 
-    for i in range(len(expected_args)):
-        expected_arg = expected_args[i]
+    expected_args_len = len(expected_args)
+
+    for i in range(len(current_args)):
         current_arg = current_args[i]
+        if current_arg.kind == current_arg.KEYWORD_ONLY:
+            current_keyword_only_args.add(current_arg.name)
+
+        if i >= expected_args_len:
+            continue
+
+        expected_arg = expected_args[i]
 
         # If the kinds of arguments are different, BC is broken
         # unless current arg is a keyword argument
@@ -67,11 +78,7 @@ def is_signature_compatible(
             if expected_arg.default != current_arg.default:
                 return False
         elif expected_arg.kind == expected_arg.KEYWORD_ONLY:
-            # Store the names of all keyword only arguments
-            # to check if all expected keyword only arguments
-            # are present in current signature
             expected_keyword_only_args.add(expected_arg.name)
-            current_keyword_only_args.add(current_arg.name)
 
     # All kwargs in expected signature must be present in current signature
     for kwarg in expected_keyword_only_args:


### PR DESCRIPTION
Summary:
We need another test case for `keyword_only` arguments - where new arguments aren't necessarily added to the end of the signature.

Also updated logic for `is_signature_compatible` to handle/check for this case

Reviewed By: PaulZhang12

Differential Revision: D62470290
