### PR TITLE
Fix Pyre test on OSS

### DIFF
--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -175,6 +175,7 @@ def _get_dim(name: str, min: Optional[int] = None, max: Optional[int] = None) ->
     """
     dim = f"{name}_{DYNAMIC_DIMS[name]}"
     DYNAMIC_DIMS[name] += 1
+    # pyre-ignore[7]: Expected `DIM` but got `Dim`.
     return Dim(dim, min=min, max=max)
 
 


### PR DESCRIPTION
Summary:
Fixing pyre error: 
````
torchrec/ir/utils.py:178:4 Incompatible return type [7]: Expected `DIM` but got `Dim`.

Differential Revision: D71656776


