### PR TITLE
[pipeline] add emb_lookup_stream option in the train pipeline

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_sparsenn.py
+++ b/torchrec/distributed/benchmark/benchmark_train_sparsenn.py
@@ -98,6 +98,7 @@ class EmbeddingTablesConfig:
 @dataclass
 class PipelineConfig:
     pipeline: str = "base"
+    emb_lookup_stream: str = "data_dist"
 
     def generate_pipeline(
         self, model: nn.Module, opt: torch.optim.Optimizer, device: torch.device
@@ -115,6 +116,13 @@ class PipelineConfig:
         if self.pipeline == "semi":
             return TrainPipelineSemiSync(
                 model=model, optimizer=opt, device=device, start_batch=0
+            )
+        elif self.pipeline == "fused":
+            return TrainPipelineFusedSparseDist(
+                model=model,
+                optimizer=opt,
+                device=device,
+                emb_lookup_stream=self.emb_lookup_stream,
             )
         elif self.pipeline in _pipeline_cls:
             Pipeline = _pipeline_cls[self.pipeline]


### PR DESCRIPTION
Summary:
# context
* in the previous diff the `output_dist.awaitable.wait()` is done in the emb_lookup_stream, it makes no difference with the default setup where the emb_lookup_stream is the data_dist_stream
* however, it makes a difference when the emb_lookup_stream is actually a new stream or the current stream (default compute).
* especially when the emb_lookup_stream is the default compute stream, it blocks the forward due to the `output_dist.awaitable.wait()`.

Differential Revision: D74012071


