### PR TITLE
add cap01 logger to un-pipelined sharded module

### DIFF
--- a/torchrec/distributed/logger.py
+++ b/torchrec/distributed/logger.py
@@ -64,6 +64,8 @@ from torch import distributed as dist
 from torchrec.distributed.logging_handlers import (
     _log_handlers,
     AllRankStaticLogger,
+    Cap01Logger,
+    Cap1Logger,
     CappedLogger,
     MethodLogger,
     SingleRankStaticLogger,
@@ -89,7 +91,9 @@ def _get_or_create_logger(destination: str) -> logging.Logger:
             a key in the `_log_handlers` dictionary. Common values include:
             - SingleRankStaticLogger: Logs only from rank 0
             - AllRankStaticLogger: Logs from all ranks
-            - CappedLogger: Logs with per-location rate limiting
+            - CappedLogger: Logs with per-location rate limiting (10 times per location per rank)
+            - Cap1Logger: Logs with per-location rate limiting (1 time per location per rank)
+            - Cap01Logger: Logs with per-location rate limiting (1 time per location on rank 0 only)
             - MethodLogger: Logs method inputs/outputs
 
     Returns:
@@ -137,6 +141,8 @@ method_logger = _get_or_create_logger(MethodLogger)
 static_logger = _get_or_create_logger(SingleRankStaticLogger)
 all_rank_logger = _get_or_create_logger(AllRankStaticLogger)
 capped_logger = _get_or_create_logger(CappedLogger)
+one_time_logger = _get_or_create_logger(Cap1Logger)
+one_time_rank0_logger = _get_or_create_logger(Cap01Logger)
 
 
 # =============================================================================

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -15,6 +15,8 @@ UnfilteredLogger = "UnfilteredLogger"
 SingleRankStaticLogger = "SingleRankStaticLogger"
 AllRankStaticLogger = "AllRankStaticLogger"
 CappedLogger = "CappedLogger"
+Cap1Logger = "Cap1Logger"
+Cap01Logger = "Cap01Logger"
 MethodLogger = "MethodLogger"
 
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -35,6 +35,7 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
+from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
     EmbeddingTrainPipelineContext,
@@ -429,6 +430,9 @@ def _rewrite_model(  # noqa C901
             pipelined_forwards.append(child)
         else:
             logger.warning(
+                f"Module '{node.target}' will NOT be pipelined, due to input modifications"
+            )
+            one_time_rank0_logger.warning(
                 f"Module '{node.target}' will NOT be pipelined, due to input modifications"
             )
             non_pipelined_sharded_modules.append(node.target)


### PR DESCRIPTION
Summary:
# context
* add more flavors for capped logger:
    - cap01_logger: only log once for one training job on rank 0
    - cap1_logger: only log once for one training job per rank
* use cap01_logger for training jobs with non-pipelined sharded module

Differential Revision: D91593132


