### PR TITLE
[benchmark] rename function and labels

### DIFF
--- a/torchrec/distributed/benchmark/README.md
+++ b/torchrec/distributed/benchmark/README.md
@@ -1,14 +1,14 @@
 # TorchRec Benchmark
-## usage
+## benchmark_train_pipeline usage
 - internal:
 ```
 buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
-    --profile_name=sparse_data_dist_base_$(hg whereami | cut -c 1-10 || echo $USER) # overrides the yaml config
+    --name=sparse_data_dist_base_$(hg whereami | cut -c 1-10 || echo $USER) # overrides the yaml config
 ```
 - oss:
 ```
 python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
-    --profile_name=sparse_data_dist_base_$(git rev-parse --short HEAD || echo $USER) # overrides the yaml config
+    --name=sparse_data_dist_base_$(git rev-parse --short HEAD || echo $USER) # overrides the yaml config
 ```

--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -681,7 +681,7 @@ def _run_benchmark_core(
     )
 
 
-def benchmark(
+def benchmark_model_with_warmup(
     name: str,
     model: torch.nn.Module,
     warmup_inputs: Union[List[KeyedJaggedTensor], List[Dict[str, Any]]],
@@ -750,6 +750,26 @@ def benchmark_func(
     pre_gpu_load: int = 0,
     export_stacks: bool = False,
 ) -> BenchmarkResult:
+    """
+    Args:
+        name: Human-readable benchmark name.
+
+        bench_inputs: List[Dict[str, Any]] will be fed to the function at once
+        prof_inputs: List[Dict[str, Any]] will be fed to the function at once
+        benchmark_func_kwargs: kwargs to be passed to func_to_benchmark
+        func_to_benchmark: Callable that executes one measured iteration.
+            func_to_benchmark(batch_inputs, **kwargs)
+
+        world_size, rank: Distributed context to correctly reset / collect GPU
+            stats. ``rank == -1`` means single-process mode.
+        num_benchmarks: Number of measured iterations.
+        device_type: "cuda" or "cpu".
+        profile_dir: Where to write chrome traces / stack files.
+
+        pre_gpu_load: Number of dummy matmul operations to run before the first
+            measured iteration (helps simulating a loaded allocator).
+        export_stacks: Whether to export flamegraph-compatible stack files.
+    """
     if benchmark_func_kwargs is None:
         benchmark_func_kwargs = {}
 

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -78,7 +78,7 @@ class RunOptions:
             Default is "kjt" (KeyedJaggedTensor).
         profile (str): Directory to save profiling results. If empty, profiling is disabled.
             Default is "" (disabled).
-        profile_name (str): Name of the profiling file. Default is pipeline classname.
+        name (str): Name of the profiling file. Default is pipeline classname.
         planner_type (str): Type of sharding planner to use. Options are:
             - "embedding": EmbeddingShardingPlanner (default)
             - "hetero": HeteroEmbeddingShardingPlanner
@@ -100,8 +100,8 @@ class RunOptions:
     sharding_type: ShardingType = ShardingType.TABLE_WISE
     compute_kernel: EmbeddingComputeKernel = EmbeddingComputeKernel.FUSED
     input_type: str = "kjt"
-    profile: str = ""
-    profile_name: str = ""
+    name: str = ""
+    profile_dir: str = ""
     planner_type: str = "embedding"
     pooling_factors: Optional[List[float]] = None
     num_poolings: Optional[List[float]] = None
@@ -261,15 +261,13 @@ def runner(
 
         result = benchmark_func(
             name=(
-                type(pipeline).__name__
-                if run_option.profile_name == ""
-                else run_option.profile_name
+                type(pipeline).__name__ if run_option.name == "" else run_option.name
             ),
             bench_inputs=bench_inputs,  # pyre-ignore
             prof_inputs=bench_inputs,  # pyre-ignore
             num_benchmarks=5,
             num_profiles=2,
-            profile_dir=run_option.profile,
+            profile_dir=run_option.profile_dir,
             world_size=run_option.world_size,
             func_to_benchmark=_func_to_benchmark,
             benchmark_func_kwargs={"model": sharded_model, "pipeline": pipeline},

--- a/torchrec/distributed/benchmark/embedding_collection_wrappers.py
+++ b/torchrec/distributed/benchmark/embedding_collection_wrappers.py
@@ -57,7 +57,12 @@ from torchrec.quant.embedding_modules import (
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 
 # Import the shared types and utilities from benchmark_utils
-from .base import benchmark, BenchmarkResult, CompileMode, multi_process_benchmark
+from .base import (
+    benchmark_model_with_warmup,
+    BenchmarkResult,
+    CompileMode,
+    multi_process_benchmark,
+)
 
 logger: logging.Logger = logging.getLogger()
 
@@ -456,7 +461,7 @@ def _init_module_and_run_benchmark(
         else:
             name = _benchmark_type_name(compile_mode, sharding_type)
 
-        res = benchmark(
+        res = benchmark_model_with_warmup(
             name,
             module,
             warmup_inputs_cuda,

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -4,8 +4,8 @@ RunOptions:
   world_size: 2
   num_batches: 10
   sharding_type: table_wise
-  profile: "."
-  profile_name: "sparse_data_dist_base"
+  profile_dir: "."
+  name: "sparse_data_dist_base"
   # export_stacks: True # enable this to export stack traces
 PipelineConfig:
   pipeline: "sparse"

--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -222,6 +222,7 @@ def run_multi_process_func(
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
     if world_size == 1:
+        # skip multiprocess env for single-rank job
         kwargs["world_size"] = 1
         kwargs["rank"] = 0
         result = func(**kwargs)

--- a/torchrec/sparse/tests/jagged_tensor_benchmark.py
+++ b/torchrec/sparse/tests/jagged_tensor_benchmark.py
@@ -16,7 +16,7 @@ import click
 
 import torch
 from torchrec.distributed.benchmark.base import (
-    benchmark,
+    benchmark_model_with_warmup,
     BenchmarkResult,
     CPUMemoryStats,
     GPUMemoryStats,
@@ -77,7 +77,7 @@ def bench(
     setattr(model, "forward", lambda kwargs: fn(**kwargs))
     prof_num = 10
     if device_type == "cuda":
-        result = benchmark(
+        result = benchmark_model_with_warmup(
             name=name,
             model=model,
             warmup_inputs=[],


### PR DESCRIPTION
Summary:
# context
* rename the over-generic function name `benchmark` to `benchmark_model_with_warmup`
* make the argument name consistency in the base.py and benchmark_train_pipeline.py, i.e., `profile_name` ==> `name`, `profile` ==> `profile_dir`
* modify the record_function labels in comm_ops.py to reduce duplication and confusion
* run command
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_base_$(git rev-parse --short HEAD || echo $USER) # overrides the yaml config
```
* [trace](https://drive.google.com/file/d/1yIl8wu2auyRmuvT6GAS1fC1O8cRxbr6H/view?usp=drive_link)
you can see the updated label in the trace (CPU-side, All2All_Pooled_bwd)
<img width="3902" height="1204" alt="image" src="https://github.com/user-attachments/assets/aca2577a-a564-46b4-975d-496b7579638a" />

Differential Revision: D83923279


