### PR TITLE
Add minimal movielens KJT + EBC example

### DIFF
--- a/torchrec/examples/movielens_example.py
+++ b/torchrec/examples/movielens_example.py
@@ -1,0 +1,35 @@
+import torch
+
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagConfig,
+    EmbeddingBagCollection,
+)
+
+def main():
+    # Dummy user interactions
+    keys = ["movie_id"]
+    values = torch.tensor([1, 4, 3, 5, 6], dtype=torch.long)
+    lengths = torch.tensor([1, 1, 1, 1, 1], dtype=torch.long)  # 5 users, 1 movie each
+
+    kjt = KeyedJaggedTensor(
+        keys=keys,
+        values=values,
+        lengths=lengths,
+    )
+
+    ebc = EmbeddingBagCollection(
+        tables=[
+            EmbeddingBagConfig(
+                name="movie_id",
+                embedding_dim=16,
+                num_embeddings=1000,
+            )
+        ]
+    )
+
+    output = ebc(kjt)
+    print("Output:", output["movie_id"].shape)  # Expected shape: (5, 16)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This PR introduces a minimal example under `torchrec/examples/` that demonstrates how to use `KeyedJaggedTensor` (KJT) in combination with `EmbeddingBagCollection` (EBC).



### Details

- Sets up dummy user interaction data with a single sparse feature: `"movie_id"`.
- Constructs a `KeyedJaggedTensor` using keys, values, and lengths.
- Passes the KJT through an `EmbeddingBagCollection` with an `EmbeddingBagConfig`.
- Prints the shape of the output embedding (expected: `(5, 16)`), where 5 is the batch size and 16 is the embedding dimension.


### Motivation

This example serves as a clear, minimal reference for new users looking to understand how to integrate KJT with EBC effectively in TorchRec.
