### PR TITLE
Fix pt2 multiprocess test

### DIFF
--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -749,6 +749,11 @@ class TestPt2Train(MultiProcessTestBase):
         model_type, sharding_type, input_type, tovb, compile_backend, config = (
             given_config_tuple
         )
+        # torch/testing/_internal/common_utils.py calls `disable_global_flags()`
+        # workaround RuntimeError: not allowed to set ... after disable_global_flags
+        setattr(  # noqa: B010
+            torch.backends, "__allow_nonbracketed_mutation_flag", True
+        )
         self._run_multi_process_test(
             callable=_test_compile_rank_fn,
             test_model_type=model_type,
@@ -760,6 +765,9 @@ class TestPt2Train(MultiProcessTestBase):
             convert_to_vb=tovb == _ConvertToVariableBatch.TRUE,
             config=config,
             torch_compile_backend=compile_backend,
+        )
+        setattr(  # noqa: B010
+            torch.backends, "__allow_nonbracketed_mutation_flag", False
         )
 
     # pyre-ignore


### PR DESCRIPTION
`common_utils.py` disables global flags, which causes this test to error.
https://www.internalfb.com/code/fbsource/[1caeee2345d0]/fbcode/caffe2/torch/testing/_internal/common_utils.py?lines=215

Test error:
```
Process ForkServerProcess-17:
Traceback (most recent call last):
  File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/re_cwd/buck-out/v2/gen/fbcode/1121f3f340860407/torchrec/distributed/tests/__test_pt2_multiprocess__/test_pt2_multiprocess#link-tree/torchrec/distributed/tests/test_pt2_multiprocess.py", line 244, in _test_compile_rank_fn
    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
  File "/re_cwd/buck-out/v2/gen/fbcode/1121f3f340860407/torchrec/distributed/tests/__test_pt2_multiprocess__/test_pt2_multiprocess#link-tree/torchrec/distributed/test_utils/multi_process.py", line 93, in __exit__
    torch.backends.cudnn.allow_tf32 = True
  File "/re_cwd/buck-out/v2/gen/fbcode/1121f3f340860407/torchrec/distributed/tests/__test_pt2_multiprocess__/test_pt2_multiprocess#link-tree/torch/backends/__init__.py", line 48, in __set__
    raise RuntimeError(
RuntimeError: not allowed to set torch.backends.cudnn flags after disable_global_flags; please use flags() context manager instead
```

Differential Revision: D77614983


