### PR TITLE
Fix guard serialization loading bugs.

### DIFF
--- a/torchrec/distributed/tests/test_lazy_awaitable.py
+++ b/torchrec/distributed/tests/test_lazy_awaitable.py
@@ -7,12 +7,13 @@
 
 # pyre-strict
 
+import pickle
 import unittest
 from typing import Dict
 
 import torch
 import torch.fx
-from torchrec.distributed.types import LazyAwaitable, LazyGetItemMixin
+from torchrec.distributed.types import LazyAwaitable, LazyGetItemMixin, LazyNoWait
 
 
 class NeedWait(LazyAwaitable[torch.Tensor]):
@@ -205,6 +206,12 @@ class TestLazyAwaitable(unittest.TestCase):
         gm = torch.fx.symbolic_trace(m)
         traced_res = gm(torch.ones(3, 4))
         self.assertTrue(torch.equal(traced_res, ref_res))
+
+    def test_awatiable_pickle(self) -> None:
+        awaitable = LazyNoWait(torch.randn(2, 3))
+        self.assertTrue(
+            torch.allclose(pickle.loads(pickle.dumps(awaitable))._obj, awaitable._obj)
+        )
 
     def test_lazy_wait_dict(self) -> None:
         class Model(torch.nn.Module):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -447,6 +447,8 @@ class LazyAwaitable(Awaitable[W], metaclass=_LazyAwaitableMeta):
                 f"LazyAwaitable type {type(self)} has not been initialized properly, "
                 f"did you forget to call 'super()'?"
             )
+        elif name == "__setstate__":
+            return super().__getattr__(name)  # pyre-ignore [16]
 
         res = LazyAwaitable._wait_async(self)
         return getattr(res, name)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/164490

Added a set of fixes triggered by fm training job. Overall the theme here is that we should get rid of saved objects as much as possible when they are not used in guard reconstruction. Sometimes for objects that cannot be saved (like local functions) we still try our best to save their closures.

Differential Revision: D83766926


