### PR TITLE
Support MCH for semi-sync

### DIFF
--- a/torchrec/distributed/composable/tests/test_ddp.py
+++ b/torchrec/distributed/composable/tests/test_ddp.py
@@ -105,11 +105,13 @@ class DDPTest(MultiProcessTestBase):
                 weighted_tables=weighted_tables,
                 dense_device=ctx.device,
             )
+            # pyre-ignore
             m.sparse.ebc = trec_shard(
                 module=m.sparse.ebc,
                 device=ctx.device,
                 plan=column_wise(ranks=list(range(world_size))),
             )
+            # pyre-ignore
             m.sparse.weighted_ebc = trec_shard(
                 module=m.sparse.weighted_ebc,
                 device=ctx.device,

--- a/torchrec/distributed/composable/tests/test_fsdp.py
+++ b/torchrec/distributed/composable/tests/test_fsdp.py
@@ -83,11 +83,13 @@ class FullyShardTest(MultiProcessTestBase):
                 m.sparse.parameters(),
                 {"lr": 0.01},
             )
+            # pyre-ignore
             m.sparse.ebc = trec_shard(
                 module=m.sparse.ebc,
                 device=ctx.device,
                 plan=row_wise(),
             )
+            # pyre-ignore
             m.sparse.weighted_ebc = trec_shard(
                 module=m.sparse.weighted_ebc,
                 device=ctx.device,


### PR DESCRIPTION
Summary: ZCH modules return a tuple of awaitables for embeddings and remapped KJTs. Update semi-sync training code to account for this

Differential Revision: D69861054


