### PR TITLE
explicitly call update_hyper_parameters

### DIFF
--- a/torchrec/optim/keyed.py
+++ b/torchrec/optim/keyed.py
@@ -413,6 +413,12 @@ class CombinedOptimizer(KeyedOptimizer):
                 # pyre-ignore [16]: Undefined attribute [16]: `KeyedOptimizer` has no attribute `set_optimizer_step`.
                 opt.set_optimizer_step(step)
 
+    def update_hyper_parameters(self, params_dict: Dict[str, Any]) -> None:
+        for _, opt in self._optims:
+            if hasattr(opt, "update_hyper_parameters"):
+                # pyre-ignore [16].
+                opt.update_hyper_parameters(params_dict)
+
 
 class KeyedOptimizerWrapper(KeyedOptimizer):
     """
@@ -440,6 +446,11 @@ class KeyedOptimizerWrapper(KeyedOptimizer):
         if hasattr(self._optimizer, "set_optimizer_step"):
             # pyre-ignore [16].
             self._optimizer.set_optimizer_step(step)
+
+    def update_hyper_parameters(self, params_dict: Dict[str, Any]) -> None:
+        if hasattr(self._optimizer, "update_hyper_parameters"):
+            # pyre-ignore [16].
+            self._optimizer.update_hyper_parameters(params_dict)
 
 
 class OptimizerWrapper(KeyedOptimizer):
@@ -493,3 +504,8 @@ class OptimizerWrapper(KeyedOptimizer):
         if hasattr(self._optimizer, "set_optimizer_step"):
             # pyre-ignore [16].
             self._optimizer.set_optimizer_step(step)
+
+    def update_hyper_parameters(self, params_dict: Dict[str, Any]) -> None:
+        if hasattr(self._optimizer, "update_hyper_parameters"):
+            # pyre-ignore [16].
+            self._optimizer.update_hyper_parameters(params_dict)


### PR DESCRIPTION
Summary: Due to various wrappers classes, the hyperparameters are not properly updated within the underlying optimizer, especially the ones that are not saved in `param_groups`. Therefore, we'd need to explicitly call the `update_hyper_parameters` method in order to channel the schedule and change the actual values used within the optimizer.

Differential Revision: D67804589


