### PR TITLE
Fix wrong return type of QuantManagedCollisionEmbeddingCollection

### DIFF
--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -2229,7 +2229,7 @@ class InferShardingsTest(unittest.TestCase):
         sharded_model.load_state_dict(quant_model.state_dict())
         sharded_output = sharded_model(*inputs[0])
 
-        assert_close(non_sharded_output, sharded_output)
+        assert_close(non_sharded_output[0], sharded_output[0])
         gm: torch.fx.GraphModule = symbolic_trace(
             sharded_model,
             leaf_modules=[
@@ -2242,7 +2242,7 @@ class InferShardingsTest(unittest.TestCase):
         gm_script = torch.jit.script(gm)
         print(f"gm_script:\n{gm_script}")
         gm_script_output = gm_script(*inputs[0])
-        assert_close(sharded_output, gm_script_output)
+        assert_close(sharded_output[0], gm_script_output[0])
 
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -1093,7 +1093,9 @@ class QuantManagedCollisionEmbeddingCollection(EmbeddingCollection):
     ) -> Dict[str, JaggedTensor]:
         features = self._managed_collision_collection(features)
 
-        return super().forward(features)
+        # mcec expects Tuple return type
+        # pyre-ignore
+        return (super().forward(features),)
 
     def _get_name(self) -> str:
         return "QuantManagedCollisionEmbeddingCollection"


### PR DESCRIPTION
Summary: this forward will be called after diff D68991644, so we need to make sure the return type is consistent with ManagedCollisionEmbeddingCollection

Reviewed By: jma99fb

Differential Revision: D71250093


