### PR TITLE
Remove torch.tx.wrapper decorator

### DIFF
--- a/torchrec/modules/tests/test_fp_embedding_modules.py
+++ b/torchrec/modules/tests/test_fp_embedding_modules.py
@@ -21,7 +21,7 @@ from torchrec.modules.feature_processor_ import (
     PositionWeightedModuleCollection,
 )
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
-from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
Fix the error in [post](https://fb.workplace.com/groups/gpuinference/permalink/496109449972692/): `'__torch__.torch.nn.modules.module.Module (of Python compilation unit at: 0x7f28f56423d0)' object has no attribute or method '__call__'. `.

This decorator [here](https://www.internalfb.com/code/fbsource/[2fb5b0775aca30f9031e62ad7d009e84897ca959]/fbcode/torchrec/modules/fp_embedding_modules.py?lines=22) prevents the function being traced. We need to remove it and also make this graph to be static.

Differential Revision: D63148032
