### PR TITLE
planner change for grid sharding

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -419,6 +419,7 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
             types += [
                 ShardingType.ROW_WISE.value,
                 ShardingType.TABLE_ROW_WISE.value,
+                ShardingType.GRID_SHARD.value,
             ]
 
         return types

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -245,7 +245,6 @@ class EmbeddingEnumerator(Enumerator):
         filtered_sharding_types = list(
             set(constrained_sharding_types) & set(allowed_sharding_types)
         )
-
         if not filtered_sharding_types:
             logger.warn(
                 "No available sharding types after applying user provided "
@@ -380,6 +379,7 @@ def get_partition_by_type(sharding_type: str) -> str:
         ShardingType.ROW_WISE.value,
         ShardingType.DATA_PARALLEL.value,
     }
+    multi_host_sharding_types = {ShardingType.GRID_SHARD.value}
 
     if sharding_type in device_sharding_types:
         return PartitionByType.DEVICE.value
@@ -387,6 +387,8 @@ def get_partition_by_type(sharding_type: str) -> str:
         return PartitionByType.HOST.value
     elif sharding_type in uniform_sharding_types:
         return PartitionByType.UNIFORM.value
+    elif sharding_type in multi_host_sharding_types:
+        return PartitionByType.MULTI_HOST.value
 
     raise ValueError(
         f"Unrecognized or unsupported sharding type provided: {sharding_type}"

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -9,6 +9,7 @@
 
 import copy
 import heapq
+import itertools
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -243,6 +244,14 @@ class GreedyPerfPartitioner(Partitioner):
         for sharding_option_group in sharding_option_groups:
             if (
                 sharding_option_group.sharding_options[0].partition_by
+                == PartitionByType.MULTI_HOST.value
+            ):
+                self._multi_hosts_partition(sharding_option_group, _host_level_devices)
+                # _multi_hosts_partition invalidates minheap_devices, force rebuild before using
+                minheap_devices = None
+
+            elif (
+                sharding_option_group.sharding_options[0].partition_by
                 == PartitionByType.HOST.value
             ):
                 self._cohost_partition(sharding_option_group, _host_level_devices)
@@ -322,6 +331,136 @@ class GreedyPerfPartitioner(Partitioner):
                     heapq.heapify(minheap_devices)
 
     @classmethod
+    def _multi_hosts_partition(
+        cls,
+        sharding_option_group: ShardingOptionGroup,
+        _host_level_devices: List[List[DeviceHardware]],
+    ) -> None:
+        """
+        Partition shards on multiple hosts. This is a greedy algorithm trying to complete partitioning on multiple hosts (sorted by perf).
+        First we do columnwise sharding among hosts, then tablewise-rowwise sharding within each host.
+        There're two cases depends on the number of hosts needed to partition shards.
+
+        Case one: `num_host_to_allocate >= len(sorted_host_level_devices)`
+            We'll try to partition only once. Hosts might be selected multiple times in a circular manner.
+            E.g, we have 3 hosts and `num_host_to_allocate` = 4. We sort all devices on host level. The devices of hosts [0, 1, 2, 0] will be selected for uniform partitioning.
+            We'll update device information if success, otherwise raise a `PlannerError`.
+
+        Case two: `num_host_to_allocate < len(sorted_host_level_devices)`
+            We'll try to partition with hosts `[host_index, host_index + num_host_to_allocate]` iteratively with host_index incremented by 1 each time.
+            1) We sort all devices on host level. Set `host_index` = 0
+            2) We select hosts`[host_index, host_index + num_host_to_allocate]` if indexes are within range.
+            3) We do uniform partitioning over all devices of the selected hosts. If we cannot partition, then we increase `host_index` by 1 and go to 2); Otherwise we go to 4)
+            4) Update device information if success, otherwise raise a `PlannerError`.
+
+        Keyword arguments:
+        sharding_option_group -- grouped sharding options
+        _host_level_devices -- devices
+
+        Example::
+            sharding_option_group.sharding_options = [
+                    ShardingOption(partition_by="multi_host",
+                            shards=[
+                                Shards(storage=1, perf=1),
+                                Shards(storage=1, perf=1),
+                                Shards(storage=1, perf=1),
+                                Shards(storage=1, perf=1),
+                            ]),
+                ]
+            topology = Topology(world_size=6, local_world_size=2)
+
+            # sharding_options[0] will be placed on host 1 and host 2 with the multi_hosts strategy, resulting in
+
+            topology.devices[0].perf.total = (1,1)
+            topology.devices[1].perf.total = (1,1)
+            topology.devices[2].perf.total = (1,1)
+            topology.devices[3].perf.total = (1,1)
+            topology.devices[4].perf.total = (0,0)
+            topology.devices[5].perf.total = (0,0)
+
+        """
+        # TODO: for now assume just one option for multi_hosts.
+        if len(sharding_option_group.sharding_options) != 1:
+            raise PlannerError(
+                error_type=PlannerErrorType.PARTITION,
+                message=f"Unexpected length for sharding options: {len(sharding_option_group.sharding_options)}. Length needs to be 1",
+            )
+        num_shards = sharding_option_group.sharding_options[0].num_shards
+
+        if _host_level_devices is None:
+            raise PlannerError(
+                error_type=PlannerErrorType.PARTITION,
+                message="host level devices is None",
+            )
+
+        local_world_size = len(_host_level_devices[0])
+        num_host_to_allocate, remainder = divmod(num_shards, local_world_size)
+
+        if remainder > 0:
+            raise PlannerError(
+                error_type=PlannerErrorType.PARTITION,
+                message=f"Grid Sharding is unable to place shards equally over hosts without overlapping. {num_shards=} % {local_world_size=} != 0",
+            )
+
+        sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
+        host_index = 0
+        all_hosts_used = False
+        while True:
+            if num_host_to_allocate >= len(sorted_host_level_devices):
+                # case one: we need to use all hosts
+                all_hosts_used = True
+                devices = []
+                for i in range(num_host_to_allocate):
+                    devices.extend(
+                        sorted_host_level_devices[i % len(sorted_host_level_devices)]
+                    )
+            else:
+                # case two: we can use some hosts
+                devices = list(
+                    itertools.chain(
+                        *sorted_host_level_devices[
+                            host_index : host_index + num_host_to_allocate
+                        ]
+                    )
+                )
+            host_index += 1  # shift to next host
+            host_devices = copy.deepcopy(devices)
+            success = True
+            sharding_option = sharding_option_group.sharding_options[0]
+            try:
+                if sharding_option.sharding_type == ShardingType.GRID_SHARD.value:
+                    cls._uniform_partition([sharding_option], host_devices)
+                else:
+                    raise PlannerError(
+                        error_type=PlannerErrorType.PARTITION,
+                        message=f"unexpected multi_host sharding type: {sharding_option.sharding_type}",
+                    )
+            except PlannerError:
+                success = False
+            if success:
+                # successfully found some hosts and partitioned on these hosts
+                # need to update the devices
+                for device, host_device in zip(devices, host_devices):
+                    # check that devices and host_devices are in the same order
+                    if device.rank != host_device.rank:
+                        raise PlannerError(
+                            error_type=PlannerErrorType.PARTITION,
+                            message=f"device rank {device.rank} is not the same as device_copy rank {host_device.rank}",
+                        )
+                    device.storage = host_device.storage
+                    device.perf = host_device.perf
+                return
+
+            if (
+                host_index + num_host_to_allocate > len(sorted_host_level_devices)
+            ) or all_hosts_used:
+                break
+        raise PlannerError(
+            error_type=PlannerErrorType.PARTITION,
+            message=f"can't find hosts for sharding option group {sharding_option_group}",
+        )
+
+    @classmethod
     def _cohost_partition(
         cls,
         sharding_option_group: ShardingOptionGroup,
@@ -358,8 +497,9 @@ class GreedyPerfPartitioner(Partitioner):
                             )
                         cls._device_partition(sharding_option, minheap_devices)
                     else:
-                        raise RuntimeError(
-                            f"unexpected cohost sharding type: {sharding_option.sharding_type}"
+                        raise PlannerError(
+                            error_type=PlannerErrorType.PARTITION,
+                            message=f"unexpected cohost sharding type: {sharding_option.sharding_type}",
                         )
                 except PlannerError:
                     success = False
@@ -395,8 +535,9 @@ class GreedyPerfPartitioner(Partitioner):
     ) -> None:
         for sharding_option in sharding_options:
             if sharding_option.num_shards != len(devices):
-                raise RuntimeError(
-                    f"For a uniform partition, the number of shards ({sharding_option.num_shards}) must equal the number of devices ({len(devices)})"
+                raise PlannerError(
+                    error_type=PlannerErrorType.PARTITION,
+                    message=f"For a uniform partition, the number of shards ({sharding_option.num_shards}) must equal the number of devices ({len(devices)})",
                 )
             for i in range(len(devices)):
                 storage_needed = cast(Storage, sharding_option.shards[i].storage)

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -413,6 +413,7 @@ class EmbeddingStats(Stats):
                     f"{so.tensor.shape[1]} ({so.shards[0].size[1]})"
                     if so.sharding_type == ShardingType.COLUMN_WISE.value
                     or so.sharding_type == ShardingType.TABLE_COLUMN_WISE.value
+                    or so.sharding_type == ShardingType.GRID_SHARD.value
                     else f"{so.tensor.shape[1]}"
                 )
                 sharder_cache_load_factor = (
@@ -875,6 +876,8 @@ def _get_sharding_type_abbr(sharding_type: str) -> str:
         return "TWRW"
     elif sharding_type == ShardingType.TABLE_COLUMN_WISE.value:
         return "TWCW"
+    elif sharding_type == ShardingType.GRID_SHARD.value:
+        return "GS"
     else:
         raise ValueError(
             f"Unrecognized or unsupported sharding type provided: {sharding_type}"

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -169,16 +169,16 @@ class TestProposers(unittest.TestCase):
                 ("table_1", "row_wise", "fused"),
             ],
             [
+                ("table_0", "grid_shard", "fused"),
+                ("table_1", "row_wise", "fused"),
+            ],
+            [
                 ("table_1", "row_wise", "fused"),
                 ("table_0", "data_parallel", "dense"),
             ],
             [
                 ("table_1", "table_row_wise", "fused"),
                 ("table_0", "data_parallel", "dense"),
-            ],
-            [
-                ("table_0", "data_parallel", "dense"),
-                ("table_1", "data_parallel", "dense"),
             ],
         ]
 
@@ -349,10 +349,9 @@ class TestProposers(unittest.TestCase):
             - fused_uvm
         DP will have 1 possible compute kernel: dense
         So the total number of pruned options will be:
-            (num_sharding_types - 1) * 3 + 1 = 16
+            (num_sharding_types - 1) * 3 + 1 = 19
         """
-        # NOTE - remove -2 from sharding type length once grid sharding in planner is added
-        num_pruned_options = (len(ShardingType) - 2) * 3 + 1
+        num_pruned_options = (len(ShardingType) - 1) * 3 + 1
         self.grid_search_proposer.load(search_space)
         for (
             sharding_options

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -248,6 +248,49 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
                     bwd_comms=0.004316567291897281,
                 ),
             ],
+            # grid_shard is the same as table_row_wise
+            ("fused", "grid_shard"): [
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
+                Perf(
+                    fwd_compute=6.804365245261984e-05,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.0001360873049052397,
+                    bwd_comms=0.00016798276699240525,
+                ),
+            ],
+            ("fused_uvm", "grid_shard"): [
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
+                Perf(
+                    fwd_compute=0.011967677696078432,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.023935355392156864,
+                    bwd_comms=0.018426483752680762,
+                ),
+            ],
+            ("fused_uvm_caching", "grid_shard"): [
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
+                Perf(
+                    fwd_compute=0.0027718054609445954,
+                    fwd_comms=6.357828776041667e-05,
+                    bwd_compute=0.005543610921889191,
+                    bwd_comms=0.004316567291897281,
+                ),
+            ],
         }
 
         perfs = {
@@ -310,6 +353,13 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ("fused", "table_row_wise"): [0.0002561205605599394, 0.0002561205605599394],
             ("fused_uvm", "table_row_wise"): [0.03392836626838235, 0.03392836626838235],
             ("fused_uvm_caching", "table_row_wise"): [
+                0.007906921553027076,
+                0.007906921553027076,
+            ],
+            # grid_shard is the same as table_row_wise
+            ("fused", "grid_shard"): [0.0002561205605599394, 0.0002561205605599394],
+            ("fused_uvm", "grid_shard"): [0.03392836626838235, 0.03392836626838235],
+            ("fused_uvm_caching", "grid_shard"): [
                 0.007906921553027076,
                 0.007906921553027076,
             ],
@@ -506,12 +556,17 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
                 0.007304490781297871,
                 0.007304490781297871,
             ],
+            ("table_0", "fused_uvm_caching", "grid_shard"): [
+                0.007304490781297871,
+                0.007304490781297871,
+            ],
             ("table_0", "fused_uvm_caching", "table_wise"): [0.014608981562595743],
             ("table_1", "fused", "column_wise"): [0.0],
             ("table_1", "fused", "row_wise"): [0.0, 0.0],
             ("table_1", "fused", "table_column_wise"): [0.0],
             ("table_1", "fused", "table_row_wise"): [0.0, 0.0],
             ("table_1", "fused", "table_wise"): [0.0],
+            ("table_1", "fused", "grid_shard"): [0.0, 0.0],
         }
 
         prefetch_computes = {

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -537,6 +537,8 @@ class PartitionByType(Enum):
     HOST = "host"
     # Uniform, (ie. fixed layout)
     UNIFORM = "uniform"
+    # Partitioning based on multiple hosts
+    MULTI_HOST = "multi_host"
 
 
 @dataclass

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -24,6 +24,7 @@ from torchrec.distributed.sharding_plan import (
     FeatureProcessedEmbeddingBagCollectionSharder,
     FusedEmbeddingBagCollectionSharder,
     get_module_to_default_sharders,
+    grid_shard,
     ManagedCollisionEmbeddingBagCollectionSharder,
     ManagedCollisionEmbeddingCollectionSharder,
     ParameterShardingGenerator,
@@ -240,7 +241,7 @@ class ConstructParameterShardingTest(unittest.TestCase):
                 embedding_dim=256,
                 num_embeddings=32 * 32,
             )
-            for idx in range(5)
+            for idx in range(6)
         ]
 
         expected = {
@@ -567,6 +568,95 @@ class ConstructParameterShardingTest(unittest.TestCase):
                     ]
                 ),
             ),
+            "table_5": ParameterSharding(
+                sharding_type="grid_shard",
+                compute_kernel="dense",
+                ranks=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                sharding_spec=EnumerableShardingSpec(
+                    shards=[
+                        ShardMetadata(
+                            shard_offsets=[0, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:0/cuda:0",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[128, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:1/cuda:1",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[256, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:2/cuda:2",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[384, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:3/cuda:3",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[512, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:4/cuda:4",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[640, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:5/cuda:5",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[768, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:6/cuda:6",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[896, 0],
+                            shard_sizes=[128, 128],
+                            placement="rank:7/cuda:7",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[0, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:8/cuda:0",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[128, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:9/cuda:1",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[256, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:10/cuda:2",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[384, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:11/cuda:3",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[512, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:12/cuda:4",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[640, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:13/cuda:5",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[768, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:14/cuda:6",
+                        ),
+                        ShardMetadata(
+                            shard_offsets=[896, 128],
+                            shard_sizes=[128, 128],
+                            placement="rank:15/cuda:7",
+                        ),
+                    ]
+                ),
+            ),
         }
 
         module_sharding_plan = construct_module_sharding_plan(
@@ -577,6 +667,7 @@ class ConstructParameterShardingTest(unittest.TestCase):
                 "table_2": row_wise(),
                 "table_3": column_wise(ranks=[8, 9]),
                 "table_4": table_row_wise(host_index=3),
+                "table_5": grid_shard(host_indexes=[0, 1]),
             },
             local_size=8,
             world_size=32,


### PR DESCRIPTION
Summary:
as titled. changes include
1) add the new grid_shard
2) extend DCD proposer and planner for grid_shard

This is backward compatible, we still can use COLUMN_TABLE_ROW_WISE together with this new type.

Reviewed By: iamzainhuda

Differential Revision: D62391522
