### PR TITLE
Fix false alarm of Adagrad

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -598,7 +598,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             yield key, param
 
     @property
-    def fused_optimizer(self) -> KeyedOptimizer:
+    def fused_optimizer(self) -> CombinedOptimizer:
         return self._optim
 
     @property


### PR DESCRIPTION
Summary: Some non-Ads PyPer models use "Adagrad" for the sparse optimizer. However, this path is not supported. The reason for the it to work on current TTK sharder is because there's no sparse parameter at all. For Torchrec sharder to honor that, this diff re-examine this path and make the behavior on-par with TTK sharder.

Differential Revision: D65957418


