### PR TITLE
Remove fused_params in `test_ssd_mixed_kernels_with_vbe`

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -572,9 +572,6 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
         dtype: DataType,
     ) -> None:
         self._set_table_weights_precision(dtype)
-        fused_params = {
-            "prefetch_pipeline": True,
-        }
         constraints = {
             table.name: ParameterConstraints(
                 min_partition=4,
@@ -601,7 +598,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             embedding_groups={},
             tables=self.tables,
             # pyre-fixme[6]
-            sharders=[EmbeddingBagCollectionSharder(fused_params=fused_params)],
+            sharders=[EmbeddingBagCollectionSharder()],
             optim=EmbOptimType.EXACT_SGD,
             # The optimizer config here will overwrite the SGD optimizer above
             apply_optimizer_in_backward_config={


### PR DESCRIPTION
Summary:
Remove the unnecessary fused param `prefetch_pipeline=true` in the unit test `test_ssd_mixed_kernels_with_vbe`.

This is only needed for `UVM_CACHING` to create a multiple-TBE scenario. Here for `KEY_VALUE` TBE this is not needed.

Differential Revision: D81150291


