### PR TITLE
Simplify batched_embedding_kernel

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -916,7 +916,8 @@ class ModelParallelBase(ModelParallelTestShared):
     )
     # pyre-fixme[56]
     @given(
-        dtype=st.sampled_from([torch.int32, torch.int64]),
+        index_dtype=st.sampled_from([torch.int32, torch.int64]),
+        offsets_dtype=st.sampled_from([torch.int32, torch.int64]),
         use_offsets=st.booleans(),
         sharder_type=st.sampled_from(
             [
@@ -932,7 +933,8 @@ class ModelParallelBase(ModelParallelTestShared):
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_diff_table_index_type(
         self,
-        dtype: torch.dtype,
+        index_dtype: torch.dtype,
+        offsets_dtype: torch.dtype,
         use_offsets: bool,
         sharder_type: str,
         kernel_type: str,
@@ -960,7 +962,7 @@ class ModelParallelBase(ModelParallelTestShared):
             variable_batch_size=False,
             pooling=PoolingType.SUM,
             use_offsets=use_offsets,
-            indices_dtype=dtype,
-            offsets_dtype=dtype,
-            lengths_dtype=dtype,
+            indices_dtype=index_dtype,
+            offsets_dtype=offsets_dtype,
+            lengths_dtype=index_dtype,
         )


### PR DESCRIPTION
Summary: FBGEMM was recently updated to support int32 for embedding tables for EmbeddingBag kernels. We no longer want TorchRec to impose an opinion on the user's input tensors' index/offset type. This was historically included in TorchRec to avoid type errors which are no longer an issue after Benson's changes. FBGEMM also includes guardrails here so TorchRec by default casting the type is redundant.

Reviewed By: dstaay-fb, TroyGarden

Differential Revision: D69560428


