### PR TITLE
add option for MODULE_ATTR_USE_BATCHING_HINTED_OUTPUT

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -85,6 +85,8 @@ MODULE_ATTR_USE_UNFLATTENED_LENGTHS_FOR_BATCHING: str = (
     "__use_unflattened_lengths_for_batching"
 )
 
+MODULE_ATTR_USE_BATCHING_HINTED_OUTPUT: str = "__use_batching_hinted_output"
+
 DEFAULT_ROW_ALIGNMENT = 16
 
 
@@ -913,7 +915,8 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
                 lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)
             else:
-                lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)
+                if getattr(self, MODULE_ATTR_USE_BATCHING_HINTED_OUTPUT, True):
+                    lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
             jt = construct_jagged_tensors_inference(
                 embeddings=lookup,


### PR DESCRIPTION
Summary: The current GPU rebatching logics for _get_batching_hinted_output does not work for pooling_factor > 1, we need to disable it for GPU model to avoid rebatching flattened feature length

Differential Revision: D65499768


