### PR TITLE
Add enumerator to logging stats

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -437,6 +437,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                     run_time=end_time - start_time,
                     best_plan=best_plan,
                     constraints=self._constraints,
+                    enumerator=self._enumerator,
                     sharders=sharders,
                     debug=self._debug,
                 )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -279,6 +279,24 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             sharders,
         )
 
+    def hash_planner_context_inputs(self) -> int:
+        """
+        Generates a hash for all planner inputs except for partitioner, proposer, performance model, and stats.
+        These are all the inputs needed to verify whether a previously generated sharding plan is still valid in a new context.
+
+        Returns:
+            Generates a hash capturing topology, batch size, enumerator, storage reservation, stats and constraints.
+        """
+        return hash(
+            (
+                self._topology,
+                self._batch_size,
+                self._enumerator,
+                self._storage_reservation,
+                frozenset(self._constraints.items()) if self._constraints else None,
+            )
+        )
+
     def plan(
         self,
         module: nn.Module,

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -37,6 +37,7 @@ from torchrec.distributed.planner.storage_reservations import (
 )
 from torchrec.distributed.planner.types import (
     CriticalPathEstimate,
+    Enumerator,
     ParameterConstraints,
     Perf,
     ShardingOption,
@@ -157,6 +158,7 @@ class EmbeddingStats(Stats):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = True,
     ) -> None:
         """
@@ -1133,6 +1135,7 @@ class NoopEmbeddingStats(Stats):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = True,
     ) -> None:
         pass

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -912,6 +912,7 @@ class Stats(abc.ABC):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = False,
     ) -> None:
         """


### PR DESCRIPTION
Summary: Add enumerator to the stats logging. We will use this in the next diff to generate a hash for the planner input context.

Differential Revision: D75616014


