### PR TITLE
Remove bandwidth adjustment factor from critical path calculations

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -1109,15 +1109,7 @@ def _calculate_critical_path(best_plan: List[ShardingOption]) -> CriticalPathEst
     }
     rank_count = len({cast(int, shard.rank) for so in best_plan for shard in so.shards})
     sharding_types = list({so.sharding_type for so in best_plan})
-    adjustment_factor = 1
-    # Default bandwidth is 12.5 is used and closer to 40 is right for internode GTT
-    if (
-        rank_count > 8
-        and len(sharding_types) == 1
-        and sharding_types[0] == "column_wise"
-    ):
-        adjustment_factor = 3
-    comms_estimate = sum(comms_rank_agg.values()) / adjustment_factor
+    comms_estimate = sum(comms_rank_agg.values())
     comp_rank_agg = {
         outer_key: max(inner_dict.values())
         for outer_key, inner_dict in comp_data.items()


### PR DESCRIPTION
Summary:
We previously introduced an adjustment factor of 3 while computing the comms part of critical path calculations before investing in HW based estimates.

This adjustment factor is no longer needed and causes issues because the objective optimized by the problem ends up being different than the critical path estimates we report in the logs.

Differential Revision: D81984456


