### PR TITLE
artifact actions v3 is depricatred

### DIFF
--- a/.github/workflows/build_dynamic_embedding_wheels.yml
+++ b/.github/workflows/build_dynamic_embedding_wheels.yml
@@ -58,3 +58,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
+          overwrite: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,6 +87,7 @@ jobs:
       with:
         name: Built-Docs
         path: docs/build/html/
+        overwrite: true
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy
@@ -109,6 +110,7 @@ jobs:
         with:
           name: Built-Docs
           path: docs
+          overwrite: true
       - name: Add no-index tag
         run: |
           find docs -name "*.html" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">';


### PR DESCRIPTION
Summary: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Differential Revision: D68931905


