### PR TITLE
Fix boolean support in cmd_conf util

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -524,6 +524,9 @@ def cmd_conf(func: Callable) -> Callable:
                 if origin in (list, List):
                     elem_type = get_args(ftype)[0]
                     arg_kwargs.update(nargs="*", type=elem_type)
+                elif ftype is bool:
+                    # Special handling for boolean arguments
+                    arg_kwargs.update(type=lambda x: x.lower() in ["true", "1", "yes"])
                 else:
                     arg_kwargs.update(type=ftype)
 


### PR DESCRIPTION
Summary: Fixed and extended the boolean argument parsing in the cmd_conf decorator utility.

Differential Revision: D78303765


