### PR TITLE
use inverse indices in KJT permute

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2489,7 +2489,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         return split_list
 
     def permute(
-        self, indices: List[int], indices_tensor: Optional[torch.Tensor] = None
+        self,
+        indices: List[int],
+        indices_tensor: Optional[torch.Tensor] = None,
+        include_inverse_indices: bool = False,
     ) -> "KeyedJaggedTensor":
         """
         Permutes the KeyedJaggedTensor.
@@ -2587,7 +2590,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             offset_per_key=None,
             index_per_key=None,
             jt_dict=None,
-            inverse_indices=None,
+            inverse_indices=(
+                self.inverse_indices_or_none() if include_inverse_indices else None
+            ),
         )
         return kjt
 


### PR DESCRIPTION
Summary: calling a kjt.permute() on a VBE KJT makes the output KJT no longer VBE. this diff fixes it such that the output KJT is VBE.

Differential Revision: D65621958


