### PR TITLE
mc_embeddingbag test remove unnecessary if else

### DIFF
--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -169,16 +169,7 @@ class SparseArch(nn.Module):
                 ),
                 is_inference=is_inference,
             )
-        else:
-            mc_modules["table_0"] = MCHManagedCollisionModule(
-                zch_size=tables[0].num_embeddings,
-                input_hash_size=4000,
-                device=device,
-                eviction_interval=2,
-                eviction_policy=DistanceLFU_EvictionPolicy(),
-            )
 
-        if use_mpzch:
             mc_modules["table_1"] = HashZchManagedCollisionModule(
                 zch_size=(tables[1].num_embeddings),
                 device=device,
@@ -192,6 +183,14 @@ class SparseArch(nn.Module):
                 is_inference=is_inference,
             )
         else:
+            mc_modules["table_0"] = MCHManagedCollisionModule(
+                zch_size=tables[0].num_embeddings,
+                input_hash_size=4000,
+                device=device,
+                eviction_interval=2,
+                eviction_policy=DistanceLFU_EvictionPolicy(),
+            )
+
             mc_modules["table_1"] = MCHManagedCollisionModule(
                 zch_size=tables[1].num_embeddings,
                 device=device,


### PR DESCRIPTION
Summary:
As a part of ramp up, I'm refactoring test_quant_mc_embedding_bag.py, test_quant_mc_embedding.py and test_mc_embeddingbag.py

I plan to make small augmented diffs to make review easier. This diff removes an unneeded if/else if `SparseArch`

Differential Revision: D91177288


