### PR TITLE
Fix copyright on TorchRec webpage

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ print(target_dir)
 # -- Project information -----------------------------------------------------
 
 project = "TorchRec"
-copyright = "2024, Meta"
+copyright = "Meta Platforms, Inc"
 author = "Meta"
 
 try:


### PR DESCRIPTION
Summary: As per OSS team, the copyright should be this format https://www.internalfb.com/wiki/Open_Source/Launch_an_OSS_Project/Launch_Preparation/Automated_Checkup/Terms_Of_Use_&_Privacy_Policy/

Reviewed By: bigfootjon

Differential Revision: D78010324


