### PR TITLE
1.65x qps - remove unnecessary cat

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -99,6 +99,11 @@ def _get_kjt_keys(feature: KeyedJaggedTensor) -> List[str]:
     return feature.keys()
 
 
+@torch.fx.wrap
+def _cat_embeddings(embeddings: List[Tensor]) -> Tensor:
+    return embeddings[0] if len(embeddings) == 1 else torch.cat(embeddings, dim=1)
+
+
 def for_each_module_of_type_do(
     module: nn.Module,
     module_types: List[Type[torch.nn.Module]],
@@ -511,7 +516,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
 
         return KeyedTensor(
             keys=self._embedding_names,
-            values=torch.cat(embeddings, dim=1),
+            values=_cat_embeddings(embeddings),
             length_per_key=self._length_per_key,
         )
 


### PR DESCRIPTION
Summary:
Research doc: https://docs.google.com/document/d/1nDdQiJDnqJKzjzM3ku__Y5j196uxRVEB00Mj6qAl31k/edit

Run ada model: https://www.internalfb.com/vanguard/serving_test_cases/487129480789691

We can see huge cpu time spend on cat, which is unnecessary for ada cases, we only cat one tensor, should be a no-op.
{F1888776749}

Conditionally remove it to improve latency and qps

Reviewed By: 842974287

Differential Revision: D63398565
