### PR TITLE
unify the definition of `EmbeddingTableType`

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -20,6 +20,12 @@ from torchrec.types import DataType
 
 
 @unique
+class EmbeddingTableType(Enum):
+    NORMAL = "NORMAL"
+    HASH_ZCH = "HASH_ZCH"
+
+
+@unique
 class PoolingType(Enum):
     SUM = "SUM"
     MEAN = "MEAN"


### PR DESCRIPTION
Summary:
# Problem
`EmbeddingTableType` is introduced recently for ZCH.

There are two same definitions of `EmbeddingTableType`
*  one is defined in [torchrec/fb/distributed/sparsenn_configs.py](https://www.internalfb.com/code/fbsource/[3a83814d95f27eec3bf425d468a5234d6ca8a381]/fbcode/torchrec/fb/distributed/sparsenn_configs.py?lines=110)
* The other is defined in [minimal_viable_ai/core/model_family_api/configs.py](https://www.internalfb.com/code/fbsource/[bbe727e13ae251889c5df57b58f2cbc05675662e]/fbcode/minimal_viable_ai/core/model_family_api/configs.py?lines=76)

**Problem is that**
The fields of `EmbeddingTable` defined in `minimal_viable_ai/core/model_family_api/configs.py` will be assigned to the `EmbeddingTable` defined in `torchrec/fb/distributed/sparsenn_configs.py`.

The assignment happens at [minimal_viable_ai/sandbox/umia_hstu/umia_configs_utils.py ](https://fburl.com/code/5gb24p9j) for model publish.
So if the EmbeddingTable are different, the assignment will fail.

# solution from this diff
* Option1: keep one of them, and the other import it. This would cause dependency loop;
* Option2(this diff): move the definition of `EmbeddingTableType` to [torchrec/modules/embedding_configs.py](https://fburl.com/code/tvob11sz)

Differential Revision: D62596655
