### PR TITLE
Convert directory fbcode/torchrec to use the Ruff Formatter

### DIFF
--- a/benchmarks/ebc_benchmarks.py
+++ b/benchmarks/ebc_benchmarks.py
@@ -163,7 +163,6 @@ def get_fused_ebc_uvm_time(
     location: EmbeddingLocation,
     epochs: int = 100,
 ) -> Tuple[float, float]:
-
     fused_ebc = FusedEmbeddingBagCollection(
         tables=embedding_bag_configs,
         optimizer_type=torch.optim.SGD,
@@ -195,7 +194,6 @@ def get_ebc_comparison(
     device: torch.device,
     epochs: int = 100,
 ) -> Tuple[float, float, float, float, float]:
-
     # Simple EBC module wrapping a list of nn.EmbeddingBag
     ebc = EmbeddingBagCollection(
         tables=embedding_bag_configs,

--- a/benchmarks/ebc_benchmarks_utils.py
+++ b/benchmarks/ebc_benchmarks_utils.py
@@ -26,7 +26,6 @@ def get_random_dataset(
     embedding_bag_configs: List[EmbeddingBagConfig],
     pooling_factors: Optional[Dict[str, int]] = None,
 ) -> IterableDataset[Batch]:
-
     if pooling_factors is None:
         pooling_factors = {}
 
@@ -57,7 +56,6 @@ def train_one_epoch(
     dataset: IterableDataset[Batch],
     device: torch.device,
 ) -> float:
-
     start_time = time.perf_counter()
 
     for data in dataset:
@@ -82,7 +80,6 @@ def train_one_epoch_fused_optimizer(
     dataset: IterableDataset[Batch],
     device: torch.device,
 ) -> float:
-
     start_time = time.perf_counter()
 
     for data in dataset:
@@ -106,7 +103,6 @@ def train(
     device: torch.device,
     epochs: int = 100,
 ) -> Tuple[float, float]:
-
     training_time = []
     for _ in range(epochs):
         if optimizer:

--- a/examples/bert4rec/bert4rec_main.py
+++ b/examples/bert4rec/bert4rec_main.py
@@ -35,7 +35,6 @@ from tqdm import tqdm
 
 # OSS import
 try:
-
     # pyre-ignore[21]
     # @manual=//torchrec/github/examples/bert4rec:bert4rec_metrics
     from bert4rec_metrics import recalls_and_ndcgs_for_ks

--- a/examples/golden_training/train_dlrm_data_parallel.py
+++ b/examples/golden_training/train_dlrm_data_parallel.py
@@ -160,7 +160,7 @@ def train(
     )
 
     def dense_filter(
-        named_parameters: Iterator[Tuple[str, nn.Parameter]]
+        named_parameters: Iterator[Tuple[str, nn.Parameter]],
     ) -> Iterator[Tuple[str, nn.Parameter]]:
         for fqn, param in named_parameters:
             if "sparse" not in fqn:

--- a/examples/retrieval/two_tower_retrieval.py
+++ b/examples/retrieval/two_tower_retrieval.py
@@ -27,7 +27,6 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 # OSS import
 try:
-
     # pyre-ignore[21]
     # @manual=//torchrec/github/examples/retrieval:knn_index
     from knn_index import get_index

--- a/tools/lint/black_linter.py
+++ b/tools/lint/black_linter.py
@@ -179,7 +179,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -351,8 +351,9 @@ class BinaryCriteoUtils:
 
             # If the ranges overlap.
             if rank_left_g <= file_right_g and rank_right_g >= file_left_g:
-                overlap_left_g, overlap_right_g = max(rank_left_g, file_left_g), min(
-                    rank_right_g, file_right_g
+                overlap_left_g, overlap_right_g = (
+                    max(rank_left_g, file_left_g),
+                    min(rank_right_g, file_right_g),
                 )
 
                 # Convert overlap in global numbers to (local) numbers specific to the

--- a/torchrec/datasets/random.py
+++ b/torchrec/datasets/random.py
@@ -33,7 +33,6 @@ class _RandomRecBatch:
         *,
         min_ids_per_features: Optional[List[int]] = None,
     ) -> None:
-
         self.keys = keys
         self.keys_length: int = len(keys)
         self.batch_size = batch_size
@@ -76,7 +75,6 @@ class _RandomRecBatch:
         return batch
 
     def _generate_batch(self) -> Batch:
-
         values = []
         lengths = []
         for key_idx, _ in enumerate(self.keys):

--- a/torchrec/datasets/test_utils/criteo_test_utils.py
+++ b/torchrec/datasets/test_utils/criteo_test_utils.py
@@ -103,7 +103,6 @@ class CriteoTest(unittest.TestCase):
         labels: Optional[np.ndarray] = None,
     ) -> Generator[Tuple[str, ...], None, None]:
         with tempfile.TemporaryDirectory() as tmpdir:
-
             if filenames is None:
                 filenames = [filename]
 

--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -785,9 +785,7 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
+        assert remove_duplicate, "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
         for config, param in zip(
             self._config.embedding_tables,
             self.emb_module.split_embedding_weights(),
@@ -899,9 +897,7 @@ class KeyValueEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerModule
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
+        assert remove_duplicate, "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
         for config, tensor in zip(
             self._config.embedding_tables,
             self.split_embedding_weights(),
@@ -1082,8 +1078,9 @@ class BatchedDenseEmbedding(BaseBatchedEmbedding[torch.Tensor]):
         combined_key = "/".join(
             [config.name for config in self._config.embedding_tables]
         )
-        yield append_prefix(prefix, f"{combined_key}.weight"), cast(
-            nn.Parameter, self._emb_module.weights
+        yield (
+            append_prefix(prefix, f"{combined_key}.weight"),
+            cast(nn.Parameter, self._emb_module.weights),
         )
 
 
@@ -1101,7 +1098,8 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         self._pg = pg
 
         self._pooling: PoolingMode = pooling_type_to_pooling_mode(
-            config.pooling, sharding_type  # pyre-ignore[6]
+            config.pooling,
+            sharding_type,  # pyre-ignore[6]
         )
 
         self._local_rows: List[int] = []
@@ -1220,9 +1218,7 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
+        assert remove_duplicate, "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
         for config, tensor in zip(
             self._config.embedding_tables,
             self.emb_module.split_embedding_weights(),
@@ -1362,9 +1358,7 @@ class KeyValueEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor], FusedOptimizer
     def named_split_embedding_weights(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, PartiallyMaterializedTensor]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
+        assert remove_duplicate, "remove_duplicate=False not supported in BaseBatchedEmbedding.named_split_embedding_weights"
         for config, tensor in zip(
             self._config.embedding_tables,
             self.split_embedding_weights(),
@@ -1567,6 +1561,7 @@ class BatchedDenseEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
         combined_key = "/".join(
             [config.name for config in self._config.embedding_tables]
         )
-        yield append_prefix(prefix, f"{combined_key}.weight"), cast(
-            nn.Parameter, self._emb_module.weights
+        yield (
+            append_prefix(prefix, f"{combined_key}.weight"),
+            cast(nn.Parameter, self._emb_module.weights),
         )

--- a/torchrec/distributed/benchmark/benchmark_inference.py
+++ b/torchrec/distributed/benchmark/benchmark_inference.py
@@ -250,9 +250,7 @@ def main() -> None:
             mb = int(float(num * dim) / 1024 / 1024)
             tables_info += f"\nTABLE[{i}][{num:9}, {dim:4}] u8: {mb:6}Mb"
 
-        report: str = (
-            f"REPORT BENCHMARK {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
-        )
+        report: str = f"REPORT BENCHMARK {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
         report += f"Module: {module_name}\n"
         report += tables_info
         report += "\n"

--- a/torchrec/distributed/benchmark/benchmark_train.py
+++ b/torchrec/distributed/benchmark/benchmark_train.py
@@ -157,9 +157,7 @@ def main() -> None:
             tables_info += f"\nTABLE[{i}][{num:9}, {dim:4}] {mb:6}Mb"
 
         ### Benchmark no VBE
-        report: str = (
-            f"REPORT BENCHMARK {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
-        )
+        report: str = f"REPORT BENCHMARK {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
         report += f"Module: {module_name}\n"
         report += tables_info
         report += "\n"
@@ -181,9 +179,7 @@ def main() -> None:
         )
 
         ### Benchmark with VBE
-        report: str = (
-            f"REPORT BENCHMARK (VBE) {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
-        )
+        report: str = f"REPORT BENCHMARK (VBE) {datetime_sfx} world_size:{args.world_size} batch_size:{args.batch_size}\n"
         report += f"Module: {module_name} (VBE)\n"
         report += tables_info
         report += "\n"

--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -128,6 +128,7 @@ class MemoryStats:
 @dataclass
 class BenchmarkResult:
     "Class for holding results of benchmark runs"
+
     short_name: str
     elapsed_time: torch.Tensor  # milliseconds
     mem_stats: List[MemoryStats]  # memory stats per rank
@@ -551,9 +552,7 @@ def transform_module(
         return fx_script_module(
             # pyre-fixme[6]: For 1st argument expected `Module` but got
             #  `Optional[Module]`.
-            sharded_module
-            if not benchmark_unsharded_module
-            else module
+            sharded_module if not benchmark_unsharded_module else module
         )
     else:
         # pyre-fixme[7]: Expected `Module` but got `Optional[Module]`.
@@ -964,7 +963,6 @@ def multi_process_benchmark(
     # pyre-ignore
     **kwargs,
 ) -> BenchmarkResult:
-
     def setUp() -> None:
         if "MASTER_ADDR" not in os.environ:
             os.environ["MASTER_ADDR"] = str("localhost")

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -477,7 +477,6 @@ def variable_batch_alltoall_pooled(
     group: Optional[dist.ProcessGroup] = None,
     codecs: Optional[QuantizedCommCodecs] = None,
 ) -> Awaitable[Tensor]:
-
     if group is None:
         group = dist.distributed_c10d._get_default_group()
 

--- a/torchrec/distributed/composable/tests/test_embedding.py
+++ b/torchrec/distributed/composable/tests/test_embedding.py
@@ -210,7 +210,6 @@ class ShardedEmbeddingCollectionParallelTest(MultiProcessTestBase):
         use_apply_optimizer_in_backward: bool,
         use_index_dedup: bool,
     ) -> None:
-
         WORLD_SIZE = 2
 
         embedding_config = [

--- a/torchrec/distributed/composable/tests/test_embeddingbag.py
+++ b/torchrec/distributed/composable/tests/test_embeddingbag.py
@@ -292,7 +292,6 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         sharding_type: str,
         use_apply_optimizer_in_backward: bool,
     ) -> None:
-
         # TODO DistributedDataParallel needs full support of registering fused optims before we can enable this.
         assume(
             not (

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -167,7 +167,6 @@ def create_sharding_infos_by_sharding(
     table_name_to_parameter_sharding: Dict[str, ParameterSharding],
     fused_params: Optional[Dict[str, Any]],
 ) -> Dict[str, List[EmbeddingShardingInfo]]:
-
     if fused_params is None:
         fused_params = {}
 
@@ -249,7 +248,6 @@ def create_sharding_infos_by_sharding_device_group(
     table_name_to_parameter_sharding: Dict[str, ParameterSharding],
     fused_params: Optional[Dict[str, Any]],
 ) -> Dict[Tuple[str, str], List[EmbeddingShardingInfo]]:
-
     if fused_params is None:
         fused_params = {}
 

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -105,7 +105,15 @@ def get_state_dict(
 
         assert embedding_table.local_rows == param.size(  # pyre-ignore[16]
             0
-        ), f"{embedding_table.local_rows=}, {param.size(0)=}, {param.shape=}"  # pyre-ignore[16]
+        ), (
+            # pyre-fixme[16]: Item `Tuple` of `PartiallyMaterializedTensor | Tensor
+            #  | Module | Tuple[Tensor, Optional[Tensor], Optional[Tensor]]` has no
+            #  attribute `size`.
+            # pyre-fixme[16]: Item `Tuple` of `PartiallyMaterializedTensor | Tensor
+            #  | Module | Tuple[Tensor, Optional[Tensor], Optional[Tensor]]` has no
+            #  attribute `shape`.
+            f"{embedding_table.local_rows=}, {param.size(0)=}, {param.shape=}"
+        )
 
         if qscale is not None:
             assert embedding_table.local_cols == param.size(1)  # pyre-ignore[16]

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -237,7 +237,6 @@ class ShardedEmbeddingTower(
         features: KeyedJaggedTensor,
         optional_features: Optional[KeyedJaggedTensor] = None,
     ) -> Awaitable[Awaitable[KJTList]]:
-
         # optional_features are populated only if both kjt and weighted kjt present in tower
         if self._wkjt_feature_names and self._kjt_feature_names:
             kjt_features = features
@@ -506,9 +505,7 @@ class ShardedEmbeddingTowerCollection(
                 if lt_tables.issubset(pt_tables):
                     found_physical_tower = True
                     break
-            assert (
-                found_physical_tower
-            ), f"tables in a logical tower must be in the same physical tower, logical tower tables: {lt_tables}, tables_per_pt: {tables_per_pt}"
+            assert found_physical_tower, f"tables in a logical tower must be in the same physical tower, logical tower tables: {lt_tables}, tables_per_pt: {tables_per_pt}"
 
         logical_to_physical_order: List[List[int]] = [
             [] for _ in range(self._cross_pg_world_size)
@@ -607,7 +604,6 @@ class ShardedEmbeddingTowerCollection(
         kjt_feature_names: List[str],
         wkjt_feature_names: List[str],
     ) -> None:
-
         if self._kjt_feature_names != kjt_feature_names:
             self._has_kjt_features_permute = True
             for f in self._kjt_feature_names:
@@ -944,7 +940,6 @@ class EmbeddingTowerCollectionSharder(BaseEmbeddingSharder[EmbeddingTowerCollect
         fused_params: Optional[Dict[str, Any]] = None,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
     ) -> None:
-
         super().__init__(
             fused_params=fused_params, qcomm_codecs_registry=qcomm_codecs_registry
         )
@@ -960,7 +955,6 @@ class EmbeddingTowerCollectionSharder(BaseEmbeddingSharder[EmbeddingTowerCollect
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedEmbeddingTowerCollection:
-
         return ShardedEmbeddingTowerCollection(
             module=module,
             table_name_to_parameter_sharding=params,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -514,7 +514,6 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         return types
 
     def shardable_parameters(self, module: M) -> Dict[str, nn.Parameter]:
-
         shardable_params: Dict[str, nn.Parameter] = {}
         for name, param in module.state_dict().items():
             if name.endswith(".weight"):

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -214,7 +214,6 @@ def create_sharding_infos_by_sharding(
     fused_params: Optional[Dict[str, Any]],
     suffix: Optional[str] = "weight",
 ) -> Dict[str, List[EmbeddingShardingInfo]]:
-
     if fused_params is None:
         fused_params = {}
 
@@ -319,7 +318,6 @@ def create_sharding_infos_by_sharding_device_group(
     fused_params: Optional[Dict[str, Any]],
     suffix: Optional[str] = "weight",
 ) -> Dict[Tuple[str, str], List[EmbeddingShardingInfo]]:
-
     if fused_params is None:
         fused_params = {}
 

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -115,7 +115,6 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
         ctx: EmbeddingBagCollectionContext,
         dist_input: KJTList,
     ) -> List[torch.Tensor]:
-
         fp_features = self.apply_feature_processors_to_kjt_list(dist_input)
         return self._embedding_bag_collection.compute(ctx, fp_features)
 
@@ -186,7 +185,6 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedFeatureProcessedEmbeddingBagCollection:
-
         if device is None:
             device = torch.device("cuda")
 

--- a/torchrec/distributed/fused_embedding.py
+++ b/torchrec/distributed/fused_embedding.py
@@ -98,13 +98,11 @@ class FusedEmbeddingCollectionSharder(BaseEmbeddingSharder[FusedEmbeddingCollect
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedFusedEmbeddingCollection:
-
         return ShardedFusedEmbeddingCollection(module, params, env, device)
 
     def shardable_parameters(
         self, module: FusedEmbeddingCollection
     ) -> Dict[str, nn.Parameter]:
-
         params = {
             # state_dict value looks like model.embeddings.table_0.weights
             name.split(".")[-2]: param

--- a/torchrec/distributed/fused_embeddingbag.py
+++ b/torchrec/distributed/fused_embeddingbag.py
@@ -96,7 +96,6 @@ class FusedEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedEmbeddingBagCollection:
-
         return ShardedFusedEmbeddingBagCollection(
             module,
             params,
@@ -108,7 +107,6 @@ class FusedEmbeddingBagCollectionSharder(
     def shardable_parameters(
         self, module: FusedEmbeddingBagCollection
     ) -> Dict[str, nn.Parameter]:
-
         params = {
             name.split(".")[-2]: param
             for name, param in module.state_dict().items()

--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -51,7 +51,7 @@ def is_fused_param_register_tbe(fused_params: Optional[Dict[str, Any]]) -> bool:
 
 
 def get_fused_param_tbe_row_alignment(
-    fused_params: Optional[Dict[str, Any]]
+    fused_params: Optional[Dict[str, Any]],
 ) -> Optional[int]:
     if fused_params is None or FUSED_PARAM_TBE_ROW_ALIGNMENT not in fused_params:
         return None
@@ -60,7 +60,7 @@ def get_fused_param_tbe_row_alignment(
 
 
 def fused_param_bounds_check_mode(
-    fused_params: Optional[Dict[str, Any]]
+    fused_params: Optional[Dict[str, Any]],
 ) -> Optional[BoundsCheckMode]:
     if fused_params is None or FUSED_PARAM_BOUNDS_CHECK_MODE not in fused_params:
         return None
@@ -69,7 +69,7 @@ def fused_param_bounds_check_mode(
 
 
 def is_fused_param_quant_state_dict_split_scale_bias(
-    fused_params: Optional[Dict[str, Any]]
+    fused_params: Optional[Dict[str, Any]],
 ) -> bool:
     return (
         fused_params
@@ -79,7 +79,7 @@ def is_fused_param_quant_state_dict_split_scale_bias(
 
 
 def tbe_fused_params(
-    fused_params: Optional[Dict[str, Any]]
+    fused_params: Optional[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
     if not fused_params:
         return None

--- a/torchrec/distributed/infer_utils.py
+++ b/torchrec/distributed/infer_utils.py
@@ -32,10 +32,13 @@ from torchrec.modules.embedding_modules import (
 def get_tbes_from_sharded_module(
     module: torch.nn.Module,
 ) -> List[IntNBitTableBatchedEmbeddingBagsCodegen]:
-    assert type(module) in [
-        ShardedQuantEmbeddingBagCollection,
-        ShardedQuantEmbeddingCollection,
-    ], "Only support ShardedQuantEmbeddingBagCollection and ShardedQuantEmbeddingCollection for get TBEs"
+    assert (
+        type(module)
+        in [
+            ShardedQuantEmbeddingBagCollection,
+            ShardedQuantEmbeddingCollection,
+        ]
+    ), "Only support ShardedQuantEmbeddingBagCollection and ShardedQuantEmbeddingCollection for get TBEs"
     tbes = []
     for lookup in module._lookups:
         for lookup_per_rank in lookup._embedding_lookups_per_rank:
@@ -49,10 +52,13 @@ def get_tbe_specs_from_sharded_module(
 ) -> List[
     Tuple[str, int, int, str, str]
 ]:  # # tuple of (feature_names, rows, dims, str(SparseType), str(EmbeddingLocation/placement))
-    assert type(module) in [
-        ShardedQuantEmbeddingBagCollection,
-        ShardedQuantEmbeddingCollection,
-    ], "Only support ShardedQuantEmbeddingBagCollection and ShardedQuantEmbeddingCollection for get TBE specs"
+    assert (
+        type(module)
+        in [
+            ShardedQuantEmbeddingBagCollection,
+            ShardedQuantEmbeddingCollection,
+        ]
+    ), "Only support ShardedQuantEmbeddingBagCollection and ShardedQuantEmbeddingCollection for get TBE specs"
     tbe_specs = []
     tbes = get_tbes_from_sharded_module(module)
     for tbe in tbes:

--- a/torchrec/distributed/itep_embeddingbag.py
+++ b/torchrec/distributed/itep_embeddingbag.py
@@ -128,7 +128,6 @@ class ShardedITEPEmbeddingBagCollection(
         ctx: ITEPEmbeddingBagCollectionContext,
         output: List[torch.Tensor],
     ) -> LazyAwaitable[KeyedTensor]:
-
         ebc_awaitable = self._embedding_bag_collection.output_dist(ctx, output)
         return ebc_awaitable
 
@@ -173,7 +172,6 @@ class ITEPEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedITEPEmbeddingBagCollection:
-
         # Enforce GPU for ITEPEmbeddingBagCollection
         if device is None:
             device = torch.device("cuda")

--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -206,7 +206,6 @@ class ShardedKeyedJaggedTensorPool(
         # TODO add quantized comms codec registry
         enable_uvm: bool = False,
     ) -> None:
-
         super().__init__()
         self._pool_size = pool_size
         self._values_dtype = values_dtype

--- a/torchrec/distributed/mc_embedding.py
+++ b/torchrec/distributed/mc_embedding.py
@@ -36,7 +36,6 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class ManagedCollisionEmbeddingCollectionContext(EmbeddingCollectionContext):
-
     def __init__(
         self,
         sharding_contexts: Optional[List[SequenceShardingContext]] = None,
@@ -126,7 +125,6 @@ class ManagedCollisionEmbeddingCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedManagedCollisionEmbeddingCollection:
-
         if device is None:
             device = torch.device("cuda")
 

--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -229,7 +229,6 @@ class BaseShardedManagedCollisionEmbeddingCollection(
         ctx: ShrdCtx,
         output: List[torch.Tensor],
     ) -> Tuple[LazyAwaitable[KeyedTensor], LazyAwaitable[Optional[KeyedJaggedTensor]]]:
-
         # pyre-ignore [6]
         ebc_awaitable = self._embedding_module.output_dist(ctx, output)
 

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -112,7 +112,6 @@ class ManagedCollisionEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedManagedCollisionEmbeddingBagCollection:
-
         if device is None:
             device = torch.device("cuda")
 

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -262,7 +262,6 @@ class ShardedManagedCollisionCollection(
     def _create_managed_collision_modules(
         self, module: ManagedCollisionCollection
     ) -> None:
-
         self._mc_module_name_shard_metadata: DefaultDict[str, List[int]] = defaultdict()
         # To map mch output indices from local to global. key: table_name
         self._table_to_offset: Dict[str, int] = {}
@@ -366,8 +365,8 @@ class ShardedManagedCollisionCollection(
                     )
                     num_sharding_features += self._table_feature_splits[-1]
 
-            assert num_sharding_features == len(
-                sharding.feature_names()
+            assert (
+                num_sharding_features == len(sharding.feature_names())
             ), f"Shared feature is not supported. {num_sharding_features=}, {self._sharding_per_table_feature_splits[-1]=}"
 
             if self._sharding_features[-1] != sharding.feature_names():
@@ -781,7 +780,6 @@ class ManagedCollisionCollectionSharder(
         device: Optional[torch.device] = None,
         use_index_dedup: bool = False,
     ) -> ShardedManagedCollisionCollection:
-
         if device is None:
             device = torch.device("cpu")
 

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -359,7 +359,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         module: nn.Module,
         path: str = "",
     ) -> nn.Module:
-
         # pre-sharded module
         if isinstance(module, ShardedModule):
             return module

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -75,7 +75,6 @@ def _group_and_sort_non_uniform_sharding_options(
     sort_by: SortBy = SortBy.STORAGE,
     balance_modules: bool = False,
 ) -> List[ShardingOptionGroup]:
-
     # count modules by name
     param_count: Dict[str, int] = {}
     for sharding_option in sharding_options:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -71,7 +71,6 @@ def _to_sharding_plan(
     sharding_options: List[ShardingOption],
     topology: Topology,
 ) -> ShardingPlan:
-
     compute_device = topology.compute_device
     local_size = topology.local_world_size
 
@@ -234,7 +233,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         self._best_plan: Optional[List[ShardingOption]] = None
         self._callbacks: List[
             Callable[[List[ShardingOption]], List[ShardingOption]]
-        ] = ([] if callbacks is None else callbacks)
+        ] = [] if callbacks is None else callbacks
 
     def collective_plan(
         self,
@@ -588,7 +587,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
         self._best_plan: Optional[List[ShardingOption]] = None
         self._callbacks: List[
             Callable[[List[ShardingOption]], List[ShardingOption]]
-        ] = ([] if callbacks is None else callbacks)
+        ] = [] if callbacks is None else callbacks
 
     def collective_plan(
         self,

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -153,9 +153,9 @@ class UniformProposer(Proposer):
     ) -> None:
         self._reset()
         all_fqns = set()
-        sharding_options_by_type_and_fqn: Dict[str, Dict[str, List[ShardingOption]]] = (
-            {}
-        )
+        sharding_options_by_type_and_fqn: Dict[
+            str, Dict[str, List[ShardingOption]]
+        ] = {}
 
         for sharding_option in search_space:
             sharding_type = sharding_option.sharding_type

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -220,9 +220,9 @@ class EmbeddingStats(Stats):
             fqn = sharding_option.fqn
 
             compute_kernels_to_count[sharding_option.compute_kernel] += 1
-            compute_kernels_to_storage[
-                sharding_option.compute_kernel
-            ] += sharding_option.total_storage
+            compute_kernels_to_storage[sharding_option.compute_kernel] += (
+                sharding_option.total_storage
+            )
 
             # for shard in sharding_option.shards:
             # compute_kernels_to_storage[sharding_option.compute_kernel] += shard.hbm

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -63,7 +63,6 @@ def _reserve_dense_storage(
     multiplier: float,
     dense_tensor_estimate: Optional[int] = None,
 ) -> Storage:
-
     dense_tensor_size = _get_dense_tensor_size(module, shardable_modules, multiplier)
     if dense_tensor_estimate:
         logger.info(

--- a/torchrec/distributed/planner/tests/test_stats.py
+++ b/torchrec/distributed/planner/tests/test_stats.py
@@ -147,9 +147,7 @@ class TestEmbeddingStats(unittest.TestCase):
         # Generate most imbalanced distribution
         normalized_p = [
             1.0,
-        ] + [
-            0.0
-        ] * (N - 1)
+        ] + [0.0] * (N - 1)
         N = len(normalized_p)
         self.assertEqual(_kl_divergence(normalized_p), _calc_max_kl_divergence(N))
 
@@ -163,9 +161,7 @@ class TestEmbeddingStats(unittest.TestCase):
         # Generate most imbalanced distribution
         normalized_p = [
             1.0,
-        ] + [
-            0.0
-        ] * (N - 1)
+        ] + [0.0] * (N - 1)
         N = len(normalized_p)
 
         self.assertTrue(

--- a/torchrec/distributed/planner/tests/test_utils.py
+++ b/torchrec/distributed/planner/tests/test_utils.py
@@ -120,7 +120,6 @@ class TestBinarySearchPredicate(unittest.TestCase):
 
 
 class TestLuusJaakolaSearch(unittest.TestCase):
-
     # Find minimum of f between x0 and x1.
     # Evaluate multiple times with different random seeds to ensure we're not
     # just getting lucky.

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -317,7 +317,6 @@ def _construct_jagged_tensors(
     cw_features_to_permute_indices: Dict[str, torch.Tensor],
     key_to_feature_permuted_coordinates: Dict[str, torch.Tensor],
 ) -> Dict[str, JaggedTensor]:
-
     # Validating sharding type and parameters
     valid_sharding_types = [
         ShardingType.ROW_WISE.value,
@@ -543,9 +542,7 @@ class ShardedQuantEmbeddingCollection(
                     _,
                 ) in self._sharding_type_device_group_to_sharding.keys()
             )
-            assert (
-                table_wise_sharded_only
-            ), "ROW_WISE,COLUMN_WISE shardings can be used only in 'quant_state_dict_split_scale_bias' mode, specify fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS]=True to __init__ argument"
+            assert table_wise_sharded_only, "ROW_WISE,COLUMN_WISE shardings can be used only in 'quant_state_dict_split_scale_bias' mode, specify fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS]=True to __init__ argument"
 
             self.embeddings: nn.ModuleDict = nn.ModuleDict()
             for table in self._embedding_configs:
@@ -692,7 +689,6 @@ class ShardedQuantEmbeddingCollection(
 
         with torch.no_grad():
             for i in range(len(self._sharding_type_device_group_to_sharding)):
-
                 ctx.sharding_contexts.append(
                     InferSequenceShardingContext(
                         features=input_dist_result_list[i],
@@ -991,7 +987,9 @@ class ShardedQuantEcInputDist(torch.nn.Module):
             persistent=False,
         )
 
-    def forward(self, features: KeyedJaggedTensor) -> Tuple[
+    def forward(
+        self, features: KeyedJaggedTensor
+    ) -> Tuple[
         List[KJTList],
         List[KeyedJaggedTensor],
         List[Optional[torch.Tensor]],

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -220,9 +220,7 @@ class ShardedQuantEmbeddingBagCollection(
                     _,
                 ) in self._sharding_type_device_group_to_sharding.keys()
             )
-            assert (
-                table_wise_sharded_only
-            ), "ROW_WISE,COLUMN_WISE shardings can be used only in 'quant_state_dict_split_scale_bias' mode, specify fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS]=True to __init__ argument"
+            assert table_wise_sharded_only, "ROW_WISE,COLUMN_WISE shardings can be used only in 'quant_state_dict_split_scale_bias' mode, specify fused_params[FUSED_PARAM_QUANT_STATE_DICT_SPLIT_SCALE_BIAS]=True to __init__ argument"
 
             self.embedding_bags: nn.ModuleDict = nn.ModuleDict()
             for table in self._embedding_bag_configs:

--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -191,9 +191,9 @@ class ShardedQuantEmbeddingModuleState(
                             ] * num_shards
 
                         column_idx = int(shard_offsets_cols / shard_sizes_cols)
-                        table_name_to_tensors_list[table.name][
-                            column_idx
-                        ] = tbe_split_qparam
+                        table_name_to_tensors_list[table.name][column_idx] = (
+                            tbe_split_qparam
+                        )
                     else:
                         qmetadata = ShardMetadata(
                             shard_offsets=metadata.shard_offsets,

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -54,9 +54,9 @@ class BaseDpEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._rank: int = self._env.rank
         self._world_size: int = self._env.world_size
         sharded_tables_per_rank = self._shard(sharding_infos)
-        self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
+        self._grouped_embedding_configs_per_rank: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
         self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs: List[GroupedEmbeddingConfig] = (
             self._grouped_embedding_configs_per_rank[env.rank]

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -92,12 +92,12 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         )
 
         sharded_tables_per_rank = self._shard(sharding_infos)
-        self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
-        self._grouped_embedding_configs_per_node: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
+        self._grouped_embedding_configs_per_rank: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
+        self._grouped_embedding_configs_per_node: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
         self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs_per_node = [
             self._grouped_embedding_configs_per_rank[rank]

--- a/torchrec/distributed/sharding/rw_kjt_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_kjt_pool_sharding.py
@@ -311,25 +311,28 @@ class KeyedJaggedTensorPoolRwSharding(ObjectPoolSharding):
         self, lookup: KeyedJaggedTensorPoolLookup
     ) -> Iterable[Tuple[str, torch.Tensor]]:
         for fqn, tensor in lookup.states_to_register():
-            yield fqn, ShardedTensor._init_from_local_shards(
-                [
-                    Shard(
-                        tensor=tensor,
-                        metadata=ShardMetadata(
-                            shard_offsets=[
-                                self._env.rank * self._block_size,
-                                0,
-                            ],
-                            shard_sizes=[
-                                tensor.shape[0],
-                                tensor.shape[1],
-                            ],
-                            placement=f"rank:{self._env.rank}/{str(tensor.device)}",
-                        ),
-                    )
-                ],
-                torch.Size([self._pool_size, tensor.shape[1]]),
-                process_group=self._env.process_group,
+            yield (
+                fqn,
+                ShardedTensor._init_from_local_shards(
+                    [
+                        Shard(
+                            tensor=tensor,
+                            metadata=ShardMetadata(
+                                shard_offsets=[
+                                    self._env.rank * self._block_size,
+                                    0,
+                                ],
+                                shard_sizes=[
+                                    tensor.shape[0],
+                                    tensor.shape[1],
+                                ],
+                                placement=f"rank:{self._env.rank}/{str(tensor.device)}",
+                            ),
+                        )
+                    ],
+                    torch.Size([self._pool_size, tensor.shape[1]]),
+                    process_group=self._env.process_group,
+                ),
             )
 
     def create_context(self) -> ObjectPoolRwShardingContext:
@@ -518,25 +521,28 @@ class KeyedJaggedTensorPoolRwReplicatedSharding(ObjectPoolSharding):
         self, lookup: KeyedJaggedTensorPoolLookup
     ) -> Iterable[Tuple[str, torch.Tensor]]:
         for fqn, tensor in lookup.states_to_register():
-            yield fqn, ShardedTensor._init_from_local_shards(
-                [
-                    Shard(
-                        tensor=tensor,
-                        metadata=ShardMetadata(
-                            shard_offsets=[
-                                self._local_env.rank * self._block_size,
-                                0,
-                            ],
-                            shard_sizes=[
-                                tensor.shape[0],
-                                tensor.shape[1],
-                            ],
-                            placement=f"rank:{self._local_env.rank}/{str(tensor.device)}",
-                        ),
-                    )
-                ],
-                torch.Size([self._pool_size, tensor.shape[1]]),
-                process_group=self._local_env.process_group,
+            yield (
+                fqn,
+                ShardedTensor._init_from_local_shards(
+                    [
+                        Shard(
+                            tensor=tensor,
+                            metadata=ShardMetadata(
+                                shard_offsets=[
+                                    self._local_env.rank * self._block_size,
+                                    0,
+                                ],
+                                shard_sizes=[
+                                    tensor.shape[0],
+                                    tensor.shape[1],
+                                ],
+                                placement=f"rank:{self._local_env.rank}/{str(tensor.device)}",
+                            ),
+                        )
+                    ],
+                    torch.Size([self._pool_size, tensor.shape[1]]),
+                    process_group=self._local_env.process_group,
+                ),
             )
 
     def create_context(self) -> ObjectPoolReplicatedRwShardingContext:

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -129,9 +129,9 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         self._device: torch.device = device
         sharded_tables_per_rank = self._shard(sharding_infos)
         self._need_pos = need_pos
-        self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
+        self._grouped_embedding_configs_per_rank: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
         self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs: List[GroupedEmbeddingConfig] = (
             self._grouped_embedding_configs_per_rank[self._rank]

--- a/torchrec/distributed/sharding/rw_tensor_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_tensor_pool_sharding.py
@@ -167,25 +167,28 @@ class TensorPoolRwSharding(ObjectPoolSharding):
         self, lookup: TensorPoolLookup
     ) -> Iterable[Tuple[str, torch.Tensor]]:
         for fqn, tensor in lookup.states_to_register():
-            yield fqn, ShardedTensor._init_from_local_shards(
-                [
-                    Shard(
-                        tensor=tensor,
-                        metadata=ShardMetadata(
-                            shard_offsets=[
-                                self._env.rank * self._block_size,
-                                0,
-                            ],
-                            shard_sizes=[
-                                tensor.shape[0],
-                                tensor.shape[1],
-                            ],
-                            placement=f"rank:{self._env.rank}/{str(tensor.device)}",
-                        ),
-                    )
-                ],
-                torch.Size([self._pool_size, tensor.shape[1]]),
-                process_group=self._env.process_group,
+            yield (
+                fqn,
+                ShardedTensor._init_from_local_shards(
+                    [
+                        Shard(
+                            tensor=tensor,
+                            metadata=ShardMetadata(
+                                shard_offsets=[
+                                    self._env.rank * self._block_size,
+                                    0,
+                                ],
+                                shard_sizes=[
+                                    tensor.shape[0],
+                                    tensor.shape[1],
+                                ],
+                                placement=f"rank:{self._env.rank}/{str(tensor.device)}",
+                            ),
+                        )
+                    ],
+                    torch.Size([self._pool_size, tensor.shape[1]]),
+                    process_group=self._env.process_group,
+                ),
             )
 
     def create_context(self) -> ObjectPoolRwShardingContext:

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -84,9 +84,9 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             sharded_tables_per_rank
         )
 
-        self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
+        self._grouped_embedding_configs_per_rank: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
         self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs: List[GroupedEmbeddingConfig] = (
             self._grouped_embedding_configs_per_rank[self._rank]

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -86,12 +86,12 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         )
 
         sharded_tables_per_rank = self._shard(sharding_infos)
-        self._grouped_embedding_configs_per_rank: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
-        self._grouped_embedding_configs_per_node: List[List[GroupedEmbeddingConfig]] = (
-            []
-        )
+        self._grouped_embedding_configs_per_rank: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
+        self._grouped_embedding_configs_per_node: List[
+            List[GroupedEmbeddingConfig]
+        ] = []
         self._grouped_embedding_configs_per_rank = group_tables(sharded_tables_per_rank)
         self._grouped_embedding_configs_per_node = [
             self._grouped_embedding_configs_per_rank[rank]

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -501,7 +501,7 @@ def table_wise(
 
 
 def row_wise(
-    sizes_placement: Optional[Tuple[List[int], Union[str, List[str]]]] = None
+    sizes_placement: Optional[Tuple[List[int], Union[str, List[str]]]] = None,
 ) -> ParameterShardingGenerator:
     """
     Returns a generator of ParameterShardingPlan for `ShardingType::ROW_WISE` for construct_module_sharding_plan.

--- a/torchrec/distributed/shards_wrapper.py
+++ b/torchrec/distributed/shards_wrapper.py
@@ -287,7 +287,9 @@ class LocalShardsWrapper(torch.Tensor):
         return self._storage_meta.size[0] == 0 and self._storage_meta.size[1] == 0
 
     def __create_write_items__(
-        self, fqn: str, object: Any  # pyre-ignore[2]
+        self,
+        fqn: str,
+        object: Any,  # pyre-ignore[2]
     ) -> List[WriteItem]:
         """
         For compatibility with DCP, we support creation of WriteItems

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -306,7 +306,7 @@ def model_input_to_forward_args(
 
 
 def create_cw_min_partition_constraints(
-    table_min_partition_pairs: List[Tuple[str, int]]
+    table_min_partition_pairs: List[Tuple[str, int]],
 ) -> Dict[str, ParameterConstraints]:
     return {
         name: ParameterConstraints(
@@ -994,9 +994,7 @@ def assert_weight_spec(
             # Assumption of only one TBE per rank
             if "rank:1" in placement:
                 tbe_idx = 1
-            sharded_weight_fqn: str = (
-                f"{ebc_fqn}.tbes.{tbe_idx}.{tbe_table_idxs[tbe_idx]}.{table_name}.weight"
-            )
+            sharded_weight_fqn: str = f"{ebc_fqn}.tbes.{tbe_idx}.{tbe_table_idxs[tbe_idx]}.{table_name}.weight"
             tbe_table_idxs[tbe_idx] += 1
             assert sharded_weight_fqn in weights_spec
             wspec = weights_spec[sharded_weight_fqn]

--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -39,7 +39,6 @@ class MultiProcessContext:
         use_deterministic_algorithms: bool = True,
         disable_cuda_tf_32: bool = True,
     ) -> None:
-
         self.rank = rank
         self.world_size = world_size
         self.backend = backend
@@ -98,7 +97,6 @@ class MultiProcessContext:
 
 
 class MultiProcessTestBase(unittest.TestCase):
-
     @seed_and_log
     def setUp(self) -> None:
         os.environ["MASTER_ADDR"] = str("localhost")

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -581,9 +581,7 @@ class ModelInput(Pipelineable):
         for rank in range(world_size):
             label_per_rank.append(torch.rand(dedup_factor * average_batch_size))
             local_float = global_float[
-                rank
-                * dedup_factor
-                * average_batch_size : (rank + 1)
+                rank * dedup_factor * average_batch_size : (rank + 1)
                 * dedup_factor
                 * average_batch_size
             ]

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -314,7 +314,6 @@ class ModelParallelSingleRankBase(unittest.TestCase):
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
         constraints: Optional[Dict[str, trec_dist.planner.ParameterConstraints]] = None,
     ) -> Tuple[List[DistributedModelParallel], ModelInput]:
-
         if constraints is None:
             constraints = {}
         if sharders is None:

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -284,7 +284,6 @@ def sharding_single_rank_test(
     variable_batch_per_feature: bool = False,  # VBE
     global_constant_batch: bool = False,
 ) -> None:
-
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         # Generate model & inputs.
         (global_model, inputs) = gen_model_and_input(

--- a/torchrec/distributed/tests/test_apply_optim_per_param.py
+++ b/torchrec/distributed/tests/test_apply_optim_per_param.py
@@ -209,7 +209,6 @@ class ShardedEmbeddingBagCollectionApplyOptimPerParamTest(MultiProcessTestBase):
         self,
         sharding_type: str,
     ) -> None:
-
         WORLD_SIZE = 2
 
         embedding_bag_config = [
@@ -427,7 +426,6 @@ class ShardedEmbeddingCollectionApplyOptimPerParamTest(MultiProcessTestBase):
         self,
         sharding_type: str,
     ) -> None:
-
         WORLD_SIZE = 2
 
         embedding_config = [

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -915,9 +915,9 @@ def _generate_sequence_embedding_batch(
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
     world_size = len(splits)
 
-    tensor_by_feature: Dict[str, List[torch.Tensor]] = (
-        {}
-    )  # Model parallel, key as feature
+    tensor_by_feature: Dict[
+        str, List[torch.Tensor]
+    ] = {}  # Model parallel, key as feature
     tensor_by_rank: Dict[str, List[torch.Tensor]] = {}  # Data parallel, key as rank
 
     emb_by_rank_feature = {}
@@ -1081,7 +1081,6 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
         variable_batch_size: bool,
         qcomms_config: Optional[QCommsConfig],
     ) -> None:
-
         world_size = 2
         seq_emb_dim = 3
         features = 3
@@ -1101,7 +1100,8 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
             lengths_after_a2a_per_rank = [
                 torch.tensor([3, 0, 2, 4, 3], dtype=int),  # pyre-ignore [6]
                 torch.tensor(
-                    [4, 1, 2, 1, 0, 1, 2, 0, 5, 0], dtype=int  # pyre-ignore [6]
+                    [4, 1, 2, 1, 0, 1, 2, 0, 5, 0],
+                    dtype=int,  # pyre-ignore [6]
                 ),
             ]
 
@@ -1122,7 +1122,8 @@ class SeqEmbeddingsAllToAllTest(MultiProcessTestBase):
             lengths_after_a2a_per_rank = [
                 torch.tensor([[3, 4, 4, 0]], dtype=int),  # pyre-ignore [6]
                 torch.tensor(
-                    [[1, 2, 2, 3], [6, 0, 1, 2]], dtype=int  # pyre-ignore [6]
+                    [[1, 2, 2, 3], [6, 0, 1, 2]],
+                    dtype=int,  # pyre-ignore [6]
                 ),
             ]
 

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -437,7 +437,6 @@ class TestGroupTablesPerRank(unittest.TestCase):
             and tables[0].pooling == tables[1].pooling
             and tables[0].has_feature_processor == tables[1].has_feature_processor
         ):
-
             self.assertEqual(
                 sorted(_get_table_names_by_groups(tables)),
                 [["table_0", "table_1"]],
@@ -452,7 +451,6 @@ class TestGroupTablesPerRank(unittest.TestCase):
     def test_use_one_tbe_per_table(
         self,
     ) -> None:
-
         tables = [
             ShardedEmbeddingTable(
                 name=f"table_{i}",

--- a/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
@@ -47,7 +47,6 @@ class QuantizationCommCodecTest(unittest.TestCase):
         rand_seed: int,
         row_dim: int,
     ) -> None:
-
         (comm_precision, loss_scale) = comm_precisions_loss_scale
 
         if comm_precision == CommType.FP8:
@@ -108,7 +107,6 @@ class QuantizationCommCodecTest(unittest.TestCase):
         col_size: int,
         rand_seed: int,
     ) -> None:
-
         torch.manual_seed(rand_seed)
         shape = (row_size, col_size)
         input_tensor = torch.rand(shape, requires_grad=False) * 2 - 1

--- a/torchrec/distributed/tests/test_fp_embeddingbag.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag.py
@@ -125,7 +125,6 @@ def _test_sharding(  # noqa C901
     use_dmp: bool = False,
     use_fp_collection: bool = False,
 ) -> None:
-
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         trec_dist.comm_ops.set_gradient_division(set_gradient_division)
 
@@ -229,7 +228,6 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
     def test_sharding_ebc(
         self, set_gradient_division: bool, use_dmp: bool, use_fp_collection: bool
     ) -> None:
-
         import hypothesis
 
         # don't need to test entire matrix

--- a/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
@@ -48,8 +48,8 @@ class SparseArch(nn.Module):
         if max_feature_lengths is None:
             max_feature_lengths = [DEFAULT_MAX_FEATURE_LENGTH] * len(feature_names)
 
-        assert len(max_feature_lengths) == len(
-            feature_names
+        assert (
+            len(max_feature_lengths) == len(feature_names)
         ), "Expect max_feature_lengths to have the same number of items as feature_names"
 
         self._fp_ebc: FeatureProcessedEmbeddingBagCollection = (
@@ -100,7 +100,6 @@ def create_module_and_freeze(
     device: torch.device,
     max_feature_lengths: Optional[List[int]] = None,
 ) -> SparseArch:
-
     sparse_arch = SparseArch(tables, use_fp_collection, device, max_feature_lengths)
 
     torch.manual_seed(0)

--- a/torchrec/distributed/tests/test_init_parameters.py
+++ b/torchrec/distributed/tests/test_init_parameters.py
@@ -59,7 +59,6 @@ def initialize_and_test_parameters(
     local_size: Optional[int] = None,
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-
         module_sharding_plan = construct_module_sharding_plan(
             embedding_tables,
             per_param_sharding={

--- a/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
@@ -63,15 +63,15 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
             )
 
             # pyre-ignore
-            sharded_keyed_jagged_tensor_pool: (
-                ShardedKeyedJaggedTensorPool
-            ) = KeyedJaggedTensorPoolSharder().shard(
-                keyed_jagged_tensor_pool,
-                plan=sharding_plan,
-                device=ctx.device,
-                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
-                #  got `Optional[ProcessGroup]`.
-                env=ShardingEnv.from_process_group(ctx.pg),
+            sharded_keyed_jagged_tensor_pool: ShardedKeyedJaggedTensorPool = (
+                KeyedJaggedTensorPoolSharder().shard(
+                    keyed_jagged_tensor_pool,
+                    plan=sharding_plan,
+                    device=ctx.device,
+                    # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                    #  got `Optional[ProcessGroup]`.
+                    env=ShardingEnv.from_process_group(ctx.pg),
+                )
             )
 
             # rank 0
@@ -213,15 +213,15 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
             )
 
             # pyre-ignore
-            sharded_keyed_jagged_tensor_pool: (
-                ShardedKeyedJaggedTensorPool
-            ) = KeyedJaggedTensorPoolSharder().shard(
-                keyed_jagged_tensor_pool,
-                plan=sharding_plan,
-                device=ctx.device,
-                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
-                #  got `Optional[ProcessGroup]`.
-                env=ShardingEnv.from_process_group(ctx.pg),
+            sharded_keyed_jagged_tensor_pool: ShardedKeyedJaggedTensorPool = (
+                KeyedJaggedTensorPoolSharder().shard(
+                    keyed_jagged_tensor_pool,
+                    plan=sharding_plan,
+                    device=ctx.device,
+                    # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                    #  got `Optional[ProcessGroup]`.
+                    env=ShardingEnv.from_process_group(ctx.pg),
+                )
             )
 
             sharded_keyed_jagged_tensor_pool.update(
@@ -346,15 +346,15 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
             )
 
             # pyre-ignore
-            sharded_keyed_jagged_tensor_pool: (
-                ShardedKeyedJaggedTensorPool
-            ) = KeyedJaggedTensorPoolSharder().shard(
-                keyed_jagged_tensor_pool,
-                plan=sharding_plan,
-                device=ctx.device,
-                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
-                #  got `Optional[ProcessGroup]`.
-                env=ShardingEnv.from_process_group(ctx.pg),
+            sharded_keyed_jagged_tensor_pool: ShardedKeyedJaggedTensorPool = (
+                KeyedJaggedTensorPoolSharder().shard(
+                    keyed_jagged_tensor_pool,
+                    plan=sharding_plan,
+                    device=ctx.device,
+                    # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                    #  got `Optional[ProcessGroup]`.
+                    env=ShardingEnv.from_process_group(ctx.pg),
+                )
             )
 
             # rank 0 input:
@@ -480,15 +480,15 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
             )
 
             # pyre-ignore
-            sharded_keyed_jagged_tensor_pool: (
-                ShardedKeyedJaggedTensorPool
-            ) = KeyedJaggedTensorPoolSharder().shard(
-                keyed_jagged_tensor_pool,
-                plan=sharding_plan,
-                device=ctx.device,
-                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
-                #  got `Optional[ProcessGroup]`.
-                env=ShardingEnv.from_process_group(ctx.pg),
+            sharded_keyed_jagged_tensor_pool: ShardedKeyedJaggedTensorPool = (
+                KeyedJaggedTensorPoolSharder().shard(
+                    keyed_jagged_tensor_pool,
+                    plan=sharding_plan,
+                    device=ctx.device,
+                    # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                    #  got `Optional[ProcessGroup]`.
+                    env=ShardingEnv.from_process_group(ctx.pg),
+                )
             )
 
             # rank 0 input:
@@ -605,15 +605,15 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
             )
 
             # pyre-ignore
-            sharded_keyed_jagged_tensor_pool: (
-                ShardedKeyedJaggedTensorPool
-            ) = KeyedJaggedTensorPoolSharder().shard(
-                keyed_jagged_tensor_pool,
-                plan=sharding_plan,
-                device=ctx.device,
-                # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
-                #  got `Optional[ProcessGroup]`.
-                env=ShardingEnv.from_process_group(ctx.pg),
+            sharded_keyed_jagged_tensor_pool: ShardedKeyedJaggedTensorPool = (
+                KeyedJaggedTensorPoolSharder().shard(
+                    keyed_jagged_tensor_pool,
+                    plan=sharding_plan,
+                    device=ctx.device,
+                    # pyre-fixme[6]: For 1st argument expected `ProcessGroup` but
+                    #  got `Optional[ProcessGroup]`.
+                    env=ShardingEnv.from_process_group(ctx.pg),
+                )
             )
 
             # init global state is

--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -168,7 +168,6 @@ def _test_sharding_and_remapping(  # noqa C901
     backend: str,
     local_size: Optional[int] = None,
 ) -> None:
-
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         kjt_input = kjt_input_per_rank[rank].to(ctx.device)
         kjt_out_per_iter = [
@@ -332,7 +331,6 @@ class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
     @given(backend=st.sampled_from(["nccl"]))
     @settings(deadline=None)
     def test_sharding_zch_mc_ebc(self, backend: str) -> None:
-
         WORLD_SIZE = 2
 
         embedding_bag_config = [

--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -428,7 +428,6 @@ class TestPt2(unittest.TestCase):
     def test_kt_regroup_as_dict(
         self,
     ) -> None:
-
         class M(torch.nn.Module):
             def forward(self, inputs: List[KeyedTensor]) -> Dict[str, torch.Tensor]:
                 groups = [["dense_0", "sparse_1", "dense_2"], ["dense_1", "sparse_0"]]

--- a/torchrec/distributed/tests/test_qcomms_embedding_modules.py
+++ b/torchrec/distributed/tests/test_qcomms_embedding_modules.py
@@ -185,7 +185,6 @@ class ConstructParameterShardingTest(MultiProcessTestBase):
         per_param_sharding: Dict[str, ParameterShardingGenerator],
         qcomms_config: QCommsConfig,
     ) -> None:
-
         WORLD_SIZE = 2
         EMBEDDING_DIM = 8
         NUM_EMBEDDINGS = 4

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -742,9 +742,7 @@ class ConstructParameterShardingTest(unittest.TestCase):
         # Make sure per_param_sharding setting override the default device_type
         device_table_0_shard_0 = (
             # pyre-ignore[16]
-            module_sharding_plan["table_0"]
-            .sharding_spec.shards[0]
-            .placement
+            module_sharding_plan["table_0"].sharding_spec.shards[0].placement
         )
         self.assertEqual(
             device_table_0_shard_0.device().type,

--- a/torchrec/distributed/tests/test_tensor_pool.py
+++ b/torchrec/distributed/tests/test_tensor_pool.py
@@ -31,7 +31,6 @@ class TestShardedTensorPool(MultiProcessTestBase):
     def _test_sharded_tensor_pool(
         rank: int, world_size: int, enable_uvm: bool = False
     ) -> None:
-
         pool_size = 5
         dim = 4
         backend = "nccl"
@@ -139,7 +138,6 @@ class TestShardedTensorPool(MultiProcessTestBase):
         rank: int,
         world_size: int,
     ) -> None:
-
         pool_size = 5
         dim = 3
         backend = "nccl"

--- a/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
+++ b/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
@@ -310,7 +310,6 @@ def runner(
     pipelines: str,
     profile: str,
 ) -> None:
-
     torch.autograd.set_detect_anomaly(True)
     with MultiProcessContext(
         rank=rank,
@@ -318,7 +317,6 @@ def runner(
         backend="nccl",
         use_deterministic_algorithms=False,
     ) as ctx:
-
         unsharded_model = TestSparseNN(
             tables=tables,
             weighted_tables=weighted_tables,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -259,9 +259,7 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
                 # Mandatory dynamo configuration for Torchrec PT2 compilation
                 torch._dynamo.config.capture_scalar_outputs = True
                 torch._dynamo.config.capture_dynamic_output_shape_ops = True
-                torch._dynamo.config.force_unspec_int_unbacked_size_like_on_torchrec_kjt = (
-                    True
-                )
+                torch._dynamo.config.force_unspec_int_unbacked_size_like_on_torchrec_kjt = True
                 torch._dynamo.config.skip_torchrec = False
 
                 # Importing only before compilation to not slow-done train_pipelines import
@@ -775,7 +773,6 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             param.grad = grad
 
     def _init_embedding_streams(self) -> None:
-
         for _ in self._pipelined_modules:
             self._embedding_odd_streams.append(
                 (torch.get_device_module(self._device).Stream(priority=0))

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -114,9 +114,7 @@ class TrainPipelineContext:
     events: List[torch.Event] = field(default_factory=list)
     preproc_fwd_results: Dict[str, Any] = field(default_factory=dict)
     index: Optional[int] = None
-    version: int = (
-        0  # 1 is current version, 0 is deprecated but supported for backward compatibility
-    )
+    version: int = 0  # 1 is current version, 0 is deprecated but supported for backward compatibility
 
 
 @dataclass
@@ -1171,8 +1169,8 @@ def _pipeline_detach_model(
             for input_dist in child_module._input_dists:
                 if hasattr(input_dist, "_dist"):
                     kjt_dists.append(input_dist._dist)
-    assert len(kjt_dists) == len(
-        original_kjt_dist_forwards
+    assert (
+        len(kjt_dists) == len(original_kjt_dist_forwards)
     ), f"Number of KJT dists ({len(kjt_dists)}) does not match number of kjt dist forwards provided ({len(original_kjt_dist_forwards)})"
 
     for kjt_dist, original_kjt_dist_fwd in zip(

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -878,7 +878,6 @@ class ShardedModule(
     def __init__(
         self, qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None
     ) -> None:
-
         super().__init__()
         torch._C._log_api_usage_once(f"torchrec.distributed.{self.__class__.__name__}")
 

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -230,7 +230,6 @@ def copy_to_device(
     current_device: torch.device,
     to_device: torch.device,
 ) -> nn.Module:
-
     with sharded_model_copy(device=None):
         copy_module = copy.deepcopy(module)
 

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -392,7 +392,6 @@ def _generate_rec_metrics(
 ) -> RecMetricList:
     rec_metrics = []
     for metric_enum, metric_def in metrics_config.rec_metrics.items():
-
         kwargs: Dict[str, Any] = {}
         if metric_def and metric_def.arguments is not None:
             kwargs = metric_def.arguments

--- a/torchrec/metrics/ndcg.py
+++ b/torchrec/metrics/ndcg.py
@@ -202,8 +202,9 @@ def _get_ndcg_states(
     (
         discounts_for_label_by_label,
         discounts_for_label_by_prediction,
-    ) = torch.reciprocal(torch.log2(label_by_label_ranks + 1)), torch.reciprocal(
-        torch.log2(label_by_prediction_ranks + 1)
+    ) = (
+        torch.reciprocal(torch.log2(label_by_label_ranks + 1)),
+        torch.reciprocal(torch.log2(label_by_prediction_ranks + 1)),
     )
 
     # Account for edge cases and when we want to compute NDCG @ K.
@@ -408,7 +409,6 @@ class NDCGComputation(RecMetricComputation):
             self._aggregate_window_state(state_name, state_value, predictions.shape[-1])
 
     def _compute(self) -> List[MetricComputationReport]:
-
         return [
             MetricComputationReport(
                 name=MetricName.NDCG,

--- a/torchrec/metrics/rauc.py
+++ b/torchrec/metrics/rauc.py
@@ -54,7 +54,6 @@ def _concat_if_needed(
 
 
 def count_reverse_pairs_divide_and_conquer(input: List[float]) -> float:
-
     n = len(input)
     total_inversions = divide(input, 0, len(input) - 1)
 
@@ -111,7 +110,6 @@ def _compute_rauc_helper(
     labels: torch.Tensor,
     weights: torch.Tensor,
 ) -> torch.Tensor:
-
     array = [
         x
         for x, _ in sorted(

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -445,7 +445,13 @@ class RecMetric(nn.Module, abc.ABC):
                     if has_valid_update > 0
                     else torch.zeros_like(metric_value)
                 )
-                yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value, metric_report.description
+                yield (
+                    task,
+                    metric_report.name,
+                    valid_metric_value,
+                    compute_scope + metric_report.metric_prefix.value,
+                    metric_report.description,
+                )
 
     def _unfused_tasks_iter(self, compute_scope: str) -> ComputeIterType:
         for task, metric_computation in zip(self._tasks, self._metrics_computations):
@@ -463,7 +469,13 @@ class RecMetric(nn.Module, abc.ABC):
                     or metric_computation.has_valid_update[0] > 0
                     else torch.zeros_like(metric_report.value)
                 )
-                yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value, metric_report.description
+                yield (
+                    task,
+                    metric_report.name,
+                    valid_metric_value,
+                    compute_scope + metric_report.metric_prefix.value,
+                    metric_report.description,
+                )
 
     def _fuse_update_buffers(self) -> Dict[str, RecModelOutput]:
         def fuse(outputs: List[RecModelOutput]) -> RecModelOutput:

--- a/torchrec/metrics/recall_session.py
+++ b/torchrec/metrics/recall_session.py
@@ -176,7 +176,6 @@ class RecallSessionMetricComputation(RecMetricComputation):
             self._aggregate_window_state(state_name, state_value, num_samples)
 
     def _compute(self) -> List[MetricComputationReport]:
-
         return [
             MetricComputationReport(
                 name=MetricName.RECALL_SESSION_LEVEL,
@@ -203,7 +202,6 @@ class RecallSessionMetricComputation(RecMetricComputation):
         weights: torch.Tensor,
         session: torch.Tensor,
     ) -> Dict[str, torch.Tensor]:
-
         predictions_ranked = ranking_within_session(predictions, session)
         # pyre-fixme[58]: `<` is not supported for operand types `Tensor` and
         #  `Optional[int]`.

--- a/torchrec/metrics/tensor_weighted_avg.py
+++ b/torchrec/metrics/tensor_weighted_avg.py
@@ -122,7 +122,6 @@ class TensorWeightedAvgMetric(RecMetric):
         *args,
         **kwargs: Dict[str, Any],
     ) -> None:
-
         super().__init__(*args, **kwargs)
 
     def _get_task_kwargs(

--- a/torchrec/metrics/test_utils/__init__.py
+++ b/torchrec/metrics/test_utils/__init__.py
@@ -268,7 +268,6 @@ def rec_metric_value_test_helper(
         time_mock: Optional[Mock] = None,
         **kwargs: Any,
     ) -> Dict[str, torch.Tensor]:
-
         window_size = world_size * batch_size * batch_window_size
         if n_classes:
             kwargs["number_of_classes"] = n_classes

--- a/torchrec/metrics/tests/test_rauc.py
+++ b/torchrec/metrics/tests/test_rauc.py
@@ -32,7 +32,6 @@ from torchrec.metrics.test_utils import (
 def compute_rauc(
     predictions: torch.Tensor, labels: torch.Tensor, weights: torch.Tensor
 ) -> torch.Tensor:
-
     n = len(predictions)
     cnt = 0.0
     for i in range(n - 1):

--- a/torchrec/metrics/tests/test_recall_session.py
+++ b/torchrec/metrics/tests/test_recall_session.py
@@ -166,7 +166,6 @@ class RecallSessionValueTest(unittest.TestCase):
             raise
 
     def test_recall_session_with_no_positive_examples(self) -> None:
-
         # if we pass a batch with no positive examples, we should get NaN
         test_data_with_no_positive_examples = (
             generate_model_output_with_no_positive_examples()
@@ -210,7 +209,6 @@ class RecallSessionValueTest(unittest.TestCase):
             raise
 
     def test_error_messages(self) -> None:
-
         task_info1 = RecTaskInfo(
             name="Task1",
             label_name="label1",

--- a/torchrec/metrics/tests/test_weighted_avg.py
+++ b/torchrec/metrics/tests/test_weighted_avg.py
@@ -28,7 +28,6 @@ class TestWeightedAvgMetric(TestMetric):
     def _get_states(
         labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
     ) -> Dict[str, torch.Tensor]:
-
         return {
             "weighted_sum": (predictions * weights).sum(dim=-1),
             "weighted_num_samples": weights.sum(dim=-1),

--- a/torchrec/modules/fp_embedding_modules.py
+++ b/torchrec/modules/fp_embedding_modules.py
@@ -24,7 +24,6 @@ def apply_feature_processors_to_kjt(
     features: KeyedJaggedTensor,
     feature_processors: Dict[str, nn.Module],
 ) -> KeyedJaggedTensor:
-
     processed_weights = []
     features_dict = features.to_dict()
 
@@ -113,16 +112,17 @@ class FeatureProcessedEmbeddingBagCollection(nn.Module):
         else:
             self._feature_processors = nn.ModuleDict(feature_processors)
 
-            assert set(
-                sum(
-                    [
-                        config.feature_names
-                        for config in self._embedding_bag_collection.embedding_bag_configs()
-                    ],
-                    [],
+            assert (
+                set(
+                    sum(
+                        [
+                            config.feature_names
+                            for config in self._embedding_bag_collection.embedding_bag_configs()
+                        ],
+                        [],
+                    )
                 )
-            ) == set(
-                feature_processors.keys()
+                == set(feature_processors.keys())
             ), "Passed in feature processors do not match feature names of embedding bag"
 
         assert (

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -226,9 +226,7 @@ class _BatchedFusedEmbeddingLookups(nn.Module, FusedOptimizerModule):
     def named_parameters(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.nn.Parameter]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in _BatchedFusedEmbeddingLookups.named_parameters"
+        assert remove_duplicate, "remove_duplicate=False not supported in _BatchedFusedEmbeddingLookups.named_parameters"
         for table, weight in zip(
             self._embedding_tables, self.split_embedding_weights()
         ):
@@ -239,9 +237,7 @@ class _BatchedFusedEmbeddingLookups(nn.Module, FusedOptimizerModule):
     def named_buffers(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, torch.Tensor]]:
-        assert (
-            remove_duplicate
-        ), "remove_duplicate=False not supported in _BatchedFusedEmbeddingLookups.named_buffers"
+        assert remove_duplicate, "remove_duplicate=False not supported in _BatchedFusedEmbeddingLookups.named_buffers"
         for table, param in zip(self._embedding_tables, self.split_embedding_weights()):
             name = f"{table.name}.weight"
             key = f"{prefix}.{name}" if (prefix and name) else (prefix + name)
@@ -618,10 +614,13 @@ class FusedEmbeddingCollection(EmbeddingCollectionInterface, FusedOptimizerModul
         if device is None:
             device = torch.device("cpu")
 
-        assert device.type in [
-            "cuda",
-            "meta",
-        ], "FusedEmbeddingCollection is only supported for device in [CUDA, meta] currently. There are plans to support device=CPU."
+        assert (
+            device.type
+            in [
+                "cuda",
+                "meta",
+            ]
+        ), "FusedEmbeddingCollection is only supported for device in [CUDA, meta] currently. There are plans to support device=CPU."
 
         if location is None:
             if device.type in ["cpu", "meta"]:

--- a/torchrec/modules/itep_modules.py
+++ b/torchrec/modules/itep_modules.py
@@ -64,7 +64,6 @@ class GenericITEPModule(nn.Module):
         enable_pruning: bool = True,
         pruning_interval: int = 1001,  # Default pruning interval 1001 iterations
     ) -> None:
-
         super(GenericITEPModule, self).__init__()
 
         # Construct in-training embedding pruning args
@@ -204,7 +203,6 @@ class GenericITEPModule(nn.Module):
             while isinstance(lookup, DistributedDataParallel):
                 lookup = lookup.module
             for emb in lookup._emb_modules:
-
                 emb_tables: List[ShardedEmbeddingTable] = emb._config.embedding_tables
                 for table in emb_tables:
                     # Skip if table was already added previously (if multiple shards assigned to same rank)

--- a/torchrec/modules/mc_embedding_modules.py
+++ b/torchrec/modules/mc_embedding_modules.py
@@ -73,7 +73,6 @@ class BaseManagedCollisionEmbeddingCollection(nn.Module):
     ) -> Tuple[
         Union[KeyedTensor, Dict[str, JaggedTensor]], Optional[KeyedJaggedTensor]
     ]:
-
         features = self._managed_collision_collection(features)
 
         embedding_res = self._embedding_module(features)

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -579,11 +579,11 @@ class LFU_EvictionPolicy(MCHEvictionPolicy):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         mch_counts = mch_metadata["counts"]
         # update metadata for matching ids
-        mch_counts[
-            coalesced_history_mch_matching_indices
-        ] += coalesced_history_sorted_unique_ids_counts[
-            coalesced_history_mch_matching_elements_mask
-        ]
+        mch_counts[coalesced_history_mch_matching_indices] += (
+            coalesced_history_sorted_unique_ids_counts[
+                coalesced_history_mch_matching_elements_mask
+            ]
+        )
 
         # incoming non-matching ids
         new_sorted_uniq_ids_counts = coalesced_history_sorted_unique_ids_counts[
@@ -657,7 +657,6 @@ class LRU_EvictionPolicy(MCHEvictionPolicy):
         additional_ids: Optional[torch.Tensor] = None,
         threshold_mask: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
-
         coalesced_history_metadata: Dict[str, torch.Tensor] = {}
         history_last_access_iter = history_metadata["last_access_iter"]
         if additional_ids is not None:
@@ -847,11 +846,11 @@ class DistanceLFU_EvictionPolicy(MCHEvictionPolicy):
         ]
 
         # update metadata for matching ids
-        mch_counts[
-            coalesced_history_mch_matching_indices
-        ] += coalesced_history_sorted_unique_ids_counts[
-            coalesced_history_mch_matching_elements_mask
-        ]
+        mch_counts[coalesced_history_mch_matching_indices] += (
+            coalesced_history_sorted_unique_ids_counts[
+                coalesced_history_mch_matching_elements_mask
+            ]
+        )
         mch_last_access_iter[coalesced_history_mch_matching_indices] = (
             coalesced_history_sorted_uniq_ids_last_access_iter[
                 coalesced_history_mch_matching_elements_mask
@@ -1336,7 +1335,6 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         output_segments: List[int],
         device: Optional[torch.device] = None,
     ) -> "MCHManagedCollisionModule":
-
         new_zch_size = output_id_range[1] - output_id_range[0]
 
         return type(self)(

--- a/torchrec/modules/mlp.py
+++ b/torchrec/modules/mlp.py
@@ -165,9 +165,7 @@ class MLP(torch.nn.Module):
                     ]
                 )
             else:
-                assert (
-                    ValueError
-                ), "This MLP only support str version activation function of relu, sigmoid, and swish_layernorm"
+                assert ValueError, "This MLP only support str version activation function of relu, sigmoid, and swish_layernorm"
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """

--- a/torchrec/modules/object_pool_lookups.py
+++ b/torchrec/modules/object_pool_lookups.py
@@ -253,13 +253,10 @@ class TensorJaggedIndexSelectLookup(KeyedJaggedTensorPoolLookup):
         )
 
     def update(self, ids: torch.Tensor, values: JaggedTensor) -> None:
-
         with record_function("## TensorPool update ##"):
             key_lengths = (
                 # pyre-ignore
-                values.lengths()
-                .view(-1, len(self._feature_max_lengths))
-                .sum(axis=1)
+                values.lengths().view(-1, len(self._feature_max_lengths)).sum(axis=1)
             )
             key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
 
@@ -408,9 +405,7 @@ class UVMCachingInt64Lookup(KeyedJaggedTensorPoolLookup):
         with record_function("## UVMCachingInt64Lookup update ##"):
             key_lengths = (
                 # pyre-ignore
-                values.lengths()
-                .view(-1, len(self._feature_max_lengths))
-                .sum(axis=1)
+                values.lengths().view(-1, len(self._feature_max_lengths)).sum(axis=1)
             )
             key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
             padded_values = torch.ops.fbgemm.jagged_to_padded_dense(
@@ -549,9 +544,7 @@ class UVMCachingInt32Lookup(KeyedJaggedTensorPoolLookup):
         with record_function("## UVMCachingInt32Lookup update##"):
             key_lengths = (
                 # pyre-ignore
-                values.lengths()
-                .view(-1, len(self._feature_max_lengths))
-                .sum(axis=1)
+                values.lengths().view(-1, len(self._feature_max_lengths)).sum(axis=1)
             )
             key_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(key_lengths)
             state = torch.ops.fbgemm.jagged_to_padded_dense(
@@ -706,7 +699,6 @@ class UVMCachingFloatLookup(TensorPoolLookup):
         dtype: torch.dtype,
         device: torch.device,
     ) -> None:
-
         super().__init__(
             pool_size=pool_size,
             dim=dim,

--- a/torchrec/modules/tests/test_deepfm.py
+++ b/torchrec/modules/tests/test_deepfm.py
@@ -16,7 +16,6 @@ from torchrec.modules.deepfm import DeepFM, FactorizationMachine
 
 class TestDeepFM(unittest.TestCase):
     def test_deepfm_shape(self) -> None:
-
         batch_size = 3
         output_dim = 30
         # the input embedding are in torch.Tensor of [batch_size, num_embeddings, embedding_dim]
@@ -113,7 +112,6 @@ class TestDeepFM(unittest.TestCase):
 
 class TestFM(unittest.TestCase):
     def test_fm_shape(self) -> None:
-
         batch_size = 3
         # the input embedding are in torch.Tensor of [batch_size, num_embeddings, embedding_dim]
         input_embeddings = [

--- a/torchrec/modules/tests/test_fp_embedding_modules.py
+++ b/torchrec/modules/tests/test_fp_embedding_modules.py
@@ -25,7 +25,6 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class PositionWeightedModuleEmbeddingBagCollectionTest(unittest.TestCase):
-
     def generate_fp_ebc(self) -> FeatureProcessedEmbeddingBagCollection:
         ebc = EmbeddingBagCollection(
             tables=[

--- a/torchrec/modules/tests/test_fused_embedding_modules.py
+++ b/torchrec/modules/tests/test_fused_embedding_modules.py
@@ -306,14 +306,18 @@ class FusedEmbeddingBagCollectionTest(unittest.TestCase):
         )
 
         state_dict = ebc.state_dict()
-        torch.testing.assert_close(
-            state_dict["embedding_bags.t1.weight"],
-            torch.Tensor([[1, 1, 1, 1], [2, 2, 2, 2]]).to(device),
-        ),
-        torch.testing.assert_close(
-            state_dict["embedding_bags.t2.weight"],
-            torch.Tensor([[4, 4, 4, 4], [8, 8, 8, 8]]).to(device),
-        ),
+        (
+            torch.testing.assert_close(
+                state_dict["embedding_bags.t1.weight"],
+                torch.Tensor([[1, 1, 1, 1], [2, 2, 2, 2]]).to(device),
+            ),
+        )
+        (
+            torch.testing.assert_close(
+                state_dict["embedding_bags.t2.weight"],
+                torch.Tensor([[4, 4, 4, 4], [8, 8, 8, 8]]).to(device),
+            ),
+        )
         torch.testing.assert_close(
             state_dict["embedding_bags.t3.weight"],
             torch.Tensor([[16, 16, 16, 16], [32, 32, 32, 32]]).to(device),

--- a/torchrec/modules/tests/test_itep_embedding_modules.py
+++ b/torchrec/modules/tests/test_itep_embedding_modules.py
@@ -175,7 +175,6 @@ class TestITEPEmbeddingBagCollection(unittest.TestCase):
         table_name_to_unpruned_hash_sizes: Dict[str, int],
         table_name_to_pruned_hash_sizes: Dict[str, int],
     ) -> torch.Tensor:
-
         address_lookup = []
         for et in list_et:
             table_name = et.name

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -125,7 +125,6 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
         )
 
         for mc_module in mc_modules:
-
             self.assertEqual(
                 mc_module._managed_collision_collection.open_slots()["t1"].item(),
                 zch_size - 1,
@@ -325,8 +324,7 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
 
             assert torch.all(
                 # pyre-ignore[16]
-                remapped_kjt1["f1"].values()
-                == zch_size - 1
+                remapped_kjt1["f1"].values() == zch_size - 1
             ), "all remapped ids should be mapped to end of range"
             assert torch.all(
                 remapped_kjt1["f2"].values() == zch_size - 1

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -64,7 +64,7 @@ def extract_module_or_tensor_callable(
         Callable[[], torch.nn.Module],
         torch.nn.Module,
         Callable[[torch.Tensor], torch.Tensor],
-    ]
+    ],
 ) -> Union[torch.nn.Module, Callable[[torch.Tensor], torch.Tensor]]:
     try:
         # pyre-ignore[20]: PositionalOnly call expects argument in position 0
@@ -150,8 +150,7 @@ def convert_list_of_modules_to_modulelist(
     assert (
         # pyre-fixme[6]: Expected `Sized` for 1st param but got
         #  `Iterable[torch.nn.Module]`.
-        len(modules)
-        == sizes[0]
+        len(modules) == sizes[0]
         # pyre-fixme[6]: For 1st argument expected `pyre_extensions.PyreReadOnly[Sized]`
         #  but got `Iterable[Module]`.
     ), f"the counts of modules ({len(modules)}) do not match with the required counts {sizes}"

--- a/torchrec/optim/__init__.py
+++ b/torchrec/optim/__init__.py
@@ -16,6 +16,7 @@ It also contains
 - several modules wrapping KeyedOptimizer, called CombinedOptimizer and OptimizerWrapper
 - Optimizers used in RecSys: e.g. rowwise adagrad/adam/etc
 """
+
 from torchrec.optim.apply_optimizer_in_backward import (  # noqa
     apply_optimizer_in_backward,
 )

--- a/torchrec/optim/keyed.py
+++ b/torchrec/optim/keyed.py
@@ -111,7 +111,6 @@ class KeyedOptimizer(optim.Optimizer):
         param_state_dict_to_load: Dict[str, Any],
         parent_keys: List[Union[str, int, float, bool, None]],
     ) -> None:
-
         for k, v in current_param_state_dict.items():
             new_v = param_state_dict_to_load[k]
             parent_keys.append(k)

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -394,7 +394,7 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin)
             embedding_specs = []
             weight_lists: Optional[
                 List[Tuple[torch.Tensor, Optional[torch.Tensor]]]
-            ] = ([] if table_name_to_quantized_weights else None)
+            ] = [] if table_name_to_quantized_weights else None
             feature_table_map: List[int] = []
 
             for idx, table in enumerate(emb_configs):
@@ -799,7 +799,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             embedding_specs = []
             weight_lists: Optional[
                 List[Tuple[torch.Tensor, Optional[torch.Tensor]]]
-            ] = ([] if table_name_to_quantized_weights else None)
+            ] = [] if table_name_to_quantized_weights else None
             feature_table_map: List[int] = []
             for idx, table in enumerate(emb_configs):
                 embedding_specs.append(

--- a/torchrec/quant/utils.py
+++ b/torchrec/quant/utils.py
@@ -21,7 +21,7 @@ from torchrec.quant.embedding_modules import (
 
 
 def populate_fx_names(
-    quant_ebc: Union[QuantEmbeddingBagCollection, ShardedQuantEmbeddingBagCollection]
+    quant_ebc: Union[QuantEmbeddingBagCollection, ShardedQuantEmbeddingBagCollection],
 ) -> None:
     """
     Assigns fx path to non registered lookup modules. This allows the Torchrec tracer to fallback to

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -149,7 +149,6 @@ def _assert_offsets_or_lengths_is_provided(
 def _regroup_keyed_tensors(
     keyed_tensors: List["KeyedTensor"], groups: List[List[str]]
 ) -> List[torch.Tensor]:
-
     embedding_dicts = [keyed_tensor.to_dict() for keyed_tensor in keyed_tensors]
     lengths = [keyed_tensor.length_per_key() for keyed_tensor in keyed_tensors]
     indices = [keyed_tensor._key_indices() for keyed_tensor in keyed_tensors]
@@ -420,7 +419,6 @@ def _jagged_values_string(
 def _optional_mask(
     tensor: Optional[torch.Tensor], mask: torch.Tensor
 ) -> Optional[torch.Tensor]:
-
     return tensor[mask] if tensor is not None else None
 
 
@@ -593,7 +591,6 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         lengths: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
     ) -> None:
-
         self._values: torch.Tensor = values
         self._weights: Optional[torch.Tensor] = weights
         _assert_offsets_or_lengths_is_provided(offsets, lengths)
@@ -1599,7 +1596,7 @@ def kjt_is_equal(kjt_1: "KeyedJaggedTensor", kjt_2: "KeyedJaggedTensor") -> bool
 
 
 def _force_length_offset_computation(
-    kjt: Union["KeyedJaggedTensor", "JaggedTensor"]
+    kjt: Union["KeyedJaggedTensor", "JaggedTensor"],
 ) -> None:
     """Helper function to force length/offset computation for KJT or JT
     Mainly used for testing equality, as equal KJT's/JT's can be formed from just using lengths or offsets.
@@ -3041,7 +3038,8 @@ def _kjt_flatten_with_keys(
 
 
 def _kjt_unflatten(
-    values: List[Optional[torch.Tensor]], context: List[str]  # context is the _keys
+    values: List[Optional[torch.Tensor]],
+    context: List[str],  # context is the _keys
 ) -> KeyedJaggedTensor:
     return KeyedJaggedTensor(context, *values)
 

--- a/torchrec/sparse/tests/jagged_tensor_benchmark.py
+++ b/torchrec/sparse/tests/jagged_tensor_benchmark.py
@@ -49,7 +49,6 @@ def bench(
     fn_kwargs: Dict[str, Any],
     output_dir: str = "",
 ) -> None:
-
     # initial call
     fn(**fn_kwargs)
 

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -84,7 +84,7 @@ def is_asan_or_tsan() -> bool:
 
 
 def skip_if_asan(
-    func: Callable[TParams, TReturn]
+    func: Callable[TParams, TReturn],
 ) -> Callable[TParams, Optional[TReturn]]:
     """Skip test run if we are in ASAN mode."""
 


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files

Reviewed By: amyreese

Differential Revision: D66013071
