### PR TITLE
skip python 3.13t since conda doesn't support it yet

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -9,6 +9,11 @@
 export PYTORCH_CUDA_PKG=""
 export CONDA_ENV="build_binary"
 
+if [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
+    echo "Conda doesn't support 3.13t yet, you can just try \`conda create -n test python=3.13t\`"
+    exit 0
+fi
+
 conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
 
 conda run -n build_binary python --version


### PR DESCRIPTION
Summary:
# context
* there are failures in torchrec binary validation {F1975312017}
* because conda can't support python 3.13t
```
$ conda create -n test python=3.13t
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: failed

PackagesNotFoundError: The following packages are not available from current channels:

  - python=3.13t

Current channels:

  - https://repo.anaconda.com/pkgs/main/linux-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/linux-64
  - https://repo.anaconda.com/pkgs/r/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.

```

Differential Revision: D69962038


