### PR TITLE
add ddr_cap config to shard_quant_model in TGIF

### DIFF
--- a/torchrec/inference/include/torchrec/inference/GPUExecutor.h
+++ b/torchrec/inference/include/torchrec/inference/GPUExecutor.h
@@ -32,7 +32,7 @@
 #include "torchrec/inference/BatchingQueue.h"
 #include "torchrec/inference/Observer.h"
 #include "torchrec/inference/ResultSplit.h"
-#include "torchrec/inference/include/torchrec/inference/Observer.h"
+#include "torchrec/inference/include/torchrec/inference/Observer.h" // @manual
 
 namespace torchrec {
 

--- a/torchrec/inference/inference_legacy/src/GPUExecutor.cpp
+++ b/torchrec/inference/inference_legacy/src/GPUExecutor.cpp
@@ -25,7 +25,7 @@
 #include <folly/stop_watch.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <torch/csrc/autograd/profiler.h>
+#include <torch/csrc/autograd/profiler.h> // @manual
 
 // remove this after we switch over to multipy externally for torchrec
 #ifdef FBCODE_CAFFE2

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -488,6 +488,7 @@ def shard_quant_model(
     sharders: Optional[List[ModuleSharder[torch.nn.Module]]] = None,
     device_memory_size: Optional[int] = None,
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    ddr_cap: Optional[int] = None,
 ) -> Tuple[torch.nn.Module, ShardingPlan]:
     """
     Shard a quantized TorchRec model, used for generating the most optimal model for inference and
@@ -557,6 +558,7 @@ def shard_quant_model(
         compute_device=compute_device,
         local_world_size=world_size,
         hbm_cap=hbm_cap,
+        ddr_cap=ddr_cap,
     )
     batch_size = 1
     model_plan = trec_dist.planner.EmbeddingShardingPlanner(


### PR DESCRIPTION
Summary:
add ddr_cap config to shard_quant_model in
inference path, so that we can fully utilize the CPU memory

Differential Revision: D65451305


