### PR TITLE
Change util to return a set of bucket metadata per shard

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -1223,3 +1223,19 @@ class ObjectPoolShardingType(Enum):
 class ObjectPoolShardingPlan(ModuleShardingPlan):
     sharding_type: ObjectPoolShardingType
     inference: bool = False
+
+
+@dataclass
+class ShardingBucketMetadata:
+    """
+    If a table is row-wise sharded with bucketization, this class contains the bucket information for the table.
+
+    Attributes:
+        num_buckets_per_shard (List[int]): Number of buckets in each shard of the table.
+        bucket_offsets_per_shard (List[int]): Index of the first bucket in each shard.
+        bucket_size (int): No. of rows in one bucket.
+    """
+
+    num_buckets_per_shard: List[int]
+    bucket_offsets_per_shard: List[int]
+    bucket_size: int


### PR DESCRIPTION
Summary:
Based on discussions, we are modifying the util to give a master set of metadata about buckets for the given shards.

We will stack a follow up diff for ShardedEC to return this data.

Differential Revision: D73522460


