### PR TITLE
Back out "Remove  _scalar_logger_steps from buffer"

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -812,6 +812,7 @@ class ShardedManagedCollisionCollection(
                 if name in [
                     "_output_segments_tensor",
                     "_current_iter_tensor",
+                    "_scalar_logger._scalar_logger_steps",
                 ]:
                     continue
                 if name in module._non_persistent_buffers_set:


### PR DESCRIPTION
Summary:
Recently TB metrics from several jobs look abnormal, for example (*fire-zezhen-f688812290*):
{F1974863187}

Suspect the root cause to be D68006780, which remvoes the `_scalar_logger_steps` buffer from `ScalarLogger`. When the job is preempted, the step counter is gone. The value is then initialized to `1` once the job restarts, causing metric data points to be placed from the beginning (instead of continuation). Note that this problem did not occur for jobs without preemption (*fire-ziqiwang-20250115-1750-6121753b*):
{F1974863322}

Looks like we used buffer to store `_scalar_logger_steps` for a reason. This Diff reverts the change.

Reviewed By: emlin

Differential Revision: D68963705


