### PR TITLE
2/n Replace Input Generation + Documentation

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -855,6 +855,12 @@ class ShardedEmbeddingBagCollection(
         """
         This provides consistency between this class and the EmbeddingBagCollection's
         nn.Module API calls (state_dict, named_modules, etc)
+
+        Args:
+            skip_registering (bool): If True, skips registering state_dict hooks. This is useful
+                for dynamic sharding where the state_dict hooks do not need to be
+                reregistered when being resharded. Default is False.
+
         """
         self.embedding_bags: nn.ModuleDict = nn.ModuleDict()
         for table_name in self._table_names:


### PR DESCRIPTION
Summary:
* Using refactored `ModelInput` generation from D71556886 for dynamic sharding unit test. This will be important for CW sharding since existing input generation call here is insufficient for handling multiple shards per table. 

* Add additional docs explaining uses for some Dynamic Sharding API

* Rename ModelInput kjt creation method to indicate static use outside of ModelInput class

Reviewed By: TroyGarden

Differential Revision: D72798357


