### PR TITLE
Enable Ebc Heterogenous Sharding

### DIFF
--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -232,6 +232,7 @@ class QuantBatchedEmbeddingBag(
         pg: Optional[dist.ProcessGroup] = None,
         device: Optional[torch.device] = None,
         fused_params: Optional[Dict[str, Any]] = None,
+        shard_index: Optional[int] = None,
     ) -> None:
         super().__init__(config, pg, device)
 
@@ -253,7 +254,9 @@ class QuantBatchedEmbeddingBag(
             fused_params
         )
 
-        self._runtime_device: torch.device = _get_runtime_device(device, config)
+        self._runtime_device: torch.device = _get_runtime_device(
+            device, config, shard_index
+        )
         # 16 for CUDA, 1 for others like CPU and MTIA.
         self._tbe_row_alignment: int = 16 if self._runtime_device.type == "cuda" else 1
         embedding_specs = []

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -752,6 +752,7 @@ class InferRwPooledEmbeddingSharding(
             world_size=self._world_size,
             fused_params=fused_params,
             device=device if device is not None else self._device,
+            device_type_from_sharding_infos=self._device_type_from_sharding_infos,
         )
 
     def create_output_dist(


### PR DESCRIPTION
Summary: Enable Ebc Heterogenous Sharding so that a single Ebc table can be sharded across hbm and cpu

Differential Revision: D70229136


