### PR TITLE
torchrec support on kvzch emb lookup module

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -468,6 +468,8 @@ def _prefetch_and_cached(
     """
     if table.compute_kernel in {
         EmbeddingComputeKernel.KEY_VALUE,
+        EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
+        EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
     }:
         return True
 

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -79,8 +79,16 @@ class EmbeddingComputeKernel(Enum):
     QUANT = "quant"
     QUANT_UVM = "quant_uvm"
     QUANT_UVM_CACHING = "quant_uvm_caching"
-    KEY_VALUE = "key_value"
+    KEY_VALUE = (
+        "key_value"  # ssd as kv backend storage for fully materialized embedding table
+    )
     CUSTOMIZED_KERNEL = "customized_kernel"
+    SSD_VIRTUAL_TABLE = (
+        "ssd_virtual_table"  # ssd as kv backend storage for virtual table
+    )
+    DRAM_VIRTUAL_TABLE = (
+        "dram_virtual_table"  # dram as kv backend storage for virtual table
+    )
 
 
 def compute_kernel_to_embedding_location(
@@ -91,6 +99,8 @@ def compute_kernel_to_embedding_location(
         EmbeddingComputeKernel.FUSED,
         EmbeddingComputeKernel.QUANT,
         EmbeddingComputeKernel.KEY_VALUE,  # use hbm for cache
+        EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,  # use hbm for cache
+        EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,  # use hbm for cache
     ]:
         return EmbeddingLocation.DEVICE
     elif compute_kernel in [
@@ -472,6 +482,8 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.FUSED_UVM.value,
                     EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                     EmbeddingComputeKernel.KEY_VALUE.value,
+                    EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+                    EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
                 ]
         else:
             # TODO re-enable model parallel and dense

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -93,7 +93,10 @@ def kernel_bw_lookup(
             caching_ratio * hbm_mem_bw + (1 - caching_ratio) * hbm_to_ddr_mem_bw
         )
         / 10,
+        # TODO: revisit whether this estimation makes sense
         ("cuda", EmbeddingComputeKernel.KEY_VALUE.value): hbm_to_ddr_mem_bw,
+        ("cuda", EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
+        ("cuda", EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
     }
 
     if (

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -43,7 +43,9 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # compute kernels that should only be used if users specified them
 GUARDED_COMPUTE_KERNELS: Set[EmbeddingComputeKernel] = {
-    EmbeddingComputeKernel.KEY_VALUE
+    EmbeddingComputeKernel.KEY_VALUE,
+    EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
+    EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
 }
 
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -1178,10 +1178,18 @@ def calculate_shard_storages(
         EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
         EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
         EmbeddingComputeKernel.KEY_VALUE.value,
+        EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+        EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
     }:
+        # TODO(wangj): for ssd/dram kv, most likely we use absolute L1 cache size instead of caching ratio, as denominator is huge
         hbm_storage = round(ddr_storage * caching_ratio)
         table_cached = True
-    if compute_kernel in {EmbeddingComputeKernel.KEY_VALUE.value}:
+    if compute_kernel in {
+        EmbeddingComputeKernel.KEY_VALUE.value,
+        EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+        EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+    }:
+        # TODO(wangj): update this to the L2 cache usage and add SSD usage
         ddr_storage = 0
 
     optimizer_class = getattr(tensor, "_optimizer_classes", [None])[0]

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -217,6 +217,8 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
                         num_embeddings_post_pruning=info.embedding_config.num_embeddings_post_pruning,
+                        total_num_buckets=info.embedding_config.total_num_buckets,
+                        use_virtual_table=info.embedding_config.use_virtual_table,
                     )
                 )
         return tables_per_rank

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -15,6 +15,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
 import torch
 import torch.nn as nn
 from tensordict import TensorDict
+from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_tower_sharding import (
     EmbeddingTowerCollectionSharder,
     EmbeddingTowerSharder,
@@ -1669,6 +1670,38 @@ class TestTowerCollectionSparseNN(TestSparseNNBase):
             )
         else:
             return pred
+
+
+class TestECSharder(EmbeddingCollectionSharder):
+    def __init__(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        fused_params: Optional[Dict[str, Any]] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        if fused_params is None:
+            fused_params = {}
+
+        self._sharding_type = sharding_type
+        self._kernel_type = kernel_type
+        super().__init__(fused_params, qcomm_codecs_registry)
+
+    """
+    Restricts sharding to single type only.
+    """
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [self._sharding_type]
+
+    """
+    Restricts to single impl.
+    """
+
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
+        return [self._kernel_type]
 
 
 class TestEBCSharder(EmbeddingBagCollectionSharder):

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -36,6 +36,7 @@ from torchrec.distributed.test_utils.test_model import (
     ModelInput,
     TestEBCSharder,
     TestEBSharder,
+    TestECSharder,
     TestETCSharder,
     TestETSharder,
     TestSparseNNBase,
@@ -63,6 +64,7 @@ class SharderType(Enum):
     EMBEDDING_BAG_COLLECTION = "embedding_bag_collection"
     EMBEDDING_TOWER = "embedding_tower"
     EMBEDDING_TOWER_COLLECTION = "embedding_tower_collection"
+    EMBEDDING_COLLECTION = "embedding_collection"
 
 
 def create_test_sharder(
@@ -72,7 +74,7 @@ def create_test_sharder(
     fused_params: Optional[Dict[str, Any]] = None,
     qcomms_config: Optional[QCommsConfig] = None,
     device: Optional[torch.device] = None,
-) -> Union[TestEBSharder, TestEBCSharder, TestETSharder, TestETCSharder]:
+) -> Union[TestEBSharder, TestEBCSharder, TestETSharder, TestETCSharder, TestECSharder]:
     if fused_params is None:
         fused_params = {}
     qcomm_codecs_registry = {}
@@ -90,6 +92,10 @@ def create_test_sharder(
             kernel_type,
             fused_params,
             qcomm_codecs_registry,
+        )
+    elif sharder_type == SharderType.EMBEDDING_COLLECTION.value:
+        return TestECSharder(
+            sharding_type, kernel_type, fused_params, qcomm_codecs_registry
         )
     elif sharder_type == SharderType.EMBEDDING_TOWER.value:
         return TestETSharder(

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import copy
 import unittest
 from typing import cast, List, OrderedDict, Union
 
@@ -17,6 +18,7 @@ from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.distributed.batched_embedding_kernel import (
     KeyValueEmbedding,
     KeyValueEmbeddingBag,
+    ZeroCollisionKeyValueEmbedding,
 )
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
@@ -37,7 +39,7 @@ from torchrec.distributed.tests.test_sequence_model import (
     TestEmbeddingCollectionSharder,
     TestSequenceSparseNN,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import KeyValueParams, ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import (
     DataType,
     EmbeddingBagConfig,
@@ -112,25 +114,20 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
                     )
 
                     emb1_kv = {
-                        t: (w, w_id, bucket_cnt)
-                        for t, w, w_id, bucket_cnt in emb_module1.get_named_split_embedding_weights_snapshot()
+                        t: pmt
+                        for t, pmt, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
-                        w,
+                        pmt,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
-                        w1 = emb1_kv[t][0]
-                        w1_full_tensor = w1.full_tensor()
+                        pmt1 = emb1_kv[t]
+                        w1 = pmt1.full_tensor()
 
                         # write value into ssd for both emb module for later comparison
-                        w.wrapped.set_range(
-                            0, 0, w1_full_tensor.size(0), w1_full_tensor
-                        )
-                        w1.wrapped.set_range(
-                            0, 0, w1_full_tensor.size(0), w1_full_tensor
-                        )
+                        pmt.wrapped.set_range(0, 0, w1.size(0), w1)
 
                     # purge after loading. This is needed, since we pass a batch
                     # through dmp when instantiating them.
@@ -193,6 +190,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             table.name: ParameterConstraints(
                 sharding_types=[sharding_type],
                 compute_kernels=[kernel_type],
+                key_value_params=KeyValueParams(bulk_init_chunk_size=1024),
             )
             for i, table in enumerate(self.tables)
         }
@@ -396,6 +394,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             table.name: ParameterConstraints(
                 sharding_types=[sharding_type],
                 compute_kernels=[kernel_type],
+                key_value_params=KeyValueParams(bulk_init_chunk_size=1024),
             )
             for i, table in enumerate(self.tables)
         }
@@ -515,6 +514,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
                 compute_kernels=(
                     [base_kernel_type] if i % 2 == fused_first else [kernel_type]
                 ),
+                key_value_params=KeyValueParams(bulk_init_chunk_size=1024),
             )
             for i, table in enumerate(self.tables)
         }
@@ -586,6 +586,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
                     else [ShardingType.ROW_WISE.value]
                 ),
                 compute_kernels=[kernel_type],
+                key_value_params=KeyValueParams(bulk_init_chunk_size=1024),
             )
             for i, table in enumerate(self.tables)
         }
@@ -686,25 +687,20 @@ class KeyValueSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
                     )
 
                     emb1_kv = {
-                        t: (w, w_id, bucket_cnt)
-                        for t, w, w_id, bucket_cnt in emb_module1.get_named_split_embedding_weights_snapshot()
+                        t: pmt
+                        for t, pmt, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
-                        w,
+                        pmt,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
-                        w1 = emb1_kv[t][0]
-                        w1_full_tensor = w1.full_tensor()
+                        pmt1 = emb1_kv[t]
+                        w1 = pmt1.full_tensor()
 
                         # write value into ssd for both emb module for later comparison
-                        w.wrapped.set_range(
-                            0, 0, w1_full_tensor.size(0), w1_full_tensor
-                        )
-                        w1.wrapped.set_range(
-                            0, 0, w1_full_tensor.size(0), w1_full_tensor
-                        )
+                        pmt.wrapped.set_range(0, 0, w1.size(0), w1)
 
                     # purge after loading. This is needed, since we pass a batch
                     # through dmp when instantiating them.
@@ -769,6 +765,7 @@ class KeyValueSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
             table.name: ParameterConstraints(
                 sharding_types=[sharding_type],
                 compute_kernels=[kernel_type],
+                key_value_params=KeyValueParams(bulk_init_chunk_size=1024),
             )
             for i, table in enumerate(self.tables)
         }
@@ -784,6 +781,359 @@ class KeyValueSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
             self._train_models(m1, m2, batch)
         self._eval_models(m1, m2, batch, is_deterministic=is_deterministic)
         self._compare_models(m1, m2, is_deterministic=is_deterministic)
+
+
+class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
+    def setUp(self, backend: str = "nccl") -> None:
+        self.shared_features = []
+        self.embedding_groups = {}
+
+        super().setUp(backend=backend)
+
+    def _create_tables(self) -> None:
+        num_features = 4
+        shared_features = 2
+
+        initial_tables = [
+            EmbeddingConfig(
+                num_embeddings=(i + 1) * 1000,
+                embedding_dim=16,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+                total_num_buckets=10,
+                use_virtual_table=True,
+            )
+            for i in range(num_features)
+        ]
+
+        shared_features_tables = [
+            EmbeddingConfig(
+                num_embeddings=(i + 1) * 20,
+                embedding_dim=16,
+                name="table_" + str(i + num_features),
+                feature_names=["feature_" + str(i)],
+                total_num_buckets=10,
+                use_virtual_table=True,
+            )
+            for i in range(shared_features)
+        ]
+
+        self.tables += initial_tables + shared_features_tables
+        self.shared_features += [f"feature_{i}" for i in range(shared_features)]
+
+        self.embedding_groups["group_0"] = [
+            (f"{feature}@{table.name}" if feature in self.shared_features else feature)
+            for table in self.tables
+            for feature in table.feature_names
+        ]
+
+    def _create_model(self) -> nn.Module:
+        return TestSequenceSparseNN(
+            tables=self.tables,
+            num_float_features=self.num_float_features,
+            embedding_groups=self.embedding_groups,
+            dense_device=self.device,
+            sparse_device=torch.device("meta"),
+        )
+
+    @staticmethod
+    def _copy_ssd_emb_modules(
+        m1: DistributedModelParallel, m2: DistributedModelParallel
+    ) -> None:
+        """
+        Util function to copy and set the SSD TBE modules of two models. It
+        requires both DMP modules to have the same sharding plan.
+        """
+        for lookup1, lookup2 in zip(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            m1.module.sparse.ec._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            m2.module.sparse.ec._lookups,
+        ):
+            for emb_module1, emb_module2 in zip(
+                lookup1._emb_modules, lookup2._emb_modules
+            ):
+                ssd_emb_modules = {
+                    ZeroCollisionKeyValueEmbedding,
+                }
+                if type(emb_module1) in ssd_emb_modules:
+                    assert type(emb_module1) is type(emb_module2), (
+                        "Expect two emb_modules to be of the same type, either both "
+                        "SSDEmbeddingBag or SSDEmbeddingBag."
+                    )
+                    emb_module1.flush()
+                    emb_module2.flush()
+
+                    emb1_kv = {
+                        t: (sharded_t, sharded_w_id, bucket)
+                        for t, sharded_t, sharded_w_id, bucket in emb_module1.get_named_split_embedding_weights_snapshot()
+                    }
+                    for (
+                        t,
+                        sharded_t2,
+                        _,
+                        _,
+                    ) in emb_module2.get_named_split_embedding_weights_snapshot():
+                        assert t in emb1_kv
+                        sharded_t1 = emb1_kv[t][0]
+                        sharded_w1_id = emb1_kv[t][1]
+                        w1_id = sharded_w1_id.local_shards()[0].tensor
+
+                        pmt1 = sharded_t1.local_shards()[0].tensor
+                        w1 = pmt1.get_weights_by_ids(w1_id)
+
+                        # write value into ssd for both emb module for later comparison
+                        pmt2 = sharded_t2.local_shards()[0].tensor
+                        pmt2.wrapped.set_weights_and_ids(w1, w1_id.view(-1))
+
+                    # purge after loading. This is needed, since we pass a batch
+                    # through dmp when instantiating them.
+                    emb_module1.purge()
+                    emb_module2.purge()
+
+    @staticmethod
+    def _copy_fused_modules_into_ssd_emb_modules(
+        fused_m: DistributedModelParallel, ssd_m: DistributedModelParallel
+    ) -> None:
+        """
+        Util function to copy from fused embedding module to SSD TBE for initialization. It
+        requires both DMP modules to have the same sharding plan.
+        """
+
+        for fused_lookup, ssd_lookup in zip(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            fused_m.module.sparse.ec._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            ssd_m.module.sparse.ec._lookups,
+        ):
+            for fused_emb_module, ssd_emb_module in zip(
+                fused_lookup._emb_modules, ssd_lookup._emb_modules
+            ):
+                ssd_emb_modules = {ZeroCollisionKeyValueEmbedding}
+                if type(ssd_emb_module) in ssd_emb_modules:
+                    fused_state_dict = fused_emb_module.state_dict()
+                    for (
+                        t,
+                        sharded_t,
+                        _,
+                        _,
+                    ) in ssd_emb_module.get_named_split_embedding_weights_snapshot():
+                        weight_key = f"{t}.weight"
+                        fused_sharded_t = fused_state_dict[weight_key]
+                        fused_weight = fused_sharded_t.local_shards()[0].tensor.to(
+                            "cpu"
+                        )
+
+                        # write value into ssd for both emb module for later comparison
+                        pmt = sharded_t.local_shards()[0].tensor
+                        pmt.wrapped.set_range(0, 0, fused_weight.size(0), fused_weight)
+
+                    # purge after loading. This is needed, since we pass a batch
+                    # through dmp when instantiating them.
+                    fused_emb_module.purge()
+                    ssd_emb_module.purge()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    # pyre-ignore[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                # TODO: add other test cases when kv embedding support other sharding
+                ShardingType.ROW_WISE.value,
+            ]
+        ),
+        kernel_type=st.sampled_from(
+            [
+                EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+            ]
+        ),
+        is_training=st.booleans(),
+        stochastic_rounding=st.booleans(),
+        dtype=st.sampled_from([DataType.FP32, DataType.FP16]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    def test_kv_zch_load_state_dict(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        is_training: bool,
+        stochastic_rounding: bool,
+        dtype: DataType,
+    ) -> None:
+        """
+        This test checks that if SSD TBE is deterministic. That is, if two SSD
+        TBEs start with the same state, they would produce the same output.
+        """
+        self._set_table_weights_precision(dtype)
+
+        fused_params = {
+            "learning_rate": 0.1,
+            "stochastic_rounding": stochastic_rounding,
+        }
+        is_deterministic = dtype == DataType.FP32 or not stochastic_rounding
+        sharders = [
+            cast(
+                ModuleSharder[nn.Module],
+                TestEmbeddingCollectionSharder(
+                    sharding_type=sharding_type,
+                    kernel_type=kernel_type,
+                    fused_params=fused_params,
+                ),
+            ),
+        ]
+
+        constraints = {
+            table.name: ParameterConstraints(
+                sharding_types=[sharding_type],
+                compute_kernels=[kernel_type],
+            )
+            for i, table in enumerate(self.tables)
+        }
+
+        models, batch = self._generate_dmps_and_batch(sharders, constraints=constraints)
+        m1, m2 = models
+
+        # load state dict for dense modules
+        m2.load_state_dict(cast("OrderedDict[str, torch.Tensor]", m1.state_dict()))
+        self._copy_ssd_emb_modules(m1, m2)
+
+        if is_training:
+            self._train_models(m1, m2, batch)
+        self._eval_models(m1, m2, batch, is_deterministic=is_deterministic)
+        self._compare_models(
+            m1, m2, is_deterministic=is_deterministic, use_virtual_table=True
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    # pyre-ignore[56]
+    @given(
+        sharder_type=st.sampled_from(
+            [
+                SharderType.EMBEDDING_COLLECTION.value,
+            ]
+        ),
+        kernel_type=st.sampled_from(
+            [
+                EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+            ]
+        ),
+        sharding_type=st.sampled_from(
+            [
+                # TODO: add other test cases when kv embedding support other sharding
+                ShardingType.ROW_WISE.value,
+            ]
+        ),
+        is_training=st.booleans(),
+        stochastic_rounding=st.booleans(),
+        dtype=st.sampled_from([DataType.FP32, DataType.FP16]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    def test_kv_zch_numerical_accuracy(
+        self,
+        sharder_type: str,
+        kernel_type: str,
+        sharding_type: str,
+        is_training: bool,
+        stochastic_rounding: bool,
+        dtype: DataType,
+    ) -> None:
+        """
+        Make sure it produces same numbers as normal TBE.
+        """
+        self._set_table_weights_precision(dtype)
+        base_kernel_type = EmbeddingComputeKernel.FUSED.value
+        learning_rate = 0.1
+        fused_params = {
+            "optimizer": EmbOptimType.EXACT_ROWWISE_ADAGRAD,
+            "learning_rate": learning_rate,
+            "stochastic_rounding": stochastic_rounding,
+        }
+        is_deterministic = dtype == DataType.FP32 or not stochastic_rounding
+        fused_sharders = [
+            cast(
+                ModuleSharder[nn.Module],
+                create_test_sharder(
+                    sharder_type,
+                    sharding_type,
+                    base_kernel_type,  # base kernel type
+                    fused_params=fused_params,
+                ),
+            ),
+        ]
+        ssd_sharders = [
+            cast(
+                ModuleSharder[nn.Module],
+                create_test_sharder(
+                    sharder_type,
+                    sharding_type,
+                    kernel_type,
+                    fused_params=fused_params,
+                ),
+            ),
+        ]
+        ssd_constraints = {
+            table.name: ParameterConstraints(
+                sharding_types=[sharding_type],
+                compute_kernels=[kernel_type],
+            )
+            for i, table in enumerate(self.tables)
+        }
+
+        # for fused model, we need to change the table config to non-kvzch
+        ssd_tables = copy.deepcopy(self.tables)
+        for table in self.tables:
+            table.total_num_buckets = None
+            table.use_virtual_table = False
+        (fused_model, _), _ = self._generate_dmps_and_batch(fused_sharders)
+        self.tables = ssd_tables
+        (ssd_model, _), batch = self._generate_dmps_and_batch(
+            ssd_sharders, constraints=ssd_constraints
+        )
+
+        # load state dict for dense modules
+        ssd_model.load_state_dict(
+            cast("OrderedDict[str, torch.Tensor]", fused_model.state_dict())
+        )
+
+        # for this to work, we expect the order of lookups to be the same
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+        assert len(fused_model.module.sparse.ec._lookups) == len(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            ssd_model.module.sparse.ec._lookups
+        ), "Expect same number of lookups"
+
+        for fused_lookup, ssd_lookup in zip(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            fused_model.module.sparse.ec._lookups,
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `ec`.
+            ssd_model.module.sparse.ec._lookups,
+        ):
+            assert len(fused_lookup._emb_modules) == len(
+                ssd_lookup._emb_modules
+            ), "Expect same number of emb modules"
+
+        self._copy_fused_modules_into_ssd_emb_modules(fused_model, ssd_model)
+
+        if is_training:
+            self._train_models(fused_model, ssd_model, batch)
+        self._eval_models(
+            fused_model, ssd_model, batch, is_deterministic=is_deterministic
+        )
+
+    # TODO: uncomment this when we have optimizer plumb through
+    # def test_ssd_fused_optimizer(
+
+    # TODO: uncomment this when we have multiple kernels in rw support(unblock input dist)
+    # def test_ssd_mixed_kernels
+
+    # TODO: uncomment this when we support different sharding types, e.g. tw, tw_rw together with rw
+    # def test_ssd_mixed_sharding_types
 
 
 # TODO: remove after development is done

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -423,7 +423,12 @@ def add_params_from_parameter_sharding(
         fused_params["output_dtype"] = parameter_sharding.output_dtype
 
     if (
-        parameter_sharding.compute_kernel in {EmbeddingComputeKernel.KEY_VALUE.value}
+        parameter_sharding.compute_kernel
+        in {
+            EmbeddingComputeKernel.KEY_VALUE.value,
+            EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+            EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+        }
         and parameter_sharding.key_value_params is not None
     ):
         kv_params = parameter_sharding.key_value_params


### PR DESCRIPTION
Summary:
# Change logs
1. add ZeroCollisionKeyValueEmbedding emb lookup
2. address existing unit test missing for ssd offloading
3. add new ut for kv zch embedding module
4. add a temp hack solution for calculate bucket metadata
5. embedding updates, details illustrated below

#######################################################################
###########################  embedding.py updates ##########################
#######################################################################

1. keep the original idea to init shardedTensor during training init
2. for kv zch table, the shardeTensor will be init using virtual size for metadata calculation, and skip actual tensor size check for ST init, this is needed as during training init, the table has 0 rows
3. the new tensor, weight_id will not be registered in the EC becuase its shape is changing in realtime, the weight_id tensor will be generated in post_state_dict hooks
4. the new tensor, bucket could be registered and preserved, but in this diff we keep it the same way as weight_id
5. in post state dict hook, we call get_named_split_embedding_weights_snapshot to get Tuple[table_name, weight(ST), weight_id(ST), bucket(ST)], all 3 tensors are return in the format of ST, and we will update destination with the returned ST directly
6. in pre_load_state_dict_hook, which is called upon load_state_dict(), we will skip all 3 tensors update, because the tensor assignment is done [on the nn.module side](https://fburl.com/code/it5nior8), which doesn't support updating KVT through PMT. This is fine for now because, checkpoint loading will be done outside of the load_state_dict call, but we need future plans to make it work cohesively with other type of tensors

Differential Revision: D73567631
