### PR TITLE
optionally checkpoint r_squared metrics when required

### DIFF
--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -110,14 +110,14 @@ class MSEMetricComputation(RecMetricComputation):
             torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
-            persistent=True,
+            persistent=include_r_squared,
         )
         self._add_state(
             "label_squared_sum",
             torch.zeros(self._n_tasks, dtype=torch.double),
             add_window_state=True,
             dist_reduce_fx="sum",
-            persistent=True,
+            persistent=include_r_squared,
         )
 
     def update(


### PR DESCRIPTION
Summary: r_squared states get checkpointed when not needed, resulting in loading issues. this bypasses by making those states persistent only when needed, ie: r_squared=True

Differential Revision: D76162934
