### PR TITLE
refactoring ModelInput generation utils

### DIFF
--- a/torchrec/distributed/test_utils/test_input.py
+++ b/torchrec/distributed/test_utils/test_input.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import cast, List, Optional, Tuple, Union
+
+import torch
+from tensordict import TensorDict
+from torchrec.distributed.embedding_types import EmbeddingTableConfig
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.streamable import Pipelineable
+
+
+@dataclass
+class ModelInput(Pipelineable):
+    """
+    basic model input for a simple standard RecSys model
+    the input is a training data batch that contains:
+    1. a tensor for dense features
+    2. a KJT for unweighted sparse features
+    3. a KJT for weighted sparse features
+    4. a tensor for the label
+    """
+
+    float_features: torch.Tensor
+    idlist_features: Optional[KeyedJaggedTensor]
+    idscore_features: Optional[KeyedJaggedTensor]
+    label: torch.Tensor
+
+    def to(self, device: torch.device, non_blocking: bool = False) -> "ModelInput":
+        return ModelInput(
+            float_features=self.float_features.to(
+                device=device, non_blocking=non_blocking
+            ),
+            idlist_features=(
+                self.idlist_features.to(device=device, non_blocking=non_blocking)
+                if self.idlist_features is not None
+                else None
+            ),
+            idscore_features=(
+                self.idscore_features.to(device=device, non_blocking=non_blocking)
+                if self.idscore_features is not None
+                else None
+            ),
+            label=self.label.to(device=device, non_blocking=non_blocking),
+        )
+
+    def record_stream(self, stream: torch.Stream) -> None:
+        self.float_features.record_stream(stream)
+        if isinstance(self.idlist_features, KeyedJaggedTensor):
+            self.idlist_features.record_stream(stream)
+        if isinstance(self.idscore_features, KeyedJaggedTensor):
+            self.idscore_features.record_stream(stream)
+        self.label.record_stream(stream)
+
+    @classmethod
+    def generate_global_and_local_batches(
+        cls,
+        world_size: int,
+        batch_size: int = 1,
+        tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        weighted_tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        num_float_features: int = 16,
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        max_feature_lengths: Optional[List[int]] = None,
+        use_offsets: bool = False,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        offsets_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> Tuple["ModelInput", List["ModelInput"]]:
+        """
+        Returns a global (single-rank training) batch, and a list of local
+        (multi-rank training) batches of world_size. The data should be
+        consistent between the local batches and the global batch so that
+        they can be used for comparison and validation.
+        """
+
+        float_features_list = [
+            (
+                torch.zeros((batch_size, num_float_features), device=device)
+                if all_zeros
+                else torch.rand((batch_size, num_float_features), device=device)
+            )
+            for _ in range(world_size)
+        ]
+        global_idlist_features, idlist_features_list = (
+            ModelInput._create_batched_standard_kjts(
+                batch_size,
+                world_size,
+                tables,
+                pooling_avg,
+                tables_pooling,
+                False,  # unweighted
+                max_feature_lengths,
+                use_offsets,
+                device,
+                indices_dtype,
+                offsets_dtype,
+                lengths_dtype,
+                all_zeros,
+            )
+            if tables is not None and len(tables) > 0
+            else (None, [None for _ in range(world_size)])
+        )
+        global_idscore_features, idscore_features_list = (
+            ModelInput._create_batched_standard_kjts(
+                batch_size,
+                world_size,
+                weighted_tables,
+                pooling_avg,
+                tables_pooling,
+                True,  # weighted
+                max_feature_lengths,
+                use_offsets,
+                device,
+                indices_dtype,
+                offsets_dtype,
+                lengths_dtype,
+                all_zeros,
+            )
+            if weighted_tables is not None and len(weighted_tables) > 0
+            else (None, [None for _ in range(world_size)])
+        )
+        label_list = [
+            (
+                torch.zeros((batch_size,), device=device)
+                if all_zeros
+                else torch.rand((batch_size,), device=device)
+            )
+            for _ in range(world_size)
+        ]
+        global_input = ModelInput(
+            float_features=torch.cat(float_features_list),
+            idlist_features=global_idlist_features,
+            idscore_features=global_idscore_features,
+            label=torch.cat(label_list),
+        )
+        local_inputs = [
+            ModelInput(
+                float_features=float_features,
+                idlist_features=idlist_features,
+                idscore_features=idscore_features,
+                label=label,
+            )
+            for float_features, idlist_features, idscore_features, label in zip(
+                float_features_list,
+                idlist_features_list,
+                idscore_features_list,
+                label_list,
+            )
+        ]
+        return global_input, local_inputs
+
+    @classmethod
+    def generate_local_batches(
+        cls,
+        world_size: int,
+        batch_size: int = 1,
+        tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        weighted_tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        num_float_features: int = 16,
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        max_feature_lengths: Optional[List[int]] = None,
+        use_offsets: bool = False,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        offsets_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> List["ModelInput"]:
+        """
+        Returns multi-rank batches of world_size
+        """
+        return [
+            cls.generate(
+                batch_size=batch_size,
+                tables=tables,
+                weighted_tables=weighted_tables,
+                num_float_features=num_float_features,
+                pooling_avg=pooling_avg,
+                tables_pooling=tables_pooling,
+                max_feature_lengths=max_feature_lengths,
+                use_offsets=use_offsets,
+                device=device,
+                indices_dtype=indices_dtype,
+                offsets_dtype=offsets_dtype,
+                lengths_dtype=lengths_dtype,
+                all_zeros=all_zeros,
+            )
+            for _ in range(world_size)
+        ]
+
+    @classmethod
+    def generate(
+        cls,
+        batch_size: int = 1,
+        tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        weighted_tables: Optional[
+            Union[
+                List[EmbeddingTableConfig],
+                List[EmbeddingBagConfig],
+                List[EmbeddingConfig],
+            ]
+        ] = None,
+        num_float_features: int = 16,
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        max_feature_lengths: Optional[List[int]] = None,
+        use_offsets: bool = False,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        offsets_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> "ModelInput":
+        """
+        Returns a single batch
+        """
+        float_features = (
+            torch.zeros((batch_size, num_float_features), device=device)
+            if all_zeros
+            else torch.rand((batch_size, num_float_features), device=device)
+        )
+        idlist_features = (
+            ModelInput._create_standard_kjt(
+                batch_size=batch_size,
+                tables=tables,
+                pooling_avg=pooling_avg,
+                tables_pooling=tables_pooling,
+                weighted=False,  # unweighted
+                max_feature_lengths=max_feature_lengths,
+                use_offsets=use_offsets,
+                device=device,
+                indices_dtype=indices_dtype,
+                offsets_dtype=offsets_dtype,
+                lengths_dtype=lengths_dtype,
+                all_zeros=all_zeros,
+            )
+            if tables is not None and len(tables) > 0
+            else None
+        )
+        idscore_features = (
+            ModelInput._create_standard_kjt(
+                batch_size=batch_size,
+                tables=weighted_tables,
+                pooling_avg=pooling_avg,
+                tables_pooling=tables_pooling,
+                weighted=False,  # weighted
+                max_feature_lengths=max_feature_lengths,
+                use_offsets=use_offsets,
+                device=device,
+                indices_dtype=indices_dtype,
+                offsets_dtype=offsets_dtype,
+                lengths_dtype=lengths_dtype,
+                all_zeros=all_zeros,
+            )
+            if weighted_tables is not None and len(weighted_tables) > 0
+            else None
+        )
+        label = (
+            torch.zeros((batch_size,), device=device)
+            if all_zeros
+            else torch.rand((batch_size,), device=device)
+        )
+        return ModelInput(
+            float_features=float_features,
+            idlist_features=idlist_features,
+            idscore_features=idscore_features,
+            label=label,
+        )
+
+    @staticmethod
+    def _create_features_lengths_indices(
+        batch_size: int,
+        tables: Union[
+            List[EmbeddingTableConfig], List[EmbeddingBagConfig], List[EmbeddingConfig]
+        ],
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        max_feature_lengths: Optional[List[int]] = None,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> Tuple[List[str], List[torch.Tensor], List[torch.Tensor]]:
+        pooling_factor_per_feature: List[int] = []
+        num_embeddings_per_feature: List[int] = []
+        max_length_per_feature: List[Optional[int]] = []
+        features: List[str] = []
+        for tid, table in enumerate(tables):
+            pooling_factor = (
+                tables_pooling[tid] if tables_pooling is not None else pooling_avg
+            )
+            max_feature_length = (
+                max_feature_lengths[tid] if max_feature_lengths is not None else None
+            )
+            features.extend(table.feature_names)
+            for _ in table.feature_names:
+                pooling_factor_per_feature.append(pooling_factor)
+                num_embeddings_per_feature.append(
+                    table.num_embeddings_post_pruning or table.num_embeddings
+                )
+                max_length_per_feature.append(max_feature_length)
+
+        lengths_per_feature: List[torch.Tensor] = []
+        indices_per_feature: List[torch.Tensor] = []
+
+        for pooling_factor, num_embeddings, max_length in zip(
+            pooling_factor_per_feature,
+            num_embeddings_per_feature,
+            max_length_per_feature,
+        ):
+            # lengths
+            _lengths = torch.max(
+                torch.normal(
+                    pooling_factor,
+                    pooling_factor / 10,  # std
+                    [batch_size],
+                    device=device,
+                ),
+                torch.tensor(1.0, device=device),
+            ).to(lengths_dtype)
+            if max_length:
+                _lengths = torch.clamp(_lengths, max=max_length)
+            lengths_per_feature.append(_lengths)
+
+            # indices
+            num_indices = cast(int, torch.sum(_lengths).item())
+            _indices = (
+                torch.zeros(
+                    (num_indices,),
+                    dtype=indices_dtype,
+                    device=device,
+                )
+                if all_zeros
+                else torch.randint(
+                    0,
+                    num_embeddings,
+                    (num_indices,),
+                    dtype=indices_dtype,
+                    device=device,
+                )
+            )
+            indices_per_feature.append(_indices)
+        return features, lengths_per_feature, indices_per_feature
+
+    @staticmethod
+    def _assemble_kjt(
+        features: List[str],
+        lengths_per_feature: List[torch.Tensor],
+        indices_per_feature: List[torch.Tensor],
+        weighted: bool = False,
+        device: Optional[torch.device] = None,
+        use_offsets: bool = False,
+        offsets_dtype: torch.dtype = torch.int64,
+    ) -> KeyedJaggedTensor:
+        lengths = torch.cat(lengths_per_feature)
+        indices = torch.cat(indices_per_feature)
+        offsets = None
+        weights = torch.rand((indices.numel(),), device=device) if weighted else None
+        if use_offsets:
+            offsets = torch.cat(
+                [torch.tensor([0], device=device), lengths.cumsum(0)]
+            ).to(offsets_dtype)
+            lengths = None
+        return KeyedJaggedTensor(features, indices, weights, lengths, offsets)
+
+    @staticmethod
+    def _create_standard_kjt(
+        batch_size: int,
+        tables: Union[
+            List[EmbeddingTableConfig], List[EmbeddingBagConfig], List[EmbeddingConfig]
+        ],
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        weighted: bool = False,
+        max_feature_lengths: Optional[List[int]] = None,
+        use_offsets: bool = False,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        offsets_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> KeyedJaggedTensor:
+        features, lengths_per_feature, indices_per_feature = (
+            ModelInput._create_features_lengths_indices(
+                batch_size=batch_size,
+                tables=tables,
+                pooling_avg=pooling_avg,
+                tables_pooling=tables_pooling,
+                max_feature_lengths=max_feature_lengths,
+                device=device,
+                indices_dtype=indices_dtype,
+                lengths_dtype=lengths_dtype,
+                all_zeros=all_zeros,
+            )
+        )
+        return ModelInput._assemble_kjt(
+            features=features,
+            lengths_per_feature=lengths_per_feature,
+            indices_per_feature=indices_per_feature,
+            weighted=weighted,
+            device=device,
+            use_offsets=use_offsets,
+            offsets_dtype=offsets_dtype,
+        )
+
+    @staticmethod
+    def _create_batched_standard_kjts(
+        batch_size: int,
+        world_size: int,
+        tables: Union[
+            List[EmbeddingTableConfig], List[EmbeddingBagConfig], List[EmbeddingConfig]
+        ],
+        pooling_avg: int = 10,
+        tables_pooling: Optional[List[int]] = None,
+        weighted: bool = False,
+        max_feature_lengths: Optional[List[int]] = None,
+        use_offsets: bool = False,
+        device: Optional[torch.device] = None,
+        indices_dtype: torch.dtype = torch.int64,
+        offsets_dtype: torch.dtype = torch.int64,
+        lengths_dtype: torch.dtype = torch.int64,
+        all_zeros: bool = False,
+    ) -> Tuple[KeyedJaggedTensor, List[KeyedJaggedTensor]]:
+        data_per_rank = [
+            ModelInput._create_features_lengths_indices(
+                batch_size,
+                tables,
+                pooling_avg,
+                tables_pooling,
+                max_feature_lengths,
+                device,
+                indices_dtype,
+                lengths_dtype,
+                all_zeros,
+            )
+            for _ in range(world_size)
+        ]
+        features = data_per_rank[0][0]
+        local_kjts = [
+            ModelInput._assemble_kjt(
+                features,
+                lengths_per_feature,
+                indices_per_feature,
+                weighted,
+                device,
+                use_offsets,
+                offsets_dtype,
+            )
+            for _, lengths_per_feature, indices_per_feature in data_per_rank
+        ]
+        global_lengths = [
+            data_per_rank[r][1][f]
+            for f in range(len(features))
+            for r in range(world_size)
+        ]
+        global_indices = [
+            data_per_rank[r][2][f]
+            for f in range(len(features))
+            for r in range(world_size)
+        ]
+        global_kjt = ModelInput._assemble_kjt(
+            features,
+            global_lengths,
+            global_indices,
+            weighted,
+            device,
+            use_offsets,
+            offsets_dtype,
+        )
+        return global_kjt, local_kjts
+
+
+# @dataclass
+# class VbModelInput(ModelInput):
+#     pass
+
+#     @staticmethod
+#     def _create_variable_batch_kjt() -> KeyedJaggedTensor:
+#         pass
+
+#     @staticmethod
+#     def _merge_variable_batch_kjts(kjts: List[KeyedJaggedTensor]) -> KeyedJaggedTensor:
+#         pass
+
+
+@dataclass
+class TdModelInput(ModelInput):
+    idlist_features: TensorDict  # pyre-ignore

--- a/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
+++ b/torchrec/distributed/train_pipeline/tests/pipeline_benchmarks.py
@@ -10,7 +10,6 @@
 #!/usr/bin/env python3
 
 import copy
-import multiprocessing
 import os
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type, Union
 
@@ -24,9 +23,13 @@ from torch.optim import Optimizer
 from torchrec.distributed import DistributedModelParallel
 from torchrec.distributed.benchmark.benchmark_utils import benchmark_func
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.test_utils.multi_process import MultiProcessContext
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    run_multi_process_func,
+)
+from torchrec.distributed.test_utils.test_input import ModelInput, TdModelInput
 from torchrec.distributed.test_utils.test_model import (
-    ModelInput,
     TestEBCSharder,
     TestOverArchLarge,
     TestSparseNN,
@@ -42,8 +45,6 @@ from torchrec.distributed.train_pipeline.train_pipelines import (
 )
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
-
-from torchrec.test_utils import get_free_port
 
 
 _pipeline_cls: Dict[str, Type[Union[TrainPipelineBase, TrainPipelineSparseDist]]] = {
@@ -87,7 +88,7 @@ def _gen_pipelines(
     help="Dim embeddings embedding.",
 )
 @click.option(
-    "--n_batches",
+    "--num_batches",
     type=int,
     default=20,
     help="Num of batchs to run.",
@@ -123,12 +124,6 @@ def _gen_pipelines(
     help="Pipeline to run: all, base, sparse, semi, prefetch",
 )
 @click.option(
-    "--multi_process",
-    type=bool,
-    default=True,
-    help="Run in multi process mode.",
-)
-@click.option(
     "--profile",
     type=str,
     default="",
@@ -139,21 +134,17 @@ def main(
     n_features: int,
     ratio_features_weighted: float,
     dim_emb: int,
-    n_batches: int,
+    num_batches: int,
     batch_size: int,
     sharding_type: ShardingType,
     pooling_factor: int,
     input_type: str,
     pipeline: str,
-    multi_process: bool,
     profile: str,
 ) -> None:
     """
     Checks that pipelined training is equivalent to non-pipelined training.
     """
-
-    os.environ["MASTER_ADDR"] = str("localhost")
-    os.environ["MASTER_PORT"] = str(get_free_port())
 
     num_weighted_features = int(n_features * ratio_features_weighted)
     num_features = n_features - num_weighted_features
@@ -176,74 +167,22 @@ def main(
         )
         for i in range(num_weighted_features)
     ]
-    batches = _generate_data(
+
+    run_multi_process_func(
+        func=runner,
         tables=tables,
         weighted_tables=weighted_tables,
-        num_float_features=10,
-        num_batches=n_batches,
+        sharding_type=sharding_type.value,
+        kernel_type=EmbeddingComputeKernel.FUSED.value,
+        fused_params={},
         batch_size=batch_size,
         world_size=world_size,
+        num_batches=num_batches,
         pooling_factor=pooling_factor,
         input_type=input_type,
+        pipelines=pipeline,
+        profile=profile,
     )
-
-    if multi_process:
-        _run_multi_process_test(
-            callable=runner,
-            tables=tables,
-            weighted_tables=weighted_tables,
-            sharding_type=sharding_type.value,
-            kernel_type=EmbeddingComputeKernel.FUSED.value,
-            batches=batches,
-            fused_params={},
-            world_size=world_size,
-            pipelines=pipeline,
-            profile=profile,
-        )
-    else:
-        single_runner(
-            tables=tables,
-            weighted_tables=weighted_tables,
-            sharding_type=sharding_type.value,
-            kernel_type=EmbeddingComputeKernel.FUSED.value,
-            batches=batches,
-            fused_params={},
-            world_size=1,
-            pipelines=pipeline,
-            profile=profile,
-        )
-
-
-def _run_multi_process_test(
-    *,
-    callable: Callable[
-        ...,
-        None,
-    ],
-    world_size: int,
-    # pyre-ignore
-    **kwargs,
-) -> None:
-    ctx = multiprocessing.get_context("spawn")
-    processes = []
-    if world_size == 1:
-        kwargs["world_size"] = 1
-        kwargs["rank"] = 0
-        callable(**kwargs)
-        return
-
-    for rank in range(world_size):
-        kwargs["rank"] = rank
-        kwargs["world_size"] = world_size
-        p = ctx.Process(
-            target=callable,
-            kwargs=kwargs,
-        )
-        p.start()
-        processes.append(p)
-
-    for p in processes:
-        p.join()
 
 
 def _generate_data(
@@ -252,22 +191,31 @@ def _generate_data(
     num_float_features: int = 10,
     num_batches: int = 100,
     batch_size: int = 4096,
-    world_size: int = 1,
     pooling_factor: int = 10,
     input_type: str = "kjt",
-) -> List[List[ModelInput]]:
-    return [
-        ModelInput.generate(
-            tables=tables,
-            weighted_tables=weighted_tables,
-            batch_size=batch_size,
-            world_size=world_size,
-            num_float_features=num_float_features,
-            pooling_avg=pooling_factor,
-            input_type=input_type,
-        )[1]
-        for i in range(num_batches)
-    ]
+) -> List[ModelInput]:
+    if input_type == "kjt":
+        return [
+            ModelInput.generate(
+                tables=tables,
+                weighted_tables=weighted_tables,
+                batch_size=batch_size,
+                num_float_features=num_float_features,
+                pooling_avg=pooling_factor,
+            )
+            for _ in range(num_batches)
+        ]
+    else:
+        return [
+            TdModelInput.generate(
+                tables=tables,
+                weighted_tables=weighted_tables,
+                batch_size=batch_size,
+                num_float_features=num_float_features,
+                pooling_avg=pooling_factor,
+            )
+            for _ in range(num_batches)
+        ]
 
 
 def _generate_sharded_model_and_optimizer(
@@ -313,8 +261,11 @@ def runner(
     sharding_type: str,
     kernel_type: str,
     fused_params: Dict[str, Any],
+    batch_size: int,
     world_size: int,
-    batches: List[List[ModelInput]],
+    num_batches: int,
+    pooling_factor: int,
+    input_type: str,
     pipelines: str,
     profile: str,
 ) -> None:
@@ -347,7 +298,15 @@ def runner(
                 "learning_rate": 0.1,
             },
         )
-        bench_inputs = [batch[rank] for batch in batches]
+        bench_inputs = _generate_data(
+            tables=tables,
+            weighted_tables=weighted_tables,
+            num_float_features=10,
+            num_batches=num_batches,
+            batch_size=batch_size,
+            pooling_factor=pooling_factor,
+            input_type=input_type,
+        )
         for pipeline_clazz in _gen_pipelines(pipelines=pipelines):
             if pipeline_clazz == TrainPipelineSemiSync:
                 # pyre-ignore [28]
@@ -391,78 +350,6 @@ def runner(
             )
             if rank == 0:
                 print(result)
-
-
-def single_runner(
-    tables: List[EmbeddingBagConfig],
-    weighted_tables: List[EmbeddingBagConfig],
-    sharding_type: str,
-    kernel_type: str,
-    fused_params: Dict[str, Any],
-    world_size: int,
-    batches: List[List[ModelInput]],
-    pipelines: str,
-    profile: str,
-) -> None:
-    device = torch.device("cuda")
-    torch.autograd.set_detect_anomaly(True)
-    model = TestSparseNN(
-        tables=tables,
-        weighted_tables=weighted_tables,
-        dense_device=device,
-        sparse_device=device,
-        over_arch_clazz=TestOverArchLarge,
-    ).to(device)
-
-    optimizer = optim.SGD(
-        [param for name, param in model.named_parameters() if "sparse" not in name],
-        lr=0.1,
-    )
-
-    bench_inputs = [batch[0] for batch in batches]
-    for pipeline_clazz in _gen_pipelines(pipelines=pipelines):
-        if pipeline_clazz == TrainPipelineSemiSync:
-            # pyre-ignore [28]
-            pipeline = pipeline_clazz(
-                model=model,
-                optimizer=optimizer,
-                device=device,
-                start_batch=0,
-            )
-        else:
-            pipeline = pipeline_clazz(
-                model=model,
-                optimizer=optimizer,
-                device=device,
-            )
-        pipeline.progress(iter(bench_inputs))
-
-        def _func_to_benchmark(
-            bench_inputs: List[ModelInput],
-            model: nn.Module,
-            pipeline: TrainPipeline,
-        ) -> None:
-            dataloader = iter(bench_inputs)
-            while True:
-                try:
-                    pipeline.progress(dataloader)
-                except StopIteration:
-                    break
-
-        result = benchmark_func(
-            name=pipeline_clazz.__name__,
-            bench_inputs=bench_inputs,  # pyre-ignore
-            prof_inputs=bench_inputs,  # pyre-ignore
-            num_benchmarks=5,
-            num_profiles=2,
-            profile_dir=profile,
-            world_size=world_size,
-            func_to_benchmark=_func_to_benchmark,
-            benchmark_func_kwargs={"model": model, "pipeline": pipeline},
-            rank=0,
-        )
-
-        print(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
# context
* refactor the ModelInput to decouple KJT generation with TD generation
* move run_multi_process_func function into test_utils

Differential Revision: D71556886


