### PR TITLE
Handle KJT with zero batch size for Column-Wise sharded EmbeddingBagCollection

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -150,6 +150,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
         pooling: PoolingType = PoolingType.SUM,
         data_type: DataType = DataType.FP32,
         use_inter_host_allreduce: bool = False,
+        allow_zero_batch_size: bool = False,
     ) -> None:
         self._build_tables_and_groups(data_type=data_type)
         self._run_multi_process_test(
@@ -172,6 +173,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
             variable_batch_per_feature=variable_batch_per_feature,
             global_constant_batch=global_constant_batch,
             use_inter_host_allreduce=use_inter_host_allreduce,
+            allow_zero_batch_size=allow_zero_batch_size,
         )
 
 
@@ -333,8 +335,9 @@ class ModelParallelBase(ModelParallelTestShared):
         ),
         variable_batch_size=st.booleans(),
         data_type=st.sampled_from([DataType.FP32, DataType.FP16]),
+        allow_zero_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=3, deadline=None)
+    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
     def test_sharding_cw(
         self,
         sharder_type: str,
@@ -345,6 +348,7 @@ class ModelParallelBase(ModelParallelTestShared):
         ],
         variable_batch_size: bool,
         data_type: DataType,
+        allow_zero_batch_size: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -377,6 +381,7 @@ class ModelParallelBase(ModelParallelTestShared):
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
             data_type=data_type,
+            allow_zero_batch_size=allow_zero_batch_size,
         )
 
     # pyre-fixme[56]


### PR DESCRIPTION
Summary:
Support new use case where some ranks have no embedding ids to look up i.e. `kjt.values() == torch.tensor([])`. In such cases, the expectation is for the returned embedding to be of shape `[0,emb_dim]`, as 0 is a valid tensor dimension. 

This diff adds support for this use case, now only for Column-Wise (CW) sharding + EmbeddingBagCollection use case.

Changes in this diff:

1) CW sharding and VLE uses FBGEMM kernel to permute pooled embeddings, which doesn't work for 0-dim tensors. If tensor has no elements (i.e. 0-dim), permute doesn't do anything so we can return early. We could also support this via an `if` statement in TorchRec codebase, but we run into FX tracing issues in this case.
2) In comm_ops.py, `[output.view(B_local, -1) for output in outputs_by_rank]` isn't supported if `output` tensor has 0 dim as it will error out with `RuntimeError: cannot reshape tensor of 0 elements into shape [0, -1] because the unspecified dimension size -1 can be any value and is ambiguous`. Instead, we can explicitly create a view with the bsz and emb_dim dimensions which will hold even if `output` is 0-dim (outputs will have shape `[0,emb_dim_for_rank]`
3) Added new unit test cases

Reviewed By: dstaay-fb

Differential Revision: D69156551


