### PR TITLE
add semi sync optimizer paradigm into torchrec

### DIFF
--- a/torchrec/optim/__init__.py
+++ b/torchrec/optim/__init__.py
@@ -38,6 +38,7 @@ from torchrec.optim.optimizers import (  # noqa
     SGD,
 )
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad  # noqa
+from torchrec.optim.semi_sync import SemisyncOptimizer  # noqa
 from torchrec.optim.warmup import WarmupOptimizer, WarmupPolicy, WarmupStage  # noqa
 
 from . import (  # noqa  # noqa  # noqa  # noqa

--- a/torchrec/optim/semi_sync.py
+++ b/torchrec/optim/semi_sync.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from typing import Any, Collection, Dict, Mapping, Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.optim.optimizer import ParamsT
+
+from torchrec.optim.keyed import KeyedOptimizer
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+SEMI_SYNC_GLOBAL_OPTIM_KEY: str = "semi_sync_global_optim"
+SEMI_SYNC_LOCAL_OPTIM_KEY: str = "semi_sync_local_optim"
+
+SEMI_SYNC_GLOBAL_STATE_KEY: str = "semi_sync_global_"
+SEMI_SYNC_LOCAL_STATE_KEY: str = "semi_sync_local_"
+
+# Step counter keys for special parameters
+SEMISYNC_GLOBAL_STEP_COUNTER_KEY: str = "__semisync_global_step_counter__"
+SEMISYNC_LOCAL_STEP_COUNTER_KEY: str = "__semisync_local_step_counter__"
+
+
+class SemisyncOptimizer(KeyedOptimizer):
+    """
+    Semi-Synchronous Optimizer. Implements semi synchronous training for cross-regional
+    distributed training for large scale recommendation models.
+
+    This optimizer:
+    1. Takes a local optimizer (e.g., Shampoo or Adam wrapped in KeyedOptimizer)
+    2. Takes a global optimizer (e.g., DiLoCo)
+    3. Performs local steps on the local optimizer
+    4. Periodically performs global aggregation steps using the logic of global optimizer
+    5. Exposes combined state from both optimizers through KeyedOptimizer interface
+
+    Args:
+        global_params (ParamsT): Global parameters for SemisyncOptimizer
+        optimizer (KeyedOptimizer): Local optimizer (typically Shampoo or Adam, wrapped in KeyedOptimizer)
+        global_optimizer (KeyedOptimizer): Global optimizer (such as DiLoCo, also wrapper in KeyedOptimizer)
+        num_local_steps (int): Number of local steps before global sync
+        semi_sync_worker_shard_group (Optional[dist.ProcessGroup]): Process group for metrics logging
+        offload_global_model (bool): Offload global model parameters onto CPU (Default: False)
+        non_blocking (bool): GPU <-> CPU communication is non blocking (Default: False)
+    """
+
+    def __init__(
+        self,
+        global_params: ParamsT,
+        optimizer: KeyedOptimizer,
+        global_optimizer: KeyedOptimizer,
+        num_local_steps: int = 16,
+        semi_sync_worker_shard_group: Optional[dist.ProcessGroup] = None,
+        offload_global_model: bool = False,
+        non_blocking: bool = False,
+    ) -> None:
+        # Store the optimizers
+        self._optimizer: KeyedOptimizer = optimizer
+        self._global_optimizer: KeyedOptimizer = global_optimizer
+
+        assert global_params is not None, "global params must be provided"
+        # Determine parameters for global optimizer
+        global_params_list = list(global_params)
+        self._worker_model_params: list[torch.Tensor] = (
+            # pyre-ignore
+            [param for pgroup in global_params_list for param in pgroup["params"]]
+            if isinstance(global_params_list[0], dict)
+            else global_params_list
+        )
+
+        # Semi-sync configuration
+
+        self._num_local_steps: int = num_local_steps
+        self._local_step_counter: torch.Tensor = torch.tensor(
+            0, dtype=torch.int64, device="cpu"
+        )
+        self._global_step_counter: torch.Tensor = torch.tensor(
+            0, dtype=torch.int64, device="cpu"
+        )
+
+        # Store process groups info for metrics logging
+        self._worker_shard_group: Optional[dist.ProcessGroup] = (
+            semi_sync_worker_shard_group
+        )
+        self._offload_global_model: bool = offload_global_model
+        self._non_blocking: bool = non_blocking
+        self.defaults: Dict[str, Any] = {"_save_param_groups": False}
+
+        logger.info(
+            "Instantiated SemisyncOptimizer with: "
+            f"num_local_steps={self._num_local_steps}, "
+            f"worker_model_params_count={len(self._worker_model_params)}, "
+            f"offload_global_model={offload_global_model}, "
+            f"non_blocking={non_blocking}, "
+            f"self.defaults={self.defaults}, "
+            f"local_optimizer={type(self._optimizer)}, "
+            f"global_optimizer={type(self._global_optimizer)}"
+        )
+
+    @property
+    def param_groups(self) -> Collection[Mapping[str, Any]]:
+        """
+        Combine param_groups from both local and global optimizers.
+        """
+        return [
+            param_group
+            for opt in [self._optimizer, self._global_optimizer]
+            for param_group in opt.param_groups
+        ]
+
+    @property
+    def params(self) -> Mapping[str, Union[torch.Tensor, ShardedTensor]]:
+        """
+        Combine params from both local and global optimizers.
+        If param_key already exists, verify that local and global point to the same parameter tensor.
+        """
+        ret = dict(self._optimizer.params)
+
+        # Add global params with collision check
+        for param_key, param in self._global_optimizer.params.items():
+            if param_key in ret:
+                assert (
+                    ret[param_key] is param
+                ), f"Parameter key '{param_key}' exists in both optimizers but points to different tensors"
+            else:
+                ret[param_key] = param
+
+        # Add step counters as special parameters
+        ret[SEMISYNC_GLOBAL_STEP_COUNTER_KEY] = self._global_step_counter
+        ret[SEMISYNC_LOCAL_STEP_COUNTER_KEY] = self._local_step_counter
+
+        return ret
+
+    @property
+    # pyre-ignore [3]
+    def state(self) -> Mapping[torch.Tensor, Any]:
+        """
+        Combine state from both local and global optimizers.
+            - For tensors that exist in both optimizers, prefix the state keys to avoid conflicts.
+            - Step counters are embedded into every global parameter's state.
+        """
+        # Start with prefixed local states
+        ret = {
+            param: {
+                f"{SEMI_SYNC_LOCAL_STATE_KEY}{key}": value
+                for key, value in local_state.items()
+            }
+            for param, local_state in self._optimizer.state.items()
+        }
+
+        # Add prefixed global states and step counters
+        for param, global_state in self._global_optimizer.state.items():
+            prefixed_global_state = {
+                f"{SEMI_SYNC_GLOBAL_STATE_KEY}{key}": value
+                for key, value in global_state.items()
+            }
+
+            if param in ret:
+                ret[param].update(prefixed_global_state)
+            else:
+                ret[param] = prefixed_global_state
+
+            # Add step counters to all global params
+            ret[param].update(
+                {
+                    SEMISYNC_GLOBAL_STEP_COUNTER_KEY: self._global_step_counter,
+                    SEMISYNC_LOCAL_STEP_COUNTER_KEY: self._local_step_counter,
+                }
+            )
+
+        return ret
+
+    @torch.no_grad()
+    def step(self, closure: Any = None) -> None:  # pyre-ignore [2]
+        """
+        Perform semi-sync optimization step:
+            1. Always perform local optimizer step
+            2. At every num_local_steps, perform global optimizer step
+
+        TODO:
+        See more details in D80683853, v8
+            - metrics: add _metrics_logger for global grad and pseudo-gradient statistics
+            - cpu cache: add GlobalModelParamsCache with non_blocking_transfer for memory efficiency
+            - gradient clipping: add gradient clipping for global optimizer if needed
+        """
+        self._local_step_counter.add_(1)
+        trigger_global_step = self._local_step_counter.item() > 0 and (
+            self._local_step_counter.item() % self._num_local_steps == 0
+        )
+
+        # Perform local optimizer step (delegate to the local optimizer)
+        self._optimizer.step(closure)
+
+        # Perform global model sync every num_local_steps
+        if trigger_global_step:
+            self._global_step_counter.add_(1)
+
+            # Step 0: Release the gradient buffer to reduce memory consumption
+            self._global_optimizer.zero_grad()
+
+            # Step 1: perform global optimizer step
+            # pyre-ignore
+            self._global_optimizer._optimizer.global_step(
+                self._local_step_counter, closure
+            )
+
+            logger.info(
+                f"Finished global optimizer step {self._global_step_counter.item()} "
+                f"(after {self._local_step_counter.item()} local steps)"
+            )
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        self._optimizer.zero_grad(set_to_none=set_to_none)
+        self._global_optimizer.zero_grad(set_to_none=set_to_none)
+
+    def post_load_state_dict(self) -> None:
+        """
+        Called after KeyedOptimizer.load_state_dict() completes.
+        This is where we separate the prefixed combined state back to individual optimizers.
+        """
+        logger.info(
+            "SemisyncOptimizer: post_load_state_dict called - separating prefixed combined state"
+        )
+
+        # Extract step counters from any param states that contain them
+        combined_state = dict(self.state)
+        self._post_load_state_dict_step_counter(combined_state)
+
+        # Separate states using dictionary comprehensions
+        local_tensors = set(self._optimizer.state.keys())
+        global_tensors = set(self._global_optimizer.state.keys())
+
+        local_state = {
+            param: self._extract_prefixed_state(param_state, SEMI_SYNC_LOCAL_STATE_KEY)
+            for param, param_state in combined_state.items()
+            if param in local_tensors
+            and any(k.startswith(SEMI_SYNC_LOCAL_STATE_KEY) for k in param_state)
+        }
+
+        global_state = {
+            param: self._extract_prefixed_state(param_state, SEMI_SYNC_GLOBAL_STATE_KEY)
+            for param, param_state in combined_state.items()
+            if param in global_tensors
+            and any(k.startswith(SEMI_SYNC_GLOBAL_STATE_KEY) for k in param_state)
+        }
+
+        # Update optimizer states
+        for opt, state, name in [
+            (self._optimizer, local_state, "local"),
+            (self._global_optimizer, global_state, "global"),
+        ]:
+            if state:
+                opt.state.clear()  # pyre-ignore
+                opt.state.update(state)  # pyre-ignore
+                logger.info(
+                    f"SemisyncOptimizer: Set state on {name} optimizer for {len(state)} parameters"
+                )
+
+        # Call post_load_state_dict on individual optimizers if they support it
+        for opt in [self._optimizer, self._global_optimizer]:
+            if hasattr(opt, "post_load_state_dict"):
+                opt.post_load_state_dict()
+
+    def save_param_groups(self, save: bool) -> None:
+        self.defaults["_save_param_groups"] = save
+        self._optimizer.save_param_groups(save)
+        self._global_optimizer.save_param_groups(save)
+
+    def __repr__(self) -> str:
+        ret = []
+        ret.append(f"{SEMI_SYNC_LOCAL_OPTIM_KEY}: {self._optimizer.__repr__()}")
+        ret.append(f"{SEMI_SYNC_GLOBAL_OPTIM_KEY}: {self._global_optimizer.__repr__()}")
+        return ", ".join(ret)
+
+    def set_optimizer_step(self, step: int) -> None:
+        for opt in [self._optimizer, self._global_optimizer]:
+            if hasattr(opt, "set_optimizer_step"):
+                # pyre-ignore [16]: Undefined attribute [16]: `KeyedOptimizer` has no attribute `set_optimizer_step`.
+                opt.set_optimizer_step(step)
+
+    def update_hyper_parameters(self, params_dict: Dict[str, Any]) -> None:
+
+        for opt in [self._optimizer, self._global_optimizer]:
+            if hasattr(opt, "update_hyper_parameters"):
+                # pyre-ignore [16]: Undefined attribute [16]: `KeyedOptimizer` has no attribute `update_hyper_parameters`.
+                opt.update_hyper_parameters(params_dict)
+
+    @staticmethod
+    def _extract_prefixed_state(
+        param_state: Dict[str, Any], prefix: str
+    ) -> Dict[str, Any]:
+        """
+        Extract state keys with a specific prefix and remove the prefix.
+
+        Args:
+            param_state: Parameter state dictionary
+            prefix: Prefix to extract and remove
+
+        Returns:
+            Dictionary with prefix removed from matching keys
+        """
+        return {
+            key[len(prefix) :]: value
+            for key, value in param_state.items()
+            if key.startswith(prefix)
+        }
+
+    def _post_load_state_dict_step_counter(
+        self,
+        combined_state: Dict[torch.Tensor, Any],  # pyre-ignore
+    ) -> None:
+        """Extract step counters from any param states that contain them."""
+        found = {"global": False, "local": False}
+
+        for param_state in combined_state.values():
+            if not found["global"] and SEMISYNC_GLOBAL_STEP_COUNTER_KEY in param_state:
+                self._global_step_counter = param_state[
+                    SEMISYNC_GLOBAL_STEP_COUNTER_KEY
+                ]
+                found["global"] = True
+            if not found["local"] and SEMISYNC_LOCAL_STEP_COUNTER_KEY in param_state:
+                self._local_step_counter = param_state[SEMISYNC_LOCAL_STEP_COUNTER_KEY]
+                found["local"] = True
+            if all(found.values()):
+                break
+
+        missing = [k for k, v in found.items() if not v]
+        if missing:
+            raise RuntimeError(
+                f"Missing {' and '.join(missing)} step counter(s) in checkpoint."
+            )

--- a/torchrec/optim/tests/test_semi_sync.py
+++ b/torchrec/optim/tests/test_semi_sync.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import Mock
+
+import torch
+
+from torchrec.optim.keyed import KeyedOptimizer
+from torchrec.optim.semi_sync import SemisyncOptimizer
+
+
+class TestSemisyncOptimizer(unittest.TestCase):
+    """Test cases for SemisyncOptimizer."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        super().setUp()
+
+        # Create test parameters with same shape to avoid tensor comparison issues
+        self.dense_param = torch.nn.Parameter(torch.randn(5, 5))
+        self.dense_param2 = torch.nn.Parameter(torch.randn(5, 5))
+        self.global_params = [self.dense_param, self.dense_param2]
+
+        # Create mock local optimizer
+        self.mock_local_optimizer = Mock(spec=KeyedOptimizer)
+        self.mock_local_optimizer.params = {
+            "dense": self.dense_param,
+            "dense2": self.dense_param2,
+        }
+        self.mock_local_optimizer.param_groups = [
+            {"params": self.global_params, "lr": 0.01}
+        ]
+        self.mock_local_optimizer.state = {}
+
+        # Create mock global optimizer
+        self.mock_global_optimizer = Mock(spec=KeyedOptimizer)
+        self.mock_global_optimizer.params = {
+            "dense": self.dense_param,
+            "dense2": self.dense_param2,
+        }
+        self.mock_global_optimizer.param_groups = [
+            {"params": self.global_params, "lr": 0.1}
+        ]
+        self.mock_global_optimizer.state = {}
+
+        # Mock the _optimizer attribute for global step calls
+        self.mock_global_optimizer._optimizer = Mock()
+        self.mock_global_optimizer._optimizer.global_step = Mock()
+
+        self.optimizer = SemisyncOptimizer(
+            global_params=self.global_params,
+            optimizer=self.mock_local_optimizer,
+            global_optimizer=self.mock_global_optimizer,
+        )
+
+    def test_initialization_with_mocks(self) -> None:
+        """Test SemisyncOptimizer initialization with mock optimizers."""
+
+        optimizer = SemisyncOptimizer(
+            global_params=self.global_params,
+            optimizer=self.mock_local_optimizer,
+            global_optimizer=self.mock_global_optimizer,
+            num_local_steps=12,
+        )
+
+        # Check that optimizers are stored
+        self.assertEqual(optimizer._optimizer, self.mock_local_optimizer)
+        self.assertEqual(optimizer._global_optimizer, self.mock_global_optimizer)
+        self.assertEqual(optimizer._num_local_steps, 12)
+
+        # Check step counters are initialized
+        self.assertEqual(optimizer._local_step_counter.item(), 0)
+        self.assertEqual(optimizer._global_step_counter.item(), 0)
+
+    def test_param_groups_property(self) -> None:
+        """Test that param_groups property combines both optimizers."""
+        optimizer = self.optimizer
+        param_groups = optimizer.param_groups
+
+        # Should have exactly 2 param groups from both optimizers
+        self.assertEqual(len(param_groups), 2)
+
+        # Check both optimizer param groups
+        expected_groups = [
+            {"index": 0, "lr": 0.01, "name": "local"},
+            {"index": 1, "lr": 0.1, "name": "global"},
+        ]
+        param_groups_list = list(param_groups)
+        for expected in expected_groups:
+            with self.subTest(optimizer=expected["name"]):
+                index = expected["index"]
+                group = param_groups_list[index]  # pyre-ignore[6]
+                self.assertIn("params", group)
+                self.assertEqual(group["lr"], expected["lr"])
+
+                # Check for parameter identity (not equality) to avoid tensor comparison issues
+                param_ids = {id(p) for p in group["params"]}
+                self.assertIn(id(self.dense_param), param_ids)
+                self.assertIn(id(self.dense_param2), param_ids)
+
+    def test_params_property(self) -> None:
+        """Test that params property combines both optimizers with exact structure."""
+        optimizer = self.optimizer
+        params = optimizer.params
+
+        # Check exact parameter keys - should contain local, global, and step counter params
+        expected_keys = {
+            "dense",
+            "dense2",
+            "__semisync_global_step_counter__",
+            "__semisync_local_step_counter__",
+        }
+        actual_keys = set(params.keys())
+        self.assertEqual(actual_keys, expected_keys)
+
+        # Verify parameter identities from local optimizer
+        self.assertTrue(params["dense"] is self.dense_param)
+        self.assertTrue(params["dense2"] is self.dense_param2)
+
+        # Verify step counters are tensors with correct properties
+        global_counter = params["__semisync_global_step_counter__"]
+        local_counter = params["__semisync_local_step_counter__"]
+
+        # Test both counters have identical properties
+        for counter_name, counter in [
+            ("global", global_counter),
+            ("local", local_counter),
+        ]:
+            with self.subTest(counter=counter_name):
+                self.assertIsInstance(counter, torch.Tensor)
+                self.assertEqual(counter.item(), 0)
+                self.assertEqual(counter.dtype, torch.int64)
+                self.assertEqual(counter.device.type, "cpu")
+
+        # Verify step counters are different tensor objects
+        self.assertIsNot(global_counter, local_counter)
+
+        # Verify the params dict has exactly the expected number of items
+        self.assertEqual(len(params), 4)
+
+    def test_state_property(self) -> None:
+        """Test state property with exact structure verification."""
+        # Set up precise mock states
+        local_momentum = torch.tensor(1.5)
+        global_momentum = torch.tensor(2.5)
+        self.mock_local_optimizer.state = {
+            self.dense_param: {"momentum": local_momentum}
+        }
+        self.mock_global_optimizer.state = {
+            self.dense_param: {"momentum": global_momentum}
+        }
+
+        optimizer = self.optimizer
+
+        state = optimizer.state
+        param_state = state[self.dense_param]
+
+        # Verify exact state structure
+        expected_keys = {
+            "semi_sync_local_momentum",
+            "semi_sync_global_momentum",
+            "__semisync_global_step_counter__",
+            "__semisync_local_step_counter__",
+        }
+        self.assertEqual(set(param_state.keys()), expected_keys)
+
+        # Verify exact tensor values
+        self.assertTrue(
+            torch.equal(param_state["semi_sync_local_momentum"], local_momentum)
+        )
+        self.assertTrue(
+            torch.equal(param_state["semi_sync_global_momentum"], global_momentum)
+        )
+
+        # Verify step counters
+        self.assertEqual(param_state["__semisync_global_step_counter__"].item(), 0)
+        self.assertEqual(param_state["__semisync_local_step_counter__"].item(), 0)
+
+    def test_step_delegation(self) -> None:
+        """Test that step() delegates to local optimizer."""
+        optimizer = SemisyncOptimizer(
+            global_params=self.global_params,
+            optimizer=self.mock_local_optimizer,
+            global_optimizer=self.mock_global_optimizer,
+            num_local_steps=4,
+        )
+
+        # Call step multiple times
+        for i in range(3):
+            optimizer.step()
+
+            # Local optimizer should be called each time
+            self.assertEqual(self.mock_local_optimizer.step.call_count, i + 1)
+
+            # Global optimizer should not be called yet
+            self.mock_global_optimizer._optimizer.global_step.assert_not_called()
+
+            # Local step counter should increment
+            self.assertEqual(optimizer._local_step_counter.item(), i + 1)
+
+    def test_global_step_triggering(self) -> None:
+        """Test that global step is triggered after num_local_steps."""
+        optimizer = SemisyncOptimizer(
+            global_params=self.global_params,
+            optimizer=self.mock_local_optimizer,
+            global_optimizer=self.mock_global_optimizer,
+            num_local_steps=2,  # Trigger global step every 2 local steps
+        )
+
+        # First step - no global step
+        optimizer.step()
+        self.mock_global_optimizer._optimizer.global_step.assert_not_called()
+        self.assertEqual(optimizer._global_step_counter.item(), 0)
+
+        # Second step - should trigger global step
+        optimizer.step()
+        self.mock_global_optimizer._optimizer.global_step.assert_called_once()
+        self.assertEqual(optimizer._global_step_counter.item(), 1)
+
+        # Third step - no global step
+        self.mock_global_optimizer._optimizer.global_step.reset_mock()
+        optimizer.step()
+        self.mock_global_optimizer._optimizer.global_step.assert_not_called()
+
+        # Fourth step - should trigger global step again
+        optimizer.step()
+        self.mock_global_optimizer._optimizer.global_step.assert_called_once()
+        self.assertEqual(optimizer._global_step_counter.item(), 2)
+
+    def test_zero_grad_delegation(self) -> None:
+        """Test zero_grad() with exact parameter verification."""
+        optimizer = self.optimizer
+
+        # Test both set_to_none values
+        for set_to_none in [False, True]:
+            with self.subTest(set_to_none=set_to_none):
+                self.mock_local_optimizer.zero_grad.reset_mock()
+                self.mock_global_optimizer.zero_grad.reset_mock()
+
+                optimizer.zero_grad(set_to_none=set_to_none)
+
+                self.mock_local_optimizer.zero_grad.assert_called_once_with(
+                    set_to_none=set_to_none
+                )
+                self.mock_global_optimizer.zero_grad.assert_called_once_with(
+                    set_to_none=set_to_none
+                )
+
+    def test_save_param_groups_delegation(self) -> None:
+        """Test save_param_groups() with exact state verification."""
+        optimizer = self.optimizer
+
+        # Test with both True and False values
+        for save_value in [True, False]:
+            with self.subTest(save_value=save_value):
+                self.mock_local_optimizer.save_param_groups.reset_mock()
+                self.mock_global_optimizer.save_param_groups.reset_mock()
+
+                optimizer.save_param_groups(save_value)
+
+                self.mock_local_optimizer.save_param_groups.assert_called_once_with(
+                    save_value
+                )
+                self.mock_global_optimizer.save_param_groups.assert_called_once_with(
+                    save_value
+                )
+                self.assertEqual(optimizer.defaults["_save_param_groups"], save_value)
+
+    def test_repr_string(self) -> None:
+        """Test repr() returns exact expected format."""
+        optimizer = self.optimizer
+
+        repr_str = repr(optimizer)
+
+        # Verify exact structure and content
+        self.assertIsInstance(repr_str, str)
+
+        # Check for required components in string representation
+        required_components = ["semi_sync_local_optim", "semi_sync_global_optim"]
+        for component in required_components:
+            with self.subTest(component=component):
+                self.assertTrue(
+                    component in repr_str, f"Missing component: {component}"
+                )
+
+    def test_extract_prefixed_state_static_method(self) -> None:
+        """Test _extract_prefixed_state static method."""
+        param_state = {
+            "semi_sync_local_momentum": torch.tensor(1.5),
+            "semi_sync_local_step": torch.tensor(10),
+            "other_key": torch.tensor(2.7),
+            "semi_sync_global_momentum": torch.tensor(3.2),
+        }
+
+        test_cases = [
+            {"prefix": "semi_sync_local_", "expected_keys": {"momentum", "step"}},
+            {"prefix": "semi_sync_global_", "expected_keys": {"momentum"}},
+            {"prefix": "nonexistent_", "expected_keys": set()},
+        ]
+
+        for case in test_cases:
+            with self.subTest(prefix=case["prefix"]):
+                result = SemisyncOptimizer._extract_prefixed_state(
+                    param_state, case["prefix"]  # pyre-ignore[6]
+                )
+                self.assertEqual(set(result.keys()), case["expected_keys"])
+
+                # Verify tensor values for non-empty results
+                if case["expected_keys"]:
+                    for key in case["expected_keys"]:
+                        original_key = case["prefix"] + key  # pyre-ignore
+                        self.assertTrue(
+                            torch.equal(result[key], param_state[original_key])
+                        )
+
+
+class TestSemisyncOptimizerEdgeCases(unittest.TestCase):
+    """Test edge cases and error conditions for SemisyncOptimizer."""
+
+    def test_empty_params_error(self) -> None:
+        """Test SemisyncOptimizer with empty parameters raises IndexError."""
+        mock_local = Mock(spec=KeyedOptimizer)
+        mock_local.params = {}
+        mock_local.param_groups = []
+        mock_local.state = {}
+
+        mock_global = Mock(spec=KeyedOptimizer)
+        mock_global.params = {}
+        mock_global.param_groups = []
+        mock_global.state = {}
+        mock_global._optimizer = Mock()
+        mock_global._optimizer.global_step = Mock()
+
+        with self.assertRaises(IndexError) as cm:
+            SemisyncOptimizer(
+                global_params=[],
+                optimizer=mock_local,
+                global_optimizer=mock_global,
+            )
+        self.assertIsInstance(cm.exception, IndexError)
+
+    def test_num_local_steps_configurations(self) -> None:
+        """Test num_local_steps trigger behavior."""
+        param = torch.nn.Parameter(torch.randn(3, 3))
+        mock_local = Mock(spec=KeyedOptimizer)
+        mock_local.params = {"param": param}
+        mock_local.param_groups = [{"params": [param]}]
+        mock_local.state = {}
+
+        mock_global = Mock(spec=KeyedOptimizer)
+        mock_global.params = {"param": param}
+        mock_global.param_groups = [{"params": [param]}]
+        mock_global.state = {}
+        mock_global._optimizer = Mock()
+        mock_global._optimizer.global_step = Mock()
+
+        for num_steps in [1, 3, 5]:
+            with self.subTest(num_local_steps=num_steps):
+                optimizer = SemisyncOptimizer(
+                    global_params=[param],
+                    optimizer=mock_local,
+                    global_optimizer=mock_global,
+                    num_local_steps=num_steps,
+                )
+
+                mock_global._optimizer.global_step.reset_mock()
+
+                # Test exact trigger: should call global step after num_steps local steps
+                for _ in range(num_steps):
+                    optimizer.step()
+                self.assertEqual(mock_global._optimizer.global_step.call_count, 1)
+
+    def test_step_counter_exact_values(self) -> None:
+        """Test step counter progression."""
+        param = torch.nn.Parameter(torch.randn(2, 2))
+        mock_local = Mock(spec=KeyedOptimizer)
+        mock_local.params = {"param": param}
+        mock_local.param_groups = [{"params": [param]}]
+        mock_local.state = {}
+
+        mock_global = Mock(spec=KeyedOptimizer)
+        mock_global.params = {"param": param}
+        mock_global.param_groups = [{"params": [param]}]
+        mock_global.state = {}
+        mock_global._optimizer = Mock()
+        mock_global._optimizer.global_step = Mock()
+
+        optimizer = SemisyncOptimizer(
+            global_params=[param],
+            optimizer=mock_local,
+            global_optimizer=mock_global,
+            num_local_steps=3,
+        )
+
+        # Test progression: global step triggers every 3 local steps
+        test_progression = [(1, 0), (2, 0), (3, 1), (4, 1), (5, 1), (6, 2)]
+
+        for expected_local, expected_global in test_progression:
+            optimizer.step()
+            self.assertEqual(optimizer._local_step_counter.item(), expected_local)
+            self.assertEqual(optimizer._global_step_counter.item(), expected_global)
+
+    def test_step_counter_tensor_properties(self) -> None:
+        """Test step counter tensor properties."""
+        param = torch.nn.Parameter(torch.randn(2, 2))
+        mock_local = Mock(spec=KeyedOptimizer)
+        mock_local.params = {"param": param}
+        mock_local.param_groups = [{"params": [param]}]
+        mock_local.state = {}
+
+        mock_global = Mock(spec=KeyedOptimizer)
+        mock_global.params = {"param": param}
+        mock_global.param_groups = [{"params": [param]}]
+        mock_global.state = {}
+        mock_global._optimizer = Mock()
+
+        optimizer = SemisyncOptimizer(
+            global_params=[param],
+            optimizer=mock_local,
+            global_optimizer=mock_global,
+        )
+
+        # Test both counters have identical properties
+        counters = [optimizer._local_step_counter, optimizer._global_step_counter]
+
+        for counter in counters:
+            self.assertIsInstance(counter, torch.Tensor)
+            self.assertEqual(counter.dtype, torch.int64)
+            self.assertEqual(counter.device.type, "cpu")
+            self.assertEqual(counter.numel(), 1)
+            self.assertEqual(counter.dim(), 0)
+            self.assertEqual(counter.item(), 0)
+
+        # Verify they are different objects
+        self.assertIsNot(counters[0], counters[1])


### PR DESCRIPTION
Summary:
add semi sync class in torchrec repo:
- SemisyncOptimizer takes a local and global optimizer
- SemisyncOptimizer inherits from KeyedOptimizer, following torchrec design to resolve CP compatibilty for modelstore and CP
- SemisyncOptimizer will delegate step function to 2 phase: 1. local optimizer step(); 2. at every num_local_step,  a global_optimizer step() is called. 

Limitation:
1. currently, it is NOT real semi sync, since global params exists in every rank for the global optimizer; and we will bring this key feature later
2. memory and QPS is NOT optimized at this point; extra work is needed for the performance

Differential Revision: D82503673


