### PR TITLE
[pipelie] refactor train_pipeline utils

### DIFF
--- a/torchrec/distributed/test_utils/test_input.py
+++ b/torchrec/distributed/test_utils/test_input.py
@@ -442,9 +442,9 @@ class ModelInput(Pipelineable):
             lengths = None
         if pin_memory:
             indices = indices.pin_memory()
-            lengths = lengths.pin_memory() if lengths else None
-            weights = weights.pin_memory() if weights else None
-            offsets = offsets.pin_memory() if offsets else None
+            lengths = lengths.pin_memory() if lengths is not None else None
+            weights = weights.pin_memory() if weights is not None else None
+            offsets = offsets.pin_memory() if offsets is not None else None
         return KeyedJaggedTensor(features, indices, weights, lengths, offsets)
 
     @staticmethod


### PR DESCRIPTION
Summary:
# context
add comments explaining the `_rewrite_model` util function, which is a critical part of the sparse-dist train pipeline.

# main changes
1. modified the `_get_leaf_module_names_helper` first introduced in D31614348

Differential Revision: D73868739


