### PR TITLE
change sharding topology for inter host all reduce

### DIFF
--- a/torchrec/distributed/comm.py
+++ b/torchrec/distributed/comm.py
@@ -226,9 +226,14 @@ def intra_and_cross_node_pg_2D(
 
     if _INTRA_PG_2D is None:
         for group_rank in range(step):
-            sharding_pg_peers = [
-                step * r + group_rank for r in range(sharding_group_size)
-            ]
+            if env.use_inter_host_allreduce:
+                # for inter host all reduce, we change the sharding group calculation to be continuous
+                ranks = group_rank * sharding_group_size
+                sharding_pg_peers = list(range(ranks, ranks + sharding_group_size))
+            else:
+                sharding_pg_peers = [
+                    step * r + group_rank for r in range(sharding_group_size)
+                ]
             for group in range(len(sharding_pg_peers) // devices_per_node):
                 intra_pg_peers = sharding_pg_peers[
                     group * devices_per_node : (group + 1) * devices_per_node

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -45,6 +45,7 @@ from torchrec.distributed.types import (
     QuantizedCommCodecs,
     ShardedTensorMetadata,
     ShardingEnv,
+    ShardingType,
     ShardMetadata,
 )
 from torchrec.distributed.utils import none_throws
@@ -191,7 +192,7 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
             for i, rank in enumerate(info.param_sharding.ranks):
                 # Remap rank by number of replica groups if 2D parallelism is enabled
                 rank = (
-                    rank // self._env.num_sharding_groups()  # pyre-ignore[16]
+                    self._env.remap_rank(rank, ShardingType.COLUMN_WISE)  # pyre-ignore[16]
                     if self._is_2D_parallel
                     else rank
                 )

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -250,7 +250,7 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
             # pyre-fixme [6]
             for i, rank in enumerate(info.param_sharding.ranks):
                 rank = (
-                    rank // self._env.num_sharding_groups()  # pyre-ignore[16]
+                    self._env.remap_rank(rank, ShardingType.GRID_SHARD)  # pyre-ignore[16]
                     if self._is_2D_parallel
                     else rank
                 )

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -149,6 +149,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
         global_constant_batch: bool = False,
         pooling: PoolingType = PoolingType.SUM,
         data_type: DataType = DataType.FP32,
+        use_inter_host_allreduce: bool = False,
     ) -> None:
         self._build_tables_and_groups(data_type=data_type)
         self._run_multi_process_test(
@@ -170,6 +171,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_per_feature=variable_batch_per_feature,
             global_constant_batch=global_constant_batch,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )
 
 

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -315,6 +315,7 @@ def sharding_single_rank_test(
     global_constant_batch: bool = False,
     world_size_2D: Optional[int] = None,
     node_group_size: Optional[int] = None,
+    use_inter_host_allreduce: bool = False,
     input_type: str = "kjt",  # "kjt" or "td"
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
@@ -432,6 +433,7 @@ def sharding_single_rank_test(
                 plan=plan,
                 sharders=sharders,
                 device=ctx.device,
+                use_inter_host_allreduce=use_inter_host_allreduce,
             )
         else:
             local_model = DistributedModelParallel(

--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -78,6 +78,7 @@ class Test2DSharding(ModelParallelTestShared):
             ]
         ),
         pooling=st.sampled_from([PoolingType.SUM]),
+        use_inter_host_allreduce=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharding_cw_2D(
@@ -89,6 +90,7 @@ class Test2DSharding(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
         pooling: PoolingType,
+        use_inter_host_allreduce: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -122,6 +124,7 @@ class Test2DSharding(ModelParallelTestShared):
             backend=self.backend,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             pooling=pooling,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )
 
     @unittest.skipIf(
@@ -164,6 +167,7 @@ class Test2DSharding(ModelParallelTestShared):
             ]
         ),
         pooling=st.sampled_from([PoolingType.SUM]),
+        use_inter_host_allreduce=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharding_tw_2D(
@@ -175,6 +179,7 @@ class Test2DSharding(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
         pooling: PoolingType,
+        use_inter_host_allreduce: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -209,6 +214,7 @@ class Test2DSharding(ModelParallelTestShared):
             backend=self.backend,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             pooling=pooling,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )
 
     @unittest.skipIf(
@@ -251,6 +257,7 @@ class Test2DSharding(ModelParallelTestShared):
             ]
         ),
         pooling=st.sampled_from([PoolingType.SUM]),
+        use_inter_host_allreduce=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharding_grid_2D(
@@ -262,6 +269,7 @@ class Test2DSharding(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
         pooling: PoolingType,
+        use_inter_host_allreduce: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -318,6 +326,7 @@ class Test2DSharding(ModelParallelTestShared):
             backend=self.backend,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             pooling=pooling,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )
 
     @unittest.skipIf(
@@ -357,6 +366,7 @@ class Test2DSharding(ModelParallelTestShared):
         ),
         variable_batch_size=st.booleans(),
         pooling=st.sampled_from([PoolingType.SUM]),
+        use_inter_host_allreduce=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharding_rw_2D(
@@ -369,6 +379,7 @@ class Test2DSharding(ModelParallelTestShared):
         ],
         variable_batch_size: bool,
         pooling: PoolingType,
+        use_inter_host_allreduce: bool,
     ) -> None:
         if self.backend == "gloo":
             self.skipTest(
@@ -401,6 +412,7 @@ class Test2DSharding(ModelParallelTestShared):
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
             pooling=pooling,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )
 
     @unittest.skipIf(
@@ -443,6 +455,7 @@ class Test2DSharding(ModelParallelTestShared):
             ]
         ),
         pooling=st.sampled_from([PoolingType.SUM]),
+        use_inter_host_allreduce=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharding_twrw_2D(
@@ -454,6 +467,7 @@ class Test2DSharding(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
         pooling: PoolingType,
+        use_inter_host_allreduce: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -488,4 +502,5 @@ class Test2DSharding(ModelParallelTestShared):
             backend=self.backend,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             pooling=pooling,
+            use_inter_host_allreduce=use_inter_host_allreduce,
         )


### PR DESCRIPTION
Summary:
Users can now change network topology such that all reduce is now inter host. This design uses the ShardingEnv to inform the rank placements since the topology now changes how the rank is remapped back.

Future work: make this extensible where user can define a sharding topology and torchrec can MP/DP across it

Differential Revision: D68729283


