### PR TITLE
Backout

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -190,7 +190,7 @@ class KeyValueEmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate_tensor,
+            "lr": emb_module.optimizer_args.learning_rate,
         }
 
         params: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}
@@ -383,7 +383,7 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate_tensor,
+            "lr": emb_module.optimizer_args.learning_rate,
         }
 
         params: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -68,7 +68,7 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate_tensor,
+            "lr": emb_module.optimizer_args.learning_rate,
         }
 
         params: Dict[str, torch.Tensor] = {}


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/3803

X-link: https://github.com/facebookresearch/FBGEMM/pull/887

Backout D68055168 as it seems to break pyper and causes S498612.

Differential Revision: D70996903


