### PR TITLE
Add base logger class for torchrec logging

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+
+__all__: list[str] = []
+
+_log_handlers: dict[str, logging.Handler] = {
+    "default": logging.NullHandler(),
+}


### PR DESCRIPTION
Summary: Adds the base logger for torchrec static api logging. This logger is to align with the broader pytorch logging framework that will be worked on in H2 2025. It should not contain any torchrec specific logic.

Reviewed By: kausv, saumishr

Differential Revision: D75791932


