### PR TITLE
Fix mutable default error in MetricsConfig dataclasses

### DIFF
--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -197,25 +197,32 @@ DefaultTaskInfo = RecTaskInfo(
 )
 
 
-DefaultMetricsConfig = MetricsConfig(
-    rec_tasks=[DefaultTaskInfo],
-    rec_metrics={
-        RecMetricEnum.NE: RecMetricDef(
-            rec_tasks=[DefaultTaskInfo], window_size=_DEFAULT_WINDOW_SIZE
-        ),
-    },
-    throughput_metric=ThroughputDef(),
-    state_metrics=[],
-)
+def _create_default_metrics_config() -> MetricsConfig:
+    return MetricsConfig(
+        rec_tasks=[DefaultTaskInfo],
+        rec_metrics={
+            RecMetricEnum.NE: RecMetricDef(
+                rec_tasks=[DefaultTaskInfo], window_size=_DEFAULT_WINDOW_SIZE
+            ),
+        },
+        throughput_metric=ThroughputDef(),
+        state_metrics=[],
+    )
 
-# Explicitly specifying the empty fields to avoid any mistakes cased by simply
-# relying on the Python default values, e.g., MetricConfig().
-EmptyMetricsConfig = MetricsConfig(
-    rec_tasks=[],
-    rec_metrics={},
-    throughput_metric=None,
-    state_metrics=[],
-)
+
+def _create_empty_metrics_config() -> MetricsConfig:
+    # Explicitly specifying the empty fields to avoid any mistakes cased by simply
+    # relying on the Python default values, e.g., MetricConfig().
+    return MetricsConfig(
+        rec_tasks=[],
+        rec_metrics={},
+        throughput_metric=None,
+        state_metrics=[],
+    )
+
+
+DefaultMetricsConfig: MetricsConfig = _create_default_metrics_config()
+EmptyMetricsConfig: MetricsConfig = _create_empty_metrics_config()
 
 
 @dataclass


### PR DESCRIPTION
Summary:
# Context
Found a dataclass validation error: "mutable default ... is not allowed: use default_factory". The issue was that `DefaultMetricsConfig` and `EmptyMetricsConfig` were created as static instances with mutable objects (lists/dicts), but then used as defaults in dataclass fields. This violates Python's dataclass rules since all instances would share the same mutable objects.

Check out this for more info on python dataclasses:
https://docs.python.org/3/library/dataclasses.html#mutable-default-values

# Changes
Converted the static config instances to factory functions that return fresh objects each time:

*   `DefaultMetricsConfig` → `_create_default_metrics_config()`
*   `EmptyMetricsConfig` → `_create_empty_metrics_config()`

Updated the dataclass field in `TrainingAppConfig` to use `field(default_factory=_create_empty_metrics_config)` instead of the static instance.

Now each dataclass gets its own separate config object, fixing the mutable default error.

Differential Revision: D77263018


