### PR TITLE
fix pre-commit issue

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,4 +21,4 @@ jobs:
       - name: Checkout Torchrec
         uses: actions/checkout@v4
       - name: Run pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Summary:
# context
* the pre-commit action is out-of-date
```
install pre-commit
Error: getCacheEntry failed: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```
* update it to latest version

Differential Revision: D73065266


