### PR TITLE
enable feature score data collection in torchrec

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -88,7 +88,6 @@ from torchrec.modules.embedding_configs import (
     NoEvictionPolicy,
     pooling_type_to_pooling_mode,
     TimestampBasedEvictionPolicy,
-    VirtualTableEvictionPolicy,
 )
 from torchrec.optim.fused import (
     EmptyFusedOptimizer,
@@ -1713,7 +1712,11 @@ class ZeroCollisionKeyValueEmbedding(
         self._split_weights_res = None
         self._optim.set_sharded_embedding_weight_ids(sharded_embedding_weight_ids=None)
 
-        return super().forward(features)
+        return self.emb_module(
+            indices=features.values().long(),
+            offsets=features.offsets().long(),
+            weights=features.weights_or_none(),
+        )
 
 
 class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerModule):

--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -33,6 +33,9 @@ FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP: str = "__register_lengths_to_offsets_look
 FUSED_PARAM_SSD_TABLE_LIST: str = "__register_ssd_table_list"
 # Bool fused param per table to check if the table is offloaded to SSD
 FUSED_PARAM_IS_SSD_TABLE: str = "__register_is_ssd_table"
+ENABLE_FEATURE_SCORE_WEIGHT_ACCUMULATION: str = (
+    "enable_feature_score_weight_accumulation"
+)
 
 
 class TBEToRegisterMixIn:


### PR DESCRIPTION
Summary:
Add enable_feature_score_weight_accumulation flag to ShardedEmbeddingCollection. When this flag is true, and dedup ec index is true, we'll accumulate kjt weight and count and reset back to kjt weight, to allow input dist to distribute feature score.

this change is part of ZCH v.Next feature score eviction story:
- collect score for every feature id in model, e.g. for positive id set to 0.5, and negative id set to 0.2.
- set score as the input id list feature kjt's weight value
- in EC forward, if there is ID dedup, aggregate the id score and occurrence of each id.
- distribute the id score in kjt weight
- in KVZCH embedding kernel, call forward with weight as an optional parameter

in ZCH TBE backend (separate diffs):
- set the feature score to ZCH TBE backend
- run eviction based on the id score value

for the whole story, please reference here:
https://docs.google.com/document/d/1TJHKvO1m3-5tYAKZGhacXnGk7iCNAzz7wQlrFbX_LDI/edit?tab=t.0

Differential Revision: D79864431
