### PR TITLE
Remove python 3.8 from dynamic embedding wheels ci

### DIFF
--- a/.github/workflows/build_dynamic_embedding_wheels.yml
+++ b/.github/workflows/build_dynamic_embedding_wheels.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        pyver: [ cp38, cp39, cp310 ]
+        pyver: [ cp39, cp310 ]
         cuver: [ "11.8" ]
 
     steps:


### PR DESCRIPTION
Summary: Python 3.8 is no longer supported, dynamic embeddings ci in oss still running it and broken: https://github.com/pytorch/torchrec/actions/runs/11111639481/job/30872010062

Reviewed By: kausv

Differential Revision: D63648749
