### PR TITLE
[HKV] enable customized emb lookup kernel for TorchRec

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -70,6 +70,7 @@ class EmbeddingComputeKernel(Enum):
     QUANT_UVM = "quant_uvm"
     QUANT_UVM_CACHING = "quant_uvm_caching"
     KEY_VALUE = "key_value"
+    CUSTOMIZED_KERNEL = "customized_kernel"
 
 
 def compute_kernel_to_embedding_location(

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -301,7 +301,11 @@ class AutoSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
     def compute_kernels(
         self, sharding_type: str, compute_device_type: str
     ) -> List[str]:
-        return [k.value for k in EmbeddingComputeKernel]
+        return [
+            k.value
+            for k in EmbeddingComputeKernel
+            if k is not EmbeddingComputeKernel.CUSTOMIZED_KERNEL
+        ]
 
 
 class TestAutoPlannerWithScaleupProposer(unittest.TestCase):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -693,10 +693,9 @@ class KeyValueParams:
 @dataclass
 class ParameterSharding:
     """
-        Describes the sharding of the parameter.
+        Describes (configures) the sharding of a parameter, which usually corresponds to a (feature) table.
 
-        sharding_type (str): how this parameter is sharded. See ShardingType for well-known
-            types.
+        sharding_type (str): how this parameter is sharded. See ShardingType for well-known types.
         compute_kernel (str): compute kernel to be used by this parameter.
         ranks (Optional[List[int]]): rank of each shard.
         sharding_spec (Optional[ShardingSpec]): list of ShardMetadata for each shard.
@@ -709,8 +708,7 @@ class ParameterSharding:
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
-      ShardingType.COLUMN_WISE - rank where the embedding shards are placed, seen as
-      individual tables
+      ShardingType.COLUMN_WISE - rank where the embedding shards are placed, seen as individual tables
       ShardingType.TABLE_ROW_WISE  - first rank when this embedding is placed
       ShardingType.ROW_WISE, ShardingType.DATA_PARALLEL - unused
 

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -436,6 +436,16 @@ def add_params_from_parameter_sharding(
             "caching params will be ignored"
         )
 
+    # calling `get_additional_fused_params` for customized kernel
+    # it will be updated to the `fused_params` dict
+    if hasattr(
+        parameter_sharding, "get_additional_fused_params"
+    ) and parameter_sharding.compute_kernel in {
+        EmbeddingComputeKernel.CUSTOMIZED_KERNEL.value
+    }:
+        # type: ignore[attr-defined]
+        fused_params.update(parameter_sharding.get_additional_fused_params())
+
     return fused_params
 
 


### PR DESCRIPTION
Summary:
# context
* NVIDIA dynamicemb package depends on an old TorchRec release (r0.7) plus a PR ([#2533](https://github.com/pytorch/torchrec/pull/2533))
* The goal is to refactor the PR ([#2533](https://github.com/pytorch/torchrec/pull/2533)) on trunk so that torchrec can accept customized kernel.

# design rationales
* Given the fact that the [`EmbeddingComputeKernel`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/embedding_types.py#L64-L72) is a Enum class which can't be dynamically extended outside of TorchRec codebase, we are adding a placeholder type named `customized_kernel` for all customized compute kernels.
* `compute_kernel` is set in [ParameterSharding](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/types.py#L694), along with `sharding_type`, `sharding_specs`, etc. User can subclass the `ParameterSharding` dataclass to add more configs and parameters needed by the customized compute kernel, including something like `customized_compute_kernel` to specify the exact one in case there are many. 
* In order to propagate some [extra config](https://fburl.com/code/bnwp44sz) to the customized kernel, we add a `get_additional_fused_params` to propagate the params to `fused_params`. (we might consider to move the [`add_params_from_parameter_sharding`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/utils.py#L359) function to a class function of ParameterSharding, so that the user can modify the function when necessary.

NOTE: `fused_params` is originally used for passing necessary parameters to the fbgemm lookup kernels (e.g., TBE, see below). It now seems to be just a convenient way of [propagating configs to the kernel from `ParametersSharding`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/utils.py#L359).
```
(Pdb) group_fused_params
{'optimizer': <EmbOptimType.EXACT_ADAGRAD: 'exact_adagrad'>, 'learning_rate': 0.1}
```

* besides the lookup module, very often the customized kernel also needs a customized input_dist and/or a customized output_dist. they all come from [EmbeddingSharding](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/embedding_sharding.py#L964) and its [child classes](https://github.com/pytorch/torchrec/tree/main/torchrec/distributed/sharding) like cw_sharding, tw_sharding, etc.
* we make it public for the main API [`create_embedding_sharding`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/embedding.py#L150) function that return a subclass of EmbeddingSharding, which further creates the user-defined input_dist, output_dist, lookup modules and so on.

WARNING: somehow the HKV-based customized compute kernel can't handle `_initialize_torch_state` likely due to the table.weight tensor is no long on the GPU, so it can't really be represented with sharded tensor or DTensor. It's the user's responsibility to correctly handle the state_dict by overriding the `_initialize_torch_state` function.

Differential Revision: D70723583


