### PR TITLE
Make KJT concat method fx-traceable

### DIFF
--- a/torchrec/sparse/tests/keyed_jagged_tensor_benchmark_lib.py
+++ b/torchrec/sparse/tests/keyed_jagged_tensor_benchmark_lib.py
@@ -35,6 +35,7 @@ DEFTAULT_BENCHMARK_FUNCS = [
     "permute",
     "to_dict",
     "split",
+    "concat",
     "__getitem__",
     "dist_splits",
     "dist_init",
@@ -296,6 +297,14 @@ class KJTSplit(torch.nn.Module):
         return kjt.split(segments)
 
 
+class KJTConcat(torch.nn.Module):
+    def forward(
+        self,
+        inputs: List[KeyedJaggedTensor],
+    ) -> KeyedJaggedTensor:
+        return KeyedJaggedTensor.concat(inputs)
+
+
 class KJTGetItem(torch.nn.Module):
     def forward(self, kjt: KeyedJaggedTensor, key: str) -> JaggedTensor:
         return kjt[key]
@@ -383,6 +392,7 @@ def bench(
         ("permute", {"kjt": kjt, "indices": permute_indices}, KJTPermute()),
         ("to_dict", {"kjt": kjt}, KJTToDict()),
         ("split", {"kjt": kjt, "segments": splits}, KJTSplit()),
+        ("concat", {"inputs": [kjt, kjt]}, KJTConcat()),
         ("__getitem__", {"kjt": kjt, "key": key}, KJTGetItem()),
         ("dist_splits", {"kjt": kjt, "key_splits": splits}, KJTDistSplits()),
         (

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -1537,6 +1537,39 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         # pyre-ignore[6]
         self.assertListEqual(kjt_expected._length_per_key, kjt_actual._length_per_key)
 
+    def test_concat_fxable(self) -> None:
+        class MyModule(torch.nn.Module):
+            def forward(self, inputs: List[KeyedJaggedTensor]) -> KeyedJaggedTensor:
+                return KeyedJaggedTensor.concat(inputs)
+
+        m = MyModule()
+
+        # input
+        values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+        keys = ["index_0", "index_1", "index_2"]
+        lengths = torch.IntTensor([0, 2, 0, 1, 1, 1, 0, 3, 0, 0, 1, 0])
+        kjt_1 = KeyedJaggedTensor.from_lengths_sync(
+            values=values[:4],
+            keys=keys[:1],
+            lengths=lengths[:4],
+        )
+        kjt_2 = KeyedJaggedTensor.from_lengths_sync(
+            values=values[4:],
+            keys=keys[1:],
+            lengths=lengths[4:],
+        )
+        inputs = [kjt_1, kjt_2]
+
+        # ensure that symbolic tracing works
+        gm = torch.fx.symbolic_trace(m)
+        kjt_expected = m(inputs)
+        kjt_actual = gm(inputs)
+
+        self.assertTrue(torch.equal(kjt_expected.lengths(), kjt_actual.lengths()))
+        self.assertTrue(torch.equal(kjt_expected.offsets(), kjt_actual.offsets()))
+        self.assertTrue(torch.equal(kjt_expected.values(), kjt_actual.values()))
+        self.assertListEqual(kjt_expected._length_per_key, kjt_actual._length_per_key)
+
     def test_length_vs_offset(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])


### PR DESCRIPTION
Summary: Make `KeyedJaggedTensor.concat` fx-traceable

Differential Revision: D63243563
