### PR TITLE
add optimizer key in EmbeddingFusedOptimizer and KeyValueEmbeddingFusedOptimizer.

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -564,7 +564,10 @@ class ShardedEmbeddingCollection(
                     for param_key, weight in m.fused_optimizer.params.items():
                         params["embeddings." + param_key] = weight
                     m.fused_optimizer.params = params
-                    optims.append(("", m.fused_optimizer))
+                    optims.append(
+                        # pyre-fixme[16]: `KeyedOptimizer` has no attribute `key`.
+                        (m.fused_optimizer.key, m.fused_optimizer)
+                    )
         self._optim: CombinedOptimizer = CombinedOptimizer(optims)
         self._embedding_dim: int = module.embedding_dim()
         self._embedding_names_per_sharding: List[List[str]] = []

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -525,9 +525,7 @@ def group_tables(
             grouped_tables = groups[grouping_key]
             # remove non-native fused params
             per_tbe_fused_params = {
-                k: v
-                for k, v in fused_params_tuple
-                if k not in ["_batch_key", USE_ONE_TBE_PER_TABLE]
+                k: v for k, v in fused_params_tuple if k not in [USE_ONE_TBE_PER_TABLE]
             }
             cache_load_factor = _get_weighted_avg_cache_load_factor(grouped_tables)
             if cache_load_factor is not None:

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -684,7 +684,10 @@ class ShardedEmbeddingBagCollection(
                         # pyre-fixme[16]: `Mapping` has no attribute `__setitem__`
                         params["embedding_bags." + param_key] = weight
                     tbe_module.fused_optimizer.params = params
-                    optims.append(("", tbe_module.fused_optimizer))
+                    optims.append(
+                        # pyre-fixme[16]: `KeyedOptimizer` has no attribute `key`.
+                        (tbe_module.fused_optimizer.key, tbe_module.fused_optimizer)
+                    )
         self._optim: CombinedOptimizer = CombinedOptimizer(optims)
 
         for i, (sharding, lookup) in enumerate(


### PR DESCRIPTION
Summary:
Add field optimizer_key in Torchrec EmbeddingFusedOptimizer. During the initialization of embedding module BatchedFusedEmbeddingBag, pass the optimizer_key information from fused parameters when creating the EmbeddingFusedOptimizer.

In sparse arch, update the optimizer key for TBE when creating a combined optimizer for different TBE modules. The optimizer_key in the combined fused optimizer can be extracted for learning rate warm up processing.

Differential Revision: D61668809
