### PR TITLE
Throw more specific error with mitigation steps for Manifold Planner

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -773,6 +773,7 @@ class PlannerErrorType(Enum):
     STRICT_CONSTRAINTS = "strict_constraints"
     PARTITION = "partition"
     OTHER = "other"
+    PLANNER_INPUT_CONTEXT_MISMATCH = "planner_input_context_mismatch"
 
 
 class PlannerError(Exception):


### PR DESCRIPTION
Summary:
Per discussions with APS, we want to throw a more **verbose and helpful** error message in case of Manifold Plan validation failure.

Updating this to raise a `PlannerError`, with  recommended solutions. 

Added a TODO: to convert this to a more detailed wiki page, once LP planner (autoplanner) design finalizes.

Differential Revision: D77760805


