### PR TITLE
Remove  _scalar_logger_steps from buffer

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -812,7 +812,6 @@ class ShardedManagedCollisionCollection(
                 if name in [
                     "_output_segments_tensor",
                     "_current_iter_tensor",
-                    "_scalar_logger._scalar_logger_steps",
                 ]:
                     continue
                 if name in module._non_persistent_buffers_set:


### PR DESCRIPTION
Summary:
The _scalar_logger_steps fqn doesn't contain any useful info, and we don't need to store it in buffer.
```
 'ec_in_task_arch_hash._managed_collision_collection._managed_collision_modules.nonpooled_post_id_duplicate._scalar_logger._scalar_logger_steps': 'overall_size, i[], shards: 1',
```

Reviewed By: zlzhao1104

Differential Revision: D68006780


