### PR TITLE
remove unused pyre ignore

### DIFF
--- a/torchrec/tensor_types.py
+++ b/torchrec/tensor_types.py
@@ -76,7 +76,6 @@ class UIntXTensor(torch.Tensor):
     @staticmethod
     def __new__(cls, N: int, elem):
         assert elem.dtype is torch.uint8
-        # pyre-ignore
         return torch.Tensor._make_wrapper_subclass(
             cls, up_size(N, elem.shape), dtype=torch.uint8
         )


### PR DESCRIPTION
Summary:
fixes a pyre failure in D75460828

```
  Failure:
    This diff stack is introducing 1 typecheck errors in a dependent project that is enforcing a clean typing state. Resolve these or get help before landing.

    [torchrec/tensor_types.py:79:8] Unused ignore [0]: The `pyre-ignore` or `pyre-fixme` comment is not suppressing type errors, please remove it.
```

Differential Revision: D75488532


