### PR TITLE
upgrade metadata call to use IMDSv2, only supported version soon

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -132,7 +132,7 @@ jobs:
           # Pulled from instance metadata endpoint for EC2
           # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
           category=$1
-          curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+            curl -H "X-aws-ec2-metadata-token: $(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")" -fsSL "http://169.254.169.254/latest/meta-data/${category}"
         }
         echo "ami-id: $(get_ec2_metadata ami-id)"
         echo "instance-id: $(get_ec2_metadata instance-id)"


### PR DESCRIPTION
Summary:
Soon we will only support metadata fetching for EC2 instances via IMDSv2 - this upgrades the existing v1 call to a v2 call - no functional changes

Test plan:
testing if the release_build.yaml workflow correctly fetches the instance metadata

NOTE: this workflow only runs on pypi release