### PR TITLE
Update CUDA versions in Github

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,9 +48,9 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
    pip install torch --index-url https://download.pytorch.org/whl/nightly/cu126
 
-   CUDA 11.8
+   CUDA 12.9
 
-   pip install torch --index-url https://download.pytorch.org/whl/nightly/cu118
+   pip install torch --index-url https://download.pytorch.org/whl/nightly/cu129
 
    CPU
 
@@ -73,9 +73,9 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
    pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu126
 
-   CUDA 11.8
+   CUDA 12.9
 
-   pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu118
+   pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu129
 
    CPU
 


### PR DESCRIPTION
Summary:
CUDA versions need to be updated as 11.8 is not supported any more.

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D80532663


