### PR TITLE
Enable Consistent SHA256 Hashing with reduced Planner Context

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -39,6 +39,7 @@ from torchrec.distributed.planner.storage_reservations import (
 )
 from torchrec.distributed.planner.types import (
     Enumerator,
+    hash_planner_context_inputs,
     ParameterConstraints,
     Partitioner,
     PerfModel,
@@ -280,7 +281,7 @@ class EmbeddingShardingPlanner(ShardingPlanner):
             sharders,
         )
 
-    def hash_planner_context_inputs(self) -> str:
+    def hash_planner_context_inputs(self) -> int:
         """
         Generates a hash for all planner inputs except for partitioner, proposer, performance model, and stats.
         These are all the inputs needed to verify whether a previously generated sharding plan is still valid in a new context.
@@ -288,17 +289,13 @@ class EmbeddingShardingPlanner(ShardingPlanner):
         Returns:
             Generates a hash capturing topology, batch size, enumerator, storage reservation, stats and constraints.
         """
-        hashable_list = [
+        return hash_planner_context_inputs(
             self._topology,
             self._batch_size,
             self._enumerator,
             self._storage_reservation,
-            frozenset(self._constraints.items()) if self._constraints else None,
-        ]
-        serialized_list = str(hashable_list).encode("utf-8")
-        hash_object = hashlib.sha256(serialized_list)
-        hash_digest = hash_object.hexdigest()
-        return hash_digest
+            self._constraints,
+        )
 
     def plan(
         self,


### PR DESCRIPTION
Summary:
Even though SHA256 hashing is used, we're still not seeing the expected same hash generated from the original planner context inputs.

This problem is due to Enumerator and Storage Reservation objects we were originally trying to hash containing attributes that differ between processes/instances.

To resolve this we reduced the hashing context to only use the specific attributes we need from enumerator and storage reservation.
Namely:
* enumerator.enumerate(...)'s output - which is used as the `search_space` in both LP and OSS planner
    * We are storing the output of enumerate as an attribute `last_stored_search_space`. **This assumes enumerate will have been called before we hash the planner context inputs**.
* StorageResveration's policy (aka whether `HeuristicalStorageReservation` is used or `FixedStorageReservation`
* StorageResveration's initialization attributes:
    * _percentage
    * _parameter_multiplier for HeuristicalStorageReservation
    * _dense_tensor_estimate for HeuristicalStorageReservation

Created helper functions:
* `hash_planner_context_inputs` to be called in both planner.hash_planner_context_inputs and manifold loading call site (see D75723272)
* `hash_sha256_to_int` to be passed in as the default hash function in hash_planner_context_inputs

Also created a multiprocess unit test to quickly check if consistent hashes are being generated across different processes given the same input.

Differential Revision: D76303748
