### PR TITLE
Simplify scaleup test to remove warn noise

### DIFF
--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -482,7 +482,7 @@ class EmbeddingOffloadScaleupProposer(Proposer):
         for table_sharding_options in sharding_options_by_fqn.values():
             if len(table_sharding_options) > 1:
                 logger.warning(
-                    f"EmbeddingOffloadScaleupProposer - ignored {len(table_sharding_options) - 1} sharding options for table {table_sharding_options[0]} in proposal"
+                    f"EmbeddingOffloadScaleupProposer - ignored {len(table_sharding_options) - 1} sharding options for table {table_sharding_options[0].name} in proposal"
                 )
 
             selected_option = next(

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -1001,14 +1001,14 @@ class TestProposers(unittest.TestCase):
         self.assertEqual(proposal[1], sharding_options_by_fqn["table-2"][1])
         self.assertRegex(
             mock_logger.warning.call_args_list[0].args[0],
-            r"^EmbeddingOffloadScaleupProposer - ignored .* sharding options for table name: table-2",
+            r"^EmbeddingOffloadScaleupProposer - ignored \d+ sharding options for table table-2",
         )
 
         # Case 3
         self.assertEqual(proposal[2], sharding_options_by_fqn["table-3"][0])
         self.assertRegex(
             mock_logger.warning.call_args_list[1].args[0],
-            r"^EmbeddingOffloadScaleupProposer - ignored .* sharding options for table name: table-3",
+            r"^EmbeddingOffloadScaleupProposer - ignored \d+ sharding options for table table-3",
         )
 
         # Case 4

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -574,6 +574,7 @@ class TestProposers(unittest.TestCase):
         # i.e. doesn't participate in scaleup.
         constraints = {
             "table_0": ParameterConstraints(
+                sharding_types=[ShardingType.COLUMN_WISE.value],
                 compute_kernels=[EmbeddingComputeKernel.FUSED_UVM_CACHING.value],
                 cache_params=CacheParams(
                     load_factor=0.1,
@@ -581,6 +582,7 @@ class TestProposers(unittest.TestCase):
                 ),
             ),
             "table_1": ParameterConstraints(
+                sharding_types=[ShardingType.COLUMN_WISE.value],
                 compute_kernels=[EmbeddingComputeKernel.FUSED_UVM_CACHING.value],
                 cache_params=CacheParams(
                     load_factor=0.1,
@@ -588,6 +590,7 @@ class TestProposers(unittest.TestCase):
                 ),
             ),
             "table_2": ParameterConstraints(
+                sharding_types=[ShardingType.COLUMN_WISE.value],
                 compute_kernels=[EmbeddingComputeKernel.FUSED_UVM_CACHING.value],
                 cache_params=CacheParams(
                     load_factor=0.002,
@@ -595,6 +598,7 @@ class TestProposers(unittest.TestCase):
                 ),
             ),
             "table_3": ParameterConstraints(
+                sharding_types=[ShardingType.COLUMN_WISE.value],
                 compute_kernels=[EmbeddingComputeKernel.FUSED.value],
                 cache_params=CacheParams(),
             ),


### PR DESCRIPTION
Summary:
D65774286 added additional logging to highlight when
EmbeddingOffloadScaleupProposer searches only the cheapest of multiple
sharding options provided. Update scaleup test so it does not
unnecessarily enumerate multiple sharding options which triggers this
warning.

Differential Revision: D66278106


