### PR TITLE
update sharding plan display to avoid incorrect pooling factor calculation and misleading num_pooling title

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -333,10 +333,11 @@ class EmbeddingStats(Stats):
                     "Perf (ms)",
                     "Storage (HBM, DDR)",
                     "Cache Load Factor",
-                    "Pooling Factor",
-                    "Num Poolings",
+                    "Sum Pooling Factor",
+                    "Sum Num Poolings",
+                    "Num Indices",
                     "Output",
-                    "Weighing",
+                    "Weighted",
                     "Sharder",
                     "Features",
                     "Emb Dim (CW Dim)",
@@ -344,21 +345,22 @@ class EmbeddingStats(Stats):
                     "Ranks",
                 ],
                 [
-                    "-----",
-                    "----------",
-                    "----------------",
-                    "-----------",
-                    "--------------------",
-                    "-------------------",
-                    "----------------",
-                    "--------------",
-                    "--------",
-                    "----------",
-                    "---------",
-                    "----------",
-                    "------------------",
-                    "-----------",
-                    "-------",
+                    "-----",  # FQN
+                    "----------",  # Sharding
+                    "----------------",  # Compute Kernel
+                    "-----------",  # Perf (ms)
+                    "--------------------",  # Storage (HBM, DDR)
+                    "-------------------",  # Cache Load Factor
+                    "--------------------",  # Sum Pooling Factor
+                    "------------------",  # Sum Num Poolings
+                    "-------------",  # Num Indices
+                    "--------",  # Output
+                    "----------",  # Weighted
+                    "---------",  # Sharder
+                    "----------",  # Features
+                    "------------------",  # Emb Dim (CW Dim)
+                    "-----------",  # Hash Size
+                    "-------",  # Ranks
                 ],
             ]
             feat_batch_sizes = [
@@ -404,9 +406,12 @@ class EmbeddingStats(Stats):
                     and constraints[so.name].num_poolings
                     else [NUM_POOLINGS] * len(so.input_lengths)
                 )
+                num_indices = str(
+                    round(sum(x * y for x, y in zip(so.input_lengths, num_poolings)), 3)
+                )
                 num_poolings = str(round(sum(num_poolings), 3))
                 output = "pooled" if so.is_pooled else "sequence"
-                weighing = "weighted" if so.is_weighted else "unweighted"
+                weighted = "weighted" if so.is_weighted else "unweighted"
                 sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
                 sharder_name = type(sharder).__name__
                 num_features = len(so.input_lengths)
@@ -441,8 +446,9 @@ class EmbeddingStats(Stats):
                         cache_load_factor,
                         pooling_factor,
                         num_poolings,
+                        num_indices,
                         output,
-                        weighing,
+                        weighted,
                         sharder_name,
                         num_features,
                         embedding_dim,


### PR DESCRIPTION
Summary:
as title, found this issue when debugging CMF UE jobs in sharding plan displays: https://fburl.com/mlhub/qz55zncn


double checked sharder estimation which does estimate correctly on input sizes with `num_pooling * pooling_factor` per feature in the table, e.g.
```

        batch_inputs = sum(
            [x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)]
        )
```

Differential Revision: D66790130


