### PR TITLE
add buck target for torchrec/inference/inference_legacy and suppress Pyre error

### DIFF
--- a/torchrec/inference/inference_legacy/tests/test_modules.py
+++ b/torchrec/inference/inference_legacy/tests/test_modules.py
@@ -40,5 +40,6 @@ class EagerModelProcessingTests(unittest.TestCase):
         quantized_model = quantize_inference_model(model)
         sharded_model, _ = shard_quant_model(quantized_model)
 
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `sparse`.
         sharded_qebc = sharded_model._module.sparse.ebc
         self.assertEqual(len(sharded_qebc.tbes), 1)


### PR DESCRIPTION
Summary: Internal and external Pyre is out of sync. One of the reasons is because one of the files is not currently being typechecked by Pyre due to not being included in a buck target. This diff adds a target to include this file so that Pyre will pick it up when typechecking, along with suppressing the actual error with a pyre-fixme

Reviewed By: PaulZhang12

Differential Revision: D67035607


