### PR TITLE
Don't torch.export over lengths_per_key default computation if values is on meta device

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1172,7 +1172,12 @@ def _maybe_compute_length_per_key(
     values: Optional[torch.Tensor],
 ) -> List[int]:
     if length_per_key is None:
-        if len(keys) and values is not None and values.is_meta:
+        if (
+            len(keys)
+            and values is not None
+            and values.is_meta
+            and not is_non_strict_exporting()
+        ):
             # create dummy lengths per key when on meta device
             total_length = values.numel()
             _length = [total_length // len(keys)] * len(keys)


### PR DESCRIPTION
Summary: Previously we torch.exported over creating dummy lengths per key when on meta device. This should never happen, as even if values is on meta device, torch.export should capture relationships necessary to compute length_per_key

Differential Revision: D66771800


