### PR TITLE
add unit test for offloading (metaheader included)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -430,7 +430,7 @@ class ZeroCollisionKeyValueEmbeddingFusedOptimizer(FusedOptimizer):
         )
 
         all_optimizer_states = emb_module.get_optimizer_state(
-            sorted_id_tensor=sorted_id_tensors
+            sorted_id_tensor=sorted_id_tensors,
         )
         opt_param_list = [param["momentum1"] for param in all_optimizer_states]
         emb_table_config_copy = copy.deepcopy(self._config.embedding_tables)

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -985,6 +985,7 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
         kernel_type=st.sampled_from(
             [
                 EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+                EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
             ]
         ),
         sharding_type=st.sampled_from(
@@ -1386,6 +1387,10 @@ class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBas
                         # write value into ssd for both emb module for later comparison
                         pmt2 = sharded_t2.local_shards()[0].tensor
                         pmt2.wrapped.set_weights_and_ids(w1, w1_id.view(-1))
+
+                    # Remove the cache to force state dict read from backend again
+                    emb_module1._split_weights_res = None
+                    emb_module2._split_weights_res = None
 
                     # purge after loading. This is needed, since we pass a batch
                     # through dmp when instantiating them.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1560

Added unit test for the following conditions, and fixed related bugs:
1. ZCH fused optimizer with offloading
2. Added DRAM kernel for stat dict loading (with metaheader)and numerical accuracy
3. Applied return whole row for DRAM kernel.

Reviewed By: emlin, bobbyliujb

Differential Revision: D77474510
