### PR TITLE
fix pre-commit error

### DIFF
--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -695,7 +695,7 @@ class TestMCH(unittest.TestCase):
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    def test_zch_hash_disable_fallback_disabled_in_oss_compatatibility(self) -> None:
+    def test_zch_hash_disable_fallback_disabled_in_oss_compatibility(self) -> None:
         m = HashZchManagedCollisionModule(
             zch_size=30,
             device=torch.device("cuda"),


### PR DESCRIPTION
Summary:
# context
* torchrec github workflow [pre-commit](https://github.com/meta-pytorch/torchrec/actions/runs/18187119531/job/51773690358) failed with the following message
```
diff --git a/torchrec/distributed/embedding_kernel.py b/torchrec/distributed/embedding_kernel.py
index e444f59..6c1dea2 100644
--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -105,7 +105,9 @@ def create_virtual_table_global_metadata(
             # The param size only has the information for my_rank. In order to
             # correctly calculate the size for other ranks, we need to use the current
             # rank's shard size compared to the shard size of my_rank.
-            curr_rank_rows = (param.size()[0] * metadata.shards_metadata[rank].shard_sizes[0]) // my_rank_shard_size  # pyre-ignore[16]
+            curr_rank_rows = (
+                param.size()[0] * metadata.shards_metadata[rank].shard_sizes[0]
+            ) // my_rank_shard_size  # pyre-ignore[16]
         else:
             curr_rank_rows = (
                 weight_count_per_rank[rank] if weight_count_per_rank is not None else 1
```
* before
<img width="3872" height="2730" alt="image" src="https://github.com/user-attachments/assets/b1e112e2-2814-4aef-a56e-bed021853fbb" />

* after
<img width="2806" height="1308" alt="image" src="https://github.com/user-attachments/assets/1ae51805-6f58-40a4-9b13-ab0e6e8f53bf" />


Differential Revision: D83755478


