### PR TITLE
change | to Union for py 3.9 compat

### DIFF
--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -576,9 +576,9 @@ def convert_tensor(t: None, feature: KeyedJaggedTensor) -> None: ...
 
 
 def convert_tensor(
-    t: torch.Tensor | None,
+    t: Union[torch.Tensor, None],
     feature: KeyedJaggedTensor,
-) -> torch.Tensor | None:
+) -> Union[torch.Tensor, None]:
     # comparing to Optional[Tensor], this solution will keep output as Tensor when input is not None
     if t is None:
         return None


### PR DESCRIPTION
Summary: `|` instead of Union causing py3.9 OSS CI to break since `|` was added in python 3.10+

Differential Revision: D70970656


