### PR TITLE
Update Planner hash to use SHA256

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -437,6 +437,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
                     run_time=end_time - start_time,
                     best_plan=best_plan,
                     constraints=self._constraints,
+                    enumerator=self._enumerator,
                     sharders=sharders,
                     debug=self._debug,
                 )

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -37,6 +37,7 @@ from torchrec.distributed.planner.storage_reservations import (
 )
 from torchrec.distributed.planner.types import (
     CriticalPathEstimate,
+    Enumerator,
     ParameterConstraints,
     Perf,
     ShardingOption,
@@ -157,6 +158,7 @@ class EmbeddingStats(Stats):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = True,
     ) -> None:
         """
@@ -1133,6 +1135,7 @@ class NoopEmbeddingStats(Stats):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = True,
     ) -> None:
         pass

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -18,6 +18,7 @@ from torchrec.distributed.planner.types import (
     ParameterConstraints,
     Shard,
     ShardingOption,
+    Topology,
 )
 from torchrec.distributed.types import (
     BoundsCheckMode,
@@ -212,6 +213,54 @@ class TestShardingOption(unittest.TestCase):
             shards=[Shard(size=shard_size, offset=offset) for offset in shard_offsets],
         )
         self.assertEqual(sharding_option.is_pooled, False)
+
+
+class TestTopologyHash(unittest.TestCase):
+    def test_hash_equality(self) -> None:
+        # Create two identical Topology instances
+        topology1 = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 2,
+            local_world_size=2,
+        )
+
+        topology2 = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 2,
+            local_world_size=2,
+        )
+
+        # Verify that the hash values are equal
+        self.assertEqual(
+            topology1._hash(),
+            topology2._hash(),
+            "Hashes should be equal for identical Topology instances",
+        )
+
+    def test_hash_inequality(self) -> None:
+        # Create two different Topology instances
+        topology1 = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 2,
+            local_world_size=2,
+        )
+
+        topology2 = Topology(
+            world_size=4,  # Different world_size
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 2,
+            local_world_size=2,
+        )
+
+        # Verify that the hash values are different
+        self.assertNotEqual(
+            topology1._hash(),
+            topology2._hash(),
+            "Hashes should be different for different Topology instances",
+        )
 
 
 class TestParameterConstraintsHash(unittest.TestCase):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -8,6 +8,8 @@
 # pyre-strict
 
 import abc
+import hashlib
+import pickle
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -248,6 +250,10 @@ class BasicCommsBandwidths(GeneralizedCommsBandwidth):
 
 
 class Topology:
+    """
+    Representation of a network of devices in a cluster.
+    """
+
     def __init__(
         self,
         world_size: int,
@@ -395,6 +401,40 @@ class Topology:
         topology_repr += f"local_world_size={self._local_world_size} \n"
         topology_repr += str(self._comms_bandwidths) + "\n"
         return topology_repr
+
+    def _hash(self) -> str:
+        """
+        Compute a consistent hash value for this Topology instance.
+
+        Returns:
+            str: A hash value for this Topology instance.
+        """
+
+        # Compute hbms and ddrs from the decives
+        hbms = [device.storage.hbm for device in self._devices]
+        ddrs = [device.storage.ddr for device in self._devices]
+
+        # Combine all attributes into a hashable tuple
+        hashable_list = [
+            self._world_size,
+            self._compute_device,
+            hbms,
+            ddrs,
+            self._local_world_size,
+            self._hbm_mem_bw,
+            self._ddr_mem_bw,
+            self._hbm_to_ddr_mem_bw,
+            self._comms_bandwidths.intra_host_bw,
+            self._comms_bandwidths.inter_host_bw,
+            self._bwd_compute_multiplier,
+            self._weighted_feature_bwd_compute_multiplier,
+            self._uneven_sharding_perf_multiplier,
+        ]
+
+        serialized_list = str(hashable_list).encode("utf-8")
+        hash_object = hashlib.sha256(serialized_list)
+        hash_digest = hash_object.hexdigest()
+        return hash_digest
 
 
 # ---- INPUT / OUTPUT ----- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -952,6 +952,7 @@ class Stats(abc.ABC):
         best_plan: List[ShardingOption],
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
+        enumerator: Optional[Enumerator] = None,
         debug: bool = False,
     ) -> None:
         """


### PR DESCRIPTION
Summary:
Use consistent hash  SHA256 for planner input context, similar to topology implemented D76004583

This is called by manifold_planner - so updated return types to be consistently str

Differential Revision: D76317306
