### PR TITLE
Remove unused-variable in tiles/test/TilesTestBase.cpp +3

### DIFF
--- a/torchrec/inference/inference_legacy/src/SingleGPUExecutor.cpp
+++ b/torchrec/inference/inference_legacy/src/SingleGPUExecutor.cpp
@@ -38,7 +38,7 @@ SingleGPUExecutor::SingleGPUExecutor(
   for (size_t i = 0; i < numProcessThreads_; ++i) {
     processExecutor_->add([&]() { process(); });
   }
-  for (const auto& exec_info : execInfos_) {
+  for ([[maybe_unused]] const auto& exec_info : execInfos_) {
     TORCHREC_CHECK(exec_info.interpIdx < manager_->allInstances().size());
   }
   TORCHREC_CHECK(observer_);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: wuyuoss

Differential Revision: D66143538


