### PR TITLE
Further improvements to EmbeddingBagCollection documentation and related classes

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -103,18 +103,18 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
 
 
     It is callable on arguments representing sparse data in the form of `KeyedJaggedTensor` with values of the shape
-    `(F, B, L_{f,i})` where:
+    `(F, B, L[f][i])` where:
 
     * `F`: number of features (keys)
     * `B`: batch size
-    * `L_{f,i}`: length of sparse features (potentially distinct for each feature `f` and batch index `i`, that is, jagged)
+    * `L[f][i]`: length of sparse features (potentially distinct for each feature `f` and batch index `i`, that is, jagged)
 
     and outputs a `KeyedTensor` with values with shape `(B, D)` where:
 
     * `B`: batch size
     * `D`: sum of embedding dimensions of all embedding tables, that is, `sum([config.embedding_dim for config in tables])`
 
-    Assuming the argument is a `KeyedJaggedTensor` `J` with `F` features, batch size `B` and `L_{f,i}` sparse lengths
+    Assuming the argument is a `KeyedJaggedTensor` `J` with `F` features, batch size `B` and `L[f][i]` sparse lengths
     such that `J[f][i]` is the bag for feature `f` and batch index `i`, the output `KeyedTensor` `KT` is defined as follows:
     `KT[i]` = `torch.cat([emb[f](J[f][i]) for f in J.keys()])` where `emb[f]` is the `EmbeddingBag` corresponding to the feature `f`.
 
@@ -157,10 +157,11 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
         pooled_embeddings = ebc(features)
         print(pooled_embeddings.values())
         tensor([
-            #   f1 pooled embeddings from bags (dim 3)          f2 pooled embeddings from bags (dim 4)
-            [-0.8899, -0.1342, -1.9060,                -0.0905, -0.2814, -0.9369, -0.7783],  # batch index 0
-            [ 0.0000,  0.0000,  0.0000,                 0.1598,  0.0695,  1.3265, -0.1011],  # batch index 1
-            [-0.4256, -1.1846, -2.1648,                -1.0893,  0.3590, -1.9784, -0.7681]],  # batch index 2
+            #  f1 pooled embeddings              f2 pooled embeddings
+            #     from bags (dim. 3)                from bags (dim. 4)
+            [-0.8899, -0.1342, -1.9060,  -0.0905, -0.2814, -0.9369, -0.7783],  # i = 0
+            [ 0.0000,  0.0000,  0.0000,   0.1598,  0.0695,  1.3265, -0.1011],  # i = 1
+            [-0.4256, -1.1846, -2.1648,  -1.0893,  0.3590, -1.9784, -0.7681]],  # i = 2
             grad_fn=<CatBackward0>)
         print(pooled_embeddings.keys())
         ['f1', 'f2']
@@ -332,20 +333,19 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
         EmbeddingCollection is an unsharded module and is not performance optimized.
         For performance-sensitive scenarios, consider using the sharded version ShardedEmbeddingCollection.
 
-    It processes sparse data in the form of `KeyedJaggedTensor` of the form [F X B X L]
-    where:
+    It is callable on arguments representing sparse data in the form of `KeyedJaggedTensor` with values of the shape
+    `(F, B, L[f][i])` where:
 
-    * F: features (keys)
-    * B: batch size
-    * L: length of sparse features (variable)
+    * `F`: number of features (keys)
+    * `B`: batch size
+    * `L[f][i]`: length of sparse features (potentially distinct for each feature `f` and batch index `i`, that is, jagged)
 
-    and outputs `Dict[feature (key), JaggedTensor]`.
-    Each `JaggedTensor` contains values of the form (B * L) X D
-    where:
+    and outputs a `result` of type `Dict[Feature, JaggedTensor]`,
+    where `result[f]` is a `JaggedTensor` with shape `(EB[f], D[f])` where:
 
-    * B: batch size
-    * L: length of sparse features (jagged)
-    * D: each feature's (key's) embedding dimension and lengths are of the form L
+    * `EB[f]`: a "expanded batch size" for feature `f` equal to the sum of the lengths of its bag values,
+      that is, `sum([len(J[f][i]) for i in range(B)])`.
+    * `D[f]`: is the embedding dimension of feature `f`.
 
     Args:
         tables (List[EmbeddingConfig]): list of embedding tables.
@@ -371,16 +371,29 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
 
         features = KeyedJaggedTensor.from_offsets_sync(
             keys=["f1", "f2"],
-            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.tensor([0, 1,                  2,    # feature 'f1'
+                                    3,      4,    5, 6, 7]),  # feature 'f2'
+                            #    i = 1    i = 2    i = 3   <--- batch indices
+            offsets=torch.tensor([
+                    0, 2, 2,       # 'f1' bags are values[0:2], values[2:2], and values[2:3]
+                    3, 4, 5, 8]),  # 'f2' bags are values[3:4], values[4:5], and values[5:8]
         )
+
         feature_embeddings = ec(features)
         print(feature_embeddings['f2'].values())
-        tensor([[-0.2050,  0.5478,  0.6054],
-        [ 0.7352,  0.3210, -3.0399],
-        [ 0.1279, -0.1756, -0.4130],
-        [ 0.7519, -0.4341, -0.0499],
-        [ 0.9329, -1.0697, -0.8095]], grad_fn=<EmbeddingBackward>)
+        tensor([
+            # embedding for value 3 in f2 bag values[3:4]:
+            [-0.2050,  0.5478,  0.6054],
+
+            # embedding for value 4 in f2 bag values[4:5]:
+            [ 0.7352,  0.3210, -3.0399],
+
+            # embedding for values 5, 6, 7 in f2 bag values[5:8]:
+            [ 0.1279, -0.1756, -0.4130],
+            [ 0.7519, -0.4341, -0.0499],
+            [ 0.9329, -1.0697, -0.8095],
+
+        ], grad_fn=<EmbeddingBackward>)
     """
 
     def __init__(  # noqa C901

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -280,68 +280,13 @@ def _fx_trec_unwrap_kjt(
 
 class EmbeddingBagCollection(EmbeddingBagCollectionInterface, ModuleNoCopyMixin):
     """
-    EmbeddingBagCollection represents a collection of pooled embeddings (EmbeddingBags).
-    This EmbeddingBagCollection is quantized for lower precision. It relies on fbgemm quantized ops and provides
-    table batching.
+    This class represents a reimplemented version of the EmbeddingBagCollection
+    class found in `torchrec/modules/embedding_modules.py`.
+    However, it is quantized for lower precision.
+    It relies on fbgemm quantized ops and provides table batching.
 
-    NOTE:
-        EmbeddingBagCollection is an unsharded module and is not performance optimized.
-        For performance-sensitive scenarios, consider using the sharded version ShardedEmbeddingBagCollection.
-
-    It processes sparse data in the form of KeyedJaggedTensor
-    with values of the form [F X B X L]
-    F: features (keys)
-    B: batch size
-    L: Length of sparse features (jagged)
-
-    and outputs a KeyedTensor with values of the form [B * (F * D)]
-    where
-    F: features (keys)
-    D: each feature's (key's) embedding dimension
-    B: batch size
-
-    Args:
-        table_name_to_quantized_weights (Dict[str, Tuple[Tensor, Tensor]]): map of tables to quantized weights
-        embedding_configs (List[EmbeddingBagConfig]): list of embedding tables
-        is_weighted: (bool): whether input KeyedJaggedTensor is weighted
-        device: (Optional[torch.device]): default compute device
-
-    Call Args:
-        features: KeyedJaggedTensor,
-
-    Returns:
-        KeyedTensor
-
-    Example::
-
-        table_0 = EmbeddingBagConfig(
-            name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
-        )
-        table_1 = EmbeddingBagConfig(
-            name="t2", embedding_dim=4, num_embeddings=10, feature_names=["f2"]
-        )
-        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
-
-        #        0       1        2  <-- batch
-        # "f1"   [0,1] None    [2]
-        # "f2"   [3]    [4]    [5,6,7]
-        #  ^
-        # feature
-        features = KeyedJaggedTensor(
-            keys=["f1", "f2"],
-            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
-        )
-
-        ebc.qconfig = torch.quantization.QConfig(
-            activation=torch.quantization.PlaceholderObserver.with_args(
-                dtype=torch.qint8
-            ),
-            weight=torch.quantization.PlaceholderObserver.with_args(dtype=torch.qint8),
-        )
-
-        qebc = QuantEmbeddingBagCollection.from_float(ebc)
-        quantized_embeddings = qebc(features)
+    For more details, including examples, please refer to
+    `torchrec/modules/embedding_modules.py`
     """
 
     def __init__(
@@ -690,62 +635,13 @@ class FeatureProcessedEmbeddingBagCollection(EmbeddingBagCollection):
 
 class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
     """
-    EmbeddingCollection represents a collection of non-pooled embeddings.
+    This class represents a reimplemented version of the EmbeddingCollection
+    class found in `torchrec/modules/embedding_modules.py`.
+    However, it is quantized for lower precision.
+    It relies on fbgemm quantized ops and provides table batching.
 
-    NOTE:
-        EmbeddingCollection is an unsharded module and is not performance optimized.
-        For performance-sensitive scenarios, consider using the sharded version ShardedEmbeddingCollection.
-
-
-    It processes sparse data in the form of `KeyedJaggedTensor` of the form [F X B X L]
-    where:
-
-    * F: features (keys)
-    * B: batch size
-    * L: length of sparse features (variable)
-
-    and outputs `Dict[feature (key), JaggedTensor]`.
-    Each `JaggedTensor` contains values of the form (B * L) X D
-    where:
-
-    * B: batch size
-    * L: length of sparse features (jagged)
-    * D: each feature's (key's) embedding dimension and lengths are of the form L
-
-    Args:
-        tables (List[EmbeddingConfig]): list of embedding tables.
-        device (Optional[torch.device]): default compute device.
-        need_indices (bool): if we need to pass indices to the final lookup result dict
-
-    Example::
-
-        e1_config = EmbeddingConfig(
-            name="t1", embedding_dim=3, num_embeddings=10, feature_names=["f1"]
-        )
-        e2_config = EmbeddingConfig(
-            name="t2", embedding_dim=3, num_embeddings=10, feature_names=["f2"]
-        )
-
-        ec = EmbeddingCollection(tables=[e1_config, e2_config])
-
-        #     0       1        2  <-- batch
-        # 0   [0,1] None    [2]
-        # 1   [3]    [4]    [5,6,7]
-        # ^
-        # feature
-
-        features = KeyedJaggedTensor.from_offsets_sync(
-            keys=["f1", "f2"],
-            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
-            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
-        )
-        feature_embeddings = ec(features)
-        print(feature_embeddings['f2'].values())
-        tensor([[-0.2050,  0.5478,  0.6054],
-        [ 0.7352,  0.3210, -3.0399],
-        [ 0.1279, -0.1756, -0.4130],
-        [ 0.7519, -0.4341, -0.0499],
-        [ 0.9329, -1.0697, -0.8095]], grad_fn=<EmbeddingBackward>)
+    For more details, including examples, please refer to
+    `torchrec/modules/embedding_modules.py`
     """
 
     def __init__(  # noqa C901


### PR DESCRIPTION
Summary:
Continue improvements to `EmbeddingBagCollection`:

* replace LaTeX-like notation `_{f,i}` by Python-like notation `[f][i]`
* Improves spatial formatting of example for readability and rendering in browser.

Futhermore, improve documentation of related classes:

* `EmbeddingCollection` had documentation similar to the previous version of `EmbeddingBagCollection` documentation, so it is now updated to the style of the new documentation, for consistency as well as greater precision and clarity.

* `fbcode/torchrec/quant/embedding_modules.py` redefines `EmbeddingBagCollection` in a distinct package, and simply duplicated the main implementation of the original class, with a few differentiating comments. Instead of merely copying-and-pasting the new documentation to this class, we change the documentation preserve the differentiating comments and merely refer to the original class documentation. This prevents duplication and possible future inconsistencies, and mirrors what other redefinitions of this class do.

Differential Revision: D66281917


