### PR TITLE
[detailed][pipeline] add fused SDD eval pipeline

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -99,7 +99,6 @@ class RunOptions(BenchFuncConfig):
 
     world_size: int = 2
     batch_size: int = 1024 * 32
-    num_float_features: int = 10
     num_batches: int = 10
     sharding_type: ShardingType = ShardingType.TABLE_WISE
     input_type: str = "kjt"

--- a/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
+++ b/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
@@ -13,7 +13,12 @@ RunOptions:
 PipelineConfig:
   pipeline: "base"
 ModelInputConfig:
+  num_float_features: 10
   feature_pooling_avg: 10
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 1000
 EmbeddingTablesConfig:
   num_unweighted_features: 20
   num_weighted_features: 20

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -13,7 +13,17 @@ RunOptions:
 PipelineConfig:
   pipeline: "sparse"
 ModelInputConfig:
+  num_float_features: 100
   feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
 EmbeddingTablesConfig:
   num_unweighted_features: 90
   num_weighted_features: 80

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
@@ -1,0 +1,42 @@
+# This is a very basic MP-ZCH benchmark configuration
+#   MP-ZCH parameters have comments next to them below.
+#   Note that MP-ZCH must be enabled for all tables in the model,
+#      and MP-ZCH only works with row-wise sharding.
+RunOptions:
+  world_size: 2
+  num_batches: 20
+  num_benchmarks: 5
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_eval"
+PipelineConfig:
+  pipeline: "eval-sdd"
+ModelInputConfig:
+  num_float_features: 1000
+  feature_pooling_avg: 30
+  use_variable_batch: False
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 1000
+    submodule_kwargs:
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 70
+  num_weighted_features: 70
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+PlannerConfig:
+  # MP-ZCH only works with row-wise sharding
+  additional_constraints:
+    FP16_table:
+      sharding_types: [row_wise]

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -18,6 +18,8 @@ from torchrec.distributed.train_pipeline import (
     TrainPipelineSparseDist,
 )
 from torchrec.distributed.train_pipeline.train_pipelines import (
+    EvalPipelineFusedSparseDist,
+    EvalPipelineSparseDist,
     PrefetchTrainPipelineSparseDist,
     TrainEvalHybridPipelineBase,
     TrainPipelineSemiSync,
@@ -98,6 +100,8 @@ class PipelineConfig:
             "semi": TrainPipelineSemiSync,
             "prefetch": PrefetchTrainPipelineSparseDist,
             "hybrid_base": TrainEvalHybridPipelineBase,
+            "eval-sdd": EvalPipelineSparseDist,
+            "eval-fused": EvalPipelineFusedSparseDist,
         }
 
         if self.pipeline == "semi":


### PR DESCRIPTION
Summary:
# context
* create a fused-sparse-dist-eval pipeline for bulk evaluation workflow
* the eval workflow doesn't have backward pass nor optimizer step, and the model weights won't change during the evaluation job
* in such use case, we can't use the `PipelinedForward` (which is used by sparse-dist pipeline) because the embedding lookup and embedding dist steps are triggered consecutively, thus the embedding dist is in the critical path
* The FusedSDD pipeline which extracts the embedding lookup from the sharded module forward would make more sense.
<img width="2820" height="856" alt="image" src="https://github.com/user-attachments/assets/f6d3a6b4-dcf7-425d-aa3f-1f3c4394e0df" />

* compute stream is fully utilized
<img width="5078" height="1218" alt="image" src="https://github.com/user-attachments/assets/76e730a1-6a00-4c11-9e9f-e4c777947a52" />


|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|eval-sdd              |32301.92 ms      |30634.99 ms      |63.41 GB                |72.75 GB                   |73.82 GB          |0.0 / 0.0 / 0.0              |60.00 GB  
|eval-fused-sdd                     |32053.71 ms      |27238.96 ms      |54.40 GB                |79.60 GB                   |80.18 GB          |1.0 / 1.0 / 1.0              |59.89 GB          |

Differential Revision: D89161589
