### PR TITLE
[detailed][pt2] PT2 IR - add kT._keys to pytree unflatten function to preserve the correct key order

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2943,7 +2943,15 @@ def _kt_unflatten(
 
 
 def _kt_flatten_spec(kt: KeyedTensor, spec: TreeSpec) -> List[torch.Tensor]:
-    return _kt_flatten(kt)[0]
+    _keys, _length_per_key = spec.context
+    #  please read https://fburl.com/workplace/8bei5iju for more context,
+    #  you can also consider use short_circuit_pytree_ebc_regroup with KTRegroupAsDict
+    logger.warning(
+        "KT's key order might change from spec from the torch.export, this could have perf impact. "
+        f"{kt.keys()} vs {_keys}"
+    )
+    res = permute_multi_embedding([kt], [_keys])
+    return [res[0]]
 
 
 # The assumption here in torch.exporting KeyedTensor is that _length_per_key is static


### PR DESCRIPTION
# Key-Order Issue in EBC with IR Export

## TL;DR
* The order of the key list (`List[str]`) in a KT could differ between the unsharded model and the sharded model. This conflicts with the torch export assumption of static spec in metadata. 
* It causes the current NE regression issue because in the APS training process we generate the exported IR from the unsharded model and shard the model afterwards. 
* A short-term workaround can mitigate the NE regression but still need to work on a mid-term solution to address the QPS regression.
* On top of the short-term workaround which addressed the numeric correctness, we developed a graph short-circuit optimization to eliminate the flatten&unflatten functions between the EBCs and the KTRegroupAsDict modules. Both QPS and NE are on-par, and unblocks the SMT model launch.

## How IR Handles KT
A [KeyedTensor](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3263) (KT) is a compact representation of a batch of multiple embeddings. The core data is the values tensor, and other metadata like keys, lengths as shown below.
<img width="1600" height="502" alt="image" src="https://github.com/user-attachments/assets/a5967621-53fd-40b7-aeaa-f8ff6db5f2fe" />

Conceptually in the IR you only need to handle a few basic data structures, like Tensor, scalar, int, bool, list, tuple, etc. When generating the IR in torch.export, a KT will be flattened to those basic elements by a designated [flatten](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3528) function registered to pytree. **The spec will be stored in metadata as static (constant) attached to the graph**. When running the graph module, the KT will be flattened using a different function named [flatten_with_spec](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3540), which directly uses the spec stored in metadata. 
<img width="1600" height="547" alt="image" src="https://github.com/user-attachments/assets/ff485827-e22b-44c6-8307-e626eec0220c" />

In the IR export, we can also [preserve module call signature](https://github.com/pytorch/pytorch/blob/main/torch/export/_trace.py#L2464-L2465), which is used for handling sparse modules (for sharding and other purposes). The basic idea for a “preserved” module is that the input and output of the module remain the same format as the original (eager) module. This makes the module swapping more feasible.
<img width="1600" height="640" alt="image" src="https://github.com/user-attachments/assets/db036ea4-998a-438f-83c4-8e215d6475a5" />

Using the KT.regroup module as an example, it takes in a list of KTs and produces a list of KTs. When running the IR graph modules, the required spec and tensors are [unflattened](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3534) to reconstruct the input KTs before feeding to the preserved module, and the output KTs will be flattened to spec and tensors again, which are compatible with the IR graph. Please note that all the spec are static and stored in the metadata from the very first torch.export run, which is before running the IR graph module.

## Why Key Order Could Change
It’s rooted in the distributed nature of sharded modules. The embedding tables will be placed in different ranks (GPUs) and the returned embeddings will come back in an arbitrary order. The key order could not only differ between sharded and unsharded modules, but also between different batches/runs of the unsharded module. 
<img width="1600" height="778" alt="image" src="https://github.com/user-attachments/assets/a2f2cf1e-dfc1-4630-bf24-ad9ed2d462db" />

## NE Regression in APS Model Training

In APS training flow, a model is created eagerly on CPU (or meta), then exported as IR artifacts. During the export, sparse modules like EBC are preserved for module call signature. an EBC outputs a KT, which will be flattened to a values tensor and spec (e.g., keys and lengths), and the latter will be stored in metadata as static. 

Then the exported graph module will be sharded in TorchRec, specifically the EBCs will be replaced by shardedEBCs, and the sharded model will be trained on a multiple-GPU environment. 

As previously described, the output KT of sharded-EBC effectively has a different key order than the eager EBC (unsharded). However, all the spec are stored in graph metadata based on the eager EBC. This means all the results from sharded-EBCs are mathematically incorrect!

We narrowed the issue down to EBC by comparing it with a PEA architecture. There is no NE regression issue with PEAs because a PEA returns an embedding dictionary, which is order-insensitive. 

## Short-Term Solution

In the beginning we are not sure about whether the key-order issue is the root cause of the NE regression problem. A natural thought of verification is that we can permute the KT everytime running the [flatten_with_spec](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3548) function so that the flattened values are in sync with the key order in the spec. 
<img width="1600" height="611" alt="image" src="https://github.com/user-attachments/assets/bd8cc294-adab-4f83-9221-e1380fdf2c70" />

However, the introduced KT.regroup (permute) operation brings extra GPU workloads on major data (pooled embeddings), and slows down the training QPS. 

With the short-term solution, the NE is within noise limit (IR vs non-IR), which confirmed the key-order root cause hypothesis, and surprisingly, the QPS increased 25% (w/ vs w/o the short-term solution). However, QPS is still 25% lower than the baseline (IR vs non-IR). 

## Mid-Term Solution

Instead of permuting the data-heavy values tensor in the unflatten function, we wonder how we can handle the key order as variables and restore the correct order in the downstream operations. 

Fortunately, we found that in the current APS model, all the KTs from the EBCs are feeded into a KTRegroupAsDict module, which is also a “preserved” module. So all the flattened KTs will be unflattened to KTs again.
<img width="1600" height="418" alt="image" src="https://github.com/user-attachments/assets/c3b21dcc-9c4c-4d68-a820-b41dc715e470" />

Considering `List[str]` and `List[int]` are currently handled as static spec, we can store the key order in an index tensor named `key_order`, which stores the index of the true key order based on the spec-stored key order. 

For example, For a true key order of k2, k1, k3, the `key_order` tensor should be [1, 0, 2], given the spec key order (in torch.export) of k1, k2, k3. Please note that the `key_order` tensor from the flatten function (in torch.export) should always be consecutive ([0, 1, 2, …]) because it’s the basis.

When we reconstruct the KT from the spec and the key_order tensor, the unflatten function just needs to permute the key order and lengths according to the key_order tensor, and the unflattened KT will be mathematically correct (key order may still differ from the eager run). 
<img width="1600" height="459" alt="image" src="https://github.com/user-attachments/assets/1e16b3ad-0718-4021-b904-8bcb8bf2744e" />


Current status of this approach is that we still encounter errors in torch.export, probably due to the complexity in the flatten/unflatten function.

## Discussions

What would be the best practice of supporting the key variability in KT/KJT with torch export, do we have a better solution than the current workaround (suppose the mid-term one can work out, otherwise it has to be the short-term solution)?

It would be much easier and more straightforward to handle the KT (probably KJT also) if the exported graph can mark some data structure as dynamic/variable in flatten/unflatten. 

## [Updated] Final Solution
The mid-term solution didn’t carry out due to its complications with torch.export. A more straightforward idea was proposed and prototyped that directly modifies the graph to remove the problematic KT flatten-unflatten pairs between the EBC and the KTRegroupAsDict modules (AKA, the short-circuit solution). This approach turns out to work well in performance as well as compatibility with the short-term solution (permute KT in the pytree unflatten function, AKA, the KT-permute solution).
<img width="1600" height="380" alt="image" src="https://github.com/user-attachments/assets/087fcd9b-1601-4be7-9c6c-0031832689a0" />


The final solution consists of both the KT-permute solution and the short-circuit solution. 

* The KT-permute solution (#2390) ensures the numeric correctness of the EBC/sharded-EBC module in the IR usa case. It has no performance impact in non-IR scenarios. It also has a [perf-impact warning](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L3544-L3547) when in use.
* The short-circuit solution (#2393) requires the EBCs followed up by a `KTRegroupAsDict` module. It’s integrated into the TorchRec IR main API, controlled by a [flag](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/ir/utils.py#L171) (default ON in APF/APS). It finds all the EBC and KTRegroupAsDict modules in a unflattened module:
    * short-circuit the EBC-KTregroupAsDict (remove the KT flatten&unflatten functions) modules if both modules exist.
    * warn performance impact if only the EBC exists
    * warn model authoring risk if only KTRegroupAsDict exists (unusual case, a KT currently only come from an EBC).
    * do nothing if neither EBC nor KTRegroupAsDict exists, this flag is safe to turn on and transparent to non-EBC models.

Reviewed By: PaulZhang12

Differential Revision: D59238744
