### PR TITLE
- For planner to use cpu for search random generator

### DIFF
--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -216,7 +216,7 @@ class LuusJaakolaSearch:
 
     def uniform(self, A: float, B: float) -> float:
         "Return a random uniform position in range [A,B]."
-        u = torch.rand(1, generator=self.gen).item()
+        u = torch.rand(1, generator=self.gen, device="cpu").item()
         return A + (B - A) * u
 
     def next(self, fy: float) -> Optional[float]:


### PR DESCRIPTION
Summary:
torch.rand() defaults to using the default device. If torch.device has
been globally set to 'meta', then this breaks the planner code. Force
the device to cpu instead. This ensures we're using the same seeded
random number alg as before (so no changes to existing plans). We only
generate a handful of random numbers so performance is not a concern.

Example breakage:
https://fb.workplace.com/groups/260102303573409/posts/507200532196917/

Differential Revision: D64260019


