### PR TITLE
enable KEY_VALUE kernel in ManagedCollisionEmbeddingCollectionSharder

### DIFF
--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -303,6 +303,7 @@ class BaseManagedCollisionEmbeddingCollectionSharder(BaseEmbeddingSharder[M]):
             EmbeddingComputeKernel.FUSED.value,
             EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
             EmbeddingComputeKernel.FUSED_UVM.value,
+            EmbeddingComputeKernel.KEY_VALUE.value,
         ]
 
     def sharding_types(self, compute_device_type: str) -> List[str]:


### PR DESCRIPTION
Summary: add `KEY_VALUE` kernel in `ManagedCollisionEmbeddingCollectionSharder`

Reviewed By: iamzainhuda

Differential Revision: D80717266


