### PR TITLE
remove ROCM build from binary validation

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -22,10 +22,6 @@ conda run -n build_binary python --version
 # installation instructions on following page
 # https://github.com/pytorch/torchrec#installations
 
-if [[ ${MATRIX_GPU_ARCH_TYPE} = 'rocm' ]]; then
-    echo "We don't support rocm"
-    exit 0
-fi
 
 # figure out CUDA VERSION
 if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -39,3 +39,4 @@ jobs:
       repository: "pytorch/torchrec"
       smoke_test: "source ./.github/scripts/validate_binaries.sh"
       with_cuda: enable
+      with_rocm: false


### PR DESCRIPTION
Summary:
# context
* torchrec github actions re-uses lots of workflows from pytorch-test-infra
* in the build-wheels-linux it disables rocm
```
  generate-matrix:
    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
    with:
      package-type: wheel
      os: linux
      test-infra-repository: pytorch/test-infra
      test-infra-ref: main
      with-rocm: false
```
* but in the validate-binaries it uses default, which generates rocm arch for testing
```
  validate-binaries:
    uses: pytorch/test-infra/.github/workflows/validate-domain-library.yml@main
    with:
      package_type: "wheel"
      os: "linux"
      channel: ${{ inputs.channel }}
      repository: "pytorch/torchrec"
      smoke_test: "source ./.github/scripts/validate_binaries.sh"
      with_cuda: enable
      with_rocm: false <---- this line is added by this diff
```
* since there's no ROCM support so the validate_binaries.sh script has to do an early return
```
if [[ ${MATRIX_GPU_ARCH_TYPE} = 'rocm' ]]; then
    echo "We don't support rocm"
    exit 0
fi
```
> WARNING: although the validate-binaries.sh script does early return but it still consume github runner to set up the docker and so. Pure waste of resources.

* this entire thing is unnecessary if we just exclude ROCM arch in the config

Differential Revision: D76107773


