### PR TITLE
exclude tensors on CPU from record_stream call

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -239,7 +239,9 @@ def recursive_record_stream(
     res: Union[torch.Tensor, Pipelineable, Iterable[Any], Dict[Any, Any]],
     stream: torch.Stream,
 ) -> None:
-    if isinstance(res, (torch.Tensor, Pipelineable)):
+    if isinstance(res, torch.Tensor) and res.device.type in ["cuda", "mtia"]:
+        res.record_stream(stream)
+    elif isinstance(res, Pipelineable):
         res.record_stream(stream)
     elif isinstance(res, (list, tuple)):
         for v in res:


### PR DESCRIPTION
Summary:
trying to call `record_stream` on a tensor that is allocated on the CPU will result in error:

```
NotImplementedError: Could not run 'aten::record_stream' with arguments from the 'CPU' backend.
```

Change logic such that we only record GPU and MTIA backend tensors on streams, as there is no concept of a "stream" on CPU.

Differential Revision: D68188314


