### PR TITLE
Reduce scaleup build proposal excessive logging

### DIFF
--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -482,7 +482,7 @@ class EmbeddingOffloadScaleupProposer(Proposer):
         for table_sharding_options in sharding_options_by_fqn.values():
             if len(table_sharding_options) > 1:
                 logger.warning(
-                    f"EmbeddingOffloadScaleupProposer - ignored {len(table_sharding_options) - 1} sharding options for table {table_sharding_options[0]} in proposal"
+                    f"EmbeddingOffloadScaleupProposer - ignored {len(table_sharding_options) - 1} sharding options for table {table_sharding_options[0].name} in proposal"
                 )
 
             selected_option = next(

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -1001,14 +1001,14 @@ class TestProposers(unittest.TestCase):
         self.assertEqual(proposal[1], sharding_options_by_fqn["table-2"][1])
         self.assertRegex(
             mock_logger.warning.call_args_list[0].args[0],
-            r"^EmbeddingOffloadScaleupProposer - ignored .* sharding options for table name: table-2",
+            r"^EmbeddingOffloadScaleupProposer - ignored \d+ sharding options for table table-2",
         )
 
         # Case 3
         self.assertEqual(proposal[2], sharding_options_by_fqn["table-3"][0])
         self.assertRegex(
             mock_logger.warning.call_args_list[1].args[0],
-            r"^EmbeddingOffloadScaleupProposer - ignored .* sharding options for table name: table-3",
+            r"^EmbeddingOffloadScaleupProposer - ignored \d+ sharding options for table table-3",
         )
 
         # Case 4


### PR DESCRIPTION
Summary:
D65774286 added additional logging to highlight when
EmbeddingOffloadScaleupProposer searches only the cheapest of multiple
sharding options provided. However it dumps the entire sharding
option, rather than just the table name. Update to just print the
table name.

Differential Revision: D66277574


