### PR TITLE
Create a new tensor arg for stride_per_key_per_rank to facilitate torch.export

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1097,11 +1097,15 @@ def _maybe_compute_stride_kjt(
     lengths: Optional[torch.Tensor],
     offsets: Optional[torch.Tensor],
     stride_per_key_per_rank: Optional[List[List[int]]],
+    inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None,
 ) -> int:
     if stride is None:
         if len(keys) == 0:
             stride = 0
         elif stride_per_key_per_rank is not None and len(stride_per_key_per_rank) > 0:
+            # For VBE KJT, use inverse_indices for the batch size of the EBC output KeyedTensor.
+            if inverse_indices is not None and inverse_indices[1].numel() > 0:
+                return inverse_indices[1].shape[-1]
             stride = max([sum(s) for s in stride_per_key_per_rank])
         elif offsets is not None and offsets.numel() > 0:
             stride = (offsets.numel() - 1) // len(keys)
@@ -2165,6 +2169,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             self._lengths,
             self._offsets,
             self._stride_per_key_per_rank,
+            self._inverse_indices,
         )
         self._stride = stride
         return stride

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1017,6 +1017,18 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             lengths=torch.tensor([], device=torch.device("meta")),
         )
 
+    def test_vbe_kjt_stride(self) -> None:
+        inverse_indices = torch.tensor([[0, 1, 0], [0, 0, 0]])
+        kjt = KeyedJaggedTensor(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([5, 6, 7, 1, 2, 3, 0, 1]),
+            lengths=torch.tensor([3, 3, 2]),
+            stride_per_key_per_rank=[[2], [1]],
+            inverse_indices=(["f1", "f2"], inverse_indices),
+        )
+
+        self.assertEqual(kjt.stride(), inverse_indices.shape[1])
+
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):
     def test_scriptable_forward(self) -> None:

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1018,16 +1018,32 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         )
 
     def test_vbe_kjt_stride(self) -> None:
+        stride_per_key_per_rank = [[2], [1]]
         inverse_indices = torch.tensor([[0, 1, 0], [0, 0, 0]])
-        kjt = KeyedJaggedTensor(
+        kjt_1 = KeyedJaggedTensor(
             keys=["f1", "f2", "f3"],
             values=torch.tensor([5, 6, 7, 1, 2, 3, 0, 1]),
             lengths=torch.tensor([3, 3, 2]),
-            stride_per_key_per_rank=[[2], [1]],
+            stride_per_key_per_rank=stride_per_key_per_rank,
+            inverse_indices=(["f1", "f2"], inverse_indices),
+        )
+        kjt_2 = KeyedJaggedTensor(
+            keys=["f1", "f2", "f3"],
+            values=torch.tensor([5, 6, 7, 1, 2, 3, 0, 1]),
+            lengths=torch.tensor([3, 3, 2]),
+            stride_per_key_per_rank_tensor=torch.tensor(stride_per_key_per_rank),
             inverse_indices=(["f1", "f2"], inverse_indices),
         )
 
-        self.assertEqual(kjt.stride(), inverse_indices.shape[1])
+        self.assertEqual(kjt_1.stride(), inverse_indices.shape[1])
+        self.assertEqual(kjt_1.stride_per_key_per_rank(), stride_per_key_per_rank)
+        self.assertEqual(
+            kjt_1._stride_per_key_per_rank_optional, stride_per_key_per_rank
+        )
+        self.assertEqual(kjt_2.stride_per_key_per_rank(), stride_per_key_per_rank)
+        self.assertEqual(
+            kjt_2._stride_per_key_per_rank_optional, stride_per_key_per_rank
+        )
 
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):


### PR DESCRIPTION
Summary:
# Context
* Currently torchrec IR serializer can't handle variable batch KJT use case.
* To support VBE KJT, the `stride_per_key_per_rank` field needs to be flattened as a variable in the pytree flatten spec for a VBE KJT to be unflattened correctly by`torch.export.
* Currently `stride_per_key_per_rank` is a List. To flatten the `stride_per_key_per_rank`  info as a variable we have to add a new tensor field for it.

# Ref

Differential Revision: D74207283


