### PR TITLE
add QuantManagedCollisionEmbeddingBagCollection

### DIFF
--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -81,7 +81,10 @@ from torchrec.modules.embedding_configs import (
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.feature_processor_ import PositionWeightedModuleCollection
 from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
-from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
+from torchrec.modules.mc_embedding_modules import (
+    ManagedCollisionEmbeddingBagCollection,
+    ManagedCollisionEmbeddingCollection,
+)
 from torchrec.quant.embedding_modules import (
     EmbeddingCollection as QuantEmbeddingCollection,
     FeatureProcessedEmbeddingBagCollection as QuantFeatureProcessedEmbeddingBagCollection,
@@ -89,6 +92,7 @@ from torchrec.quant.embedding_modules import (
     MODULE_ATTR_REGISTER_TBES_BOOL,
     quant_prep_enable_quant_state_dict_split_scale_bias_for_types,
     quant_prep_enable_register_tbes,
+    QuantManagedCollisionEmbeddingBagCollection,
     QuantManagedCollisionEmbeddingCollection,
 )
 
@@ -333,6 +337,7 @@ def quantize(
     module_types: List[Type[torch.nn.Module]] = [
         torchrec.modules.embedding_modules.EmbeddingBagCollection,
         torchrec.modules.embedding_modules.EmbeddingCollection,
+        torchrec.modules.mc_embedding_modules.ManagedCollisionEmbeddingBagCollection,
         torchrec.modules.mc_embedding_modules.ManagedCollisionEmbeddingCollection,
     ]
     if register_tbes:
@@ -359,11 +364,13 @@ def quantize(
         qconfig_spec={
             EmbeddingBagCollection: qconfig,
             EmbeddingCollection: qconfig,
+            ManagedCollisionEmbeddingBagCollection: qconfig,
             ManagedCollisionEmbeddingCollection: qconfig,
         },
         mapping={
             EmbeddingBagCollection: QuantEmbeddingBagCollection,
             EmbeddingCollection: QuantEmbeddingCollection,
+            ManagedCollisionEmbeddingBagCollection: QuantManagedCollisionEmbeddingBagCollection,
             ManagedCollisionEmbeddingCollection: QuantManagedCollisionEmbeddingCollection,
         },
         inplace=inplace,

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -2217,7 +2217,7 @@ class InferShardingsTest(unittest.TestCase):
             [sharder],
         )
 
-        sharded_model = shard_qec(
+        sharded_model = shard_qebc(
             mi,
             sharding_type=ShardingType.ROW_WISE,
             device=local_device,

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -56,6 +56,7 @@ from torchrec.modules.fp_embedding_modules import (
     FeatureProcessedEmbeddingBagCollection as OriginalFeatureProcessedEmbeddingBagCollection,
 )
 from torchrec.modules.mc_embedding_modules import (
+    ManagedCollisionEmbeddingBagCollection as OriginalManagedCollisionEmbeddingBagCollection,
     ManagedCollisionEmbeddingCollection as OriginalManagedCollisionEmbeddingCollection,
 )
 from torchrec.modules.mc_modules import ManagedCollisionCollection
@@ -921,6 +922,170 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
         return self._device
 
 
+class QuantManagedCollisionEmbeddingBagCollection(EmbeddingBagCollection):
+    """QuantManagedCollisionEmbeddingBagCollection represents a quantized EBC module.
+
+    The inputs into the MC-EC/EBC will first be modified by the managed collision module
+    before being passed into the embedding collection.
+
+    Args:
+        tables (List[EmbeddingBagConfig]): A list of EmbeddingBagConfig
+            objects representing the embedding tables in the collection.
+        is_weighted (bool): whether input `KeyedJaggedTensor` is weighted.
+        device (torch.device): The device on which the embedding bag collection will
+            be allocated.
+        output_dtype (torch.dtype, optional): The data type of the output embeddings.
+            Defaults to torch.float.
+        table_name_to_quantized_weights (Dict[str, Tuple[Tensor, Tensor]], optional):
+            A dictionary mapping table names to their corresponding quantized weights.
+            Defaults to None.
+        register_tbes (bool, optional): Whether to register the TBEs in the model.
+            Defaults to False.
+        quant_state_dict_split_scale_bias (bool, optional): Whether to split the scale
+            and bias parameters when saving the quantized state dict. Defaults to False.
+        row_alignment (int, optional): The alignment of rows in the quantized weights.
+            Defaults to DEFAULT_ROW_ALIGNMENT.
+        managed_collision_collection (ManagedCollisionCollection, optional): The managed
+            collision collection to use for managing collisions. Defaults to None.
+        return_remapped_features (bool, optional): Whether to return the remapped input
+            features in addition to the embeddings. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        tables: List[EmbeddingBagConfig],
+        is_weighted: bool,
+        device: torch.device,
+        output_dtype: torch.dtype = torch.float,
+        table_name_to_quantized_weights: Optional[
+            Dict[str, Tuple[Tensor, Tensor]]
+        ] = None,
+        register_tbes: bool = False,
+        quant_state_dict_split_scale_bias: bool = False,
+        row_alignment: int = DEFAULT_ROW_ALIGNMENT,
+        managed_collision_collection: Optional[ManagedCollisionCollection] = None,
+        return_remapped_features: bool = False,
+    ) -> None:
+        super().__init__(
+            tables,
+            is_weighted,
+            device,
+            output_dtype,
+            table_name_to_quantized_weights,
+            register_tbes,
+            quant_state_dict_split_scale_bias,
+            row_alignment,
+        )
+        assert (
+            managed_collision_collection
+        ), "Managed collision collection cannot be None"
+        self._managed_collision_collection: ManagedCollisionCollection = (
+            managed_collision_collection
+        )
+        self._return_remapped_features = return_remapped_features
+
+        assert str(self.embedding_bag_configs()) == str(
+            self._managed_collision_collection.embedding_configs()
+        ), (
+            "EmbeddingBagCollection and Managed Collision Collection must contain the "
+            "same Embedding Configs"
+        )
+
+        # Assuming quantized MC-EBC is used in inference only
+        for (
+            managed_collision_module
+        ) in self._managed_collision_collection._managed_collision_modules.values():
+            managed_collision_module.reset_inference_mode()
+
+    def to(
+        self, *args: List[Any], **kwargs: Dict[str, Any]
+    ) -> "QuantManagedCollisionEmbeddingBagCollection":
+        device, dtype, non_blocking, _ = torch._C._nn._parse_to(
+            *args,  # pyre-ignore
+            **kwargs,  # pyre-ignore
+        )
+        for param in self.parameters():
+            if param.device.type != "meta":
+                param.to(device)
+
+        for buffer in self.buffers():
+            if buffer.device.type != "meta":
+                buffer.to(device)
+        # Skip device movement and continue with other args
+        super().to(
+            dtype=dtype,
+            non_blocking=non_blocking,
+        )
+        return self
+
+    # pyre-ignore
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+    ) -> Tuple[KeyedTensor, Optional[KeyedJaggedTensor]]:
+        features = self._managed_collision_collection(features)
+        embedding_res = super().forward(features)
+
+        if not self._return_remapped_features:
+            return embedding_res, None
+        return embedding_res, features
+
+    def _get_name(self) -> str:
+        return "QuantManagedCollisionEmbeddingBagCollection"
+
+    @classmethod
+    # pyre-ignore
+    def from_float(
+        cls,
+        module: OriginalManagedCollisionEmbeddingBagCollection,
+        return_remapped_features: bool = False,
+    ) -> "QuantManagedCollisionEmbeddingBagCollection":
+        mc_ebc = module
+        ebc = module._embedding_module
+
+        # pyre-ignore[9]
+        qconfig: torch.quantization.QConfig = module.qconfig
+        assert hasattr(module, "qconfig"), (
+            "QuantManagedCollisionEmbeddingBagCollection input float module must "
+            "have qconfig defined"
+        )
+
+        # pyre-ignore[29]
+        embedding_configs = copy.deepcopy(ebc.embedding_bag_configs())
+        _update_embedding_configs(
+            cast(List[BaseEmbeddingConfig], embedding_configs),
+            qconfig,
+        )
+        _update_embedding_configs(
+            mc_ebc._managed_collision_collection._embedding_configs,
+            qconfig,
+        )
+
+        # pyre-ignore[9]
+        table_name_to_quantized_weights: Dict[str, Tuple[Tensor, Tensor]] | None = (
+            ebc._table_name_to_quantized_weights
+            if hasattr(ebc, "_table_name_to_quantized_weights")
+            else None
+        )
+        device = _get_device(ebc)
+        return cls(
+            embedding_configs,
+            ebc.is_weighted(),
+            device=device,
+            output_dtype=qconfig.activation().dtype,
+            table_name_to_quantized_weights=table_name_to_quantized_weights,
+            register_tbes=getattr(module, MODULE_ATTR_REGISTER_TBES_BOOL, False),
+            quant_state_dict_split_scale_bias=getattr(
+                ebc, MODULE_ATTR_QUANT_STATE_DICT_SPLIT_SCALE_BIAS, False
+            ),
+            row_alignment=getattr(
+                ebc, MODULE_ATTR_ROW_ALIGNMENT_INT, DEFAULT_ROW_ALIGNMENT
+            ),
+            managed_collision_collection=mc_ebc._managed_collision_collection,
+            return_remapped_features=mc_ebc._return_remapped_features,
+        )
+
+
 class QuantManagedCollisionEmbeddingCollection(EmbeddingCollection):
     """
     QuantManagedCollisionEmbeddingCollection represents a quantized EC module and a set of managed collision modules.
@@ -1006,10 +1171,13 @@ class QuantManagedCollisionEmbeddingCollection(EmbeddingCollection):
     def forward(
         self,
         features: KeyedJaggedTensor,
-    ) -> Dict[str, JaggedTensor]:
+    ) -> Tuple[Dict[str, JaggedTensor], Optional[KeyedJaggedTensor]]:
         features = self._managed_collision_collection(features)
+        embedding_res = super().forward(features)
 
-        return super().forward(features)
+        if not self._return_remapped_features:
+            return embedding_res, None
+        return embedding_res, features
 
     def _get_name(self) -> str:
         return "QuantManagedCollisionEmbeddingCollection"


### PR DESCRIPTION
Add quant MC-EBC for inference.
Additionally, to ensure consistency with the output formats of MC-EBC and MC-BC, modify the forward outputs of Quant MC-EBC and MC-BC to be Tuples.