### PR TITLE
Update build-wheels-linux runner to Ubuntu-24.04

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -27,7 +27,7 @@ jobs:
       with-rocm: false
   filter-matrix:
     needs: generate-matrix
-    runs-on: linux.20_04.4x
+    runs-on: linux.24_04.4x
     outputs:
       matrix: ${{ steps.filter.outputs.matrix }}
     steps:


### PR DESCRIPTION
As Ubuntu-20.04 reaches EOL in April 2025