### PR TITLE
[optimization] use pin_memory for ModelInput and minor refactoring

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_sparsenn.py
+++ b/torchrec/distributed/benchmark/benchmark_train_sparsenn.py
@@ -54,8 +54,8 @@ from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 @dataclass
 class RunOptions:
-    world_size: int = 4
-    num_batches: int = 20
+    world_size: int = 2
+    num_batches: int = 10
     sharding_type: ShardingType = ShardingType.TABLE_WISE
     input_type: str = "kjt"
     profile: str = ""
@@ -63,8 +63,8 @@ class RunOptions:
 
 @dataclass
 class EmbeddingTablesConfig:
-    num_unweighted_features: int = 4
-    num_weighted_features: int = 4
+    num_unweighted_features: int = 100
+    num_weighted_features: int = 100
     embedding_feature_dim: int = 512
 
     def generate_tables(

--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -867,6 +867,7 @@ def benchmark_func(
                 profile_memory=True,
                 with_flops=True,
                 with_modules=True,
+                with_stack=False,  # usually we don't want to show the entire stack in the trace
                 on_trace_ready=trace_handler,
             ) as p:
                 for i in range(num_profiles):


### PR DESCRIPTION
Summary:
# context
* this is some BE work and minor refactoring when working on pipeline optimization
* major change is to add "pin_memory" option to the test_input file for `ModelInput` generation:
```
        The `pin_memory()` call for all KJT tensors are important for training benchmark, and
        also valid argument for the prod training scenario: TrainModelInput should be created
        on pinned memory for a fast transfer to gpu. For more on pin_memory:
        https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html#pin-memory
```

* minor refactoring includes 
(1) default parameters for TrainPipeline benchmark so that the embedding size, batch size, etc. are resonable.
(2) fix the batch index error in trace, previously used (curr_index+1)
(3) split the `EmbeddingPipelinedForward` __call__ function into two parts.
* trace comparison: the `pin_memory()` for the ModelInput is critical for a non_blocking cpu to gpu data copy
before copy_batch_to_gpu is the same size as gpu data transfer <img width="2266" height="1306" alt="image" src="https://github.com/user-attachments/assets/1665dedd-8158-4821-a84a-a541a0a3d8d4" />
after: copy_batch_to_gpu is hardly seen in trace <img width="2842" height="1248" alt="image" src="https://github.com/user-attachments/assets/bc6805fe-c722-4d00-a24c-f850134e65a9" />

Differential Revision: D73514639


