### PR TITLE
KJT permute - more efficient keys manipulation

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2511,14 +2511,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         permuted_stride_per_key_per_rank: List[List[int]] = []
         permuted_length_per_key: List[int] = []
         permuted_length_per_key_sum = 0
-        for index in indices:
-            key = self.keys()[index]
-            permuted_keys.append(key)
-            permuted_length_per_key.append(length_per_key[index])
-            if self.variable_stride_per_key():
-                permuted_stride_per_key_per_rank.append(
-                    self.stride_per_key_per_rank()[index]
-                )
+        keys = self.keys()
+
+        permuted_keys = [keys[idx] for idx in indices]
+        permuted_length_per_key = [length_per_key[idx] for idx in indices]
+        if self.variable_stride_per_key():
+            stride_per_key = self.stride_per_key_per_rank()
+            permuted_stride_per_key_per_rank = [stride_per_key[idx] for idx in indices]
 
         permuted_length_per_key_sum = sum(permuted_length_per_key)
         if not torch.jit.is_scripting() and is_non_strict_exporting():


### PR DESCRIPTION
Summary:
Slightly optimizes the way KJT.permute handles keys and lengths - which could come in handy for KJTs with large number of keys (i.e. lots of features bundled into a single KJT)

Tried two versions:

* Optimized1 - simply replace `self.keys()` with `key = self.keys()` (i.e. replace function calls with local variable access)
* Optimized2 - replace a single loop with multiple list comprehensions

```
Timing Optimized1
122 µs ± 2.59 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Timing Optimized2
83.8 µs ± 1.76 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
Timing Original
331 µs ± 6.97 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

A bit surprisingly, list comprehensions win with ~1.5x gap.

Differential Revision: D64232574


