### PR TITLE
Add attempt QPS metric

### DIFF
--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -45,6 +45,7 @@ class MetricName(MetricNameBase):
     LOG_LOSS = "logloss"
     THROUGHPUT = "throughput"
     TOTAL_EXAMPLES = "total_examples"
+    ATTEMPT_EXAMPLES = "attempt_examples"
     CTR = "ctr"
     CALIBRATION = "calibration"
     MSE = "mse"
@@ -124,6 +125,7 @@ class MetricPrefix(StrValueMixin, Enum):
     DEFAULT = ""
     LIFETIME = "lifetime_"
     WINDOW = "window_"
+    ATTEMPT = "attempt_"
 
 
 def task_wildcard_metrics_pattern(


### PR DESCRIPTION
Summary:
Add an attempt QPS metric to measure throughput (QPS) performance of a job attempt. 

This is relevant when different job attempts can be scheduled on different hardware types. When that happens, the lifetime qps metric ends up being an average across different hardware types that can have very different capabilities and is no longer useful for performance analysis. Having a metric that calculates QPS at an attempt level allows for meaningful performance analysis even across different hardware types.

Differential Revision: D64878139


