### PR TITLE
skip python 3.13t for pip install fbgemm-gpu

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -73,21 +73,19 @@ conda env config vars set -n ${CONDA_ENV}  \
 #     export PYTORCH_CUDA_PKG="pytorch-cuda=${MATRIX_GPU_ARCH_VERSION}"
 # fi
 
-conda run -n "${CONDA_ENV}" pip install importlib-metadata
-
 conda run -n "${CONDA_ENV}" pip install torch --index-url "$PYTORCH_URL"
 
 # install fbgemm
 conda run -n "${CONDA_ENV}" pip install fbgemm-gpu --index-url "$PYTORCH_URL"
-
-# install requirements from pypi
-conda run -n "${CONDA_ENV}" pip install torchmetrics==1.0.3
 
 # install tensordict from pypi
 conda run -n "${CONDA_ENV}" pip install tensordict==0.8.1
 
 # install torchrec
 conda run -n "${CONDA_ENV}" pip install torchrec --index-url "$PYTORCH_URL"
+
+# install other requirements
+conda run -n "${CONDA_ENV}" pip install -r requirements.txt
 
 # Run small import test
 conda run -n "${CONDA_ENV}" python -c "import torch; import fbgemm_gpu; import torchrec"

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -125,6 +125,7 @@ else
 fi
 
 if [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
+    exit 0  # fbgemm-gpu can't support python=3.13t in PYPI
     # use conda-forge to install python3.13t
     conda create -y -n "${CONDA_ENV}" python="3.13" python-freethreading -c conda-forge
     conda run -n "${CONDA_ENV}" python -c "import sys; print(f'python GIL enabled: {sys._is_gil_enabled()}')"

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -11,14 +11,14 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/validate-nightly-binaries.yml
-      - .github/workflows/validate-binaries.yml
-      - .github/scripts/validate-binaries.sh
+      - '.github/workflows/validate-nightly-binaries.yml'
+      - '.github/workflows/validate-binaries.yml'
+      - '.github/scripts/validate-binaries.sh'
   pull_request:
     paths:
-      - .github/workflows/validate-nightly-binaries.yml
-      - .github/workflows/validate-binaries.yml
-      - .github/scripts/validate-binaries.sh
+      - '.github/workflows/validate-nightly-binaries.yml'
+      - '.github/workflows/validate-binaries.yml'
+      - '.github/scripts/validate-binaries.sh'
 jobs:
   nightly:
     uses: ./.github/workflows/validate-binaries.yml


### PR DESCRIPTION
Summary:
# context
* the release validation use pip install from PYPI
* fbgemm-gpu can't support python 3.13t in PYPI yet
* skip python 3.13t in the release validation

Differential Revision: D76998935


