### PR TITLE
Add support for compile optimizer step

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -24,6 +24,7 @@ from torchrec.distributed.test_utils.test_model import (
     TestEBCSharderMCH,
     TestSparseNN,
 )
+from torchrec.distributed.train_pipeline import TorchCompileConfig
 from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
 from torchrec.distributed.types import ModuleSharder, ShardingEnv
 from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig
@@ -62,6 +63,7 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
 
         self.device = torch.device("cuda:0")
         self.pipeline_class = TrainPipelineSparseDist
+        self.optimizer_compile_config = TorchCompileConfig()
 
     def tearDown(self) -> None:
         super().tearDown()


### PR DESCRIPTION
Summary:
This diff adds support for compiling the optimizer step in the train pipeline of TorchRec. The changes include:
1. Add a new argument to the TrainPipeline constructor to enable compilation of the optimizer step, and modify the optimizer step to be compiled if the argument is set to True.
2. The test_equal_to_non_pipelined_compiled test cases are also added to ensure that the compiled optimizer step produces the same results as the non-compiled version.

Differential Revision: D71031049


