### PR TITLE
Migrate to correct logger interface (#2996)

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -416,7 +416,7 @@ class ShardedManagedCollisionCollection(
             ), f"Shared feature is not supported. {num_sharding_features=}, {self._sharding_per_table_feature_splits[-1]=}"
 
             if self._sharding_features[-1] != sharding.feature_names():
-                logger.warn(
+                logger.warning(
                     "The order of tables of this sharding is altered due to grouping: "
                     f"{self._sharding_features[-1]=} vs {sharding.feature_names()=}"
                 )
@@ -1122,7 +1122,7 @@ class ShardedQuantManagedCollisionCollection(
             ), f"Shared feature is not supported. {num_sharding_features=}, {self._sharding_per_table_feature_splits[-1]=}"
 
             if self._sharding_features[-1] != sharding.feature_names():
-                logger.warn(
+                logger.warning(
                     "The order of tables of this sharding is altered due to grouping: "
                     f"{self._sharding_features[-1]=} vs {sharding.feature_names()=}"
                 )

--- a/torchrec/distributed/model_tracker/model_delta_tracker.py
+++ b/torchrec/distributed/model_tracker/model_delta_tracker.py
@@ -100,7 +100,9 @@ class ModelDeltaTracker:
         for fqn, feature_names in self._fqn_to_feature_map.items():
             for feature_name in feature_names:
                 if feature_name in self.feature_to_fqn:
-                    logger.warn(f"Duplicate feature name: {feature_name} in fqn {fqn}")
+                    logger.warning(
+                        f"Duplicate feature name: {feature_name} in fqn {fqn}"
+                    )
                     continue
                 self.feature_to_fqn[feature_name] = fqn
         logger.info(f"feature_to_fqn: {self.feature_to_fqn}")

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -279,7 +279,7 @@ class EmbeddingEnumerator(Enumerator):
             set(constrained_sharding_types) & set(allowed_sharding_types)
         )
         if not filtered_sharding_types:
-            logger.warn(
+            logger.warning(
                 "No available sharding types after applying user provided "
                 f"constraints for {name}. Constrained sharding types: "
                 f"{constrained_sharding_types}, allowed sharding types: "
@@ -326,7 +326,7 @@ class EmbeddingEnumerator(Enumerator):
                 filtered_compute_kernels.remove(EmbeddingComputeKernel.DENSE.value)
 
         if not filtered_compute_kernels:
-            logger.warn(
+            logger.warning(
                 "No available compute kernels after applying user provided "
                 f"constraints for {name}. Constrained compute kernels: "
                 f"{constrained_compute_kernels}, allowed compute kernels: "

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -731,7 +731,7 @@ class TestEnumerators(unittest.TestCase):
         )
 
         sharder = ManagedCollisionEmbeddingBagCollectionSharder()
-        with self.assertWarns(Warning):
+        with self.assertLogs(level="WARNING"):
             allowed_sharding_types = enumerator._filter_sharding_types(
                 "table_0", sharder.sharding_types("cuda")
             )
@@ -811,7 +811,7 @@ class TestEnumerators(unittest.TestCase):
 
         sharder = ManagedCollisionEmbeddingBagCollectionSharder()
         sharding_type = ShardingType.ROW_WISE.value
-        with self.assertWarns(Warning):
+        with self.assertLogs(level="WARNING"):
             allowed_compute_kernels = enumerator._filter_compute_kernels(
                 "table_0", sharder.compute_kernels(sharding_type, "cuda"), sharding_type
             )

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -402,7 +402,7 @@ def _rewrite_model(  # noqa C901
             input_model.module = graph_model
 
     if non_pipelined_sharded_modules:
-        logger.warn(
+        logger.warning(
             "Sharded modules were not pipelined: %s. "
             + "This should be fixed for pipelining to work to the full extent.",
             ", ".join(non_pipelined_sharded_modules),

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -99,7 +99,7 @@ class ThroughputMetric(nn.Module):
             )
 
         if window_seconds > MAX_WINDOW_TS:
-            logger.warn(
+            logger.warning(
                 f"window_seconds is greater than {MAX_WINDOW_TS}, capping to {MAX_WINDOW_TS} to make sure window_qps is not staled"
             )
             window_seconds = MAX_WINDOW_TS

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2688,7 +2688,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             Dict[str, JaggedTensor]: dictionary of JaggedTensor for each key.
         """
         if not torch.jit.is_scripting() and is_non_strict_exporting():
-            logger.warn(
+            logger.warning(
                 "Trying to non-strict torch.export KJT to_dict, which is extremely slow and not recommended!"
             )
         _jt_dict = _maybe_compute_kjt_to_jt_dict(


### PR DESCRIPTION
Summary:
## PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
See [CI logs](https://github.com/pytorch/torchrec/actions/runs/15201361250/job/42755956905#step:15:5170) for those warnings.


Reviewed By: spmex

Differential Revision: D77035942

Pulled By: TroyGarden


