### PR TITLE
[benchmark] add memory snapshot support in benchmark_core

### DIFF
--- a/torchrec/distributed/benchmark/README.md
+++ b/torchrec/distributed/benchmark/README.md
@@ -17,10 +17,10 @@ python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
 - internal:
 ```
 buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_comms -- \
-    a2a_single --name=a2a_sync_base-$(hg whereami | cut -c 1-10)
+    a2a_single --name=a2a_sync_base-$(hg whereami | cut -c 1-10) --memory_snapshot=true
 ```
 - oss:
 ```
 python -m torchrec.distributed.benchmark.benchmark_comms \
-  a2a_single --name=a2a_sync_base-$(git rev-parse --short HEAD || echo $USER)
+  a2a_single --name=a2a_sync_base-$(git rev-parse --short HEAD || echo $USER) --memory_snapshot=true
 ```


### PR DESCRIPTION
Summary:
# context
* add memory snapshot support in the torchrec benchmark core

> NOTE: memory snapshot runs with the profiler (enabled by providing a valid `profile_dir`), so the trace file is also available

* instructions: https://pytorch.org/blog/understanding-gpu-memory-1/
* visualization tool: https://docs.pytorch.org/memory_viz
* example snapshot
rank-0
<img width="2549" height="1388" alt="image" src="https://github.com/user-attachments/assets/f8367b01-4a4a-4079-bd32-9b978b887865" />
rank-1
<img width="5092" height="2660" alt="image" src="https://github.com/user-attachments/assets/208c637f-8d19-4d2a-9bfe-feee97a666f7" />

* command

```
python -m torchrec.distributed.benchmark.benchmark_comms \
        a2a_single \
        --name=a2a_sync_base-$(hg whereami | cut -c 1-10) \
        --all_rank_traces=1 \
        --memory_snapshot=1
```
Differential Revision: D83991566


