### PR TITLE
Extend FSDP1 global clipping support for optimizers other than Shampoo

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -88,7 +88,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
                 else:
                     self._replicate_params.append(param)
         logger.info(
-            f"Optimizer found {sharded_param_cnt} dist params and {len(self._replicate_params)} replicate params."
+            f"Clipping [Rank {dist.get_rank()}] Optimizer found {sharded_param_cnt} dist params and {len(self._replicate_params)} replicate params."
         )
 
         # Sanity check: this path is currently not used in any production.


### PR DESCRIPTION
Summary:
This diff is a followup of D73474285 and lets other dense optimizers take it the `enable_global_grad_clip` optim config. When `enalbe_global_grad_clip=True` and FSDP1 is used, it would calculate global gradient norm at a cost of extra communication. 

Next steps:
1. global clipping more generic and work for FSDP2.

Differential Revision:
D73969566

Privacy Context Container: L1235913


