### PR TITLE
add dispatch option for release channel

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -9,9 +9,6 @@ on:
       # only run tests on main branch & nightly; release should be triggered manually
       - nightly
       - main
-    tags:
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
     paths-ignore:
       - "docs/*"
       - "third_party/*"
@@ -24,6 +21,15 @@ on:
       - .gitignore
       - "*.md"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use for torch and fbgemm"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
 
 jobs:
   build_test:
@@ -76,15 +82,23 @@ jobs:
         conda info
         python --version
         conda run -n build_binary python --version
+        if [[ "${{ inputs.channel }}" = "release" ]]; then
+          index_url=https://download.pytorch.org/whl/${{ matrix.cuda-tag }}
+        elif [ -z "${{ inputs.channel }}" ]; then
+          index_url=https://download.pytorch.org/whl/nightly/${{ matrix.cuda-tag }}
+        else
+          index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/${{ matrix.cuda-tag }}
+        fi
+        echo "index_url: $index_url"
         conda run -n build_binary \
-          pip install torch --index-url https://download.pytorch.org/whl/nightly/${{ matrix.cuda-tag }}
+          pip install torch --index-url $index_url
         conda run -n build_binary \
           python -c "import torch; print(torch.__version__)"
         echo "torch succeeded"
         conda run -n build_binary \
           python -c "import torch.distributed"
         conda run -n build_binary \
-          pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/${{ matrix.cuda-tag }}
+          pip install fbgemm-gpu --index-url $index_url
         conda run -n build_binary \
           python -c "import fbgemm_gpu; print(fbgemm_gpu.__version__)"
         echo "fbgemm_gpu succeeded"

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -9,9 +9,6 @@ on:
       # only run tests on main branch & nightly; release should be triggered manually
       - nightly
       - main
-    tags:
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
     paths-ignore:
       - "docs/*"
       - "third_party/*"
@@ -24,6 +21,15 @@ on:
       - .gitignore
       - "*.md"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use for torch and fbgemm"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
 
 jobs:
   build_test:
@@ -66,15 +72,23 @@ jobs:
         conda info
         python --version
         conda run -n build_binary python --version
+        if [[ "${{ inputs.channel }}" = "release" ]]; then
+          index_url=https://download.pytorch.org/whl/cpu
+        elif [ -z "${{ inputs.channel }}" ]; then
+          index_url=https://download.pytorch.org/whl/nightly/cpu
+        else
+          index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/cpu
+        fi
+        echo "index_url: $index_url"
         conda run -n build_binary \
-          pip install torch --index-url https://download.pytorch.org/whl/nightly/cpu
+          pip install torch --index-url $index_url
         conda run -n build_binary \
           python -c "import torch; print(torch.__version__)"
         echo "torch succeeded"
         conda run -n build_binary \
           python -c "import torch.distributed"
         conda run -n build_binary \
-          pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cpu
+          pip install fbgemm-gpu --index-url $index_url
         conda run -n build_binary \
           python -c "import fbgemm_gpu; print(fbgemm_gpu.__version__)"
         echo "fbgemm_gpu succeeded"

--- a/README.MD
+++ b/README.MD
@@ -40,13 +40,13 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
 1. Install pytorch. See [pytorch documentation](https://pytorch.org/get-started/locally/).
    ```
-   CUDA 12.8
-
-   pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128
-
    CUDA 12.6
 
    pip install torch --index-url https://download.pytorch.org/whl/nightly/cu126
+
+   CUDA 12.8
+
+   pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128
 
    CUDA 12.9
 
@@ -65,13 +65,13 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
 3. Install FBGEMM.
    ```
-   CUDA 12.8
-
-   pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu128
-
    CUDA 12.6
 
    pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu126
+
+   CUDA 12.8
+
+   pip install fbgemm-gpu --index-url https://download.pytorch.org/whl/nightly/cu128
 
    CUDA 12.9
 

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ def main(argv: List[str]) -> None:
             "Intended Audience :: Science/Research",
             "License :: OSI Approved :: BSD License",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Summary:
# context
* current the github CI (cpu and gpu) always uses nightly build for torch and fbgemm
* there's need to verify the torchrec library during release
* added dispatch option to select the channel (nightly, release, test) for torch and fbgemm

Differential Revision: D82362972


