### PR TITLE
chunking opt split and fix duplicate flush

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -1435,7 +1435,6 @@ class ZeroCollisionKeyValueEmbedding(
 
         pmt_list, weight_ids_list, bucket_cnt_list = self.split_embedding_weights(
             no_snapshot=False,
-            should_flush=True,
         )
         emb_table_config_copy = copy.deepcopy(self._config.embedding_tables)
         for emb_table in emb_table_config_copy:
@@ -1528,7 +1527,7 @@ class ZeroCollisionKeyValueEmbedding(
 
     # pyre-ignore [15]
     def split_embedding_weights(
-        self, no_snapshot: bool = True, should_flush: bool = True
+        self, no_snapshot: bool = True, should_flush: bool = False
     ) -> Tuple[
         Union[List[PartiallyMaterializedTensor], List[torch.Tensor]],
         Optional[List[torch.Tensor]],

--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -1444,7 +1444,7 @@ class ZeroCollisionKeyValueEmbedding(
                     emb_table.local_metadata,
                     f"local_metadata is None for emb_table: {emb_table.name}",
                 ).placement,
-                "placement is None for local_metadata of emb table: {emb_table.name}",
+                f"placement is None for local_metadata of emb table: {emb_table.name}",
             )._device = torch.device("cpu")
 
         pmt_sharded_t_list = create_virtual_sharded_tensors(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1338

changesets
1. in ZeroCollisionKeyValueEmbedding, we force flush when calling split_embedding_weights, remove that to utilize the cached weights on the same global step.
2. on split embedding optimizer, rocksdb has to read the whole value part(embedding + optimizer) out into dram, without chunking we essentially read everything into dram at once(temporarily huge mem spike), with chunk loading, we could keep mem spike low.

Differential Revision: D75988991


