### PR TITLE
Add serving_ae_loss metrics

### DIFF
--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -45,6 +45,7 @@ class RecMetricEnum(RecMetricEnumBase):
     RECALL = "recall"
     SERVING_NE = "serving_ne"
     SERVING_CALIBRATION = "serving_calibration"
+    SERVING_AE_LOSS = "serving_ae_loss"
     OUTPUT = "output"
     TENSOR_WEIGHTED_AVG = "tensor_weighted_avg"
     CALI_FREE_NE = "cali_free_ne"

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -79,6 +79,7 @@ class MetricName(MetricNameBase):
 
     SERVING_NE = "serving_ne"
     SERVING_CALIBRATION = "serving_calibration"
+    SERVING_AE_LOSS = "serving_ae_loss"
     TENSOR_WEIGHTED_AVG = "tensor_weighted_avg"
 
     CALI_FREE_NE = "cali_free_ne"
@@ -141,6 +142,7 @@ class MetricNamespace(MetricNamespaceBase):
 
     SERVING_NE = "serving_ne"
     SERVING_CALIBRATION = "serving_calibration"
+    SERVING_AE_LOSS = "serving_ae_loss"
 
     OUTPUT = "output"
     TENSOR_WEIGHTED_AVG = "tensor_weighted_avg"


### PR DESCRIPTION
Summary: Add serving_ae_loss metric and unit tests. This extends the existing serving metrics to track AE loss, allowing per-domain loss analysis using traffic indicator weights.

Differential Revision: D90655224


