### PR TITLE
fix test_all_recmetrics_are_covered failure in python 3.10

### DIFF
--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -1076,6 +1076,9 @@ class MetricCoverageTest(unittest.TestCase):
         # e.g., "SomeMetric": "deprecated, will be removed in next release",
     }
 
+    @unittest.skipIf(
+        sys.version < "3.11", "concurrent.futures._base.Future is type but not a class"
+    )
     def test_all_recmetrics_are_covered(self) -> None:
         import importlib
         import pkgutil


### PR DESCRIPTION
Summary:
# context
* somehow the github cpu unittest workflow [job](https://github.com/meta-pytorch/torchrec/actions/runs/21465185422/job/61825608236) is failing due to the following error:
```
______________ MetricCoverageTest.test_all_recmetrics_are_covered ______________

self = <test_metric_fqn_backward_compatibility.MetricCoverageTest testMethod=test_all_recmetrics_are_covered>

    def test_all_recmetrics_are_covered(self) -> None:
        import importlib
        import pkgutil

        import torchrec.metrics

        discovered_metrics: Set[str] = set()

        package_path = torchrec.metrics.__path__
        for _, module_name, _ in pkgutil.iter_modules(package_path):
            try:
                module = importlib.import_module(f"torchrec.metrics.{module_name}")
                for attr_name in dir(module):
                    attr = getattr(module, attr_name)
                    if (
                        isinstance(attr, type)
>                       and issubclass(attr, RecMetric)
                        and attr is not RecMetric
                        and not attr_name.startswith("_")
                    ):

torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py:1095:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'torchrec.metrics.rec_metric.RecMetric'>
subclass = concurrent.futures._base.Future[typing.Dict[str, typing.Union[float, torch.Tensor]]]

    def __subclasscheck__(cls, subclass):
        """Override for issubclass(subclass, cls)."""
>       return _abc_subclasscheck(cls, subclass)
E       TypeError: issubclass() arg 1 must be a class

/opt/conda/envs/build_binary/lib/python3.10/abc.py:123: TypeError
```
* local repro shows the `attr` is `concurrent.futures._base.Future[typing.Dict[str, typing.Union[float, torch.Tensor]]] `, and in python 3.10 `isinstance(attr, type)` returns `True`.
* workaround: skip this test in python 3.10

Differential Revision: D91757340


