### PR TITLE
Dynamic Sharding API + Test for EBC, TW, ShardedTensor

### DIFF
--- a/torchrec/distributed/sharding/dynamic_sharding.py
+++ b/torchrec/distributed/sharding/dynamic_sharding.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Callable, Dict, List, Tuple
+
+import torch
+import torch.distributed as dist
+from torch.distributed._shard.sharded_tensor import Shard
+from torchrec.distributed.types import (
+    ParameterSharding,
+    ShardedModule,
+    ShardedTensor,
+    ShardingEnv,
+)
+
+
+def shards_all_to_all(
+    module: ShardedModule[Any, Any, Any, Any],  # pyre-ignore
+    state_dict: Dict[str, ShardedTensor],
+    device: torch.device,
+    changed_sharding_params: Dict[str, ParameterSharding],
+    env: ShardingEnv,
+    extend_shard_name: Callable[[str], str] = lambda x: x,
+) -> Tuple[List[str], torch.Tensor]:
+    """
+    Performs an all-to-all communication to redistribute shards across ranks based on new sharding parameters.
+    Assumes ranks are ordered in ParameterSharding.ranks.
+
+    Args:
+        module (ShardedEmbeddingBagCollection): The module containing sharded tensors to be redistributed.
+            TODO: Update to support more modules
+
+        state_dict (Dict[str, ShardedTensor]): The state dictionary containing the current sharded tensors.
+
+        device (torch.device): The device on which the output tensors will be placed.
+
+        changed_sharding_params (Dict[str, ParameterSharding]): A dictionary mapping shard names to their new sharding parameters.
+
+        env (ShardingEnv): The sharding environment containing world size and other distributed information.
+
+        extend_shard_name (Callable[[str], str], optional): A function to extend shard names to the full name in state_dict.
+
+    Returns:
+        Tuple[List[str], torch.Tensor]: A tuple containing:
+            - A list of shard names that were sent from a specific rank to the current rank, ordered by rank, then shard order.
+            - The tensor containing all shards received by the current rank after the all-to-all operation.
+    """
+    if env.output_dtensor:
+        raise RuntimeError("We do not yet support DTensor for resharding yet")
+        return
+
+    # Module sharding plan is used to get the source ranks for each shard
+    assert hasattr(module, "module_sharding_plan")
+
+    world_size = env.world_size
+    rank = dist.get_rank()
+    input_splits_per_rank = [[0] * world_size for _ in range(world_size)]
+    output_splits_per_rank = [[0] * world_size for _ in range(world_size)]
+    local_input_tensor = torch.empty([0], device=device)
+    local_output_tensor = torch.empty([0], device=device)
+
+    shard_names_by_src_rank = []
+    for shard_name, param in changed_sharding_params.items():
+        sharded_t = state_dict[extend_shard_name(shard_name)]
+        assert param.ranks is not None
+        dst_ranks = param.ranks
+        state_dict[extend_shard_name(shard_name)]
+        # pyre-ignore
+        src_ranks = module.module_sharding_plan[shard_name].ranks
+
+        # TODO: Implement changing rank sizes for beyond TW sharding
+        assert len(dst_ranks) == len(src_ranks)
+
+        # index needed to distinguish between multiple shards
+        # within the same shardedTensor for each table
+        for i in range(len(src_ranks)):
+            dst_rank = dst_ranks[i]
+            src_rank = src_ranks[i]
+
+            shard_size = sharded_t.metadata().shards_metadata[i].shard_sizes
+            shard_size_dim_0 = shard_size[0]
+            input_splits_per_rank[src_rank][dst_rank] += shard_size_dim_0
+            output_splits_per_rank[dst_rank][src_rank] += shard_size_dim_0
+            if src_rank == rank:
+                local_shards = sharded_t.local_shards()
+                assert len(local_shards) == 1
+                local_input_tensor = torch.cat(
+                    (
+                        local_input_tensor,
+                        sharded_t.local_shards()[0].tensor,
+                    )
+                )
+            if dst_rank == rank:
+                shard_names_by_src_rank.append(shard_name)
+                local_output_tensor = torch.cat(
+                    (local_output_tensor, torch.empty(shard_size, device=device))
+                )
+
+    local_input_splits = input_splits_per_rank[rank]
+    local_output_splits = output_splits_per_rank[rank]
+
+    assert sum(local_output_splits) == len(local_output_tensor)
+    assert sum(local_input_splits) == len(local_input_tensor)
+    dist.all_to_all_single(
+        output=local_output_tensor,
+        input=local_input_tensor,
+        output_split_sizes=local_output_splits,
+        input_split_sizes=local_input_splits,
+        group=dist.group.WORLD,
+    )
+
+    return shard_names_by_src_rank, local_output_tensor
+
+
+def update_state_dict_post_resharding(
+    state_dict: Dict[str, ShardedTensor],
+    shard_names_by_src_rank: List[str],
+    output_tensor: torch.Tensor,
+    new_sharding_params: Dict[str, ParameterSharding],
+    curr_rank: int,
+    extend_shard_name: Callable[[str], str] = lambda x: x,
+) -> Dict[str, ShardedTensor]:
+    """
+    Updates and returns the given state_dict with new placements and
+    local_shards based on the output tensor of the AllToAll collective.
+
+    Args:
+        state_dict (Dict[str, Any]): The state dict to be updated with new shard placements and local shards.
+
+        shard_names_by_src_rank (List[str]): A list of shard names that were sent from a specific rank to the
+            current rank, ordered by rank, then shard order.
+
+        output_tensor (torch.Tensor): The tensor containing the output data from the AllToAll operation.
+
+        new_sharding_params (Dict[str, ParameterSharding]): A dictionary mapping shard names to their new sharding parameters.
+            This should only contain shard names that were updated during the AllToAll operation.
+
+        curr_rank (int): The current rank of the process in the distributed environment.
+
+        extend_shard_name (Callable[[str], str], optional): A function to extend shard names to the full name in state_dict.
+
+    Returns:
+        Dict[str, ShardedTensor]: The updated state dictionary with new shard placements and local shards.
+    """
+    slice_index = 0
+    shard_names_by_src_rank
+
+    shard_name_to_local_output_tensor: Dict[str, torch.Tensor] = {}
+
+    for shard_name in shard_names_by_src_rank:
+        shard_size = state_dict[extend_shard_name(shard_name)].size(0)
+        end_slice_index = slice_index + shard_size
+        shard_name_to_local_output_tensor[shard_name] = output_tensor[
+            slice_index:end_slice_index
+        ]
+        slice_index = end_slice_index
+
+    for shard_name, param in new_sharding_params.items():
+        extended_name = extend_shard_name(shard_name)
+        # pyre-ignore
+        for i in range(len(param.ranks)):
+            # pyre-ignore
+            r = param.ranks[i]
+            sharded_t = state_dict[extended_name]
+            # Update placements
+            sharded_t.metadata().shards_metadata[i].placement = (
+                torch.distributed._remote_device(f"rank:{r}/cuda:{r}")
+            )
+            if r == curr_rank:
+                assert len(output_tensor) > 0
+                # slice output tensor for correct size.
+                sharded_t._local_shards = [
+                    Shard(
+                        tensor=shard_name_to_local_output_tensor[shard_name],
+                        metadata=state_dict[extended_name]
+                        .metadata()
+                        .shards_metadata[i],
+                    )
+                ]
+                break
+            else:
+                sharded_t._local_shards = []
+
+    return state_dict

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import copy
+
+import random
+import unittest
+
+from typing import Any, Dict, List, Optional, Union
+
+import hypothesis.strategies as st
+
+import torch
+
+from hypothesis import given, settings, Verbosity
+from torch import nn
+
+from torchrec import distributed as trec_dist, EmbeddingBagCollection, KeyedJaggedTensor
+from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
+
+from torchrec.distributed.sharding_plan import (
+    construct_module_sharding_plan,
+    get_module_to_default_sharders,
+    table_wise,
+)
+
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+
+from torchrec.distributed.types import (
+    EmbeddingModuleShardingPlan,
+    ParameterSharding,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import data_type_to_dtype, EmbeddingBagConfig
+
+from torchrec.test_utils import skip_if_asan_class
+from torchrec.types import DataType
+
+
+# Utils:
+def table_name(i: int) -> str:
+    return "table_" + str(i)
+
+
+def feature_name(i: int) -> str:
+    return "feature_" + str(i)
+
+
+def generate_input_by_world_size(
+    world_size: int,
+    num_tables: int,
+    num_embeddings: int = 4,
+    max_mul: int = 3,
+) -> List[KeyedJaggedTensor]:
+    # TODO merge with new ModelInput generator in TestUtils
+    kjt_input_per_rank = []
+    mul = random.randint(1, max_mul)
+    total_size = num_tables * mul
+
+    for _ in range(world_size):
+        feature_names = [feature_name(i) for i in range(num_tables)]
+        lengths = []
+        values = []
+        counting_l = 0
+        for i in range(total_size):
+            if i == total_size - 1:
+                lengths.append(total_size - counting_l)
+                break
+            next_l = random.randint(0, total_size - counting_l)
+            values.extend(
+                [random.randint(0, num_embeddings - 1) for _ in range(next_l)]
+            )
+            lengths.append(next_l)
+            counting_l += next_l
+
+        # for length in lengths:
+
+        kjt_input_per_rank.append(
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=feature_names,
+                values=torch.LongTensor(values),
+                lengths=torch.LongTensor(lengths),
+            )
+        )
+
+    return kjt_input_per_rank
+
+
+def generate_embedding_bag_config(
+    data_type: DataType,
+    num_tables: int = 3,
+    embedding_dim: int = 16,
+    num_embeddings: int = 4,
+) -> List[EmbeddingBagConfig]:
+    embedding_bag_config = []
+    for i in range(num_tables):
+        embedding_bag_config.append(
+            EmbeddingBagConfig(
+                name=table_name(i),
+                feature_names=[feature_name(i)],
+                embedding_dim=embedding_dim,
+                num_embeddings=num_embeddings,
+                data_type=data_type,
+            ),
+        )
+    return embedding_bag_config
+
+
+def create_test_initial_state_dict(
+    sharded_module_type: nn.Module,
+    num_tables: int,
+    data_type: DataType,
+    embedding_dim: int = 16,
+    num_embeddings: int = 4,
+) -> Dict[str, torch.Tensor]:
+    """
+    Helpful for debugging:
+
+    initial_state_dict = {
+        "embedding_bags.table_0.weight": torch.tensor(
+            [
+                [1] * 16,
+                [2] * 16,
+                [3] * 16,
+                [4] * 16,
+            ],
+        ),
+        "embedding_bags.table_1.weight": torch.tensor(
+            [
+                [101] * 16,
+                [102] * 16,
+                [103] * 16,
+                [104] * 16,
+            ],
+            dtype=data_type_to_dtype(data_type),
+        ),
+        ...
+    }
+    """
+
+    initial_state_dict = {}
+    for i in range(num_tables):
+        # pyre-ignore
+        extended_name = sharded_module_type.extend_shard_name(table_name(i))
+        initial_state_dict[extended_name] = torch.tensor(
+            [[j + (i * 100)] * embedding_dim for j in range(num_embeddings)],
+            dtype=data_type_to_dtype(data_type),
+        )
+
+    return initial_state_dict
+
+
+def are_modules_identical(
+    module1: Union[EmbeddingBagCollection, ShardedEmbeddingBagCollection],
+    module2: Union[EmbeddingBagCollection, ShardedEmbeddingBagCollection],
+) -> None:
+    # Check if both modules have the same type
+    assert type(module1) is type(module2)
+
+    # Check if both modules have the same parameters
+    params1 = list(module1.named_parameters())
+    params2 = list(module2.named_parameters())
+
+    assert len(params1) == len(params2)
+
+    for param1, param2 in zip(params1, params2):
+        # Check parameter names
+        assert param1[0] == param2[0]
+        # Check parameter values
+        assert torch.allclose(param1[1], param2[1])
+
+    # Check if both modules have the same buffers
+    buffers1 = list(module1.named_buffers())
+    buffers2 = list(module2.named_buffers())
+
+    assert len(buffers1) == len(buffers2)
+
+    for buffer1, buffer2 in zip(buffers1, buffers2):
+        assert buffer1[0] == buffer2[0]  # Check buffer names
+        assert torch.allclose(buffer1[1], buffer2[1])  # Check buffer values
+
+
+def output_sharding_plan_delta(
+    old_plan: EmbeddingModuleShardingPlan, new_plan: EmbeddingModuleShardingPlan
+) -> EmbeddingModuleShardingPlan:
+    assert len(old_plan) == len(new_plan)
+    return_plan = copy.deepcopy(new_plan)
+    for shard_name, old_param in old_plan.items():
+        if shard_name not in return_plan:
+            raise ValueError(f"Shard {shard_name} not found in new plan")
+        new_param = return_plan[shard_name]
+        old_ranks = old_param.ranks
+        new_ranks = new_param.ranks
+        if old_ranks == new_ranks:
+            del return_plan[shard_name]
+
+    return return_plan
+
+
+def _test_ebc_resharding(
+    tables: List[EmbeddingBagConfig],
+    initial_state_dict: Dict[str, Any],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    backend: str,
+    module_sharding_plan: EmbeddingModuleShardingPlan,
+    new_module_sharding_plan: EmbeddingModuleShardingPlan,
+    local_size: Optional[int] = None,
+) -> None:
+    """
+    Distributed call to test resharding for ebc by creating 2 models with identical config and
+    states:
+        m1 sharded with new_module_sharding_plan
+        m2 sharded with module_sharding_plan, then resharded with new_module_sharding_plan
+
+    Expects m1 and resharded m2 to be the same, and predictions outputted from the same KJT
+    inputs to be the same.
+
+    TODO: modify to include other modules once dynamic sharding is built out.
+    """
+    trec_dist.comm_ops.set_gradient_division(False)
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
+
+        initial_state_dict = {
+            fqn: tensor.to(ctx.device) for fqn, tensor in initial_state_dict.items()
+        }
+        m1 = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+
+        m2 = EmbeddingBagCollection(
+            tables=tables,
+            device=ctx.device,
+        )
+
+        # Load initial State - making sure models are identical
+        m1.load_state_dict(initial_state_dict)
+        copy_state_dict(
+            loc=m1.state_dict(),
+            glob=copy.deepcopy(initial_state_dict),
+        )
+
+        m2.load_state_dict(initial_state_dict)
+        copy_state_dict(
+            loc=m2.state_dict(),
+            glob=copy.deepcopy(initial_state_dict),
+        )
+
+        sharder = get_module_to_default_sharders()[type(m1)]
+
+        # pyre-ignore
+        env = ShardingEnv.from_process_group(ctx.pg)
+
+        sharded_m1 = sharder.shard(
+            module=m1,
+            params=new_module_sharding_plan,
+            env=env,
+            device=ctx.device,
+        )
+
+        sharded_m2 = sharder.shard(
+            module=m1,
+            params=module_sharding_plan,
+            env=env,
+            device=ctx.device,
+        )
+
+        new_module_sharding_plan_delta = output_sharding_plan_delta(
+            module_sharding_plan, new_module_sharding_plan
+        )
+
+        # pyre-ignore
+        resharded_m2 = sharder.reshard(
+            sharded_module=sharded_m2,
+            changed_shard_to_params=new_module_sharding_plan_delta,
+            env=env,
+            device=ctx.device,
+        )
+
+        are_modules_identical(sharded_m1, resharded_m2)
+
+        feature_keys = []
+        for table in tables:
+            feature_keys.extend(table.feature_names)
+
+        # For current test model and inputs, the prediction should be the exact same
+        rtol = 0
+        atol = 0
+
+        for _ in range(world_size):
+            # sharded model
+            # each rank gets a subbatch
+            sharded_m1_pred_kt_no_dict = sharded_m1(kjt_input_per_rank[ctx.rank])
+            resharded_m2_pred_kt_no_dict = resharded_m2(kjt_input_per_rank[ctx.rank])
+
+            sharded_m1_pred_kt = sharded_m1_pred_kt_no_dict.to_dict()
+            resharded_m2_pred_kt = resharded_m2_pred_kt_no_dict.to_dict()
+            sharded_m1_pred = torch.stack(
+                [sharded_m1_pred_kt[feature] for feature in feature_keys]
+            )
+
+            resharded_m2_pred = torch.stack(
+                [resharded_m2_pred_kt[feature] for feature in feature_keys]
+            )
+            # cast to CPU because when casting unsharded_model.to on the same module, there could some race conditions
+            # in normal author modelling code this won't be an issue because each rank would individually create
+            # their model. output from sharded_pred is correctly on the correct device.
+
+            # Compare predictions of sharded vs unsharded models.
+            torch.testing.assert_close(
+                sharded_m1_pred.cpu(), resharded_m2_pred.cpu(), rtol=rtol, atol=atol
+            )
+
+            sharded_m1_pred.sum().backward()
+            resharded_m2_pred.sum().backward()
+
+
+@skip_if_asan_class
+class MultiRankDynamicShardingTest(MultiProcessTestBase):
+    def _run_ebc_resharding_test(
+        self,
+        per_param_sharding: Dict[str, ParameterSharding],
+        new_per_param_sharding: Dict[str, ParameterSharding],
+        num_tables: int,
+        world_size: int,
+        data_type: DataType,
+        embedding_dim: int = 16,
+        num_embeddings: int = 4,
+    ) -> None:
+        embedding_bag_config = generate_embedding_bag_config(
+            data_type, num_tables, embedding_dim, num_embeddings
+        )
+
+        module_sharding_plan = construct_module_sharding_plan(
+            EmbeddingBagCollection(tables=embedding_bag_config),
+            # pyre-ignore
+            per_param_sharding=per_param_sharding,
+            local_size=world_size,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+        )
+
+        new_module_sharding_plan = construct_module_sharding_plan(
+            EmbeddingBagCollection(tables=embedding_bag_config),
+            # pyre-ignore
+            per_param_sharding=new_per_param_sharding,
+            local_size=world_size,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+        )
+
+        # Row-wise not supported on gloo
+        if (
+            not torch.cuda.is_available()
+            and new_module_sharding_plan["table_0"].sharding_type
+            == ShardingType.ROW_WISE.value
+        ):
+            return
+
+        kjt_input_per_rank = generate_input_by_world_size(
+            world_size, num_tables, num_embeddings
+        )
+
+        # initial_state_dict filled with deterministic dummy values
+        initial_state_dict = create_test_initial_state_dict(
+            ShardedEmbeddingBagCollection,  # pyre-ignore
+            num_tables,
+            data_type,
+            embedding_dim,
+            num_embeddings,
+        )
+
+        self._run_multi_process_test(
+            callable=_test_ebc_resharding,
+            world_size=world_size,
+            tables=embedding_bag_config,
+            initial_state_dict=initial_state_dict,
+            kjt_input_per_rank=kjt_input_per_rank,
+            backend="nccl" if torch.cuda.is_available() else "gloo",
+            module_sharding_plan=module_sharding_plan,
+            new_module_sharding_plan=new_module_sharding_plan,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @given(  # pyre-ignore
+        num_tables=st.sampled_from([2, 3, 4]),
+        data_type=st.sampled_from([DataType.FP32, DataType.FP16]),
+        world_size=st.sampled_from([2, 4]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    def test_dynamic_sharding_ebc_tw(
+        self,
+        num_tables: int,
+        data_type: DataType,
+        world_size: int,
+    ) -> None:
+        # Tests EBC dynamic sharding implementation for TW
+
+        # Cannot include old/new rank generation with hypothesis library due to depedency on world_size
+        old_ranks = [random.randint(0, world_size - 1) for _ in range(num_tables)]
+        new_ranks = [random.randint(0, world_size - 1) for _ in range(num_tables)]
+
+        if new_ranks == old_ranks:
+            return
+        per_param_sharding = {}
+        new_per_param_sharding = {}
+
+        # Construct parameter shardings
+        for i in range(num_tables):
+            per_param_sharding[table_name(i)] = table_wise(rank=old_ranks[i])
+            new_per_param_sharding[table_name(i)] = table_wise(rank=new_ranks[i])
+
+        self._run_ebc_resharding_test(
+            per_param_sharding,
+            new_per_param_sharding,
+            num_tables,
+            world_size,
+            data_type,
+        )


### PR DESCRIPTION
Summary:
Add initial dynamic sharding API and test. This current version supports EBC, TW, and Sharded Tensor. Other variants beyond those configurations (e.g. CW, RW, DTensor etc..) to be added in next few diffs.

Motivation for Dynamic Sharding: [Doc [Work in Progress]](https://docs.google.com/document/d/1ujIZTV7VAcPSar34__255m4tOdMv1TtsI-1Zrl8bPIQ/edit?tab=t.0#heading=h.bx4cw5g8bu8g)
Design: [WIP]

What's added here: 
1. A `reshard` API which implements the `update_shards` APIs for `ShardedEmbeddingBagCollection`
2. Util functions for dynamic sharding - these are used by the `update_shards` API:
    1. `extend_shard_name`: for extending `table_i` to `embedding_bags.table_i.weight`
    2. `shards_all_to_all`: containing the all to all collective call to redistribute shards in a distributed environment, based on the `changed_sharding_params`
    3. `update_state_dict_post_resharding`: for updating a given `state_dict` with new shard `placements` and `local_shards`. 

3. A multi-process unit test `test_dynamic_sharding_ebc_tw` testing TW sharded EBCs calling the `reshard` API, sampling from  various: `world_sizes`, `num_tables`, `data_types`. 
    1. This unit test also uses a few utils to generate random inputs and rank placements. A future todo will be to merge this input generation to use the generate call hereD71703434 

Future work items (features not yet supported in this diff):
* CW, RW, and many other sharding types
* Optimizer saving
* DTensor implementation

Differential Revision: D69095169


