### PR TITLE
Handle train/eval mode in base class

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -379,6 +379,16 @@ class ShardedEmbeddingModule(
 
         return "\n ".join(rep)
 
+    def train(self, mode: bool = True):  # pyre-ignore[3]
+        r"""Set the module in training mode."""
+        super().train(mode)
+
+        # adding additional handling for lookups
+        for lookup in self._lookups:
+            lookup.train(mode)
+
+        return self
+
 
 M = TypeVar("M", bound=nn.Module)
 

--- a/torchrec/distributed/tests/test_embedding_types.py
+++ b/torchrec/distributed/tests/test_embedding_types.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Dict, List
+
+import torch
+from torchrec.distributed.embedding_types import KJTList, ShardedEmbeddingModule
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionContext
+from torchrec.distributed.types import Awaitable, LazyAwaitable
+
+Out = Dict[str, torch.Tensor]
+CompIn = KJTList
+DistOut = List[torch.Tensor]
+ShrdCtx = EmbeddingBagCollectionContext
+
+
+class FakeShardedEmbeddingModule(ShardedEmbeddingModule[CompIn, DistOut, Out, ShrdCtx]):
+    def __init__(self) -> None:
+        super().__init__()
+        self._lookups = [
+            torch.nn.Module(),
+            torch.nn.Module(),
+        ]
+
+    def create_context(self) -> ShrdCtx:
+        # pyre-fixme[7]: Expected `EmbeddingBagCollectionContext` but got implicit
+        #  return value of `None`.
+        pass
+
+    def input_dist(
+        self,
+        ctx: ShrdCtx,
+        # pyre-ignore[2]
+        *input,
+        # pyre-ignore[2]
+        **kwargs,
+    ) -> Awaitable[Awaitable[CompIn]]:
+        # pyre-fixme[7]: Expected `Awaitable[Awaitable[KJTList]]` but got implicit
+        #  return value of `None`.
+        pass
+
+    def compute(self, ctx: ShrdCtx, dist_input: CompIn) -> DistOut:
+        # pyre-fixme[7]: Expected `List[Tensor]` but got implicit return value of
+        #  `None`.
+        pass
+
+    def output_dist(self, ctx: ShrdCtx, output: DistOut) -> LazyAwaitable[Out]:
+        # pyre-fixme[7]: Expected `LazyAwaitable[Dict[str, Tensor]]` but got
+        #  implicit return value of `None`.
+        pass
+
+
+class TestShardedEmbeddingModule(unittest.TestCase):
+    def test_train_mode(self) -> None:
+        embedding_module = FakeShardedEmbeddingModule()
+        for mode in [True, False]:
+            with self.subTest(mode=mode):
+                embedding_module.train(mode)
+                self.assertEqual(embedding_module.training, mode)
+                for lookup in embedding_module._lookups:
+                    self.assertEqual(lookup.training, mode)


### PR DESCRIPTION
Summary:
When running for evaluation, the model needs to be set to eval mode by setting self.training=False. This flag should be propagated to all sub-modules. However, for `ShardedEmbeddingModule` only the weights of TBE are registered (https://fburl.com/code/9g0uykxu) but the TBE module is not taken care of. This causes a problem when running eval: the TBE is not put into eval mode, especially when GWD is enabled which requires different behavior for training vs eval (eval shouldn't be doing weight decay).

D59817443 supported ShardedPooledEmbeddingArch. Here we upstream the support to the base class `ShardedEmbeddingModule` so that all other impl can directly inherit.

Differential Revision: D63758562
