### PR TITLE
Fix flaky Github test

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2992,18 +2992,19 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                             values.numel(),
                         )
                     elif single_batch_per_rank:
-                        (
-                            lengths,
-                            values,
-                            weights,
-                        ) = torch.ops.fbgemm.permute_2D_sparse_data(
-                            torch.jit._unwrap_optional(recat),
-                            lengths.view(-1, stride),
-                            values,
-                            weights,
-                            values.numel(),
-                        )
-                        lengths = lengths.view(-1)
+                        if stride > 0:
+                            (
+                                lengths,
+                                values,
+                                weights,
+                            ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                                torch.jit._unwrap_optional(recat),
+                                lengths.view(-1, stride),
+                                values,
+                                weights,
+                                values.numel(),
+                            )
+                            lengths = lengths.view(-1)
                     else:  # variable batch size per rank
                         (
                             lengths,


### PR DESCRIPTION
Summary:
`_maybe_compute_stride_kjt` returns `stride = 0` when `len(keys) == 0` or when `stride_per_key_per_rank` has invalid values.

Adding a guard condition `if stride > 0:` before the problematic `lengths.view(-1, stride)` operation in the `dist_init` method. When `stride` is 0 (e.g. indicating empty keys), skip the permutation.

Differential Revision: D80948346


