### PR TITLE
Update cuda versions for CI tests

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -23,11 +23,11 @@ jobs:
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: 3.9
             python-tag: "py39"
-            cuda-tag: "cu121"
+            cuda-tag: "cu126"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: 3.9
             python-tag: "py39"
-            cuda-tag: "cu124"
+            cuda-tag: "cu128"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.10'
             python-tag: "py310"
@@ -35,11 +35,11 @@ jobs:
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.10'
             python-tag: "py310"
-            cuda-tag: "cu121"
+            cuda-tag: "cu126"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.10'
             python-tag: "py310"
-            cuda-tag: "cu124"
+            cuda-tag: "cu128"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.11'
             python-tag: "py311"
@@ -47,11 +47,11 @@ jobs:
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.11'
             python-tag: "py311"
-            cuda-tag: "cu121"
+            cuda-tag: "cu126"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.11'
             python-tag: "py311"
-            cuda-tag: "cu124"
+            cuda-tag: "cu128"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.12'
             python-tag: "py312"
@@ -59,11 +59,11 @@ jobs:
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.12'
             python-tag: "py312"
-            cuda-tag: "cu121"
+            cuda-tag: "cu126"
           - os: linux.g5.12xlarge.nvidia.gpu
             python-version: '3.12'
             python-tag: "py312"
-            cuda-tag: "cu124"
+            cuda-tag: "cu128"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Summary: Set the CUDA versions supported by Pytorch as per https://pytorch.org/get-started/locally/

Differential Revision: D75248197


