### PR TITLE
Fix  failing CI failures on Github workflow

### DIFF
--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -213,7 +213,6 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharded_quant_kv_zch(self) -> None:
         device = torch.device("cuda:0")
         num_features = 4


### PR DESCRIPTION
Summary:
Removing the `settings` decorator from `test_sharded_quant_kv_zch`.  This decorator is only meaningful for Hypothesis property-based tests that use `given` with generated parameters. Since `test_sharded_quant_kv_zch` is a regular unit test with fixed inputs and no `given` decorator, the `settings` decorator serves no purpose and causes CI failures.

Example reference:
https://github.com/pytorch/torchrec/actions/runs/16298208915/job/46025529461?pr=3193#step:15:7136

Differential Revision: D78357214


