### PR TITLE
Refactor monolithic ArgInfoStep into separate classes encoding different operations

### DIFF
--- a/torchrec/distributed/train_pipeline/__init__.py
+++ b/torchrec/distributed/train_pipeline/__init__.py
@@ -26,6 +26,7 @@ from torchrec.distributed.train_pipeline.utils import (  # noqa
     _to_device,  # noqa
     _wait_for_batch,  # noqa
     ArgInfo,  # noqa
+    ArgInfoStep,  # noqa
     DataLoadingThread,  # noqa
     In,  # noqa
     Out,  # noqa

--- a/torchrec/distributed/train_pipeline/__init__.py
+++ b/torchrec/distributed/train_pipeline/__init__.py
@@ -26,7 +26,8 @@ from torchrec.distributed.train_pipeline.utils import (  # noqa
     _to_device,  # noqa
     _wait_for_batch,  # noqa
     ArgInfo,  # noqa
-    ArgInfoStep,  # noqa
+    ArgInfoStepFactory,  # noqa
+    CallArgs,  # noqa
     DataLoadingThread,  # noqa
     In,  # noqa
     Out,  # noqa

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -1024,9 +1024,10 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
 
         # Check pipelined args
         for ebc in [pipelined_ebc, pipelined_weighted_ebc]:
-            self.assertEqual(len(ebc.forward._args), 1)
-            self.assertEqual(len(ebc.forward._args[0].steps), 2)
-            [step1, step2] = ebc.forward._args[0].steps
+            self.assertEqual(len(ebc.forward._args.args), 1)
+            self.assertEqual(len(ebc.forward._args.kwargs), 0)
+            self.assertEqual(len(ebc.forward._args.args[0].steps), 2)
+            [step1, step2] = ebc.forward._args.args[0].steps
 
             self.assertEqual(step1.input_attr, "")
             self.assertEqual(step1.is_getitem, False)
@@ -1036,13 +1037,13 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
             self.assertIsNone(step2.postproc_module)
 
         self.assertEqual(
-            pipelined_ebc.forward._args[0].steps[0].postproc_module,
+            pipelined_ebc.forward._args.args[0].steps[0].postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_nonweighted`.
             pipelined_model.module.postproc_nonweighted,
         )
         self.assertEqual(
-            pipelined_weighted_ebc.forward._args[0].steps[0].postproc_module,
+            pipelined_weighted_ebc.forward._args.args[0].steps[0].postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_weighted`.
             pipelined_model.module.postproc_weighted,
@@ -1053,9 +1054,10 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
         input_attr_names = {"idlist_features", "idscore_features"}
         for i in range(len(pipeline._pipelined_postprocs)):
             postproc_mod = pipeline._pipelined_postprocs[i]
-            self.assertEqual(len(postproc_mod._args), 1)
-            self.assertEqual(len(postproc_mod._args[0].steps), 2)
-            [step1, step2] = postproc_mod._args[0].steps
+            self.assertEqual(len(postproc_mod._args.args), 1)
+            self.assertEqual(len(postproc_mod._args.kwargs), 0)
+            self.assertEqual(len(postproc_mod._args.args[0].steps), 2)
+            [step1, step2] = postproc_mod._args.args[0].steps
 
             self.assertTrue(step2.input_attr in input_attr_names)
 
@@ -1112,9 +1114,10 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
 
         # Check pipelined args
         for ebc in [pipelined_ebc, pipelined_weighted_ebc]:
-            self.assertEqual(len(ebc.forward._args), 1)
-            self.assertEqual(len(ebc.forward._args[0].steps), 2)
-            [step1, step2] = ebc.forward._args[0].steps
+            self.assertEqual(len(ebc.forward._args.args), 1)
+            self.assertEqual(len(ebc.forward._args.kwargs), 0)
+            self.assertEqual(len(ebc.forward._args.args[0].steps), 2)
+            [step1, step2] = ebc.forward._args.args[0].steps
 
             self.assertEqual(step1.input_attr, "")
             self.assertEqual(step1.is_getitem, False)
@@ -1124,13 +1127,13 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
             self.assertIsNone(step2.postproc_module)
 
         self.assertEqual(
-            pipelined_ebc.forward._args[0].steps[0].postproc_module,
+            pipelined_ebc.forward._args.args[0].steps[0].postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_nonweighted`.
             pipelined_model.module.postproc_nonweighted,
         )
         self.assertEqual(
-            pipelined_weighted_ebc.forward._args[0].steps[0].postproc_module,
+            pipelined_weighted_ebc.forward._args.args[0].steps[0].postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_weighted`.
             pipelined_model.module.postproc_weighted,
@@ -1147,8 +1150,9 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_nonweighted`.
             if postproc_mod == pipelined_model.module.postproc_nonweighted:
-                self.assertEqual(len(postproc_mod._args), 1)
-                args = postproc_mod._args[0]
+                self.assertEqual(len(postproc_mod._args.args), 1)
+                self.assertEqual(len(postproc_mod._args.kwargs), 0)
+                args = postproc_mod._args.args[0]
                 self.assertEqual(len(args.steps), 2)
                 self.assertEqual(
                     [step.input_attr for step in args.steps], ["", "idlist_features"]
@@ -1161,8 +1165,9 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_weighted`.
             elif postproc_mod == pipelined_model.module.postproc_weighted:
-                self.assertEqual(len(postproc_mod._args), 1)
-                args = postproc_mod._args[0]
+                self.assertEqual(len(postproc_mod._args.args), 1)
+                self.assertEqual(len(postproc_mod._args.kwargs), 0)
+                args = postproc_mod._args.args[0]
                 self.assertEqual(len(args.steps), 2)
                 self.assertEqual(
                     [step.input_attr for step in args.steps], ["", "idscore_features"]
@@ -1173,8 +1178,9 @@ class TrainPipelinePreprocTest(TrainPipelineSparseDistTestBase):
                 self.assertEqual(args.steps[0].postproc_module, parent_postproc_mod)
                 self.assertIsNone(args.steps[1].postproc_module)
             elif postproc_mod == parent_postproc_mod:
-                self.assertEqual(len(postproc_mod._args), 1)
-                args = postproc_mod._args[0]
+                self.assertEqual(len(postproc_mod._args.args), 1)
+                self.assertEqual(len(postproc_mod._args.kwargs), 0)
+                args = postproc_mod._args.args[0]
                 self.assertEqual(len(args.steps), 1)
                 self.assertEqual(args.steps[0].input_attr, "")
                 self.assertFalse(args.steps[0].is_getitem)

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -24,9 +24,9 @@ from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import 
 )
 from torchrec.distributed.train_pipeline.utils import (
     _build_args_kwargs,
-    _get_node_args,
     _rewrite_model,
     ArgInfo,
+    NodeArgsHelper,
     PipelinedForward,
     PipelinedPostproc,
     TrainPipelineContext,
@@ -367,10 +367,9 @@ class TestUtils(unittest.TestCase):
             {},
         )
 
-        num_found = 0
-        _, num_found = _get_node_args(
-            MagicMock(), kjt_node, set(), TrainPipelineContext(), False
-        )
+        node_args_helper = NodeArgsHelper(MagicMock(), TrainPipelineContext(), False)
+
+        _, num_found = node_args_helper.get_node_args(kjt_node)
 
         # Weights is call_module node, so we should only find 2 args unmodified
         self.assertEqual(num_found, len(kjt_args) - 1)

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -26,6 +26,7 @@ from torchrec.distributed.train_pipeline.utils import (
     _build_args_kwargs,
     _rewrite_model,
     ArgInfo,
+    ArgInfoStep,
     NodeArgsHelper,
     PipelinedForward,
     PipelinedPostproc,
@@ -110,7 +111,7 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         self.assertEqual(
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `sparse`.
-            sharded_model.module.sparse.ebc.forward._args[0].postproc_modules[0],
+            sharded_model.module.sparse.ebc.forward._args[0].steps[0].postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_module`.
             sharded_model.module.postproc_module,
@@ -118,9 +119,9 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         self.assertEqual(
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `sparse`.
-            sharded_model.module.sparse.weighted_ebc.forward._args[0].postproc_modules[
-                0
-            ],
+            sharded_model.module.sparse.weighted_ebc.forward._args[0]
+            .steps[0]
+            .postproc_module,
             # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
             #  `postproc_module`.
             sharded_model.module.postproc_module,
@@ -263,19 +264,18 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
                 [
                     # Empty attrs to ignore any attr based logic.
                     ArgInfo(
-                        input_attrs=[
-                            "",
+                        steps=[
+                            ArgInfoStep(
+                                input_attr="",
+                                is_getitem=False,
+                                postproc_module=None,
+                                constant=None,
+                            )
                         ],
-                        is_getitems=[False],
-                        postproc_modules=[None],
-                        constants=[None],
                         name="id_list_features",
                     ),
                     ArgInfo(
-                        input_attrs=[],
-                        is_getitems=[],
-                        postproc_modules=[],
-                        constants=[],
+                        steps=[],
                         name="id_score_list_features",
                     ),
                 ],
@@ -286,19 +286,18 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
                 [
                     # Empty attrs to ignore any attr based logic.
                     ArgInfo(
-                        input_attrs=[
-                            "",
+                        steps=[
+                            ArgInfoStep(
+                                input_attr="",
+                                is_getitem=False,
+                                postproc_module=None,
+                                constant=None,
+                            )
                         ],
-                        is_getitems=[False],
-                        postproc_modules=[None],
-                        constants=[None],
                         name=None,
                     ),
                     ArgInfo(
-                        input_attrs=[],
-                        is_getitems=[],
-                        postproc_modules=[],
-                        constants=[],
+                        steps=[],
                         name=None,
                     ),
                 ],
@@ -309,19 +308,18 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
                 [
                     # Empty attrs to ignore any attr based logic.
                     ArgInfo(
-                        input_attrs=[
-                            "",
+                        steps=[
+                            ArgInfoStep(
+                                input_attr="",
+                                is_getitem=False,
+                                postproc_module=None,
+                                constant=None,
+                            )
                         ],
-                        is_getitems=[False],
-                        postproc_modules=[None],
-                        constants=[None],
                         name=None,
                     ),
                     ArgInfo(
-                        input_attrs=[],
-                        is_getitems=[],
-                        postproc_modules=[],
-                        constants=[],
+                        steps=[],
                         name="id_score_list_features",
                     ),
                 ],


### PR DESCRIPTION
Summary:
Torchrec rewriting logic got a bit hairy over the years, this sequence of changes aims to refactor the rewrite logic to be less convoluted and more maintainable in the future.

This change: Splits monolithic ArgInfoStep into multiple classes, each handling single potential operation (+minimum data necessary to perform it).

Internal

Diff stack navigation:
1. D69292525 and below - before refactoring
2. D69438143 - Refactor get_node_args and friends into a class 
3. D69461227 - refactor "joint lists" in ArgInfo into a list of ArgInfoStep
4. D69461226 - refactor `_build_args_kwargs` into instance methods on ArgInfo and ArgInfoStep 
5. D69461228 - split monolithic `ArgInfoStep` into a class hierarchy (**you are here**)

Differential Revision: D69461228


