### PR TITLE
Introduce TrainPipelineSparseDistLite (SDD LIte) pipeline

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
@@ -1,0 +1,38 @@
+# this is a very basic sparse data dist config
+# runs on 2 ranks, showing traces with reasonable workloads
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_lite"
+  # export_stacks: True # enable this to export stack traces
+PipelineConfig:
+  pipeline: "sparse_lite"
+ModelInputConfig:
+  feature_pooling_avg: 30
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -20,6 +20,7 @@ from torchrec.distributed.train_pipeline import (
 from torchrec.distributed.train_pipeline.train_pipelines import (
     PrefetchTrainPipelineSparseDist,
     TrainPipelineSemiSync,
+    TrainPipelineSparseDistLite,
 )
 
 
@@ -90,6 +91,7 @@ class PipelineConfig:
             str, Type[Union[TrainPipelineBase, TrainPipelineSparseDist]]
         ] = {
             "base": TrainPipelineBase,
+            "sparse_lite": TrainPipelineSparseDistLite,
             "sparse": TrainPipelineSparseDist,
             "fused": TrainPipelineFusedSparseDist,
             "semi": TrainPipelineSemiSync,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1035,6 +1035,176 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._batch_ip1 = self._copy_batch_to_gpu(dataloader_iter)
 
 
+class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
+    """
+    Memory-efficient 2-stage pipelined training with minimal memory overhead.
+
+    This pipeline extends TrainPipelineSparseDist by trading off some throughput
+    improvement for significantly reduced memory overhead. It maintains only one
+    batch in flight for data transfer, making it ideal for memory-constrained
+    deployments where the full SDD pipeline's memory cost is prohibitive.
+
+    Pipeline Architecture:
+        The pipeline maintains 1 batch in flight (vs 2 for full SDD):
+
+        Stage 1 (Batch i+1): Device Transfer
+            - Stream: memcpy CUDA stream
+            - Operation: Copy batch from CPU to GPU memory
+            - Overlap: Runs concurrently with forward/backward of batch i
+
+        Stage 2 (Batch i): Input Distribution + Forward/Backward/Optimizer
+            - Stream: default CUDA stream
+            - Operation: start_sparse_data_dist -> wait_sparse_data_dist ->
+                         forward -> backward -> optimizer step
+            - Note: Input distribution stays in critical path (not overlapped)
+
+    Requirements:
+        - Input model must be symbolically traceable except for ShardedModule and
+          DistributedDataParallel modules
+
+    Performance Characteristics:
+        - Best suited for memory-constrained environments where full SDD is impractical
+        - Achieves ~4-5% QPS improvement over TrainPipelineBase
+        - Memory overhead: ~1 batch size (1 batch in flight for transfer)
+        - Lower throughput than full SDD but much lower memory cost
+
+    Args:
+        model (torch.nn.Module): Model to pipeline. Must contain ShardedModule instances
+            for sparse features.
+        optimizer (torch.optim.Optimizer): Optimizer to use for parameter updates.
+        device (torch.device): Device where all pipeline stages will execute (typically
+            CUDA device).
+        apply_jit (bool): If True, applies torch.jit.script to non-pipelined (unsharded)
+            modules for additional optimization. Default: False.
+        context_type (Type[TrainPipelineContext]): Context type to use for pipeline
+            contexts. Default: TrainPipelineContext.
+        pipeline_postproc (bool): If True, enables pipelining of post-processing
+            operations. Default: False.
+        custom_model_fwd (Optional[Callable]): Custom forward function to use instead
+            of model's default forward. Should return (losses, output) tuple.
+        inplace_copy_batch_to_gpu (bool): If True, performs in-place device transfer
+            to reduce memory allocations. Default: False.
+
+    Example:
+        >>> model = MyShardedModel()
+        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        >>> pipeline = TrainPipelineSparseDistLite(
+        ...     model=model,
+        ...     optimizer=optimizer,
+        ...     device=torch.device("cuda:0"),
+        ... )
+        >>> for _ in range(num_batches):
+        ...     output = pipeline.progress(dataloader_iter)
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        apply_jit: bool = False,
+        context_type: Type[TrainPipelineContext] = TrainPipelineContext,
+        pipeline_postproc: bool = False,
+        custom_model_fwd: Optional[
+            Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
+        ] = None,
+        inplace_copy_batch_to_gpu: bool = False,
+    ) -> None:
+        super().__init__(
+            model=model,
+            optimizer=optimizer,
+            device=device,
+            execute_all_batches=True,
+            apply_jit=apply_jit,
+            context_type=context_type,
+            pipeline_postproc=pipeline_postproc,
+            custom_model_fwd=custom_model_fwd,
+            dmp_collection_sync_interval_batches=None,
+            enqueue_batch_after_forward=False,
+            inplace_copy_batch_to_gpu=inplace_copy_batch_to_gpu,
+        )
+
+        # SDD Lite only uses memcpy stream for H2D copy.
+        # When invoking self._stream_context() in start_sparse_data_dist and
+        # wait_sparse_data_dist, the stream will be set to the default stream.
+        self._data_dist_stream = None
+
+    def fill_pipeline(self, dataloader_iter: Iterator[In]) -> None:
+        """
+        Fill the pipeline with a single batch (vs 2 batches in full SDD).
+        SDD Lite maintains only 1 batch in flight to reduce memory overhead.
+        """
+        # Pipeline is already filled with max capacity (1 for Lite)
+        if len(self.batches) >= 1:
+            return
+
+        # batch i: load data and create context
+        if not self.enqueue_batch(dataloader_iter):
+            logger.info("fill_pipeline: failed to load batch i")
+            return
+
+    def _wait_for_batch(self) -> None:
+        """
+        Wait for batch to be available on device.
+        SDD Lite uses memcpy_stream (no dedicated data_dist_stream).
+        """
+        batch_id = self.contexts[0].index if len(self.contexts) > 0 else "?"
+        with record_function(f"## wait_for_batch {batch_id} ##"):
+            _wait_for_batch(cast(In, self.batches[0]), self._memcpy_stream)
+
+    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+        self._state = PipelineState.IDLE
+
+        if not self._model_attached:
+            self.attach(self._model)
+
+        self.fill_pipeline(dataloader_iter)
+
+        if not self.batches:
+            one_time_rank0_logger.info(
+                f"training stopped at {self._batch_count} batches"
+            )
+            raise StopIteration
+
+        # TODO: Remove once Bulk Eval migrated (needed for bwd compat, this class only)
+        self._set_module_context(self.contexts[0])
+
+        if self._model.training:
+            with record_function("## zero_grad ##"):
+                self._optimizer.zero_grad()
+
+        # Wait for batch to be on device
+        self._wait_for_batch()
+
+        # Input dist in critical path (key difference from full SDD)
+        self._init_pipelined_modules(
+            self.batches[0],
+            self.contexts[0],
+            self._pipelined_forward_type,
+        )
+        self.wait_sparse_data_dist(self.contexts[0])
+
+        # Forward
+        with record_function(f"## forward {self.contexts[0].index} ##"):
+            self._state = PipelineState.CALL_FWD
+            losses, output = self._model_fwd(self.batches[0])
+
+        if self._model.training:
+            # Backward
+            self._state = PipelineState.CALL_BWD
+            self._backward(losses)
+
+        self.enqueue_batch(dataloader_iter)
+
+        if self._model.training:
+            with record_function(f"## optimizer {self.contexts[0].index} ##"):
+                self._optimizer.step()
+
+        self.dequeue_batch()
+
+        return output
+
+
 class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
     """
     This pipeline modifies TrainPipelineSparseDist by running embedding lookup in a


### PR DESCRIPTION
Summary:
# Context

The full SDD pipeline improves QPS by overlapping data transfer and input distribution with forward/backward, but maintains two batches in flight which increases memory overhead (~12% in certain models). This poses challenges for memory-constrained deployments. The base pipeline has minimal memory footprint but achieves limited overlap, leading to inefficient GPU utilization.

# What is SDD Lite

SDD Lite is a hybrid approach combining communication overlap benefits of SDD with memory efficiency of the base pipeline:

- Memory overhead: 0-1% (vs ~12% for full SDD)
- QPS improvement: 4-5% over base pipeline
- Batches in flight: 1 (vs 2 for full SDD)

Execution flow per iteration
- Batch i: start_sparse_data_dist -> wait_sparse_data_dist -> forward -> backward
- Batch i+1: copy_batch_to_gpu (overlaps with forward/backward of batch i)

This design enables several key optimizations:
- Input dist all-to-alls start sequentially before model forward and overlap with completed lookups
- Output dist comms overlap with subsequent lookups
- Minimized blocking between input_dist and output_dist communications

# Requirements
Input model must be symbolically traceable

# Changes
- Added `TrainPipelineSparseDistLite` class & unit tests
- Updated benchmark config yaml

Differential Revision: D86913302
