### PR TITLE
Remove logging from   metrics computation

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -11,7 +11,6 @@
 
 import abc
 import itertools
-import logging
 import math
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -48,7 +47,6 @@ from torchrec.metrics.metrics_namespace import (
     MetricPrefix,
 )
 
-logger: logging.Logger = logging.getLogger(__name__)
 
 RecModelOutput = Union[torch.Tensor, Dict[str, torch.Tensor]]
 
@@ -525,24 +523,15 @@ class RecMetric(nn.Module, abc.ABC):
                 task_names = [task.name for task in self._tasks]
 
                 if not isinstance(predictions, torch.Tensor):
-                    logger.info(
-                        "Converting predictions to tensors for RecComputeMode.FUSED_TASKS_COMPUTATION"
-                    )
                     predictions = torch.stack(
                         [predictions[task_name] for task_name in task_names]
                     )
 
                 if not isinstance(labels, torch.Tensor):
-                    logger.info(
-                        "Converting labels to tensors for RecComputeMode.FUSED_TASKS_COMPUTATION"
-                    )
                     labels = torch.stack(
                         [labels[task_name] for task_name in task_names]
                     )
                 if weights is not None and not isinstance(weights, torch.Tensor):
-                    logger.info(
-                        "Converting weights to tensors for RecComputeMode.FUSED_TASKS_COMPUTATION"
-                    )
                     weights = torch.stack(
                         [weights[task_name] for task_name in task_names]
                     )


### PR DESCRIPTION
Summary:
Followup to D64205895 to remove logging since that adds a lot of walltime to metrics update (see f656229217)

{F1944676792}

Reviewed By: iamzainhuda

Differential Revision: D64854969


