### PR TITLE
PT2 Compile Individual Metrics

### DIFF
--- a/torchrec/metrics/accuracy.py
+++ b/torchrec/metrics/accuracy.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -84,6 +85,7 @@ class AccuracyMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -21,6 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -243,6 +244,7 @@ class AUCMetricComputation(RecMetricComputation):
         if self._grouped_auc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/auprc.py
+++ b/torchrec/metrics/auprc.py
@@ -21,6 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -235,6 +236,7 @@ class AUPRCMetricComputation(RecMetricComputation):
         if self._grouped_auprc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 CALIBRATION_NUM = "calibration_num"
 CALIBRATION_DENOM = "calibration_denom"
@@ -65,6 +66,7 @@ class CalibrationMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -10,6 +10,7 @@
 from typing import Any, cast, Dict, List, Optional, Type
 
 import torch
+
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
 from torchrec.metrics.rec_metric import (
     MetricComputationReport,
@@ -17,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 CTR_NUM = "ctr_num"
 CTR_DENOM = "ctr_denom"
@@ -61,6 +63,7 @@ class CTRMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/mae.py
+++ b/torchrec/metrics/mae.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -72,6 +73,7 @@ class MAEMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     # pyre-fixme[14]: `update` overrides method defined in `RecMetricComputation`
     #  inconsistently.
     def update(

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -393,6 +393,8 @@ def _generate_rec_metrics(
         if metric_def and metric_def.arguments is not None:
             kwargs = metric_def.arguments
 
+        kwargs["enable_pt2_compile"] = metrics_config.enable_pt2_compile
+
         rec_tasks: List[RecTaskInfo] = []
         if metric_def.rec_tasks and metric_def.rec_task_indices:
             raise ValueError(
@@ -468,7 +470,7 @@ def generate_metric_module(
         metrics_config, world_size, my_rank, batch_size, process_group
     )
     """
-    Batch_size_stages currently only used by ThroughputMetric to ensure total_example correct so 
+    Batch_size_stages currently only used by ThroughputMetric to ensure total_example correct so
     different training jobs have aligned mertics.
     TODO: update metrics other than ThroughputMetric if it has dependency on batch_size
     """

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -158,6 +158,7 @@ class MetricsConfig:
         should_validate_update (bool): whether to check the inputs of update() and skip
             update if the inputs are invalid. Invalid inputs include the case where all
             examples have 0 weights for a batch.
+        enable_pt2_compile (bool): whether to enable PT2 compilation for metrics.
     """
 
     rec_tasks: List[RecTaskInfo] = field(default_factory=list)
@@ -171,6 +172,7 @@ class MetricsConfig:
     max_compute_interval: float = float("inf")
     compute_on_all_ranks: bool = False
     should_validate_update: bool = False
+    enable_pt2_compile: bool = False
 
 
 DefaultTaskInfo = RecTaskInfo(

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -10,6 +10,7 @@
 from typing import Any, cast, Dict, List, Optional, Type
 
 import torch
+
 from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
 from torchrec.metrics.rec_metric import (
     MetricComputationReport,
@@ -17,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -80,6 +82,7 @@ class MSEMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/multiclass_recall.py
+++ b/torchrec/metrics/multiclass_recall.py
@@ -18,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_true_positives_at_k(
@@ -109,6 +110,7 @@ class MulticlassRecallMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ndcg.py
+++ b/torchrec/metrics/ndcg.py
@@ -19,6 +19,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 SUM_NDCG = "sum_ndcg"
 NUM_SESSIONS = "num_sessions"
@@ -331,6 +332,7 @@ class NDCGComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_cross_entropy(
@@ -148,6 +149,7 @@ class NEMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ne_positive.py
+++ b/torchrec/metrics/ne_positive.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_cross_entropy_positive(
@@ -130,6 +131,7 @@ class NEPositiveMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/output.py
+++ b/torchrec/metrics/output.py
@@ -21,6 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricException,
     RecTaskInfo,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 class OutputMetricComputation(RecMetricComputation):
@@ -46,6 +47,7 @@ class OutputMetricComputation(RecMetricComputation):
             persistent=False,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/precision.py
+++ b/torchrec/metrics/precision.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -96,6 +97,7 @@ class PrecisionMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/rauc.py
+++ b/torchrec/metrics/rauc.py
@@ -21,6 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -287,6 +288,7 @@ class RAUCMetricComputation(RecMetricComputation):
         if self._grouped_rauc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/recall.py
+++ b/torchrec/metrics/recall.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -96,6 +97,7 @@ class RecallMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/recall_session.py
+++ b/torchrec/metrics/recall_session.py
@@ -21,6 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -128,6 +129,7 @@ class RecallSessionMetricComputation(RecMetricComputation):
         self.run_ranking_of_labels: bool = session_metric_def.run_ranking_of_labels
         self.session_var_name: Optional[str] = session_metric_def.session_var_name
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetric,
     RecMetricComputation,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 class ScalarMetricComputation(RecMetricComputation):
@@ -41,6 +42,7 @@ class ScalarMetricComputation(RecMetricComputation):
             persistent=False,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/segmented_ne.py
+++ b/torchrec/metrics/segmented_ne.py
@@ -19,6 +19,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -206,6 +207,7 @@ class SegmentedNEMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/serving_calibration.py
+++ b/torchrec/metrics/serving_calibration.py
@@ -18,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 CALIBRATION_NUM = "calibration_num"
 CALIBRATION_DENOM = "calibration_denom"
@@ -57,6 +58,7 @@ class ServingCalibrationMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/serving_ne.py
+++ b/torchrec/metrics/serving_ne.py
@@ -18,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 NUM_EXAMPLES = "num_examples"
@@ -98,6 +99,7 @@ class ServingNEMetricComputation(RecMetricComputation):
             eta=self.eta,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/tensor_weighted_avg.py
+++ b/torchrec/metrics/tensor_weighted_avg.py
@@ -18,6 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 def get_mean(value_sum: torch.Tensor, num_samples: torch.Tensor) -> torch.Tensor:
@@ -54,6 +55,7 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/tower_qps.py
+++ b/torchrec/metrics/tower_qps.py
@@ -22,6 +22,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricException,
     RecModelOutput,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 WARMUP_STEPS = 100
 
@@ -78,6 +79,7 @@ class TowerQPSMetricComputation(RecMetricComputation):
         self._previous_ts = 0
         self._steps = 0
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/weighted_avg.py
+++ b/torchrec/metrics/weighted_avg.py
@@ -16,6 +16,7 @@ from torchrec.metrics.rec_metric import (
     RecMetric,
     RecMetricComputation,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 def get_mean(value_sum: torch.Tensor, num_samples: torch.Tensor) -> torch.Tensor:
@@ -40,6 +41,7 @@ class WeightedAvgMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/xauc.py
+++ b/torchrec/metrics/xauc.py
@@ -17,6 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
+from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -101,6 +102,7 @@ class XAUCMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
+    @pt2_compile_callable
     # pyre-fixme[14]: `update` overrides method defined in `RecMetricComputation`
     #  inconsistently.
     def update(


### PR DESCRIPTION
Summary:
We find that PT2 compiling the TorchMetrics helper functions that are called during  `.update()` and `._compute()` for `XMetricComputation` classes improves both the CPU  wall time (95.4ms -> 65.4ms) and GPU wall time (3.3ms -> 1.2ms)

Without PT2 compile
 {F1941555284} 

With PT2 Compile 
{F1941555918} 



With PT2 compile
 {F1935701090}

Differential Revision: D64244129


