### PR TITLE
Fix return results of forward method of DecoupleEmbeddingColletion

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -1189,7 +1189,9 @@ class ShardedMCECLookup(torch.nn.Module):
     def forward(
         self,
         features: KeyedJaggedTensor,
-    ) -> torch.Tensor:
+    ) -> Tuple[
+        Union[KeyedTensor, Dict[str, JaggedTensor]], Optional[KeyedJaggedTensor]
+    ]:
         remapped_kjt = self._mcc_remapper(features)
         return self._ec_lookup(remapped_kjt)
 

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -1091,15 +1091,16 @@ class QuantManagedCollisionEmbeddingCollection(EmbeddingCollection):
         )
         return self
 
+    # pyre-ignore
     def forward(
         self,
         features: KeyedJaggedTensor,
-    ) -> Dict[str, JaggedTensor]:
+    ) -> Tuple[
+        Union[KeyedTensor, Dict[str, JaggedTensor]], Optional[KeyedJaggedTensor]
+    ]:
         features = self._managed_collision_collection(features)
 
-        # mcec expects Tuple return type
-        # pyre-ignore
-        return (super().forward(features),)
+        return (super().forward(features), features)
 
     def _get_name(self) -> str:
         return "QuantManagedCollisionEmbeddingCollection"


### PR DESCRIPTION
Summary: The decouple_di_pass will replace ManagedCollisionEmbeddingCollection with DecoupleEmbeddingColletion. The forward method of the former returns a tuple of the embedding results and the features inself (Tuple[Dict[str, KJT], KJT]), but the latter only returns the embedding results (Dict[str, KJT]). This caused incompatibility issues in following TGIF transform passes, namely QuantizationPass.

Differential Revision: D71412636


