### PR TITLE
fix issue in validate_binaries.sh

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -44,6 +44,8 @@ if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then
     elif [[ ${MATRIX_GPU_ARCH_VERSION} = '12.9' ]]; then
         export CUDA_VERSION="cu129"
     elif [[ ${MATRIX_GPU_ARCH_VERSION} = '13.0' ]]; then
+        echo "fbgemm does not support cuda 13.0 so far, exit"
+        exit 0
         export CUDA_VERSION="cu130"
     else
         export CUDA_VERSION="cu126"

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -18,7 +18,7 @@ on:
     paths:
       - '.github/workflows/validate-nightly-binaries.yml'
       - '.github/workflows/validate-binaries.yml'
-      - '.github/scripts/validate-binaries.sh'
+      - '.github/scripts/validate_binaries.sh.sh'
       - '.github/scripts/filter.py'
 jobs:
   nightly:


### PR DESCRIPTION
Summary:
# context
* filter.py is not used in binary validation
* it has to be skipped in the script.

Differential Revision: D81469520


