### PR TITLE
Remove `_compiled_autograd_should_lift`

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -358,9 +358,6 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
 
 
 class CommOpGradientScaling(torch.autograd.Function):
-    # user override: inline autograd.Function is safe to trace since only tensor mutations / no global state
-    _compiled_autograd_should_lift = False
-
     @staticmethod
     # pyre-ignore
     def forward(


### PR DESCRIPTION
Summary:
We're deprecating this flag. xmfan tells me we should have fixed the problem
that required us to add this in the first place. Testing that with this PR.

Differential Revision: D66761623


