### PR TITLE
Add `description` to tensor weighted avg metric

### DIFF
--- a/torchrec/metrics/tensor_weighted_avg.py
+++ b/torchrec/metrics/tensor_weighted_avg.py
@@ -30,6 +30,7 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
         *args: Any,
         tensor_name: Optional[str] = None,
         weighted: bool = True,
+        description: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -53,6 +54,7 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=True,
         )
+        self._description = description
 
     def update(
         self,
@@ -96,6 +98,7 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
                     cast(torch.Tensor, self.weighted_sum),
                     cast(torch.Tensor, self.weighted_num_samples),
                 ),
+                description=self._description,
             ),
             MetricComputationReport(
                 name=MetricName.WEIGHTED_AVG,
@@ -104,6 +107,7 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
                     self.get_window_state("weighted_sum"),
                     self.get_window_state("weighted_num_samples"),
                 ),
+                description=self._description,
             ),
         ]
 


### PR DESCRIPTION
Summary: Adds `description` arg to tensor weighted average metric, so one can annotate a description for arbitrary tensors.

Differential Revision:
D65969601

Privacy Context Container: L1144028


