### PR TITLE
[HKV] Refactor EmbeddingSharding grouping logic (#2082)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -147,88 +147,6 @@ def get_ec_index_dedup() -> bool:
     return EC_INDEX_DEDUP
 
 
-def create_sharding_infos_by_sharding(
-    module: EmbeddingCollectionInterface,
-    table_name_to_parameter_sharding: Dict[str, ParameterSharding],
-    fused_params: Optional[Dict[str, Any]],
-) -> Dict[str, List[EmbeddingShardingInfo]]:
-
-    if fused_params is None:
-        fused_params = {}
-
-    sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = {}
-    # state_dict returns parameter.Tensor, which loses parameter level attributes
-    parameter_by_name = dict(module.named_parameters())
-    # QuantEBC registers weights as buffers (since they are INT8), and so we need to grab it there
-    state_dict = module.state_dict()
-
-    for (
-        config,
-        embedding_names,
-    ) in zip(module.embedding_configs(), module.embedding_names_by_table()):
-        table_name = config.name
-        assert table_name in table_name_to_parameter_sharding
-
-        parameter_sharding = table_name_to_parameter_sharding[table_name]
-        if parameter_sharding.compute_kernel not in [
-            kernel.value for kernel in EmbeddingComputeKernel
-        ]:
-            raise ValueError(
-                f"Compute kernel not supported {parameter_sharding.compute_kernel}"
-            )
-
-        param_name = "embeddings." + config.name + ".weight"
-        assert param_name in parameter_by_name or param_name in state_dict
-        param = parameter_by_name.get(param_name, state_dict[param_name])
-
-        if parameter_sharding.sharding_type not in sharding_type_to_sharding_infos:
-            sharding_type_to_sharding_infos[parameter_sharding.sharding_type] = []
-
-        optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
-        optimizer_classes = getattr(param, "_optimizer_classes", [None])
-
-        assert (
-            len(optimizer_classes) == 1 and len(optimizer_params) == 1
-        ), f"Only support 1 optimizer, given {len(optimizer_classes)}"
-
-        optimizer_class = optimizer_classes[0]
-        optimizer_params = optimizer_params[0]
-        if optimizer_class:
-            optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
-                optimizer_class
-            )
-
-        per_table_fused_params = merge_fused_params(fused_params, optimizer_params)
-        per_table_fused_params = add_params_from_parameter_sharding(
-            per_table_fused_params, parameter_sharding
-        )
-        per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
-
-        sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
-            (
-                EmbeddingShardingInfo(
-                    embedding_config=EmbeddingTableConfig(
-                        num_embeddings=config.num_embeddings,
-                        embedding_dim=config.embedding_dim,
-                        name=config.name,
-                        data_type=config.data_type,
-                        feature_names=copy.deepcopy(config.feature_names),
-                        pooling=PoolingType.NONE,
-                        is_weighted=False,
-                        has_feature_processor=False,
-                        embedding_names=embedding_names,
-                        weight_init_max=config.weight_init_max,
-                        weight_init_min=config.weight_init_min,
-                    ),
-                    param_sharding=parameter_sharding,
-                    param=param,
-                    fused_params=per_table_fused_params,
-                )
-            )
-        )
-    return sharding_type_to_sharding_infos
-
-
 def create_sharding_infos_by_sharding_device_group(
     module: EmbeddingCollectionInterface,
     table_name_to_parameter_sharding: Dict[str, ParameterSharding],
@@ -503,7 +421,7 @@ class ShardedEmbeddingCollection(
         self._output_dtensor: bool = env.output_dtensor
         # TODO get rid of get_ec_index_dedup global flag
         self._use_index_dedup: bool = use_index_dedup or get_ec_index_dedup()
-        sharding_type_to_sharding_infos = create_sharding_infos_by_sharding(
+        sharding_type_to_sharding_infos = self.create_grouped_sharding_infos(
             module,
             table_name_to_parameter_sharding,
             fused_params,
@@ -596,6 +514,92 @@ class ShardedEmbeddingCollection(
 
         if module.device != torch.device("meta"):
             self.load_state_dict(module.state_dict())
+
+    @classmethod
+    def create_grouped_sharding_infos(
+        cls,
+        module: EmbeddingCollectionInterface,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        fused_params: Optional[Dict[str, Any]],
+    ) -> Dict[str, List[EmbeddingShardingInfo]]:
+        """
+        convert ParameterSharding (table_name_to_parameter_sharding: Dict[str, ParameterSharding]) to
+        EmbeddingShardingInfo that are grouped by sharding_type, and propagate the configs/parameters
+        """
+        if fused_params is None:
+            fused_params = {}
+
+        sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = {}
+        # state_dict returns parameter.Tensor, which loses parameter level attributes
+        parameter_by_name = dict(module.named_parameters())
+        # QuantEBC registers weights as buffers (since they are INT8), and so we need to grab it there
+        state_dict = module.state_dict()
+
+        for (
+            config,
+            embedding_names,
+        ) in zip(module.embedding_configs(), module.embedding_names_by_table()):
+            table_name = config.name
+            assert table_name in table_name_to_parameter_sharding
+
+            parameter_sharding = table_name_to_parameter_sharding[table_name]
+            if parameter_sharding.compute_kernel not in [
+                kernel.value for kernel in EmbeddingComputeKernel
+            ]:
+                raise ValueError(
+                    f"Compute kernel not supported {parameter_sharding.compute_kernel}"
+                )
+
+            param_name = "embeddings." + config.name + ".weight"
+            assert param_name in parameter_by_name or param_name in state_dict
+            param = parameter_by_name.get(param_name, state_dict[param_name])
+
+            if parameter_sharding.sharding_type not in sharding_type_to_sharding_infos:
+                sharding_type_to_sharding_infos[parameter_sharding.sharding_type] = []
+
+            optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
+            optimizer_classes = getattr(param, "_optimizer_classes", [None])
+
+            assert (
+                len(optimizer_classes) == 1 and len(optimizer_params) == 1
+            ), f"Only support 1 optimizer, given {len(optimizer_classes)}"
+
+            optimizer_class = optimizer_classes[0]
+            optimizer_params = optimizer_params[0]
+            if optimizer_class:
+                optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
+                    optimizer_class
+                )
+
+            per_table_fused_params = merge_fused_params(fused_params, optimizer_params)
+            per_table_fused_params = add_params_from_parameter_sharding(
+                per_table_fused_params, parameter_sharding
+            )
+            per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
+
+            sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
+                (
+                    EmbeddingShardingInfo(
+                        embedding_config=EmbeddingTableConfig(
+                            num_embeddings=config.num_embeddings,
+                            embedding_dim=config.embedding_dim,
+                            name=config.name,
+                            data_type=config.data_type,
+                            feature_names=copy.deepcopy(config.feature_names),
+                            pooling=PoolingType.NONE,
+                            is_weighted=False,
+                            has_feature_processor=False,
+                            embedding_names=embedding_names,
+                            weight_init_max=config.weight_init_max,
+                            weight_init_min=config.weight_init_min,
+                        ),
+                        param_sharding=parameter_sharding,
+                        param=param,
+                        fused_params=per_table_fused_params,
+                    )
+                )
+            )
+        return sharding_type_to_sharding_infos
 
     @classmethod
     def create_embedding_sharding(

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -170,115 +170,6 @@ def replace_placement_with_meta_device(
             )
 
 
-def create_sharding_infos_by_sharding(
-    module: EmbeddingBagCollectionInterface,
-    table_name_to_parameter_sharding: Dict[str, ParameterSharding],
-    prefix: str,
-    fused_params: Optional[Dict[str, Any]],
-    suffix: Optional[str] = "weight",
-) -> Dict[str, List[EmbeddingShardingInfo]]:
-    """
-    convert ParameterSharding (table_name_to_parameter_sharding: Dict[str, ParameterSharding]) to
-    EmbeddingShardingInfo that are grouped by sharding_type, and propagate the configs/parameters
-    """
-
-    if fused_params is None:
-        fused_params = {}
-
-    shared_feature: Dict[str, bool] = {}
-    for embedding_config in module.embedding_bag_configs():
-        if not embedding_config.feature_names:
-            embedding_config.feature_names = [embedding_config.name]
-        for feature_name in embedding_config.feature_names:
-            if feature_name not in shared_feature:
-                shared_feature[feature_name] = False
-            else:
-                shared_feature[feature_name] = True
-
-    sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = (
-        defaultdict(list)
-    )
-
-    # state_dict returns parameter.Tensor, which loses parameter level attributes
-    parameter_by_name = dict(module.named_parameters())
-    # QuantEBC registers weights as buffers (since they are INT8), and so we need to grab it there
-    state_dict = module.state_dict()
-
-    for config in module.embedding_bag_configs():
-        table_name = config.name
-        assert (
-            table_name in table_name_to_parameter_sharding
-        ), f"{table_name} not in table_name_to_parameter_sharding"
-        parameter_sharding = table_name_to_parameter_sharding[table_name]
-        if parameter_sharding.compute_kernel not in [
-            kernel.value for kernel in EmbeddingComputeKernel
-        ]:
-            raise ValueError(
-                f"Compute kernel not supported {parameter_sharding.compute_kernel}"
-            )
-        embedding_names: List[str] = []
-        for feature_name in config.feature_names:
-            if shared_feature[feature_name]:
-                embedding_names.append(feature_name + "@" + config.name)
-            else:
-                embedding_names.append(feature_name)
-
-        param_name = prefix + table_name
-        if suffix is not None:
-            param_name = f"{param_name}.{suffix}"
-
-        assert param_name in parameter_by_name or param_name in state_dict
-        param = parameter_by_name.get(param_name, state_dict[param_name])
-
-        optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
-        optimizer_classes = getattr(param, "_optimizer_classes", [None])
-
-        assert (
-            len(optimizer_classes) == 1 and len(optimizer_params) == 1
-        ), f"Only support 1 optimizer, given {len(optimizer_classes)} optimizer classes \
-        and {len(optimizer_params)} optimizer kwargs."
-
-        optimizer_class = optimizer_classes[0]
-        optimizer_params = optimizer_params[0]
-        if optimizer_class:
-            optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
-                optimizer_class
-            )
-
-        per_table_fused_params = merge_fused_params(fused_params, optimizer_params)
-        per_table_fused_params = add_params_from_parameter_sharding(
-            per_table_fused_params, parameter_sharding
-        )
-        per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
-
-        sharding_info = EmbeddingShardingInfo(
-            embedding_config=EmbeddingTableConfig(
-                num_embeddings=config.num_embeddings,
-                embedding_dim=config.embedding_dim,
-                name=config.name,
-                data_type=config.data_type,
-                feature_names=copy.deepcopy(config.feature_names),
-                pooling=config.pooling,
-                is_weighted=module.is_weighted(),
-                has_feature_processor=False,
-                embedding_names=embedding_names,
-                weight_init_max=config.weight_init_max,
-                weight_init_min=config.weight_init_min,
-                num_embeddings_post_pruning=(
-                    getattr(config, "num_embeddings_post_pruning", None)
-                    # TODO: Need to check if attribute exists for BC
-                ),
-            ),
-            param_sharding=parameter_sharding,
-            param=param,
-            fused_params=per_table_fused_params,
-        )
-        sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
-            sharding_info
-        )
-    return sharding_type_to_sharding_infos
-
-
 def create_sharding_infos_by_sharding_device_group(
     module: EmbeddingBagCollectionInterface,
     table_name_to_parameter_sharding: Dict[str, ParameterSharding],
@@ -584,7 +475,7 @@ class ShardedEmbeddingBagCollection(
         # output parameters as DTensor in state dict
         self._output_dtensor: bool = env.output_dtensor
         self.sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = (
-            create_sharding_infos_by_sharding(
+            self.create_grouped_sharding_infos(
                 module,
                 table_name_to_parameter_sharding,
                 "embedding_bags.",
@@ -680,6 +571,116 @@ class ShardedEmbeddingBagCollection(
             "cpu",
         ]:
             self.load_state_dict(module.state_dict(), strict=False)
+
+    @classmethod
+    def create_grouped_sharding_infos(
+        cls,
+        module: EmbeddingBagCollectionInterface,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        prefix: str,
+        fused_params: Optional[Dict[str, Any]],
+        suffix: Optional[str] = "weight",
+    ) -> Dict[str, List[EmbeddingShardingInfo]]:
+        """
+        convert ParameterSharding (table_name_to_parameter_sharding: Dict[str, ParameterSharding]) to
+        EmbeddingShardingInfo that are grouped by sharding_type, and propagate the configs/parameters
+        """
+
+        if fused_params is None:
+            fused_params = {}
+
+        shared_feature: Dict[str, bool] = {}
+        for embedding_config in module.embedding_bag_configs():
+            if not embedding_config.feature_names:
+                embedding_config.feature_names = [embedding_config.name]
+            for feature_name in embedding_config.feature_names:
+                if feature_name not in shared_feature:
+                    shared_feature[feature_name] = False
+                else:
+                    shared_feature[feature_name] = True
+
+        sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = (
+            defaultdict(list)
+        )
+
+        # state_dict returns parameter.Tensor, which loses parameter level attributes
+        parameter_by_name = dict(module.named_parameters())
+        # QuantEBC registers weights as buffers (since they are INT8), and so we need to grab it there
+        state_dict = module.state_dict()
+
+        for config in module.embedding_bag_configs():
+            table_name = config.name
+            assert (
+                table_name in table_name_to_parameter_sharding
+            ), f"{table_name} not in table_name_to_parameter_sharding"
+            parameter_sharding = table_name_to_parameter_sharding[table_name]
+            if parameter_sharding.compute_kernel not in [
+                kernel.value for kernel in EmbeddingComputeKernel
+            ]:
+                raise ValueError(
+                    f"Compute kernel not supported {parameter_sharding.compute_kernel}"
+                )
+            embedding_names: List[str] = []
+            for feature_name in config.feature_names:
+                if shared_feature[feature_name]:
+                    embedding_names.append(feature_name + "@" + config.name)
+                else:
+                    embedding_names.append(feature_name)
+
+            param_name = prefix + table_name
+            if suffix is not None:
+                param_name = f"{param_name}.{suffix}"
+
+            assert param_name in parameter_by_name or param_name in state_dict
+            param = parameter_by_name.get(param_name, state_dict[param_name])
+
+            optimizer_params = getattr(param, "_optimizer_kwargs", [{}])
+            optimizer_classes = getattr(param, "_optimizer_classes", [None])
+
+            assert (
+                len(optimizer_classes) == 1 and len(optimizer_params) == 1
+            ), f"Only support 1 optimizer, given {len(optimizer_classes)} optimizer classes \
+            and {len(optimizer_params)} optimizer kwargs."
+
+            optimizer_class = optimizer_classes[0]
+            optimizer_params = optimizer_params[0]
+            if optimizer_class:
+                optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
+                    optimizer_class
+                )
+
+            per_table_fused_params = merge_fused_params(fused_params, optimizer_params)
+            per_table_fused_params = add_params_from_parameter_sharding(
+                per_table_fused_params, parameter_sharding
+            )
+            per_table_fused_params = convert_to_fbgemm_types(per_table_fused_params)
+
+            sharding_info = EmbeddingShardingInfo(
+                embedding_config=EmbeddingTableConfig(
+                    num_embeddings=config.num_embeddings,
+                    embedding_dim=config.embedding_dim,
+                    name=config.name,
+                    data_type=config.data_type,
+                    feature_names=copy.deepcopy(config.feature_names),
+                    pooling=config.pooling,
+                    is_weighted=module.is_weighted(),
+                    has_feature_processor=False,
+                    embedding_names=embedding_names,
+                    weight_init_max=config.weight_init_max,
+                    weight_init_min=config.weight_init_min,
+                    num_embeddings_post_pruning=(
+                        getattr(config, "num_embeddings_post_pruning", None)
+                        # TODO: Need to check if attribute exists for BC
+                    ),
+                ),
+                param_sharding=parameter_sharding,
+                param=param,
+                fused_params=per_table_fused_params,
+            )
+            sharding_type_to_sharding_infos[parameter_sharding.sharding_type].append(
+                sharding_info
+            )
+        return sharding_type_to_sharding_infos
 
     @classmethod
     def create_embedding_bag_sharding(

--- a/torchrec/distributed/planner/tests/test_embedding_utils.py
+++ b/torchrec/distributed/planner/tests/test_embedding_utils.py
@@ -11,8 +11,8 @@ import copy
 import unittest
 
 from torchrec.distributed.embedding import (
-    create_sharding_infos_by_sharding,
     EmbeddingCollectionSharder,
+    ShardedEmbeddingCollection,
 )
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
@@ -79,10 +79,12 @@ class CreateShardingInfoTest(unittest.TestCase):
         )
         self.expected_plan = planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
 
-        self.expected_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            fused_params=None,
+        self.expected_sharding_infos = (
+            ShardedEmbeddingCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                fused_params=None,
+            )
         )
 
     def test_create_sharding_infos_by_sharding_override(self) -> None:
@@ -92,10 +94,12 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # with sharder fused params that will get overridden
         sharder_fused_params = {"enforce_hbm": False}
-        overriden_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),
-            fused_params=sharder_fused_params,
+        overriden_sharding_infos = (
+            ShardedEmbeddingCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),
+                fused_params=sharder_fused_params,
+            )
         )
         for sharding_type, overriden_sharding_info in overriden_sharding_infos.items():
             expected_sharding_info = self.expected_sharding_infos[sharding_type]
@@ -104,10 +108,12 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # with sharder fused params that won't get overridden
         sharder_fused_params = {"ABC": True}
-        not_overriden_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),
-            fused_params=sharder_fused_params,
+        not_overriden_sharding_infos = (
+            ShardedEmbeddingCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),
+                fused_params=sharder_fused_params,
+            )
         )
         for (
             sharding_type,
@@ -138,10 +144,12 @@ class CreateShardingInfoTest(unittest.TestCase):
         # provide that two fused params from sharder
         sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": False}
 
-        combined_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            fused_params=sharder_fused_params,
+        combined_sharding_infos = (
+            ShardedEmbeddingCollection.create_grouped_sharding_infos(
+                self.model,
+                new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                fused_params=sharder_fused_params,
+            )
         )
 
         # directly assertion won't work, since sharding_infos also have parameter_sharding
@@ -152,10 +160,12 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # provide that two fused params from sharder wrongly
         sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": True}
-        wrong_combined_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            fused_params=sharder_fused_params,
+        wrong_combined_sharding_infos = (
+            ShardedEmbeddingCollection.create_grouped_sharding_infos(
+                self.model,
+                new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                fused_params=sharder_fused_params,
+            )
         )
         for (
             sharding_type,

--- a/torchrec/distributed/planner/tests/test_embeddingbag_utils.py
+++ b/torchrec/distributed/planner/tests/test_embeddingbag_utils.py
@@ -11,8 +11,8 @@ import copy
 import unittest
 
 from torchrec.distributed.embeddingbag import (
-    create_sharding_infos_by_sharding,
     EmbeddingBagCollectionSharder,
+    ShardedEmbeddingBagCollection,
 )
 from torchrec.distributed.planner import (
     EmbeddingShardingPlanner,
@@ -79,11 +79,13 @@ class CreateShardingInfoTest(unittest.TestCase):
         )
         self.expected_plan = planner.plan(self.model, [self.sharder])  # pyre-ignore[6]
 
-        self.expected_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            prefix="embedding_bags.",
-            fused_params=None,
+        self.expected_sharding_infos = (
+            ShardedEmbeddingBagCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                prefix="embedding_bags.",
+                fused_params=None,
+            )
         )
 
     def test_create_sharding_infos_by_group_override(self) -> None:
@@ -93,11 +95,13 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # with sharder fused params that will get overridden
         sharder_fused_params = {"enforce_hbm": False}
-        overriden_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),
-            prefix="embedding_bags.",
-            fused_params=sharder_fused_params,
+        overriden_sharding_infos = (
+            ShardedEmbeddingBagCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),
+                prefix="embedding_bags.",
+                fused_params=sharder_fused_params,
+            )
         )
         for sharding_type, overriden_sharding_info in overriden_sharding_infos.items():
             expected_sharding_info = self.expected_sharding_infos[sharding_type]
@@ -106,11 +110,13 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # with sharder fused params that won't get overridden
         sharder_fused_params = {"ABC": True}
-        not_overriden_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            self.expected_plan.get_plan_for_module(""),
-            prefix="embedding_bags.",
-            fused_params=sharder_fused_params,
+        not_overriden_sharding_infos = (
+            ShardedEmbeddingBagCollection.create_grouped_sharding_infos(
+                self.model,
+                self.expected_plan.get_plan_for_module(""),
+                prefix="embedding_bags.",
+                fused_params=sharder_fused_params,
+            )
         )
         for (
             sharding_type,
@@ -141,11 +147,13 @@ class CreateShardingInfoTest(unittest.TestCase):
         # provide that two fused params from sharder
         sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": False}
 
-        combined_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            prefix="embedding_bags.",
-            fused_params=sharder_fused_params,
+        combined_sharding_infos = (
+            ShardedEmbeddingBagCollection.create_grouped_sharding_infos(
+                self.model,
+                new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                prefix="embedding_bags.",
+                fused_params=sharder_fused_params,
+            )
         )
 
         # directly assertion won't work, since sharding_infos also have parameter_sharding
@@ -156,11 +164,13 @@ class CreateShardingInfoTest(unittest.TestCase):
 
         # provide that two fused params from sharder wrongly
         sharder_fused_params = {"enforce_hbm": True, "stochastic_rounding": True}
-        wrong_combined_sharding_infos = create_sharding_infos_by_sharding(
-            self.model,
-            new_plan.get_plan_for_module(""),  # pyre-ignore[6]
-            prefix="embedding_bags.",
-            fused_params=sharder_fused_params,
+        wrong_combined_sharding_infos = (
+            ShardedEmbeddingBagCollection.create_grouped_sharding_infos(
+                self.model,
+                new_plan.get_plan_for_module(""),  # pyre-ignore[6]
+                prefix="embedding_bags.",
+                fused_params=sharder_fused_params,
+            )
         )
         for (
             sharding_type,


### PR DESCRIPTION
Summary:

# context
* previously we use a util function [`create_sharding_infos_by_sharding`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/embedding.py#L150-L229) to group the `sharding_info`s so that a sharded module can create an [`EmbeddingSharding`](https://github.com/pytorch/torchrec/blob/main/torchrec/distributed/embedding.py#L601-L643) with grouped sharding_infos.
* after recent refactoring [#2887](https://github.com/pytorch/torchrec/pull/2887) the `create_embedding_sharding` becomes a public API, it's also reasonable to promote create_sharding_infos_by_sharding as a public API (classmethod) so that user can subclass it and overrides it. 
* since "grouping" is more relevant to this function, we'll rename it as "create_grouped_sharding_infos".

Differential Revision: D58221182


