### PR TITLE
batch size scheduling remove asending batch size constraint

### DIFF
--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -236,11 +236,6 @@ def validate_batch_size_stages(
     if len(batch_size_stages) == 0:
         raise ValueError("Batch size stages should not be empty")
 
-    for i in range(len(batch_size_stages) - 1):
-        if batch_size_stages[i].batch_size >= batch_size_stages[i + 1].batch_size:
-            raise ValueError(
-                f"Batch size should be in ascending order. Got {batch_size_stages}"
-            )
     if batch_size_stages[-1].max_iters is not None:
         raise ValueError(
             f"Batch size stages last stage should have max_iters = None, but get {batch_size_stages[-1].max_iters}"


### PR DESCRIPTION
Summary: In the use case of NE verification for paft, there are cases that global batch will decrease. Remove the sanity check in batch size scheduling to couple with this scenario for NE verification.

Reviewed By: xunnanxu

Differential Revision: D68284699


