### PR TITLE
[detailed] How Lower Precision Weights in Embedding Tables Are Handled in TorchRec

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -223,8 +223,7 @@ class ModelInput(Pipelineable):
         else:
             raise ValueError(f"For IdList features, unknown input type {input_type}")
 
-        for idx in range(len(idscore_ind_ranges)):
-            ind_range = idscore_ind_ranges[idx]
+        for idx, ind_range in enumerate(idscore_ind_ranges):
             lengths_ = torch.abs(
                 torch.randn(batch_size * world_size, device=device)
                 + (

--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -248,7 +248,11 @@ class EmbeddingBagCollection(EmbeddingBagCollectionInterface):
                 res = embedding_bag(
                     input=f.values(),
                     offsets=f.offsets(),
-                    per_sample_weights=f.weights() if self._is_weighted else None,
+                    per_sample_weights=(
+                        f.weights().to(embedding_bag.weight.dtype)
+                        if self._is_weighted
+                        else None
+                    ),
                 ).float()
                 pooled_embeddings.append(res)
         return KeyedTensor(


### PR DESCRIPTION
# How Lower Precision Weights in Embedding Tables Are Handled in TorchRec

## TL;DR
* Found behavior discrepancy between the unsharded EBC and sharded EBCs when resolving flaky TorchRec sharding tests (test_sharding_tw, test_sharding_twcw, test_sharding_twrw).
* Although the embedding tables are stored in a lower precision (FP16), the input_kjt.weights are still in a higher precision (FP32), which differs from how nn.EmbeddingBag handles the [per_sample_weights](https://pytorch.org/docs/stable/generated/torch.nn.EmbeddingBag.html#torch.nn.EmbeddingBag.forward).
* It gives better tradeoffs between memory (embedding table size) and effective accuracy in training.

## context
Usually the sparse module weights (sparse embeddings) are less sensitive to a model than the dense module weights. So in practice (production) the embedding tables are stored in a lower precision (FP16) on GPU, and then upscaled to a higher precision (FP32) for the follow-up computations.

The unsharded EBC uses nn.EmbeddingBag to do the weighted pooled embedding ([codepointer](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/modules/embedding_modules.py#L247-L255)),where the argument “per_sample_weights” has to have the same precision as the embedding bag’s weight. In the case with a higher precision input.weights (FP32), it has to be downscale to the lower precision (FP16) as the embedding tables. 
However, the sharded EBC uses a more sophisticated fbgemm (batched) table lookup operator, which upscales the lower precision (FP16) embedding to the higher precision (FP32) before doing the pooling.
<img width="3648" height="1838" alt="image" src="https://github.com/user-attachments/assets/79aacb66-8faa-4261-8da5-ec4da101efc1" />


In general it’s better to keep higher precision for the gradients as late as possible in the back-propogation chain.

The flaky [test_model_parallel](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/test_utils/test_model_parallel.py#L368) added FP16 in the tests to cover the sharded EBC testing, however, the unsharded EBC needs to take in a downscaled input.weights to avoid dtype RuntimeError (expected scalar type Half but found Float). Moreover, the accuracy tests are too tight due to the precision handling discrepancy between the sharded and unsharded EBCs.

Differential Revision: D70126859


