### PR TITLE
Create an interface to enable eviction policy

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -646,6 +646,8 @@ class ShardedManagedCollisionCollection(
                         table: JaggedTensor(
                             values=kjt.values(),
                             lengths=kjt.lengths(),
+                            # TODO: improve this temp solution by passing real weights
+                            weights=torch.tensor(kjt.length_per_key()),
                         )
                     }
                     mcm = self._managed_collision_modules[table]
@@ -660,6 +662,8 @@ class ShardedManagedCollisionCollection(
                     table: JaggedTensor(
                         values=features.values(),
                         lengths=features.lengths(),
+                        # TODO: improve this temp solution by passing real weights
+                        weights=torch.tensor(kjt.length_per_key()),
                     )
                 }
                 mcm = self._managed_collision_modules[table]
@@ -673,6 +677,7 @@ class ShardedManagedCollisionCollection(
                     keys=fns,
                     values=values,
                     lengths=features.lengths(),
+                    # original weights instead of features splits
                     weights=features.weights_or_none(),
                 )
             )

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -368,6 +368,7 @@ class ManagedCollisionCollection(nn.Module):
                 table: JaggedTensor(
                     values=kjt.values(),
                     lengths=kjt.lengths(),
+                    weights=torch.tensor(kjt.length_per_key()),
                 )
             }
             mc_input = mc_module(mc_input)


### PR DESCRIPTION
Summary:
To support various types of eviction policy, the `HashZchManagedCollisionModule` needs to be able to calculate a score (e.g., TTL) for each incoming ID and pass it to the kernel. The latter will make an informed eviction decision based on the existing score associated with the identity (stored in metadata), and a reference value (e.g., current timestamp). Refer to [Doc](https://docs.google.com/document/d/19s6N4-CWhveqhV1ePwrHAF8SIlzePsoxKElPRnnlo8c/edit?usp=sharing) for details.

This Diff uses per-feature TTL as an example, and creates a scorer to assign a TTL for each ID with regard to the expiration hr of the feature. The score will be passed to the kernel (in a separate Diff) to perform eviction.

Differential Revision: D63879449


