### PR TITLE
Pass param_dict through EmbeddingFusedOptimizer

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -624,6 +624,9 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
     def set_optimizer_step(self, step: int) -> None:
         self._emb_module.set_optimizer_step(step)
 
+    def update_hyper_parameters(self, params_dict: Dict[str, Any]) -> None:
+        self._emb_module.update_hyper_parameters(params_dict)
+
 
 def _gen_named_parameters_by_table_ssd(
     emb_module: SSDTableBatchedEmbeddingBags,


### PR DESCRIPTION
Summary: For sparse optimizer which uses FBGEMM TBE, it is wrapped by `EmbeddingFusedOptimizer` (and `OptimizerWrapper`s for APS D67804589). We need to pass the `param_dict` down through `EmbeddingFusedOptimizer` in order to inject into TBE https://fburl.com/code/rwnu75wd

Differential Revision: D68021858


