### PR TITLE
positional and kwargs corner case fix in for _build_args_kwargs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ torchmetrics==1.0.3
 torchx
 tqdm
 usort
+parameterized
 
 # for tests
 # https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -230,7 +230,10 @@ def _build_args_kwargs(
             else:
                 args.append(arg)
         else:
-            args.append(None)
+            if arg_info.name:
+                kwargs[arg_info.name] = None
+            else:
+                args.append(None)
     return args, kwargs
 
 


### PR DESCRIPTION
Summary: 

## Context:
Setting None in positional args is colliding with the kwargs in situations when kwargs contains the argument name accepted by the method.

Eg :
```
def input_dist(ctx, id_feature_list):
    ...

// If _build_args_kwargs returns:
args = [None]
kwargs = {'id_feature_list': KJT}

input_dist(ctx, *args, **kwargs)
// extends to
input_dist(ctx, None, id_feature_list=KJT)
```

which results in "TypeError: got multiple values for argument 'id_feature_list'" because id_feature_list is provided both positionally (None) and via kwargs.

Differential Revision: D68892351


