### PR TITLE
fix calculate_shard_storages to handle optimizer correctly

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -1142,7 +1142,7 @@ def calculate_shard_storages(
     if compute_kernel in {EmbeddingComputeKernel.KEY_VALUE.value}:
         ddr_storage = 0
 
-    optimizer_class = getattr(tensor, "_optimizer_class", None)
+    optimizer_class = getattr(tensor, "_optimizer_classes", [None])[0]
 
     hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
         storage=hbm_storage,


### PR DESCRIPTION
The parameter no longer possesses the `optimizer_class` attribute; instead, it has been updated to `optimizer_classes`. However, the current implementation of the `EmbeddingStorageEstimator` still relies on the outdated `optimizer_class` attribute to determine whether the parameter includes an optimizer. As a result, the `EmbeddingStorageEstimator` fails to estimate the storage requirements for the optimizer, leading to CUDA out-of-memory errors during training.