### PR TITLE
Update comment in VectorCrossNet in crossnet.py to correctly reflect …

### DIFF
--- a/torchrec/modules/crossnet.py
+++ b/torchrec/modules/crossnet.py
@@ -196,7 +196,7 @@ class VectorCrossNet(torch.nn.Module):
 
     On each layer l, the tensor is transformed into
 
-    .. math::    x_{l+1} = x_0 * (W_l . x_l + b_l) + x_l
+    .. math::    x_{l+1} = x_0 * (W_l . x_l) + b_l + x_l
 
     where :math:`W_l` is either a vector, :math:`*` means element-wise multiplication;
     :math:`.` means dot operations.


### PR DESCRIPTION
…the code and spec in DCN V1 paper

The original comment mentioned the bias was scaled by x_0. The paper mentions the bias is a separate term in the update

https://arxiv.org/abs/1708.05123

Section 2.2. Mentions the update eqn in the cross Network 


X_{l+1} = x_0 x_l^T  w_l + b_l + x_l

