### PR TITLE
Add row based sharding support for FeaturedProcessedEBC

### DIFF
--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -8,7 +8,18 @@
 # pyre-strict
 
 from functools import partial
-from typing import Any, Dict, Iterator, List, Optional, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import torch
 from torch import nn
@@ -31,13 +42,19 @@ from torchrec.distributed.types import (
     ShardingEnv,
     ShardingType,
 )
-from torchrec.distributed.utils import append_prefix, init_parameters
+from torchrec.distributed.utils import (
+    append_prefix,
+    init_parameters,
+    modify_input_for_feature_processor,
+)
 from torchrec.modules.feature_processor_ import FeatureProcessorsCollection
 from torchrec.modules.fp_embedding_modules import (
     apply_feature_processors_to_kjt,
     FeatureProcessedEmbeddingBagCollection,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
+
+_T = TypeVar("_T")
 
 
 def param_dp_sync(kt: KeyedTensor, no_op_tensor: torch.Tensor) -> KeyedTensor:
@@ -74,6 +91,16 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
             )
         )
 
+        self._row_wise_sharded: bool = False
+        for param_sharding in table_name_to_parameter_sharding.values():
+            if param_sharding.sharding_type in [
+                ShardingType.ROW_WISE.value,
+                ShardingType.TABLE_ROW_WISE.value,
+                ShardingType.GRID_SHARD.value,
+            ]:
+                self._row_wise_sharded = True
+                break
+
         self._lookups: List[nn.Module] = self._embedding_bag_collection._lookups
 
         self._is_collection: bool = False
@@ -96,6 +123,11 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
     def input_dist(
         self, ctx: EmbeddingBagCollectionContext, features: KeyedJaggedTensor
     ) -> Awaitable[Awaitable[KJTList]]:
+        if not self.is_pipelined and self._row_wise_sharded:
+            # transform input to support row based sharding when not pipelined
+            modify_input_for_feature_processor(
+                features, self._feature_processors, self._is_collection
+            )
         return self._embedding_bag_collection.input_dist(ctx, features)
 
     def apply_feature_processors_to_kjt_list(self, dist_input: KJTList) -> KJTList:
@@ -105,10 +137,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
                 kjt_list.append(self._feature_processors(features))
             else:
                 kjt_list.append(
-                    apply_feature_processors_to_kjt(
-                        features,
-                        self._feature_processors,
-                    )
+                    apply_feature_processors_to_kjt(features, self._feature_processors)
                 )
         return KJTList(kjt_list)
 
@@ -117,7 +146,6 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
         ctx: EmbeddingBagCollectionContext,
         dist_input: KJTList,
     ) -> List[torch.Tensor]:
-
         fp_features = self.apply_feature_processors_to_kjt_list(dist_input)
         return self._embedding_bag_collection.compute(ctx, fp_features)
 
@@ -163,6 +191,18 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
             if "_embedding_bag_collection" in fqn:
                 yield append_prefix(prefix, fqn)
 
+    def preprocess_input(
+        self, args: List[_T], kwargs: Mapping[str, _T]
+    ) -> Tuple[List[_T], Mapping[str, _T]]:
+        for x in args + list(kwargs.values()):
+            if isinstance(x, KeyedJaggedTensor):
+                modify_input_for_feature_processor(
+                    features=x,
+                    feature_processors=self._feature_processors,
+                    is_collection=self._is_collection,
+                )
+        return args, kwargs
+
 
 class FeatureProcessedEmbeddingBagCollectionSharder(
     BaseEmbeddingSharder[FeatureProcessedEmbeddingBagCollection]
@@ -188,7 +228,6 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         device: Optional[torch.device] = None,
         module_fqn: Optional[str] = None,
     ) -> ShardedFeatureProcessedEmbeddingBagCollection:
-
         if device is None:
             device = torch.device("cuda")
 
@@ -225,12 +264,14 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         if compute_device_type in {"mtia"}:
             return [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value]
 
-        # No row wise because position weighted FP and RW don't play well together.
         types = [
             ShardingType.DATA_PARALLEL.value,
             ShardingType.TABLE_WISE.value,
             ShardingType.COLUMN_WISE.value,
             ShardingType.TABLE_COLUMN_WISE.value,
+            ShardingType.TABLE_ROW_WISE.value,
+            ShardingType.ROW_WISE.value,
+            ShardingType.GRID_SHARD.value,
         ]
 
         return types

--- a/torchrec/distributed/tests/test_fp_embeddingbag.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag.py
@@ -231,7 +231,6 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
     def test_sharding_ebc(
         self, set_gradient_division: bool, use_dmp: bool, use_fp_collection: bool
     ) -> None:
-
         import hypothesis
 
         # don't need to test entire matrix

--- a/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag_utils.py
@@ -86,7 +86,12 @@ class SparseArch(nn.Module):
         pred = torch.cat(
             [
                 fp_ebc_out[key]
-                for key in ["feature_0", "feature_1", "feature_2", "feature_3"]
+                for key in [
+                    "feature_0",
+                    "feature_1",
+                    "feature_2",
+                    "feature_3",
+                ]
             ],
             dim=1,
         )

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -40,7 +40,7 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
         self.pg = init_distributed_single_host(backend=backend, rank=0, world_size=1)
 
         num_features = 4
-        num_weighted_features = 2
+        num_weighted_features = 4
         self.tables = [
             EmbeddingBagConfig(
                 num_embeddings=(i + 1) * 100,

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -147,6 +147,7 @@ def _start_data_dist(
         # and this info was done in the _rewrite_model by tracing the
         # entire model to get the arg_info_list
         args, kwargs = forward.args.build_args_kwargs(batch)
+        args, kwargs = module.preprocess_input(args, kwargs)
 
         # Start input distribution.
         module_ctx = module.create_context()
@@ -379,6 +380,8 @@ def _rewrite_model(  # noqa C901
             logger.info(f"Module '{node.target}' will be pipelined")
             child = sharded_modules[node.target]
             original_forwards.append(child.forward)
+            # Set pipelining flag on the child module
+            child.is_pipelined = True
             # pyre-ignore[8] Incompatible attribute type
             child.forward = pipelined_forward(
                 node.target,

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -19,7 +19,10 @@ from typing import (
     Generic,
     Iterator,
     List,
+    Mapping,
     Optional,
+    ParamSpec,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -77,6 +80,8 @@ from torch.distributed._shard.sharding_spec import (  # noqa
     ShardMetadata,
 )
 from torchrec.streamable import Multistreamable
+
+_T = TypeVar("_T")
 
 
 def _tabulate(
@@ -1012,6 +1017,8 @@ class ShardedModule(
         if qcomm_codecs_registry is None:
             qcomm_codecs_registry = {}
         self._qcomm_codecs_registry = qcomm_codecs_registry
+        # In pipelining, this flag is flipped in rewrite_model when the forward is replaced with the pipelined forward
+        self.is_pipelined = False
 
     @abc.abstractmethod
     def create_context(self) -> ShrdCtx:
@@ -1078,6 +1085,19 @@ class ShardedModule(
     def sharded_parameter_names(self, prefix: str = "") -> Iterator[str]:
         for key, _ in self.named_parameters(prefix):
             yield key
+
+    def preprocess_input(
+        self,
+        args: List[_T],
+        kwargs: Mapping[str, _T],
+    ) -> Tuple[List[_T], Mapping[str, _T]]:
+        """
+        This function can be used to preprocess the input arguments prior to module forward call.
+
+        For example, it is used in ShardedFeatureProcessorEmbeddingBagCollection to transform the input data
+        prior to the forward call.
+        """
+        return args, kwargs
 
     @property
     @abc.abstractmethod

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -26,8 +26,10 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
 from torch import nn
 from torch.autograd.profiler import record_function
 from torchrec import optim as trec_optim
-from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    KeyedJaggedTensor,
+)
 from torchrec.distributed.types import (
     DataType,
     EmbeddingEvent,
@@ -38,6 +40,7 @@ from torchrec.distributed.types import (
     ShardMetadata,
 )
 from torchrec.modules.embedding_configs import data_type_to_sparse_type
+from torchrec.modules.feature_processor_ import FeatureProcessorsCollection
 from torchrec.types import CopyMixIn
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -686,3 +689,46 @@ def _quantize_embedding_modules(module: nn.Module, converted_dtype: DataType) ->
         )
 
         emb_kernel.weights_precision = converted_sparse_dtype  # pyre-ignore [16]
+
+
+def modify_input_for_feature_processor(
+    features: KeyedJaggedTensor,
+    feature_processors: Union[nn.ModuleDict, FeatureProcessorsCollection],
+    is_collection: bool,
+) -> None:
+    """
+    This function applies the feature processor pre input dist. This way we
+    can support row wise based sharding mechanisms.
+
+    This is an inplace modifcation of the input KJT.
+    """
+    with torch.no_grad():
+        if features.weights_or_none() is None:
+            # force creation of weights, this way the feature jagged tensor weights are tied to the original KJT
+            features._weights = torch.zeros_like(features.values(), dtype=torch.float32)
+
+        if is_collection:
+            if hasattr(feature_processors, "pre_process_pipeline_input"):
+                feature_processors.pre_process_pipeline_input(features)  # pyre-ignore[29]
+            else:
+                logging.info(
+                    f"[Feature Processor Pipeline] Skipping pre_process_pipeline_input for feature processor {feature_processors=}"
+                )
+        else:
+            # per feature process
+            for feature in features.keys():
+                if feature in feature_processors:  # pyre-ignore[58]
+                    feature_processor = feature_processors[feature]  # pyre-ignore[29]
+                    if hasattr(feature_processor, "pre_process_pipeline_input"):
+                        feature_processor.pre_process_pipeline_input(features[feature])
+                    else:
+                        logging.info(
+                            f"[Feature Processor Pipeline] Skipping pre_process_pipeline_input for feature processor {feature_processor=}"
+                        )
+                else:
+                    features[feature].weights().copy_(
+                        torch.ones(
+                            features[feature].values().shape[0],
+                            device=features[feature].values().device,
+                        )
+                    )

--- a/torchrec/modules/feature_processor_.py
+++ b/torchrec/modules/feature_processor_.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional
 
 import torch
 
-from torch import nn
+from torch import distributed as dist, nn
 
 from torchrec.pt2.checks import is_non_strict_exporting
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
@@ -71,6 +71,7 @@ class PositionWeightedModule(FeatureProcessor):
             torch.empty([max_feature_length], device=device),
             requires_grad=True,
         )
+        self.pipelined = False
 
         self.reset_parameters()
 
@@ -84,15 +85,18 @@ class PositionWeightedModule(FeatureProcessor):
     ) -> JaggedTensor:
         """
         Args:
-            features (JaggedTensor]): feature representation
+            features (JaggedTensor): feature representation
 
         Returns:
             JaggedTensor: same as input features with `weights` field being populated.
         """
-
-        seq = torch.ops.fbgemm.offsets_range(
-            features.offsets().long(), torch.numel(features.values())
-        )
+        if self.pipelined:
+            # position is embedded as weights
+            seq = features.weights().clone().to(torch.int64)
+        else:
+            seq = torch.ops.fbgemm.offsets_range(
+                features.offsets().long(), torch.numel(features.values())
+            )
         weighted_features = JaggedTensor(
             values=features.values(),
             lengths=features.lengths(),
@@ -100,6 +104,20 @@ class PositionWeightedModule(FeatureProcessor):
             weights=torch.gather(self.position_weight, dim=0, index=seq),
         )
         return weighted_features
+
+    def pre_process_pipeline_input(self, features: JaggedTensor) -> None:
+        """
+        Args:
+            features (JaggedTensor]): feature representation
+
+        Returns:
+            torch.Tensor: position weights
+        """
+        self.pipelined = True
+        cat_seq = torch.ops.fbgemm.offsets_range(
+            features.offsets().long(), torch.numel(features.values())
+        )
+        features.weights().copy_(cat_seq.to(torch.float32))
 
 
 class FeatureProcessorsCollection(nn.Module):
@@ -168,7 +186,7 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection, CopyMixIn):
         for length in self.max_feature_lengths.values():
             if length <= 0:
                 raise
-
+        self.pipelined = False  # if pipelined, input dist has performed part of input feature processing
         self.position_weights: nn.ParameterDict = nn.ParameterDict()
         # needed since nn.ParameterDict isn't torchscriptable (get_items)
         self.position_weights_dict: Dict[str, nn.Parameter] = {}
@@ -190,7 +208,6 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection, CopyMixIn):
                 self.position_weights_dict[key] = self.position_weights[key]
 
     def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
-        # TODO unflattener doesnt work well with aten.to at submodule boundaries
         if is_non_strict_exporting():
             offsets = features.offsets()
             if offsets.dtype == torch.int64:
@@ -202,9 +219,12 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection, CopyMixIn):
                     features.offsets().long(), torch.numel(features.values())
                 )
         else:
-            cat_seq = torch.ops.fbgemm.offsets_range(
-                features.offsets().long(), torch.numel(features.values())
-            )
+            if self.pipelined:
+                cat_seq = features.weights().clone().to(torch.int64)
+            else:
+                cat_seq = torch.ops.fbgemm.offsets_range(
+                    features.offsets().long(), torch.numel(features.values())
+                )
 
         return KeyedJaggedTensor(
             keys=features.keys(),
@@ -232,3 +252,10 @@ class PositionWeightedModuleCollection(FeatureProcessorsCollection, CopyMixIn):
             self.position_weights_dict[k] = param
 
         return self
+
+    def pre_process_pipeline_input(self, features: KeyedJaggedTensor) -> None:
+        self.pipelined = True
+        cat_seq = torch.ops.fbgemm.offsets_range(
+            features.offsets().long(), torch.numel(features.values())
+        )
+        features.weights().copy_(cat_seq.to(torch.float32))


### PR DESCRIPTION
Summary:
In this diff we introduce row based sharding (TWRW, RW, GRID) type support for feature processors.  Previously, feature processors did not support row based sharding since feature processors are data parallel. This means by splitting up the input for row based shards the accessed feature processor weights were in correct. In column/data sharding based approaches, the data is duplicated ensuring the correct weight is accessed across ranks.

The indices/buckets are calculated post input split/distribution, to make it compatible with row based sharding we calculate this pre input split/distribution. This couples the train pipeline and feature processors. For each feature, we preprocess the input and place the calculated indices in KJT.weights, this propagates the indices correctly and indexs into the right weight to use for the final step in the feature processing.

This applies in both pipelined and non pipelined situations - the input modification is done either at the pipelined forward call or in the input dist of the FPEBC. This is determined by the pipelining flag set through rewrite_model in train pipeline.

Differential Revision: D69125073


