### PR TITLE
ci: Update linux.20_04 --> linux.24_04

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -27,7 +27,7 @@ jobs:
       with-rocm: false
   filter-matrix:
     needs: generate-matrix
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-         - os: linux.20_04.4x
+         - os: linux.24_04.4x
            python-version: 3.9
            python-tag: "py39"
     steps:


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/149142

Ubuntu 20.04 is getting deprecated soon so we might as well proactively
move to the latest LTS which is 24.04