### PR TITLE
Fix UnboundLocalError in weights assignment

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -663,7 +663,7 @@ class ShardedManagedCollisionCollection(
                         values=features.values(),
                         lengths=features.lengths(),
                         # TODO: improve this temp solution by passing real weights
-                        weights=torch.tensor(kjt.length_per_key()),
+                        weights=torch.tensor(features.length_per_key()),
                     )
                 }
                 mcm = self._managed_collision_modules[table]


### PR DESCRIPTION
Summary: See D64163927 for details. This block is not hit by testing so the typo was not captured.

Differential Revision: D64609231


