### PR TITLE
Swap CPU TBE lookup kernel with SSD TBE lookup kernel for tables being offloaded to SSD

### DIFF
--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -224,6 +224,7 @@ class ShardedQuantEmbeddingBagCollection(
         self._is_weighted: bool = module.is_weighted()
         self._lookups: List[nn.Module] = []
         self._create_lookups(fused_params, device)
+        self._fused_params = fused_params
 
         # Ensure output dist is set for post processing from an inference runtime (ie. setting device from runtime).
         self._output_dists: torch.nn.ModuleList = torch.nn.ModuleList()


### PR DESCRIPTION
Summary:
Once, we TW shard the SSD tables here: D74444699 along with remaining tables, we traverse the model def and swap cpu tbe look up kernel for these ssd tables with the ssd look up kernel introduced here: D74536076 during TGIF publish

If and when SSD embedding db based look up kernel is open sourced we can directly map the ssd tbe kernel during sharding without any swap

Differential Revision: D74537413


