### PR TITLE
migrate TorchRec from PyTorch to meta-pytorch on GitHub

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -30,7 +30,7 @@ conda run -n "${CONDA_ENV}" python --version
 
 # Install pytorch, torchrec and fbgemm as per
 # installation instructions on following page
-# https://github.com/pytorch/torchrec#installations
+# https://github.com/meta-pytorch/torchrec#installations
 
 
 # figure out CUDA VERSION

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Checkout torchrec repository
       uses: actions/checkout@v4
       with:
-        repository: pytorch/torchrec
+        repository: meta-pytorch/torchrec
     - name: Filter Generated Built Matrix
       id: filter
       env:
@@ -49,10 +49,10 @@ jobs:
         echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
   build:
     needs: filter-matrix
-    name: pytorch/torchrec
+    name: meta-pytorch/torchrec
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
-      repository: pytorch/torchrec
+      repository: meta-pytorch/torchrec
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,4 +121,4 @@ jobs:
           s3-bucket: doc-previews
           if-no-files-found: error
           path: docs
-          s3-prefix: pytorch/torchrec/${{ github.event.pull_request.number }}
+          s3-prefix: meta-pytorch/torchrec/${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -36,7 +36,7 @@ jobs:
       package_type: "wheel"
       os: "linux"
       channel: ${{ inputs.channel }}
-      repository: "pytorch/torchrec"
+      repository: "meta-pytorch/torchrec"
       smoke_test: "source ./.github/scripts/validate_binaries.sh"
       with_cuda: enable
       with_rocm: false

--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
 2. Clone TorchRec.
    ```
-   git clone --recursive https://github.com/pytorch/torchrec
+   git clone --recursive https://github.com/meta-pytorch/torchrec
    cd torchrec
    ```
 
@@ -108,7 +108,7 @@ Check out the [Getting Started](https://pytorch.org/torchrec/setup-torchrec.html
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/pytorch/torchrec/blob/main/CONTRIBUTING.md) for details about contributing to TorchRec!
+See [CONTRIBUTING.md](https://github.com/meta-pytorch/torchrec/blob/main/CONTRIBUTING.md) for details about contributing to TorchRec!
 
 ## Citation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,7 @@ We evaluate the performance of two EmbeddingBagCollection modules:
 
 1. `EmbeddingBagCollection` (EBC) ([code](https://pytorch.org/torchrec/torchrec.modules.html#torchrec.modules.embedding_modules.EmbeddingBagCollection)): a simple module backed by [torch.nn.EmbeddingBag](https://pytorch.org/docs/stable/generated/torch.nn.EmbeddingBag.html).
 
-2. `FusedEmbeddingBagCollection` (Fused EBC) ([code](https://github.com/pytorch/torchrec/blob/main/torchrec/modules/fused_embedding_bag_collection.py#L299)): a module backed by [FBGEMM](https://github.com/pytorch/FBGEMM) kernels which enables more efficient, high-performance operations on embedding tables. It is equipped with a fused optimizer, and UVM caching/management that makes much larger memory available for GPUs.
+2. `FusedEmbeddingBagCollection` (Fused EBC) ([code](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/modules/fused_embedding_bag_collection.py#L299)): a module backed by [FBGEMM](https://github.com/pytorch/FBGEMM) kernels which enables more efficient, high-performance operations on embedding tables. It is equipped with a fused optimizer, and UVM caching/management that makes much larger memory available for GPUs.
 
 
 ## Module architecture and running setup
@@ -24,7 +24,7 @@ Other setup includes:
 
 ## How to run
 
-After the installation of Torchrec (see "Binary" in the "Installation" section,  [link](https://github.com/pytorch/torchrec)), run the following command under the benchmark directory (/torchrec/torchrec/benchmarks):
+After the installation of Torchrec (see "Binary" in the "Installation" section,  [link](https://github.com/meta-pytorch/torchrec)), run the following command under the benchmark directory (/torchrec/torchrec/benchmarks):
 
 ```
 python ebc_benchmarks.py [--mode MODE] [--cpu_only]

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def main(argv: List[str]) -> None:
         description="TorchRec: Pytorch library for recommendation systems",
         long_description=readme,
         long_description_content_type="text/markdown",
-        url="https://github.com/pytorch/torchrec",
+        url="https://github.com/meta-pytorch/torchrec",
         license="BSD-3",
         keywords=[
             "pytorch",

--- a/torchrec/distributed/train_pipeline/pipeline_stage.py
+++ b/torchrec/distributed/train_pipeline/pipeline_stage.py
@@ -449,7 +449,7 @@ class SparseDataDistUtil(Generic[In]):
         ) -> None:
             # Note: tricky part - a bit delicate choreography between
             # StagedPipeline and this class
-            # (see https://github.com/pytorch/torchrec/pull/2239 for details)
+            # (see https://github.com/meta-pytorch/torchrec/pull/2239 for details)
             # wait_dist need to be called as post_forward hook
             # at the end of the batch N, so that the data is awaited
             # before start of the next batch.

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -76,7 +76,7 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
             self._name in self._context.input_dist_tensors_requests
         ), f"Invalid PipelinedForward usage, input_dist of {self._name} is not available, probably consumed by others"
         # we made a basic assumption that an embedding module (EBC, EC, etc.) should only be evoked only
-        # once in the model's forward pass. For more details: https://github.com/pytorch/torchrec/pull/3294
+        # once in the model's forward pass. For more details: https://github.com/meta-pytorch/torchrec/pull/3294
         request = self._context.input_dist_tensors_requests.pop(self._name)
         assert isinstance(request, Awaitable)
         with record_function("## wait_sparse_data_dist ##"):
@@ -125,7 +125,7 @@ class EmbeddingPipelinedForward(BaseForward[EmbeddingTrainPipelineContext]):
             self._name in self._context.embedding_a2a_requests
         ), f"Invalid PipelinedForward usage, input_dist of {self._name} is not available, probably consumed by others"
         # we made a basic assumption that an embedding module (EBC, EC, etc.) should only be evoked only
-        # once in the model's forward pass. For more details: https://github.com/pytorch/torchrec/pull/3294
+        # once in the model's forward pass. For more details: https://github.com/meta-pytorch/torchrec/pull/3294
 
         ctx = self._context.module_contexts.pop(self._name)
         cur_stream = torch.get_device_module(self._device).current_stream()

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -521,7 +521,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         Detaches the model from sparse data dist (SDD) pipeline. A user might want to get
         the original model back after training. The original model.forward was previously
         modified by the train pipeline. for more please see:
-        https://github.com/pytorch/torchrec/pull/2076
+        https://github.com/meta-pytorch/torchrec/pull/2076
 
         To use the pipeline after detaching the model, pipeline.attach(model)
         needs to be called.
@@ -547,7 +547,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         """
         should be used with detach function. these functions should only be used from user code,
         when user want to switch the train pipeline. for more please see:
-        https://github.com/pytorch/torchrec/pull/2076
+        https://github.com/meta-pytorch/torchrec/pull/2076
         """
         if model:
             self._model = model

--- a/torchrec/inference/README.md
+++ b/torchrec/inference/README.md
@@ -40,7 +40,7 @@ export FBGEMM_LIB=""
 Here, we generate the DLRM model in Torchscript and save it for model loading later on.
 
 ```
-git clone https://github.com/pytorch/torchrec.git
+git clone https://github.com/meta-pytorch/torchrec.git
 
 cd ~/torchrec/torchrec/inference/
 python3 dlrm_packager.py --output_path /tmp/model.pt


### PR DESCRIPTION
Summary:
# context
Build Linux Wheels failed due to meta-pytorch migration
* TorchRec (https://github.com/meta-pytorch/torchrec) is now with meta-pytorch on GitHub. 
* The Build Linux Wheels ([codepointer](https://github.com/meta-pytorch/torchrec/blob/main/.github/workflows/build-wheels-linux.yml#L53)) uses test-infra's [build_wheels_linux.yml](https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_linux.yml) workflow
* the ([jobs](https://github.com/meta-pytorch/torchrec/actions/runs/18128527424)) are failing with cedential error when uploadin the wheel to download.pytorch.org/whl/nightly
<img width="2720" height="2726" alt="image" src="https://github.com/user-attachments/assets/0f7ead28-08ce-42bc-95f3-6be32a453a86" />
* after
<img width="3288" height="1998" alt="image" src="https://github.com/user-attachments/assets/1233f8ce-e68a-4c01-9864-ae4dc3369796" />


Differential Revision: D83571097


