### PR TITLE
Back out D91704824: fix torch.package backward compatibility

### DIFF
--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -51,7 +51,6 @@ from torchrec.modules.fp_embedding_modules import (
     apply_feature_processors_to_kjt,
     FeatureProcessedEmbeddingBagCollection,
 )
-from torchrec.pt2.utils import pt2_compatible_justknobs_check
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor, KeyedTensor
 
 _T = TypeVar("_T")
@@ -123,7 +122,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
     def input_dist(
         self, ctx: EmbeddingBagCollectionContext, features: KeyedJaggedTensor
     ) -> Awaitable[Awaitable[KJTList]]:
-        if pt2_compatible_justknobs_check(
+        if torch._utils_internal.justknobs_check(
             "pytorch/torchrec:enable_rw_feature_processor"
         ):
             if not self.is_pipelined and self._row_wise_sharded:
@@ -286,7 +285,7 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
             ShardingType.TABLE_COLUMN_WISE.value,
         ]
 
-        if pt2_compatible_justknobs_check(
+        if torch._utils_internal.justknobs_check(
             "pytorch/torchrec:enable_rw_feature_processor"
         ):
             types.extend(

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -61,7 +61,6 @@ from torchrec.distributed.train_pipeline.tracing import (
 )
 from torchrec.distributed.train_pipeline.types import CallArgs  # noqa
 from torchrec.distributed.types import Awaitable
-from torchrec.pt2.utils import pt2_compatible_justknobs_check
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable, Pipelineable
 
@@ -179,7 +178,7 @@ def _start_data_dist(
         # and this info was done in the _rewrite_model by tracing the
         # entire model to get the arg_info_list
         args, kwargs = forward.args.build_args_kwargs(batch)
-        if pt2_compatible_justknobs_check(
+        if torch._utils_internal.justknobs_check(
             "pytorch/torchrec:enable_rw_feature_processor"
         ):
             args, kwargs = module.preprocess_input(args, kwargs)

--- a/torchrec/pt2/utils.py
+++ b/torchrec/pt2/utils.py
@@ -25,11 +25,6 @@ convert_to_vb - If True recreates KJT as Variable Batch.
 """
 
 
-@torch._dynamo.assume_constant_result
-def pt2_compatible_justknobs_check(name: str, default: bool = True) -> bool:
-    return torch._utils_internal.justknobs_check(name, default=default)
-
-
 def kjt_for_pt2_tracing(
     kjt: KeyedJaggedTensor,
     convert_to_vb: bool = False,


### PR DESCRIPTION
Summary:
Release blocker: https://www.internalfb.com/ci/results/slp/668555599615864?tag=conveyor_artifact%3A%3A%2F%2Ffblearner%2Fflow%2Fprojects%2Flego%3Alego_flow

D91704824 introduced `from torchrec.pt2.utils import pt2_compatible_justknobs_check` in several torchrec modules. This import breaks torch.package backward compatibility during repackaging because old packages on Manifold have bundled `torchrec.pt2.utils` that doesn't contain the new `pt2_compatible_justknobs_check` function, causing ImportError.

The author should address the backward compatibility issue before re-landing by either:
1. Adding the import inside a try/except block
2. Adding `torchrec.pt2.**` to extern_modules in the packager

Reviewed By: amrshennawi, TroyGarden

Differential Revision: D91941786


