### PR TITLE
Add hashing for planner context inputs

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -279,6 +279,24 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             sharders,
         )
 
+    def hash_planner_context_inputs(self) -> int:
+        """
+        Generates a hash for all planner inputs except for partitioner, proposer, performance model, and stats.
+        These are all the inputs needed to verify whether a previously generated sharding plan is still valid in a new context.
+
+        Returns:
+            Generates a hash capturing topology, batch size, enumerator, storage reservation, stats and constraints.
+        """
+        return hash(
+            (
+                self._topology,
+                self._batch_size,
+                self._enumerator,
+                self._storage_reservation,
+                frozenset(self._constraints.items()) if self._constraints else None,
+            )
+        )
+
     def plan(
         self,
         module: nn.Module,


### PR DESCRIPTION
Summary:
In order to check whether previously generated plans are still valid, we are adding functionality to hash contextual information in the `EmbeddingShardingPlanner` class. Specifically, previously generated plans would still be valid if the following haven't changed:

1. Topology
2. Batch size
3. Enumerator (since we use this to construct the search space)
4. Storage reservation
5. Parameter constraints

We have added a `hash_planner_context_inputs` method to the `EmbeddingShardingPlanner` class that generates a hash value depending on these 5 inputs. We will later use this to ensure that previously generated plans are still valid while loading them in.

Differential Revision: D75567115


