### PR TITLE
PlanLoader addition into planner

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -42,6 +42,7 @@ from torchrec.distributed.planner.types import (
     ParameterConstraints,
     Partitioner,
     PerfModel,
+    PlanDebugStats,
     PlannerError,
     PlannerErrorType,
     Proposer,
@@ -528,6 +529,10 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     sharders=sharders,
                     debug=self._debug,
+                    debug_stats=PlanDebugStats(
+                        planner_type=self.__class__.__name__,
+                        timeout_seconds=self._timeout_seconds,
+                    ),
                 )
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -40,6 +40,7 @@ from torchrec.distributed.planner.types import (
     Enumerator,
     ParameterConstraints,
     Perf,
+    PlanDebugStats,
     ShardingOption,
     Stats,
     Storage,
@@ -160,6 +161,7 @@ class EmbeddingStats(Stats):
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
         enumerator: Optional[Enumerator] = None,
         debug: bool = True,
+        debug_stats: Optional[PlanDebugStats] = None,
     ) -> None:
         """
         Logs stats for a given sharding plan.
@@ -1138,5 +1140,6 @@ class NoopEmbeddingStats(Stats):
         sharders: Optional[List[ModuleSharder[nn.Module]]] = None,
         enumerator: Optional[Enumerator] = None,
         debug: bool = True,
+        debug_stats: Optional[PlanDebugStats] = None,
     ) -> None:
         pass

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -998,6 +998,40 @@ class Stats(abc.ABC):
         ...
 
 
+class PlanLoader(abc.ABC):
+    """
+    Retrieves a pre-computed sharding plan from its stored location. This is useful in two scenarios:
+        1. To utilize a specific sharding plan that was previously computed and stored, saving the cost of re-generating the plan
+        2. To use a sharding plan from previous runs as a starting point for the next run, allowing for improvement over time.
+    """
+
+    @abc.abstractmethod
+    def load(
+        self,
+    ) -> Optional[Dict[int, ShardingOption]]:
+        """
+        Load sharding plan from its stored location.
+
+        Returns:
+            Dict[int, ShardingOption]: loaded sharding plan. key is hash of sharding option to map to sharding option with enumerated sharding option.
+        """
+        ...
+
+    @abc.abstractmethod
+    def plan_context_hash(
+        self,
+    ) -> Optional[str]:
+        """
+        Input context hash of a sharding plan.
+
+        Returns:
+            str: hash of sharding plan context.
+        """
+        ...
+
+    ...
+
+
 @dataclass
 class CriticalPathEstimate:
     comms_estimate: float

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -638,6 +638,22 @@ class ShardingOption:
             )
         )
 
+    def storage_hash(self) -> int:
+        """
+        Hash needed to preserve sharding option uniquely based on input before
+        planning. This is needed to restore sharding option from the loaded plan.
+        Hash is computed based on the following attributes:
+            - fqn
+            - sharding_type
+            - compute_kernel
+            - column_wise_shard_dim
+        """
+        # Use BLAKE2b for deterministic hashing, constrained to 64-bit signed int range
+        hash_str = f"{self.fqn}|{self.sharding_type}|{self.compute_kernel}|{self.cache_load_factor}|{self.num_shards}"
+        hash_bytes = hashlib.blake2b(hash_str.encode("utf-8"), digest_size=7).digest()
+        hash_int = int.from_bytes(hash_bytes, byteorder="big")
+        return hash_int
+
     def __deepcopy__(
         self, memo: Optional[Dict[int, "ShardingOption"]]
     ) -> "ShardingOption":


### PR DESCRIPTION
Summary:
**Summary:**

*   Added PlanLoader abstract base class to enable loading pre-computed sharding plans from stored locations within planner. 
*   Supports two key scenarios:
    1.  Reusing previously computed and stored sharding plans to avoid regeneration costs
    2.  Using sharding plans from previous runs as starting points for iterative improvements
*   Defines two abstract methods:
    *   `load()`: Returns a dictionary mapping sharding option hashes to ShardingOption objects
    *   `plan_validation_str()`: Provides validation string for plan integrity checks
*   Part of the broader effort to improve planner UX and reliability by enabling plan persistence and reuse across training runs

Differential Revision: D81571293


