### PR TITLE
Add new argument for sharding_plan

### DIFF
--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -71,7 +71,7 @@ from torchrec.distributed.types import (
     ShardingPlan,
 )
 from torchrec.distributed.utils import CopyableMixin
-from torchrec.inference.modules import set_pruning_data
+from torchrec.inference.modules import set_pruning_data, shard_quant_model
 from torchrec.modules.embedding_configs import (
     data_type_to_sparse_type,
     dtype_to_data_type,
@@ -901,15 +901,15 @@ def shard_qebc(
 
     # We want to leave quant_model unchanged to compare the results with it
     quant_model_copy = copy.deepcopy(mi.quant_model)
-    sharded_model = _shard_modules(
-        module=quant_model_copy,
+    sharded_model, _ = shard_quant_model(
+        model=quant_model_copy,
         # pyre-fixme[6]: For 2nd argument expected
         #  `Optional[List[ModuleSharder[Module]]]` but got `List[TestQuantEBCSharder]`.
         sharders=[sharder],
-        device=device,
-        plan=plan,
+        sharding_device=str(device),
         # pyre-ignore
-        env=ShardingEnv.from_local(world_size=mi.topology.world_size, rank=0),
+        world_size=mi.topology.world_size,
+        sharding_plan=plan,
     )
     return sharded_model
 

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -499,7 +499,6 @@ def shard_quant_model(
     device_memory_size: Optional[int] = None,
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
     ddr_cap: Optional[int] = None,
-    sharding_type: ShardingType = ShardingType.TABLE_WISE,
 ) -> Tuple[torch.nn.Module, ShardingPlan]:
     """
     Shard a quantized TorchRec model, used for generating the most optimal model for inference and
@@ -535,10 +534,6 @@ def shard_quant_model(
         quant_model = quantize_inference_model(module)
         sharded_model, _ = shard_quant_model(quant_model)
     """
-    # TODO(T220572301): remove after new sharding types are validated.
-    assert (
-        sharding_type == ShardingType.TABLE_WISE
-    ), "Only table-wise sharding is supported now."
 
     if constraints is None:
         table_fqns = []
@@ -557,7 +552,7 @@ def shard_quant_model(
         constraints = {}
         for name in table_fqns:
             constraints[name] = ParameterConstraints(
-                sharding_types=[sharding_type.value],
+                sharding_types=[ShardingType.TABLE_WISE.value],
                 compute_kernels=[EmbeddingComputeKernel.QUANT.value],
             )
 

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -499,6 +499,7 @@ def shard_quant_model(
     device_memory_size: Optional[int] = None,
     constraints: Optional[Dict[str, ParameterConstraints]] = None,
     ddr_cap: Optional[int] = None,
+    sharding_plan: Optional[ShardingPlan] = None,
 ) -> Tuple[torch.nn.Module, ShardingPlan]:
     """
     Shard a quantized TorchRec model, used for generating the most optimal model for inference and
@@ -534,6 +535,20 @@ def shard_quant_model(
         quant_model = quantize_inference_model(module)
         sharded_model, _ = shard_quant_model(quant_model)
     """
+
+    if sharding_plan is not None:
+        model = _shard_modules(
+            module=model,
+            device=torch.device(sharding_device),
+            plan=sharding_plan,
+            env=trec_dist.ShardingEnv.from_local(
+                world_size,
+                0,
+            ),
+            sharders=sharders if sharders else DEFAULT_SHARDERS,
+        )
+
+        return model, sharding_plan
 
     if constraints is None:
         table_fqns = []


### PR DESCRIPTION
Summary: Add param to allow users to use their own sharding plan when calling `shard_quant_model`. This is helpful for users that do not rely on the TorchRec planner for the sharding plan.

Differential Revision: D75728320


