### PR TITLE
[PT2 IR] add emb cast in KTRegroupAsDict module

### DIFF
--- a/torchrec/ir/schema.py
+++ b/torchrec/ir/schema.py
@@ -54,3 +54,4 @@ class PositionWeightedModuleCollectionMetadata:
 class KTRegroupAsDictMetadata:
     groups: List[List[str]]
     keys: List[str]
+    emb_dtype: Optional[str]

--- a/torchrec/ir/serializer.py
+++ b/torchrec/ir/serializer.py
@@ -411,6 +411,11 @@ class KTRegroupAsDictJsonSerializer(JsonSerializer):
             # pyre-fixme[6]: For 2nd argument expected `List[List[str]]` but got
             #  `Union[Module, Tensor]`.
             groups=module._groups,
+            emb_dtype=(
+                module._emb_dtype.value  # pyre-ignore[16]
+                if module._emb_dtype is not None
+                else None
+            ),
         )
         return metadata.__dict__
 
@@ -425,6 +430,9 @@ class KTRegroupAsDictJsonSerializer(JsonSerializer):
         return KTRegroupAsDict(
             keys=metadata.keys,
             groups=metadata.groups,
+            emb_dtype=(
+                DataType(metadata.emb_dtype) if metadata.emb_dtype is not None else None
+            ),
         )
 
 


### PR DESCRIPTION
Summary:
# context
* add `emb_dtype` to the `KTRegroupAsDict` module because in APS some customized regroup module there is a casting operation
* to make the model ir-compatible with the "short-circuit" solution, we'll need to absorb this casting function inside the KTRegroupAsDict module

Differential Revision: D75326034


