### PR TITLE
Log estimated memory util to scuba

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -171,7 +171,9 @@ def _get_batch_inputs_and_shardable_parameters(
 
 class FixedPercentageStorageReservation(StorageReservation):
     def __init__(self, percentage: float) -> None:
-        assert percentage >= 0 and percentage <= 1
+        assert (
+            percentage >= 0 and percentage <= 1
+        ), f"reserved dense storage percentage must be between 0 and 1, got {percentage}"
         self._percentage: float = percentage
         self._last_reserved_topology: Optional[Topology] = None
         self._kjt_storage: Optional[Storage] = None


### PR DESCRIPTION
Summary:
## Why
We want to keep track of the estimated memory utilization before and after tuning to get a sense on how much it help with OOMing case and under-memory-util case.

## What
This diff updates VariableTrainerFixedGlobalBatchSizeTuning. Can follow same pattern to update the other strategy if necessary.
1. In VariableTrainerFixedGlobalBatchSizeTuning, instead of calling has_valid_sharding_plan() to tell if a sharding plan can be found in current hw/world_size/batch_size, calling estimate_static_sparse_memory() to get the actual max sharding memory, and compute memory utilization from that ((estimated max sharding memory + estimated dense memory) / hardware HBM).
2. Keep the memory util and related information in VariableTrainerTuningOption, and log them to scuba in log_variable_tuning_event().
3. Will treat a candidate hw/world_size/batch_size as valid option if the estimated memory util is not 0 (i.e. we can get a valid estimate for it)

Differential Revision: D88898274
