### PR TITLE
enable cudagraph for AUCMetricComputation

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -370,6 +370,7 @@ def _generate_rec_metrics(
             kwargs = metric_def.arguments
 
         kwargs["enable_pt2_compile"] = metrics_config.enable_pt2_compile
+        kwargs["should_clone_update_inputs"] = metrics_config.should_clone_update_inputs
 
         rec_tasks: List[RecTaskInfo] = []
         if metric_def.rec_tasks and metric_def.rec_task_indices:

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -170,6 +170,8 @@ class MetricsConfig:
             update if the inputs are invalid. Invalid inputs include the case where all
             examples have 0 weights for a batch.
         enable_pt2_compile (bool): whether to enable PT2 compilation for metrics.
+        should_clone_update_inputs (bool): whether to clone the inputs of update(). This
+            prevents CUDAGraph error on overwritting tensor outputs by subsequent runs.
     """
 
     rec_tasks: List[RecTaskInfo] = field(default_factory=list)
@@ -184,6 +186,7 @@ class MetricsConfig:
     compute_on_all_ranks: bool = False
     should_validate_update: bool = False
     enable_pt2_compile: bool = False
+    should_clone_update_inputs: bool = False
 
 
 DefaultTaskInfo = RecTaskInfo(


### PR DESCRIPTION
Summary:
Previously, enable cudagraph leads to [errors](https://fb.workplace.com/groups/1075192433118967/permalink/1661777797793758/) on AUCMetricComputation.

The root cause is that model forward output tensors `predictions`, `labels`, `weights`, and `grouping_keys`
 got overwritten by the next CUDAGraph replay. This diff fixes the issue by clone these tensors before they are overwritten. The overhead should be small since these tensors only have shape `(n_task, n_examples)`.

Differential Revision: D74293458


