### PR TITLE
Enable proper optimizer state storing + Test between batches

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -687,7 +687,10 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             self.device,
         )
 
-        self._optim: CombinedOptimizer = self._init_optim(self._dmp_wrapped_module)
+        # Need to use .module to maintain FQN consistency
+        self._optim: CombinedOptimizer = self._init_optim(
+            self._dmp_wrapped_module.module  # pyre-ignore
+        )
         self._plan.plan[sharded_module_fqn] = sharded_module.module_sharding_plan
         return sharded_module
 

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -8,8 +8,6 @@
 # pyre-strict
 
 
-import copy
-
 import random
 import unittest
 
@@ -21,7 +19,7 @@ import torch
 
 from hypothesis import assume, given, settings, Verbosity
 
-from torch import nn
+from torch import nn, optim
 
 from torchrec import distributed as trec_dist, EmbeddingBagCollection, KeyedJaggedTensor
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -531,8 +529,10 @@ class MultiRankDMPDynamicShardingTest(ModelParallelTestShared):
             [
                 None,
                 {
+                    "embedding_bags": (optim.Adagrad, {"lr": 0.04}),
+                },
+                {
                     "embedding_bags": (torch.optim.SGD, {"lr": 0.01}),
-                    "embeddings": (torch.optim.SGD, {"lr": 0.2}),
                 },
             ]
         ),


### PR DESCRIPTION
Summary:
# Main Changes
1. Enable unit test with an adaptive optimizer `Adagrad` 
   1. Previously I tested the optimizer state  with an optimizer `SGD` that is static throughout training so didn't , instead here I used the `Adagrad` which exposed the previous implementation did not properly store optimziers.
2. Properly store optimizer state in `update_optimizer_state`
    2. Append optimizer tensors as inputs to the all2all call, then parse through the output tensors to store the right tensors. 
    2. Optimizer tensors that did not need to be sent to a new rank are persisted and resaved. 
    2. After new lookups are created, use `load_state_dict` to load in the saved optimizer state to the current optimizers.
3. Helpers & other small changes
    3. Helper to compare optimizer tensors for unit tests
    3. Update `DMP` reshard - optimizer saving to match the same fqn

Differential Revision: D75565054


