### PR TITLE
Add ability in SSDTBE to fetch weights from L1 and SP from outside of the module

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -176,6 +176,7 @@ def _populate_ssd_tbe_params(config: GroupedEmbeddingConfig) -> Dict[str, Any]:
                 "by max_l1_cache_size, cap at max_cache_sets instead"
             )
             ssd_tbe_params["cache_sets"] = int(max_cache_sets)
+    ssd_tbe_params["table_names"] = [table.name for table in config.embedding_tables]
 
     # populate res_params, which is used for raw embedding streaming
     # here only populates the params available in fused_params and TBE configs


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/4450

X-link: https://github.com/facebookresearch/FBGEMM/pull/1513

Given row ids, fetch the updated weighs from L1 and SP.
`register_backward_hook_before_eviction` This function will be called in delta tracker
- register the hook to be executed in backward before the sp eviction.
- So the hooks are reordered to let the hook registered through this function to execute first.

`fetch_from_l1_sp_w_row_ids` will be called inside the backward hook registered using above function
- to get updated weights for the given row ids already added offset to SSDTBE tables.
- fetch from `lxu_cache_weights (L1)` and rest from `inserted_rows (SP) `

`table_names` is added to let the delta tracker aware of the table to TBE map.
- the delta tracker stores the updated ids in forward pass's lookup module, it stores ids as a 'fqn' -> 'ids' map.
- in backward pass, per TBE module we need to know which ids we want to fetch for the updated weights, thus the table names is needed to infer fqn.

Reviewed By: q10

Differential Revision: D72188513


