### PR TITLE
Guard with PT2 instead of Dynamo

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -55,7 +55,7 @@ def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     """
     moving a tensor from cpu to cuda using pinned memory (non_blocking) is generally faster
     """
-    if is_torchdynamo_compiling():
+    if is_pt2_compiling():
         # TODO: remove once FakeTensor supports pin_memory() and to(..., non_blocking=True)
         return tensor.to(device=device)
 


### PR DESCRIPTION
Summary:
FakeTensor pin memory issue applies in all PT2 compilation, not just dynamo compilation

This changes the pin-memory issue in APS IR (T215287736) into the KTRegroup issue

Differential Revision: D76432510
