### PR TITLE
[detailed][pipeline] add base train-eval-hybrid pipeline for knowledge distillation

### DIFF
--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -19,6 +19,7 @@ from torchrec.distributed.train_pipeline import (
 )
 from torchrec.distributed.train_pipeline.train_pipelines import (
     PrefetchTrainPipelineSparseDist,
+    TrainEvalHybridPipelineBase,
     TrainPipelineSemiSync,
     TrainPipelineSparseDistLite,
 )
@@ -96,6 +97,7 @@ class PipelineConfig:
             "fused": TrainPipelineFusedSparseDist,
             "semi": TrainPipelineSemiSync,
             "prefetch": PrefetchTrainPipelineSparseDist,
+            "hybrid_base": TrainEvalHybridPipelineBase,
         }
 
         if self.pipeline == "semi":


### PR DESCRIPTION
# Sparse-Data-Dist Train Pipeline: Iterator Handling and Hybrid Pipeline Mismatch

## Overview

This document explains how the TorchRec sparse-data-dist train pipeline handles iterators and the `pipeline.progress()` method in training loops. It also describes a critical mismatch issue that arises with hybrid train-eval pipelines, particularly during mode switches.

---

## 1. Basic Pipeline Mechanics

The sparse-data-dist pipeline uses a **3-phase pipelining** approach to overlap data transfer, communication, and computation:

| Phase | Description |
|-------|-------------|
| **Phase 1** | Copy data from CPU to GPU (host-to-device transfer) |
| **Phase 2** | Device-to-device communication (sparse data distribution across devices) |
| **Phase 3** | Forward/backward pass and the rest of the compute |

### Training Loop Structure

```python
step = 0
while True:
    phase3_output = pipeline.progress(data_iter)
    step += 1
```

---

## 2. Pure Training Pipeline Behavior

<img width="2258" height="1088" alt="Image" src="https://github.com/user-attachments/assets/06930717-0d29-4312-a912-f37f6c7b52c4" />

### 2.1 Pipeline Initialization (`fill_pipeline`)

At **step 0**, `fill_pipeline` runs **once** to partially prime the pipeline:

```
fill_pipeline only does:
┌─────────────────────────────┐
│  batch 0      batch 1       │
│  ┌────────┐  ┌────────┐     │
│  │phase 1 │  │phase 1 │     │
│  │phase 2 │  └────────┘     │
│  └────────┘                 │
└─────────────────────────────┘
```

- **Batch 0**: Phase 1 (CPU→GPU) + Phase 2 (device-to-device comm)
- **Batch 1**: Phase 1 (CPU→GPU) only

The rest (batch 0's phase 3, batch 1's phase 2, batch 2's phase 1, etc.) happens during regular `progress` calls.

### 2.2 Pipeline Progression (`pipeline.progress`)

Each call to `pipeline.progress(data_iter)`:
1. **Returns** the completed phase 3 output from the oldest batch in the pipeline
2. **Advances** each in-flight batch to the next phase
3. **Fetches** a new batch from `data_iter` and starts phase 1

### 2.3 Iterator Exhaustion Delay

**Key Insight**: Due to pipeline depth, there is a **2-step delay** between when the iterator exhausts and when `StopIteration` is raised. The mapping is **batch i+2 → step i** (i.e., batch i+2's phase 3 output is returned at step i).

| Event | Step |
|-------|------|
| `data_iter` exhausted (no more batches) | Step i+3 |
| Pipeline drains remaining batches | Steps i+3, i+4 |
| `StopIteration` raised | Step i+5 |

```
Timeline (batch i+2 maps to step i):
───────────────────────────────────────────────────────────────────────────────►
  batch i+2   batch i+3   batch i+4
     │           │           │
     ▼           ▼           ▼
   step i    step i+1    step i+2    step i+3    step i+4    step i+5
                                        ▲                       ▲
                                        │                       │
                                  data_iter                StopIteration
                                  exhausted                  raised
                               (no new batch)          (pipeline drained)
```

---

## 3. Hybrid Train-Eval Pipeline Mismatch Issue

<img width="3750" height="1470" alt="Image" src="https://github.com/user-attachments/assets/368a0848-0688-4bdb-831c-f0fc34c43c3a" />

### 3.1 The Problem

In hybrid training-evaluation scenarios, the training loop interleaves train and eval batches. The **critical issue** is that `pipeline.progress()` returns output from a batch that entered the pipeline **2 steps ago**, but the current `is_training` flag reflects the **current** mode.

### 3.2 Mode Switch Scenario

Consider a scenario where eval kicks in at step `i-1`:

```
Step i-2:  phase3_out = TRAIN batch    ✓ is_training=True  (MATCH)
Step i-1:  phase3_out = TRAIN batch    ✓ is_training=True  (MATCH)
                                       └── eval_iter kicks in here
Step i:    phase3_out = TRAIN batch    ✗ is_training=False (MISMATCH!)
Step i+1:  phase3_out = EVAL batch     ✓ is_training=False (MATCH)
```

### 3.3 The Fatal Mismatch

```python
step = 0
# some loop management:
    phase3_output = pipeline.progress(data_iter, is_training)
    other_process(phase3_out, is_training)  # ← POTENTIAL MISMATCH
    step += 1
```

**Note**: The current implementation inside `pipeline.progress` is correct — it properly tracks each batch's `is_training` status and executes the model accordingly. The issue arises when **downstream processing** (`other_process`) uses the current `is_training` flag instead of the batch's original flag:

- Delta streaming
- Knowledge distillation
- Metric logging
- External callbacks

...may behave incorrectly if they rely on the current `is_training` flag rather than the batch's original mode.

### 3.4 Eval Iterator Exhaustion

Consider a scenario where eval_iter exhausts at step `i+3`:

```
Step i+1:  phase3_out = EVAL batch     ✓ is_training=False (MATCH)
Step i+2:  phase3_out = EVAL batch     ✓ is_training=False (MATCH)
Step i+3:  eval_iter exhausted → StopIteration → skip execution
                                       └── switch to train_iter here
Step i+3': phase3_out = EVAL batch     ✗ is_training=True  (MISMATCH!)
Step i+4:  phase3_out = TRAIN batch    ✓ is_training=True  (MATCH)
```

The pipeline must:
1. Handle the `StopIteration` from eval
2. Switch back to train iterator
3. Start feeding train batches into phase 1 (while existing eval batches continue draining through the pipeline)
4. Continue without corrupting the phase3 output type

---

## 4. Timeline of Hybrid Pipeline Events

| Step | Iterator Used | Phase 3 Output Type | is_training Flag | Status |
|------|---------------|---------------------|------------------|--------|
| i-2  | train_iter    | TRAIN               | True             | ✓ Match |
| i-1  | train_iter    | TRAIN               | True             | ✓ Match |
| i    | **eval_iter** | TRAIN               | **False**        | ✗ **Mismatch** |
| i+1  | eval_iter     | EVAL                | False            | ✓ Match |
| i+2  | eval_iter     | EVAL                | False            | ✓ Match |
| i+3  | eval_iter (exhausted) | — | — | StopIteration |
| i+3' | train_iter    | EVAL                | **True**         | ✗ **Mismatch** |
| i+4  | train_iter    | TRAIN               | True             | ✓ Match |

---

## 5. Discussions

### 5.1 Root Cause

The mismatch occurs because:

1. **Pipeline Depth = 3**: Batches take 3 steps to traverse the pipeline
2. **Output Delay = 2**: `phase3_output` corresponds to a batch from 2 steps ago
3. **Mode Flag Marks Input Data Type**: `is_training` only marks the type of input data being enqueued, not the model execution
4. **No Tracking of Output Origin**: The returned output doesn't carry metadata about which mode it originated from

### 5.2 Implications

Without proper handling:
- **Train batches' output processed as eval**: Delta streaming or knowledge distillation may skip train outputs
- **Eval batches' output processed as train**: Unnecessary processing, corrupted metrics

During iterator switch:
- **StopIteration at unexpected times**: Pipeline draining behavior differs from single-iterator case
- **Re-fill complexity**: Must carefully manage which iterator feeds the pipeline after a switch

### 5.3 Potential Solutions

1. **Track batch origin in pipeline**: Annotate each batch with its `is_training` status when it enters the pipeline, and return this with `phase3_output`

2. **Decouple data_iter with other process**: Separate the iterator management from downstream processing to avoid mode flag mismatch

3. **Drain pipeline on mode switch**: Fully drain the pipeline before switching modes to ensure clean state, and re-fill pipeline after restart

4. **Use separate pipelines**: Maintain distinct train and eval pipelines to avoid interleaving *(not recommended: unable to use optimization techniques like overlapping eval with train backward)*

---

## 6. References

- D91540396 - Introduces `TrainEvalHybridPipelineBase` with `is_training` flag support for interleaved train/eval batches [#3695]
- D92786767 - Fixes eval iterator exhaustion handling to allow training to continue after eval completes [#3750]
- [Pipelining: Train forward & Eval forward overlapping](https://docs.google.com/document/d/1JtkOvbEV4Z6WDpsetkPHVc2H2gypq_C9bRnwSDnL65Q/edit) - Design doc exploring options for overlapping train and eval forward passes
- TorchRec Train Pipeline Implementation: `torchrec/distributed/train_pipeline/train_pipelines.py`

## Summary:
This diff introduces `TrainEvalHybridPipelineBase`, a new hybrid pipeline class that extends `TrainPipelineSparseDist` to support seamless switching between training and evaluation modes within a single pipelined execution flow.

**Motivation:**
In scenarios where training and evaluation batches need to be interleaved (e.g., periodic validation during training), having separate pipelines introduces overhead from context switching. This hybrid pipeline allows fine-grained control over which batches trigger gradient computation and weight updates via a per-batch `is_training` flag.

**Key Features:**
- Extends `TrainPipelineSparseDist` with hybrid train/eval capability
- **The trainer can set the `is_training` flag directly via the `progress()` API to control whether the newly enqueued batch should execute backward/optimizer steps**
- `enqueue_batch()` method accepts an `is_training` flag that marks each batch's context
- `progress()` method conditionally executes backward pass and optimizer step based on both:
  1. The model's overall training mode (`self._model.training`)
  2. The per-batch training flag (`context.is_training`)
- Maintains all pipelining benefits (overlapping data transfer, sparse data distribution, and forward pass) for both modes

**Pipeline Stages (3-stage pipeline):**
- Stage 1: Device transfer (batch i+2)
- Stage 2: Sparse data distribution (batch i+1)
- Stage 3: Forward/Backward/Optimizer (current batch)


## test
manually change the following:
```
        def _func_to_benchmark(
            bench_inputs: List[ModelInput],
            model: nn.Module,
            pipeline: TrainPipeline,
        ) -> None:
            pipeline.reset()
            dataloader = iter(bench_inputs)
            batch_id = -1
            while True:
                try:
                    batch_id += 1
                    pipeline.progress(dataloader, is_training=batch_id) # alterate train and eval
                except StopIteration:
                    break
```
logging
```
INFO:torchrec.distributed.train_pipeline.train_pipelines:initial fill batch-0 with train
INFO:torchrec.distributed.train_pipeline.train_pipelines:initial fill batch-1 with train
```
batch 0~2 starting with `training`, and batch 3, 5, 7 only do `eval`. 
<img width="2537" height="1340" alt="image" src="https://github.com/user-attachments/assets/ab0f9b40-0917-451c-bdaa-69ec0ab3ac85" />

Differential Revision: D91540396


