### PR TITLE
Enable default TW sharding for modules in AIMP

### DIFF
--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -526,11 +526,14 @@ def shard_quant_model(
 
     if constraints is None:
         table_fqns = []
-
+        sharders = sharders if sharders else DEFAULT_SHARDERS
+        module_types = [sharder.module_type for sharder in sharders]
         for module in model.modules():
-            if isinstance(module, QuantEmbeddingBagCollection):
-                for table in module.embedding_bags:
-                    table_fqns.append(table)
+            if type(module) in module_types:
+                # TODO: handle other cases/reduce hardcoding
+                if hasattr(module, "embedding_bags"):
+                    for table in module.embedding_bags:
+                        table_fqns.append(table)
 
         # Default table wise constraints
         constraints = {}


### PR DESCRIPTION
Summary:
D62780756 exposed a bug where the `shard_quant_model` API only defaults to TW sharding for EBC and no other module types - this was hard coded.

This diff will enable TW sharding as default sharding for all modules, unblocking RecGPT case where we will need VLE module to default to TW sharding.

We decided to hardcode on AIMP side to specify constraints for default TW sharding - because VLE is internal only so should not be exposed in OS code.

Reviewed By: PaulZhang12

Differential Revision: D63552253
