### PR TITLE
Only compile RecMetric update and compute methods

### DIFF
--- a/torchrec/metrics/accuracy.py
+++ b/torchrec/metrics/accuracy.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -85,7 +84,6 @@ class AccuracyMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -21,7 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -244,7 +244,6 @@ class AUCMetricComputation(RecMetricComputation):
         if self._grouped_auc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/auprc.py
+++ b/torchrec/metrics/auprc.py
@@ -21,7 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -236,7 +236,6 @@ class AUPRCMetricComputation(RecMetricComputation):
         if self._grouped_auprc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -17,7 +17,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 CALIBRATION_NUM = "calibration_num"
 CALIBRATION_DENOM = "calibration_denom"
@@ -66,7 +66,6 @@ class CalibrationMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -18,7 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 CTR_NUM = "ctr_num"
 CTR_DENOM = "ctr_denom"
@@ -63,7 +63,6 @@ class CTRMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/mae.py
+++ b/torchrec/metrics/mae.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -73,7 +72,6 @@ class MAEMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     # pyre-fixme[14]: `update` overrides method defined in `RecMetricComputation`
     #  inconsistently.
     def update(

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -18,7 +18,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -82,7 +81,6 @@ class MSEMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/multiclass_recall.py
+++ b/torchrec/metrics/multiclass_recall.py
@@ -18,7 +18,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_true_positives_at_k(
@@ -110,7 +109,6 @@ class MulticlassRecallMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ndcg.py
+++ b/torchrec/metrics/ndcg.py
@@ -19,7 +19,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 SUM_NDCG = "sum_ndcg"
 NUM_SESSIONS = "num_sessions"
@@ -332,7 +332,6 @@ class NDCGComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_cross_entropy(
@@ -149,7 +148,6 @@ class NEMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/ne_positive.py
+++ b/torchrec/metrics/ne_positive.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 def compute_cross_entropy_positive(
@@ -131,7 +130,6 @@ class NEPositiveMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/output.py
+++ b/torchrec/metrics/output.py
@@ -21,7 +21,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricException,
     RecTaskInfo,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 class OutputMetricComputation(RecMetricComputation):
@@ -47,7 +46,6 @@ class OutputMetricComputation(RecMetricComputation):
             persistent=False,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/precision.py
+++ b/torchrec/metrics/precision.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -97,7 +96,6 @@ class PrecisionMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/rauc.py
+++ b/torchrec/metrics/rauc.py
@@ -21,7 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -288,7 +288,6 @@ class RAUCMetricComputation(RecMetricComputation):
         if self._grouped_rauc:
             getattr(self, GROUPING_KEYS).append(torch.tensor([-1], device=self.device))
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/recall.py
+++ b/torchrec/metrics/recall.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 THRESHOLD = "threshold"
@@ -97,7 +96,6 @@ class RecallMetricComputation(RecMetricComputation):
         )
         self._threshold: float = threshold
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/recall_session.py
+++ b/torchrec/metrics/recall_session.py
@@ -21,7 +21,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -129,7 +129,6 @@ class RecallSessionMetricComputation(RecMetricComputation):
         self.run_ranking_of_labels: bool = session_metric_def.run_ranking_of_labels
         self.session_var_name: Optional[str] = session_metric_def.session_var_name
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetric,
     RecMetricComputation,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 class ScalarMetricComputation(RecMetricComputation):
@@ -42,7 +41,6 @@ class ScalarMetricComputation(RecMetricComputation):
             persistent=False,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/segmented_ne.py
+++ b/torchrec/metrics/segmented_ne.py
@@ -19,7 +19,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 PREDICTIONS = "predictions"
 LABELS = "labels"
@@ -207,7 +207,6 @@ class SegmentedNEMetricComputation(RecMetricComputation):
         )
         self.eta = 1e-12
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/serving_calibration.py
+++ b/torchrec/metrics/serving_calibration.py
@@ -18,7 +18,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 CALIBRATION_NUM = "calibration_num"
 CALIBRATION_DENOM = "calibration_denom"
@@ -58,7 +58,6 @@ class ServingCalibrationMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/serving_ne.py
+++ b/torchrec/metrics/serving_ne.py
@@ -18,7 +18,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 NUM_EXAMPLES = "num_examples"
@@ -99,7 +98,6 @@ class ServingNEMetricComputation(RecMetricComputation):
             eta=self.eta,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/tensor_weighted_avg.py
+++ b/torchrec/metrics/tensor_weighted_avg.py
@@ -18,7 +18,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 def get_mean(value_sum: torch.Tensor, num_samples: torch.Tensor) -> torch.Tensor:
@@ -55,7 +54,6 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/tests/test_accuracy.py
+++ b/torchrec/metrics/tests/test_accuracy.py
@@ -224,7 +224,6 @@ class ThresholdValueTest(unittest.TestCase):
             # pyre-ignore
             threshold=threshold,  # threshold is one of the kwargs
         )
-        # pyre-ignore
         accuracy.update(**inputs)
         actual_accuracy = accuracy.compute()
 

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -405,7 +405,6 @@ class GroupedAUCValueTest(unittest.TestCase):
             # pyre-ignore
             grouped_auc=True,
         )
-        # pyre-ignore
         auc.update(**inputs)
         actual_auc = auc.compute()
 

--- a/torchrec/metrics/tests/test_auprc.py
+++ b/torchrec/metrics/tests/test_auprc.py
@@ -292,7 +292,6 @@ class GroupedAUPRCValueTest(unittest.TestCase):
             # pyre-ignore
             grouped_auprc=True,
         )
-        # pyre-ignore
         auprc.update(**inputs)
         actual_auprc = auprc.compute()
 

--- a/torchrec/metrics/tests/test_precision.py
+++ b/torchrec/metrics/tests/test_precision.py
@@ -225,7 +225,6 @@ class ThresholdValueTest(unittest.TestCase):
             # pyre-ignore
             threshold=threshold,  # threshold is one of the kwargs
         )
-        # pyre-ignore
         precision.update(**inputs)
         actual_precision = precision.compute()
 

--- a/torchrec/metrics/tests/test_rauc.py
+++ b/torchrec/metrics/tests/test_rauc.py
@@ -379,7 +379,6 @@ class GroupedRAUCValueTest(unittest.TestCase):
             # pyre-ignore
             grouped_rauc=True,
         )
-        # pyre-ignore
         rauc.update(**inputs)
         actual_rauc = rauc.compute()
 

--- a/torchrec/metrics/tests/test_recall.py
+++ b/torchrec/metrics/tests/test_recall.py
@@ -219,7 +219,6 @@ class ThresholdValueTest(unittest.TestCase):
             # pyre-ignore
             threshold=threshold,  # threshold is one of the kwargs
         )
-        # pyre-ignore
         recall.update(**inputs)
         actual_recall = recall.compute()
 

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -111,11 +111,7 @@ class RecMetricTest(unittest.TestCase):
         self.assertGreater(mse_computation.weighted_num_samples, torch.tensor(0.0))
 
         res = mse.compute()
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
         self.assertGreater(res["mse-DefaultTask|lifetime_mse"], torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
         self.assertGreater(res["mse-DefaultTask|lifetime_rmse"], torch.tensor(0.0))
 
         # Test if weights = 0 for one task of an update
@@ -165,8 +161,6 @@ class RecMetricTest(unittest.TestCase):
 
         res = ne.compute()
         self.assertEqual(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
         self.assertGreater(res["ne-t2|lifetime_ne"], torch.tensor(0.0))
 
         ne.update(
@@ -182,8 +176,6 @@ class RecMetricTest(unittest.TestCase):
         self.assertGreater(ne_computation[0].weighted_num_samples, torch.tensor(0.0))
 
         res = ne.compute()
-        # pyre-fixme[6]: For 2nd param expected `SupportsDunderLT[Variable[_T]]` but
-        #  got `Tensor`.
         self.assertGreater(res["ne-t1|lifetime_ne"], torch.tensor(0.0))
 
     def test_compute(self) -> None:

--- a/torchrec/metrics/tests/test_segmented_ne.py
+++ b/torchrec/metrics/tests/test_segmented_ne.py
@@ -65,7 +65,6 @@ class SegementedNEValueTest(unittest.TestCase):
             # pyre-ignore
             num_groups=max(2, torch.unique(grouping_keys)[-1].item() + 1),
         )
-        # pyre-ignore
         ne.update(**inputs)
         actual_ne = ne.compute()
 

--- a/torchrec/metrics/tests/test_weighted_avg.py
+++ b/torchrec/metrics/tests/test_weighted_avg.py
@@ -174,7 +174,6 @@ class WeightedAvgValueTest(unittest.TestCase):
             batch_size=batch_size,
             tasks=task_list,
         )
-        # pyre-ignore
         weighted_avg.update(**inputs)
         actual_weighted_avg = weighted_avg.compute()
 

--- a/torchrec/metrics/tower_qps.py
+++ b/torchrec/metrics/tower_qps.py
@@ -22,7 +22,7 @@ from torchrec.metrics.rec_metric import (
     RecMetricException,
     RecModelOutput,
 )
-from torchrec.pt2.utils import pt2_compile_callable
+
 
 WARMUP_STEPS = 100
 
@@ -79,7 +79,6 @@ class TowerQPSMetricComputation(RecMetricComputation):
         self._previous_ts = 0
         self._steps = 0
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/weighted_avg.py
+++ b/torchrec/metrics/weighted_avg.py
@@ -16,7 +16,6 @@ from torchrec.metrics.rec_metric import (
     RecMetric,
     RecMetricComputation,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 def get_mean(value_sum: torch.Tensor, num_samples: torch.Tensor) -> torch.Tensor:
@@ -41,7 +40,6 @@ class WeightedAvgMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     def update(
         self,
         *,

--- a/torchrec/metrics/xauc.py
+++ b/torchrec/metrics/xauc.py
@@ -17,7 +17,6 @@ from torchrec.metrics.rec_metric import (
     RecMetricComputation,
     RecMetricException,
 )
-from torchrec.pt2.utils import pt2_compile_callable
 
 
 ERROR_SUM = "error_sum"
@@ -102,7 +101,6 @@ class XAUCMetricComputation(RecMetricComputation):
             persistent=True,
         )
 
-    @pt2_compile_callable
     # pyre-fixme[14]: `update` overrides method defined in `RecMetricComputation`
     #  inconsistently.
     def update(


### PR DESCRIPTION
Summary:
Compiling update and compute on RecMetric also compiles it for the RecMetricComputation class. This allows us to remove the decorator from each individual MetricComputation class. We still see the torch.compiled regions

 {F1948512771}

Reviewed By: iamzainhuda

Differential Revision: D65003124


