### PR TITLE
fixed issue with sharded_grads with multiple process groups

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -149,7 +149,9 @@ class GradientClippingOptimizer(OptimizerWrapper):
         sharded_grads = {
             pgs: _get_grads(dist_params) for pgs, dist_params in sharded_params.items()
         }
-        all_grads.extend(*sharded_grads.values())
+
+        for grads in sharded_grads.values():
+            all_grads.extend(grads)
 
         # Process replicated parameters and gradients
         replicate_grads = _get_grads(replicate_params)


### PR DESCRIPTION
Summary: added a hot fix to an issue in clipping where sharded_grads was not appropriately initialized in the case with multiple process groups.

Reviewed By: tsunghsienlee

Differential Revision: D79853515


