### PR TITLE
Add the torchrec scuba logger extension of the base scuba logger

### DIFF
--- a/torchrec/distributed/torchrec_logging_handlers.py
+++ b/torchrec/distributed/torchrec_logging_handlers.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import logging
+
+from torchrec.distributed.logging_handlers import _log_handlers
+
+TORCHREC_LOGGER_NAME = "torchrec"
+
+_log_handlers.update({TORCHREC_LOGGER_NAME: logging.NullHandler()})


### PR DESCRIPTION
Summary: This is the wrapper around the base logger to create the torchrec specific instance of the logger. This is where the scuba table name used for torchrec logging can be specified.

Reviewed By: kausv, saumishr

Differential Revision: D76294253


