### PR TITLE
Update __init__.py

### DIFF
--- a/examples/retrieval/knn_index.py
+++ b/examples/retrieval/knn_index.py
@@ -43,6 +43,7 @@ def get_index(
         res = faiss.StandardGpuResources()
         # pyre-fixme[16]
         config = faiss.GpuIndexIVFPQConfig()
+        # pyre-ignore[16]
         index = faiss.GpuIndexIVFPQ(
             res,
             embedding_dim,


### PR DESCRIPTION
Summary:
Fix erroneous logging `Failed to load GPU Faiss: No module named 'swigfaiss_gpu'. Will not load constructor refs for GPU indexes.` when I was running on a GPU-based index just fine.

`GpuIndex...` is loaded via loader.py.

X-link: https://github.com/facebookresearch/faiss/pull/4086

Reviewed By: mnorris11

Differential Revision: D67118292

Pulled By: asadoughi


