### PR TITLE
Inference mode configuration support for benchmarking

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -91,6 +91,9 @@ class RunOptions:
             Default is "EXACT_ADAGRAD".
         sparse_lr (float): Learning rate for sparse parameters.
             Default is 0.1.
+        training_mode (bool): Whether to run the model in training mode.
+            If True, model remains in training mode. If False, model.eval() is called.
+            Default is True.
     """
 
     world_size: int = 2
@@ -110,6 +113,7 @@ class RunOptions:
     sparse_lr: float = 0.1
     sparse_momentum: Optional[float] = None
     sparse_weight_decay: Optional[float] = None
+    training_mode: bool = True
 
 
 @dataclass
@@ -342,6 +346,9 @@ def runner(
             dense_weight_decay=run_option.dense_weight_decay,
             planner=planner,
         )
+
+        if not run_option.training_mode:
+            sharded_model.eval()
 
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],

--- a/torchrec/distributed/benchmark/benchmark_utils.py
+++ b/torchrec/distributed/benchmark/benchmark_utils.py
@@ -524,6 +524,9 @@ def cmd_conf(func: Callable) -> Callable:
                 if origin in (list, List):
                     elem_type = get_args(ftype)[0]
                     arg_kwargs.update(nargs="*", type=elem_type)
+                elif ftype is bool:
+                    # Special handling for boolean arguments
+                    arg_kwargs.update(type=lambda x: x.lower() in ["true", "1", "yes"])
                 else:
                     arg_kwargs.update(type=ftype)
 


### PR DESCRIPTION
Summary: Added a configuration option to run end-to-end pipeline benchmark in inference mode (`.eval()` mode). Previously the models were in training mode by default. Models in training mode have additional overhead of loss computation, backward pass, etc...

Differential Revision: D78303867


