### PR TITLE
Prevent retries on Shampoo NaN errors

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -53,6 +53,7 @@ class OptimType(Enum):
     LION = "LION"
     ADAMW = "ADAMW"
     SHAMPOO_V2_MRS = "SHAMPOO_V2_MRS"
+    SHAMPOO_MRS = "SHAMPOO_MRS"
 
 
 @unique


### PR DESCRIPTION
Summary:
These NaN errors from the Shampoo stack consume 60kWs of IG's GPU power - N5687170. If a NaN error occurs, there is no point retrying it. This diff makes the error non-retryable. I'm hoping this diff will get the footprint down to at least half of the current value. But final number will be available only once this diff is in prod for a few weeks.

atuljangra is also looking into making more such errors non-retryable. The impact of this diff is beyond just IG. Across the fleet, this error is consuming 108kWs, so other PGs should benefit as well. Will try to identify more such cases and flag to atuljangra.

Reviewed By: hjmshi

Differential Revision: D62043743
