### PR TITLE
fix py3.9 build

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -66,7 +66,9 @@ from torchrec.streamable import Multistreamable
 
 @dataclass
 class EmbeddingCollectionContext(Multistreamable):
-    sharding_contexts: List[InferSequenceShardingContext | SequenceShardingContext]
+    sharding_contexts: List[
+        Union[InferSequenceShardingContext, SequenceShardingContext]
+    ]
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:


### PR DESCRIPTION
Summary: The `|` operator is only supported for python >= 3.10, which breaks python 3.9 build

Differential Revision: D67723223


