### PR TITLE
Update correct DMP link on Tutorial

### DIFF
--- a/TorchRec_Interactive_Tutorial_Notebook_OSS_version.ipynb
+++ b/TorchRec_Interactive_Tutorial_Notebook_OSS_version.ipynb
@@ -1818,7 +1818,7 @@
       "source": [
         "### DistributedModelParallel\n",
         "\n",
-        "We have now explored sharding a single EmbeddingBagCollection! We were able to take the `EmbeddingBagCollectionSharder` and use the unsharded `EmbeddingBagCollection` to generate a `ShardedEmbeddingBagCollection` module. This workflow is fine, but typically when doing model parallel, [`DistributedModelParallel`](https://pytorch.org/torchrec/torchrec.distributed.html#torchrec.distributed.model_parallel.DistributedModelParallel) (DMP) is used as the standard interface. When wrapping your model (in our case `ebc`), with DMP, the following will occur:\n",
+        "We have now explored sharding a single EmbeddingBagCollection! We were able to take the `EmbeddingBagCollectionSharder` and use the unsharded `EmbeddingBagCollection` to generate a `ShardedEmbeddingBagCollection` module. This workflow is fine, but typically when doing model parallel, [`DistributedModelParallel`](https://pytorch.org/torchrec/model-parallel-api-reference.html#model-parallel) (DMP) is used as the standard interface. When wrapping your model (in our case `ebc`), with DMP, the following will occur:\n",
         "\n",
         "1. Decide how to shard the model. DMP will collect the available ‘sharders’ and come up with a ‘plan’ of the optimal way to shard the embedding table(s) (i.e, the EmbeddingBagCollection)\n",
         "2. Actually shard the model. This includes allocating memory for each embedding table on the appropriate device(s).\n",


### PR DESCRIPTION
Summary: Noticed this link was not updated from recent update to docs when i went through the tutorial again

Differential Revision: D68924131


