### PR TITLE
Pass pipeline_postproc argument to IG Retrieval SparseDistUtil

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -1921,6 +1921,7 @@ class SparseDataDistUtil(Generic[In]):
         data_dist_stream: torch.Stream,
         apply_jit: bool = False,
         prefetch_stream: Optional[torch.Stream] = None,
+        pipeline_postproc: bool = False,
     ) -> None:
         super().__init__()
         self.model = model
@@ -1967,6 +1968,7 @@ class SparseDataDistUtil(Generic[In]):
         # correctness invariant. However, if that changes, having invariants monitored/enforced
         # during exhastion phase might become necessary.
         self._exhausting_mode = False
+        self._pipeline_postproc = pipeline_postproc
 
     @property
     def _with_prefetch(self) -> bool:
@@ -2206,6 +2208,7 @@ class SparseDataDistUtil(Generic[In]):
             batch=batch,
             apply_jit=self.apply_jit,
             pipelined_forward=self._pipelined_forward,
+            pipeline_postproc=self._pipeline_postproc,
             default_stream=self._default_stream,
         )
         # Setting the stage for the first batch


### PR DESCRIPTION
Summary:
**General context:** Torchrec SparseDist pipeline improves QPS (~5-15% from past applications) by distributing embedding IDs ahead of time - improving communication/computation overlap, and often running these in parallel with previous batch backward/optimizer. As a result, when embeddings are actually needed (i.e. Embedding(Bag)Collection modules are called from sparse arch), it takes one less NCCL communication to get them.

This diff stack aims to enable SDD pipeline for OMNI_HSTU_ROO model, and have three main logical parts:
* Adding support for pipelined postproc to the SparseDataDistUtil
* Adjustments to the IG Retrieval training pipeline to make OMNI_HSTU_ROO trainable with pipelined trainer (no SDD yet) + allow enabling pipeline_postproc through the pipeline config 
* Adjust the model to enable SDD pipeline - (1) make model FX-traceablle, (2) make embedding collections pipelinable and (3) using the sparse dist

**In this diff:** Adds a config flag to enable pipelining postprocs 
*Side note:* this will need to be refactored to support other kinds of pipelines (e.g. SemiSync) - we'll deal with excessive config flag proliferation at that time

Diff stack navigation:
* Supporting pipelined postprocs in the Torchrec SparseDistUtil:
    * D73824600 - add a context manager to simplify temporarily setting pipelined posptrocs forward context to the next one
    * D73824601 - support pipelining postprocs in SDDUtil
* Adjusting IG Retrieval training pipeline:
    * D73496449 **(you are here)** - adds pipeline_postproc flag to the OmniConfig and pass it through pipeline-creation machinery
    * D73496447 - pass `mini_batch.all_labels` to `model_labels.all_labels` in the pipelined_forward
    * D73655204 - OMNI_HSTU_IGR add `compute_loss` function needed to run model with pipelined trainer
* Model pipelining:
    * D73649633 - adds test to exercise FX-traceability (condition one) 
    * D73649631 - makes model FX-traceable
    * D73649629 - expands the test to check sparse module pipelinability (condition two) 
    * D73649628 - make modules pipelinable
    * D73649627 - enables SDD pipeline

Reviewed By: arsatis

Differential Revision: D73496449


