### PR TITLE
Update Hash function Rounding

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -42,6 +42,9 @@ WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER: float = 1  # empirical studies
 WEIGHTED_KERNEL_MULTIPLIER: float = 1.1  # empirical studies
 DP_ELEMENTWISE_KERNELS_PERF_FACTOR: float = 9.22  # empirical studies
 
+# For rounding memory hashing to nearest 100GB (10^11 bytes):
+HUNDRED_GB = 100 * 1024**3  # 107,374,182,400
+
 
 def kernel_bw_lookup(
     compute_device: str,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -25,6 +25,7 @@ from torchrec.distributed.planner.constants import (
     HBM_CAP,
     HBM_MEM_BW,
     HBM_TO_DDR_MEM_BW,
+    HUNDRED_GB,
     INTRA_NODE_BANDWIDTH,
     POOLING_FACTOR,
     WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
@@ -40,9 +41,8 @@ from torchrec.modules.embedding_configs import DataType
 from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
 
+
 # ---- Perf ---- #
-
-
 @dataclass(repr=True, eq=True)
 class Perf:
     """
@@ -1114,8 +1114,31 @@ def hash_planner_context_inputs(
         storage_reservation._last_reserved_topology is not None  # pyre-ignore
     ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
 
+    # Round device memory to 1% to avoid hash mismatches due to minor driver version differences which does not impact the behavior of planner
+    rounded_devices = []
+    for device in topology.devices:
+        rounded_hbm = round_to_nearest(device.storage.hbm, HUNDRED_GB)
+        rounded_ddr = round_to_nearest(device.storage.ddr, HUNDRED_GB)
+        rounded_devices.append((device.rank, rounded_hbm, rounded_ddr))
+
+    topology_hash_components = [
+        topology.world_size,
+        topology.compute_device,
+        rounded_devices,
+        topology.local_world_size,
+        topology.hbm_mem_bw,
+        topology.ddr_mem_bw,
+        topology.hbm_to_ddr_mem_bw,
+        topology.comms_bandwidths.intra_host_bw,
+        topology.comms_bandwidths.inter_host_bw,
+        topology.bwd_compute_multiplier,
+        topology.weighted_feature_bwd_compute_multiplier,
+        topology.uneven_sharding_perf_multiplier,
+    ]
+    hashed_topology = hash_function(topology_hash_components)
+
     hashable_list = [
-        topology,
+        hashed_topology,
         batch_size,
         [
             [
@@ -1174,3 +1197,8 @@ def hash_planner_context_inputs_str(
         constraints.items() if constraints else None,
     ]
     return hash_function(hashable_list)
+
+
+def round_to_nearest(x: int, unit: int) -> int:
+    """Round to nearest unit (e.g., 100GB)."""
+    return round(x / unit) * unit


### PR DESCRIPTION
Summary: This diff updates the hashing logic in hash_planner_context_inputs to round device memory (HBM and DDR) to the nearest 100GB before computing the hash. This prevents hash mismatches caused by minor memory reporting differences (e.g., from driver version variations across machines) that don't actually impact planner behavior.

Reviewed By: aporialiao

Differential Revision: D88526054


