### PR TITLE
explicitly disable pt2 compile on gauc

### DIFF
--- a/torchrec/metrics/gauc.py
+++ b/torchrec/metrics/gauc.py
@@ -100,6 +100,7 @@ def to_3d(
     return torch.ops.fbgemm.jagged_2d_to_dense(tensor_2d, offsets, max_length)
 
 
+@torch.compiler.disable
 def get_auc_states(
     labels: torch.Tensor,
     predictions: torch.Tensor,


### PR DESCRIPTION
Summary:
Context: the recent changes to GAUC have made it incompatible with PT2 compile, thus causing several issues with launching jobs on the latest trunk. After some digging, it turns out that the incompatibility lies with `torch.Tensor.item()`: https://github.com/pytorch/pytorch/issues/130917.

This diff: explicitly disables PT2 compilation on the problematic function, thus preventing training jobs from crashing due to incompatibility with PT2 compile.

Reviewed By: shz117

Differential Revision: D68629159


