### PR TITLE
Integrate DLRM to the benchmarking framework

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_pipeline_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_pipeline_utils.py
@@ -48,7 +48,9 @@ from torchrec.distributed.train_pipeline.train_pipelines import (
     TrainPipelineSemiSync,
 )
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
+from torchrec.models.dlrm import DLRMWrapper
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
 
 
 @dataclass
@@ -203,8 +205,16 @@ class DLRMConfig(BaseModelConfig):
         weighted_tables: List[EmbeddingBagConfig],
         dense_device: torch.device,
     ) -> nn.Module:
-        # TODO: Implement DLRM model generation
-        raise NotImplementedError("DLRM model generation not yet implemented")
+        # DLRM only uses unweighted tables
+        ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
+
+        return DLRMWrapper(
+            embedding_bag_collection=ebc,
+            dense_in_features=self.num_float_features,
+            dense_arch_layer_sizes=self.dense_arch_layer_sizes,
+            over_arch_layer_sizes=self.over_arch_layer_sizes,
+            dense_device=dense_device,
+        )
 
 
 # pyre-ignore[2]: Missing parameter annotation

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -190,8 +190,8 @@ class ModelSelectionConfig:
     deep_fm_dimension: int = 5
 
     # DLRM specific config
-    dense_arch_layer_sizes: List[int] = field(default_factory=lambda: [20, 10])
-    over_arch_layer_sizes: List[int] = field(default_factory=lambda: [5, 3])
+    dense_arch_layer_sizes: List[int] = field(default_factory=lambda: [20, 128])
+    over_arch_layer_sizes: List[int] = field(default_factory=lambda: [5, 1])
 
 
 @cmd_conf

--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -20,7 +20,7 @@ import logging
 import os
 import time
 import timeit
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass, MISSING
 from enum import Enum
 from typing import (
     Any,
@@ -500,8 +500,15 @@ def cmd_conf(func: Callable) -> Callable:
                         ftype = non_none[0]
                         origin = get_origin(ftype)
 
+                # Handle default_factory value
+                default_value = (
+                    f.default_factory()  # pyre-ignore [29]
+                    if f.default_factory is not MISSING
+                    else f.default
+                )
+
                 arg_kwargs = {
-                    "default": f.default,
+                    "default": default_value,
                     "help": f"({cls.__name__}) {arg_name}",
                 }
 


### PR DESCRIPTION
Summary:
Integrate DLRM to the benchmarking framework and set the default arch layer sizes. 
The last dense arch layer size should be the same as `embedding_feature_dim`

Differential Revision: D77896635


