### PR TITLE
Revert D80742183

### DIFF
--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -367,21 +367,20 @@ class TwPooledEmbeddingDist(
         """
         if self._dist is None:
             self._create_output_dist_module(sharding_ctx)
-        if isinstance(self._dist, VariableBatchPooledEmbeddingsAllToAll):
-            sharding_ctx = none_throws(sharding_ctx)
+
+        if sharding_ctx is None:
+            return cast(PooledEmbeddingsAllToAll, self._dist)(local_embs)
+        elif sharding_ctx.variable_batch_per_feature:
             return cast(VariableBatchPooledEmbeddingsAllToAll, self._dist)(
                 local_embs,
-                batch_size_per_rank_per_feature=sharding_ctx.batch_size_per_rank_per_feature
-                or sharding_ctx.batch_size_per_rank,
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a
-                or sharding_ctx.batch_size_per_rank,
+                batch_size_per_rank_per_feature=sharding_ctx.batch_size_per_rank_per_feature,
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
             )
-        return cast(PooledEmbeddingsAllToAll, self._dist)(
-            local_embs,
-            batch_size_per_rank=(
-                sharding_ctx.batch_size_per_rank if sharding_ctx else None
-            ),
-        )
+        else:
+            return cast(PooledEmbeddingsAllToAll, self._dist)(
+                local_embs,
+                batch_size_per_rank=sharding_ctx.batch_size_per_rank,
+            )
 
     def _create_output_dist_module(
         self, sharding_ctx: Optional[EmbeddingShardingContext] = None

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -504,21 +504,14 @@ class TwRwPooledEmbeddingDist(
             self._create_output_dist_modules(sharding_ctx)
         local_rank = self._rank % self._intra_pg.size()
         current_node = self._rank // self._intra_pg.size()
-        if isinstance(
-            self._intra_dist, VariableBatchPooledEmbeddingsReduceScatter
-        ) and isinstance(self._cross_dist, VariableBatchPooledEmbeddingsAllToAll):
-            assert sharding_ctx is not None and (
-                sharding_ctx.batch_size_per_rank_per_feature
-                or sharding_ctx.batch_size_per_rank
-            ), "Batch size not found in KJT input for VBE"
+        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
             (
                 batch_size_per_rank_per_feature_by_cross_group,
                 batch_size_per_feature_sum_by_cross_group,
             ) = self._preprocess_batch_size_per_rank_per_feature(
                 self._intra_pg.size(),
                 self._cross_pg.size(),
-                sharding_ctx.batch_size_per_rank_per_feature
-                or [sharding_ctx.batch_size_per_rank],
+                sharding_ctx.batch_size_per_rank_per_feature,
             )
             rs_result = cast(
                 VariableBatchPooledEmbeddingsReduceScatter, self._intra_dist
@@ -532,8 +525,7 @@ class TwRwPooledEmbeddingDist(
                 batch_size_per_rank_per_feature=batch_size_per_rank_per_feature_by_cross_group[
                     local_rank
                 ],
-                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a
-                or sharding_ctx.batch_size_per_rank,
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
             )
         elif (
             sharding_ctx is not None and len(set(sharding_ctx.batch_size_per_rank)) > 1


### PR DESCRIPTION
Summary:
This diff reverts D80742183
Ths breaks the IG ESR model: https://www.internalfb.com/conveyor/mvai/mvai_ig_ranking/releases/3977.1/nodes/cogwheel_ig_ranking_esr_test/runs/1023784516392755?pipeline_names[0]=main&node_details_tab=run_details_summary

Depends on D80742183

Differential Revision: D82025171


