### PR TITLE
Make streams device-agnostic

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1002,6 +1002,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
                         context,
                         source_stream=self._data_dist_stream,
                         target_stream=stream,
+                        stream_context=self._stream_context,
                     )
                     event = torch.get_device_module(self._device).Event()
                     event.record()


### PR DESCRIPTION
Summary: https://github.com/pytorch/torchrec/pull/2598 (D64220706) causes failures when using other accelerators that do not support CUDA. Making the stream contexts hardware agnostic.

Differential Revision: D67363141


