### PR TITLE
Fix backward compatibility for rec metric fuse states issue

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -10,6 +10,7 @@
 #!/usr/bin/env python3
 
 import abc
+import inspect
 import itertools
 import math
 from collections import defaultdict, deque
@@ -141,9 +142,11 @@ class RecMetricComputation(Metric, abc.ABC):
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        metric_init_signature = inspect.signature(Metric.__init__)
+        if "fuse_state_tensors" in metric_init_signature.parameters:
+            kwargs["fuse_state_tensors"] = fuse_state_tensors
         super().__init__(
             process_group=process_group,
-            fuse_state_tensors=fuse_state_tensors,
             *args,
             **kwargs,
         )


### PR DESCRIPTION
Summary:
`Metric` seems to be wrapped by packages. In some tests, `rec_metric` may import the old version `Metric` that doesn't have `fuse_tensor_states` attribute. This caused breakage: https://www.internalfb.com/diff/D72010614?dst_version_fbid=1727492137979220&transaction_fbid=1212653170466199 in D72010614. 

So this diff fixes that by examining the signature of `Metric` and only input `fuse_tensor_states` when it's there.

Differential Revision: D73217574


