### PR TITLE
Integrate new EmbeddingPerfEstimatorFactory with Enumerator and Legacy EmbeddingPerfEstimator for backward compatibility

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -45,7 +45,8 @@ DP_ELEMENTWISE_KERNELS_PERF_FACTOR: float = 9.22  # empirical studies
 # For rounding memory hashing to nearest 100GB (10^11 bytes):
 HUNDRED_GB = 100 * 1024**3  # 107,374,182,400
 
-DEFAULT_PERF_ESTIMATOR: str = "oss_estimator"
+# Default perf estimator name - use this constant when creating estimators
+DEFAULT_PERF_ESTIMATOR: str = "default_estimator"
 
 
 def kernel_bw_lookup(

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -45,6 +45,8 @@ DP_ELEMENTWISE_KERNELS_PERF_FACTOR: float = 9.22  # empirical studies
 # For rounding memory hashing to nearest 100GB (10^11 bytes):
 HUNDRED_GB = 100 * 1024**3  # 107,374,182,400
 
+DEFAULT_PERF_ESTIMATOR: str = "oss_estimator"
+
 
 def kernel_bw_lookup(
     compute_device: str,

--- a/torchrec/distributed/planner/estimator/__init__.py
+++ b/torchrec/distributed/planner/estimator/__init__.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""TorchRec Performance Estimator Module.
+
+This module provides a refactored, extensible architecture for embedding
+performance estimation with hardware-specific configurations.
+
+Key components:
+    - HardwarePerfConfig: Base class for hardware-specific configurations.
+    - EmbeddingPerfEstimatorFactory: Factory for creating estimators.
+    - EmbeddingPerfEstimatorV2: Refactored estimator implementation.
+"""
+from torchrec.distributed.planner.estimator.annotations import (
+    backward_compute as backward_compute,  # noqa: F401
+    bwd_coefficient as bwd_coefficient,  # noqa: F401
+    device_bw as device_bw,  # noqa: F401
+    forward_compute as forward_compute,  # noqa: F401
+    fwd_coefficient as fwd_coefficient,  # noqa: F401
+    output_write_size as output_write_size,  # noqa: F401
+    prefetch_coefficient as prefetch_coefficient,  # noqa: F401
+    supported_sharding_types as supported_sharding_types,  # noqa: F401
+)
+from torchrec.distributed.planner.estimator.config import (
+    EmbeddingPerfEstimatorConfig as EmbeddingPerfEstimatorConfig,  # noqa: F401
+)
+from torchrec.distributed.planner.estimator.estimator import (
+    EmbeddingPerfEstimatorFactory as EmbeddingPerfEstimatorFactory,  # noqa: F401
+    EmbeddingPerfEstimatorV2 as EmbeddingPerfEstimatorV2,  # noqa: F401
+)
+from torchrec.distributed.planner.estimator.types import (
+    EstimatorPerfCoefficients as EstimatorPerfCoefficients,  # noqa: F401
+    HardwarePerfConfig as HardwarePerfConfig,  # noqa: F401
+    PerfCoefficient as PerfCoefficient,  # noqa: F401
+    PerfCoefficientConfig as PerfCoefficientConfig,  # noqa: F401
+    PrefetchCoefficients as PrefetchCoefficients,  # noqa: F401
+    ShardPerfContext as ShardPerfContext,  # noqa: F401
+)

--- a/torchrec/distributed/planner/estimator/annotations.py
+++ b/torchrec/distributed/planner/estimator/annotations.py
@@ -1,0 +1,1359 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Purpose:
+This module provides decorator functions to annotate hardware-specific properties and communication patterns on
+HardwarePerfConfig classes, enabling flexible and hardware-aware performance modeling for distributed training in TorchRec.
+
+Key Features:
+Hardware Property Annotations: Use decorators like @hbm_mem_bw, @ddr_mem_bw, and @bwd_compute_multiplier to
+specify hardware characteristics (such as memory bandwidth and compute multipliers) on config classes.
+Sharding-Type Specific Overrides: Communication decorators (@fwd_comms, @bwd_comms, @input_dist_comms) can be
+applied to methods, optionally filtered by sharding type (e.g., TABLE_WISE, ROW_WISE). This enables custom
+performance formulas for specific sharding strategies, while using defaults for others.
+Usage Example: You can annotate a config class with hardware properties and override communication formulas
+for particular sharding types.
+Flexible Method Resolution: When an estimator calls a communication method, it checks for sharding-type-specific
+overrides. If a method is annotated for a specific sharding type and matches the context, it uses the custom method; otherwise, it falls back to the default implementation. This keeps code DRY and allows targeted optimizations.
+
+Typical Use Cases:
+Modeling hardware performance for distributed training.
+Customizing communication cost formulas for different sharding strategies.
+Creating hardware-specific estimators for Meta’s infrastructure.
+
+"""
+
+from typing import Any, Callable, cast, List, Optional, overload, Type, TypeVar, Union
+
+# Type variable for decorator return types
+T = TypeVar("T")
+
+# =============================================================================
+# Helper Functions for Accessing Annotated Methods
+# =============================================================================
+
+
+def _matches_sharding_type(method: Callable[..., float], sharding_type: str) -> bool:
+    """
+    Check if a custom method matches the given sharding type.
+
+    Args:
+        method: The custom method to check
+        sharding_type: The sharding type to match against (e.g., 'table_wise')
+
+    Returns:
+        True if the method applies to this sharding type
+    """
+    custom_sharding_type = getattr(method, "_custom_sharding_type", None)
+    if custom_sharding_type is None:
+        # No sharding type restriction - applies to all
+        return True
+
+    # Handle list/tuple of sharding types
+    if isinstance(custom_sharding_type, (list, tuple)):
+        return sharding_type.lower() in [st.lower() for st in custom_sharding_type]
+
+    # Single sharding type - normalize both to lowercase for comparison
+    return custom_sharding_type.lower() == sharding_type.lower()
+
+
+def _get_annotated_method(
+    config: Any,
+    annotation_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., float]]:
+    """
+    Scan all methods on config for the annotation attribute.
+
+    This function finds any method that has the specified annotation attribute,
+    regardless of the method name. The annotation is the source of truth.
+
+    Args:
+        config: The hardware config to check
+        annotation_attr: The annotation attribute to look for (e.g., '_is_custom_output_write_size')
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+
+    Returns:
+        The annotated method if found and matches sharding type, otherwise None.
+    """
+    for attr_name in dir(config):
+        if attr_name.startswith("_"):
+            continue
+        attr = getattr(config, attr_name, None)
+        if attr and callable(attr) and getattr(attr, annotation_attr, False):
+            # Cast to the expected return type
+            method = cast(Callable[..., float], attr)
+            # Check sharding type if provided
+            if sharding_type is not None:
+                if not _matches_sharding_type(method, sharding_type):
+                    continue
+            return method
+    return None
+
+
+def get_custom_method(
+    obj: Any,
+    method_name: str,
+    annotation_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., float]]:
+    """
+    Get a method from an object if it has the specified annotation attribute
+    and optionally matches the specified sharding type.
+
+    Args:
+        obj: The object to get the method from
+        method_name: Name of the method to retrieve
+        annotation_attr: The annotation attribute to check for
+        sharding_type: Optional sharding type to filter by. If provided, the method
+            must either have no sharding_type restriction or match this sharding_type.
+
+    Returns:
+        The method if it exists, has the annotation, and matches the sharding type
+        (if specified), otherwise None
+    """
+
+    method = getattr(obj, method_name, None)
+    if method and getattr(method, annotation_attr, False):
+        # Check sharding type if provided
+        if sharding_type is not None:
+            if not _matches_sharding_type(method, sharding_type):
+                return None
+        return method
+    return None
+
+
+def get_forward_compute(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom forward compute method if annotated with @forward_compute.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_forward_compute", sharding_type)
+
+
+def get_backward_compute(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom backward compute method if annotated with @backward_compute.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_backward_compute", sharding_type)
+
+
+def get_prefetch_compute(config: Any) -> Optional[Callable[..., float]]:
+    """Get custom prefetch compute method if annotated with @prefetch_compute."""
+    return _get_annotated_method(config, "_is_custom_prefetch_compute")
+
+
+def get_input_dist_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom input dist comms method if annotated with @input_dist_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_input_dist_comms", sharding_type)
+
+
+def get_fwd_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom fwd comms method if annotated with @fwd_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_fwd_comms", sharding_type)
+
+
+def get_bwd_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom bwd comms method if annotated with @bwd_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_bwd_comms", sharding_type)
+
+
+def get_output_write_size(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom output write size method if annotated with @output_write_size.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+    The annotation is the source of truth, not the method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_output_write_size", sharding_type)
+
+
+# =============================================================================
+# SECTION 1: Bandwidth Decorators
+# =============================================================================
+
+
+def hbm_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set HBM memory bandwidth for a hardware config.
+
+    HBM High Bandwidth Memory
+
+    Args:
+        value: HBM memory bandwidth in bytes/second
+
+    Example:
+        @hbm_mem_bw(6200 * 1024 * 1024 * 1024)  # 6200 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.hbm_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set DDR memory bandwidth for a hardware config.
+
+    DDR memory is the system/host memory.
+
+    Args:
+        value: DDR memory bandwidth in bytes/second
+
+    Example:
+        @ddr_mem_bw(100 * 1024 * 1024 * 1024)  # 100 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.ddr_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def hbm_to_ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set HBM to DDR memory bandwidth for a hardware config.
+
+    This is the bandwidth for UVM (Unified Virtual Memory) operations
+    that move data between GPU HBM and system DDR memory.
+
+    Args:
+        value: HBM to DDR bandwidth in bytes/second
+
+    Example:
+        @hbm_to_ddr_mem_bw(25.6 * 1024 * 1024 * 1024)  # 25.6 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.hbm_to_ddr_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def device_bw(
+    bandwidth: Optional[float] = None,
+    *,
+    device: Optional[str] = None,
+    compute_kernel: Optional[str] = None,
+) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set device bandwidth for a hardware config.
+
+    Usage:
+        # General device bandwidth (existing behavior)
+        @device_bw(3200 * 1024 * 1024 * 1024)
+        class MyConfig(HardwarePerfConfig): pass
+
+        # Specific device + kernel bandwidth (NEW)
+        @device_bw(bandwidth=5000, device='cuda', compute_kernel='fused')
+        @device_bw(bandwidth=3000, device='cuda', compute_kernel='dense')
+        class MyConfig(HardwarePerfConfig): pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        if device is not None and compute_kernel is not None:
+            # Bind to local variables to satisfy type narrowing
+            device_str: str = device
+            compute_kernel_str: str = compute_kernel
+            # Specific device + kernel override
+            # IMPORTANT: Check if kernel_device_bandwidths is inherited from parent class
+            # If so, create a new dictionary for this class to avoid modifying the shared one
+            if (
+                not hasattr(cls, "kernel_device_bandwidths")
+                or cls.kernel_device_bandwidths is None
+            ):
+                cls.kernel_device_bandwidths = {}  # pyre-ignore[16]
+            else:
+                # Check if we're using an inherited dictionary by comparing with parent's
+                # If so, create a new copy for this class
+                for base in cls.__mro__[1:]:
+                    if (
+                        hasattr(base, "kernel_device_bandwidths")
+                        and cls.kernel_device_bandwidths
+                        is base.kernel_device_bandwidths
+                    ):
+                        cls.kernel_device_bandwidths = dict(
+                            cls.kernel_device_bandwidths
+                        )  # pyre-ignore[16]
+                        break
+            # Store with lowercase keys for case-insensitive lookup
+            key = (device_str.lower(), compute_kernel_str.lower())
+            cls.kernel_device_bandwidths[key] = bandwidth  # pyre-ignore[16]
+        else:
+            # General device bandwidth (existing behavior)
+            cls.device_bw = bandwidth  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 4: Communication Bandwidth Decorators
+# =============================================================================
+
+
+def intra_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set intra-host communication bandwidth.
+
+    This is the bandwidth for communication between GPUs within the
+    same host (e.g., NVLink, NVSwitch).
+
+    Args:
+        value: Intra-host bandwidth in bytes/second
+
+    Example:
+        @intra_host_bw(600 * 1024 * 1024 * 1024)  # 600 GB/s (NVLink)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.intra_host_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def inter_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set inter-host communication bandwidth.
+
+    This is the bandwidth for communication between GPUs across
+    different hosts (e.g., InfiniBand, RoCE).
+
+    Args:
+        value: Inter-host bandwidth in bytes/second
+
+    Example:
+        @inter_host_bw(25 * 1024 * 1024 * 1024)  # 25 GB/s (IB HDR)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.inter_host_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 3: Custom Compute Method Decorators
+# =============================================================================
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def forward_compute(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def forward_compute(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom forward compute implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing forward pass time instead of the default linear regression model.
+    This is useful for hardware with unique kernel breakdown patterns
+    (e.g., Athena's BCI + IRLE model).
+    Example:
+        class AthenaHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @forward_compute
+            def compute_fwd(self, ctx: ShardPerfContext) -> float:
+                # Custom Athena kernel breakdown logic
+                bci_time = self._compute_bci(ctx)
+                irle_time = self._compute_irle(ctx)
+                return self.bci_coeff * bci_time + self.irle_coeff * irle_time
+
+            # Applies only to TABLE_WISE sharding
+            @forward_compute(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_fwd(self, ctx: ShardPerfContext) -> float:
+                return self._compute_table_wise_fwd(ctx)
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_forward_compute = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @forward_compute (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @forward_compute(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @forward_compute('table_wise') or @forward_compute(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @forward_compute() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def backward_compute(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def backward_compute(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom backward compute implementation.
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_backward_compute = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @backward_compute (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @backward_compute(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @backward_compute('table_wise') or @backward_compute(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @backward_compute() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+def prefetch_compute(
+    method: Callable[..., float],
+) -> Callable[..., float]:
+    """
+    Decorator to mark a method as custom prefetch compute implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing prefetch/cache loading time.
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            @prefetch_compute
+            def compute_prefetch(self, ctx: ShardPerfContext, expected_cache_fetches: float) -> float:
+                # Custom prefetch logic
+                return expected_cache_fetches * ctx.shard_embedding_dim / self.custom_prefetch_bw
+    """
+    method._is_custom_prefetch_compute = True  # pyre-ignore[16]
+    return method
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def input_dist_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def input_dist_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom input distribution communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing input distribution communication time (A2A input dist latency).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @input_dist_comms
+            def compute_input_dist_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.input_read_size / self.custom_input_dist_bw
+
+            # Applies only to TABLE_WISE sharding
+            @input_dist_comms(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_input_dist_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.input_read_size / self.table_wise_input_dist_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_input_dist_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @input_dist_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @input_dist_comms(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @input_dist_comms('table_wise') or @input_dist_comms(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @input_dist_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def fwd_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def fwd_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom forward communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing forward pass communication time (e.g., All-to-all, Reduce-scatter).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @fwd_comms
+            def compute_fwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.fwd_output_write_size / self.custom_fwd_comms_bw
+
+            # Applies only to TABLE_WISE sharding
+            @fwd_comms(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_fwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.fwd_output_write_size / self.table_wise_fwd_comms_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_fwd_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @fwd_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @fwd_comms(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @fwd_comms('table_wise') or @fwd_comms(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @fwd_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def bwd_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def bwd_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom backward communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing backward pass communication time (e.g., All-gather, All-reduce).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @bwd_comms
+            def compute_bwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.bwd_output_write_size / self.custom_bwd_comms_bw
+
+            # Applies only to ROW_WISE sharding
+            @bwd_comms(sharding_type=ShardingType.ROW_WISE.value)
+            def compute_bwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.bwd_output_write_size / self.row_wise_bwd_comms_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_bwd_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @bwd_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @bwd_comms(sharding_type='row_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @bwd_comms('row_wise') or @bwd_comms(['row_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @bwd_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def output_write_size(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def output_write_size(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom output write size implementation.
+
+    Use this decorator when a hardware config needs to use a different data type
+    size for fwd_output_write_size calculation. For example, FB legacy estimators
+    use output_data_type_size instead of fwd_a2a_comm_data_type_size.
+
+    The method should have signature:
+        def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float
+
+    Example:
+        class FBHardwarePerfConfig(HardwarePerfConfig):
+            # Applies to all sharding types
+            @output_write_size
+            def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float:
+                # FB legacy uses output_data_type_size for compute formula
+                return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * ctx.output_data_type_size
+
+            # Applies only to TABLE_WISE sharding
+            @output_write_size(sharding_type=ShardingType.TABLE_WISE.value)
+            def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float:
+                return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * ctx.output_data_type_size
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_output_write_size = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @output_write_size (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @output_write_size(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @output_write_size('table_wise') or @output_write_size(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @output_write_size() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 4: Strategy Hook Decorators
+# =============================================================================
+
+
+def use_min_dim_for_lookup(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to enable/disable min_dim constraint for embedding lookup size.
+
+    When enabled (True), embedding lookup uses max(emb_dim, 32) for kernel
+    efficiency. This is the TABLE_WISE behavior per OSS EmbeddingPerfEstimator.
+
+    Args:
+        value: Whether to use min_dim constraint (default: True)
+
+    Example:
+        @use_min_dim_for_lookup(True)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_min_dim_for_lookup = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def use_block_usage_penalty(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to enable/disable block usage penalty for forward compute.
+
+    When enabled (True), forward compute is multiplied by a penalty factor
+    based on emb_dim alignment with GPU block sizes. This is the TABLE_WISE
+    behavior per OSS EmbeddingPerfEstimator.
+
+    Penalty factors:
+    - emb_dim >= 128: 1.0 (no penalty)
+    - emb_dim >= 64: HALF_BLOCK_PENALTY
+    - emb_dim >= 32: QUARTER_BLOCK_PENALTY
+
+    Args:
+        value: Whether to apply block usage penalty (default: True)
+
+    Example:
+        @use_block_usage_penalty(True)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_block_usage_penalty = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def use_bytes_for_input_read_size(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to control whether input_read_size is calculated in bytes or counts.
+
+    When enabled (True, default/OSS behavior):
+        input_read_size = batch_inputs * world_size * input_data_type_size  (BYTES)
+    When disabled (False, FB legacy behavior):
+        input_read_size = batch_inputs * world_size  (COUNT of indices)
+
+    This affects the forward/backward compute formulas where input_read_size is used.
+
+    Args:
+        value: Whether to multiply by input_data_type_size (default: True)
+
+    Example:
+        @use_bytes_for_input_read_size(False)  # FB legacy: use counts, not bytes
+        class GrandTetonHardwarePerfConfig(HardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_bytes_for_input_read_size = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def input_data_type_size(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set a custom input_data_type_size for the hardware config.
+
+    This allows hardware configs to override the default BIGINT_DTYPE (8 bytes)
+    used in ShardPerfContext. FB legacy estimators use INT_DTYPE (4 bytes).
+
+    Args:
+        value: The input data type size in bytes (e.g., 4.0 for INT_DTYPE, 8.0 for BIGINT_DTYPE)
+
+    Example:
+        @input_data_type_size(4.0)  # FB legacy uses 4 bytes, not 8
+        class GrandTetonHardwarePerfConfig(HardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._input_data_type_size = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def supported_sharding_types(*sharding_types: str) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to specify which sharding types a HardwarePerfConfig supports.
+
+    If not specified, all sharding types are evaluated (default behavior).
+    If specified, only listed sharding types are evaluated; others raise ValueError.
+
+    The annotation is inherited - child classes get parent's supported types
+    unless they override with their own @supported_sharding_types annotation.
+
+    Args:
+        *sharding_types: Sharding type values (e.g., "table_wise", "row_wise")
+
+    Example:
+        @supported_sharding_types("table_wise", "row_wise")
+        class HeterogeneousHardwarePerfConfig(HardwarePerfConfig):
+            pass
+
+    Raises:
+        ValueError: When attempting to evaluate an unsupported sharding type
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        # Store as a frozenset for O(1) lookup, lowercase for case-insensitive matching
+        cls._supported_sharding_types = frozenset(  # pyre-ignore[16]
+            st.lower() for st in sharding_types
+        )
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 5: Coefficient Decorators
+# =============================================================================
+# These decorators allow defining performance coefficients via annotations
+# instead of manually creating PerfCoefficientConfig objects. The evaluator
+# uses these annotations to discover coefficients for each sharding type.
+#
+# Usage example:
+#     class MyHardwarePerfConfig(HardwarePerfConfig):
+#         @fwd_coefficient(sharding_type=["table_wise", "column_wise"])
+#         def tw_cw_fwd(self) -> PerfCoefficient:
+#             return PerfCoefficient(
+#                 input_read_size_multiplier=100.0,
+#                 lookup_size_multiplier=1.0,
+#                 embedding_output_multiplier=1.0,
+#                 hash_size_multiplier=4.5,
+#             )
+#
+#         @bwd_coefficient(sharding_type=["table_wise", "column_wise"])
+#         def tw_cw_bwd(self) -> PerfCoefficient:
+#             return PerfCoefficient(...)
+#
+#         @prefetch_coefficient()
+#         def prefetch_coeff(self) -> PrefetchCoefficients:
+#             return PrefetchCoefficients(...)
+# =============================================================================
+
+
+def fwd_coefficient(
+    sharding_type: Optional[Union[str, list[str]]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing forward pass performance coefficients.
+
+    The decorated method should return a PerfCoefficient object. Method name is
+    arbitrary - only the annotation matters for discovery.
+
+    Args:
+        sharding_type: Sharding type(s) this coefficient applies to.
+                       Can be a single string or list of strings.
+                       If None, applies to all sharding types.
+
+    Example:
+        @fwd_coefficient(sharding_type=["table_wise", "column_wise"])
+        def compute_tw_cw_fwd(self) -> PerfCoefficient:
+            return PerfCoefficient(
+                input_read_size_multiplier=100.0,
+                lookup_size_multiplier=1.0,
+                embedding_output_multiplier=1.0,
+                hash_size_multiplier=4.5,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_fwd_coefficient = True  # pyre-ignore[16]
+        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+def bwd_coefficient(
+    sharding_type: Optional[Union[str, list[str]]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing backward pass performance coefficients.
+
+    The decorated method should return a PerfCoefficient object. Method name is
+    arbitrary - only the annotation matters for discovery.
+
+    Args:
+        sharding_type: Sharding type(s) this coefficient applies to.
+                       Can be a single string or list of strings.
+                       If None, applies to all sharding types.
+
+    Example:
+        @bwd_coefficient(sharding_type=["table_wise", "column_wise"])
+        def compute_tw_cw_bwd(self) -> PerfCoefficient:
+            return PerfCoefficient(
+                input_read_size_multiplier=600.0,
+                lookup_size_multiplier=3.0,
+                embedding_output_multiplier=3.0,
+                hash_size_multiplier=9.0,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_bwd_coefficient = True  # pyre-ignore[16]
+        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+def prefetch_coefficient() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing prefetch pipeline coefficients.
+
+    The decorated method should return a PrefetchCoefficients object.
+    Prefetch coefficients are global (no sharding type filter).
+
+    Example:
+        @prefetch_coefficient()
+        def get_prefetch_coeff(self) -> PrefetchCoefficients:
+            return PrefetchCoefficients(
+                expected_num_lookups_coefficient=4.337620774386766e-07,
+                expected_num_unique_lookups_coefficient=1.0654341763287636e-05,
+                expected_size_cache_fetches_coefficient=1.3311586664661257e-07,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_prefetch_coefficient = True  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+# =============================================================================
+# Helper Functions for Coefficient Annotations
+# =============================================================================
+
+
+def _matches_coefficient_sharding_type(
+    method: Callable[..., Any], sharding_type: str
+) -> bool:
+    """
+    Check if a coefficient method matches the given sharding type.
+
+    Args:
+        method: The coefficient method to check
+        sharding_type: The sharding type to match against (e.g., 'table_wise')
+
+    Returns:
+        True if the method applies to this sharding type
+    """
+    method_sharding_type = getattr(method, "_coefficient_sharding_type", None)
+    if method_sharding_type is None:
+        return True  # No filter = matches all
+
+    if isinstance(method_sharding_type, (list, tuple)):
+        return sharding_type.lower() in [st.lower() for st in method_sharding_type]
+
+    return method_sharding_type.lower() == sharding_type.lower()
+
+
+def _get_coefficient_method(
+    config: Any,
+    marker_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., Any]]:
+    """
+    Find a coefficient method on config marked with the given attribute.
+
+    Scans ALL methods by attribute (not by method name). Returns the first
+    method that has the marker attribute and matches the sharding type.
+
+    Args:
+        config: The hardware config to scan
+        marker_attr: The annotation attribute to look for (e.g., '_is_fwd_coefficient')
+        sharding_type: Optional sharding type to filter by
+
+    Returns:
+        The matching method if found, otherwise None
+    """
+    # Skip these attributes to avoid infinite recursion (coefficients property
+    # calls get_fwd_coefficient which calls this function)
+    skip_attrs = {"coefficients", "_coefficients"}
+
+    for attr_name in dir(config):
+        if attr_name.startswith("_") or attr_name in skip_attrs:
+            continue
+        method = getattr(config, attr_name, None)
+        if method and callable(method) and getattr(method, marker_attr, False):
+            if sharding_type is not None:
+                if not _matches_coefficient_sharding_type(method, sharding_type):
+                    continue
+            return method
+    return None
+
+
+def get_fwd_coefficient(
+    config: Any,
+    sharding_type: str,
+) -> Optional[Any]:
+    """
+    Get forward coefficient for the given sharding type from config annotations.
+
+    Scans all methods on the config for @fwd_coefficient annotation.
+    Returns the PerfCoefficient if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: The sharding type to get coefficient for
+
+    Returns:
+        PerfCoefficient if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_fwd_coefficient", sharding_type)
+    if method:
+        return method()
+    return None
+
+
+def get_bwd_coefficient(
+    config: Any,
+    sharding_type: str,
+) -> Optional[Any]:
+    """
+    Get backward coefficient for the given sharding type from config annotations.
+
+    Scans all methods on the config for @bwd_coefficient annotation.
+    Returns the PerfCoefficient if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: The sharding type to get coefficient for
+
+    Returns:
+        PerfCoefficient if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_bwd_coefficient", sharding_type)
+    if method:
+        return method()
+    return None
+
+
+def get_prefetch_coefficient(
+    config: Any,
+) -> Optional[Any]:
+    """
+    Get prefetch coefficients from config annotations.
+
+    Scans all methods on the config for @prefetch_coefficient annotation.
+    Returns the PrefetchCoefficients if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+
+    Returns:
+        PrefetchCoefficients if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_prefetch_coefficient")
+    if method:
+        return method()
+    return None

--- a/torchrec/distributed/planner/estimator/config.py
+++ b/torchrec/distributed/planner/estimator/config.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Hardware Performance Configuration.
+
+This module contains:
+- EmbeddingPerfEstimatorConfig: Default  configuration with coefficients
+For custom hardware configurations, extend EmbeddingPerfEstimatorConfig or
+HardwarePerfConfig and use decorators from annotations.py.
+"""
+
+from torchrec.distributed.planner.constants import (
+    BWD_COMPUTE_MULTIPLIER,
+    DEFAULT_PERF_ESTIMATOR,
+    WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
+    WEIGHTED_KERNEL_MULTIPLIER,
+)
+
+# Import factory from estimator module to avoid circular import
+# Note: This import must be after types imports
+from torchrec.distributed.planner.estimator.estimator import (
+    EmbeddingPerfEstimatorFactory,
+)
+from torchrec.distributed.planner.estimator.types import (  # noqa: F401
+    EstimatorPerfCoefficients,
+    HardwarePerfConfig,
+    PerfCoefficient,
+    PerfCoefficientConfig,
+)
+
+
+# =============================================================================
+# Default  Configuration
+# =============================================================================
+
+# Shared coefficients for sharding types with block usage penalty (TABLE_WISE, COLUMN_WISE)
+_TABLE_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
+    fwd=PerfCoefficient(
+        input_read_size_multiplier=1.0,
+        lookup_size_multiplier=1.0,
+        embedding_output_multiplier=1.0,
+        hash_size_multiplier=0.0,  #  doesn't use hash_size
+    ),
+    bwd=PerfCoefficient(
+        input_read_size_multiplier=1.0,
+        lookup_size_multiplier=1.0,
+        embedding_output_multiplier=1.0,
+        hash_size_multiplier=0.0,
+    ),
+)
+
+# Shared coefficients for sharding types without block usage penalty (ROW_WISE, TABLE_ROW_WISE)
+_ROW_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
+    fwd=PerfCoefficient(
+        input_read_size_multiplier=1.0,
+        lookup_size_multiplier=1.0,
+        embedding_output_multiplier=1.0,
+        hash_size_multiplier=0.0,
+    ),
+    bwd=PerfCoefficient(
+        input_read_size_multiplier=1.0,
+        lookup_size_multiplier=1.0,
+        embedding_output_multiplier=0.0,
+        hash_size_multiplier=0.0,
+    ),
+)
+
+
+@EmbeddingPerfEstimatorFactory.register(DEFAULT_PERF_ESTIMATOR)
+class EmbeddingPerfEstimatorConfig(HardwarePerfConfig):
+    """
+    Default  EmbeddingPerfEstimator configuration.
+
+    This configuration matches   EmbeddingPerfEstimator formulas:
+    - All coefficients are 1.0 (no hardware-specific tuning)
+    - Block usage penalty is enabled for TABLE_WISE/COLUMN_WISE sharding
+    - Uses topology bandwidth values (HBM, DDR, etc.) from base class
+
+    Block usage penalty ( TABLE_WISE only):
+        - emb_dim >= 128: 1.0 (no penalty)
+        - emb_dim >= 64:  1.15 (HALF_BLOCK_PENALTY)
+        - emb_dim >= 32:  1.75 (QUARTER_BLOCK_PENALTY)
+
+    Usage:
+        # Use directly
+        config = EmbeddingPerfEstimatorConfig()
+
+        # Or extend for custom hardware with bandwidth override
+        @hbm_mem_bw(2400 * 1024 * 1024 * 1024 / 1000)
+        class MyHardwareConfig(EmbeddingPerfEstimatorConfig):
+            pass
+    """
+
+    # =========================================================================
+    # Default  Coefficients
+    # Bandwidth values are inherited from HardwarePerfConfig base class
+    # =========================================================================
+    coefficients: PerfCoefficientConfig = PerfCoefficientConfig(
+        # TABLE_WISE sharding (includes COLUMN_WISE, TABLE_COLUMN_WISE)
+        # uses block_usage_penalty for these sharding types
+        table_wise=_TABLE_WISE_COEFFICIENTS,
+        column_wise=_TABLE_WISE_COEFFICIENTS,  # Same as TABLE_WISE
+        # ROW_WISE sharding
+        # does NOT use block_usage_penalty for ROW_WISE
+        row_wise=_ROW_WISE_COEFFICIENTS,
+        # TABLE_ROW_WISE sharding (includes GRID_SHARD)
+        # does NOT use block_usage_penalty for TABLE_ROW_WISE
+        table_row_wise=_ROW_WISE_COEFFICIENTS,  # Same as ROW_WISE
+        # DATA_PARALLEL sharding
+        # does NOT use block_usage_penalty for DATA_PARALLEL
+        data_parallel=_ROW_WISE_COEFFICIENTS,  # Same as ROW_WISE
+        # Compute multipliers
+        bwd_compute_multiplier=BWD_COMPUTE_MULTIPLIER,  # 2.0
+        weighted_kernel_multiplier=WEIGHTED_KERNEL_MULTIPLIER,  # 1.1
+        weighted_feature_bwd_compute_multiplier=WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,  # 1.0
+    )

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1,0 +1,1884 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Embedding Performance Estimator with Evaluator Pattern.
+This module contains
+- EmbeddingShardingPerfEvaluator: Base class with the strategy pattern
+- Evaluator implementations for each sharding type
+- EmbeddingPerfEstimatorFactory: Factory for creating estimators
+- EmbeddingPerfEstimator: Main estimator class
+"""
+
+import logging
+import math
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, List, Optional, Type
+
+from torch import nn
+from torchrec.distributed.planner.constants import (
+    BATCHED_COPY_PERF_FACTOR,
+    DP_ELEMENTWISE_KERNELS_PERF_FACTOR,
+    FULL_BLOCK_EMB_DIM,
+    HALF_BLOCK_PENALTY,
+    QUARTER_BLOCK_PENALTY,
+)
+from torchrec.distributed.planner.estimator.annotations import get_output_write_size
+from torchrec.distributed.planner.estimator.types import (
+    HardwarePerfConfig,
+    ShardPerfContext,
+)
+from torchrec.distributed.planner.types import (
+    CollectiveType,
+    ParameterConstraints,
+    Perf,
+    ShardingOption,
+    Topology,
+)
+from torchrec.distributed.planner.utils import sharder_name
+from torchrec.distributed.types import ModuleSharder, ShardingType
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# EmbeddingPerfShardingEvaluator Base Class
+# =============================================================================
+
+
+class EmbeddingShardingPerfEvaluator(ABC):
+    """
+    #TODO: override for inference cases later
+    This class is the base class for all sharding type evaluators.
+    """
+
+    # =========================================================================
+    # Composable Communication Primitives
+    # =========================================================================
+
+    def _compute_collective_comms(
+        self,
+        ctx: ShardPerfContext,
+        output_size: float,
+        collective_type: CollectiveType,
+        world_size: int,
+        local_world_size: int,
+    ) -> float:
+        """
+        Compute communication time for a single collective operation.
+
+        This is the fundamental building block for all communication calculations.
+        Strategies can compose this to build complex communication patterns.
+
+        Args:
+            ctx: Shard performance context
+            output_size: Size of data to communicate in bytes
+            collective_type: Type of collective (ALL_TO_ALL, REDUCE_SCATTER, ALL_GATHER, ALL_REDUCE)
+            world_size: World size for the collective
+            local_world_size: Local world size for bandwidth lookup
+
+        Returns:
+            Communication time in seconds
+        """
+        assert ctx.comms_bandwidths is not None
+
+        comms_bw = ctx.comms_bandwidths.get_bw(
+            world_size=world_size,
+            local_world_size=local_world_size,
+            collective_type=collective_type,
+        )
+
+        assert comms_bw > 0, f"Invalid comms bw: {comms_bw}"
+
+        return output_size / comms_bw
+
+    def _compute_batched_copy(
+        self,
+        ctx: ShardPerfContext,
+        config: HardwarePerfConfig,
+        output_size: float,
+    ) -> float:
+        """
+        Compute batched copy time (used by ROW_WISE and TABLE_ROW_WISE backward).
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+            output_size: Size of data to copy in bytes
+
+        Returns:
+            Batched copy time in seconds
+        """
+        device_bw = self._get_device_bw(ctx, config)
+        assert device_bw > 0, f"Invalid device bw: {device_bw}"
+        return output_size * BATCHED_COPY_PERF_FACTOR / device_bw
+
+    def _compute_single_level_comms(
+        self,
+        ctx: ShardPerfContext,
+        output_size: float,
+        collective_type: CollectiveType,
+    ) -> float:
+        """
+        Compute communication time for a single-level collective (world-wide).
+
+        This is used by TABLE_WISE (A2A) and ROW_WISE (RS/AG) strategies.
+
+        Args:
+            ctx: Shard performance context
+            output_size: Size of data to communicate in bytes
+            collective_type: Type of collective
+
+        Returns:
+            Communication time in seconds
+        """
+        return self._compute_collective_comms(
+            ctx=ctx,
+            output_size=output_size,
+            collective_type=collective_type,
+            world_size=ctx.world_size,
+            local_world_size=ctx.local_world_size,
+        )
+
+    def _compute_two_level_comms(
+        self,
+        ctx: ShardPerfContext,
+        output_size: float,
+        intra_collective: CollectiveType,
+        inter_collective: CollectiveType,
+    ) -> float:
+        """
+        Compute communication time for a two-level hierarchical collective.
+
+        This is used by TABLE_ROW_WISE which has:
+        - Intra-host collective (within a node)
+        - Inter-host collective (across nodes)
+
+        Args:
+            ctx: Shard performance context
+            output_size: Size of data to communicate in bytes
+            intra_collective: Collective type for intra-host communication
+            inter_collective: Collective type for inter-host communication
+
+        Returns:
+            Total communication time (intra + inter) in seconds
+        """
+
+        # Intra-host communication
+        intra_comms = self._compute_collective_comms(
+            ctx=ctx,
+            output_size=output_size,
+            collective_type=intra_collective,
+            world_size=ctx.local_world_size,
+            local_world_size=ctx.local_world_size,
+        )
+
+        # Inter-host communication
+        inter_comms = self._compute_collective_comms(
+            ctx=ctx,
+            output_size=output_size,
+            collective_type=inter_collective,
+            world_size=ctx.num_hosts,
+            local_world_size=1,
+        )
+
+        return intra_comms + inter_comms
+
+    # =========================================================================
+    # Bandwidth Getters
+    # =========================================================================
+
+    def _get_device_bw(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Get device bandwidth, preferring config annotation if set.
+
+        Priority:
+        1. config.device_bw (if annotated via @device_bw decorator)
+        2. ctx.device_bw (computed from topology via kernel_bw_lookup)
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Device bandwidth in bytes/second
+        """
+        if config.device_bw is not None:
+            return config.device_bw
+        return ctx.device_bw
+
+    def _get_hbm_to_ddr_mem_bw(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Get HBM-to-DDR bandwidth, preferring config annotation if set.
+
+        Priority:
+        1. config.hbm_to_ddr_mem_bw (if annotated via @hbm_to_ddr_mem_bw decorator)
+        2. ctx.hbm_to_ddr_mem_bw (from topology)
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            HBM-to-DDR bandwidth in bytes/second
+        """
+        if config.hbm_to_ddr_mem_bw is not None:
+            return config.hbm_to_ddr_mem_bw
+        return ctx.hbm_to_ddr_mem_bw
+
+    def _get_intra_host_bw(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Get intra-host bandwidth, preferring config annotation if set.
+
+        Priority:
+        1. config.intra_host_bw (if annotated via @intra_host_bw decorator)
+        2. ctx.intra_host_bw (from topology)
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Intra-host bandwidth in bytes/second
+        """
+        if config.intra_host_bw is not None:
+            return config.intra_host_bw
+        return ctx.intra_host_bw
+
+    def _get_inter_host_bw(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Get inter-host bandwidth, preferring config annotation if set.
+
+        Priority:
+        1. config.inter_host_bw (if annotated via @inter_host_bw decorator)
+        2. ctx.inter_host_bw (from topology)
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Inter-host bandwidth in bytes/second
+        """
+        if config.inter_host_bw is not None:
+            return config.inter_host_bw
+        return ctx.inter_host_bw
+
+    # =========================================================================
+    # Custom method invocation helper
+    # =========================================================================
+
+    def execute_custom_fn(
+        self,
+        config: HardwarePerfConfig,
+        method_name: str,
+        custom_flag_attr: str,
+        ctx: ShardPerfContext,
+        check_sharding_type: bool = True,
+    ) -> Optional[float]:
+        """
+        This is a generalized helper for checking and invoking custom methods
+        decorated with annotations like @compute_fwd, @compute_bwd, @fwd_comms, etc.
+
+        Args:
+            config: Hardware performance configuration
+            method_name: Name of the method to look for (e.g., "compute_fwd")
+            custom_flag_attr: Attribute name that marks this as a custom method
+                             (e.g., "_is_custom_forward_compute")
+            ctx: Shard performance context
+            check_sharding_type: Whether to check if method applies to current sharding type
+
+        Returns:
+            Result from custom method if it exists and applies, None otherwise
+        """
+        compute_method = getattr(config, method_name, None)
+        if compute_method and getattr(compute_method, custom_flag_attr, False):
+            if check_sharding_type:
+                custom_sharding_type = getattr(
+                    compute_method, "_custom_sharding_type", None
+                )
+                if custom_sharding_type is not None:
+                    # Handle list/tuple of sharding types
+                    if isinstance(custom_sharding_type, (list, tuple)):
+                        if ctx.sharding_type.lower() not in [
+                            st.lower() for st in custom_sharding_type
+                        ]:
+                            return None
+                    elif custom_sharding_type.lower() != ctx.sharding_type.lower():
+                        return None
+            return compute_method(ctx)
+        return None
+
+    # =========================================================================
+    # Batch inputs helpers
+    # =========================================================================
+
+    def get_batch_inputs(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Get batch inputs (number of indices to lookup per batch) adjusted for sharding.
+
+        This is computed as: batch_size * pooling_factor / divisor
+        where divisor depends on sharding type:
+        - TABLE_WISE: 1 (each device handles all lookups for its tables)
+        - ROW_WISE: world_size (lookups split across all devices)
+        - TABLE_ROW_WISE: local_world_size (lookups split within host)
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration (unused, kept for API consistency)
+
+        Returns:
+            Effective batch inputs for this shard
+        """
+        divisor = self.get_batch_inputs_divisor(ctx)
+        assert divisor > 0, f"Invalid divisor: {divisor}"
+        return ctx.batch_inputs / divisor
+
+    def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
+        """
+        Get the divisor for batch_inputs based on sharding type.
+
+        Override in subclasses that need dynamic divisors (e.g., ROW_WISE uses world_size).
+        Returns:
+            Divisor value
+        """
+        return 1
+
+    # =========================================================================
+    # Prefetch helpers
+    # =========================================================================
+
+    def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
+        """
+        Get divisor for prefetch compute based on sharding type.
+
+        Override in subclasses. Default is 1 (no division).
+
+        Args:
+            ctx: Shard performance context (unused in base class, but available for subclass overrides)
+        """
+        return 1
+
+    # =========================================================================
+    # Forward compute
+    # =========================================================================
+
+    def compute_fwd_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute forward pass time.
+
+        This checks if the config has a custom forward_compute method (via @forward_compute
+        decorator). If so, use it. Otherwise, use the default coefficient-based formula.
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Forward compute time in seconds
+        """
+        # Check for custom forward compute method via @compute_fwd annotation
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_fwd",
+            "_is_custom_forward_compute",
+            ctx,
+            check_sharding_type=True,
+        )
+        if custom_result is not None:
+            return custom_result
+
+        return self._default_fwd_comp(ctx, config)
+
+    def _default_fwd_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default forward using coefficient-based formula.
+
+        Formula:
+            fwd_compute = (input_read_size * input_read_size_multiplier
+                          + embedding_lookup_size * lookup_size_multiplier
+                          + fwd_output_write_size * embedding_output_multiplier
+                          + hash_size * hash_size_multiplier)
+                          * block_usage_penalty / device_bw
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Forward compute time in seconds
+        """
+        device_bw = self._get_device_bw(ctx, config)
+
+        # Get coefficients for this sharding type
+        coefficients = config.get_coefficients_for_sharding(
+            ctx.sharding_type, ctx.compute_kernel
+        )
+        fwd_coeff = coefficients.fwd
+        # Compute block usage penalty based on strategy
+        block_penalty = (
+            compute_block_usage_penalty(ctx.emb_dim)
+            if self.use_block_usage_penalty(config)
+            else 1.0
+        )
+
+        # Compute raw sizes
+        input_read_size = self._get_input_read_size(ctx=ctx, config=config)
+        embedding_lookup_size = self._get_embedding_lookup_size(
+            ctx=ctx, use_min_dim=self.use_min_dim_for_lookup(config)
+        )
+
+        # Check for custom output_write_size method from config (via @output_write_size decorator)
+        custom_output_write_size_fn = get_output_write_size(config, ctx.sharding_type)
+        if custom_output_write_size_fn:
+            fwd_output_write_size = custom_output_write_size_fn(ctx, is_fwd=True)
+        else:
+            fwd_output_write_size = self._get_output_write_size(
+                ctx, self._get_comm_data_type_size(ctx, is_fwd=True)
+            )
+
+        # Apply coefficients
+        compute_size = (
+            fwd_coeff.input_read_size_multiplier * input_read_size
+            + fwd_coeff.lookup_size_multiplier * embedding_lookup_size
+            + fwd_coeff.embedding_output_multiplier * fwd_output_write_size
+            + fwd_coeff.hash_size_multiplier * ctx.hash_size
+        )
+
+        return compute_size * block_penalty / device_bw
+
+    def use_min_dim_for_lookup(self, config: HardwarePerfConfig) -> bool:
+        """
+        Whether to use max(emb_dim, 32) for embedding lookup size.
+
+        TABLE_WISE returns True for kernel efficiency. Other strategies return False.
+        Can be overridden via @use_min_dim_for_lookup annotation on HardwarePerfConfig.
+        """
+        return getattr(config, "_use_min_dim_for_lookup", False)
+
+    def use_block_usage_penalty(self, config: HardwarePerfConfig) -> bool:
+        """
+        Whether to apply block usage penalty to fwd_compute.
+
+        TABLE_WISE returns True per OSS. Other strategies return False.
+        Can be overridden via @use_block_usage_penalty annotation on HardwarePerfConfig.
+        """
+        return getattr(config, "_use_block_usage_penalty", False)
+
+    # =========================================================================
+    # Backward compute
+    # =========================================================================
+    def compute_bwd_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute backward pass compute time.
+
+        This checks if the config has a custom backward_compute method (via @backward_compute
+        decorator). If so, use it. Otherwise, use the default formula.
+
+        Default formula:
+            bwd_compute = fwd_compute * bwd_compute_multiplier
+            if is_weighted: bwd_compute *= weighted_feature_bwd_compute_multiplier
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Backward compute time in seconds (includes bwd_grad_indice_weights_kernel)
+        """
+        # Check for custom backward compute method via @backward_compute annotation
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_bwd",
+            "_is_custom_backward_compute",
+            ctx,
+            check_sharding_type=True,
+        )
+        if custom_result is not None:
+            return custom_result
+
+        return self._default_bwd_comp(ctx, config)
+
+    def _default_bwd_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default backward compute - supports both OSS and FB formulas.
+
+        Two approaches based on coefficient configuration:
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Backward compute time in seconds
+        """
+        coeffs = config.get_coefficients_for_sharding(
+            ctx.sharding_type, ctx.compute_kernel
+        )
+        bwd_coeff = coeffs.bwd
+
+        # Calculate sizes (same as fwd but may use different coefficients)
+        # Use getter methods for sharding-specific data sizes
+
+        input_read_size = self._get_input_read_size(ctx=ctx, config=config)
+        embedding_lookup_size = self._get_embedding_lookup_size(ctx=ctx)
+
+        # Check for custom output_write_size method from config (via @output_write_size decorator)
+        custom_output_write_size_fn = get_output_write_size(config, ctx.sharding_type)
+        if custom_output_write_size_fn:
+            output_write_size = custom_output_write_size_fn(ctx, is_fwd=False)
+        else:
+            output_write_size = self._get_output_write_size(
+                ctx, data_type_size=self._get_comm_data_type_size(ctx, is_fwd=False)
+            )
+
+        fwd_compute = self._default_fwd_comp(ctx=ctx, config=config)
+        if config.name == "default":
+            bwd_compute = fwd_compute * config.coefficients.bwd_compute_multiplier
+        else:
+            device_bw = self._get_device_bw(ctx=ctx, config=config)
+            compute_size = (
+                bwd_coeff.input_read_size_multiplier * input_read_size
+                + bwd_coeff.lookup_size_multiplier * embedding_lookup_size
+                + bwd_coeff.embedding_output_multiplier * output_write_size
+                + bwd_coeff.hash_size_multiplier * ctx.hash_size
+            )
+            bwd_compute = compute_size / device_bw
+
+        # Add bwd_grad_indice_weights_kernel for weighted features
+        bwd_grad_indice_weights_kernel = self._compute_bwd_grad_indice_weights_kernel(
+            fwd_compute, ctx, config
+        )
+        # Apply weighted feature multiplier if applicable
+        if ctx.is_weighted:
+            bwd_compute = (
+                bwd_compute
+                * config.coefficients.weighted_feature_bwd_compute_multiplier
+            )
+
+        return bwd_compute + bwd_grad_indice_weights_kernel
+
+    def _get_embedding_lookup_size(
+        self, ctx: ShardPerfContext, use_min_dim: bool = False
+    ) -> float:
+        """
+        Get embedding lookup size based on sharding type.
+
+        Args:
+            ctx: Shard performance context
+            use_min_dim: If True, use max(emb_dim, 32) for kernel alignment (TABLE_WISE)
+
+        Returns:
+            Embedding lookup size in bytes.
+        """
+
+        emb_dim = max(ctx.emb_dim, 32) if use_min_dim else ctx.emb_dim
+        return ctx.batch_inputs * ctx.world_size * emb_dim * ctx.table_data_type_size
+
+    def _get_output_write_size(
+        self, ctx: ShardPerfContext, data_type_size: float
+    ) -> float:
+        """
+        Get output write size for the given data type.
+
+        Args:
+            ctx: Shard performance context
+            data_type_size: Data type size in bytes
+
+        Returns:
+            Output write size in bytes.
+        """
+        return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * data_type_size
+
+    def _get_comm_data_type_size(
+        self, ctx: ShardPerfContext, is_fwd: bool = True
+    ) -> float:
+        """
+        Get communication data type size for forward or backward pass.
+
+        Default uses A2A comm data type. ROW_WISE/TABLE_ROW_WISE override
+        to use SR comm data type.
+
+        Args:
+            ctx: Shard performance context
+            is_fwd: If True, return forward comm data type; else backward
+
+        Returns:
+            Data type size in bytes.
+        """
+        if is_fwd:
+            return ctx.fwd_a2a_comm_data_type_size
+        return ctx.bwd_a2a_comm_data_type_size
+
+    def _get_input_read_size(
+        self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
+    ) -> float:
+        """
+        Get input read size.
+
+        Default includes world_size multiplier. DATA_PARALLEL overrides
+        to NOT use world_size.
+
+        The config can control whether to use bytes or counts via
+        @use_bytes_for_input_read_size decorator:
+        - True (default/OSS): size = batch_inputs * world_size * input_data_type_size
+        - False (FB legacy): size = batch_inputs * world_size (count of indices)
+        """
+        use_bytes = (
+            self.use_bytes_for_input_read_size(config)
+            if config is not None
+            else True  # Default to OSS behavior (bytes)
+        )
+
+        if use_bytes:
+            size = math.ceil(
+                ctx.batch_inputs * ctx.world_size * ctx.input_data_type_size
+            )
+        else:
+            # FB legacy: use count of indices, not bytes
+            size = math.ceil(ctx.batch_inputs * ctx.world_size)
+
+        if ctx.is_weighted:
+            size *= 2
+        return size
+
+    def use_bytes_for_input_read_size(self, config: HardwarePerfConfig) -> bool:
+        """
+        Whether to multiply input_read_size by input_data_type_size.
+
+        Default is True (OSS behavior - calculate in bytes).
+        Can be overridden via @use_bytes_for_input_read_size(False) annotation on HardwarePerfConfig.
+        """
+        return getattr(config, "_use_bytes_for_input_read_size", True)
+
+    def _compute_bwd_grad_indice_weights_kernel(
+        self, compute_value: float, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute backward gradient indice weights kernel time.
+
+        For weighted features (e.g., id-score lists), there's an additional
+        kernel that computes gradients for the indice weights.
+
+        OSS Formula:
+            bwd_grad_indice_weights_kernel = fwd_compute * WEIGHTED_KERNEL_MULTIPLIER
+            (only if is_weighted is True)
+
+        Args:
+            fwd_compute: Forward compute time
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Backward gradient indice weights kernel time in seconds
+        """
+
+        if ctx.is_weighted:
+            return compute_value * config.coefficients.weighted_kernel_multiplier
+        return 0.0
+
+    # =========================================================================
+    # Prefetch compute
+    # =========================================================================
+
+    def compute_prefetch_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute prefetch/cache loading time.
+
+        This checks if the config has a custom prefetch_compute method (via @prefetch_compute
+        decorator). If so, use it. Otherwise, use the default formula.
+
+        OSS Formula:
+            prefetch_bytes = expected_cache_fetches * emb_dim * table_data_type_size
+            prefetch_compute = prefetch_bytes / hbm_to_ddr_mem_bw
+
+        For ROW_WISE: expected_cache_fetches /= world_size
+        For TABLE_ROW_WISE: expected_cache_fetches /= local_world_size
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Prefetch compute time in seconds
+        """
+        # Check for custom prefetch compute method via @prefetch_compute annotation
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_prefetch",
+            "_is_custom_prefetch_compute",
+            ctx,
+            check_sharding_type=False,
+        )
+        if custom_result is not None:
+            return custom_result
+        # Default implementation
+        return self._default_prefetch_comp(ctx, config)
+
+    def _default_prefetch_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default prefetch compute with support for both OSS and FB hardware formulas.
+        The prefetch_divisor varies by sharding type:
+        - TABLE_WISE: 1 (no division)
+        - ROW_WISE: world_size
+        - TABLE_ROW_WISE: local_world_size
+
+        For linear regression (FB hardware):
+            prefetch_time = (
+                expected_num_lookups_coefficient * expected_lookups +
+                expected_num_unique_lookups_coefficient * expected_unique_lookups +
+                expected_size_cache_fetches_coefficient * prefetch_bytes
+            )
+            where prefetch_bytes = expected_cache_fetches * emb_dim (NO table_data_type_size!)
+
+        For default (OSS):
+            prefetch_time = prefetch_bytes / hbm_to_ddr_mem_bw
+            where prefetch_bytes = expected_cache_fetches * emb_dim * table_data_type_size
+        """
+
+        # Apply prefetch divisor based on sharding type
+        prefetch_divisor = self.get_prefetch_divisor(ctx)
+
+        # Get expected cache fetches with divisor applied
+        expected_cache_fetches = ctx.expected_cache_fetches
+        if prefetch_divisor > 0:
+            expected_cache_fetches = expected_cache_fetches / prefetch_divisor
+
+        # Check if linear regression mode is enabled (FB hardware estimators)
+        # If prefetch coefficients are defined and lookup data is available, use linear regression
+        prefetch_coeffs = config.coefficients.prefetch
+        if (
+            prefetch_coeffs
+            and ctx.expected_lookups is not None
+            and ctx.expected_unique_lookups is not None
+        ):
+            # Apply divisor to lookups as well
+            expected_lookups = ctx.expected_lookups
+            expected_unique_lookups = ctx.expected_unique_lookups
+            if prefetch_divisor > 0:
+                expected_lookups = expected_lookups / prefetch_divisor
+                expected_unique_lookups = expected_unique_lookups / prefetch_divisor
+
+            # IMPORTANT: For linear regression, prefetch_bytes does NOT include table_data_type_size
+            # This matches the FB hardware estimator implementation (D89929552)
+            prefetch_bytes = expected_cache_fetches * ctx.emb_dim
+
+            return (
+                prefetch_coeffs.expected_num_lookups_coefficient * expected_lookups
+                + prefetch_coeffs.expected_num_unique_lookups_coefficient
+                * expected_unique_lookups
+                + prefetch_coeffs.expected_size_cache_fetches_coefficient
+                * prefetch_bytes
+            )
+        else:
+            # Default OSS formula: prefetch_bytes / hbm_to_ddr_mem_bw
+            # For OSS, prefetch_bytes includes table_data_type_size
+            prefetch_bytes = (
+                expected_cache_fetches * ctx.emb_dim * ctx.table_data_type_size
+            )
+            hbm_to_ddr_bw = self._get_hbm_to_ddr_mem_bw(ctx, config)
+            return prefetch_bytes / hbm_to_ddr_bw if hbm_to_ddr_bw > 0 else 0.0
+
+    # =========================================================================
+    # Communication methods
+    # Check for annotations, then delegate to evaluator-specific implementation
+    # =========================================================================
+
+    def compute_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute forward communication time.
+
+        Checks for @fwd_comms annotation on config first, then uses
+        evaluator-specific implementation.
+
+        Each sharding type has different communication patterns:
+        - TABLE_WISE: All-to-all
+        - ROW_WISE: Reduce-scatter
+        - DATA_PARALLEL: No communication
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Forward communication time in seconds
+        """
+        # Check for custom method via @fwd_comms annotation
+        # Pass sharding_type to allow sharding-type-specific custom methods
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_fwd_comms",
+            "_is_custom_fwd_comms",
+            ctx,
+            check_sharding_type=True,
+        )
+        if custom_result is not None:
+            return custom_result
+
+        return self._default_fwd_comms(ctx, config)
+
+    @abstractmethod
+    def _default_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default forward communication implementation.
+
+        Must be implemented by evaluator subclasses.
+        """
+        pass
+
+    def compute_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute backward communication time.
+
+        Checks for @bwd_comms annotation on config first, then uses
+        evaluator-specific implementation.
+
+        Each sharding type has different communication patterns:
+        - TABLE_WISE: All-to-all
+        - ROW_WISE: All-gather + batched copy
+        - DATA_PARALLEL: All-reduce
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Backward communication time in seconds
+        """
+        # Check for custom method via @bwd_comms annotation
+        # Pass sharding_type to allow sharding-type-specific custom methods
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_bwd_comms",
+            "_is_custom_bwd_comms",
+            ctx,
+            check_sharding_type=True,
+        )
+        if custom_result is not None:
+            return custom_result
+        return self._default_bwd_comms(ctx, config)
+
+    @abstractmethod
+    def _default_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default backward communication implementation.
+
+        Must be implemented by evaluator subclasses.
+        """
+        pass
+
+    # =========================================================================
+    # Input distribution communication
+    # =========================================================================
+
+    def compute_input_dist_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Compute input distribution communication time.
+
+        This checks if the config has a custom input_dist_comms method (via @input_dist_comms
+        decorator). If so, use it. Otherwise, use the default formula.
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Input distribution communication time in seconds
+        """
+        # Check for custom input dist comms method via @input_dist_comms annotation
+        # Pass sharding_type to allow sharding-type-specific custom methods
+        custom_result = self.execute_custom_fn(
+            config,
+            "compute_input_dist_comms",
+            "_is_custom_input_dist_comms",
+            ctx,
+            check_sharding_type=True,
+        )
+
+        if custom_result is not None:
+            return custom_result
+
+        return self._default_input_dist_comms(ctx, config)
+
+    def _default_input_dist_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        """
+        Default input distribution communication formula.
+
+        This is the same for TABLE_WISE, ROW_WISE, and TABLE_ROW_WISE sharding.
+        Only DATA_PARALLEL overrides this to return 0.0.
+
+        Formula from OSS _input_dist_expected_latency:
+        - input_read_size = batch_inputs * world_size * input_data_type_size
+        - Return input_read_size / comms_bw (using ALL_TO_ALL collective)
+
+        Note: OSS has the is_weighted logic in the function but callers DON'T
+        pass is_weighted, so it defaults to False. We match this behavior by
+        NOT applying the weighted multiplier here.
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Input distribution communication time in seconds
+        """
+
+        # Calculate input_read_size WITHOUT the weighted multiplier
+        # (matches OLD estimator _input_dist_expected_latency which is called
+        # without is_weighted parameter, so it defaults to False)
+        #
+        # NOTE: input_dist_comms always uses BYTES since it's about actual data
+        # transfer over the network. The use_bytes_for_input_read_size annotation
+        # only affects compute formulas (fwd_compute, bwd_compute).
+        input_read_size = math.ceil(
+            ctx.batch_inputs * ctx.world_size * ctx.input_data_type_size
+        )
+
+        assert ctx.comms_bandwidths is not None
+
+        comms_bw = ctx.comms_bandwidths.get_bw(
+            world_size=ctx.world_size,
+            local_world_size=ctx.local_world_size,
+            collective_type=CollectiveType.ALL_TO_ALL,
+        )
+        assert comms_bw is not None and comms_bw > 0
+
+        return input_read_size / comms_bw
+
+    # =========================================================================
+    # Main compute_perf method
+    # =========================================================================
+
+    def compute_perf(self, ctx: ShardPerfContext, config: HardwarePerfConfig) -> Perf:
+        """
+        Compute the full performance estimate for a shard.
+
+        This is the main entry point that orchestrates all the compute and
+        communication calculations.
+
+        Args:
+            ctx: Shard performance context
+            config: Hardware performance configuration
+
+        Returns:
+            Perf object with fwd_compute, fwd_comms, bwd_compute, bwd_comms, prefetch_compute
+        """
+
+        fwd_compute = self.compute_fwd_comp(ctx=ctx, config=config)
+        fwd_comms = self.compute_fwd_comms(ctx=ctx, config=config)
+        bwd_compute = self.compute_bwd_comp(ctx=ctx, config=config)
+        bwd_comms = self.compute_bwd_comms(ctx=ctx, config=config)
+        prefetch_compute = self.compute_prefetch_comp(ctx=ctx, config=config)
+
+        # OSS always computes input_dist_comms for applicable sharding types
+        input_dist_comms = self.compute_input_dist_comms(ctx=ctx, config=config)
+
+        return Perf(
+            fwd_compute=fwd_compute,
+            fwd_comms=fwd_comms,
+            bwd_compute=bwd_compute,
+            bwd_comms=bwd_comms,
+            prefetch_compute=prefetch_compute,
+            input_dist_comms=input_dist_comms,
+        )
+
+
+# =============================================================================
+class TableWiseEvaluator(EmbeddingShardingPerfEvaluator):
+    """
+    Evaluator for TABLE_WISE sharding.
+
+    Differences from other strategies:
+    - No batch_inputs division (divisor = 1)
+    - Uses max(emb_dim, 32) for embedding lookup (kernel efficiency)
+    - Uses A2A comm data type
+    - Uses block_usage_penalty
+    - Forward/Backward: All-to-all
+    - Prefetch divisor = 1
+    """
+
+    def use_min_dim_for_lookup(self, config: HardwarePerfConfig) -> bool:
+        return getattr(config, "_use_min_dim_for_lookup", True)
+
+    def use_block_usage_penalty(self, config: HardwarePerfConfig) -> bool:
+        return getattr(config, "_use_block_usage_penalty", True)
+
+    def _default_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        fwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=True)
+        )
+        return self._compute_single_level_comms(
+            ctx=ctx,
+            output_size=fwd_output_write_size,
+            collective_type=CollectiveType.ALL_TO_ALL,
+        )
+
+    def _default_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        bwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
+        )
+        return self._compute_single_level_comms(
+            ctx=ctx,
+            output_size=bwd_output_write_size,
+            collective_type=CollectiveType.ALL_TO_ALL,
+        )
+
+
+class RowWiseEvaluator(EmbeddingShardingPerfEvaluator):
+    """
+    Evaluator for ROW_WISE sharding.
+
+    Differences from base (TABLE_WISE):
+    - batch_inputs divided by world_size
+    - Uses SR comm data type (if pooled) instead of A2A
+    - No block_usage_penalty
+    - Forward: Reduce-scatter, Backward: All-gather + batched_copy
+    - Prefetch divided by world_size
+    """
+
+    def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
+        return ctx.world_size
+
+    def _get_input_read_size(
+        self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
+    ) -> float:
+        """
+        ROW_WISE: input_read_size does NOT multiply by world_size.
+
+        In OLD estimator, batch_inputs is pre-divided by world_size, then multiplied back.
+        The world_size factors cancel out, so input_read_size = raw * input_data_type_size.
+
+        Note: ROW_WISE always uses bytes (input_data_type_size), ignoring the
+        use_bytes_for_input_read_size config flag since legacy behavior was consistent.
+        """
+        size = math.ceil(ctx.batch_inputs * ctx.input_data_type_size)
+        if ctx.is_weighted:
+            size *= 2
+        return size
+
+    def _get_embedding_lookup_size(
+        self, ctx: ShardPerfContext, use_min_dim: bool = False
+    ) -> float:
+        """
+        ROW_WISE: embedding_lookup_size does NOT multiply by world_size.
+
+        In OLD estimator, batch_inputs is pre-divided by world_size, then multiplied back.
+        The world_size factors cancel out.
+        """
+        return ctx.batch_inputs * ctx.emb_dim * ctx.table_data_type_size
+
+    def _get_output_write_size(
+        self, ctx: ShardPerfContext, data_type_size: float
+    ) -> float:
+        """
+        ROW_WISE: output_write_size calculation.
+
+        For pooled: batch_outputs * world_size * emb_dim * data_type_size
+        For non-pooled (sequence): batch_outputs * emb_dim * data_type_size (NO world_size)
+
+        Explanation:
+        In OLD estimator, batch_inputs is pre-divided by world_size for ROW_WISE:
+          batch_inputs = raw / world_size
+          batch_outputs = (pooled) sum(...) or (non-pooled) batch_inputs = raw / world_size
+          output_write_size = batch_outputs * world_size * emb_dim * data_type_size
+
+        For pooled: (sum(...)) * world_size * ... (world_size stays)
+        For non-pooled: (raw / world_size) * world_size * ... = raw * ... (world_size cancels)
+
+        In NEW estimator, batch_inputs/batch_outputs are RAW values, so we need to
+        NOT multiply by world_size for non-pooled to match the cancellation behavior.
+        """
+        if ctx.is_pooled:
+            return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * data_type_size
+        else:
+            # For non-pooled (sequence), world_size factor cancels out in OLD estimator
+            return ctx.batch_outputs * ctx.emb_dim * data_type_size
+
+    def _get_comm_data_type_size(
+        self, ctx: ShardPerfContext, is_fwd: bool = True
+    ) -> float:
+        if is_fwd:
+            return (
+                ctx.fwd_sr_comm_data_type_size
+                if ctx.is_pooled
+                else ctx.fwd_a2a_comm_data_type_size
+            )
+        return (
+            ctx.bwd_sr_comm_data_type_size
+            if ctx.is_pooled
+            else ctx.bwd_a2a_comm_data_type_size
+        )
+
+    def _default_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        fwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=True)
+        )
+        return self._compute_single_level_comms(
+            ctx=ctx,
+            output_size=fwd_output_write_size,
+            collective_type=CollectiveType.REDUCE_SCATTER,
+        )
+
+    def _default_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        # All-gather
+        bwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
+        )
+        bwd_comms = self._compute_single_level_comms(
+            ctx=ctx,
+            output_size=bwd_output_write_size,
+            collective_type=CollectiveType.ALL_GATHER,
+        )
+
+        # Batched copy (per OSS formula)
+        bwd_batched_copy = self._compute_batched_copy(
+            ctx=ctx,
+            config=config,
+            output_size=bwd_output_write_size,
+        )
+
+        return bwd_comms + bwd_batched_copy
+
+    def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
+        return ctx.world_size
+
+
+class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
+    """
+    Evaluator for TABLE_ROW_WISE sharding.
+
+    Differences from base (TABLE_WISE):
+    - batch_inputs divided by local_world_size
+    - Uses SR comm data type (always, unlike ROW_WISE which checks is_pooled)
+    - No block_usage_penalty
+    - Forward: Reduce-scatter (intra) + All-to-all (inter)
+    - Backward: All-to-all (inter) + All-gather (intra) + batched_copy
+    - Prefetch divided by local_world_size
+    """
+
+    def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
+        return ctx.local_world_size
+
+    def _get_input_read_size(
+        self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
+    ) -> float:
+        """
+        TABLE_ROW_WISE: input_read_size = (raw / local_world_size) * world_size * input_data_type_size.
+
+        This is different from ROW_WISE where world_size cancels out.
+
+        Note: TABLE_ROW_WISE always uses bytes (input_data_type_size), ignoring the
+        use_bytes_for_input_read_size config flag since legacy behavior was consistent.
+        """
+        effective_batch_inputs = ctx.batch_inputs / ctx.local_world_size
+        size = math.ceil(
+            effective_batch_inputs * ctx.world_size * ctx.input_data_type_size
+        )
+        if ctx.is_weighted:
+            size *= 2
+        return size
+
+    def _get_embedding_lookup_size(
+        self, ctx: ShardPerfContext, use_min_dim: bool = False
+    ) -> float:
+        """
+        TABLE_ROW_WISE: embedding_lookup_size = (raw / local_world_size) * world_size * emb_dim * table_data_type_size.
+        """
+        effective_batch_inputs = ctx.batch_inputs / ctx.local_world_size
+        return (
+            effective_batch_inputs
+            * ctx.world_size
+            * ctx.emb_dim
+            * ctx.table_data_type_size
+        )
+
+    def _get_output_write_size(
+        self, ctx: ShardPerfContext, data_type_size: float
+    ) -> float:
+        """
+        TABLE_ROW_WISE: output_write_size uses batch_outputs * world_size * emb_dim.
+
+        This matches the OLD estimator formula exactly.
+        """
+        return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * data_type_size
+
+    def _get_comm_data_type_size(
+        self, ctx: ShardPerfContext, is_fwd: bool = True
+    ) -> float:
+        return (
+            ctx.fwd_sr_comm_data_type_size if is_fwd else ctx.bwd_sr_comm_data_type_size
+        )
+
+    def _default_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        if ctx.comms_bandwidths is None:
+            return 0.0
+
+        fwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=True)
+        )
+
+        # Intra-host: reduce-scatter within the host
+        intra_comms = self._compute_collective_comms(
+            ctx=ctx,
+            output_size=fwd_output_write_size,
+            collective_type=CollectiveType.REDUCE_SCATTER,
+            world_size=ctx.local_world_size,
+            local_world_size=ctx.local_world_size,
+        )
+
+        # Inter-host: all-to-all across hosts (only if num_hosts > 1)
+        inter_comms = 0.0
+        if ctx.num_hosts > 1:
+            # Inter-host uses A2A data type and different output size
+            inter_host_fwd_output_write_size = (
+                ctx.batch_outputs
+                * ctx.num_hosts
+                * ctx.emb_dim
+                * ctx.fwd_a2a_comm_data_type_size
+            )
+            inter_comms = self._compute_collective_comms(
+                ctx=ctx,
+                output_size=inter_host_fwd_output_write_size,
+                collective_type=CollectiveType.ALL_TO_ALL,
+                world_size=ctx.num_hosts,
+                local_world_size=1,
+            )
+
+        return intra_comms + inter_comms
+
+    def _default_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+
+        bwd_output_write_size = self._get_output_write_size(
+            ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
+        )
+
+        # Inter-host: all-to-all across hosts (only if num_hosts > 1)
+        inter_comms = 0.0
+        if ctx.num_hosts > 1:
+
+            # Inter-host uses A2A data type and different output size
+            inter_host_bwd_output_write_size = (
+                ctx.batch_outputs
+                * ctx.num_hosts
+                * ctx.emb_dim
+                * ctx.bwd_a2a_comm_data_type_size
+            )
+            inter_comms = self._compute_collective_comms(
+                ctx=ctx,
+                output_size=inter_host_bwd_output_write_size,
+                collective_type=CollectiveType.ALL_TO_ALL,
+                world_size=ctx.num_hosts,
+                local_world_size=1,
+            )
+
+        # Intra-host: all-gather within the host
+        intra_comms = self._compute_collective_comms(
+            ctx=ctx,
+            output_size=bwd_output_write_size,
+            collective_type=CollectiveType.ALL_GATHER,
+            world_size=ctx.local_world_size,
+            local_world_size=ctx.local_world_size,
+        )
+
+        # Batched copy (same formula as ROW_WISE)
+        bwd_batched_copy = self._compute_batched_copy(
+            ctx=ctx,
+            config=config,
+            output_size=bwd_output_write_size,
+        )
+
+        return inter_comms + intra_comms + bwd_batched_copy
+
+    def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
+        """TABLE_ROW_WISE divides prefetch by local_world_size (per OSS)."""
+        return ctx.local_world_size
+
+
+class DataParallelEvaluator(EmbeddingShardingPerfEvaluator):
+    """
+    Evaluator for DATA_PARALLEL sharding.
+
+    Differences from other strategies:
+    - No batch_inputs multiplication by world_size (local batch only)
+    - Forward: No communication (each device has full table)
+    - Backward: All-reduce of gradients + optimizer kernels
+    - No prefetch compute, no input_dist_comms
+    """
+
+    # =========================================================================
+    # Override size calculations to NOT use world_size (local batch only)
+    # This enables reuse of base class _default_fwd_comp() and _default_bwd_comp()
+    # =========================================================================
+
+    def _get_input_read_size(
+        self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
+    ) -> float:
+        """DATA_PARALLEL: input_read_size without world_size (local batch only)."""
+        size = math.ceil(ctx.batch_inputs * ctx.input_data_type_size)
+        if ctx.is_weighted:
+            size *= 2
+        return size
+
+    def _get_embedding_lookup_size(
+        self, ctx: ShardPerfContext, use_min_dim: bool = False
+    ) -> float:
+        return ctx.batch_inputs * ctx.emb_dim * ctx.table_data_type_size
+
+    def _get_output_write_size(
+        self, ctx: ShardPerfContext, data_type_size: float
+    ) -> float:
+        return ctx.batch_outputs * ctx.emb_dim * ctx.table_data_type_size
+
+    def _default_fwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        return 0
+
+    def _default_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        # Table size (gradient size for all-reduce)
+        table_size = ctx.hash_size * ctx.emb_dim * ctx.table_data_type_size
+
+        # All-reduce: NCCL ring-reduce formula
+        num_nodes = min(ctx.world_size / ctx.local_world_size, 2)
+        comms_bw = (
+            ctx.comms_bandwidths.get_bw(
+                world_size=ctx.world_size,
+                local_world_size=ctx.local_world_size,
+                collective_type=CollectiveType.ALL_REDUCE,
+            )
+            if ctx.comms_bandwidths is not None
+            else None
+        )
+        all_reduce = (
+            table_size * (2 * num_nodes - 1) / num_nodes / comms_bw
+            if comms_bw and comms_bw > 0
+            else 0.0
+        )
+
+        # Inter-host communication constraint
+        if ctx.world_size > 2 * ctx.local_world_size:
+            all_reduce *= 2
+
+        # Optimizer kernels (SGD + Fill + Binary)
+        device_bw = self._get_device_bw(ctx, config)
+        optimizer_kernels = (
+            table_size * DP_ELEMENTWISE_KERNELS_PERF_FACTOR / device_bw
+            if device_bw > 0
+            else 0.0
+        )
+
+        return all_reduce + optimizer_kernels
+
+    # =========================================================================
+    # Prefetch and Input Dist - not applicable for DATA_PARALLEL
+    # =========================================================================
+
+    def compute_prefetch_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        return 0.0
+
+    def compute_input_dist_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        return 0.0
+
+
+class ColumnWiseEvaluator(TableWiseEvaluator):
+    pass
+
+
+class TableColumnWiseEvaluator(TableWiseEvaluator):
+
+    pass
+
+
+class GridShardEvaluator(TableRowWiseEvaluator):
+
+    pass
+
+
+# =============================================================================
+# EmbeddingPerfEstimator Factory
+# =============================================================================
+
+
+class EmbeddingPerfEstimatorFactory:
+    """
+    Factory for creating hardware-specific EmbeddingPerfEstimator instances.
+
+    This factory maintains a registry of hardware configurations and provides
+    a simple interface to create estimators for different hardware types.
+
+    Usage:
+        # Register a hardware config
+        @EmbeddingPerfEstimatorFactory.register("my_hardware")
+        class MyHardwarePerfConfig(HardwarePerfConfig):
+            ...
+
+        # Create an estimator
+        estimator = EmbeddingPerfEstimatorFactory.create(
+            "my_hardware",
+            is_inference=False,
+        )
+    """
+
+    _registry: Dict[str, Type[HardwarePerfConfig]] = {}
+
+    @classmethod
+    def register(
+        cls, name: str
+    ) -> Callable[[Type[HardwarePerfConfig]], Type[HardwarePerfConfig]]:
+        """
+        Decorator to register a hardware config class.
+
+        Args:
+            name: Name to register the config under (e.g., "grand_teton", "athena")
+
+        Returns:
+            Decorator function that registers the class
+
+        Example:
+            @EmbeddingPerfEstimatorFactory.register("grand_teton")
+            class GrandTetonHardwarePerfConfig(HardwarePerfConfig):
+                ...
+        """
+
+        def decorator(
+            config_cls: Type[HardwarePerfConfig],
+        ) -> Type[HardwarePerfConfig]:
+            cls._registry[name.lower()] = config_cls
+            return config_cls
+
+        return decorator
+
+    @classmethod
+    def create(
+        cls,
+        hardware_name: str,
+        is_inference: bool = False,
+        topology: Optional[Topology] = None,
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> "EmbeddingPerfEstimatorV2":
+        """
+        Create an EmbeddingPerfEstimatorV2 for the specified hardware.
+
+        Args:
+            hardware_name: Name of the registered hardware config
+            is_inference: Whether this is for inference
+            topology: Device topology with bandwidth and world size info
+            constraints: Optional parameter constraints
+            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+                If False (default), uses expected_miss_rate * expected_unique_lookups.
+            use_linear_regression_prefetch_estimate: If True, enables linear regression
+                based prefetch time estimation using hardware-specific coefficients.
+
+        Returns:
+            EmbeddingPerfEstimatorV2 instance configured for the hardware
+
+        Raises:
+            ValueError: If hardware_name is not registered
+        """
+        name_lower = hardware_name.lower()
+        if name_lower not in cls._registry:
+            available = list(cls._registry.keys())
+            raise ValueError(
+                f"Unknown hardware: '{hardware_name}'. "
+                f"Available: {available}. "
+                f"Use 'default' for OSS defaults."
+            )
+
+        config_cls = cls._registry[name_lower]
+        config = config_cls()
+        logger.info(
+            f" EmbeddingPerfEstimatorFactory is creating the Perf Estimator for {hardware_name} "
+        )
+        if topology is None:
+            raise ValueError("topology is required to create EmbeddingPerfEstimatorV2")
+        return EmbeddingPerfEstimatorV2(
+            topology=topology,
+            constraints=constraints,
+            is_inference=is_inference,
+            config=config,
+            use_batch_inputs_for_expected_cache_fetches=use_batch_inputs_for_expected_cache_fetches,
+            use_linear_regression_prefetch_estimate=use_linear_regression_prefetch_estimate,
+        )
+
+    @classmethod
+    def create_with_config(
+        cls,
+        config: HardwarePerfConfig,
+        is_inference: bool = False,
+        topology: Optional[Topology] = None,
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> "EmbeddingPerfEstimatorV2":
+        """
+        Create an EmbeddingPerfEstimatorV2 with a specific config instance.
+
+        This is useful when you need to customize a config at runtime.
+
+        Args:
+            config: HardwarePerfConfig instance
+            is_inference: Whether this is for inference
+            topology: Device topology with bandwidth and world size info
+            constraints: Optional parameter constraints
+            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+                If False (default), uses expected_miss_rate * expected_unique_lookups.
+            use_linear_regression_prefetch_estimate: If True, enables linear regression
+                based prefetch time estimation using hardware-specific coefficients.
+
+        Returns:
+            EmbeddingPerfEstimatorV2 instance
+        """
+        if topology is None:
+            raise ValueError("topology is required to create EmbeddingPerfEstimatorV2")
+        return EmbeddingPerfEstimatorV2(
+            topology=topology,
+            constraints=constraints,
+            is_inference=is_inference,
+            config=config,
+            use_batch_inputs_for_expected_cache_fetches=use_batch_inputs_for_expected_cache_fetches,
+            use_linear_regression_prefetch_estimate=use_linear_regression_prefetch_estimate,
+        )
+
+    @classmethod
+    def list_registered(cls) -> List[str]:
+        """List all registered hardware names."""
+        return list(cls._registry.keys())
+
+    @classmethod
+    def is_registered(cls, name: str) -> bool:
+        """Check if a hardware name is registered."""
+        return name.lower() in cls._registry
+
+
+# =============================================================================
+#  InferencePerfEvaluator
+# =============================================================================
+
+
+class InferenceShardingPerfEvaluator(EmbeddingShardingPerfEvaluator):
+    """
+    Inference sharding performance evaluator.
+
+    Implement common inference behaviour
+        - No backward compute
+        - No backward comms
+        - Inherits forward compute/comms from traning evaluator
+    """
+
+    def compute_bwd_comp(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        return 0.0
+
+    def compute_bwd_comms(
+        self, ctx: ShardPerfContext, config: HardwarePerfConfig
+    ) -> float:
+        return 0.0
+
+
+class TableWiseInferenceEvaluator(InferenceShardingPerfEvaluator, TableWiseEvaluator):
+    # TODO inference perf logic for TW should go here in future, if need more customization
+    pass
+
+
+class RowWiseInferenceEvaluator(InferenceShardingPerfEvaluator, RowWiseEvaluator):
+    pass
+
+
+class TableRowWiseInferenceEvaluator(
+    InferenceShardingPerfEvaluator, TableRowWiseEvaluator
+):
+    pass
+
+
+class ColumnWiseInferenceEvaluator(InferenceShardingPerfEvaluator, ColumnWiseEvaluator):
+    pass
+
+
+class DataParallelInferenceEvaluator(
+    InferenceShardingPerfEvaluator, DataParallelEvaluator
+):
+    pass
+
+
+class TableColumnWiseInferenceEvaluator(
+    InferenceShardingPerfEvaluator, TableColumnWiseEvaluator
+):
+    pass
+
+
+class GridShardInferenceEvaluator(InferenceShardingPerfEvaluator, GridShardEvaluator):
+    pass
+
+
+def compute_block_usage_penalty(embedding_dim: int) -> float:
+    """
+    Compute block usage penalty based on embedding dimension.
+    Args:
+        embedding_dim: Embedding dimension
+
+    Returns:
+        Penalty multiplier (1.0 = no penalty)
+    """
+    if embedding_dim < FULL_BLOCK_EMB_DIM:
+        if embedding_dim >= 64:
+            return HALF_BLOCK_PENALTY
+        else:
+            return QUARTER_BLOCK_PENALTY
+    return 1.0
+
+
+TRAINING_EVALUATORS: Dict[str, EmbeddingShardingPerfEvaluator] = {
+    ShardingType.TABLE_WISE.value: TableWiseEvaluator(),
+    ShardingType.ROW_WISE.value: RowWiseEvaluator(),
+    ShardingType.TABLE_ROW_WISE.value: TableRowWiseEvaluator(),
+    ShardingType.COLUMN_WISE.value: ColumnWiseEvaluator(),
+    ShardingType.DATA_PARALLEL.value: DataParallelEvaluator(),
+    ShardingType.TABLE_COLUMN_WISE.value: TableColumnWiseEvaluator(),
+    ShardingType.GRID_SHARD.value: GridShardEvaluator(),
+}
+
+INFERENCE_EVALUATORS: Dict[str, EmbeddingShardingPerfEvaluator] = {
+    ShardingType.TABLE_WISE.value: TableWiseInferenceEvaluator(),
+    ShardingType.ROW_WISE.value: RowWiseInferenceEvaluator(),
+    ShardingType.TABLE_ROW_WISE.value: TableRowWiseInferenceEvaluator(),
+    ShardingType.COLUMN_WISE.value: ColumnWiseInferenceEvaluator(),
+    ShardingType.DATA_PARALLEL.value: DataParallelInferenceEvaluator(),
+    ShardingType.TABLE_COLUMN_WISE.value: TableColumnWiseInferenceEvaluator(),
+    ShardingType.GRID_SHARD.value: GridShardInferenceEvaluator(),
+}
+
+
+def get_embedding_perf_sharding_evaluator(
+    sharding_type: str, is_inference: bool = False
+) -> EmbeddingShardingPerfEvaluator:
+    """Get the appropriate evaluator for a sharding type.
+
+    Args:
+        sharding_type: The sharding type (e.g., "table_wise", "row_wise")
+        is_inference: Whether this is for inference mode
+
+    Returns:
+        The appropriate evaluator instance
+    """
+    evaluators = INFERENCE_EVALUATORS if is_inference else TRAINING_EVALUATORS
+    return evaluators.get(sharding_type, TableWiseEvaluator())
+
+
+# =============================================================================
+#  EmbeddingPerfEstimatorV2
+# =============================================================================
+
+
+class EmbeddingPerfEstimatorV2:  # TODO rename this later
+    """
+    Embedding Performance Estimator using HardwarePerfConfig.
+    This estimator uses :
+    - ShardPerfContext: Computed sizes and performance parameters
+    - HardwarePerfConfig: Hardware-specific coefficients and compute methods
+    - EmbeddingShardingPerfEvaluator: Sharding-type-specific communication patterns
+
+    Implements ShardEstimator interface for drop-in replacement of EmbeddingPerfEstimator.
+
+    Args:
+        topology: Device topology with bandwidth and world size info
+        constraints: Optional parameter constraints
+        is_inference: Whether this is for inference
+        config: Hardware-specific performance config
+        use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+            is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+            If False (default), uses expected_miss_rate * expected_unique_lookups
+            (from CacheStatistics).
+        use_linear_regression_prefetch_estimate: If True, enables linear regression
+            based prefetch time estimation using hardware-specific coefficients.
+            Also clamps num_unique_lookups to min(num_unique_lookups, batch_inputs, hash_size).
+
+    Example:
+        # Using factory (recommended)
+        estimator = EmbeddingPerfEstimatorFactory.create(
+            "grand_teton",
+            topology=topology,
+        )
+
+        # Using directly with config
+        config = GrandTetonHardwarePerfConfig()
+        estimator = EmbeddingPerfEstimatorV2(
+            topology=topology,
+            config=config,
+        )
+
+        # Drop-in replacement for EmbeddingPerfEstimator
+        estimator = EmbeddingPerfEstimatorFactory.create_default(
+            topology=topology,
+            constraints=constraints,
+        )
+    """
+
+    def __init__(
+        self,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+        is_inference: bool = False,
+        config: Optional[HardwarePerfConfig] = None,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> None:
+        # Note: We don't call super().__init__() because ShardEstimator is an ABC
+        # with abstract __init__ that defines the interface signature
+        self._topology = topology
+        self._constraints = constraints
+        self._is_inference = is_inference
+        self._config = config if config is not None else HardwarePerfConfig()
+        self._use_batch_inputs_for_expected_cache_fetches = (
+            use_batch_inputs_for_expected_cache_fetches
+        )
+        self._use_linear_regression_prefetch_estimate = (
+            use_linear_regression_prefetch_estimate
+        )
+        if self._use_linear_regression_prefetch_estimate:
+            logger.info("use_linear_regression_prefetch_estimate is enabled.")
+
+    @property
+    def config(self) -> HardwarePerfConfig:
+        return self._config
+
+    @property
+    def is_inference(self) -> bool:
+        return self._is_inference
+
+    def estimate(
+        self,
+        sharding_options: List[ShardingOption],
+        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+    ) -> None:
+        """
+        Estimates the wall time of given sharding options
+        Args:
+            sharding_options: List of sharding options to estimate
+            sharder_map: Map of sharder names to sharder instances
+        """
+
+        if not sharder_map:
+            assert not sharding_options, "sharder_map not provided for sharding_options"
+            return
+
+        assert self._topology is not None, "Topology must be set to use estimate method"
+
+        num_feature_processors = 0
+        for sharding_option in sharding_options:
+            # Validate sharding type is supported by this config
+            # (raises ValueError if not supported)
+            self._config.validate_sharding_type(sharding_option.sharding_type)
+
+            sharder_key = sharder_name(type(sharding_option.module[1]))
+            sharder = sharder_map[sharder_key]
+
+            shard_sizes = [shard.size for shard in sharding_option.shards]
+
+            # Build all contexts at once using shard_sizes list
+            # This follows OSS pattern: extract common params ONCE per sharding_option
+            contexts = ShardPerfContext.build_shard_perf_contexts(
+                config=self._config,
+                shard_sizes=shard_sizes,
+                sharding_option=sharding_option,
+                topology=self._topology,
+                constraints=self._constraints,
+                sharder=sharder,
+                is_inference=self._is_inference,
+                use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
+                use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
+            )
+
+            # Update is_weighted from first context (common across all shards)
+            if contexts:
+                sharding_option.is_weighted = contexts[0].is_weighted
+                # Track feature processors
+                if contexts[0].has_feature_processor:
+                    num_feature_processors += 1
+
+            # Compute perf for each context and assign to corresponding shard
+            for shard, ctx in zip(sharding_option.shards, contexts):
+                evaluator = get_embedding_perf_sharding_evaluator(
+                    sharding_type=ctx.sharding_type, is_inference=ctx.is_inference
+                )
+                shard.perf = evaluator.compute_perf(
+                    ctx=ctx,
+                    config=self._config,
+                )
+
+            # Post-process perfs (e.g., uneven sharding adjustment)
+            # This allows configs to apply cross-shard adjustments
+            shard_perfs = [
+                shard.perf for shard in sharding_option.shards if shard.perf is not None
+            ]
+            shard_perfs = self._config.post_process_perfs(
+                shard_perfs=shard_perfs,
+                shard_sizes=shard_sizes,
+                sharding_type=sharding_option.sharding_type,
+                uneven_sharding_perf_multiplier=self._topology.uneven_sharding_perf_multiplier,
+            )
+            for shard, perf in zip(sharding_option.shards, shard_perfs):
+                shard.perf = perf
+
+        logger.info(f"Total {num_feature_processors} feature processor.")

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -38,6 +38,7 @@ from torchrec.distributed.planner.types import (
     CollectiveType,
     ParameterConstraints,
     Perf,
+    ShardEstimator,
     ShardingOption,
     Topology,
 )
@@ -1731,7 +1732,7 @@ def get_embedding_perf_sharding_evaluator(
 # =============================================================================
 
 
-class EmbeddingPerfEstimatorV2:  # TODO rename this later
+class EmbeddingPerfEstimatorV2(ShardEstimator):  # TODO rename this later
     """
     Embedding Performance Estimator using HardwarePerfConfig.
     This estimator uses :

--- a/torchrec/distributed/planner/estimator/tests/test_annotations.py
+++ b/torchrec/distributed/planner/estimator/tests/test_annotations.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the annotations module.
+
+These tests cover the decorators and helper functions used in the estimator package:
+- Coefficient decorators: @fwd_coefficient, @bwd_coefficient, @prefetch_coefficient
+- Helper functions: get_fwd_coefficient, get_bwd_coefficient, get_prefetch_coefficient
+- Other decorators: @device_bw, @output_write_size, @supported_sharding_types
+"""
+
+import unittest
+
+from torchrec.distributed.planner.estimator.annotations import (
+    bwd_coefficient,
+    device_bw,
+    fwd_coefficient,
+    get_bwd_coefficient,
+    get_fwd_coefficient,
+    get_output_write_size,
+    get_prefetch_coefficient,
+    output_write_size,
+    prefetch_coefficient,
+    supported_sharding_types,
+)
+
+
+class FwdCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @fwd_coefficient decorator and get_fwd_coefficient helper."""
+
+    def test_fwd_coefficient_decorator_marks_method(self) -> None:
+        """Test that @fwd_coefficient decorator marks method with correct attributes."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+        method = config.get_table_wise_fwd
+
+        self.assertTrue(hasattr(method, "_is_fwd_coefficient"))
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
+        self.assertEqual(
+            method._coefficient_sharding_type, "table_wise"  # pyre-ignore[16]
+        )
+
+    def test_fwd_coefficient_decorator_with_multiple_sharding_types(self) -> None:
+        """Test @fwd_coefficient decorator with multiple sharding types."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type=["table_wise", "row_wise"])
+            def get_fwd(self) -> object:
+                return {"emb_lookup": 2.0}
+
+        config = TestConfig()
+        method = config.get_fwd
+
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertEqual(
+            method._coefficient_sharding_type,  # pyre-ignore[16]
+            ["table_wise", "row_wise"],
+        )
+
+    def test_fwd_coefficient_decorator_no_sharding_type(self) -> None:
+        """Test @fwd_coefficient decorator with no sharding type (applies to all)."""
+
+        class TestConfig:
+            @fwd_coefficient()
+            def get_fwd_all(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+        method = config.get_fwd_all
+
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertIsNone(method._coefficient_sharding_type)  # pyre-ignore[16]
+
+    def test_get_fwd_coefficient_returns_coefficient_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns the coefficient for matching sharding type."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5, "hash_size": 0.1}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "table_wise")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["emb_lookup"], 1.5)  # pyre-ignore[16]
+
+    def test_get_fwd_coefficient_returns_none_for_non_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns None when sharding type doesn't match."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "row_wise")
+
+        self.assertIsNone(result)
+
+    def test_get_fwd_coefficient_returns_none_when_no_decorator(self) -> None:
+        """Test get_fwd_coefficient returns None when no @fwd_coefficient decorator."""
+
+        class TestConfig:
+            def some_method(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "table_wise")
+
+        self.assertIsNone(result)
+
+    def test_get_fwd_coefficient_matches_any_when_no_sharding_type_specified(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns coefficient when no sharding_type filter."""
+
+        class TestConfig:
+            @fwd_coefficient()  # No sharding_type = matches all
+            def get_fwd_all(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+
+        # Should match any sharding type
+        result_tw = get_fwd_coefficient(config, "table_wise")
+        result_rw = get_fwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(result_tw)
+        self.assertIsNotNone(result_rw)
+
+
+class BwdCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @bwd_coefficient decorator and get_bwd_coefficient helper."""
+
+    def test_bwd_coefficient_decorator_marks_method(self) -> None:
+        """Test that @bwd_coefficient decorator marks method with correct attributes."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 2.0}
+
+        config = TestConfig()
+        method = config.get_row_wise_bwd
+
+        self.assertTrue(hasattr(method, "_is_bwd_coefficient"))
+        self.assertTrue(method._is_bwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
+        self.assertEqual(
+            method._coefficient_sharding_type, "row_wise"  # pyre-ignore[16]
+        )
+
+    def test_get_bwd_coefficient_returns_coefficient_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_bwd_coefficient returns the coefficient for matching sharding type."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 3.0}
+
+        config = TestConfig()
+        result = get_bwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["emb_lookup"], 3.0)  # pyre-ignore[16]
+
+    def test_get_bwd_coefficient_returns_none_for_non_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_bwd_coefficient returns None when sharding type doesn't match."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 3.0}
+
+        config = TestConfig()
+        result = get_bwd_coefficient(config, "table_wise")
+
+        self.assertIsNone(result)
+
+
+class PrefetchCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @prefetch_coefficient decorator and get_prefetch_coefficient helper."""
+
+    def test_prefetch_coefficient_decorator_marks_method(self) -> None:
+        """Test that @prefetch_coefficient decorator marks method correctly."""
+
+        class TestConfig:
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {
+                    "expected_num_lookups_coefficient": 0.5,
+                    "expected_num_unique_lookups_coefficient": 0.3,
+                }
+
+        config = TestConfig()
+        method = config.get_prefetch
+
+        self.assertTrue(hasattr(method, "_is_prefetch_coefficient"))
+        self.assertTrue(method._is_prefetch_coefficient)  # pyre-ignore[16]
+
+    def test_get_prefetch_coefficient_returns_coefficients(self) -> None:
+        """Test get_prefetch_coefficient returns prefetch coefficients."""
+
+        class TestConfig:
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {
+                    "expected_num_lookups_coefficient": 0.5,
+                    "expected_num_unique_lookups_coefficient": 0.3,
+                }
+
+        config = TestConfig()
+        result = get_prefetch_coefficient(config)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+        )
+
+    def test_get_prefetch_coefficient_returns_none_when_no_decorator(self) -> None:
+        """Test get_prefetch_coefficient returns None when no decorator."""
+
+        class TestConfig:
+            def some_method(self) -> object:
+                return {}
+
+        config = TestConfig()
+        result = get_prefetch_coefficient(config)
+
+        self.assertIsNone(result)
+
+
+class DeviceBwDecoratorTest(unittest.TestCase):
+    """Tests for @device_bw class decorator."""
+
+    def test_device_bw_decorator_sets_general_bandwidth(self) -> None:
+        """Test that @device_bw sets general device bandwidth."""
+
+        @device_bw(bandwidth=100.0)
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "device_bw"))
+        self.assertEqual(config.device_bw, 100.0)  # pyre-ignore[16]
+
+    def test_device_bw_decorator_with_specific_device_and_kernel(self) -> None:
+        """Test @device_bw decorator with specific device and compute kernel."""
+
+        @device_bw(bandwidth=200.0, device="cuda", compute_kernel="fused")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "kernel_device_bandwidths"))
+        self.assertIn(
+            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            200.0,
+        )
+
+    def test_device_bw_decorator_stacking(self) -> None:
+        """Test multiple @device_bw decorators can be stacked."""
+
+        @device_bw(bandwidth=200.0, device="cuda", compute_kernel="fused")
+        @device_bw(bandwidth=150.0, device="cuda", compute_kernel="dense")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertIn(
+            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertIn(
+            ("cuda", "dense"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            200.0,
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "dense")],  # pyre-ignore[16]
+            150.0,
+        )
+
+
+class OutputWriteSizeDecoratorTest(unittest.TestCase):
+    """Tests for @output_write_size decorator and get_output_write_size helper."""
+
+    def test_output_write_size_decorator_marks_method(self) -> None:
+        """Test that @output_write_size decorator marks method correctly."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = config.custom_output_write
+
+        self.assertTrue(hasattr(method, "_is_custom_output_write_size"))
+        self.assertTrue(method._is_custom_output_write_size)  # pyre-ignore[16]
+
+    def test_get_output_write_size_returns_method_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_output_write_size returns method for matching sharding type."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = get_output_write_size(config, "table_wise")
+
+        self.assertIsNotNone(method)
+
+    def test_get_output_write_size_returns_none_for_non_matching(self) -> None:
+        """Test get_output_write_size returns None for non-matching sharding type."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = get_output_write_size(config, "row_wise")
+
+        self.assertIsNone(method)
+
+
+class SupportedShardingTypesDecoratorTest(unittest.TestCase):
+    """Tests for @supported_sharding_types class decorator."""
+
+    def test_supported_sharding_types_sets_class_attribute(self) -> None:
+        """Test that @supported_sharding_types sets _supported_sharding_types."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "_supported_sharding_types"))
+        self.assertIn("table_wise", config._supported_sharding_types)  # pyre-ignore[16]
+        self.assertIn("row_wise", config._supported_sharding_types)  # pyre-ignore[16]
+        self.assertNotIn(
+            "column_wise", config._supported_sharding_types  # pyre-ignore[16]
+        )
+
+
+class MultipleCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for configs with multiple coefficient decorators."""
+
+    def test_config_with_both_fwd_and_bwd_coefficients(self) -> None:
+        """Test config that has both fwd and bwd coefficient decorators."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_fwd_table_wise(self) -> object:
+                return {"emb_lookup": 1.0}
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def get_bwd_table_wise(self) -> object:
+                return {"emb_lookup": 2.0}
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def get_fwd_row_wise(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+
+        # Get fwd coefficients
+        fwd_tw = get_fwd_coefficient(config, "table_wise")
+        fwd_rw = get_fwd_coefficient(config, "row_wise")
+        bwd_tw = get_bwd_coefficient(config, "table_wise")
+        bwd_rw = get_bwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(fwd_tw)
+        self.assertEqual(fwd_tw["emb_lookup"], 1.0)  # pyre-ignore[16]
+
+        self.assertIsNotNone(fwd_rw)
+        self.assertEqual(fwd_rw["emb_lookup"], 1.5)  # pyre-ignore[16]
+
+        self.assertIsNotNone(bwd_tw)
+        self.assertEqual(bwd_tw["emb_lookup"], 2.0)  # pyre-ignore[16]
+
+        # No bwd for row_wise
+        self.assertIsNone(bwd_rw)
+
+    def test_config_with_prefetch_and_fwd_coefficients(self) -> None:
+        """Test config that has both fwd and prefetch coefficient decorators."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_fwd(self) -> object:
+                return {"emb_lookup": 1.0}
+
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {"expected_num_lookups_coefficient": 0.5}
+
+        config = TestConfig()
+
+        fwd = get_fwd_coefficient(config, "table_wise")
+        prefetch = get_prefetch_coefficient(config)
+
+        self.assertIsNotNone(fwd)
+        self.assertIsNotNone(prefetch)
+        self.assertEqual(fwd["emb_lookup"], 1.0)  # pyre-ignore[16]
+        self.assertEqual(
+            prefetch["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+        )

--- a/torchrec/distributed/planner/estimator/tests/test_estimator.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the estimator module - main EmbeddingPerfEstimator and evaluators.
+
+Tests the core estimator classes:
+- EmbeddingShardingPerfEvaluator base class methods
+- Sharding-specific evaluators (TableWise, RowWise, etc.)
+- EmbeddingPerfEstimatorFactory registration and creation
+- EmbeddingPerfEstimatorV2 estimate method
+"""
+
+import unittest
+from typing import Optional
+from unittest.mock import MagicMock
+
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.constants import HBM_MEM_BW
+from torchrec.distributed.planner.estimator.annotations import (
+    bwd_coefficient,
+    forward_compute,
+    fwd_coefficient,
+    prefetch_coefficient,
+)
+from torchrec.distributed.planner.estimator.estimator import (
+    ColumnWiseEvaluator,
+    compute_block_usage_penalty,
+    DataParallelEvaluator,
+    EmbeddingPerfEstimatorFactory,
+    EmbeddingPerfEstimatorV2,
+    get_embedding_perf_sharding_evaluator,
+    RowWiseEvaluator,
+    TableRowWiseEvaluator,
+    TableWiseEvaluator,
+    TRAINING_EVALUATORS,
+)
+from torchrec.distributed.planner.estimator.types import (
+    HardwarePerfConfig,
+    PerfCoefficient,
+    PrefetchCoefficients,
+    ShardPerfContext,
+)
+from torchrec.distributed.planner.types import CollectiveType, GeneralizedCommsBandwidth
+from torchrec.distributed.types import ShardingType
+
+
+class MockCommsBandwidth(GeneralizedCommsBandwidth):
+    """Mock bandwidth class for testing."""
+
+    def __init__(self, bw: float = 1000.0) -> None:
+        self._bw = bw
+
+    def get_bw(
+        self,
+        local_world_size: int,
+        world_size: int,
+        collective_type: CollectiveType,
+    ) -> float:
+        return self._bw
+
+    @property
+    def intra_host_bw(self) -> float:
+        return self._bw
+
+    @property
+    def inter_host_bw(self) -> float:
+        return self._bw
+
+
+def create_test_context(
+    sharding_type: str = ShardingType.TABLE_WISE.value,
+    compute_kernel: str = EmbeddingComputeKernel.FUSED.value,
+    hash_size: int = 10000,
+    emb_dim: int = 128,
+    batch_sizes: Optional[list] = None,  # pyre-ignore[24]
+    num_poolings: Optional[list] = None,  # pyre-ignore[24]
+    input_lengths: Optional[list] = None,  # pyre-ignore[24]
+    world_size: int = 8,
+    local_world_size: int = 4,
+    device_bw: float = HBM_MEM_BW,
+    is_pooled: bool = True,
+    is_weighted: bool = False,
+    comms_bw: float = 1000.0,
+) -> ShardPerfContext:
+    """Helper to create a ShardPerfContext for testing."""
+    return ShardPerfContext(
+        sharding_type=sharding_type,
+        compute_kernel=compute_kernel,
+        hash_size=hash_size,
+        emb_dim=emb_dim,
+        batch_sizes=batch_sizes or [64],
+        num_poolings=num_poolings or [1.0],
+        input_lengths=input_lengths or [10.0],
+        world_size=world_size,
+        local_world_size=local_world_size,
+        device_bw=device_bw,
+        hbm_to_ddr_mem_bw=device_bw,
+        is_pooled=is_pooled,
+        is_weighted=is_weighted,
+        comms_bandwidths=MockCommsBandwidth(comms_bw),
+        table_data_type_size=4.0,
+        output_data_type_size=4.0,
+        input_data_type_size=8.0,
+        fwd_a2a_comm_data_type_size=4.0,
+        bwd_a2a_comm_data_type_size=4.0,
+        fwd_sr_comm_data_type_size=4.0,
+        bwd_sr_comm_data_type_size=4.0,
+    )
+
+
+class ComputeBlockUsagePenaltyTest(unittest.TestCase):
+    """Tests for compute_block_usage_penalty helper function."""
+
+    def test_full_block_no_penalty(self) -> None:
+        """Test that emb_dim >= 128 has no penalty."""
+        penalty = compute_block_usage_penalty(128)
+        self.assertEqual(penalty, 1.0)
+        penalty = compute_block_usage_penalty(256)
+        self.assertEqual(penalty, 1.0)
+
+    def test_half_block_penalty(self) -> None:
+        """Test that 64 <= emb_dim < 128 gets half block penalty."""
+        penalty = compute_block_usage_penalty(64)
+        self.assertGreater(penalty, 1.0)
+
+    def test_quarter_block_penalty(self) -> None:
+        """Test that emb_dim < 64 gets quarter block penalty."""
+        penalty = compute_block_usage_penalty(32)
+        self.assertGreater(penalty, compute_block_usage_penalty(64))
+
+
+class GetEmbeddingPerfShardingEvaluatorTest(unittest.TestCase):
+    """Tests for get_embedding_perf_sharding_evaluator function."""
+
+    def test_returns_table_wise_evaluator(self) -> None:
+        """Test that TABLE_WISE returns TableWiseEvaluator."""
+        evaluator = get_embedding_perf_sharding_evaluator(ShardingType.TABLE_WISE.value)
+        self.assertIsInstance(evaluator, TableWiseEvaluator)
+
+    def test_returns_row_wise_evaluator(self) -> None:
+        """Test that ROW_WISE returns RowWiseEvaluator."""
+        evaluator = get_embedding_perf_sharding_evaluator(ShardingType.ROW_WISE.value)
+        self.assertIsInstance(evaluator, RowWiseEvaluator)
+
+    def test_returns_table_row_wise_evaluator(self) -> None:
+        """Test that TABLE_ROW_WISE returns TableRowWiseEvaluator."""
+        evaluator = get_embedding_perf_sharding_evaluator(
+            ShardingType.TABLE_ROW_WISE.value
+        )
+        self.assertIsInstance(evaluator, TableRowWiseEvaluator)
+
+    def test_returns_column_wise_evaluator(self) -> None:
+        """Test that COLUMN_WISE returns ColumnWiseEvaluator."""
+        evaluator = get_embedding_perf_sharding_evaluator(
+            ShardingType.COLUMN_WISE.value
+        )
+        self.assertIsInstance(evaluator, ColumnWiseEvaluator)
+
+    def test_returns_data_parallel_evaluator(self) -> None:
+        """Test that DATA_PARALLEL returns DataParallelEvaluator."""
+        evaluator = get_embedding_perf_sharding_evaluator(
+            ShardingType.DATA_PARALLEL.value
+        )
+        self.assertIsInstance(evaluator, DataParallelEvaluator)
+
+    def test_unknown_sharding_returns_table_wise(self) -> None:
+        """Test that unknown sharding type returns TableWiseEvaluator as default."""
+        evaluator = get_embedding_perf_sharding_evaluator("unknown_sharding")
+        self.assertIsInstance(evaluator, TableWiseEvaluator)
+
+
+class TableWiseEvaluatorTest(unittest.TestCase):
+    """Tests for TableWiseEvaluator."""
+
+    def setUp(self) -> None:
+        self.evaluator = TableWiseEvaluator()
+        self.config = HardwarePerfConfig()
+
+    def test_use_min_dim_for_lookup_default_true(self) -> None:
+        """Test that TABLE_WISE uses min dim for lookup by default."""
+        self.assertTrue(self.evaluator.use_min_dim_for_lookup(self.config))
+
+    def test_use_block_usage_penalty_default_true(self) -> None:
+        """Test that TABLE_WISE uses block usage penalty by default."""
+        self.assertTrue(self.evaluator.use_block_usage_penalty(self.config))
+
+    def test_compute_perf_returns_perf_object(self) -> None:
+        """Test that compute_perf returns a Perf object with all fields."""
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_WISE.value)
+        perf = self.evaluator.compute_perf(ctx, self.config)
+        self.assertIsNotNone(perf)
+        self.assertIsInstance(perf.fwd_compute, float)
+        self.assertIsInstance(perf.bwd_compute, float)
+        self.assertIsInstance(perf.fwd_comms, float)
+        self.assertIsInstance(perf.bwd_comms, float)
+
+    def test_get_batch_inputs_divisor_is_one(self) -> None:
+        """Test that TABLE_WISE batch inputs divisor is 1 (no division)."""
+        ctx = create_test_context()
+        divisor = self.evaluator.get_batch_inputs_divisor(ctx)
+        self.assertEqual(divisor, 1)
+
+    def test_fwd_compute_is_positive(self) -> None:
+        """Test that forward compute time is positive."""
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_WISE.value)
+        fwd_compute = self.evaluator.compute_fwd_comp(ctx, self.config)
+        self.assertGreater(fwd_compute, 0.0)
+
+    def test_bwd_compute_is_positive(self) -> None:
+        """Test that backward compute time is positive."""
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_WISE.value)
+        bwd_compute = self.evaluator.compute_bwd_comp(ctx, self.config)
+        self.assertGreater(bwd_compute, 0.0)
+
+
+class RowWiseEvaluatorTest(unittest.TestCase):
+    """Tests for RowWiseEvaluator."""
+
+    def setUp(self) -> None:
+        self.evaluator = RowWiseEvaluator()
+        self.config = HardwarePerfConfig()
+
+    def test_batch_inputs_divisor_is_world_size(self) -> None:
+        """Test that ROW_WISE divides batch inputs by world_size."""
+        ctx = create_test_context(world_size=8)
+        divisor = self.evaluator.get_batch_inputs_divisor(ctx)
+        self.assertEqual(divisor, 8)
+
+    def test_prefetch_divisor_is_world_size(self) -> None:
+        """Test that ROW_WISE prefetch divisor is world_size."""
+        ctx = create_test_context(world_size=8)
+        divisor = self.evaluator.get_prefetch_divisor(ctx)
+        self.assertEqual(divisor, 8)
+
+    def test_use_min_dim_for_lookup_default_false(self) -> None:
+        """Test that ROW_WISE does not use min dim for lookup by default."""
+        self.assertFalse(self.evaluator.use_min_dim_for_lookup(self.config))
+
+    def test_use_block_usage_penalty_default_false(self) -> None:
+        """Test that ROW_WISE does not use block usage penalty by default."""
+        self.assertFalse(self.evaluator.use_block_usage_penalty(self.config))
+
+    def test_compute_perf_returns_perf_object(self) -> None:
+        """Test that compute_perf returns a Perf object."""
+        ctx = create_test_context(sharding_type=ShardingType.ROW_WISE.value)
+        perf = self.evaluator.compute_perf(ctx, self.config)
+        self.assertIsNotNone(perf)
+
+
+class TableRowWiseEvaluatorTest(unittest.TestCase):
+    """Tests for TableRowWiseEvaluator."""
+
+    def setUp(self) -> None:
+        self.evaluator = TableRowWiseEvaluator()
+        self.config = HardwarePerfConfig()
+
+    def test_batch_inputs_divisor_is_local_world_size(self) -> None:
+        """Test that TABLE_ROW_WISE divides batch inputs by local_world_size."""
+        ctx = create_test_context(world_size=8, local_world_size=4)
+        divisor = self.evaluator.get_batch_inputs_divisor(ctx)
+        self.assertEqual(divisor, 4)
+
+    def test_prefetch_divisor_is_local_world_size(self) -> None:
+        """Test that TABLE_ROW_WISE prefetch divisor is local_world_size."""
+        ctx = create_test_context(world_size=8, local_world_size=4)
+        divisor = self.evaluator.get_prefetch_divisor(ctx)
+        self.assertEqual(divisor, 4)
+
+    def test_compute_perf_returns_perf_object(self) -> None:
+        """Test that compute_perf returns a Perf object."""
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_ROW_WISE.value)
+        perf = self.evaluator.compute_perf(ctx, self.config)
+        self.assertIsNotNone(perf)
+
+
+class ColumnWiseEvaluatorTest(unittest.TestCase):
+    """Tests for ColumnWiseEvaluator."""
+
+    def setUp(self) -> None:
+        self.evaluator = ColumnWiseEvaluator()
+        self.config = HardwarePerfConfig()
+
+    def test_compute_perf_returns_perf_object(self) -> None:
+        """Test that compute_perf returns a Perf object."""
+        ctx = create_test_context(sharding_type=ShardingType.COLUMN_WISE.value)
+        perf = self.evaluator.compute_perf(ctx, self.config)
+        self.assertIsNotNone(perf)
+
+
+class DataParallelEvaluatorTest(unittest.TestCase):
+    """Tests for DataParallelEvaluator."""
+
+    def setUp(self) -> None:
+        self.evaluator = DataParallelEvaluator()
+        self.config = HardwarePerfConfig()
+
+    def test_fwd_comms_is_zero(self) -> None:
+        """Test that DATA_PARALLEL has no forward communication."""
+        ctx = create_test_context(sharding_type=ShardingType.DATA_PARALLEL.value)
+        fwd_comms = self.evaluator._default_fwd_comms(ctx, self.config)
+        self.assertEqual(fwd_comms, 0.0)
+
+    def test_input_dist_comms_is_zero(self) -> None:
+        """Test that DATA_PARALLEL has no input distribution communication."""
+        ctx = create_test_context(sharding_type=ShardingType.DATA_PARALLEL.value)
+        input_dist_comms = self.evaluator.compute_input_dist_comms(ctx, self.config)
+        self.assertEqual(input_dist_comms, 0.0)
+
+    def test_compute_perf_returns_perf_object(self) -> None:
+        """Test that compute_perf returns a Perf object."""
+        ctx = create_test_context(sharding_type=ShardingType.DATA_PARALLEL.value)
+        perf = self.evaluator.compute_perf(ctx, self.config)
+        self.assertIsNotNone(perf)
+
+
+class EmbeddingPerfEstimatorFactoryTest(unittest.TestCase):
+    """Tests for EmbeddingPerfEstimatorFactory."""
+
+    def test_create_unknown_hardware_raises(self) -> None:
+        """Test that creating with unknown hardware raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            EmbeddingPerfEstimatorFactory.create(
+                hardware_name="nonexistent_hardware_xyz",
+                topology=MagicMock(),
+            )
+        self.assertIn("Unknown hardware", str(ctx.exception))
+
+    def test_list_registered(self) -> None:
+        """Test that list_registered returns a list."""
+        registered = EmbeddingPerfEstimatorFactory.list_registered()
+        self.assertIsInstance(registered, list)
+
+    def test_register_hardware(self) -> None:
+        """Test registering a new hardware config."""
+
+        @EmbeddingPerfEstimatorFactory.register("test_hardware_for_unit_test")
+        class TestHardwareConfig(HardwarePerfConfig):
+            name = "test_hardware_for_unit_test"
+
+        self.assertIn(
+            "test_hardware_for_unit_test",
+            EmbeddingPerfEstimatorFactory.list_registered(),
+        )
+
+    def test_create_with_config(self) -> None:
+        """Test creating estimator with a specific config instance."""
+        config = HardwarePerfConfig()
+        config.name = "custom_config"
+        estimator = EmbeddingPerfEstimatorFactory.create_with_config(
+            config=config,
+            topology=MagicMock(),
+        )
+        self.assertIsInstance(estimator, EmbeddingPerfEstimatorV2)
+        self.assertEqual(estimator.config.name, "custom_config")
+
+
+class EmbeddingPerfEstimatorV2Test(unittest.TestCase):
+    """Tests for EmbeddingPerfEstimatorV2."""
+
+    def test_config_property(self) -> None:
+        """Test that config property returns the config."""
+        config = HardwarePerfConfig()
+        config.name = "test_config"
+        estimator = EmbeddingPerfEstimatorV2(
+            topology=MagicMock(),
+            config=config,
+        )
+        self.assertEqual(estimator.config.name, "test_config")
+
+    def test_is_inference_property(self) -> None:
+        """Test is_inference property."""
+        estimator = EmbeddingPerfEstimatorV2(
+            topology=MagicMock(),
+            is_inference=True,
+        )
+        self.assertTrue(estimator.is_inference)
+
+        estimator2 = EmbeddingPerfEstimatorV2(
+            topology=MagicMock(),
+            is_inference=False,
+        )
+        self.assertFalse(estimator2.is_inference)
+
+    def test_default_config_created_when_none(self) -> None:
+        """Test that default HardwarePerfConfig is created when none provided."""
+        estimator = EmbeddingPerfEstimatorV2(
+            topology=MagicMock(),
+        )
+        self.assertIsInstance(estimator.config, HardwarePerfConfig)
+
+
+class EvaluatorCustomMethodTest(unittest.TestCase):
+    """Tests for evaluator with custom annotation methods."""
+
+    def test_custom_forward_compute_annotation(self) -> None:
+        """Test that @forward_compute annotation is used when present."""
+
+        class CustomConfig(HardwarePerfConfig):
+            name = "custom_fwd"
+
+            @forward_compute(sharding_type="table_wise")
+            def compute_fwd(self, ctx: ShardPerfContext) -> float:
+                return 999.0
+
+        config = CustomConfig()
+        evaluator = TableWiseEvaluator()
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_WISE.value)
+
+        fwd_compute = evaluator.compute_fwd_comp(ctx, config)
+        self.assertEqual(fwd_compute, 999.0)
+
+    def test_custom_coefficient_annotation(self) -> None:
+        """Test that @fwd_coefficient and @bwd_coefficient annotations are used."""
+
+        class CoefficientConfig(HardwarePerfConfig):
+            name = "coeff_config"
+
+            @fwd_coefficient(sharding_type="table_wise")
+            def tw_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=10.0)
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def tw_bwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=20.0)
+
+        config = CoefficientConfig()
+        coeffs = config.get_coefficients_for_sharding(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 10.0)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 20.0)
+
+
+class EvaluatorBandwidthPriorityTest(unittest.TestCase):
+    """Tests for bandwidth priority in evaluators."""
+
+    def test_device_bw_uses_config_when_set(self) -> None:
+        """Test that config.device_bw takes priority over ctx.device_bw."""
+
+        class ConfigWithDeviceBW(HardwarePerfConfig):
+            name = "with_device_bw"
+            device_bw = 5000.0
+
+        config = ConfigWithDeviceBW()
+        evaluator = TableWiseEvaluator()
+        ctx = create_test_context(device_bw=1000.0)
+
+        device_bw = evaluator._get_device_bw(ctx, config)
+        self.assertEqual(device_bw, 5000.0)
+
+    def test_device_bw_uses_ctx_when_config_none(self) -> None:
+        """Test that ctx.device_bw is used when config.device_bw is None."""
+        config = HardwarePerfConfig()
+        evaluator = TableWiseEvaluator()
+        ctx = create_test_context(device_bw=2000.0)
+
+        device_bw = evaluator._get_device_bw(ctx, config)
+        self.assertEqual(device_bw, 2000.0)
+
+
+class EvaluatorPrefetchTest(unittest.TestCase):
+    """Tests for prefetch compute in evaluators."""
+
+    def test_default_prefetch_comp_no_cache_fetches(self) -> None:
+        """Test default prefetch compute when no cache fetches."""
+        evaluator = TableWiseEvaluator()
+        config = HardwarePerfConfig()
+        ctx = create_test_context()
+        ctx.expected_cache_fetches = 0.0
+
+        prefetch = evaluator.compute_prefetch_comp(ctx, config)
+        self.assertEqual(prefetch, 0.0)
+
+    def test_prefetch_with_cache_fetches(self) -> None:
+        """Test prefetch compute with cache fetches."""
+        evaluator = TableWiseEvaluator()
+        config = HardwarePerfConfig()
+        ctx = create_test_context()
+        ctx.expected_cache_fetches = 100.0
+        ctx.hbm_to_ddr_mem_bw = 500.0
+
+        prefetch = evaluator.compute_prefetch_comp(ctx, config)
+        self.assertGreater(prefetch, 0.0)
+
+    def test_prefetch_with_linear_regression(self) -> None:
+        """Test prefetch compute with linear regression coefficients."""
+
+        class LinearRegressionConfig(HardwarePerfConfig):
+            name = "linear_regression"
+
+            @prefetch_coefficient()
+            def get_prefetch(self) -> PrefetchCoefficients:
+                return PrefetchCoefficients(
+                    expected_num_lookups_coefficient=0.1,
+                    expected_num_unique_lookups_coefficient=0.2,
+                    expected_size_cache_fetches_coefficient=0.3,
+                )
+
+        config = LinearRegressionConfig()
+        evaluator = TableWiseEvaluator()
+        ctx = create_test_context()
+        ctx.expected_cache_fetches = 100.0
+        ctx.expected_lookups = 1000.0
+        ctx.expected_unique_lookups = 500.0
+
+        prefetch = evaluator.compute_prefetch_comp(ctx, config)
+        expected = 0.1 * 1000.0 + 0.2 * 500.0 + 0.3 * (100.0 * 128)
+        self.assertAlmostEqual(prefetch, expected, places=2)
+
+
+class TrainingEvaluatorsRegistryTest(unittest.TestCase):
+    """Tests for TRAINING_EVALUATORS registry."""
+
+    def test_all_sharding_types_have_evaluators(self) -> None:
+        """Test that all standard sharding types have evaluators."""
+        expected_types = [
+            ShardingType.TABLE_WISE.value,
+            ShardingType.ROW_WISE.value,
+            ShardingType.TABLE_ROW_WISE.value,
+            ShardingType.COLUMN_WISE.value,
+            ShardingType.DATA_PARALLEL.value,
+        ]
+        for sharding_type in expected_types:
+            self.assertIn(sharding_type, TRAINING_EVALUATORS)
+
+    def test_evaluators_are_correct_types(self) -> None:
+        """Test that evaluators in registry are correct types."""
+        self.assertIsInstance(
+            TRAINING_EVALUATORS[ShardingType.TABLE_WISE.value], TableWiseEvaluator
+        )
+        self.assertIsInstance(
+            TRAINING_EVALUATORS[ShardingType.ROW_WISE.value], RowWiseEvaluator
+        )
+        self.assertIsInstance(
+            TRAINING_EVALUATORS[ShardingType.TABLE_ROW_WISE.value],
+            TableRowWiseEvaluator,
+        )
+        self.assertIsInstance(
+            TRAINING_EVALUATORS[ShardingType.COLUMN_WISE.value], ColumnWiseEvaluator
+        )
+        self.assertIsInstance(
+            TRAINING_EVALUATORS[ShardingType.DATA_PARALLEL.value], DataParallelEvaluator
+        )
+
+
+class EvaluatorComputePerfIntegrationTest(unittest.TestCase):
+    """Integration tests for compute_perf across evaluators."""
+
+    def test_table_wise_perf_values_are_reasonable(self) -> None:
+        """Test that TABLE_WISE perf values are non-negative."""
+        evaluator = TableWiseEvaluator()
+        config = HardwarePerfConfig()
+        ctx = create_test_context(sharding_type=ShardingType.TABLE_WISE.value)
+
+        perf = evaluator.compute_perf(ctx, config)
+        self.assertGreaterEqual(perf.fwd_compute, 0.0)
+        self.assertGreaterEqual(perf.bwd_compute, 0.0)
+        self.assertGreaterEqual(perf.fwd_comms, 0.0)
+        self.assertGreaterEqual(perf.bwd_comms, 0.0)
+        self.assertGreaterEqual(perf.prefetch_compute, 0.0)
+
+    def test_row_wise_perf_values_are_reasonable(self) -> None:
+        """Test that ROW_WISE perf values are non-negative."""
+        evaluator = RowWiseEvaluator()
+        config = HardwarePerfConfig()
+        ctx = create_test_context(sharding_type=ShardingType.ROW_WISE.value)
+
+        perf = evaluator.compute_perf(ctx, config)
+        self.assertGreaterEqual(perf.fwd_compute, 0.0)
+        self.assertGreaterEqual(perf.bwd_compute, 0.0)
+        self.assertGreaterEqual(perf.fwd_comms, 0.0)
+        self.assertGreaterEqual(perf.bwd_comms, 0.0)
+
+    def test_data_parallel_has_zero_fwd_comms(self) -> None:
+        """Test that DATA_PARALLEL has zero forward comms."""
+        evaluator = DataParallelEvaluator()
+        config = HardwarePerfConfig()
+        ctx = create_test_context(sharding_type=ShardingType.DATA_PARALLEL.value)
+
+        perf = evaluator.compute_perf(ctx, config)
+        self.assertEqual(perf.fwd_comms, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the types module in the estimator package.
+
+Tests the core dataclasses and config classes:
+- PerfCoefficient, EstimatorPerfCoefficients, PrefetchCoefficients
+- PerfCoefficientConfig with get_coefficients() method
+- HardwarePerfConfig with coefficient lookup and validation
+- ShardPerfContext computed properties
+"""
+
+import unittest
+
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.estimator.annotations import (
+    bwd_coefficient,
+    fwd_coefficient,
+    prefetch_coefficient,
+    supported_sharding_types,
+)
+from torchrec.distributed.planner.estimator.types import (
+    EstimatorPerfCoefficients,
+    HardwarePerfConfig,
+    PerfCoefficient,
+    PerfCoefficientConfig,
+    PrefetchCoefficients,
+    ShardPerfContext,
+)
+from torchrec.distributed.types import ShardingType
+
+
+class PerfCoefficientTest(unittest.TestCase):
+    """Tests for the PerfCoefficient frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default coefficient values."""
+        coeff = PerfCoefficient()
+        self.assertEqual(coeff.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeff.lookup_size_multiplier, 1.0)
+        self.assertEqual(coeff.embedding_output_multiplier, 1.0)
+        self.assertEqual(coeff.hash_size_multiplier, 0.0)
+
+    def test_custom_values(self) -> None:
+        """Test creating coefficient with custom values."""
+        coeff = PerfCoefficient(
+            input_read_size_multiplier=2.0,
+            lookup_size_multiplier=1.5,
+            embedding_output_multiplier=0.5,
+            hash_size_multiplier=0.1,
+        )
+        self.assertEqual(coeff.input_read_size_multiplier, 2.0)
+        self.assertEqual(coeff.lookup_size_multiplier, 1.5)
+        self.assertEqual(coeff.embedding_output_multiplier, 0.5)
+        self.assertEqual(coeff.hash_size_multiplier, 0.1)
+
+    def test_frozen(self) -> None:
+        """Test that PerfCoefficient is frozen (immutable)."""
+        coeff = PerfCoefficient()
+        with self.assertRaises(AttributeError):
+            coeff.input_read_size_multiplier = 2.0  # pyre-ignore[41]
+
+
+class EstimatorPerfCoefficientsTest(unittest.TestCase):
+    """Tests for EstimatorPerfCoefficients frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default fwd and bwd coefficients."""
+        coeffs = EstimatorPerfCoefficients()
+        self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+
+    def test_custom_fwd_bwd(self) -> None:
+        """Test creating with custom forward and backward coefficients."""
+        fwd = PerfCoefficient(lookup_size_multiplier=2.0)
+        bwd = PerfCoefficient(lookup_size_multiplier=3.0)
+        coeffs = EstimatorPerfCoefficients(fwd=fwd, bwd=bwd)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 3.0)
+
+
+class PrefetchCoefficientsTest(unittest.TestCase):
+    """Tests for PrefetchCoefficients frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default prefetch coefficient values."""
+        prefetch = PrefetchCoefficients()
+        self.assertEqual(prefetch.expected_num_lookups_coefficient, 0.0)
+        self.assertEqual(prefetch.expected_num_unique_lookups_coefficient, 0.0)
+        self.assertEqual(prefetch.expected_size_cache_fetches_coefficient, 0.0)
+
+    def test_custom_values(self) -> None:
+        """Test creating prefetch coefficients with custom values."""
+        prefetch = PrefetchCoefficients(
+            expected_num_lookups_coefficient=1.5,
+            expected_num_unique_lookups_coefficient=2.0,
+            expected_size_cache_fetches_coefficient=0.8,
+        )
+        self.assertEqual(prefetch.expected_num_lookups_coefficient, 1.5)
+        self.assertEqual(prefetch.expected_num_unique_lookups_coefficient, 2.0)
+        self.assertEqual(prefetch.expected_size_cache_fetches_coefficient, 0.8)
+
+
+class PerfCoefficientConfigTest(unittest.TestCase):
+    """Tests for PerfCoefficientConfig with get_coefficients() method."""
+
+    def test_get_coefficients_returns_default_when_no_specific(self) -> None:
+        """Test that get_coefficients returns default when no specific coefficients."""
+        config = PerfCoefficientConfig()
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+
+    def test_get_coefficients_returns_sharding_specific(self) -> None:
+        """Test that get_coefficients returns sharding-specific coefficients."""
+        table_wise_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=2.0),
+            bwd=PerfCoefficient(lookup_size_multiplier=3.0),
+        )
+        config = PerfCoefficientConfig(table_wise=table_wise_coeffs)
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 3.0)
+
+    def test_get_coefficients_kernel_override_takes_priority(self) -> None:
+        """Test that kernel-specific overrides take priority over sharding type."""
+        table_wise_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=2.0),
+        )
+        kernel_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=5.0),
+        )
+        config = PerfCoefficientConfig(
+            table_wise=table_wise_coeffs,
+            by_kernel={("table_wise", "fused"): kernel_coeffs},
+        )
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value, "fused")
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 5.0)
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+
+    def test_get_coefficients_all_sharding_types(self) -> None:
+        """Test get_coefficients works for all standard sharding types."""
+        config = PerfCoefficientConfig(
+            table_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=1.0)
+            ),
+            row_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=2.0)
+            ),
+            table_row_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=3.0)
+            ),
+            column_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=4.0)
+            ),
+            data_parallel=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=5.0)
+            ),
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.TABLE_WISE.value
+            ).fwd.lookup_size_multiplier,
+            1.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.ROW_WISE.value
+            ).fwd.lookup_size_multiplier,
+            2.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.TABLE_ROW_WISE.value
+            ).fwd.lookup_size_multiplier,
+            3.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.COLUMN_WISE.value
+            ).fwd.lookup_size_multiplier,
+            4.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.DATA_PARALLEL.value
+            ).fwd.lookup_size_multiplier,
+            5.0,
+        )
+
+    def test_get_coefficients_case_insensitive(self) -> None:
+        """Test that sharding type lookup is case-insensitive."""
+        config = PerfCoefficientConfig(
+            table_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=2.0)
+            ),
+        )
+        coeffs = config.get_coefficients("TABLE_WISE")
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+
+
+class HardwarePerfConfigTest(unittest.TestCase):
+    """Tests for HardwarePerfConfig class."""
+
+    def test_default_name(self) -> None:
+        """Test default hardware config name."""
+        config = HardwarePerfConfig()
+        self.assertEqual(config.name, "default")
+
+    def test_is_sharding_type_supported_all_by_default(self) -> None:
+        """Test that all sharding types are supported by default."""
+        config = HardwarePerfConfig()
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.TABLE_WISE.value)
+        )
+        self.assertTrue(config.is_sharding_type_supported(ShardingType.ROW_WISE.value))
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.COLUMN_WISE.value)
+        )
+
+    def test_is_sharding_type_supported_with_restriction(self) -> None:
+        """Test sharding type support with explicit restrictions."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class RestrictedConfig(HardwarePerfConfig):
+            name = "restricted"
+
+        config = RestrictedConfig()
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.TABLE_WISE.value)
+        )
+        self.assertTrue(config.is_sharding_type_supported(ShardingType.ROW_WISE.value))
+        self.assertFalse(
+            config.is_sharding_type_supported(ShardingType.COLUMN_WISE.value)
+        )
+
+    def test_validate_sharding_type_raises_for_unsupported(self) -> None:
+        """Test validate_sharding_type raises ValueError for unsupported types."""
+
+        @supported_sharding_types("table_wise")
+        class LimitedConfig(HardwarePerfConfig):
+            name = "limited"
+
+        config = LimitedConfig()
+        config.validate_sharding_type(ShardingType.TABLE_WISE.value)
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_sharding_type(ShardingType.ROW_WISE.value)
+        self.assertIn("row_wise", str(ctx.exception))
+
+    def test_get_coefficients_for_sharding_with_annotations(self) -> None:
+        """Test get_coefficients_for_sharding uses annotation-based coefficients."""
+
+        class AnnotatedConfig(HardwarePerfConfig):
+            name = "annotated"
+
+            @fwd_coefficient(sharding_type="table_wise")
+            def table_wise_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=5.0)
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def table_wise_bwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=6.0)
+
+        config = AnnotatedConfig()
+        coeffs = config.get_coefficients_for_sharding(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 5.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 6.0)
+
+    def test_coefficients_property_builds_from_annotations(self) -> None:
+        """Test that coefficients property builds config from annotations."""
+
+        class ConfigWithAnnotations(HardwarePerfConfig):
+            name = "with_annotations"
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def row_wise_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=3.0)
+
+            @prefetch_coefficient()
+            def get_prefetch(self) -> PrefetchCoefficients:
+                return PrefetchCoefficients(expected_num_lookups_coefficient=1.0)
+
+        config = ConfigWithAnnotations()
+        perf_config = config.coefficients
+        self.assertIsNotNone(perf_config.row_wise)
+        self.assertEqual(
+            perf_config.row_wise.fwd.lookup_size_multiplier,  # pyre-ignore[16]
+            3.0,
+        )
+        self.assertIsNotNone(perf_config.prefetch)
+        self.assertEqual(perf_config.prefetch.expected_num_lookups_coefficient, 1.0)
+
+    def test_get_device_bw_priority_kernel_specific(self) -> None:
+        """Test get_device_bw priority: kernel-specific takes precedence."""
+
+        class ConfigWithKernelBW(HardwarePerfConfig):
+            name = "kernel_bw"
+            kernel_device_bandwidths = {("cuda", "fused"): 1000.0}
+            device_bw = 500.0
+
+        config = ConfigWithKernelBW()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel="fused",
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 1000.0)
+
+    def test_get_device_bw_priority_device_bw_override(self) -> None:
+        """Test get_device_bw priority: device_bw override when no kernel match."""
+
+        class ConfigWithDeviceBW(HardwarePerfConfig):
+            name = "device_bw"
+            device_bw = 500.0
+
+        config = ConfigWithDeviceBW()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel="dense",
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 500.0)
+
+    def test_get_device_bw_uses_kernel_bw_lookup_fallback(self) -> None:
+        """Test get_device_bw falls back to kernel_bw_lookup."""
+        config = HardwarePerfConfig()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 900.0)
+
+    def test_get_device_bw_invalid_kernel_raises(self) -> None:
+        """Test get_device_bw raises for invalid compute kernel."""
+        config = HardwarePerfConfig()
+        with self.assertRaises(ValueError) as ctx:
+            config.get_device_bw(
+                compute_device="cuda",
+                compute_kernel="invalid_kernel",
+                hbm_mem_bw=900.0,
+                ddr_mem_bw=100.0,
+                hbm_to_ddr_mem_bw=200.0,
+            )
+        self.assertIn("invalid_kernel", str(ctx.exception))
+
+    def test_post_process_perfs_returns_unchanged_by_default(self) -> None:
+        """Test post_process_perfs returns input unchanged by default."""
+        from torchrec.distributed.planner.types import Perf
+
+        config = HardwarePerfConfig()
+        perfs = [
+            Perf(fwd_compute=1.0, fwd_comms=2.0, bwd_compute=3.0, bwd_comms=4.0),
+            Perf(fwd_compute=5.0, fwd_comms=6.0, bwd_compute=7.0, bwd_comms=8.0),
+        ]
+        shard_sizes = [[100, 64], [200, 64]]
+        result = config.post_process_perfs(
+            perfs, shard_sizes, ShardingType.TABLE_WISE.value
+        )
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].fwd_compute, 1.0)
+        self.assertEqual(result[1].fwd_compute, 5.0)
+
+
+class ShardPerfContextTest(unittest.TestCase):
+    """Tests for ShardPerfContext dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test ShardPerfContext default values."""
+        ctx = ShardPerfContext()
+        self.assertEqual(ctx.sharding_type, "")
+        self.assertEqual(ctx.compute_kernel, "")
+        self.assertEqual(ctx.hash_size, 0)
+        self.assertEqual(ctx.emb_dim, 0)
+        self.assertEqual(ctx.world_size, 1)
+        self.assertEqual(ctx.local_world_size, 1)
+        self.assertFalse(ctx.is_inference)
+        self.assertFalse(ctx.is_weighted)
+        self.assertTrue(ctx.is_pooled)
+
+    def test_num_hosts_property(self) -> None:
+        """Test num_hosts computed property."""
+        ctx = ShardPerfContext(world_size=8, local_world_size=4)
+        self.assertEqual(ctx.num_hosts, 2)
+        ctx2 = ShardPerfContext(world_size=4, local_world_size=4)
+        self.assertEqual(ctx2.num_hosts, 1)
+
+    def test_batch_inputs_property(self) -> None:
+        """Test batch_inputs computed property."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+        )
+        self.assertEqual(ctx.batch_inputs, 1600.0)
+
+    def test_batch_outputs_property_pooled(self) -> None:
+        """Test batch_outputs for pooled embeddings."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+            is_pooled=True,
+        )
+        self.assertEqual(ctx.batch_outputs, 96.0)
+
+    def test_batch_outputs_property_unpooled(self) -> None:
+        """Test batch_outputs for unpooled embeddings (same as batch_inputs)."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+            is_pooled=False,
+        )
+        self.assertEqual(ctx.batch_outputs, ctx.batch_inputs)
+
+    def test_is_uvm_caching_property(self) -> None:
+        """Test is_uvm_caching computed property."""
+        ctx = ShardPerfContext(compute_kernel=EmbeddingComputeKernel.FUSED.value)
+        self.assertFalse(ctx.is_uvm_caching)
+        ctx2 = ShardPerfContext(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        )
+        self.assertTrue(ctx2.is_uvm_caching)
+
+    def test_custom_initialization(self) -> None:
+        """Test ShardPerfContext with custom initialization."""
+        ctx = ShardPerfContext(
+            sharding_type=ShardingType.TABLE_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            hash_size=10000,
+            emb_dim=128,
+            batch_sizes=[64],
+            num_poolings=[1.0],
+            input_lengths=[50.0],
+            world_size=8,
+            local_world_size=4,
+            is_inference=True,
+            is_weighted=True,
+            is_pooled=False,
+        )
+        self.assertEqual(ctx.sharding_type, ShardingType.TABLE_WISE.value)
+        self.assertEqual(ctx.compute_kernel, EmbeddingComputeKernel.FUSED.value)
+        self.assertEqual(ctx.hash_size, 10000)
+        self.assertEqual(ctx.emb_dim, 128)
+        self.assertEqual(ctx.world_size, 8)
+        self.assertTrue(ctx.is_inference)
+        self.assertTrue(ctx.is_weighted)
+        self.assertFalse(ctx.is_pooled)
+
+
+class HardwarePerfConfigIntegrationTest(unittest.TestCase):
+    """Integration tests for HardwarePerfConfig with annotations."""
+
+    def test_full_config_with_all_annotation_types(self) -> None:
+        """Test a full config class with all annotation types."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class FullConfig(HardwarePerfConfig):
+            name = "full_config"
+
+            @fwd_coefficient(sharding_type="table_wise")
+            def tw_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=1.5)
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def tw_bwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=2.0)
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def rw_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=1.2)
+
+            @prefetch_coefficient()
+            def prefetch(self) -> PrefetchCoefficients:
+                return PrefetchCoefficients(
+                    expected_num_lookups_coefficient=0.5,
+                    expected_num_unique_lookups_coefficient=0.3,
+                )
+
+        config = FullConfig()
+
+        self.assertTrue(config.is_sharding_type_supported("table_wise"))
+        self.assertTrue(config.is_sharding_type_supported("row_wise"))
+        self.assertFalse(config.is_sharding_type_supported("column_wise"))
+
+        tw_coeffs = config.get_coefficients_for_sharding("table_wise")
+        self.assertEqual(tw_coeffs.fwd.lookup_size_multiplier, 1.5)
+        self.assertIsNotNone(tw_coeffs.bwd)
+        self.assertEqual(tw_coeffs.bwd.lookup_size_multiplier, 2.0)
+
+        rw_coeffs = config.get_coefficients_for_sharding("row_wise")
+        self.assertEqual(rw_coeffs.fwd.lookup_size_multiplier, 1.2)
+
+        perf_config = config.coefficients
+        self.assertIsNotNone(perf_config.prefetch)
+        self.assertEqual(perf_config.prefetch.expected_num_lookups_coefficient, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+"""
+Performance Estimator Types.
+
+This module contains the core dataclasses  performance estimator:
+- Coefficient classes: PerfCoefficient, EstimatorPerfCoefficients, PerfCoefficientConfig
+- Context class: ShardPerfContext
+- Config class: HardwarePerfConfig
+
+Evaluator classes and factory are in estimator.py.
+"""
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+from torch import nn
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.constants import (
+    BIGINT_DTYPE,
+    BWD_COMPUTE_MULTIPLIER,
+    DDR_MEM_BW,
+    HBM_MEM_BW,
+    kernel_bw_lookup,
+    WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
+    WEIGHTED_KERNEL_MULTIPLIER,
+)
+from torchrec.distributed.planner.estimator.annotations import (
+    get_bwd_coefficient,
+    get_fwd_coefficient,
+    get_prefetch_coefficient,
+)
+from torchrec.distributed.planner.types import (
+    GeneralizedCommsBandwidth,
+    ParameterConstraints,
+    Perf,
+    PlannerError,
+    ShardingOption,
+    Topology,
+)
+from torchrec.distributed.planner.utils import (
+    extract_comm_data_type_size,
+    get_num_poolings,
+    is_prefetch_pipelined,
+)
+from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
+from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Coefficient Dataclasses
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PerfCoefficient:
+    # Multiplier for number of indices to lookup.
+    input_read_size_multiplier: float = 1.0
+
+    # Multiplier for lookup size.
+    lookup_size_multiplier: float = 1.0
+
+    # Multiplier after pooled operation,basically the size of the output.
+    embedding_output_multiplier: float = 1.0
+
+    # Multiplier for table size
+    hash_size_multiplier: float = 0.0
+
+
+@dataclass(frozen=True)
+class EstimatorPerfCoefficients:
+    # Coefficients for forward pass
+    fwd: PerfCoefficient = field(default_factory=PerfCoefficient)
+    # Coefficients for backward pass
+    bwd: PerfCoefficient = field(default_factory=PerfCoefficient)
+
+
+@dataclass(frozen=True)
+class PrefetchCoefficients:
+    """
+    Prefetch pipeline per estimation coefficients.
+    """
+
+    # Multiplier for number of lookups
+    expected_num_lookups_coefficient: float = 0.0
+    # Multipliers for number of unique lookups
+    expected_num_unique_lookups_coefficient: float = 0.0
+    # Multiplier for number of cache fetches
+    expected_size_cache_fetches_coefficient: float = 0.0
+
+
+@dataclass
+class PerfCoefficientConfig:
+    """
+    Each sharding type has a set of coefficients for forward and backward passes., If these coefficients are need to be specified for
+    a specific sharding type,for a particular compute kernel, then they can be specified in the by_kernel dictionary.
+    Priority order:
+    1. by_kernel[(sharding_type, compute_kernel)] if compute_kernel provided
+    2. Sharding-type specific attribute
+    3. default
+    """
+
+    table_wise: Optional[EstimatorPerfCoefficients] = None
+    row_wise: Optional[EstimatorPerfCoefficients] = None
+    table_row_wise: Optional[EstimatorPerfCoefficients] = None
+    data_parallel: Optional[EstimatorPerfCoefficients] = None
+    column_wise: Optional[EstimatorPerfCoefficients] = None
+
+    # Kernel-specific overrides: (sharding_type, compute_kernel) -> coefficients
+    by_kernel: Dict[Tuple[str, str], EstimatorPerfCoefficients] = field(
+        default_factory=dict
+    )
+
+    # Default fallback
+    default: EstimatorPerfCoefficients = field(
+        default_factory=lambda: EstimatorPerfCoefficients()
+    )
+
+    # Compute multipliers (imported from constants)
+    bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER
+    weighted_kernel_multiplier: float = WEIGHTED_KERNEL_MULTIPLIER
+    weighted_feature_bwd_compute_multiplier: float = (
+        WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER
+    )
+
+    # Prefetch coefficients (optional, for FB hardware estimators)
+    # When set and use_linear_regression=True, enables extended prefetch formula
+    prefetch: Optional[PrefetchCoefficients] = None
+
+    def get_coefficients(
+        self, sharding_type: str, compute_kernel: Optional[str] = None
+    ) -> EstimatorPerfCoefficients:
+        """
+        Get coefficients for a sharding type and optional compute kernel.
+
+        Priority order:
+        1. by_kernel[(sharding_type, compute_kernel)] if compute_kernel provided
+        2. Sharding-type specific attribute
+        3. default
+        """
+        # Priority 1: Check kernel-specific override
+        if compute_kernel:
+            key = (sharding_type.lower(), compute_kernel.lower())
+            if key in self.by_kernel:
+                return self.by_kernel[key]
+
+        # Priority 2: Check sharding-type specific
+        sharding_type_lower = sharding_type.lower()
+
+        if sharding_type_lower == ShardingType.TABLE_WISE.value:
+            coeff = self.table_wise
+        elif sharding_type_lower == ShardingType.ROW_WISE.value:
+            coeff = self.row_wise
+        elif sharding_type_lower == ShardingType.TABLE_ROW_WISE.value:
+            coeff = self.table_row_wise
+        elif sharding_type_lower == ShardingType.DATA_PARALLEL.value:
+            coeff = self.data_parallel
+        elif sharding_type_lower == ShardingType.COLUMN_WISE.value:
+            coeff = self.column_wise
+        elif sharding_type_lower == ShardingType.TABLE_COLUMN_WISE.value:
+            coeff = self.column_wise
+        elif sharding_type_lower == ShardingType.GRID_SHARD.value:
+            coeff = self.default
+        else:
+            coeff = None
+
+        if coeff is not None:
+            return coeff
+
+        # Priority 3: Default
+        return self.default
+
+
+# =============================================================================
+# HardwarePerfConfig
+# =============================================================================
+
+
+class HardwarePerfConfig:
+    """
+    Hardware-specific performance configuration.
+
+    This class contains hardware-specific coefficients and compute methods.
+    It is used by the EmbeddingPerfEstimator to estimate performance for a given hardware.
+
+    Args:
+        name: Name of the hardware (e.g. "H100", "A100", "V100").
+        coefficients: Coefficients for each sharding type.
+    """
+
+    # Internal storage for coefficients (populated lazily from annotations)
+    _coefficients: Optional[PerfCoefficientConfig] = None
+
+    name: str = "default"
+
+    @property
+    def coefficients(self) -> PerfCoefficientConfig:
+        """
+        Get coefficients config, populated from annotations.
+
+        This property dynamically builds the PerfCoefficientConfig from
+        annotation-based coefficients (@fwd_coefficient, @bwd_coefficient, @prefetch_coefficient).
+        The result is cached for subsequent accesses.
+
+        Returns:
+            PerfCoefficientConfig with coefficients populated from annotations.
+        """
+        if self._coefficients is not None:
+            return self._coefficients
+
+        # Build coefficients from annotations for each sharding type
+        sharding_types = [
+            ShardingType.TABLE_WISE,
+            ShardingType.ROW_WISE,
+            ShardingType.TABLE_ROW_WISE,
+            ShardingType.COLUMN_WISE,
+            ShardingType.DATA_PARALLEL,
+        ]
+
+        config_kwargs: Dict[str, Optional[EstimatorPerfCoefficients]] = {}
+
+        for sharding_type in sharding_types:
+            fwd_coeff = get_fwd_coefficient(self, sharding_type.value)
+            bwd_coeff = get_bwd_coefficient(self, sharding_type.value)
+
+            if fwd_coeff is not None or bwd_coeff is not None:
+                config_kwargs[sharding_type.value] = EstimatorPerfCoefficients(
+                    fwd=fwd_coeff if fwd_coeff is not None else PerfCoefficient(),
+                    bwd=bwd_coeff if bwd_coeff is not None else PerfCoefficient(),
+                )
+
+        # Get prefetch coefficients
+        prefetch = get_prefetch_coefficient(self)
+
+        self._coefficients = PerfCoefficientConfig(
+            table_wise=config_kwargs.get(ShardingType.TABLE_WISE.value),
+            row_wise=config_kwargs.get(ShardingType.ROW_WISE.value),
+            table_row_wise=config_kwargs.get(ShardingType.TABLE_ROW_WISE.value),
+            column_wise=config_kwargs.get(ShardingType.COLUMN_WISE.value),
+            data_parallel=config_kwargs.get(ShardingType.DATA_PARALLEL.value),
+            prefetch=prefetch,
+        )
+
+        return self._coefficients
+
+    # Hardware bandwidth defaults (can be overridden by decorators)
+    hbm_mem_bw: float = HBM_MEM_BW
+    ddr_mem_bw: float = DDR_MEM_BW
+
+    # Optional bandwidth overrides (None = use ctx/topology values)
+    device_bw: Optional[float] = None
+    hbm_to_ddr_mem_bw: Optional[float] = None
+    intra_host_bw: Optional[float] = None
+    inter_host_bw: Optional[float] = None
+
+    kernel_device_bandwidths: Dict[Tuple[str, str], float] = {}
+
+    # Supported sharding types (None = all supported, set via @supported_sharding_types)
+    _supported_sharding_types: Optional[FrozenSet[str]] = None
+
+    # Configurable data type defaults (can be overridden by subclasses)
+    # FB legacy uses INT_DTYPE (4.0) as default output_data_type_size when output_dtype is None
+    # OSS uses tensor.element_size() (can be 2.0 for FP16)
+    # Set to 4.0 in FBHardwarePerfConfig to match FB legacy behavior, None for OSS default
+    _default_output_data_type_size: Optional[float] = None
+
+    def get_coefficients_for_sharding(
+        self, sharding_type: str, compute_kernel: Optional[str] = None
+    ) -> EstimatorPerfCoefficients:
+        """
+        Get coefficients for a specific sharding type.
+
+        Priority order:
+        1. Annotation-based coefficients (@fwd_coefficient, @bwd_coefficient)
+        2. Explicit self.coefficients attribute (PerfCoefficientConfig)
+        3. Default coefficients
+
+        Args:
+            sharding_type: The sharding type to get coefficients for
+            compute_kernel: Optional compute kernel for kernel-specific overrides
+
+        Returns:
+            EstimatorPerfCoefficients with fwd and bwd coefficients
+        """
+        # Priority 1: Check for annotation-based coefficients
+        fwd_coeff = get_fwd_coefficient(self, sharding_type)
+        bwd_coeff = get_bwd_coefficient(self, sharding_type)
+
+        if fwd_coeff is not None or bwd_coeff is not None:
+            return EstimatorPerfCoefficients(
+                fwd=fwd_coeff if fwd_coeff is not None else PerfCoefficient(),
+                bwd=bwd_coeff if bwd_coeff is not None else PerfCoefficient(),
+            )
+
+        # Priority 2 & 3: Use explicit coefficients attribute (falls back to default)
+        return self.coefficients.get_coefficients(sharding_type, compute_kernel)
+
+    def is_sharding_type_supported(self, sharding_type: str) -> bool:
+        """
+        Check if a sharding type is supported by this config.
+
+        If _supported_sharding_types is None, all types are supported.
+        If set (via @supported_sharding_types decorator), only listed types are supported.
+
+        Args:
+            sharding_type: The sharding type to check
+
+        Returns:
+            True if supported, False otherwise
+        """
+        if self._supported_sharding_types is None:
+            return True  # All supported by default
+        return sharding_type.lower() in self._supported_sharding_types
+
+    def validate_sharding_type(self, sharding_type: str) -> None:
+        """
+        Validate that a sharding type is supported, raise ValueError if not.
+
+        Args:
+            sharding_type: The sharding type to validate
+
+        Raises:
+            ValueError: If sharding type is not supported
+        """
+        if not self.is_sharding_type_supported(sharding_type):
+            supported = self._supported_sharding_types or "all"
+            raise ValueError(
+                f"Sharding type '{sharding_type}' is not supported by {self.__class__.__name__}. "
+                f"Supported types: {supported}"
+            )
+
+    def post_process_perfs(
+        self,
+        shard_perfs: List[Perf],
+        shard_sizes: List[List[int]],
+        sharding_type: str,
+        uneven_sharding_perf_multiplier: float = 1.0,
+    ) -> List[Perf]:
+        """
+        Optional post-processing hook for adjusting shard perfs after computation.
+
+        This method is called after all shards have been computed individually.
+        Override in subclasses for custom cross-shard adjustments (e.g., uneven sharding).
+
+        Default implementation: returns shard_perfs unchanged.
+
+        Args:
+            shard_perfs: List of computed Perf objects, one per shard
+            shard_sizes: List of [hash_size, emb_dim] for each shard
+            sharding_type: The sharding type being evaluated
+            uneven_sharding_perf_multiplier: Multiplier for uneven sharding adjustment
+
+        Returns:
+            List of (potentially adjusted) Perf objects
+        """
+        return shard_perfs
+
+    def get_device_bw(
+        self,
+        compute_device: str,
+        compute_kernel: str,
+        hbm_mem_bw: float,
+        ddr_mem_bw: float,
+        hbm_to_ddr_mem_bw: float,
+        caching_ratio: Optional[float] = None,
+        prefetch_pipeline: bool = False,
+    ) -> Optional[float]:
+        """
+        Get device bandwidth with priority-based lookup.
+
+        Priority order:
+        1. kernel_device_bandwidths (specific device+kernel overrides)
+        2. device_bw (general device bandwidth override)
+        3. kernel_bw_lookup() (computed from memory bandwidth)
+
+        Args:
+            compute_device: The compute device (e.g., "cuda", "cpu", "mtia")
+            compute_kernel: The embedding compute kernel (e.g., "fused", "dense")
+            hbm_mem_bw: HBM memory bandwidth
+            ddr_mem_bw: DDR memory bandwidth
+            hbm_to_ddr_mem_bw: HBM to DDR bandwidth
+            caching_ratio: Optional caching ratio for UVM caching
+            prefetch_pipeline: Whether prefetch pipeline is enabled
+
+        Returns:
+            The device bandwidth in bytes/ms, or None if not found
+        """
+        # Following same logic as kernel_bw_lookup
+        effective_compute_kernel = compute_kernel
+        if (
+            prefetch_pipeline
+            and compute_device.lower() == "cuda"
+            and compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        ):
+            effective_compute_kernel = EmbeddingComputeKernel.FUSED.value
+
+        # Priority 1: Check kernel-specific overrides (case-insensitive lookup)
+        key = (compute_device.lower(), effective_compute_kernel.lower())
+        if key in self.kernel_device_bandwidths:
+            return self.kernel_device_bandwidths[key]
+
+        # Priority 2: Check general device_bw override
+        if self.device_bw is not None:
+            return self.device_bw
+
+        # Priority 3: Use kernel_bw_lookup (returns None for invalid kernels)
+        bw = kernel_bw_lookup(
+            compute_device=compute_device,
+            compute_kernel=compute_kernel,
+            hbm_mem_bw=hbm_mem_bw,
+            ddr_mem_bw=ddr_mem_bw,
+            hbm_to_ddr_mem_bw=hbm_to_ddr_mem_bw,
+            caching_ratio=caching_ratio,
+            prefetch_pipeline=prefetch_pipeline,
+        )
+        if bw is None:
+            raise ValueError(
+                f"Unrecognized or unsupported compute kernel: {compute_kernel} for hardware aware perf estimators."
+            )
+        return bw
+
+
+# =============================================================================
+# ShardPerfContext
+# =============================================================================
+
+
+@dataclass
+class ShardPerfContext:
+    """
+    Raw data container for shard performance estimation.
+
+    This is a pure data container - all computation logic is in the evaluator classes.
+    Evaluators use the raw data fields to compute sizes and performance metrics.
+    """
+
+    # Identifiers
+    sharding_type: str = ""
+    compute_kernel: str = ""
+
+    # Shard dimensions
+    hash_size: int = 0
+    emb_dim: int = 0
+
+    # Raw inputs
+    batch_sizes: List[int] = field(default_factory=list)
+    num_poolings: List[float] = field(default_factory=list)
+    input_lengths: List[float] = field(default_factory=list)
+
+    # Topology info
+    world_size: int = 1
+    local_world_size: int = 1
+
+    # Data type sizes
+    input_data_type_size: float = BIGINT_DTYPE
+    table_data_type_size: float = 4.0
+    output_data_type_size: float = 4.0
+    fwd_a2a_comm_data_type_size: float = 4.0
+    bwd_a2a_comm_data_type_size: float = 4.0
+    fwd_sr_comm_data_type_size: float = 4.0
+    bwd_sr_comm_data_type_size: float = 4.0
+
+    # Bandwidth values
+    device_bw: float = HBM_MEM_BW
+    hbm_to_ddr_mem_bw: float = HBM_MEM_BW
+    intra_host_bw: float = 0.0
+    inter_host_bw: float = 0.0
+
+    # Communication bandwidths
+    comms_bandwidths: Optional[GeneralizedCommsBandwidth] = None
+
+    # Flags
+    is_inference: bool = False
+    is_weighted: bool = False
+    is_pooled: bool = True
+    has_feature_processor: bool = False
+
+    # Multipliers from topology
+    bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER
+    weighted_feature_bwd_compute_multiplier: float = (
+        WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER
+    )
+
+    # Cache-related
+    expected_cache_fetches: float = 0.0
+
+    # Extended prefetch fields (used by FB hardware estimators for linear regression)
+    # These are optional and only populated when cache stats are available
+    expected_lookups: Optional[float] = None
+    expected_unique_lookups: Optional[float] = None
+
+    # =========================================================================
+    # Class method to build from ShardingOption
+    # =========================================================================
+
+    @classmethod
+    def build_shard_perf_contexts(
+        cls,
+        config: HardwarePerfConfig,
+        shard_sizes: List[List[int]],
+        sharding_option: ShardingOption,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        sharder: ModuleSharder[nn.Module],
+        is_inference: bool = False,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> List["ShardPerfContext"]:
+        """
+        Build list of ShardPerfContexts from ShardingOption and Topology.
+
+        This follows the exact logic from OSS EmbeddingPerfEstimator.estimate.
+
+        Args:
+            config: Hardware performance configuration
+            shard_sizes: List of [hash_size, emb_dim] for each shard
+            sharding_option: The sharding option being evaluated
+            topology: Device topology with bandwidth and world size info
+            constraints: Optional parameter constraints
+            sharder: Module sharder for this option
+            is_inference: Whether this is for inference
+            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+                If False (default), uses expected_miss_rate * expected_unique_lookups.
+            use_linear_regression_prefetch_estimate: If True, clamps num_unique_lookups
+                to min(num_unique_lookups, batch_inputs, hash_size) before computing
+                prefetch time.
+
+        Returns:
+            List of ShardPerfContext instances, one per shard.
+        """
+        # Get caching ratio
+        caching_ratio = sharding_option.cache_load_factor
+        if caching_ratio is None:
+            caching_ratio = (
+                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                if hasattr(sharder, "fused_params") and sharder.fused_params
+                else None
+            )
+
+        # Get num_poolings and batch_sizes
+        num_poolings = get_num_poolings(constraints, sharding_option)
+        batch_sizes = (
+            list(constraints[sharding_option.name].batch_sizes or [])
+            if constraints
+            and constraints.get(sharding_option.name)
+            and constraints[sharding_option.name].batch_sizes
+            else [sharding_option.batch_size] * sharding_option.num_inputs
+        )
+
+        assert (
+            len(sharding_option.input_lengths) == len(num_poolings) == len(batch_sizes)
+        ), "Provided `pooling_factors`, `num_poolings`, and `batch_sizes` constraints must match."
+
+        # Check for feature processor
+        module = sharding_option.module[1]
+        has_feature_processor = False
+        if (
+            hasattr(module, "_feature_processor")
+            and hasattr(module._feature_processor, "feature_processor_modules")
+            and isinstance(
+                module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
+                nn.ModuleDict,
+            )
+            and sharding_option.name
+            in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
+        ):
+            has_feature_processor = True
+
+        # Determine is_weighted
+        if isinstance(module, EmbeddingBagCollectionInterface):
+            is_weighted = module.is_weighted()
+        elif (
+            constraints
+            and constraints.get(sharding_option.name)
+            and constraints[sharding_option.name].is_weighted
+        ):
+            is_weighted = constraints[sharding_option.name].is_weighted
+        else:
+            is_weighted = False
+
+        is_weighted = is_weighted or has_feature_processor
+
+        # Get data type sizes
+        table_data_type_size = sharding_option.tensor.element_size()
+        (
+            fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size,
+        ) = extract_comm_data_type_size(sharder, sharding_option)
+
+        # Check prefetch pipeline
+        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder)
+
+        # Output data type size - fetch default from config if output_dtype not specified
+        # FB legacy uses INT_DTYPE (4.0), OSS uses tensor.element_size()
+        default_output_data_type_size = getattr(
+            config, "_default_output_data_type_size", None
+        )
+        output_data_type_size: float = (
+            DATA_TYPE_NUM_BITS[sharding_option.output_dtype] / 8
+            if sharding_option.output_dtype
+            else (
+                default_output_data_type_size
+                if default_output_data_type_size is not None
+                else sharding_option.tensor.element_size()
+            )
+        )
+
+        # Calculate expected cache fetches and extended prefetch fields
+        expected_cache_fetches = 0.0
+        expected_lookups: Optional[float] = None
+        expected_unique_lookups: Optional[float] = None
+
+        # Calculate batch_inputs for all features
+        batch_inputs = math.ceil(
+            topology.world_size
+            * sum(
+                x * y * z
+                for x, y, z in zip(
+                    sharding_option.input_lengths, num_poolings, batch_sizes
+                )
+            )
+        )
+
+        if (
+            caching_ratio is not None
+            and sharding_option.cache_params is not None
+            and sharding_option.cache_params.stats is not None
+            and sharding_option.compute_kernel
+            == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        ):
+            _stats = sharding_option.cache_params.stats
+
+            # Get num_unique_lookups from cache stats
+            num_unique_lookups = float(_stats.expected_lookups)
+
+            # If linear regression prefetch estimate is enabled, clamp num_unique_lookups
+            if use_linear_regression_prefetch_estimate:
+                num_unique_lookups = min(
+                    num_unique_lookups,
+                    batch_inputs,
+                    sharding_option.tensor.shape[0],  # hash size
+                )
+                logger.info(
+                    "Since use_linear_regression_prefetch_estimate is enabled, "
+                    "adjusting num_unique_lookups to be min(estimated_num_unique_lookups, batch_input_count, hash_size)."
+                )
+
+            expected_miss_rate = _stats.expected_miss_rate(caching_ratio)
+
+            # Calculate expected_cache_fetches based on flag
+            if use_batch_inputs_for_expected_cache_fetches:
+                expected_cache_fetches = expected_miss_rate * batch_inputs
+                logger.info(
+                    f"Since use_batch_inputs_for_expected_cache_fetches is enabled, "
+                    f"computing expected_cache_fetches = expected_miss_rate * batch_inputs. "
+                    f"For example, [expected_cache_fetches] table={sharding_option.name} "
+                    f"using batch_inputs: expected_miss_rate={expected_miss_rate} * "
+                    f"batch_inputs={batch_inputs} = {expected_cache_fetches}"
+                )
+            else:
+                expected_cache_fetches = expected_miss_rate * num_unique_lookups
+                logger.info(
+                    f"Computing expected_cache_fetches = expected_miss_rate * expected_unique_lookups. "
+                    f"For example, [expected_cache_fetches] table={sharding_option.name} "
+                    f"using expected_unique_lookups: expected_miss_rate={expected_miss_rate} * "
+                    f"expected_unique_lookups={num_unique_lookups} = {expected_cache_fetches}"
+                )
+
+            # Extended prefetch fields for FB hardware estimators (linear regression)
+            expected_unique_lookups = num_unique_lookups
+            # expected_lookups is total lookups (batch_inputs)
+            expected_lookups = float(batch_inputs)
+
+        # Get device bandwidth
+        device_bw = config.get_device_bw(
+            topology.compute_device,
+            sharding_option.compute_kernel,
+            topology.hbm_mem_bw,
+            topology.ddr_mem_bw,
+            topology.hbm_to_ddr_mem_bw,
+            caching_ratio,
+            prefetch_pipeline,
+        )
+
+        if device_bw is None:
+            raise PlannerError(
+                f"No kernel bandwidth for compute device: {topology.compute_device}, "
+                f"compute kernel: {sharding_option.compute_kernel}"
+            )
+
+        # Get input_data_type_size from config annotation (if set) or use default BIGINT_DTYPE
+        input_data_type_size = getattr(config, "_input_data_type_size", BIGINT_DTYPE)
+
+        # Build contexts
+        contexts = []
+        for hash_size, emb_dim in shard_sizes:
+            # Calculate expected_lookups for this shard (based on input_read_size formula)
+            # This matches FB hardware estimator's usage: expected_lookups=input_read_size
+            shard_expected_lookups = expected_lookups
+            if expected_unique_lookups is not None:
+                # batch_inputs * world_size * input_data_type_size
+                batch_inputs = sum(
+                    x * y * z
+                    for x, y, z in zip(
+                        sharding_option.input_lengths, num_poolings, batch_sizes
+                    )
+                )
+                shard_expected_lookups = (
+                    batch_inputs * topology.world_size * BIGINT_DTYPE
+                )
+
+            ctx = cls(
+                sharding_type=sharding_option.sharding_type,
+                compute_kernel=sharding_option.compute_kernel,
+                hash_size=hash_size,
+                emb_dim=emb_dim,
+                batch_sizes=batch_sizes,
+                num_poolings=num_poolings,
+                input_lengths=sharding_option.input_lengths,
+                world_size=topology.world_size,
+                local_world_size=topology.local_world_size,
+                input_data_type_size=input_data_type_size,
+                table_data_type_size=table_data_type_size,
+                output_data_type_size=output_data_type_size,
+                fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
+                bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
+                fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
+                bwd_sr_comm_data_type_size=bwd_sr_comm_data_type_size,
+                device_bw=device_bw,
+                hbm_to_ddr_mem_bw=topology.hbm_to_ddr_mem_bw,
+                comms_bandwidths=topology.comms_bandwidths,
+                is_inference=is_inference,
+                is_weighted=is_weighted,
+                is_pooled=sharding_option.is_pooled,
+                has_feature_processor=has_feature_processor,
+                bwd_compute_multiplier=topology.bwd_compute_multiplier,
+                weighted_feature_bwd_compute_multiplier=topology.weighted_feature_bwd_compute_multiplier,
+                expected_cache_fetches=expected_cache_fetches,
+                expected_lookups=shard_expected_lookups,
+                expected_unique_lookups=expected_unique_lookups,
+            )
+            contexts.append(ctx)
+
+        return contexts
+
+    # =========================================================================
+    # Computed properties - raw derived values only
+    # =========================================================================
+
+    @property
+    def num_hosts(self) -> int:
+        """Number of hosts in the topology."""
+        return max(1, self.world_size // self.local_world_size)
+
+    @property
+    def batch_inputs(self) -> float:
+        """Raw batch inputs: sum of input_lengths * num_poolings * batch_sizes."""
+        return sum(
+            x * y * z
+            for x, y, z in zip(self.input_lengths, self.num_poolings, self.batch_sizes)
+        )
+
+    @property
+    def batch_outputs(self) -> float:
+        """
+        Raw batch outputs.
+
+        For pooled: sum of num_poolings * batch_sizes.
+        For unpooled: same as batch_inputs.
+        """
+        if self.is_pooled:
+            return sum(x * y for x, y in zip(self.num_poolings, self.batch_sizes))
+        return self.batch_inputs
+
+    @property
+    def is_uvm_caching(self) -> bool:
+        """Check if using UVM caching."""
+        return self.compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING.value


### PR DESCRIPTION
Summary:
This integrates the Enumerator with new EmbeddingPerfEstimator-> EmbeddingPerfEstimatorFactory.create method.

Integrates EmbeddingPerfEstimatorFactory with legacy EmbeddingPerfEstimator for backward compatibility.

We use Kill-Switch to do this integration and subsequent diffs will remove this kill switch
url: https://www.internalfb.com/intern/justknobs/?name=pytorch%2Ftorchrec#enable_config_based_fb_perf_estimators

Differential Revision: D91859861


