### PR TITLE
Fixes typo in _infer_parameters that is leading to test failure

### DIFF
--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -168,7 +168,7 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
     def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:
         r"""Infers the size and initializes the parameters according to the provided input batch.
 
-        Given a module that contains parameters that were declared inferrable
+        Given a module that contains parameters that were declared inferable
         using :class:`torch.nn.parameter.ParameterMode.Infer`, runs a forward pass
         in the complete module using the provided input to initialize all the parameters
         as needed.


### PR DESCRIPTION
Summary:

Fixes a small typo in `_infer_parameters` that is leading to the following test to fail:

'torchrec/modules/tests:test_lazy_extension -
torchrec.modules.tests.test_lazy_extension.TestLazyModuleExtensionMixin:
test_source_code_parity_on_infer_parameters' in accordance with D77726092

Why this would even be covered in a test?

Differential Revision: D77744509


