### PR TITLE
Handle Virtual Table sizing in planner

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -441,6 +441,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                     sharders=sharders,
                     debug=self._debug,
                 )
+            logger.info(f"Found sharding plan {sharding_plan}")
             return sharding_plan
         else:
             global_storage_capacity = reduce(

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -696,7 +696,6 @@ def create_test_model(
 
     mi.model = TorchTypesModelInputWrapper(
         TestSparseNN(
-            # pyre-ignore [6]
             tables=mi.tables,
             weighted_tables=mi.weighted_tables,
             num_float_features=mi.num_float_features,

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -15,6 +15,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
 import torch
 import torch.nn as nn
 from tensordict import TensorDict
+from torchrec import EmbeddingCollection
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_tower_sharding import (
     EmbeddingTowerCollectionSharder,
@@ -1209,6 +1210,47 @@ def _post_sparsenn_forward(
         )
 
 
+class TestECSparseArch(nn.Module):
+    """
+    Basic nn.Module for testing
+
+    Args:
+        tables
+        device
+
+    Call Args:
+        features
+
+    Returns:
+        KeyedTensor
+    """
+
+    def __init__(
+        self,
+        tables: List[EmbeddingConfig],
+        # weighted_tables: List[EmbeddingBagConfig],
+        device: Optional[torch.device] = None,
+        # max_feature_lengths: Optional[Dict[str, int]] = None,
+    ) -> None:
+        super().__init__()
+        if device is None:
+            device = torch.device("cpu")
+        self.ec: EmbeddingCollection = EmbeddingCollection(
+            tables=tables,
+            device=device,
+        )
+
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+        weighted_features: Optional[KeyedJaggedTensor] = None,
+        batch_size: Optional[int] = None,
+    ) -> KeyedTensor:
+        ec = self.ec(features)
+        result = _post_sparsenn_forward(ec, None, None, batch_size)
+        return result
+
+
 class TestSparseArch(nn.Module):
     """
     Basic nn.Module for testing
@@ -1351,7 +1393,7 @@ class TestSparseNN(TestSparseNNBase, CopyableMixin):
 
     def __init__(
         self,
-        tables: List[EmbeddingBagConfig],
+        tables: Union[List[EmbeddingBagConfig], List[EmbeddingConfig]],
         num_float_features: int = 10,
         weighted_tables: Optional[List[EmbeddingBagConfig]] = None,
         embedding_groups: Optional[Dict[str, List[str]]] = None,
@@ -1375,14 +1417,19 @@ class TestSparseNN(TestSparseNNBase, CopyableMixin):
         self.dense = TestDenseArch(num_float_features, dense_device)
         if zch:
             self.sparse: nn.Module = TestSparseArchZCH(
-                tables,
+                tables,  # pyre-ignore
                 weighted_tables,
                 torch.device("meta"),
                 return_remapped=True,
             )
+        elif isinstance(tables[0], EmbeddingConfig):
+            self.sparse = TestECSparseArch(
+                tables,  # pyre-ignore [6]
+                sparse_device,
+            )
         else:
             self.sparse = TestSparseArch(
-                tables,
+                tables,  # pyre-ignore
                 weighted_tables,
                 sparse_device,
                 max_feature_lengths,


### PR DESCRIPTION
Summary:
Virtual Embedding Tables is a new feature in ZCH v.Next. These do not allocate the embedding table memory on init.
This allows us to have larger embedding tables and paired with Embedding Offloading kernels to DRAM and SSD.
Since the memory is kernel dependent, we check for the specific kernel and override the hbm and dram sizes accordingly.
https://docs.google.com/document/d/1NjtP01PSOHKwyRxAicV7wrdWPVI1NN9A3aPYuBaOpsg/edit?tab=t.0

Differential Revision: D74557713


