### PR TITLE
Internal ignores for [pytorch][PR] Fix type-safety of `torch.nn.Module` instances

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -623,13 +623,17 @@ def _gen_named_parameters_by_table_fused(
         table_count = table_name_to_count.pop(table_name)
         if emb_module.weights_precision == SparseType.INT8:
             dim += emb_module.int8_emb_row_dim_offset
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         offset = emb_module.weights_physical_offsets[t_idx]
         weights: torch.Tensor
         if location == EmbeddingLocation.DEVICE.value:
+            # pyre-fixme[9]: weights has type `Tensor`; used as `Union[Module, Tensor]`.
             weights = emb_module.weights_dev
         elif location == EmbeddingLocation.HOST.value:
+            # pyre-fixme[9]: weights has type `Tensor`; used as `Union[Module, Tensor]`.
             weights = emb_module.weights_host
         else:
+            # pyre-fixme[9]: weights has type `Tensor`; used as `Union[Module, Tensor]`.
             weights = emb_module.weights_uvm
         weight = TableBatchedEmbeddingSlice(
             data=weights,

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -778,6 +778,8 @@ class ShardedEmbeddingCollection(
             for (
                 table_name,
                 tbe_slice,
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+                #  `named_parameters_by_table`.
             ) in lookup.named_parameters_by_table():
                 self.embeddings[table_name].register_parameter("weight", tbe_slice)
         for table_name in self._model_parallel_name_to_local_shards.keys():
@@ -1089,6 +1091,8 @@ class ShardedEmbeddingCollection(
         if self._features_order:
             unpadded_features = unpadded_features.permute(
                 self._features_order,
+                # pyre-fixme[6]: For 2nd argument expected `Optional[Tensor]` but
+                #  got `TypeUnion[Module, Tensor]`.
                 self._features_order_tensor,
             )
 
@@ -1148,6 +1152,8 @@ class ShardedEmbeddingCollection(
             if self._features_order:
                 features = features.permute(
                     self._features_order,
+                    # pyre-fixme[6]: For 2nd argument expected `Optional[Tensor]`
+                    #  but got `TypeUnion[Module, Tensor]`.
                     self._features_order_tensor,
                 )
             features_by_shards = features.split(self._feature_splits)

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -175,6 +175,8 @@ class ShardedEmbeddingTower(
             )
 
         # Setup output dists for quantized comms
+        # pyre-fixme[8]: Attribute has type `ModuleList`; used as `Union[Module,
+        #  Tensor]`.
         self._output_dists: nn.ModuleList = (
             self.embedding._output_dists if self.embedding else nn.ModuleList()
         )
@@ -377,6 +379,7 @@ class ShardedEmbeddingTower(
     @property
     def fused_optimizer(self) -> KeyedOptimizer:
         if self.embedding:
+            # pyre-fixme[7]: Expected `KeyedOptimizer` but got `Union[Module, Tensor]`.
             return self.embedding.fused_optimizer
         else:
             return CombinedOptimizer([])
@@ -570,6 +573,7 @@ class ShardedEmbeddingTowerCollection(
                         table.name for table in tower.embedding.embedding_configs()
                     }
                 elif hasattr(tower.embedding, "tables"):
+                    # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                     table_names = {table.name for table in tower.embedding.tables()}
                 else:
                     # Use all tables if unable to determine from tower.embedding

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -885,6 +885,8 @@ class ShardedEmbeddingBagCollection(
             for (
                 table_name,
                 tbe_slice,
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+                #  `named_parameters_by_table`.
             ) in lookup.named_parameters_by_table():
                 self.embedding_bags[table_name].register_parameter("weight", tbe_slice)
 
@@ -990,6 +992,7 @@ class ShardedEmbeddingBagCollection(
                     # unwrap DDP
                     lookup = lookup.module
                 else:
+                    # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                     for key, v in lookup.get_named_split_embedding_weights_snapshot():
                         destination_key = f"{prefix}embedding_bags.{key}.weight"
                         assert key in sharded_kvtensors_copy
@@ -1160,6 +1163,8 @@ class ShardedEmbeddingBagCollection(
             if self._has_features_permute:
                 features = features.permute(
                     self._features_order,
+                    # pyre-fixme[6]: For 2nd argument expected `Optional[Tensor]`
+                    #  but got `Union[Module, Tensor]`.
                     self._features_order_tensor,
                 )
             if self._has_mean_pooling_callback:

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -76,6 +76,7 @@ class ShardedFusedEmbeddingBagCollection(
                     broadcast_buffers=False,
                     static_graph=True,
                 )
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 self._lookups[index]._register_fused_optim(
                     optimizer_type, **optimizer_kwargs
                 )

--- a/torchrec/distributed/infer_utils.py
+++ b/torchrec/distributed/infer_utils.py
@@ -37,6 +37,7 @@ def get_tbes_from_sharded_module(
         ShardedQuantEmbeddingCollection,
     ], "Only support ShardedQuantEmbeddingBagCollection and ShardedQuantEmbeddingCollection for get TBEs"
     tbes = []
+    # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a function.
     for lookup in module._lookups:
         for lookup_per_rank in lookup._embedding_lookups_per_rank:
             for emb_module in lookup_per_rank._emb_modules:

--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -329,7 +329,9 @@ class ShardedKeyedJaggedTensorPool(
         # somewhat hacky. ideally, we should be able to invoke this method on
         # any update to the lookup's key_lengths field.
         lengths, offsets = lookup._infer_jagged_lengths_inclusive_offsets()
+        # pyre-fixme[16]: `KeyedJaggedTensorPoolLookup` has no attribute `_lengths`.
         lookup._lengths = lengths
+        # pyre-fixme[16]: `KeyedJaggedTensorPoolLookup` has no attribute `_offsets`.
         lookup._offsets = offsets
 
     def _lookup_ids_dist(
@@ -552,9 +554,11 @@ class ShardedInferenceKeyedJaggedTensorPool(
             )
             if module._device != torch.device("meta"):
                 self._local_kjt_pool_shards[rank]._values.copy_(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     module.values[offset : offset + this_rank_size]
                 )
                 self._local_kjt_pool_shards[rank]._key_lengths.copy_(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     module.key_lengths[offset : offset + this_rank_size]
                 )
                 jagged_lengths, jagged_offsets = self._local_kjt_pool_shards[
@@ -585,6 +589,7 @@ class ShardedInferenceKeyedJaggedTensorPool(
 
     @property
     def dim(self) -> int:
+        # pyre-fixme[7]: Expected `int` but got `Union[Tensor, Module]`.
         return self._dim
 
     @property

--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -133,6 +133,8 @@ class BaseShardedManagedCollisionEmbeddingCollection(
         # pyre-ignore
         self._table_to_tbe_and_index = {}
         for lookup in self._embedding_module._lookups:
+            # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not
+            #  a function.
             for emb_module in lookup._emb_modules:
                 for table_idx, table in enumerate(emb_module._config.embedding_tables):
                     self._table_to_tbe_and_index[table.name] = (
@@ -182,12 +184,16 @@ class BaseShardedManagedCollisionEmbeddingCollection(
 
                     if self.bagged:
                         table_weight_param = (
+                            # pyre-fixme[16]: Item `Tensor` of `Tensor | ModuleDict
+                            #  | Module` has no attribute `get_parameter`.
                             self._embedding_module.embedding_bags.get_parameter(
                                 f"{table}.weight"
                             )
                         )
                     else:
                         table_weight_param = (
+                            # pyre-fixme[16]: Item `Tensor` of `Tensor | ModuleDict
+                            #  | Module` has no attribute `get_parameter`.
                             self._embedding_module.embeddings.get_parameter(
                                 f"{table}.weight"
                             )

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -410,8 +410,12 @@ class ShardedManagedCollisionCollection(
             )
             self._input_dists.append(input_dist)
 
+        # pyre-fixme[16]: `ShardedManagedCollisionCollection` has no attribute
+        #  `_features_order`.
         self._features_order: List[int] = []
         for f in self._feature_names:
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `append`.
             self._features_order.append(input_feature_names.index(f))
         self._features_order = (
             []
@@ -532,7 +536,11 @@ class ShardedManagedCollisionCollection(
         with torch.no_grad():
             if self._features_order:
                 features = features.permute(
+                    # pyre-fixme[6]: For 1st argument expected `List[int]` but got
+                    #  `Union[Module, Tensor]`.
                     self._features_order,
+                    # pyre-fixme[6]: For 2nd argument expected `Optional[Tensor]`
+                    #  but got `Union[Module, Tensor]`.
                     self._features_order_tensor,
                 )
 

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -120,10 +120,12 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
             ),
         )
         if self._allreduce_comm_precision == "fp16":
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             dmp._dmp_wrapped_module.register_comm_hook(
                 None, ddp_default_hooks.fp16_compress_hook
             )
         elif self._allreduce_comm_precision == "bf16":
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             dmp._dmp_wrapped_module.register_comm_hook(
                 None, ddp_default_hooks.bf16_compress_hook
             )
@@ -404,6 +406,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
             # Init parameters if at least one parameter is over 'meta' device.
             if has_meta_param and hasattr(module, "reset_parameters"):
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 module.reset_parameters()
 
         module.apply(init_parameters)

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -147,10 +147,14 @@ class EmbeddingPerfEstimator(ShardEstimator):
                 hasattr(module, "_feature_processor")
                 and hasattr(module._feature_processor, "feature_processor_modules")
                 and isinstance(
+                    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                    #  attribute `feature_processor_modules`.
                     module._feature_processor.feature_processor_modules,
                     nn.ModuleDict,
                 )
                 and sharding_option.name
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `feature_processor_modules`.
                 in module._feature_processor.feature_processor_modules.keys()
             ):
                 has_feature_processor = True

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -671,6 +671,8 @@ class ShardedQuantEmbeddingCollection(
         features: KeyedJaggedTensor,
     ) -> ListOfKJTList:
         if self._has_uninitialized_input_dist:
+            # pyre-fixme[16]: `ShardedQuantEmbeddingCollection` has no attribute
+            #  `_input_dist`.
             self._input_dist = ShardedQuantEcInputDist(
                 input_feature_names=features.keys() if features is not None else [],
                 sharding_type_device_group_to_sharding=self._sharding_type_device_group_to_sharding,
@@ -688,6 +690,7 @@ class ShardedQuantEmbeddingCollection(
             unbucketize_permute_tensor_list,
             bucket_mapping_tensor_list,
             bucketized_length_list,
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
         ) = self._input_dist(features)
 
         with torch.no_grad():

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -348,6 +348,7 @@ class QuantBatchedEmbeddingBag(
             module, "qconfig"
         ), "BaseEmbedding input float module must have qconfig defined"
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `weight`.
         data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         sparse_type = data_type_to_sparse_type(data_type)
 
@@ -504,6 +505,7 @@ class QuantBatchedEmbedding(
             module, "qconfig"
         ), "BaseEmbedding input float module must have qconfig defined"
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `weight`.
         data_type = dtype_to_data_type(module.qconfig.weight().dtype)
         sparse_type = data_type_to_sparse_type(data_type)
 

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -623,6 +623,8 @@ class ShardedQuantEbcInputDist(torch.nn.Module):
             if self._has_features_permute:
                 features = features.permute(
                     self._features_order,
+                    # pyre-fixme[6]: For 2nd argument expected `Optional[Tensor]`
+                    #  but got `Union[Module, Tensor]`.
                     self._features_order_tensor,
                 )
             else:

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -1093,5 +1093,7 @@ def replace_sharded_quant_modules_tbes_with_mock_tbes(M: torch.nn.Module) -> Non
     for m in M.modules():
         if isinstance(m, ShardedQuantEmbeddingBagCollection):
             for lookup in m._lookups:
+                # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Module, Tensor]` is
+                #  not a function.
                 for lookup_per_rank in lookup._embedding_lookups_per_rank:
                     replace_registered_tbes_with_mock_tbes(lookup_per_rank)

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -1322,7 +1322,11 @@ class TestTowerSparseNN(TestSparseNNBase):
 
         self.over = nn.Linear(
             in_features=8
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + self.tower_0.interaction.linear.out_features
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + self.tower_1.interaction.linear.out_features
             + tables[1].embedding_dim * len(tables[1].feature_names)
             + weighted_tables[0].embedding_dim * len(weighted_tables[0].feature_names),
@@ -1414,8 +1418,14 @@ class TestTowerCollectionSparseNN(TestSparseNNBase):
         self.tower_arch = EmbeddingTowerCollection(towers=[tower_0, tower_1, tower_2])
         self.over = nn.Linear(
             in_features=8
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + tower_0.interaction.linear.out_features
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + tower_1.interaction.linear.out_features
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + tower_2.interaction.linear.out_features,
             out_features=16,
             device=dense_device,

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -1153,6 +1153,8 @@ class ModelParallelStateDictBase(ModelParallelSingleRankBase):
         (dense_model, _), batch = self._generate_dmps_and_batch(dense_sharders)
 
         dense_opt = RowWiseAdagrad(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `parameters`.
             dense_model.module.sparse.parameters(),
             lr=learning_rate,
             eps=1e-8,  # TBE has default eps 1e-8

--- a/torchrec/distributed/tests/test_apply_optimizer_to_dense_tbe.py
+++ b/torchrec/distributed/tests/test_apply_optimizer_to_dense_tbe.py
@@ -107,6 +107,8 @@ class ApplyOptmizerDenseTBETest(ModelParallelSingleRankBase):
 
         ### apply Rowwise Adagrad optimizer to fused TBEs ###
         # fused TBE optimizer needs to be configured before initializing
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `named_parameters`.
         for _, param in unsharded_model.sparse.named_parameters():
             apply_optimizer_in_backward(
                 RowWiseAdagrad,
@@ -128,6 +130,8 @@ class ApplyOptmizerDenseTBETest(ModelParallelSingleRankBase):
         non_fused_tables_optimizer = KeyedOptimizerWrapper(
             dict(
                 in_backward_optimizer_filter(
+                    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                    #  attribute `named_parameters`.
                     sharded_model.module.sparse.named_parameters()
                 )
             ),
@@ -160,11 +164,15 @@ class ApplyOptmizerDenseTBETest(ModelParallelSingleRankBase):
         batch = local_batch[0].to(self.device)
 
         # record signatures
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `dhn_arch`.
         dense_signature = sharded_model.module.over.dhn_arch.linear0.weight.sum().item()
         non_fused_table_signature = (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             sharded_model.module.sparse.ebc.embedding_bags.table_0.weight.sum().item()
         )
         fused_table_signature = (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             sharded_model.module.sparse.ebc.embedding_bags.table_1.weight.sum().item()
         )
 
@@ -182,16 +190,20 @@ class ApplyOptmizerDenseTBETest(ModelParallelSingleRankBase):
         dense_opt.step()
 
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             sharded_model.module.sparse.ebc.embedding_bags.table_1.weight.sum().item()
             != fused_table_signature,
             bool(fused_learning_rate),
         )
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             sharded_model.module.sparse.ebc.embedding_bags.table_0.weight.sum().item()
             != non_fused_table_signature,
             bool(non_fused_learning_rate),
         )
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `dhn_arch`.
             sharded_model.module.over.dhn_arch.linear0.weight.sum().item()
             != dense_signature,
             bool(dense_learning_rate),

--- a/torchrec/distributed/tests/test_cache_prefetch.py
+++ b/torchrec/distributed/tests/test_cache_prefetch.py
@@ -133,6 +133,7 @@ class ShardedEmbeddingModuleCachePrefetchTest(unittest.TestCase):
         sharded_ebc = sharded_model.module
         self.assertIsInstance(sharded_ebc, ShardedEmbeddingBagCollection)
         lookups = sharded_ebc._lookups
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         emb_module = lookups[0]._emb_modules[0]._emb_module
         self.assertIsInstance(emb_module, SplitTableBatchedEmbeddingBagsCodegen)
 
@@ -143,6 +144,7 @@ class ShardedEmbeddingModuleCachePrefetchTest(unittest.TestCase):
         self.assertEqual(self.get_cache_unique_misses(emb_module), 3)
 
         kjt_list = KJTList([batch_1_kjt])
+        # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
         sharded_ebc.prefetch(kjt_list)
 
         # Reset cache stats so that local uvm cache stats are reset
@@ -213,9 +215,11 @@ class ShardedEmbeddingModuleCachePrefetchTest(unittest.TestCase):
         )
         sharded_ebc = sharded_model.module
         lookups = sharded_ebc._lookups
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         emb_module = lookups[0]._emb_modules[0]._emb_module
 
         kjt_list = KJTList([batch_1_kjt])
+        # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
         sharded_ebc.prefetch(kjt_list)
 
         # Reset cache stats so that local uvm cache stats are reset

--- a/torchrec/distributed/tests/test_fp_embeddingbag.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag.py
@@ -104,6 +104,8 @@ def get_unsharded_and_sharded_module(
 
         replicate(
             sharded_sparse_arch,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_bag_collection`.
             ignored_modules=[sharded_sparse_arch._fp_ebc._embedding_bag_collection],
             process_group=ctx.pg,
             gradient_as_bucket_view=True,

--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -74,6 +74,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
         sharder = QuantEmbeddingCollectionSharder()
         compute_kernel = EmbeddingComputeKernel.QUANT.value
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(([20, 10, 100], "cpu")),
@@ -119,19 +120,24 @@ class InferHeteroShardingsTest(unittest.TestCase):
             env=env_dict,
         )
 
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_lookups"))
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self.assertTrue(len(sharded_model._module_kjt_input[0]._lookups) == 2)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_input_dists"))
 
         for i, env in enumerate(env_dict.values()):
             self.assertTrue(
                 hasattr(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     sharded_model._module_kjt_input[0]._lookups[i],
                     "_embedding_lookups_per_rank",
                 )
             )
             self.assertTrue(
                 len(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     sharded_model._module_kjt_input[0]
                     ._lookups[i]
                     ._embedding_lookups_per_rank
@@ -175,6 +181,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
         sharder = QuantEmbeddingBagCollectionSharder()
         compute_kernel = EmbeddingComputeKernel.QUANT.value
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(([20, 10, 100], "cpu")),
@@ -211,17 +218,21 @@ class InferHeteroShardingsTest(unittest.TestCase):
             plan=plan,
             env=env_dict,
         )
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_lookups"))
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self.assertTrue(len(sharded_model._module_kjt_input[0]._lookups) == 2)
         for i, env in enumerate(env_dict.values()):
             self.assertTrue(
                 hasattr(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     sharded_model._module_kjt_input[0]._lookups[i],
                     "_embedding_lookups_per_rank",
                 )
             )
             self.assertTrue(
                 len(
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     sharded_model._module_kjt_input[0]
                     ._lookups[i]
                     ._embedding_lookups_per_rank

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -256,12 +256,16 @@ class InferShardingsTest(unittest.TestCase):
 
         self.assertEqual(
             len(
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse`.
                 sharded_model._module.sparse.ebc._lookups[0]._embedding_lookups_per_rank
             ),
             2,
         )
         self.assertEqual(
             len(
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse`.
                 sharded_model._module.sparse.weighted_ebc._lookups[
                     0
                 ]._embedding_lookups_per_rank
@@ -419,6 +423,8 @@ class InferShardingsTest(unittest.TestCase):
             )
 
             module_plan = construct_module_sharding_plan(
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse`.
                 non_sharded_model._module.sparse.ebc,
                 per_param_sharding={
                     "table_0": column_wise(ranks=[1, 0, 1, 0]),
@@ -621,6 +627,8 @@ class InferShardingsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             non_sharded_model._module.sparse.ebc,
             per_param_sharding={
                 "table_0": column_wise(ranks=[1, 0]),
@@ -747,6 +755,8 @@ class InferShardingsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             non_sharded_model._module.sparse.ebc,
             per_param_sharding={
                 "table_0": column_wise(ranks=[2, 1]),
@@ -1290,6 +1300,7 @@ class InferShardingsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(
@@ -1331,6 +1342,7 @@ class InferShardingsTest(unittest.TestCase):
         gm_script_output = gm_script(*inputs[0])
         assert_close(sharded_output, gm_script_output)
 
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         tbes = get_tbes_from_sharded_module(sharded_model._module_kjt_input[0])
         for tbe in tbes:
             self.assertTrue(tbe.weight_initialized)
@@ -1414,6 +1426,7 @@ class InferShardingsTest(unittest.TestCase):
         sharder = QuantEmbeddingCollectionSharder()
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(),
@@ -1525,6 +1538,7 @@ class InferShardingsTest(unittest.TestCase):
         sharder = QuantEmbeddingCollectionSharder()
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             non_sharded_model._module_kjt_input[0],
             per_param_sharding={
                 "table_0": row_wise(),
@@ -1627,6 +1641,8 @@ class InferShardingsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             non_sharded_model._module.sparse.ebc,
             per_param_sharding={
                 "table_0": row_wise(([size0, size1, size2], device)),
@@ -1778,6 +1794,8 @@ class InferShardingsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             non_sharded_model._module.sparse.ebc,
             per_param_sharding={
                 "table_0": row_wise(
@@ -1856,6 +1874,8 @@ class InferShardingsTest(unittest.TestCase):
         sharder = QuantEmbeddingBagCollectionSharder()
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             non_sharded_model._module.sparse.ebc,
             per_param_sharding={
                 "table_0": row_wise(

--- a/torchrec/distributed/tests/test_infer_utils.py
+++ b/torchrec/distributed/tests/test_infer_utils.py
@@ -87,6 +87,7 @@ class UtilsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             quant_model[0],
             per_param_sharding={
                 "table_0": table_wise(rank=1),
@@ -102,6 +103,7 @@ class UtilsTest(unittest.TestCase):
         plan = ShardingPlan(plan={"": module_plan})
 
         sharded_model = _shard_modules(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             module=quant_model[0],
             # pyre-fixme[6]: For 2nd argument expected
             #  `Optional[List[ModuleSharder[Module]]]` but got
@@ -164,6 +166,7 @@ class UtilsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             quant_model[0],
             per_param_sharding={
                 "table_0": table_wise(rank=1),
@@ -179,6 +182,7 @@ class UtilsTest(unittest.TestCase):
         plan = ShardingPlan(plan={"": module_plan})
 
         sharded_model = _shard_modules(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             module=quant_model[0],
             # pyre-fixme[6]: For 2nd argument expected
             #  `Optional[List[ModuleSharder[Module]]]` but got
@@ -245,6 +249,7 @@ class UtilsTest(unittest.TestCase):
         )
 
         module_plan = construct_module_sharding_plan(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             quant_model[0],
             per_param_sharding={
                 "table_0": table_wise(rank=0),
@@ -259,6 +264,7 @@ class UtilsTest(unittest.TestCase):
         plan = ShardingPlan(plan={"": module_plan})
 
         sharded_model = _shard_modules(
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             module=quant_model[0],
             # pyre-fixme[6]: For 2nd argument expected
             #  `Optional[List[ModuleSharder[Module]]]` but got
@@ -349,7 +355,11 @@ class UtilsTest(unittest.TestCase):
         all_trec_mdoules = get_all_torchrec_modules(sharded_model)
 
         expected_all_trec_modules = {
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             "_module.sparse.ebc": sharded_model._module.sparse.ebc,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             "_module.sparse.weighted_ebc": sharded_model._module.sparse.weighted_ebc,
         }
 
@@ -365,6 +375,8 @@ class UtilsTest(unittest.TestCase):
         self.assertDictEqual(
             all_trec_mdoules,
             {
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse`.
                 "_module.sparse.ebc": sharded_model._module.sparse.ebc,
             },
         )

--- a/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
@@ -818,6 +818,7 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
         for input in input_cases:
             input = torch.tensor(input, dtype=torch.int64)
             ref = kjt_pool_orig.lookup(input)
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             val = sharded_inference_kjt_pool.lookup(input.to(cuda_device))
 
             torch.testing.assert_close(ref.values().cpu(), val.values().cpu())

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -166,27 +166,42 @@ def _test_sharding_and_remapping(  # noqa C901
             sharded_sparse_arch._mc_ec, ShardedManagedCollisionEmbeddingCollection
         )
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             sharded_sparse_arch._mc_ec._embedding_collection,
             ShardedEmbeddingCollection,
         )
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             sharded_sparse_arch._mc_ec._embedding_collection._has_uninitialized_input_dist
             is False
         )
         assert (
             not hasattr(
-                sharded_sparse_arch._mc_ec._embedding_collection, "_input_dists"
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `_embedding_collection`.
+                sharded_sparse_arch._mc_ec._embedding_collection,
+                "_input_dists",
             )
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             or len(sharded_sparse_arch._mc_ec._embedding_collection._input_dists) == 0
         )
 
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ec._managed_collision_collection,
             ShardedManagedCollisionCollection,
         )
 
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ec._managed_collision_collection._use_index_dedup
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             == sharded_sparse_arch._mc_ec._embedding_collection._use_index_dedup
         )
 
@@ -285,21 +300,32 @@ def _test_sharding_and_resharding(  # noqa C901
             sharded_sparse_arch._mc_ec, ShardedManagedCollisionEmbeddingCollection
         )
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             sharded_sparse_arch._mc_ec._embedding_collection,
             ShardedEmbeddingCollection,
         )
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             sharded_sparse_arch._mc_ec._embedding_collection._has_uninitialized_input_dist
             is False
         )
         assert (
             not hasattr(
-                sharded_sparse_arch._mc_ec._embedding_collection, "_input_dists"
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `_embedding_collection`.
+                sharded_sparse_arch._mc_ec._embedding_collection,
+                "_input_dists",
             )
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             or len(sharded_sparse_arch._mc_ec._embedding_collection._input_dists) == 0
         )
 
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ec._managed_collision_collection,
             ShardedManagedCollisionCollection,
         )
@@ -456,21 +482,33 @@ def _test_sharding_dedup(  # noqa C901
         )
 
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ec._managed_collision_collection._use_index_dedup
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             == sharded_sparse_arch._mc_ec._embedding_collection._use_index_dedup
         )
 
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ec._managed_collision_collection._use_index_dedup
             is False
         )
 
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             dedup_sharded_sparse_arch._mc_ec._managed_collision_collection._use_index_dedup
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_collection`.
             == dedup_sharded_sparse_arch._mc_ec._embedding_collection._use_index_dedup
         )
 
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             dedup_sharded_sparse_arch._mc_ec._managed_collision_collection._use_index_dedup
             is True
         )

--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -152,6 +152,8 @@ def _test_sharding(  # noqa C901
             sharded_sparse_arch._mc_ebc, ShardedManagedCollisionEmbeddingBagCollection
         )
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ebc._managed_collision_collection,
             ShardedManagedCollisionCollection,
         )
@@ -216,22 +218,33 @@ def _test_sharding_and_remapping(  # noqa C901
             sharded_sparse_arch._mc_ebc, ShardedManagedCollisionEmbeddingBagCollection
         )
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_bag_collection`.
             sharded_sparse_arch._mc_ebc._embedding_bag_collection,
             ShardedEmbeddingBagCollection,
         )
         assert (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_bag_collection`.
             sharded_sparse_arch._mc_ebc._embedding_bag_collection._has_uninitialized_input_dist
             is False
         )
         assert (
             not hasattr(
-                sharded_sparse_arch._mc_ebc._embedding_bag_collection, "_input_dists"
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `_embedding_bag_collection`.
+                sharded_sparse_arch._mc_ebc._embedding_bag_collection,
+                "_input_dists",
             )
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_embedding_bag_collection`.
             or len(sharded_sparse_arch._mc_ebc._embedding_bag_collection._input_dists)
             == 0
         )
 
         assert isinstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `_managed_collision_collection`.
             sharded_sparse_arch._mc_ebc._managed_collision_collection,
             ShardedManagedCollisionCollection,
         )

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -96,7 +96,10 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
         requires both DMP modules to have the same sharding plan.
         """
         for lookup1, lookup2 in zip(
-            m1.module.sparse.ebc._lookups, m2.module.sparse.ebc._lookups
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
+            m1.module.sparse.ebc._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
+            m2.module.sparse.ebc._lookups,
         ):
             for emb_module1, emb_module2 in zip(
                 lookup1._emb_modules, lookup2._emb_modules
@@ -290,12 +293,17 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
         )
 
         # for this to work, we expect the order of lookups to be the same
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
         assert len(fused_model.module.sparse.ebc._lookups) == len(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             ssd_model.module.sparse.ebc._lookups
         ), "Expect same number of lookups"
 
         for fused_lookup, ssd_lookup in zip(
-            fused_model.module.sparse.ebc._lookups, ssd_model.module.sparse.ebc._lookups
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
+            fused_model.module.sparse.ebc._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
+            ssd_model.module.sparse.ebc._lookups,
         ):
             assert len(fused_lookup._emb_modules) == len(
                 ssd_lookup._emb_modules
@@ -639,7 +647,10 @@ class KeyValueSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
         requires both DMP modules to have the same sharding plan.
         """
         for lookup1, lookup2 in zip(
-            m1.module.sparse.ec._lookups, m2.module.sparse.ec._lookups
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            m1.module.sparse.ec._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            m2.module.sparse.ec._lookups,
         ):
             for emb_module1, emb_module2 in zip(
                 lookup1._emb_modules, lookup2._emb_modules

--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -392,20 +392,33 @@ def _test_compile_rank_fn(
             tbe = None
             if test_model_type == _ModelType.EBC:
                 tbe = (
-                    dmp._dmp_wrapped_module._ebc._lookups[0]._emb_modules[0]._emb_module
+                    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                    #  attribute `_lookups`.
+                    dmp._dmp_wrapped_module._ebc._lookups[0]
+                    ._emb_modules[0]
+                    ._emb_module
                 )
             elif test_model_type == _ModelType.FPEBC:
                 tbe = (
+                    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                    #  attribute `_lookups`.
                     dmp._dmp_wrapped_module._fpebc._lookups[0]
                     ._emb_modules[0]
                     ._emb_module
                 )
             elif test_model_type == _ModelType.EC:
                 tbe = (
-                    dmp._dmp_wrapped_module._ec._lookups[0]._emb_modules[0]._emb_module
+                    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                    #  attribute `_lookups`.
+                    dmp._dmp_wrapped_module._ec._lookups[0]
+                    ._emb_modules[0]
+                    ._emb_module
                 )
             assert isinstance(tbe, SplitTableBatchedEmbeddingBagsCodegen)
 
+            # pyre-fixme[29]: `Union[(self: TensorBase, memory_format:
+            #  Optional[memory_format] = ...) -> Tensor, Tensor, Module]` is not a
+            #  function.
             return tbe.weights_dev.clone().detach()
 
         original_weights = get_weights(dmp)
@@ -630,8 +643,13 @@ def _test_compile_fake_pg_fn(
     dmp_compile.train(True)
 
     def get_weights(dmp: DistributedModelParallel) -> torch.Tensor:
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_lookups`.
         tbe = dmp._dmp_wrapped_module._ebc._lookups[0]._emb_modules[0]._emb_module
         assert isinstance(tbe, SplitTableBatchedEmbeddingBagsCodegen)
+        # pyre-fixme[29]: `Union[(self: TensorBase, memory_format:
+        #  Optional[memory_format] = ...) -> Tensor, Tensor, Module]` is not a
+        #  function.
         return tbe.weights_dev.clone().detach()
 
     original_weights = get_weights(dmp)

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -94,12 +94,12 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             list(module_copy.named_buffers(recurse=recurse))
             + list(module_copy.named_parameters(recurse=recurse)),
         ):
-            self.assertEquals(name, name_copy)
+            self.assertEqual(name, name_copy)
             actual, expected = buffer.detach().cpu(), buffer_copy.detach().cpu()
             rtol, atol = _get_default_rtol_and_atol(actual, expected)
             torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
-            self.assertEquals(buffer.detach().device, device)
-            self.assertEquals(buffer_copy.detach().device, device_copy)
+            self.assertEqual(buffer.detach().device, device)
+            self.assertEqual(buffer_copy.detach().device, device_copy)
 
     def _recursive_device_check(
         self,
@@ -393,7 +393,9 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
             dense_device=device,
             sparse_device=torch.device("meta"),
         )
+        # pyre-fixme[16]: `TestSparseNN` has no attribute `copy_module`.
         model.copy_module = CopyModule()
+        # pyre-fixme[16]: `TestSparseNN` has no attribute `no_copy_module`.
         model.no_copy_module = NoCopyModule()
         quant_model = quantize(model, inplace=True)
         dmp = DistributedModelParallel(
@@ -413,7 +415,9 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
 
         dmp_1 = dmp.copy(device_1)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `tensor`.
         self.assertEqual(dmp_1.module.copy_module.tensor.device, device_1)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `tensor`.
         self.assertEqual(dmp_1.module.no_copy_module.tensor.device, torch.device("cpu"))
 
 
@@ -531,6 +535,8 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             # flake8: noqa:C419
             all(
                 param.device.type == sharding_device_type
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `ebc`.
                 for param in dmp.module.sparse.ebc.buffers()
             )
         )
@@ -538,6 +544,8 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
             # flake8: noqa:C419
             all(
                 param.device.type == sparse_device.type
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `weighted_ebc`.
                 for param in dmp.module.sparse.weighted_ebc.buffers()
             )
         )
@@ -613,12 +621,15 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         )
 
         self.assertTrue(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ebc`.
             all(param.device == device for param in dmp.module.sparse.ebc.buffers())
         )
         self.assertTrue(
             # flake8: noqa:C419
             all(
                 param.device == torch.device("meta")
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `weighted_ebc`.
                 for param in dmp.module.sparse.weighted_ebc.buffers()
             )
         )
@@ -696,6 +707,8 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         self.assertTrue(
             all(
                 param.device.type == device.type
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `ebc`.
                 for param in dmp.module.sparse.ebc.buffers()
             )
         )
@@ -703,6 +716,8 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         self.assertTrue(
             all(
                 param.device.type == device.type
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `weighted_ebc`.
                 for param in dmp.module.sparse.weighted_ebc.buffers()
             )
         )

--- a/torchrec/distributed/tests/test_quant_pruning.py
+++ b/torchrec/distributed/tests/test_quant_pruning.py
@@ -74,6 +74,7 @@ def create_quant_and_sharded_ebc_models(
     pruning_ebc_dict = {"table_0": num_rows_post_pruned}
     quant_model = prune_and_quantize_model(mi.model, pruning_ebc_dict)
 
+    # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
     quant_model = quant_model[0]
     mi.quant_model = quant_model
 
@@ -96,9 +97,12 @@ class QuantPruneTest(unittest.TestCase):
     ) -> None:
         for module in sharded_model.modules():
             if module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
+                # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+                #  `Union[Tensor, Module]`.
                 for i, spec in enumerate(module.embedding_specs):
                     if spec[0] in pruned_dict:
                         self.assertEqual(
+                            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                             module.split_embedding_weights()[i][0].size(0),
                             pruned_dict[spec[0]],
                         )

--- a/torchrec/distributed/tests/test_sequence_model.py
+++ b/torchrec/distributed/tests/test_sequence_model.py
@@ -198,7 +198,11 @@ class TestSequenceTowerSparseNN(TestSparseNNBase):
         )
         self.over = nn.Linear(
             in_features=8
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + self.tower_0.interaction.linear.out_features
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `out_features`.
             + self.tower_1.interaction.linear.out_features,
             out_features=16,
             device=dense_device,

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -264,6 +264,7 @@ class TrainPipelinePT2Test(unittest.TestCase):
         ]
 
         def pre_compile_fn(model: nn.Module) -> None:
+            # pyre-fixme[16]: `Module` has no attribute `_dummy_setting`.
             model._dummy_setting = "dummy modified"
 
         dataloader = iter(data)
@@ -298,7 +299,11 @@ class TrainPipelinePT2Test(unittest.TestCase):
         )
 
         model_gpu.load_state_dict(model_cpu.state_dict())
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `parameters`.
         optimizer_cpu = optim.SGD(model_cpu.model.parameters(), lr=0.01)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `parameters`.
         optimizer_gpu = optim.SGD(model_gpu.model.parameters(), lr=0.01)
 
         data = [i.idlist_features for i in local_model_inputs]
@@ -645,7 +650,11 @@ class TrainPipelineSparseDistTest(TrainPipelineSparseDistTestBase):
 
         # Check internal states
         ebcs = [
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.ebc,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.weighted_ebc,
         ]
         for ebc in ebcs:
@@ -748,7 +757,11 @@ class TrainPipelineSparseDistTest(TrainPipelineSparseDistTestBase):
 
         # Check internal states
         ebcs = [
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.ebc,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.weighted_ebc,
         ]
         for ebc in ebcs:
@@ -1015,10 +1028,14 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
 
         self.assertEqual(
             pipelined_ebc.forward._args[0].preproc_modules[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_nonweighted`.
             pipelined_model.module.preproc_nonweighted,
         )
         self.assertEqual(
             pipelined_weighted_ebc.forward._args[0].preproc_modules[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_weighted`.
             pipelined_model.module.preproc_weighted,
         )
 
@@ -1094,19 +1111,27 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
 
         self.assertEqual(
             pipelined_ebc.forward._args[0].preproc_modules[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_nonweighted`.
             pipelined_model.module.preproc_nonweighted,
         )
         self.assertEqual(
             pipelined_weighted_ebc.forward._args[0].preproc_modules[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_weighted`.
             pipelined_model.module.preproc_weighted,
         )
 
         # preproc args
         self.assertEqual(len(pipeline._pipelined_preprocs), 3)
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_preproc_module`.
         parent_preproc_mod = pipelined_model.module._preproc_module
 
         for preproc_mod in pipeline._pipelined_preprocs:
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_nonweighted`.
             if preproc_mod == pipelined_model.module.preproc_nonweighted:
                 self.assertEqual(len(preproc_mod._args), 1)
                 args = preproc_mod._args[0]
@@ -1118,6 +1143,8 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
                     parent_preproc_mod,
                 )
                 self.assertEqual(args.preproc_modules[1], None)
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_weighted`.
             elif preproc_mod == pipelined_model.module.preproc_weighted:
                 self.assertEqual(len(preproc_mod._args), 1)
                 args = preproc_mod._args[0]
@@ -1289,6 +1316,8 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
         self.assertEqual(pipeline._pipelined_modules[0]._is_weighted, True)
         self.assertEqual(
             pipeline._pipelined_preprocs[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_weighted`.
             sharded_model_pipelined.module.preproc_weighted,
         )
 
@@ -1486,6 +1515,8 @@ class EmbeddingTrainPipelineTest(TrainPipelineSparseDistTestBase):
             stash_gradients=stash_gradients,
         )
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `sparse_forward`.
         prior_sparse_out = sharded_model._dmp_wrapped_module.sparse_forward(
             data[0].to(self.device)
         )
@@ -1498,10 +1529,14 @@ class EmbeddingTrainPipelineTest(TrainPipelineSparseDistTestBase):
             # Forward + backward w/o pipelining
             batch = batch.to(self.device)
 
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `dense_forward`.
             loss, pred = sharded_model._dmp_wrapped_module.dense_forward(
                 prior_batch, prior_sparse_out
             )
             if batch_index - 1 >= start_batch:
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse_forward`.
                 sparse_out = sharded_model._dmp_wrapped_module.sparse_forward(batch)
 
             loss.backward()
@@ -1524,6 +1559,8 @@ class EmbeddingTrainPipelineTest(TrainPipelineSparseDistTestBase):
             optim.zero_grad()
 
             if batch_index - 1 < start_batch:
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `sparse_forward`.
                 sparse_out = sharded_model._dmp_wrapped_module.sparse_forward(batch)
 
             prior_stashed_grads = stashed_grads
@@ -2013,7 +2050,11 @@ class StagedTrainPipelineTest(TrainPipelineSparseDistTestBase):
 
         # Check internal states
         ebcs = [
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.ebc,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model_pipelined.module.sparse.weighted_ebc,
         ]
         for ebc in ebcs:

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -106,11 +106,19 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
         )
         if enable_fsdp:
             unsharded_model.over.dhn_arch.linear0 = FSDP(
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `dhn_arch`.
                 unsharded_model.over.dhn_arch.linear0
             )
             unsharded_model.over.dhn_arch.linear1 = FSDP(
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `dhn_arch`.
                 unsharded_model.over.dhn_arch.linear1
             )
+            # pyre-fixme[16]: `Module` has no attribute `dhn_arch`.
+            # pyre-fixme[16]: `Tensor` has no attribute `dhn_arch`.
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `dhn_arch`.
             unsharded_model.over.dhn_arch = FSDP(unsharded_model.over.dhn_arch)
 
         return unsharded_model

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -74,10 +74,16 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
             dist_stream=None,
         )
         self.assertNotIsInstance(
-            sharded_model.module.sparse.ebc.forward, PipelinedForward
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
+            sharded_model.module.sparse.ebc.forward,
+            PipelinedForward,
         )
         self.assertNotIsInstance(
-            sharded_model.module.sparse.weighted_ebc.forward, PipelinedForward
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
+            sharded_model.module.sparse.weighted_ebc.forward,
+            PipelinedForward,
         )
 
         # Now provide preproc module explicitly
@@ -89,18 +95,30 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
             pipeline_preproc=True,
         )
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `sparse`.
         self.assertIsInstance(sharded_model.module.sparse.ebc.forward, PipelinedForward)
         self.assertIsInstance(
-            sharded_model.module.sparse.weighted_ebc.forward, PipelinedForward
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
+            sharded_model.module.sparse.weighted_ebc.forward,
+            PipelinedForward,
         )
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model.module.sparse.ebc.forward._args[0].preproc_modules[0],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_module`.
             sharded_model.module.preproc_module,
         )
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `sparse`.
             sharded_model.module.sparse.weighted_ebc.forward._args[0].preproc_modules[
                 0
             ],
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `preproc_module`.
             sharded_model.module.preproc_module,
         )
         state_dict = sharded_model.state_dict()

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1590,6 +1590,8 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
 
         # it will check this path on model to inject configuration other than
         # the default one.
+        # pyre-fixme[8]: Attribute has type `Dict[str, Union[bool, str]]`; used as
+        #  `Union[Tensor, Module]`.
         self.compiled_autograd_options: Dict[str, Union[str, bool]] = getattr(
             model,
             "_compiled_autograd_options",

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -470,6 +470,7 @@ def init_parameters(module: nn.Module, device: torch.device) -> None:
 
             def maybe_reset_parameters(m: nn.Module) -> None:
                 if hasattr(m, "reset_parameters"):
+                    # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                     m.reset_parameters()
 
             module.apply(maybe_reset_parameters)

--- a/torchrec/fx/tracer.py
+++ b/torchrec/fx/tracer.py
@@ -135,6 +135,7 @@ class Tracer(torch.fx.Tracer):
         """
 
         if hasattr(mod, "_fx_path"):
+            # pyre-fixme[7]: Expected `str` but got `Union[Tensor, Module]`.
             return mod._fx_path
         else:
             return super().path_of_module(mod)

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -426,6 +426,8 @@ def quantize_inference_model(
         """
 
         quant_prep_enable_register_tbes(model, [FeatureProcessedEmbeddingBagCollection])
+        # pyre-fixme[16]: `FeatureProcessedEmbeddingBagCollection` has no attribute
+        #  `qconfig`.
         fp_module.qconfig = QuantConfig(
             activation=quant.PlaceholderObserver.with_args(dtype=output_dtype),
             weight=quant.PlaceholderObserver.with_args(dtype=weight_dtype),
@@ -532,6 +534,8 @@ def shard_quant_model(
             if type(module) in module_types:
                 # TODO: handle other cases/reduce hardcoding
                 if hasattr(module, "embedding_bags"):
+                    # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Module, Tensor]`
+                    #  is not a function.
                     for table in module.embedding_bags:
                         table_fqns.append(table)
 

--- a/torchrec/ir/serializer.py
+++ b/torchrec/ir/serializer.py
@@ -240,8 +240,10 @@ class EBCJsonSerializer(JsonSerializer):
         ebc_metadata = EBCMetadata(
             tables=[
                 embedding_bag_config_to_metadata(table_config)
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 for table_config in module.embedding_bag_configs()
             ],
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             is_weighted=module.is_weighted(),
             device=str(module.device),
         )
@@ -307,7 +309,10 @@ class PWMCJsonSerializer(JsonSerializer):
     def serialize_to_dict(cls, module: nn.Module) -> Dict[str, Any]:
         metadata = PositionWeightedModuleCollectionMetadata(
             max_feature_lengths=[  # convert to list of tuples to preserve the order
-                (feature, len) for feature, len in module.max_feature_lengths.items()
+                (feature, len)
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `items`.
+                for feature, len in module.max_feature_lengths.items()
             ],
         )
         return metadata.__dict__
@@ -348,6 +353,8 @@ class FPEBCJsonSerializer(JsonSerializer):
         else:
             metadata = FPEBCMetadata(
                 is_fp_collection=False,
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `keys`.
                 features=list(module._feature_processors.keys()),
             )
         return metadata.__dict__
@@ -398,7 +405,11 @@ class KTRegroupAsDictJsonSerializer(JsonSerializer):
         module: nn.Module,
     ) -> Dict[str, Any]:
         metadata = KTRegroupAsDictMetadata(
+            # pyre-fixme[6]: For 1st argument expected `List[str]` but got
+            #  `Union[Module, Tensor]`.
             keys=module._keys,
+            # pyre-fixme[6]: For 2nd argument expected `List[List[str]]` but got
+            #  `Union[Module, Tensor]`.
             groups=module._groups,
         )
         return metadata.__dict__

--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -89,6 +89,10 @@ class CompoundModuleSerializer(JsonSerializer):
         while hasattr(unflatten_ep.list, str(i)):
             mlist.append(getattr(unflatten_ep.list, str(i)))
             i += 1
+        # pyre-fixme[6]: For 1st argument expected `EmbeddingBagCollection` but got
+        #  `Union[Module, Tensor]`.
+        # pyre-fixme[6]: For 2nd argument expected `Optional[CompoundModule]` but
+        #  got `Union[Module, Tensor]`.
         return CompoundModule(ebc, comp, mlist)
 
 
@@ -298,7 +302,9 @@ class TestJsonSerializer(unittest.TestCase):
 
     def test_ir_emb_lookup_device(self) -> None:
         model = self.generate_model()
+        # pyre-fixme[16]: `Module` has no attribute `fpebc1`.
         model.fpebc1 = copy.deepcopy(model.ebc1)
+        # pyre-fixme[16]: `Module` has no attribute `fpebc2`.
         model.fpebc2 = copy.deepcopy(model.ebc1)
         feature1 = KeyedJaggedTensor.from_offsets_sync(
             keys=["f1", "f2", "f3"],
@@ -423,9 +429,13 @@ class TestJsonSerializer(unittest.TestCase):
         deserialized_model = decapsulate_ir_modules(unflatten_ep, JsonSerializer)
         # Check if Compound Module is deserialized correctly
         self.assertIsInstance(deserialized_model.comp, CompoundModule)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `comp`.
         self.assertIsInstance(deserialized_model.comp.comp, CompoundModule)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `comp`.
         self.assertIsInstance(deserialized_model.comp.comp.comp, CompoundModule)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `list`.
         self.assertIsInstance(deserialized_model.comp.list[1], CompoundModule)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `list`.
         self.assertIsInstance(deserialized_model.comp.list[1].comp, CompoundModule)
 
         deserialized_model.load_state_dict(model.state_dict())
@@ -505,8 +515,12 @@ class TestJsonSerializer(unittest.TestCase):
             preserve_module_call_signature=(tuple(sparse_fqns)),
         )
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_is_inited`.
         self.assertFalse(model.regroup._is_inited)
         eager_out = model(id_list_features)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_is_inited`.
         self.assertFalse(model.regroup._is_inited)
 
         # Run forward on ExportedProgram
@@ -516,8 +530,12 @@ class TestJsonSerializer(unittest.TestCase):
         # Deserialize EBC
         unflatten_ep = torch.export.unflatten(ep)
         deserialized_model = decapsulate_ir_modules(unflatten_ep, JsonSerializer)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_is_inited`.
         self.assertFalse(deserialized_model.regroup._is_inited)
         deserialized_out = deserialized_model(id_list_features)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `_is_inited`.
         self.assertTrue(deserialized_model.regroup._is_inited)
         for key in eager_out.keys():
             self.assertEqual(deserialized_out[key].shape, eager_out[key].shape)
@@ -603,6 +621,8 @@ class TestJsonSerializer(unittest.TestCase):
         #  we export the model with ebc1 and unflatten the model,
         #  and then swap with ebc2 (you can think this as the the sharding process
         #  resulting a shardedEBC), so that we can mimic the key-order change
+        # pyre-fixme[16]: `Module` has no attribute `ebc`.
+        # pyre-fixme[16]: `Tensor` has no attribute `ebc`.
         deserialized_model.sparse.ebc = ebc2
 
         deserialized_out = deserialized_model(id_list_features)

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -163,6 +163,7 @@ def decapsulate_ir_modules(
     if finalize_interpreter_modules:
         for mod in module.modules():
             if isinstance(mod, InterpreterModule):
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 mod.finalize()
 
     return module
@@ -241,6 +242,7 @@ def move_to_copy_nodes_to_device(
     """
     Moves all the copy nodes to the given device.
     """
+    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `nodes`.
     for nodes in unflattened_module.graph.nodes:
         if "_to_copy" in nodes.name:
             new_kwargs = {}
@@ -299,6 +301,7 @@ def prune_pytree_flatten_unflatten(
     """
 
     def _get_graph_node(mod: nn.Module, fqn: str) -> Tuple[nn.Module, Node]:
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `nodes`.
         for node in mod.graph.nodes:
             if node.op == "call_module" and node.target == fqn:
                 return mod, node
@@ -329,6 +332,8 @@ def prune_pytree_flatten_unflatten(
         logger.info(f"Removing tree_unflatten from {fqn}")
         input_nodes = tree_unflatten.args[0]
         node.args = (input_nodes,)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `eliminate_dead_code`.
         submodule.graph.eliminate_dead_code()
 
     # remove tree_flatten_spec from the out_fqns (out-going nodes)
@@ -349,5 +354,7 @@ def prune_pytree_flatten_unflatten(
         logger.info(f"Removing tree_flatten_spec from {fqn}")
         getitem_node = tree_flatten_users[0]
         getitem_node.replace_all_uses_with(node)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `eliminate_dead_code`.
         submodule.graph.eliminate_dead_code()
     return module

--- a/torchrec/metrics/output.py
+++ b/torchrec/metrics/output.py
@@ -78,12 +78,16 @@ class OutputMetricComputation(RecMetricComputation):
             MetricComputationReport(
                 name=MetricName.OUTPUT,
                 metric_prefix=MetricPrefix.DEFAULT,
+                # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 value=self.latest_imp,
                 description="_latest_imp",
             ),
             MetricComputationReport(
                 name=MetricName.OUTPUT,
                 metric_prefix=MetricPrefix.DEFAULT,
+                # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 value=self.total_latest_imp,
                 description="_total_latest_imp",
             ),

--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -66,6 +66,8 @@ class ScalarMetricComputation(RecMetricComputation):
             MetricComputationReport(
                 name=MetricName.SCALAR,
                 metric_prefix=MetricPrefix.LIFETIME,
+                # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
+                #  `Union[Tensor, Module]`.
                 value=self.labels,
             ),
             MetricComputationReport(

--- a/torchrec/metrics/segmented_ne.py
+++ b/torchrec/metrics/segmented_ne.py
@@ -248,9 +248,13 @@ class SegmentedNEMetricComputation(RecMetricComputation):
     def _compute(self) -> List[MetricComputationReport]:
         reports = []
         computed_ne = compute_ne(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self.cross_entropy_sum[0],
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self.weighted_num_samples[0],
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self.pos_labels[0],
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self.neg_labels[0],
             num_groups=self._num_groups,
             eta=self.eta,
@@ -268,8 +272,11 @@ class SegmentedNEMetricComputation(RecMetricComputation):
 
         if self._include_logloss:
             log_loss_groups = compute_logloss(
+                # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _Nes...
                 self.cross_entropy_sum[0],
+                # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _Nes...
                 self.pos_labels[0],
+                # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _Nes...
                 self.neg_labels[0],
                 eta=self.eta,
             )

--- a/torchrec/modules/crossnet.py
+++ b/torchrec/modules/crossnet.py
@@ -83,7 +83,9 @@ class CrossNet(torch.nn.Module):
         x_l = x_0
 
         for layer in range(self._num_layers):
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             xl_w = torch.matmul(self.kernels[layer], x_l)  # (B, N, 1)
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             x_l = x_0 * (xl_w + self.bias[layer]) + x_l  # (B, N, 1)
 
         return torch.squeeze(x_l, dim=2)
@@ -250,9 +252,11 @@ class VectorCrossNet(torch.nn.Module):
         for layer in range(self._num_layers):
             xl_w = torch.tensordot(
                 x_l,
+                # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                 self.kernels[layer],
                 dims=([1], [0]),
             )  # (B, 1, 1)
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             x_l = torch.matmul(x_0, xl_w) + self.bias[layer] + x_l  # (B, N, 1)
 
         return torch.squeeze(x_l, dim=2)  # (B, N)
@@ -403,17 +407,21 @@ class LowRankMixtureCrossNet(torch.nn.Module):
             experts = []
             for i in range(self._num_experts):
                 expert = torch.matmul(
+                    # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                     self.V_kernels[layer][i],
                     x_l,
                 )  # (B, r, 1)
                 expert = torch.matmul(
+                    # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                     self.C_kernels[layer][i],
                     self._activation(expert),
                 )  # (B, r, 1)
                 expert = torch.matmul(
+                    # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                     self.U_kernels[layer][i],
                     self._activation(expert),
                 )  # (B, N, 1)
+                # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                 expert = x_0 * (expert + self.bias[layer])  # (B, N, 1)
                 experts.append(expert.squeeze(2))  # (B, N)
             experts = torch.stack(experts, 2)  # (B, N, K)

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -443,6 +443,7 @@ class FusedEmbeddingBagCollection(
         ):
             for embedding_config, weight in zip(
                 tables,
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 emb_module.split_embedding_weights(),
                 #  torch._tensor.Tensor]` is not a function.
             ):
@@ -697,6 +698,7 @@ class FusedEmbeddingCollection(EmbeddingCollectionInterface, FusedOptimizerModul
         ):
             for embedding_config, weight in zip(
                 tables,
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 emb_module.split_embedding_weights(),
                 #  torch._tensor.Tensor]` is not a function.
             ):

--- a/torchrec/modules/itep_modules.py
+++ b/torchrec/modules/itep_modules.py
@@ -164,16 +164,20 @@ class GenericITEPModule(nn.Module):
         with torch.no_grad():
             # Don't use register_buffer for buffer_offsets and emb_sizes because they
             # may change as the sharding plan changes between preemption/resumption
+            # pyre-fixme[16]: `GenericITEPModule` has no attribute `buffer_offsets`.
             self.buffer_offsets = torch.tensor(
                 buffer_offsets, dtype=torch.int64, device=self.current_device
             )
+            # pyre-fixme[16]: `GenericITEPModule` has no attribute `emb_sizes`.
             self.emb_sizes = torch.tensor(
                 emb_sizes, dtype=torch.int64, device=self.current_device
             )
 
+            # pyre-fixme[16]: `GenericITEPModule` has no attribute `address_lookup`.
             self.address_lookup = torch.zeros(
                 buffer_size, dtype=torch.int64, device=self.current_device
             )
+            # pyre-fixme[16]: `GenericITEPModule` has no attribute `row_util`.
             self.row_util = torch.zeros(
                 buffer_size, dtype=torch.float32, device=self.current_device
             )
@@ -182,10 +186,12 @@ class GenericITEPModule(nn.Module):
             for idx, table_name in enumerate(table_names):
                 self.register_buffer(
                     f"{table_name}_itp_address_lookup",
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     self.address_lookup[buffer_offsets[idx] : buffer_offsets[idx + 1]],
                 )
                 self.register_buffer(
                     f"{table_name}_itp_row_util",
+                    # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, ...
                     self.row_util[buffer_offsets[idx] : buffer_offsets[idx + 1]],
                 )
 

--- a/torchrec/modules/keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/keyed_jagged_tensor_pool.py
@@ -212,6 +212,7 @@ class KeyedJaggedTensorPool(ObjectPool[KeyedJaggedTensor]):
             error_msgs,
         )
 
+        # pyre-fixme[16]: `KeyedJaggedTensorPoolLookup` has no attribute `_values`.
         self._lookup._values = state_dict[prefix + "values"]
         self._lookup._key_lengths = state_dict[prefix + "key_lengths"]
 

--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -30,9 +30,12 @@ def _apply_functions_after_first_forward(
 ) -> None:
     _functions_to_lazy_apply = getattr(module, "_functions_to_lazy_apply", None)
     if _functions_to_lazy_apply is not None:
+        # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a
+        #  function.
         for fn in _functions_to_lazy_apply:
             module.apply(fn)
         delattr(module, "_functions_to_lazy_apply")
+    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `remove`.
     module._lazy_apply_hook.remove()
     delattr(module, "_lazy_apply_hook")
 
@@ -80,11 +83,14 @@ def lazy_apply(
     """
 
     if not hasattr(module, "_functions_to_lazy_apply"):
+        # pyre-fixme[16]: `Module` has no attribute `_functions_to_lazy_apply`.
         module._functions_to_lazy_apply = []
     if not hasattr(module, "_lazy_apply_hook"):
+        # pyre-fixme[16]: `Module` has no attribute `_lazy_apply_hook`.
         module._lazy_apply_hook = module.register_forward_hook(
             _apply_functions_after_first_forward
         )
+    # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `append`.
     module._functions_to_lazy_apply.append(fn)
     return module
 

--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -57,12 +57,16 @@ class BaseManagedCollisionEmbeddingCollection(nn.Module):
 
         if isinstance(embedding_module, EmbeddingBagCollection):
             assert (
+                # pyre-fixme[29]: `Union[(self: EmbeddingBagCollection) ->
+                #  list[EmbeddingBagConfig], Module, Tensor]` is not a function.
                 self._embedding_module.embedding_bag_configs()
                 == self._managed_collision_collection.embedding_configs()
             ), "Embedding Bag Collection and Managed Collision Collection must contain the Embedding Configs"
 
         else:
             assert (
+                # pyre-fixme[29]: `Union[(self: EmbeddingCollection) ->
+                #  list[EmbeddingConfig], Module, Tensor]` is not a function.
                 self._embedding_module.embedding_configs()
                 == self._managed_collision_collection.embedding_configs()
             ), "Embedding Collection and Managed Collision Collection must contain the Embedding Configs"

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -1073,6 +1073,8 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         self._input_history_buffer_size = int(
             input_batch_value_size_cumsum * self._eviction_interval * 1.25
         )
+        # pyre-fixme[16]: `MCHManagedCollisionModule` has no attribute
+        #  `_history_accumulator`.
         self._history_accumulator: torch.Tensor = torch.empty(
             self._input_history_buffer_size,
             dtype=torch.int64,
@@ -1121,11 +1123,19 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
 
     @torch.no_grad()
     def _sort_mch_buffers(self) -> None:
+        # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[Module,
+        #  Tensor]`.
         argsorted_sorted_raw_ids = torch.argsort(self._mch_sorted_raw_ids, stable=True)
+        # pyre-fixme[29]: `Union[(self: TensorBase, src: Tensor, non_blocking: bool
+        #  = ...) -> Tensor, Module, Tensor]` is not a function.
         self._mch_sorted_raw_ids.copy_(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self._mch_sorted_raw_ids[argsorted_sorted_raw_ids]
         )
+        # pyre-fixme[29]: `Union[(self: TensorBase, src: Tensor, non_blocking: bool
+        #  = ...) -> Tensor, Module, Tensor]` is not a function.
         self._mch_remapped_ids_mapping.copy_(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self._mch_remapped_ids_mapping[argsorted_sorted_raw_ids]
         )
         for mch_metadata_buffer in self._mch_metadata.values():
@@ -1145,7 +1155,10 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         frequency_sorted_uniq_ids_counts = uniq_ids_counts[argsorted_uniq_ids_counts]
 
         matching_eles, matched_indices = self._match_indices(
-            self._mch_sorted_raw_ids, frequency_sorted_uniq_ids
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+            #  `Union[Module, Tensor]`.
+            self._mch_sorted_raw_ids,
+            frequency_sorted_uniq_ids,
         )
 
         new_frequency_sorted_uniq_ids = frequency_sorted_uniq_ids[~matching_eles]
@@ -1166,6 +1179,7 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
             self._mch_metadata,
             uniq_ids_metadata,
         )
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         self._mch_sorted_raw_ids[evicted_indices] = new_frequency_sorted_uniq_ids[
             selected_new_indices
         ]
@@ -1178,11 +1192,13 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
                 torch.cat(
                     [
                         self._evicted_emb_indices,
+                        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[No...
                         self._mch_remapped_ids_mapping[evicted_indices],
                     ]
                 )
             )
         else:
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self._evicted_emb_indices = self._mch_remapped_ids_mapping[evicted_indices]
         self._evicted = True
 
@@ -1191,6 +1207,7 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
 
     @torch.no_grad()
     def _coalesce_history(self) -> None:
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         current_history_accumulator = self._history_accumulator[
             : self._current_history_buffer_offset
         ]
@@ -1252,6 +1269,7 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
                 self._input_history_buffer_size - self._current_history_buffer_offset
             )
             values = values[:free_elements]
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedS...
             self._history_accumulator[
                 self._current_history_buffer_offset : self._current_history_buffer_offset
                 + values.shape[0]
@@ -1306,8 +1324,17 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         return self._input_hash_size
 
     def open_slots(self) -> torch.Tensor:
+        # pyre-fixme[29]: `Union[(self: TensorBase, other: Any) -> Tensor, Module,
+        #  Tensor]` is not a function.
         return self._mch_slots - torch.searchsorted(
-            self._mch_sorted_raw_ids, self._delimiter
+            # pyre-fixme[6]: For 1st argument expected `Tensor` but got
+            #  `Union[Module, Tensor]`.
+            # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
+            #  `Union[Module, Tensor]`.
+            self._mch_sorted_raw_ids,
+            # pyre-fixme[6]: For 2nd argument expected `Tensor` but got
+            #  `Union[Module, Tensor]`.
+            self._delimiter,
         )
 
     @torch.no_grad()

--- a/torchrec/modules/tests/test_feature_processor_.py
+++ b/torchrec/modules/tests/test_feature_processor_.py
@@ -178,8 +178,12 @@ class PositionWeightedCollectionModuleTest(unittest.TestCase):
             pwmc, current_device=torch.device("cpu"), to_device=torch.device("meta")
         )
 
+        # pyre-fixme[29]: `Union[(self: TensorBase) -> Tensor, Tensor, Module]` is
+        #  not a function.
         self.assertTrue(all(param.is_meta for param in res.position_weights.values()))
         self.assertTrue(
+            # pyre-fixme[29]: `Union[(self: TensorBase) -> Tensor, Tensor, Module]`
+            #  is not a function.
             all(param.is_meta for param in res.position_weights_dict.values())
         )
 

--- a/torchrec/modules/tests/test_lazy_extension.py
+++ b/torchrec/modules/tests/test_lazy_extension.py
@@ -290,6 +290,8 @@ class TestLazyModuleExtensionMixin(unittest.TestCase):
         # and the function will be applied right after first forward pass.
         net = torch.nn.Sequential(TestModule(), TestModule())
         net = lazy_apply(net, init_weights)
+        # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
         self.assertTrue(torch.allclose(net[0].param, torch.tensor(1.0)))
         net(torch.tensor(2.0))
+        # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
         self.assertTrue(torch.allclose(net[0].param, torch.tensor(7.0)))

--- a/torchrec/modules/tests/test_mc_modules.py
+++ b/torchrec/modules/tests/test_mc_modules.py
@@ -35,13 +35,19 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
 
         # insert some values to zch
         # we have 10 counts of 4 and 1 count of 5
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         mc_module._mch_sorted_raw_ids[0:2] = torch.tensor([4, 5])
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         mc_module._mch_counts[0:2] = torch.tensor([10, 1])
 
         ids = [3, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 10]
@@ -57,10 +63,15 @@ class TestEvictionPolicy(unittest.TestCase):
         # 6, 7, 8 will be added
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
-            list(_mch_sorted_raw_ids), [4, 6, 7, 8, torch.iinfo(torch.int64).max]
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
+            list(_mch_sorted_raw_ids),
+            [4, 6, 7, 8, torch.iinfo(torch.int64).max],
         )
         # 11 counts of 5, 3 counts of 6, 3 counts of 7, 3 counts of 8
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [11, 3, 3, 3, torch.iinfo(torch.int64).max])
 
     def test_lru_eviction(self) -> None:
@@ -74,8 +85,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
 
         ids = [5, 6, 7]
@@ -108,10 +123,14 @@ class TestEvictionPolicy(unittest.TestCase):
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
             list(_mch_sorted_raw_ids),
             [3, 4, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [2, 2, 3, 3, 3])
         self.assertEqual(mc_module.open_slots().item(), 0)
 
@@ -126,10 +145,16 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
 
         ids = [5, 5, 5, 5, 5, 6]
@@ -161,12 +186,18 @@ class TestEvictionPolicy(unittest.TestCase):
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
             list(_mch_sorted_raw_ids),
             [3, 5, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [1, 5, 1, 1, torch.iinfo(torch.int64).max])
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [2, 1, 3, 3, 3])
 
     def test_distance_lfu_eviction_fast_decay(self) -> None:
@@ -180,10 +211,16 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
 
         ids = [5, 5, 5, 5, 5, 6]
@@ -215,12 +252,18 @@ class TestEvictionPolicy(unittest.TestCase):
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
             list(_mch_sorted_raw_ids),
             [3, 4, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [1, 1, 1, 1, torch.iinfo(torch.int64).max])
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_last_access_iter), [2, 2, 3, 3, 3])
 
     def test_dynamic_threshold_filter(self) -> None:
@@ -238,8 +281,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
 
         ids = [5, 5, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1]
@@ -255,10 +302,14 @@ class TestEvictionPolicy(unittest.TestCase):
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
             list(_mch_sorted_raw_ids),
             [3, 4, 5, torch.iinfo(torch.int64).max, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [3, 4, 5, 0, torch.iinfo(torch.int64).max])
 
     def test_average_threshold_filter(self) -> None:
@@ -274,13 +325,19 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
 
         # insert some values to zch
         # we have 10 counts of 4 and 1 count of 5
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         mc_module._mch_sorted_raw_ids[0:2] = torch.tensor([4, 5])
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, _NestedSeque...
         mc_module._mch_counts[0:2] = torch.tensor([10, 1])
 
         ids = [3, 4, 5, 6, 6, 6, 7, 8, 8, 9, 10]
@@ -298,10 +355,15 @@ class TestEvictionPolicy(unittest.TestCase):
         # 7 is not added because it's below the average threshold
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
-            list(_mch_sorted_raw_ids), [4, 5, 6, 8, torch.iinfo(torch.int64).max]
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Tensor, Module]`.
+            list(_mch_sorted_raw_ids),
+            [4, 5, 6, 8, torch.iinfo(torch.int64).max],
         )
         # count for 4 is not updated since it's below the average threshold
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [10, 1, 3, 2, torch.iinfo(torch.int64).max])
 
     def test_probabilistic_threshold_filter(self) -> None:
@@ -320,8 +382,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+        #  `Union[Tensor, Module]`.
         self.assertEqual(list(_mch_counts), [0] * 5)
 
         unique_ids = [5, 4, 3, 2, 1]
@@ -341,6 +407,8 @@ class TestEvictionPolicy(unittest.TestCase):
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         self.assertEqual(
+            # pyre-fixme[29]: `Union[(self: TensorBase) -> list[Any], Tensor,
+            #  Module]` is not a function.
             sorted(_mch_sorted_raw_ids.tolist()),
             [2, 3, 4, 5, torch.iinfo(torch.int64).max],
         )

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -160,7 +160,10 @@ def convert_list_of_modules_to_modulelist(
     else:
         # recursively create nested list
         return torch.nn.ModuleList(
-            convert_list_of_modules_to_modulelist(m, sizes[1:]) for m in modules
+            # pyre-fixme[6]: For 1st argument expected `Iterable[Module]` but got
+            #  `Module`.
+            convert_list_of_modules_to_modulelist(m, sizes[1:])
+            for m in modules
         )
 
 

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -455,6 +455,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         ):
             for embedding_config, (weight, qscale, qbias) in zip(
                 tables,
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 emb_module.split_embedding_weights_with_scale_bias(
                     split_scale_bias_mode=2 if quant_state_dict_split_scale_bias else 0
                 ),
@@ -554,6 +555,8 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
         embedding_bag_configs = copy.deepcopy(module.embedding_bag_configs())
         _update_embedding_configs(
             cast(List[BaseEmbeddingConfig], embedding_bag_configs),
+            # pyre-fixme[6]: For 2nd argument expected `Union[QuantConfig, QConfig]`
+            #  but got `Union[Module, Tensor]`.
             module.qconfig,
             pruning_dict,
         )
@@ -569,6 +572,8 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
             embedding_bag_configs,
             module.is_weighted(),
             device=device,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `activation`.
             output_dtype=module.qconfig.activation().dtype,
             table_name_to_quantized_weights=table_name_to_quantized_weights,
             register_tbes=getattr(module, MODULE_ATTR_REGISTER_TBES_BOOL, False),
@@ -659,6 +664,8 @@ class FeatureProcessedEmbeddingBagCollection(EmbeddingBagCollection):
         embedding_bag_configs = copy.deepcopy(ebc.embedding_bag_configs())
         _update_embedding_configs(
             cast(List[BaseEmbeddingConfig], embedding_bag_configs),
+            # pyre-fixme[6]: For 2nd argument expected `Union[QuantConfig, QConfig]`
+            #  but got `Union[Module, Tensor]`.
             qconfig,
             pruning_dict,
         )
@@ -674,6 +681,8 @@ class FeatureProcessedEmbeddingBagCollection(EmbeddingBagCollection):
             embedding_bag_configs,
             ebc.is_weighted(),
             device=device,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `activation`.
             output_dtype=qconfig.activation().dtype,
             table_name_to_quantized_weights=table_name_to_quantized_weights,
             register_tbes=getattr(module, MODULE_ATTR_REGISTER_TBES_BOOL, False),
@@ -943,7 +952,10 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         ), "EmbeddingCollection input float module must have qconfig defined"
         embedding_configs = copy.deepcopy(module.embedding_configs())
         _update_embedding_configs(
-            cast(List[BaseEmbeddingConfig], embedding_configs), module.qconfig
+            cast(List[BaseEmbeddingConfig], embedding_configs),
+            # pyre-fixme[6]: For 2nd argument expected `Union[QuantConfig, QConfig]`
+            #  but got `Union[Module, Tensor]`.
+            module.qconfig,
         )
         table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] = {}
         device = quantize_state_dict(
@@ -955,6 +967,8 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             embedding_configs,
             device=device,
             need_indices=module.need_indices(),
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `activation`.
             output_dtype=module.qconfig.activation().dtype,
             table_name_to_quantized_weights=table_name_to_quantized_weights,
             register_tbes=getattr(module, MODULE_ATTR_REGISTER_TBES_BOOL, False),

--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -83,6 +83,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
 
         # test forward
         if not per_table_weight_dtype:
+            # pyre-fixme[16]: `EmbeddingBagCollection` has no attribute `qconfig`.
             ebc.qconfig = torch.quantization.QConfig(
                 activation=torch.quantization.PlaceholderObserver.with_args(
                     dtype=output_type
@@ -305,6 +306,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         ebc = EmbeddingBagCollection(tables=tables)
 
         # test forward
+        # pyre-fixme[16]: `EmbeddingBagCollection` has no attribute `qconfig`.
         ebc.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type
@@ -404,6 +406,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
 
         ebc = EmbeddingBagCollection(tables=tables)
         # test forward
+        # pyre-fixme[16]: `EmbeddingBagCollection` has no attribute `qconfig`.
         ebc.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type
@@ -443,6 +446,7 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         )
 
         ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+        # pyre-fixme[16]: `EmbeddingBagCollection` has no attribute `qconfig`.
         ebc.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type
@@ -530,6 +534,7 @@ class EmbeddingCollectionTest(unittest.TestCase):
         embeddings = ec(features)
 
         # test forward
+        # pyre-fixme[16]: `EmbeddingCollection` has no attribute `qconfig`.
         ec.qconfig = QuantConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type
@@ -725,6 +730,7 @@ class EmbeddingCollectionTest(unittest.TestCase):
             inplace=True,
             per_table_weight_dtype={"t1": torch.float16},
         )
+        # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
         configs = model.m.embedding_configs()
         self.assertEqual(len(configs), 2)
         self.assertNotEqual(configs[0].name, configs[1].name)
@@ -755,6 +761,7 @@ class EmbeddingCollectionTest(unittest.TestCase):
             inplace=True,
             per_table_weight_dtype={"t1": torch.float16},
         )
+        # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
         configs = model.m.embedding_bag_configs()
         self.assertEqual(len(configs), 2)
         self.assertNotEqual(configs[0].name, configs[1].name)
@@ -786,6 +793,7 @@ class EmbeddingCollectionTest(unittest.TestCase):
         )
 
         ec = EmbeddingCollection(tables=[ec1_config, ec2_config])
+        # pyre-fixme[16]: `EmbeddingCollection` has no attribute `qconfig`.
         ec.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type
@@ -888,6 +896,7 @@ class EmbeddingCollectionTest(unittest.TestCase):
         )
 
         ec = EmbeddingCollection(tables=[ec1_config, ec2_config])
+        # pyre-fixme[16]: `EmbeddingCollection` has no attribute `qconfig`.
         ec.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type

--- a/torchrec/quant/tests/test_quant_utils.py
+++ b/torchrec/quant/tests/test_quant_utils.py
@@ -46,6 +46,7 @@ class QuantUtilsTest(unittest.TestCase):
         ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
 
         # test forward
+        # pyre-fixme[16]: `EmbeddingBagCollection` has no attribute `qconfig`.
         ebc.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type

--- a/torchrec/quant/utils.py
+++ b/torchrec/quant/utils.py
@@ -35,6 +35,7 @@ def populate_fx_names(
             for config in emb_configs:
                 table_names.append(config.name)
             joined_table_names = ",".join(table_names)
+            # pyre-fixme[16]: `Module` has no attribute `_fx_path`.
             emb_module._fx_path = f"emb_module.{joined_table_names}"
     elif isinstance(quant_ebc, ShardedQuantEmbeddingBagCollection):
         for i, (emb_module, emb_dist_module) in enumerate(
@@ -43,6 +44,8 @@ def populate_fx_names(
             embedding_fx_path = f"embedding_lookup.sharding_{i}"
             emb_module._fx_path = embedding_fx_path
             emb_dist_module._fx_path = f"embedding_dist.{i}"
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
+            #  `Union[Module, Tensor]`.
             for rank, rank_module in enumerate(emb_module._embedding_lookups_per_rank):
                 rank_fx_path = f"{embedding_fx_path}.rank_{rank}"
                 rank_module._fx_path = rank_fx_path


### PR DESCRIPTION
Summary:
X-link: https://github.com/ctrl-labs/src2/pull/38525

#buildall

Differential Revision: D65778272
