### PR TITLE
fix train pipeple ArgInfo to work with dedup_id_list_feature_list

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -191,7 +191,7 @@ class ArgInfo:
             positional arg.
     """
 
-    input_attrs: List[str]
+    input_attrs: List[Union[str, int]]
     is_getitems: List[bool]
     # recursive dataclass as postproc_modules.args -> arginfo.postproc_modules -> so on
     postproc_modules: List[Optional["PipelinedPostproc"]]
@@ -1092,7 +1092,12 @@ def _get_node_args_helper_inner(
                 ph_keys = ph_key.split(".")
                 for key in ph_keys:
                     if "]" in key:
-                        arg_info.input_attrs.append(key[:-1])
+                        k_ = key[:-1]
+                        try:
+                            k_ = int(k_)
+                        except ValueError:
+                            pass
+                        arg_info.input_attrs.append(k_)
                         arg_info.is_getitems.append(True)
                     else:
                         arg_info.input_attrs.append(key)


### PR DESCRIPTION
Summary:
Original issue described in https://docs.google.com/document/d/1kbqMXCCSkWCg_BD7URf-TYapCO6S-d3kWGHtdfYtJ58/edit?usp=sharing
**Summary:**
After export, in training, we had following error:
```
attr = '0'

arg = [KeyJaggedTensor]

list indices must be integers or slices, not str
  File "/data/users/zhenyuhou/fbsource/fbcode/torchrec/distributed/train_pipeline/utils.py", line 216, in _build_args_kwargs
    arg = arg[attr]
```

P1670461644
 {F1973933529}

When `Enable_sparse_dedup`, the arg is a list instead of dictionary, therefore need to support indexing by int.

Reviewed By: malaybag

Differential Revision: D65375421


