### PR TITLE
add max L1 cache size in torchrec

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -649,7 +649,8 @@ class KeyValueParams:
     gather_ssd_cache_stats: Optional[bool] = None
     stats_reporter_config: Optional[TBEStatsReporterConfig] = None
     use_passed_in_path: bool = True
-    l2_cache_size: Optional[int] = None
+    l2_cache_size: Optional[int] = None  # size in GB
+    max_l1_cache_size: Optional[int] = None  # size in MB
     enable_async_update: Optional[bool] = None
 
     # Parameter Server (PS) Attributes
@@ -673,6 +674,7 @@ class KeyValueParams:
                 self.gather_ssd_cache_stats,
                 self.stats_reporter_config,
                 self.l2_cache_size,
+                self.max_l1_cache_size,
                 self.enable_async_update,
             )
         )


### PR DESCRIPTION
Summary:
Currently we use cache load factor, a ratio to embedding table size to decide L1 cache size.
However when using ssd offloading, we usually see extremely large embedding table, keep using ratios might be meaningless and not straightforward, this diff provide a new way to set cap L1 cache size instead

Reviewed By: jiayulu

Differential Revision: D67071717


