### PR TITLE
Fix invalid record_stream arg for Request awaitable

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -119,7 +119,7 @@ class Request(Awaitable[W]):
         """
 
         ret = self.wait_function.apply(self.pg, self, self.dummy_tensor)
-        if isinstance(ret, torch.Tensor):
+        if isinstance(ret, torch.Tensor) and ret.device.type == "cuda":
             ret.record_stream(torch.get_device_module(ret.device).current_stream())
         self.req = None
         self.tensor = None

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -119,10 +119,6 @@ def _test_sharding(
 
 @skip_if_asan_class
 class ConstructParameterShardingAndShardTest(MultiProcessTestBase):
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
     # pyre-fixme[56]
     @given(
         per_param_sharding=st.sampled_from(


### PR DESCRIPTION
Summary:
https://github.com/pytorch/torchrec/pull/2598 causes failures when running on cpu:

```
RuntimeError: unknown parameter type
```

This is because `record_stream` doesn't accept CPU streams. This diff forward fixes the issue.

Differential Revision: D67171994


