### PR TITLE
Added loglevel configuration for running benchmarks

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -20,7 +20,7 @@ import logging
 import os
 import time
 import timeit
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass, MISSING
 from enum import Enum
 from typing import (
     Any,
@@ -500,8 +500,15 @@ def cmd_conf(func: Callable) -> Callable:
                         ftype = non_none[0]
                         origin = get_origin(ftype)
 
+                # Handle default_factory value
+                default_value = (
+                    f.default_factory()  # pyre-ignore [29]
+                    if f.default_factory is not MISSING
+                    else f.default
+                )
+
                 arg_kwargs = {
-                    "default": f.default,
+                    "default": default_value,
                     "help": f"({cls.__name__}) {arg_name}",
                 }
 


### PR DESCRIPTION
Summary:
#### Overview

This diff adds a new configuration option for running benchmarks in TorchRec.

#### Key Changes

*   In `benchmark_utils.py`, a new argument `loglevel` is added to the argument parser. This allows users to set the logging level when running benchmarks.
*   The `loglevel` argument is optional and defaults to `"INFO"` if not provided.
*   The diff also includes additional code to set the logging level based on the provided `loglevel` argument.

#### Impact

This change adds more flexibility to the benchmarking process in TorchRec, allowing users to control the verbosity of the logging output. By setting the `loglevel` argument, users can choose to display more or less detailed logging information, which can be helpful for debugging or optimizing benchmark runs.

Differential Revision: D77950216


