### PR TITLE
fix upload-artifact v4 issue in dynamic embedding wheel

### DIFF
--- a/.github/workflows/build_dynamic_embedding_wheels.yml
+++ b/.github/workflows/build_dynamic_embedding_wheels.yml
@@ -57,4 +57,15 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}-${{ matrix.pyver }}-cu${{ matrix.cuver }}
           path: wheelhouse/*.whl
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: artifact
+          pattern: artifact-*


### PR DESCRIPTION
Summary:
# context
* TorchRec's OSS workflow "build dynamic embedding wheels" has been [failing](https://github.com/pytorch/torchrec/actions/runs/13416363464/job/37478091546) due to an upgrading of upload action [bug report](https://github.com/actions/upload-artifact/issues/506)

# solution
* as described in this [migration.md](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), adding additional job (merge) the artifacts.

Differential Revision: D69904715


