### PR TITLE
recmetrics for fault tolerance

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -479,6 +479,10 @@ class RecMetric(nn.Module, abc.ABC):
                 yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value, metric_report.description
 
     def _unfused_tasks_iter(self, compute_scope: str) -> ComputeIterType:
+        """
+        For each task, we generate an associated RecMetricComputation object for it.
+        This would mean in the states of each RecMetricComputation object, the n_tasks dimension is 1.
+        """
         for task, metric_computation in zip(self._tasks, self._metrics_computations):
             metric_computation.pre_compute()
             for metric_report in getattr(
@@ -494,6 +498,7 @@ class RecMetric(nn.Module, abc.ABC):
                     or metric_computation.has_valid_update[0] > 0
                     else torch.zeros_like(metric_report.value)
                 )
+                # ultimately compute result comes here, and is then written to tensorboard, for fused tasks we need to know the metric prefix val and description
                 yield task, metric_report.name, valid_metric_value, compute_scope + metric_report.metric_prefix.value, metric_report.description
 
     def _fuse_update_buffers(self) -> Dict[str, RecModelOutput]:


### PR DESCRIPTION
Summary:
in this diff we expose two new methods for metric module: get_pre_compute_states and load_pre_compute_states. like the name suggests this function returns the metric states before the metric.compute() call. we aggregate the states and apply the reduction function to those intermediate states and return the result.

will add fused task aggregation in a later diff. this diff supports unfused task computation only.

usage:
pass in the devicemesh from DMPCollection or can pass in DMPCollection.sharding_pg

example output is setup as:
```
ne:
  {
     task_name: {state : tensor, state : tensor}, task_name : {state : tensor, state : tensor}
   },
mse:
   ...
```

real output:
```
'ne': {'DefaultTask': {'cross_entropy_sum': tensor([18453.3014], device='cuda:1', dtype=torch.float64), 'window_cross_entropy_sum': tensor([18453.3014], device='cuda:1', dtype=torch.float64), 'weighted_num_samples': tensor([12778.6176], device='cuda:1', dtype=torch.float64), 'window_weighted_num_samples': tensor([12778.6176], device='cuda:1', dtype=torch.float64), 'pos_labels': tensor([6420.7206], device='cuda:1', dtype=torch.float64), 'window_pos_labels': tensor([6420.7206], device='cuda:1', dtype=torch.float64), 'neg_labels': tensor([6357.8971], device='cuda:1', dtype=torch.float64), 'window_neg_labels': tensor([6357.8971], device='cuda:1', dtype=torch.float64)}}}
```

Reviewed By: peterfu0

Differential Revision: D71934160


