### PR TITLE
add size_in_bytes function for sparse data class

### DIFF
--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -145,6 +145,19 @@ class ModelInput(Pipelineable):
             self.idscore_features.record_stream(stream)
         self.label.record_stream(stream)
 
+    def size_in_bytes(self) -> int:
+        """
+        Returns the size of the ModelInput in bytes.
+        Recursively computes size for all contained tensors and sparse data structures.
+        """
+        size = self.float_features.element_size() * self.float_features.numel()
+        size += self.label.element_size() * self.label.numel()
+        if self.idlist_features is not None:
+            size += self.idlist_features.size_in_bytes()
+        if self.idscore_features is not None:
+            size += self.idscore_features.size_in_bytes()
+        return size
+
     @classmethod
     def generate_global_and_local_batches(
         cls,

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -837,6 +837,19 @@ class ModelInput(Pipelineable):
             self.idscore_features.record_stream(stream)
         self.label.record_stream(stream)
 
+    def size_in_bytes(self) -> int:
+        """
+        Returns the size of the ModelInput in bytes.
+        Recursively computes size for all contained tensors and sparse data structures.
+        """
+        size = self.float_features.element_size() * self.float_features.numel()
+        size += self.label.element_size() * self.label.numel()
+        if isinstance(self.idlist_features, KeyedJaggedTensor):
+            size += self.idlist_features.size_in_bytes()
+        if isinstance(self.idscore_features, KeyedJaggedTensor):
+            size += self.idscore_features.size_in_bytes()
+        return size
+
 
 DENSE_LAYER_OUT_SIZE = 8
 OVER_ARCH_OUT_SIZE = 16

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -244,6 +244,32 @@ class TestKeyedTensor(unittest.TestCase):
         torch.allclose(actual_kt_0_grad, expected_kt_0_grad)
         torch.allclose(actual_kt_1_grad, expected_kt_1_grad)
 
+    def test_size_in_bytes(self) -> None:
+        # Test size_in_bytes with float32 tensor (4 bytes per element)
+        tensor_list = [
+            torch.Tensor([[1.0, 1.0]]),
+            torch.Tensor([[2.0, 2.0], [3.0, 3.0]]),
+        ]
+        keys = ["dense_0", "dense_1"]
+        kt = KeyedTensor.from_tensor_list(keys, tensor_list, cat_dim=0, key_dim=0)
+
+        # Expected: 6 float32 elements (2 + 4) * 4 bytes = 24 bytes
+        expected_size = 6 * 4
+        self.assertEqual(kt.size_in_bytes(), expected_size)
+
+    def test_size_in_bytes_different_dtypes(self) -> None:
+        # Test size_in_bytes with float64 tensor (8 bytes per element)
+        tensor_list = [
+            torch.DoubleTensor([[1.0, 1.0]]),
+            torch.DoubleTensor([[2.0, 2.0], [3.0, 3.0]]),
+        ]
+        keys = ["dense_0", "dense_1"]
+        kt = KeyedTensor.from_tensor_list(keys, tensor_list, cat_dim=0, key_dim=0)
+
+        # Expected: 6 float64 elements (2 + 4) * 8 bytes = 48 bytes
+        expected_size = 6 * 8
+        self.assertEqual(kt.size_in_bytes(), expected_size)
+
     # pyre-ignore[56]
     @given(
         device_str=st.sampled_from(["cpu", "cuda"]),


### PR DESCRIPTION
Summary:
This diff adds a `size_in_bytes()` method to sparse data classes (`JaggedTensor`, `KeyedJaggedTensor`, `KeyedTensor`) and to `ModelInput` in test_utils.

The `size_in_bytes()` method calculates the memory footprint of these data structures by summing up the sizes of all contained tensors (values, weights, lengths, offsets as applicable).

For `ModelInput`, the method recursively computes the size by summing the float_features, label tensors, and calling `size_in_bytes()` on the embedded `KeyedJaggedTensor` features.

This enables memory profiling and debugging of TorchRec sparse data pipelines.

Differential Revision: D92176961


