### PR TITLE
Dynamic 2D sparse parallel

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -1617,3 +1617,7 @@ class EmbeddingCollectionSharder(BaseEmbeddingSharder[EmbeddingCollection]):
     @property
     def module_type(self) -> Type[EmbeddingCollection]:
         return EmbeddingCollection
+
+    @property
+    def sharded_module_type(self) -> Type[ShardedEmbeddingCollection]:
+        return ShardedEmbeddingCollection

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1853,6 +1853,10 @@ class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]
     def module_type(self) -> Type[EmbeddingBagCollection]:
         return EmbeddingBagCollection
 
+    @property
+    def sharded_module_type(self) -> Type[ShardedEmbeddingBagCollection]:
+        return ShardedEmbeddingBagCollection
+
 
 class EmbeddingAwaitable(LazyAwaitable[torch.Tensor]):
     def __init__(

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -215,6 +215,12 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
     def module_type(self) -> Type[FeatureProcessedEmbeddingBagCollection]:
         return FeatureProcessedEmbeddingBagCollection
 
+    @property
+    def sharded_module_type(
+        self,
+    ) -> Type[ShardedFeatureProcessedEmbeddingBagCollection]:
+        return ShardedFeatureProcessedEmbeddingBagCollection
+
     def sharding_types(self, compute_device_type: str) -> List[str]:
         if compute_device_type in {"mtia"}:
             return [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value]

--- a/torchrec/distributed/itep_embeddingbag.py
+++ b/torchrec/distributed/itep_embeddingbag.py
@@ -321,6 +321,10 @@ class ITEPEmbeddingBagCollectionSharder(
     def module_type(self) -> Type[ITEPEmbeddingBagCollection]:
         return ITEPEmbeddingBagCollection
 
+    @property
+    def sharded_module_type(self) -> Type[ShardedITEPEmbeddingBagCollection]:
+        return ShardedITEPEmbeddingBagCollection
+
     def sharding_types(self, compute_device_type: str) -> List[str]:
         types = list(SHARDING_TYPE_TO_GROUP.keys())
         return types

--- a/torchrec/distributed/mc_embedding.py
+++ b/torchrec/distributed/mc_embedding.py
@@ -144,3 +144,7 @@ class ManagedCollisionEmbeddingCollectionSharder(
     @property
     def module_type(self) -> Type[ManagedCollisionEmbeddingCollection]:
         return ManagedCollisionEmbeddingCollection
+
+    @property
+    def sharded_module_type(self) -> Type[ShardedManagedCollisionEmbeddingCollection]:
+        return ShardedManagedCollisionEmbeddingCollection

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -134,12 +134,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         tables_per_rank: List[List[ShardedEmbeddingTable]] = [
             [] for _ in range(world_size)
         ]
-        peer_group = (
-            # pyre-ignore [6]
-            get_process_group_ranks(self._pg)
-            if self._is_2D_parallel
-            else None
-        )
+        peer_group = get_process_group_ranks(self._pg) if self._is_2D_parallel else None
         for info in sharding_infos:
             # Under 2D parallelism we transform rank to the logical ordering in a regular parallelism scheme
             rank = (

--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -18,7 +18,10 @@ from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
-from torchrec.distributed.test_utils.test_model import TestSparseNNBase
+from torchrec.distributed.test_utils.test_model import (
+    TestMixedEmbeddingSparseArch,
+    TestSparseNNBase,
+)
 from torchrec.distributed.test_utils.test_model_parallel import ModelParallelTestShared
 from torchrec.distributed.test_utils.test_sharding import (
     create_test_sharder,
@@ -29,8 +32,14 @@ from torchrec.distributed.tests.test_sequence_model import (
     TestEmbeddingCollectionSharder,
     TestSequenceSparseNN,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingType
-from torchrec.modules.embedding_configs import EmbeddingConfig, PoolingType
+from torchrec.distributed.types import DMPCollectionConfig, ModuleSharder, ShardingType
+from torchrec.modules.embedding_configs import (
+    DataType,
+    EmbeddingBagConfig,
+    EmbeddingConfig,
+    PoolingType,
+)
+from torchrec.modules.embedding_modules import EmbeddingCollection
 from torchrec.test_utils import skip_if_asan_class
 
 
@@ -810,4 +819,168 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
             variable_batch_size=variable_batch_size,
             variable_batch_per_feature=variable_batch_per_feature,
             global_constant_batch=True,
+        )
+
+
+class TestDynamic2DParallel(MultiProcessTestBase):
+    """
+    Tests for dynamic 2D parallelism
+    """
+
+    WORLD_SIZE = 8
+    WORLD_SIZE_2D = 4
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        num_ec_features = 2
+        num_ebc_features = 2
+        num_features = num_ec_features + num_ebc_features
+
+        ec_tables = [
+            EmbeddingConfig(
+                num_embeddings=(i + 1) * 11,
+                embedding_dim=16,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(num_ec_features)
+        ]
+
+        ebc_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 10,
+                embedding_dim=(i + 2) * 8,
+                name="table_" + str(i + num_ec_features),
+                feature_names=["feature_" + str(i)],
+                data_type=DataType.FP32,
+            )
+            for i in range(num_features)
+        ]
+
+        self.tables = ec_tables + ebc_tables
+
+        self.embedding_groups = {
+            "group_0": [
+                (feature) for table in self.tables for feature in table.feature_names
+            ]
+        }
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 7,
+        "Not enough GPUs, this test requires at least eight GPUs",
+    )
+    # pyre-fixme[56]
+    @given(
+        sharding_type=st.just(ShardingType.ROW_WISE.value),
+        kernel_type=st.sampled_from(
+            [
+                # EmbeddingComputeKernel.DENSE.value,
+                EmbeddingComputeKernel.FUSED.value,
+            ]
+        ),
+        qcomms_config=st.sampled_from(
+            [
+                None,
+                QCommsConfig(
+                    forward_precision=CommType.FP16, backward_precision=CommType.BF16
+                ),
+            ]
+        ),
+        apply_optimizer_in_backward_config=st.sampled_from(
+            [
+                None,
+                {
+                    "embedding_bags": (torch.optim.SGD, {"lr": 0.01}),
+                    "embeddings": (torch.optim.SGD, {"lr": 0.2}),
+                },
+            ]
+        ),
+        variable_batch_size=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    def test_sharding_dynamic_2D(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        qcomms_config: Optional[QCommsConfig],
+        apply_optimizer_in_backward_config: Optional[
+            Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
+        ],
+        variable_batch_size: bool,
+    ) -> None:
+        assume(
+            apply_optimizer_in_backward_config is None
+            or kernel_type != EmbeddingComputeKernel.DENSE.value
+        )
+
+        # add sharding plan for embedding collection later
+        ec_submodule_config = DMPCollectionConfig(
+            module=EmbeddingCollection,
+            sharding_group_size=2,
+            plan=None,  # pyre-ignore[6]
+        )
+
+        self._test_sharding(
+            world_size=self.WORLD_SIZE,
+            world_size_2D=self.WORLD_SIZE_2D,
+            sharders=[  # pyre-ignore[6]
+                cast(
+                    ModuleSharder[nn.Module],
+                    create_test_sharder(
+                        SharderType.EMBEDDING_BAG_COLLECTION.value,
+                        sharding_type,
+                        kernel_type,
+                        qcomms_config=qcomms_config,
+                        device=torch.device("cuda"),
+                    ),
+                ),
+            ],
+            backend="nccl",
+            qcomms_config=qcomms_config,
+            constraints={
+                table.name: ParameterConstraints(min_partition=2)
+                for table in self.tables
+            },
+            apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
+            submodule_configs=[ec_submodule_config],
+        )
+
+    def _test_sharding(
+        self,
+        sharders: List[TestEmbeddingCollectionSharder],
+        backend: str = "gloo",
+        world_size: int = 2,
+        world_size_2D: int = 1,
+        local_size: Optional[int] = None,
+        node_group_size: Optional[int] = None,
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+        model_class: Type[TestSparseNNBase] = TestMixedEmbeddingSparseArch,
+        qcomms_config: Optional[QCommsConfig] = None,
+        apply_optimizer_in_backward_config: Optional[
+            Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
+        ] = None,
+        variable_batch_size: bool = False,
+        variable_batch_per_feature: bool = False,
+        submodule_configs: Optional[List[DMPCollectionConfig]] = None,
+    ) -> None:
+        self._run_multi_process_test(
+            callable=sharding_single_rank_test,
+            world_size=world_size,
+            world_size_2D=world_size_2D,
+            local_size=local_size,
+            model_class=model_class,
+            tables=self.tables,
+            embedding_groups=self.embedding_groups,
+            sharders=sharders,
+            optim=EmbOptimType.EXACT_SGD,
+            backend=backend,
+            constraints=constraints,
+            qcomms_config=qcomms_config,
+            apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            variable_batch_size=variable_batch_size,
+            variable_batch_per_feature=variable_batch_per_feature,
+            global_constant_batch=True,
+            submodule_configs=submodule_configs,
         )


### PR DESCRIPTION
Summary:
We add the ability to set 2D parallel configuration per module (coined as Dynamic 2D parallel). This means an EBC and EC can be sharded differently on the data parallel dimension. We can have 4 replicas per EBC shard and 2 replicas per EC shard. The previous setting requires all modules to have the same replication factor.

To do this, we introduce a lightweight dataclass that is used to provide per module configurations, allowing very granular control should it be required by the user:
```python
class DMPCollectionConfig:
    module: nn.Module  # this is expected to be unsharded module
    plan: "ShardingPlan"  # sub-tree-specific sharding plan
    sharding_group_size: int
    use_inter_host_allreduce: bool = False
```

The dataclass is used to provide the context for each module we are sharding. And, if configured, create separate process groups and sync logic for each of these modules.

Usage is as follows, suppose we want to use a different 2D configuration for EmbeddingCollection:
```python
# create plan for model tables over Y world size
# create plan for EmbeddingCollection tables over X world size
ec_config = DMPCollectionConfig(EmbeddingCollection, embedding_collection_plan, sharding_group_size)
model = DMPCollection(
  # pass in defaults args
  submodule_configs = [ec_config]
)
```

Future work includes:
- making it easier for users to create seperate sharding plans per module
- per table 2D

Differential Revision: D76774334


