### PR TITLE
Reset module state post sharding, regroup

### DIFF
--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -28,6 +28,7 @@ from torchrec.distributed.types import (
     ShardingPlan,
 )
 from torchrec.distributed.utils import init_parameters
+from torchrec.modules.utils import reset_module_states_post_sharding
 from torchrec.types import CacheMixin
 
 
@@ -280,8 +281,6 @@ def _shard_modules(  # noqa: C901
         init_parameters(module, device)
         module = module.to(device)
 
-    for submod in module.modules():
-        if isinstance(submod, CacheMixin):
-            submod.clear_cache()
+    reset_module_states_post_sharding(module)
 
     return module


### PR DESCRIPTION
Summary:
After sharding, cached tensors can be wrong: https://fb.workplace.com/groups/1028545332188949/permalink/1042204770823005/

Here, we add API to reset module states generically for TorchRec modules and add a call to it where necessary

Reviewed By: ZhengkaiZ

Differential Revision: D63322784
