### PR TITLE
Enable custom perf models in MemoryBalancedPartitioner

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -581,13 +581,16 @@ class MemoryBalancedPartitioner(Partitioner):
         self,
         proposal: List[ShardingOption],
         storage_constraint: Topology,
+        perf_model: Optional[PerfModel] = None,
     ) -> List[ShardingOption]:
         """
         Repeatedly calls the GreedyPerfPartitioner to find a plan with perf
         within the tolerance of the original plan that uses the least amount
         of memory.
         """
-        _perf_model: PerfModel = NoopPerfModel(storage_constraint)
+        _perf_model = (
+            perf_model if perf_model else NoopPerfModel(topology=storage_constraint)
+        )
         _partitioner = GreedyPerfPartitioner(
             sort_by=SortBy.PERF, balance_modules=self._balance_modules
         )


### PR DESCRIPTION
Summary:
We are enabling custom perf models while evaluating candidate plans in  `MemoryBalancedPartitioner`. This will enable us to leverage the new critical path model defined in `NoopCriticalPathPerfModel` while trying to construct a memory balanced plan with the greedy partitioner.

Upcoming diffs will modify the greedy partitioner to leverage the new perf model.

Differential Revision: D73292939


