### PR TITLE
Fix the assignment logic of the variable "self.num_batches" in RandomRecDataset 

### DIFF
--- a/torchrec/datasets/random.py
+++ b/torchrec/datasets/random.py
@@ -212,7 +212,7 @@ class RandomRecDataset(IterableDataset[Batch]):
             num_generated_batches=num_generated_batches,
             min_ids_per_features=min_ids_per_features,
         )
-        self.num_batches: int = cast(int, num_batches if not None else sys.maxsize)
+        self.num_batches: int = cast(int, num_batches if num_batches is not None else sys.maxsize)
 
     def __iter__(self) -> Iterator[Batch]:
         return itertools.islice(iter(self.batch_generator), self.num_batches)

--- a/torchrec/datasets/random.py
+++ b/torchrec/datasets/random.py
@@ -212,7 +212,9 @@ class RandomRecDataset(IterableDataset[Batch]):
             num_generated_batches=num_generated_batches,
             min_ids_per_features=min_ids_per_features,
         )
-        self.num_batches: int = cast(int, num_batches if num_batches is not None else sys.maxsize)
+        self.num_batches: int = cast(
+            int, num_batches if num_batches is not None else sys.maxsize
+        )
 
     def __iter__(self) -> Iterator[Batch]:
         return itertools.islice(iter(self.batch_generator), self.num_batches)


### PR DESCRIPTION
https://github.com/pytorch/torchrec/blob/main/torchrec/datasets/random.py#L215

```python
self.num_batches: int = cast(int, num_batches if not None else sys.maxsize)
```

**self.num_batches** is always assigned to **num_batches** even if **num_batches** is None. 