### PR TITLE
fix OSS pre-commit error

### DIFF
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -525,7 +525,8 @@ def create_global_tensor_shape_stride_from_metadata(
     """
     size = None
     if parameter_sharding.sharding_type == ShardingType.COLUMN_WISE.value:
-        row_dim = parameter_sharding.sharding_spec.shards[0].shard_sizes[0]  # pyre-ignore[16]
+        # pyre-ignore[16]
+        row_dim = parameter_sharding.sharding_spec.shards[0].shard_sizes[0]
         col_dim = 0
         for shard in parameter_sharding.sharding_spec.shards:
             col_dim += shard.shard_sizes[1]
@@ -551,4 +552,5 @@ def create_global_tensor_shape_stride_from_metadata(
         for _ in range(devices_per_node):
             row_dim += parameter_sharding.sharding_spec.shards[0].shard_sizes[0]
         size = torch.Size([row_dim, col_dim])
-    return size, (size[1], 1) if size else (torch.Size([0, 0]), (0, 1))  # pyre-ignore[7]
+    # pyre-ignore[7]
+    return size, (size[1], 1) if size else (torch.Size([0, 0]), (0, 1))


### PR DESCRIPTION
Summary:
# context
to address the following issue:
```
check toml...............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
Format files with µfmt...................................................::debug::Aborting download, socket timed out after 5000 ms
Failed
- hook id: ufmt
- files were modified by this hook

Formatted /home/runner/work/torchrec/torchrec/torchrec/distributed/utils.py
✨ 1 file formatted, 448 files already formatted ✨

pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/torchrec/distributed/utils.py b/torchrec/distributed/utils.py
index 8a3db12..830fef4 100644
--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -525,7 +525,9 @@ def create_global_tensor_shape_stride_from_metadata(
     """
     size = None
     if parameter_sharding.sharding_type == ShardingType.COLUMN_WISE.value:
-        row_dim = parameter_sharding.sharding_spec.shards[0].shard_sizes[0]  # pyre-ignore[16]
+        row_dim = parameter_sharding.sharding_spec.shards[0].shard_sizes[
+            0
+        ]  # pyre-ignore[16]
         col_dim = 0
         for shard in parameter_sharding.sharding_spec.shards:
             col_dim += shard.shard_sizes[1]
@@ -551,4 +553,6 @@ def create_global_tensor_shape_stride_from_metadata(
         for _ in range(devices_per_node):
             row_dim += parameter_sharding.sharding_spec.shards[0].shard_sizes[0]
         size = torch.Size([row_dim, col_dim])
-    return size, (size[1], 1) if size else (torch.Size([0, 0]), (0, 1))  # pyre-ignore[7]
+    return size, (
+        (size[1], 1) if size else (torch.Size([0, 0]), (0, 1))
+    )  # pyre-ignore[7]
Error: The process '/opt/hostedtoolcache/Python/3.9.20/x64/bin/pre-commit' failed with exit code 1
```

Differential Revision: D67914742


