### PR TITLE
stop dealloc of coarse quantizer when it is deleted

### DIFF
--- a/examples/retrieval/knn_index.py
+++ b/examples/retrieval/knn_index.py
@@ -43,7 +43,6 @@ def get_index(
         res = faiss.StandardGpuResources()
         # pyre-fixme[16]
         config = faiss.GpuIndexIVFPQConfig()
-        # pyre-ignore[16]
         index = faiss.GpuIndexIVFPQ(
             res,
             embedding_dim,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/faiss/pull/4045

Edit: Pytorch summary: When fixing the other PR in FAISS repo, I got a red signal in Phabricator saying that this pyre-ignore is no longer doing anything. So, we can land this after landing the FAISS PR linked above.

Summary from main diff:

Need to add to `__init__.py` like Matthijs mentioned on the github issue https://github.com/facebookresearch/faiss/issues/3993. But we can't do it for non-GPU code, otherwise it will throw an exception and fail many tests than include fbcode/faiss. So we need to check if FAISS GPU is importable first.

To find the class names, I checked everything under faiss/gpu where the constructor accepts an Index. The other Index is always parameter at index 1 (0-indexed), so that's why we use 1 in the function calls.

Differential Revision: D66675910


