### PR TITLE
Use device-agnostic synchronize in train_pipelines

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1302,7 +1302,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             del context
 
         if len(self.batches) >= 1 and not is_semi_sync:
-            torch.cuda.synchronize()  # needed to avoid race condition
+            torch.get_device_module().synchronize()  # needed to avoid race condition
             # pyre-ignore [6]
             self.start_embedding_lookup(self.batches[0], self.contexts[0])
 


### PR DESCRIPTION
Summary: Using the cuda specific torch.cuda.synchronize() causes failures for other device backends. This diff introduces device agnostic synchronization that will auto detect the backend API to use.

Differential Revision: D83840439


