### PR TITLE
provide basic integration of trec 2d emb to training pipeline

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -15,6 +15,7 @@ from typing import (
     Any,
     Dict,
     Generic,
+    Iterable,
     Iterator,
     List,
     Optional,
@@ -329,7 +330,7 @@ class ModuleShardingMixIn:
 
 
 Out = TypeVar("Out")
-CompIn = TypeVar("CompIn")
+CompIn = TypeVar("CompIn", KJTList, ListOfKJTList, KeyedJaggedTensor)
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 
@@ -358,14 +359,14 @@ class ShardedEmbeddingModule(
 
     def prefetch(
         self,
-        dist_input: KJTList,
+        dist_input: CompIn,
         forward_stream: Optional[Union[torch.cuda.Stream, torch.mtia.Stream]] = None,
         ctx: Optional[ShrdCtx] = None,
     ) -> None:
         """
         Prefetch input features for each lookup module.
         """
-
+        assert isinstance(dist_input, Iterable)
         for feature, emb_lookup in zip(dist_input, self._lookups):
             while isinstance(emb_lookup, DistributedDataParallel):
                 emb_lookup = emb_lookup.module

--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -26,6 +26,9 @@ from torch.distributed._shard.sharded_tensor import (
 from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo
 from torchrec.distributed.embedding_types import (
     GroupedEmbeddingConfig,
+    KeyedJaggedTensor,
+    KJTList,
+    ListOfKJTList,
     ShardedEmbeddingModule,
 )
 from torchrec.distributed.types import ParameterSharding, ShardingType
@@ -34,7 +37,7 @@ from torchrec.streamable import Multistreamable
 from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
 
 Out = TypeVar("Out")
-CompIn = TypeVar("CompIn")
+CompIn = TypeVar("CompIn", KJTList, ListOfKJTList, KeyedJaggedTensor)
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -76,6 +76,17 @@ if not torch._running_with_deploy():
     torch.ops.import_module("fbgemm_gpu.sparse_ops")
 
 
+# Note: doesn't make much sense but better than throwing.
+# Somehow some users would mess up their dependency when using torch package,
+# and we cannot fix their problem sorry
+has_2d_support = True
+try:
+    from torchrec.distributed.model_parallel import DMPCollection
+except ImportError:
+    logger.warning("DMPCollection is not available. 2D sharding is not supported.")
+    has_2d_support = False
+
+
 class ModelDetachedException(Exception):
     pass
 
@@ -84,6 +95,39 @@ class TrainPipeline(abc.ABC, Generic[In, Out]):
     @abc.abstractmethod
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         pass
+
+    def sync_embeddings(
+        self,
+        model: torch.nn.Module,
+        interval_batches: Optional[int],
+        context: Optional[TrainPipelineContext] = None,
+    ) -> None:
+        """
+        Sync the embedding weights and fused optimizer states across replicas.
+        Only enabled if DMPCollection is used to shard the model.
+        Otherwise this is a no op.
+        """
+        if (
+            not has_2d_support
+            or not isinstance(model, DMPCollection)
+            or interval_batches is None
+        ):
+            return
+
+        if not context:
+            logger.warning(
+                f"{self.__class__.__name__} does not support context (not expected). "
+                "Embedding weight sync is disabled."
+            )
+            return
+
+        index = context.index
+        assert (
+            index is not None
+        ), f"{self.__class__.__name__} context does not provide number of batches: {context=}"
+        if index % interval_batches == 0:
+            with record_function("## dmp_collection_sync ##"):
+                model.sync()
 
 
 @dataclass
@@ -343,6 +387,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         execute_all_batches (bool): executes remaining batches in pipeline after
             exhausting dataloader iterator.
         apply_jit (bool): apply torch.jit.script to non-pipelined (unsharded) modules.
+        dmp_collection_sync_interval_batches (Optional[int]):
+            (applicable to 2D sharding only)
+            if set and DMP collection is enabled for 2D sharding,
+            sync DMPs every N batches (default to 1, i.e. every batch, None to disable)
     """
 
     # The PipelinedForward class that is used in _rewrite_model
@@ -361,6 +409,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         custom_model_fwd: Optional[
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
+        dmp_collection_sync_interval_batches: Optional[int] = 1,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -416,6 +465,15 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._model_fwd: Callable[[Optional[In]], Tuple[torch.Tensor, Out]] = (
             custom_model_fwd if custom_model_fwd else model
         )
+        self._pipelined_forward_type = PipelinedForward
+        self._dmp_collection_sync_interval_batches = (
+            dmp_collection_sync_interval_batches
+        )
+        if self._dmp_collection_sync_interval_batches is not None:
+            logger.info(
+                f"{self.__class__.__name__}: [Sparse 2D] DMP collection will sync every "
+                f"{self._dmp_collection_sync_interval_batches} batches"
+            )
 
         # DEPRECATED FIELDS
         self._batch_i: Optional[In] = None
@@ -609,6 +667,12 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         if self._model.training:
             # backward
             self._backward(losses)
+
+            self.sync_embeddings(
+                self._model,
+                self._dmp_collection_sync_interval_batches,
+                self.contexts[0],
+            )
 
             # update
             with record_function("## optimizer ##"):
@@ -823,6 +887,10 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
         start_batch (int): batch to begin semi-sync training.  Typically small period of synchronous training reduces early stage NEX.
         stash_gradients (bool): if True, will store gradients for each parameter to insure true "Semi-Sync"
             training.  If False, will update dense optimizer as soon as gradients available (naive "Semi-Sync)
+        dmp_collection_sync_interval_batches (Optional[int]):
+            (applicable to 2D sharding only)
+            if set and DMP collection is enabled for 2D sharding,
+            sync DMPs every N batches (default to 1, i.e. every batch, None to disable)
     """
 
     # The PipelinedForward class that is used in _rewrite_model
@@ -842,6 +910,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
         strict: bool = False,
+        dmp_collection_sync_interval_batches: Optional[int] = 1,
     ) -> None:
         super().__init__(
             model=model,
@@ -852,6 +921,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             context_type=EmbeddingTrainPipelineContext,
             pipeline_postproc=pipeline_postproc,
             custom_model_fwd=custom_model_fwd,
+            dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
         )
         self._start_batch = start_batch
         self._stash_gradients = stash_gradients
@@ -972,6 +1042,11 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
                 # pyre-ignore [6]
                 self.embedding_backward(context)
 
+            self.sync_embeddings(
+                self._model,
+                self._dmp_collection_sync_interval_batches,
+                context,
+            )
             del context  # context is no longer needed, deleting to free up memory
 
             with record_function(f"## optimizer {iteration - 1} ##"):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -1731,7 +1731,7 @@ def _prefetch_embeddings(
     context: PrefetchTrainPipelineContext,
     pipelined_modules: List[ShardedModule],
     device: torch.device,
-    stream_context: torch.Stream,
+    stream_context: Callable[[Optional[torch.Stream]], torch.cuda.StreamContext],
     data_dist_stream: Optional[torch.Stream],
     default_stream: Optional[torch.Stream],
 ) -> Dict[str, KJTList]:
@@ -1739,7 +1739,6 @@ def _prefetch_embeddings(
     for sharded_module in pipelined_modules:
         forward = sharded_module.forward
         assert isinstance(forward, PrefetchPipelinedForward)
-
         assert forward._name in context.input_dist_tensors_requests
         request = context.input_dist_tensors_requests.pop(forward._name)
         assert isinstance(request, Awaitable)
@@ -1762,10 +1761,12 @@ def _prefetch_embeddings(
                 data, (torch.Tensor, Multistreamable)
             ), f"{type(data)} must implement Multistreamable interface"
             data.record_stream(cur_stream)
-            data.record_stream(default_stream)
+            if default_stream:
+                data.record_stream(default_stream)
 
             module_context.record_stream(cur_stream)
-            module_context.record_stream(default_stream)
+            if default_stream:
+                module_context.record_stream(default_stream)
 
         sharded_module.prefetch(
             ctx=module_context,

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -1003,6 +1003,14 @@ class ShardedModule(
     def output_dist(self, ctx: ShrdCtx, output: DistOut) -> LazyAwaitable[Out]:
         pass
 
+    def prefetch(
+        self,
+        dist_input: CompIn,
+        forward_stream: Optional[torch.Stream] = None,
+        ctx: Optional[ShrdCtx] = None,
+    ) -> None:
+        return None
+
     def compute_and_output_dist(
         self, ctx: ShrdCtx, input: CompIn
     ) -> LazyAwaitable[Out]:

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -45,6 +45,17 @@ version checks
 """
 
 
+def get_class_name(obj: object) -> str:
+    if obj is None:
+        return "None"
+    return obj.__class__.__name__
+
+
+def assert_instance(obj: object, t: Type[_T]) -> _T:
+    assert isinstance(obj, t), f"Got {get_class_name(obj)}"
+    return obj
+
+
 def none_throws(optional: Optional[_T], message: str = "Unexpected `None`") -> _T:
     """Convert an optional to its value. Raises an `AssertionError` if the
     value is `None`"""


### PR DESCRIPTION
Summary:
* add `dmp_collection_sync_interval_batches` as a config value to SDD pipeline (and semi sync)
* default to 1 (every batch).
* disable using `None`
* disabled if DMPC not used

Differential Revision: D70988786


