### PR TITLE
Output non-pipelined sharded modules from rewrite + enhance pipelinability test

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -531,6 +531,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             self._model,
             self._original_forwards,
             self._pipelined_preprocs,
+            _,
         ) = _rewrite_model(
             model=self._model,
             context=context,


### PR DESCRIPTION
Summary:
TSIA - includes non-pipelined modules to `_rewrite_model` output; for testing and logging purposes.

See D66283978 for intended use

Differential Revision: D63445036


