### PR TITLE
Enable EC Dedup for training

### DIFF
--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -121,6 +121,11 @@ class BaseShardedManagedCollisionEmbeddingCollection(
                 env=env,
                 device=device,
                 embedding_shardings=embedding_shardings,
+                use_index_dedup=(
+                    e_sharder._use_index_dedup
+                    if isinstance(e_sharder, EmbeddingCollectionSharder)
+                    else False
+                ),
             )
         )
         self._return_remapped_features: bool = module._return_remapped_features


### PR DESCRIPTION
Summary: EC Deduplication support for sparse ids using MC Modules / ZCH; applied at table level (similiar to traditional EC).  One caveat is the existing kernels linearize sparse ids at Collection level, so added relevant logic to ensure correct configuration.  Will refactor kernel in followup task to avoid constraint.

Differential Revision: D62552115
