### PR TITLE
Update Hashing Logic for ParameterConstraints

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1152,7 +1152,11 @@ def hash_planner_context_inputs(
         ],
         storage_reservation_policy,
         storage_reservation._last_reserved_topology,
-        constraints.items() if constraints else None,
+        (
+            tuple((k, v.__hash__()) for k, v in sorted(constraints.items()))
+            if constraints
+            else None
+        ),
     ]
     return hash_function(hashable_list)
 
@@ -1194,7 +1198,11 @@ def hash_planner_context_inputs_str(
         ],
         storage_reservation_policy,
         storage_reservation._last_reserved_topology,
-        constraints.items() if constraints else None,
+        (
+            tuple((k, v.__hash__()) for k, v in sorted(constraints.items()))
+            if constraints
+            else None
+        ),
     ]
     return hash_function(hashable_list)
 


### PR DESCRIPTION
Summary: Improves hashing logic for ParameterConstraints in the planner to ensure deterministic and valid hash computation. Previously, hashing constraints.items() directly could produce non-deterministic results due to dictionary ordering. Now converts constraints to a sorted tuple of ```(key, value.__hash__())``` pairs, ensuring consistent hashing behavior and reliable planner caching. The previous implementation would also fail to hash the ParameterConstraint correctly. By explicitly calling the ```__hash__()``` method of each ParameterConstraint object, we now ensure that each constraint itself is hashed (as opposed to its memory address).

Reviewed By: micrain

Differential Revision: D90544694


