### PR TITLE
adding tensordict dependency in validate_binaries.sh

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -80,6 +80,9 @@ conda run -n "${CONDA_ENV}" pip install fbgemm-gpu --index-url "$PYTORCH_URL"
 # install requirements from pypi
 conda run -n "${CONDA_ENV}" pip install torchmetrics==1.0.3
 
+# install tensordict from pypi
+conda run -n "${CONDA_ENV}" pip install tensordict==0.7.1
+
 # install torchrec
 conda run -n "${CONDA_ENV}" pip install torchrec --index-url "$PYTORCH_URL"
 


### PR DESCRIPTION
Summary:
# context
* failed to directly install torchrec from nightly build: P1736807637
* the reason is that tensordict is not available from https://download.pytorch.org/whl/nightly/*
* so the tensordict has to be installed separately

# changes
* install current tensordict version in the validate_binaries.sh script

Differential Revision: D69950708


