### PR TITLE
Fix linter

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -124,7 +124,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
                 torch.nn.utils.clip_grad_norm_(
                     replicate_params,
                     self._max_gradient,
-                    norm_type=self._norm_type,
+                    norm_type=float(self._norm_type),
                 )
             else:
                 self.clip_grad_norm_()


### PR DESCRIPTION
Summary: the variable is kept optional str for "inf"

Reviewed By: iamzainhuda

Differential Revision: D75900311


