### PR TITLE
Fix Unit Test SkipIf Worldsize check

### DIFF
--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -401,8 +401,8 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(  # pyre-ignore
         num_tables=st.sampled_from([2, 3, 4]),
@@ -445,8 +445,8 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(  # pyre-ignore
         num_tables=st.sampled_from([2, 3, 4]),


### PR DESCRIPTION
Summary:
These unit tests actually require at least 4 GPUs - due to world size requirements. Updating skipif to match

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: aliafzal

Differential Revision: D76621861
