### PR TITLE
Add fwd trace annotations for input_dist, lookup and output dist for each (fqn, sharding type) combination

### DIFF
--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -839,6 +839,7 @@ class EmbeddingTowerSharder(BaseEmbeddingSharder[EmbeddingTower]):
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedEmbeddingTower:
         kjt_features, wkjt_features = self.embedding_feature_names(module)
 
@@ -939,6 +940,7 @@ class EmbeddingTowerCollectionSharder(BaseEmbeddingSharder[EmbeddingTowerCollect
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedEmbeddingTowerCollection:
 
         return ShardedEmbeddingTowerCollection(

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -57,6 +57,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
         ebc_sharder: EmbeddingBagCollectionSharder,
         env: ShardingEnv,
         device: torch.device,
+        module_fqn: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -69,6 +70,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
                 table_name_to_parameter_sharding,
                 env=env,
                 device=device,
+                module_fqn=module_fqn,
             )
         )
 
@@ -179,6 +181,7 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedFeatureProcessedEmbeddingBagCollection:
 
         if device is None:
@@ -190,6 +193,7 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
             ebc_sharder=self._ebc_sharder,
             env=env,
             device=device,
+            module_fqn=module_fqn,
         )
 
     @property

--- a/torchrec/distributed/fused_embedding.py
+++ b/torchrec/distributed/fused_embedding.py
@@ -96,6 +96,7 @@ class FusedEmbeddingCollectionSharder(BaseEmbeddingSharder[FusedEmbeddingCollect
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedFusedEmbeddingCollection:
 
         return ShardedFusedEmbeddingCollection(module, params, env, device)

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -94,6 +94,7 @@ class FusedEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedEmbeddingBagCollection:
 
         return ShardedFusedEmbeddingBagCollection(

--- a/torchrec/distributed/itep_embeddingbag.py
+++ b/torchrec/distributed/itep_embeddingbag.py
@@ -168,6 +168,7 @@ class ITEPEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedITEPEmbeddingBagCollection:
 
         # Enforce GPU for ITEPEmbeddingBagCollection

--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -683,6 +683,7 @@ class KeyedJaggedTensorPoolSharder(ModuleSharder[KeyedJaggedTensorPool]):
         plan: ObjectPoolShardingPlan,
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> Union[ShardedKeyedJaggedTensorPool, ShardedInferenceKeyedJaggedTensorPool]:
         if plan.inference:
             return ShardedInferenceKeyedJaggedTensorPool(

--- a/torchrec/distributed/mc_embedding.py
+++ b/torchrec/distributed/mc_embedding.py
@@ -124,6 +124,7 @@ class ManagedCollisionEmbeddingCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedManagedCollisionEmbeddingCollection:
 
         if device is None:

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -110,6 +110,7 @@ class ManagedCollisionEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedManagedCollisionEmbeddingBagCollection:
 
         if device is None:

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -373,6 +373,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                 module_sharding_plan,
                 self._env,
                 self.device,
+                path,
             )
             return module
 

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -876,6 +876,7 @@ class QuantEmbeddingCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: Union[ShardingEnv, Dict[str, ShardingEnv]],
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantEmbeddingCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -353,6 +353,7 @@ class QuantEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: Union[ShardingEnv, Dict[str, ShardingEnv]],
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantEmbeddingBagCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
@@ -475,6 +476,7 @@ class QuantFeatureProcessedEmbeddingBagCollectionSharder(
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantEmbeddingBagCollection:
         qebc = module
         assert isinstance(qebc, QuantEmbeddingBagCollection)

--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -256,7 +256,7 @@ def _shard_modules(  # noqa: C901
         # If the top level module is itself a shardable module, return the sharded variant.
         # Note, we cannot do an inplace replacement in this case.
         return sharder_map[type(module)].shard(
-            module, plan.get_plan_for_module(""), env, device
+            module, plan.get_plan_for_module(""), env, device, ""
         )
 
     def _replace(_model: nn.Module, path: str = "") -> None:
@@ -267,7 +267,11 @@ def _shard_modules(  # noqa: C901
                 sharded_params = plan.get_plan_for_module(child_path)
                 if sharded_params is not None:
                     sharded_module = sharder_map[type(child)].shard(
-                        child, sharded_params, env, device
+                        child,
+                        sharded_params,
+                        env,
+                        device,
+                        child_path,
                     )
                     _model.register_module(
                         child_name,

--- a/torchrec/distributed/tensor_pool.py
+++ b/torchrec/distributed/tensor_pool.py
@@ -480,6 +480,7 @@ class TensorPoolSharder(ModuleSharder[TensorPool]):
         plan: ObjectPoolShardingPlan,
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> Union[ShardedTensorPool, ShardedInferenceTensorPool]:
         if plan.inference:
             return ShardedInferenceTensorPool(

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -432,6 +432,7 @@ class TestQuantFPEBCSharder(QuantFeatureProcessedEmbeddingBagCollectionSharder):
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantFeatureProcessedEmbeddingBagCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
@@ -479,6 +480,7 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
         params: Dict[str, ParameterSharding],
         env: Union[ShardingEnv, Dict[str, ShardingEnv]],
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantEmbeddingBagCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(
@@ -525,6 +527,7 @@ class TestQuantECSharder(QuantEmbeddingCollectionSharder):
         params: Dict[str, ParameterSharding],
         env: Union[Dict[str, ShardingEnv], ShardingEnv],
         device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
     ) -> ShardedQuantEmbeddingCollection:
         fused_params = self.fused_params if self.fused_params else {}
         fused_params["output_dtype"] = data_type_to_sparse_type(

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -13,16 +13,19 @@ import pdb  # noqa
 import sys
 
 from collections import OrderedDict
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union
 
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from torch import nn
+from torch.autograd.profiler import record_function
 from torchrec import optim as trec_optim
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.types import (
     DataType,
+    EmbeddingEvent,
     ParameterSharding,
     ShardedModule,
     ShardingType,
@@ -470,6 +473,16 @@ def init_parameters(module: nn.Module, device: torch.device) -> None:
                     m.reset_parameters()
 
             module.apply(maybe_reset_parameters)
+
+
+def maybe_annotate_embedding_event(
+    event: EmbeddingEvent, module_fqn: Optional[str], sharding_type: Optional[str]
+) -> AbstractContextManager[None]:
+    if module_fqn and sharding_type:
+        annotation = f"[{event.value}]_[{module_fqn}]_[{sharding_type}]"
+        return record_function(annotation)
+    else:
+        return nullcontext()
 
 
 class ForkedPdb(pdb.Pdb):


### PR DESCRIPTION
Summary:
When debugging traces without callstack tracing enabled, it is hard to see which input_dist, lookup and embs dist correspond to what modules / sharding types. This diff adds profiler trace annotations for kjt splits dist, lookup and output dist for each sharding type + embedding module FQN combination, at a torchrec library level so all runs can benefit from it.

These are formatted as: f" ### {event_type}_{fqn}_{shard_type} ### ", where event_types are:
- splits_dist (first part of input dist, comms for kjt splits metadata)
- tensors_dist (second part of input dist, comms for kjt values, lengths and optionally weights)
- lookup
- output_dist
- output_dist_wait (when .wait() is called on embeddings dist awaitable, used to link backward emb dist with corresponding forward event).

Adds support for `EmbeddingCollection` and `EmbeddingBagCollection` for now.

Reviewed By: dstaay-fb

Differential Revision: D62531269
