### PR TITLE
Fix optimizer check edge case

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1533,7 +1533,9 @@ class ShardedEmbeddingBagCollection(
             return
 
         current_state = self.state_dict()
-        has_optimizer = len(self._optim._optims) > 0
+        has_optimizer = len(self._optim._optims) > 0 and all(
+            len(i) > 0 for i in self._optim.state_dict()["state"].values()
+        )
 
         # TODO: Saving lookups tensors to CPU to eventually avoid recreating them completely again
         # TODO: Ensure lookup tensors are actually being deleted


### PR DESCRIPTION
Summary:
There's an edge case for detecting an optimizer - where no optimizer is applied during backwards, but the compute kernel is fused, so techncially an EBC.optimizer would be created. 

In this case for dynamic sharding, we still don't need to store any optimizers - I've added the condition to properly check for optimizers to pass the unit test.

Differential Revision: D76203188


