### PR TITLE
Revert D69560428: Multisect successfully blamed "D69560428: [2/n] Simplify batched_embedding_kernel" for one test failure

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -916,8 +916,7 @@ class ModelParallelBase(ModelParallelTestShared):
     )
     # pyre-fixme[56]
     @given(
-        index_dtype=st.sampled_from([torch.int32, torch.int64]),
-        offsets_dtype=st.sampled_from([torch.int32, torch.int64]),
+        dtype=st.sampled_from([torch.int32, torch.int64]),
         use_offsets=st.booleans(),
         sharder_type=st.sampled_from(
             [
@@ -933,8 +932,7 @@ class ModelParallelBase(ModelParallelTestShared):
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_sharding_diff_table_index_type(
         self,
-        index_dtype: torch.dtype,
-        offsets_dtype: torch.dtype,
+        dtype: torch.dtype,
         use_offsets: bool,
         sharder_type: str,
         kernel_type: str,
@@ -962,7 +960,7 @@ class ModelParallelBase(ModelParallelTestShared):
             variable_batch_size=False,
             pooling=PoolingType.SUM,
             use_offsets=use_offsets,
-            indices_dtype=index_dtype,
-            offsets_dtype=offsets_dtype,
-            lengths_dtype=index_dtype,
+            indices_dtype=dtype,
+            offsets_dtype=dtype,
+            lengths_dtype=dtype,
         )


### PR DESCRIPTION
Summary:
This diff reverts D69560428
Depends on D70793007
D69560428: [2/n] Simplify batched_embedding_kernel by basilwong causes the following test failure:

Tests affected:
- [cogwheel:cogwheel_mtia_aps_dpa_single_trainer_random_fallback_ops_collection#test_launcher](https://www.internalfb.com/intern/test/562950151615932/)

Here's the Multisect link:
https://www.internalfb.com/multisect/22664498
Here are the tasks that are relevant to this breakage:
T214694004: 50+ CI signals failing for aps_mtia_ci

The backout may land if someone accepts it.

If this diff has been generated in error, you can Commandeer and Abandon it.

Reviewed By: dstaay-fb, basilwong

Differential Revision: D70793024


