### PR TITLE
[benchmark] explore using a side stream for two data-dependent all_to_all_single comms

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -597,10 +597,7 @@ class ShardedEmbeddingBagCollection(
         if env.process_group and dist.get_backend(env.process_group) != "fake":
             self._initialize_torch_state()
 
-        if module.device not in ["meta", "cpu"] and module.device.type not in [
-            "meta",
-            "cpu",
-        ]:
+        if module.device != "meta" and module.device.type != "meta":
             self.load_state_dict(module.state_dict(), strict=False)
 
     @classmethod

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -419,8 +419,8 @@ def _test_hashing_consistency(
 
 
 class TestConsistentHashingBetweenProcesses(MultiProcessTestBase):
-
-    def test_hash_consistency(self) -> None:
+    # the proposal order might vary in github action so skip this test
+    def test_hash_consistency_disabled_in_oss_compatibility(self) -> None:
         # planner
         world_size = 2
         return_hash_dict = multiprocessing.Manager().dict()

--- a/torchrec/distributed/tests/test_init_parameters.py
+++ b/torchrec/distributed/tests/test_init_parameters.py
@@ -223,7 +223,7 @@ class ParameterInitializationTest(MultiProcessTestBase):
         device=st.sampled_from(
             [
                 torch.device("cuda"),
-                # torch.device("cpu"),
+                torch.device("cpu"),
             ]
         ),
     )


### PR DESCRIPTION
Summary:
# context
* table-wise-row-wise (TWRW) sharding takes the advantage of high bandwidth intra-node comms for the data-intensive row-wise sharded embedding table pooling. 
* it uses [two output dist components](https://github.com/meta-pytorch/torchrec/blob/release/v1.3.0/torchrec/distributed/sharding/twrw_sharding.py#L479-L490): intra-node dist and cross-node dist. The cross-node dist relies on the data/result from intra-node dist.
* This data dependency actually creates a blocking situation on the main cuda (compute) stream, as shown below (nccl:_reduce_scatter for the intra-node dist, nccl:_all_to_all for the cross-node dist)
<img width="2548" height="990" alt="image" src="https://github.com/user-attachments/assets/3f095ef6-b737-45d8-9c90-0bc31bf41959" />

# experiment
* the correct approach is to use a side stream to process the data-dependent comms

* without side stream: [trace](https://drive.google.com/file/d/1lpa-NrBD0IWcpskdN1Lwiu0XcSTe01bW/view?usp=sharing)
the first comms is blocking the main stream execution
<img width="1940" height="604" alt="image" src="https://github.com/user-attachments/assets/ab4e3bd9-b761-4c7b-ae49-5cb22a1f1534" />

* with side stream: [trace](https://drive.google.com/file/d/1FqNpq4yMx9H6vL47S8KX5dvk2PJv_QGa/view?usp=sharing)
both comms are non-blocking on the main stream
<img width="1972" height="638" alt="image" src="https://github.com/user-attachments/assets/5fc5bfe9-e66f-47ef-8c7c-3a0eb2126555" />

Differential Revision: D82002643


