### PR TITLE
Replace LR access with wrapper

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -190,7 +190,7 @@ class KeyValueEmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate,
+            "lr": emb_module.get_learning_rate(),
         }
 
         params: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}
@@ -383,7 +383,7 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate,
+            "lr": emb_module.get_learning_rate(),
         }
 
         params: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}

--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -68,7 +68,7 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
         state: Dict[Any, Any] = {}
         param_group: Dict[str, Any] = {
             "params": [],
-            "lr": emb_module.optimizer_args.learning_rate,
+            "lr": emb_module.get_learning_rate(),
         }
 
         params: Dict[str, torch.Tensor] = {}


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/3849

X-link: https://github.com/facebookresearch/FBGEMM/pull/937

Currently, `learning_rate` has been accessed directly through `optimizer_args.learning_rate`. Hence, any changes to `learning_rate` will be affected.

This diff adds a wrapper function for accessing `learning_rate`.

**Usage**
```
emb_op = SplitTableBatchedEmbeddingBagsCodegen(....)
lr = emb_op.get_learning_rate()
```

We plan to remove `learning_rate` from `optimizer_args` to avoid recompilation in PT2.
- PT2 adds a guard on the float inputs, and if the value is changed, it will be recompiled.  
- Re-compilation is expensive
- Especially during warm up stage in e2e training, learning rate changes gradually for each iteration. If there is 10k warm up step, it recompiles 10k times.
- Hence, we cannot keep `learning_rate` as float

More context in D65511904.

Differential Revision: D71444136


