### PR TITLE
[Do NOT MERGE] Example of hiding content

### DIFF
--- a/docs/source/torchrec.modules.rst
+++ b/docs/source/torchrec.modules.rst
@@ -43,7 +43,6 @@ torchrec.modules.embedding\_modules
 -----------------------------------
 
 .. automodule:: torchrec.modules.embedding_modules
-.. autofunction:: torchrec.modules.embedding_modules
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/torchrec.modules.rst
+++ b/docs/source/torchrec.modules.rst
@@ -1,93 +1,100 @@
 torchrec.modules
 ================
 
-.. automodule:: torchrec.modules
+..
+  This is a commment and all the indented text is a comment
+  It will never show up in the final HTML
 
-torchrec.modules.activation
----------------------------
+  .. automodule:: torchrec.modules
 
-.. automodule:: torchrec.modules.activation
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.activation
+  ---------------------------
 
-torchrec.modules.crossnet
--------------------------
+  .. automodule:: torchrec.modules.activation
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-.. automodule:: torchrec.modules.crossnet
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.crossnet
+  -------------------------
 
-torchrec.modules.deepfm
------------------------
+  .. automodule:: torchrec.modules.crossnet
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-.. automodule:: torchrec.modules.deepfm
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.deepfm
+  -----------------------
 
-torchrec.modules.embedding\_configs
------------------------------------
+  .. automodule:: torchrec.modules.deepfm
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-.. automodule:: torchrec.modules.embedding_configs
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.embedding\_configs
+  -----------------------------------
+
+  .. automodule:: torchrec.modules.embedding_configs
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
 torchrec.modules.embedding\_modules
 -----------------------------------
 
-.. automodule:: torchrec.modules.embedding_modules
+.. autofunction:: torchrec.modules.embedding_modules
    :members:
    :undoc-members:
    :show-inheritance:
 
-torchrec.modules.feature\_processor
------------------------------------
+.. 
+  This is a comment too and all the indented text below is hidden in the build as well
 
-.. automodule:: torchrec.modules.feature_processor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.feature\_processor
+  -----------------------------------
 
-torchrec.modules.lazy\_extension
---------------------------------
+  .. automodule:: torchrec.modules.feature_processor
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-.. automodule:: torchrec.modules.lazy_extension
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.lazy\_extension
+  --------------------------------
 
-torchrec.modules.mlp
---------------------
+  .. automodule:: torchrec.modules.lazy_extension
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-.. automodule:: torchrec.modules.mlp
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  torchrec.modules.mlp
+  --------------------
+
+  .. automodule:: torchrec.modules.mlp
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
 
-torchrec.modules.utils
-----------------------
+  torchrec.modules.utils
+  ----------------------
 
-.. automodule:: torchrec.modules.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  .. automodule:: torchrec.modules.utils
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-torchrec.modules.mc_modules
----------------
+  torchrec.modules.mc_modules
+  ---------------
 
-.. automodule:: torchrec.modules.mc_modules
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  .. automodule:: torchrec.modules.mc_modules
+     :members:
+     :undoc-members:
+     :show-inheritance:
 
-torchrec.modules.mc_embedding_modules
----------------
+  torchrec.modules.mc_embedding_modules
+  ---------------
 
-.. automodule:: torchrec.modules.mc_embedding_modules
-   :members:
-   :undoc-members:
-   :show-inheritance:
+  .. automodule:: torchrec.modules.mc_embedding_modules
+     :members:
+     :undoc-members:
+     :show-inheritance:

--- a/docs/source/torchrec.modules.rst
+++ b/docs/source/torchrec.modules.rst
@@ -1,11 +1,11 @@
 torchrec.modules
 ================
 
+.. automodule:: torchrec.modules
+
 ..
   This is a commment and all the indented text is a comment
   It will never show up in the final HTML
-
-  .. automodule:: torchrec.modules
 
   torchrec.modules.activation
   ---------------------------
@@ -42,6 +42,7 @@ torchrec.modules
 torchrec.modules.embedding\_modules
 -----------------------------------
 
+.. automodule:: torchrec.modules.embedding_modules
 .. autofunction:: torchrec.modules.embedding_modules
    :members:
    :undoc-members:


### PR DESCRIPTION
This is an example of how we can hide content in .rst files that we don't want to expose yet. We can hide the APIs that we don't want to yet publish or the pages that are empty.

In Sphinx, comments can hide the content that you don't want to yet be available on your site. Here is how you can add a comment:
```
.. 
  This is my comment
  All lines that are indented will be hidden. 
  See the changed files in this PR for example
```
More about .rst [here](https://stackoverflow.com/questions/4783814/how-to-comment-a-string-in-restructured-text). 

Compare: 
* Published: https://pytorch.org/torchrec/torchrec.modules.html#module-torchrec.modules.embedding_modules (Every single automodule, autofunction is published)
vs
* Preview: https://docs-preview.pytorch.org/pytorch/torchrec/2385/torchrec.modules.html (Everything that is hidden by a comment, does not appear in the HTML)
