### PR TITLE
another torch deploy protection :(

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -74,7 +74,8 @@ try:
 except ImportError:
     logger.warning("torchrec_use_sync_collectives is not available")
 
-torch.ops.import_module("fbgemm_gpu.sparse_ops")
+if not torch._running_with_deploy():
+    torch.ops.import_module("fbgemm_gpu.sparse_ops")
 
 
 class ModelDetachedException(Exception):


### PR DESCRIPTION
Summary: this import doesnt work in torch dceploy for whatever reason (we're getting rid of it all in 2 months so just bare with this for now)

Differential Revision: D64830919


