### PR TITLE
increase gpu test timeout from 30min to 60min

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -69,7 +69,7 @@ jobs:
       contents: read
     with:
       runner: ${{ matrix.os }}
-      timeout: 30
+      timeout: 60
       script: |
         ldd --version
         conda create -y --name build_binary python=${{ matrix.python.version }}


### PR DESCRIPTION
Summary:
# context
* enable torchrec OSS GPU CI tests but find it frequently times out
* right now the timeout limit is 30 mins so increase it to 60 mins

Differential Revision: D76291745


