### PR TITLE
filter out py3.14 and cu130

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -60,7 +60,11 @@ def main():
     new_matrix_entries = []
 
     for entry in full_matrix["include"]:
-        if entry["desired_cuda"] == "cu129":
+        if entry["desired_cuda"] == "cu130":
+            # fbgemm only supports cuda 12.6, 12.8 and 12.9
+            continue
+        if entry["python_version"] == "3.14":
+            # it seems stuck `conda create myenv python=3.14 -c conda-forge`
             continue
         new_matrix_entries.append(entry)
 

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -19,6 +19,7 @@ on:
       - '.github/workflows/validate-nightly-binaries.yml'
       - '.github/workflows/validate-binaries.yml'
       - '.github/scripts/validate-binaries.sh'
+      - '.github/scripts/filter.py'
 jobs:
   nightly:
     uses: ./.github/workflows/validate-binaries.yml


### PR DESCRIPTION
Summary:
# context
* based on fbgemm v1.3.0, the cuda version are 12.6, 12.8, and 12.9
```
The packages are now available for download and test:

# PyTorch PIP (download.pytorch.org, recommended)
pip install --pre fbgemm-gpu==1.3.0 --index-url https://download.pytorch.org/whl/test/cpu/
pip install --pre fbgemm-gpu==1.3.0 --index-url https://download.pytorch.org/whl/test/cu126/
pip install --pre fbgemm-gpu==1.3.0 --index-url https://download.pytorch.org/whl/test/cu128/
pip install --pre fbgemm-gpu==1.3.0 --index-url https://download.pytorch.org/whl/test/cu129/

# PyPI
pip install fbgemm-gpu==1.3.0rc2
pip install fbgemm-gpu-cpu==1.3.0rc2
pip install fbgemm-gpu-genai==1.3.0rc2
```
* also python 3.14 seems not work

* before
<img width="3446" height="2528" alt="image" src="https://github.com/user-attachments/assets/dc9e473f-d1dc-4267-b506-f2be612222dc" />

* after
<img width="3014" height="2744" alt="image" src="https://github.com/user-attachments/assets/d8879712-99cb-42b2-880f-e2c8ecf09be4" />


Differential Revision: D81467034


