### PR TITLE
Fix IntEnum str() behavior for Python 3.11+ compatibility

### DIFF
--- a/torchrec/distributed/infer_utils.py
+++ b/torchrec/distributed/infer_utils.py
@@ -62,7 +62,7 @@ def get_tbe_specs_from_sharded_module(
                     spec[1],
                     spec[2],
                     str(spec[3]),
-                    str(spec[4]),
+                    f"{type(spec[4]).__name__}.{spec[4].name}",
                 )
             )
     return tbe_specs


### PR DESCRIPTION
Summary:
In Python 3.11+, `IntEnum.__str__()` was changed to return the integer value instead of the enum name (e.g., `'0'` instead of `'EmbeddingLocation.DEVICE'`). This caused `test_get_tbe_specs_from_sqebc` to fail on Python 3.12.

Fix the `get_tbe_specs_from_sharded_module` function to explicitly construct the enum string representation using `.name` property, ensuring consistent behavior across all Python versions.

Doc reference: https://peps.python.org/pep-0663/

Differential Revision: D92099369


