### PR TITLE
Always remove the num_batch key from the checkpoint dict

### DIFF
--- a/torchrec/metrics/tests/test_throughput.py
+++ b/torchrec/metrics/tests/test_throughput.py
@@ -323,7 +323,7 @@ class ThroughputMetricTest(unittest.TestCase):
 
     def test_load_state_dict_hook_restores_value(self) -> None:
         """
-        Checks that load_state_dict_hook correctly restores the 'num_batch' value
+        Checks that the load_state_dict_hook correctly restores the 'num_batch' value
         from the state_dict.
         """
         throughput_metric = ThroughputMetric(
@@ -337,3 +337,43 @@ class ThroughputMetricTest(unittest.TestCase):
         state_dict[f"{prefix}num_batch"] = torch.tensor(10, dtype=torch.long)
         throughput_metric.load_state_dict_hook(state_dict, prefix, {}, True, [], [], [])
         self.assertEqual(throughput_metric._num_batch, 10)
+
+    def test_load_state_dict_hook_resumes_from_checkpoint_without_bss(self) -> None:
+        """
+        Verifies that the load_state_dict_hook correctly handles the case where a
+        previously checkpointed job used the batch_size_stages, but a subsequent job,
+        restored from a checkpoint, isn't using them.
+        """
+        throughput_metric = ThroughputMetric(
+            batch_size=32,
+            world_size=4,
+            window_seconds=100,
+            batch_size_stages=None,  # No batch_size_stages
+        )
+        state_dict: OrderedDict[str, torch.Tensor] = OrderedDict()
+        prefix: str = "test_prefix_"
+        state_dict[f"{prefix}num_batch"] = torch.tensor(10, dtype=torch.long)
+        throughput_metric.load_state_dict_hook(state_dict, prefix, {}, True, [], [], [])
+
+        self.assertFalse(hasattr(throughput_metric, "_num_batch"))
+
+    def test_load_state_dict_hook_resumes_from_checkpoint_with_bss_without_key(
+        self,
+    ) -> None:
+        """
+        Verifies that the load_state_dict_hook correctly handles the case where a
+        previously checkpointed job didn't use batch_size_stages, but a subsequent job,
+        restored from a checkpoint, is using them.
+        """
+        throughput_metric = ThroughputMetric(
+            batch_size=32,
+            world_size=4,
+            window_seconds=100,
+            batch_size_stages=[BatchSizeStage(256, 1), BatchSizeStage(512, None)],
+        )
+        # Empty state_dict
+        state_dict: OrderedDict[str, torch.Tensor] = OrderedDict()
+        prefix: str = "test_prefix_"
+        throughput_metric.load_state_dict_hook(state_dict, prefix, {}, True, [], [], [])
+        # Expecting 0
+        self.assertEqual(throughput_metric._num_batch, 0)

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -305,7 +305,9 @@ class ThroughputMetric(nn.Module):
         error_msgs: List[str],
     ) -> None:
         key = f"{prefix}num_batch"
-        if key in state_dict and self._batch_size_stages is not None:
-            # Restore the number of batches used for the throughput calculation from the state dict
+        if key in state_dict:
+            # If present, pop the number of batches used for the throughput calculation from the state dict
             num_batch_tensor = state_dict.pop(key)
-            self._num_batch = int(num_batch_tensor.item())
+            # Apply the number of batches to the module if using batch_size_stages
+            if self._batch_size_stages is not None:
+                self._num_batch = int(num_batch_tensor.item())


### PR DESCRIPTION
Summary: For the cases where a previously run job used the batch_size_stages, but a subsequent job, restored from a checkpoint, isn't using them

Differential Revision: D71648110


