### PR TITLE
Allow undefined libraries to fix CMake errors

### DIFF
--- a/.github/workflows/cpp_unittest_ci_cpu.yml
+++ b/.github/workflows/cpp_unittest_ci_cpu.yml
@@ -47,6 +47,30 @@ jobs:
         conda create -y --name build_binary python=${{ matrix.python-version }}
         conda info
         python --version
+        conda run -n build_binary python --version
+        conda run -n build_binary \
+          pip install torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        conda run -n build_binary \
+          python -c "import torch"
+        echo "torch succeeded"
+        conda run -n build_binary \
+          python -c "import torch.distributed"
+        conda run -n build_binary \
+          pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cpu
+        conda run -n build_binary \
+          python -c "import fbgemm_gpu"
+        echo "fbgemm_gpu succeeded"
+        conda run -n build_binary \
+          pip install -r requirements.txt
+        conda run -n build_binary \
+          python setup.py bdist_wheel \
+          --python-tag=${{ matrix.python-tag }}
+        conda run -n build_binary \
+          python -c "import torchrec"
+        echo "torch.distributed succeeded"
+        conda run -n build_binary \
+          python -c "import numpy"
+        echo "numpy succeeded"
         echo "Starting C++ Tests"
         conda install -n build_binary -y gxx_linux-64
         conda run -n build_binary \
@@ -58,6 +82,8 @@ jobs:
         conda run -n build_binary cmake \
             -DBUILD_TEST=ON \
             -DBUILD_REDIS_IO=ON \
+            -D_GLIBCXX_USE_CXX11_ABI=0 \
+            -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined \
             -DCMAKE_PREFIX_PATH=/opt/conda/envs/build_binary/lib/python${{ matrix.python-version }}/site-packages/torch/share/cmake ..
         conda run -n build_binary make -j
         conda run -n build_binary ctest -V .


### PR DESCRIPTION
Summary:
This should get rid of the `libtorch_cpu.so: undefined reference to `logf@GLIBC_2.27'` etc.. we see in our cpp unit tests on Github CI See: https://fb.workplace.com/groups/1405155842844877/permalink/23944202491846891/

Note there is another error of undefined reference - but it's related to our library not installing google benchmark rather than something inside of torch.so file like the ones mentioned in post.

Differential Revision: D71862824


