### PR TITLE
Simplify permute indices for Sharded EBC output_dist creation

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1172,16 +1172,13 @@ class ShardedEmbeddingBagCollection(
         for i, name in enumerate(self._uncombined_embedding_names):
             embedding_name_order.setdefault(name, i)
 
-        def sort_key(input: Tuple[int, str]) -> Tuple[int, int]:
-            index, name = input
-            return (embedding_name_order[name], embedding_shard_offsets[index])
-
-        permute_indices = [
-            i
-            for i, _ in sorted(
-                enumerate(self._uncombined_embedding_names), key=sort_key
-            )
-        ]
+        permute_indices = sorted(
+            range(len(self._uncombined_embedding_names)),
+            key=lambda i: (
+                embedding_name_order[self._uncombined_embedding_names[i]],
+                embedding_shard_offsets[i],
+            ),
+        )
         self._permute_op: PermutePooledEmbeddings = PermutePooledEmbeddings(
             self._uncombined_embedding_dims, permute_indices, self._device
         )

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -175,7 +175,6 @@ def _get_dim(name: str, min: Optional[int] = None, max: Optional[int] = None) ->
     """
     dim = f"{name}_{DYNAMIC_DIMS[name]}"
     DYNAMIC_DIMS[name] += 1
-    # pyre-ignore[7]: Expected `DIM` but got `Dim`.
     return Dim(dim, min=min, max=max)
 
 


### PR DESCRIPTION
Summary: Simplify create_output_dist call

Differential Revision: D72079015


