### PR TITLE
avoid synced copy in tensor pool

### DIFF
--- a/torchrec/distributed/tensor_pool.py
+++ b/torchrec/distributed/tensor_pool.py
@@ -282,6 +282,7 @@ class LocalShardPool(torch.nn.Module):
         Returns:
             torch.Tensor: Tensor of values corresponding to the given rank ids.
         """
+        rank_ids.to(self._shard.device, non_blocking=not self._shard.is_cpu)
         return self._shard[rank_ids]
 
     def update(self, rank_ids: torch.Tensor, values: torch.Tensor) -> None:


### PR DESCRIPTION
Summary:
index select will implicitly move the indices to device if it was in CPU. However, this copy would be blocking.

An additional improvement we could do is to make sure indices tensor is on pinned memory.

Differential Revision: D64840859


