### PR TITLE
update docstring for num_pooling and pooling_factor

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -299,7 +299,8 @@ class EmbeddingPerfEstimator(ShardEstimator):
             world_size (int): the number of devices for all hosts.
             local_world_size (int): the number of the device for each host.
             input_lengths (List[float]): the list of the average number of lookups of each
-                input query feature.
+                input query feature. Also referred to as pooling_mean, and it's equal to
+                the pooling_factor * num_pooling.
             input_data_type_size (float): the data type size of the distributed
                 data_parallel input.
             table_data_type_size (float): the data type size of the table.
@@ -308,7 +309,8 @@ class EmbeddingPerfEstimator(ShardEstimator):
                 data_parallel input during forward communication.
             bwd_comm_data_type_size (float): the data type size of the distributed
                 data_parallel input during backward communication.
-            num_poolings (List[float]): number of poolings per sample, typically 1.0.
+            num_poolings (List[float]): number of poolings per sample, typically 1.0 for
+                non-EBF use cases. In EBF use cases, this is the number of events per sample.
             hbm_mem_bw (float): the bandwidth of the device HBM.
             ddr_mem_bw (float): the bandwidth of the system DDR memory.
             hbm_to_ddr_bw (float): the bandwidth between device HBM and system DDR.


### PR DESCRIPTION
Summary:
# context
* Often confused by the terminology related to pooling
* for normal use cases, the pooling factor means the average id count in a pooled embedding.
for example, sparse feature of "books a person has read", the pooling factor would be the average book count perople has read
* for EBF (event-based feature), there would be multiple events in a feature, the num_pooling describes the event count in a feature.
for example, the EBF of "books a person has read" for "people I met in past week", would have the pooling factor, while the num_pooling is the average met-people count.

Differential Revision: D83356999


