### PR TITLE
add activation on last logic

### DIFF
--- a/torchrec/modules/mlp.py
+++ b/torchrec/modules/mlp.py
@@ -128,6 +128,7 @@ class MLP(torch.nn.Module):
         ] = torch.relu,
         device: Optional[torch.device] = None,
         dtype: torch.dtype = torch.float32,
+        activation_on_last: bool = True,
     ) -> None:
         super().__init__()
 
@@ -143,7 +144,11 @@ class MLP(torch.nn.Module):
                         layer_sizes[i - 1] if i > 0 else in_size,
                         layer_sizes[i],
                         bias=bias,
-                        activation=extract_module_or_tensor_callable(activation),
+                        activation=(
+                            torch.nn.Identity()
+                            if not activation_on_last and i == len(layer_sizes) - 1
+                            else extract_module_or_tensor_callable(activation)
+                        ),
                         device=device,
                         dtype=dtype,
                     )
@@ -158,7 +163,11 @@ class MLP(torch.nn.Module):
                             layer_sizes[i - 1] if i > 0 else in_size,
                             layer_sizes[i],
                             bias=bias,
-                            activation=SwishLayerNorm(layer_sizes[i], device=device),
+                            activation=(
+                                torch.nn.Identity()
+                                if not activation_on_last and i == len(layer_sizes) - 1
+                                else SwishLayerNorm(layer_sizes[i], device=device)
+                            ),
                             device=device,
                         )
                         for i in range(len(layer_sizes))


### PR DESCRIPTION
Summary:
# context

Adding parity for activation on last flag to make module more configurable.

activation_on_last is a flag that toggles the given (or default) activation function to the last layer of the MLP. Typically ALL layers of the MLP will have the activation function. If it is set to false, then the last layer will not have the activation function applied. This is so users can optionally use the raw MLP output for their own customized needs.

Reviewed By: TroyGarden

Differential Revision: D73691616


