### PR TITLE
Optimize to 1 TBE per rank (no longer separate by quant dtype) for Sharded & Quantized EBC & PEA

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -446,6 +446,15 @@ def _prefetch_and_cached(
     )
 
 
+def _all_tables_are_quant_kernel(
+    tables: List[ShardedEmbeddingTable],
+) -> bool:
+    """
+    Return if all tables have quant compute kernel.
+    """
+    return all(table.compute_kernel == EmbeddingComputeKernel.QUANT for table in tables)
+
+
 # group tables by `DataType`, `PoolingType`, and `EmbeddingComputeKernel`.
 def group_tables(
     tables_per_rank: List[List[ShardedEmbeddingTable]],
@@ -489,6 +498,8 @@ def group_tables(
         # Collect groups
         groups = defaultdict(list)
         grouping_keys = []
+        # Assumes all compute kernels within tables are the same
+        is_inference = _all_tables_are_quant_kernel(embedding_tables)
         for table in embedding_tables:
             bucketer = (
                 prefetch_cached_dim_bucketer
@@ -499,12 +510,16 @@ def group_tables(
                 _get_grouping_fused_params(table.fused_params, table.name) or {}
             )
             grouping_key = (
-                table.data_type,
+                table.data_type if not is_inference else None,
                 table.pooling,
                 table.has_feature_processor,
                 tuple(sorted(group_fused_params.items())),
                 _get_compute_kernel_type(table.compute_kernel),
-                bucketer.get_bucket(table.local_cols, table.data_type),
+                # TODO: Unit test to check if table.data_type affects table grouping
+                bucketer.get_bucket(
+                    table.local_cols,
+                    table.data_type,
+                ),
                 _prefetch_and_cached(table),
             )
             # micromanage the order of we traverse the groups to ensure backwards compatibility

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -429,6 +429,21 @@ class TestGroupTablesPerRank(unittest.TestCase):
             )
             return
 
+        # If both kernels are quantized, we assume this is inference which we no longer split by data_type
+        # So if other attributes are the same between the two tables (regardless of data type), we combine them
+        if (
+            tables[0].compute_kernel == EmbeddingComputeKernel.QUANT
+            and tables[1].compute_kernel == EmbeddingComputeKernel.QUANT
+            and tables[0].pooling == tables[1].pooling
+            and tables[0].has_feature_processor == tables[1].has_feature_processor
+        ):
+
+            self.assertEqual(
+                sorted(_get_table_names_by_groups(tables)),
+                [["table_0", "table_1"]],
+            )
+            return
+
         self.assertEqual(
             sorted(_get_table_names_by_groups(tables)),
             [["table_0"], ["table_1"]],

--- a/torchrec/inference/tests/test_inference.py
+++ b/torchrec/inference/tests/test_inference.py
@@ -215,3 +215,86 @@ class InferenceTest(unittest.TestCase):
         # 3 TBES (1 FPEBC, 2 EBCs (1 weighted, 1 unweighted))
 
         self.assertEqual(num_tbes, 3)
+
+    def test_sharded_quantized_tbe_count(self) -> None:
+        set_propogate_device(True)
+
+        model = TestSparseNN(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            num_float_features=10,
+            dense_device=torch.device("cpu"),
+            sparse_device=torch.device("cpu"),
+            over_arch_clazz=TestOverArchRegroupModule,
+        )
+
+        per_table_weight_dtypes = {}
+
+        for table in self.tables + self.weighted_tables:
+            # quint4x2 different than int8, which is default
+            per_table_weight_dtypes[table.name] = (
+                torch.quint4x2 if table.name == "table_0" else torch.quint8
+            )
+
+        model.eval()
+        _, local_batch = ModelInput.generate(
+            batch_size=16,
+            world_size=1,
+            num_float_features=10,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+        )
+
+        # with torch.inference_mode(): # TODO: Why does inference mode fail when using different quant data types
+        output = model(local_batch[0])
+
+        # Quantize the model and collect quantized weights
+        quantized_model = quantize_inference_model(
+            model, per_table_weight_dtype=per_table_weight_dtypes
+        )
+        quantized_output = quantized_model(local_batch[0])
+        table_to_weight = get_table_to_weights_from_tbe(quantized_model)
+
+        # Shard the model, all weights are initialized back to 0, so have to reassign weights
+        sharded_quant_model, _ = shard_quant_model(
+            quantized_model,
+            world_size=1,
+            compute_device="cpu",
+            sharding_device="cpu",
+        )
+        assign_weights_to_tbe(quantized_model, table_to_weight)
+        sharded_quant_output = sharded_quant_model(local_batch[0])
+
+        # When world_size = 1, we should have 1 TBE per sharded, quantized ebc
+        self.assertTrue(len(sharded_quant_model.sparse.ebc.tbes) == 1)
+        self.assertTrue(len(sharded_quant_model.sparse.weighted_ebc.tbes) == 1)
+
+        # Check the weights are close
+        self.assertTrue(torch.allclose(output, quantized_output, atol=1e-3))
+        self.assertTrue(torch.allclose(output, sharded_quant_output, atol=1e-3))
+
+        # Check the sizes are correct
+        expected_num_embeddings = {}
+
+        for table in self.tables:
+            expected_num_embeddings[table.name] = table.num_embeddings
+
+        for module in quantized_model.modules():
+            if module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
+                for i, spec in enumerate(module.embedding_specs):
+                    if spec[0] in expected_num_embeddings:
+                        # We only expect the first table to be quantized to int4 due to test set up
+                        if spec[0] == "table_0":
+                            self.assertEqual(spec[3], SparseType.INT4)
+                        else:
+                            self.assertEqual(spec[3], SparseType.INT8)
+
+                        # Check sizes are equal
+                        self.assertEqual(
+                            module.split_embedding_weights()[i][0].size(0),
+                            expected_num_embeddings[spec[0]],
+                        )
+                        self.assertEqual(
+                            spec[1],
+                            expected_num_embeddings[spec[0]],
+                        )


### PR DESCRIPTION
Summary:
Reduce the number of TBEs created per Sharded & Quantized EBC & PEA.

We realized we are creating a separate TBE for different datatype for every EBC or PEA module. However, FBGEMM's TBE module actually supports having embedding_tables with different data types all within the same TBE.

This optimization can help reduce the # of inputs to the merge net after model split - which we realized was the portion with the most regression for TorchRec Inference

Differential Revision: D64066446


