### PR TITLE
Capture max memory reserved and malloc_retries metric

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
+++ b/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
@@ -382,9 +382,7 @@ def runner(
                 rank=rank,
             )
             if rank == 0:
-                print(
-                    f"  {pipeline_clazz.__name__: <{35}} | Runtime (P90): {result.runtime_percentile(90)/1000:5.3f} s | Memory (P90): {result.max_mem_percentile(90)/1000:5.3f} GB"
-                )
+                print(result)
 
 
 def single_runner(
@@ -456,9 +454,7 @@ def single_runner(
             rank=0,
         )
 
-        print(
-            f"  {pipeline_clazz.__name__: <{35}} | Runtime (P90): {result.runtime_percentile(90)/1000:5.3f} s | Memory (P90): {result.max_mem_percentile(90)/1000:5.3f} GB"
-        )
+        print(result)
 
 
 if __name__ == "__main__":

--- a/torchrec/sparse/tests/jagged_tensor_benchmark.py
+++ b/torchrec/sparse/tests/jagged_tensor_benchmark.py
@@ -15,7 +15,11 @@ from typing import Any, Callable, Dict, List
 import click
 
 import torch
-from torchrec.distributed.benchmark.benchmark_utils import benchmark, BenchmarkResult
+from torchrec.distributed.benchmark.benchmark_utils import (
+    benchmark,
+    BenchmarkResult,
+    MemoryStats,
+)
 from torchrec.modules.regroup import KTRegroupAsDict
 from torchrec.sparse.jagged_tensor import (
     _fbgemm_permute_pooled_embs,
@@ -104,11 +108,13 @@ def bench(
         result = BenchmarkResult(
             short_name=name,
             elapsed_time=torch.tensor(times) * 1e3,
-            max_mem_allocated=[0],
+            mem_stats=[MemoryStats(0, 0, 0, 0)],
         )
 
+    mem_alloc = f"Memory alloc (P90): {result.max_mem_alloc_percentile(90):5.1f}"
+    mem_reserved = f"Memory alloc (P90): {result.max_mem_reserved_percentile(90):5.1f}"
     print(
-        f"  {name : <{30}} | B: {batch_size : <{8}} | F: {feature_count : <{8}} | device: {device_type : <{8}} | Runtime (P90): {result.runtime_percentile(90):5.2f} ms | Memory (P90): {result.max_mem_percentile(90):5.1f}"
+        f"  {name : <{30}} | B: {batch_size : <{8}} | F: {feature_count : <{8}} | device: {device_type : <{8}} | Runtime (P90): {result.runtime_percentile(90):5.2f} ms | {mem_alloc} | {mem_reserved}"
     )
 
 

--- a/torchrec/sparse/tests/keyed_jagged_tensor_benchmark_lib.py
+++ b/torchrec/sparse/tests/keyed_jagged_tensor_benchmark_lib.py
@@ -20,7 +20,7 @@ import torch
 # Otherwise will get error
 # NotImplementedError: fbgemm::permute_1D_sparse_data: We could not find the abstract impl for this operator.
 from fbgemm_gpu import sparse_ops  # noqa: F401, E402
-from torchrec.distributed.benchmark.benchmark_utils import BenchmarkResult
+from torchrec.distributed.benchmark.benchmark_utils import BenchmarkResult, MemoryStats
 from torchrec.distributed.dist_data import _get_recat
 
 from torchrec.distributed.test_utils.test_model import ModelInput
@@ -227,7 +227,7 @@ def benchmark_kjt(
     result = BenchmarkResult(
         short_name=f"{test_name}-{transform_type.name}",
         elapsed_time=torch.tensor(times),
-        max_mem_allocated=[0],
+        mem_stats=[MemoryStats(0, 0, 0, 0)],
     )
 
     p50_runtime = result.runtime_percentile(50, interpolation="linear").item()


### PR DESCRIPTION
Summary:
# This diff

Adds two metrics to the pipeline benchmarks:
* `num_alloc_retries` - this is bumped by one every time allocator cannot grab memory from device, and have to perform memory defrag/reclaiming
* `max reserved memory` - metric that captures the total reserved memory in addition to already collected `max allocated memory`

Differential Revision: D64896100


