### PR TITLE
Refactor jagged_tensor_benchmark to use torchrec benchmark framework

### DIFF
--- a/.github/scripts/run_benchmarks.sh
+++ b/.github/scripts/run_benchmarks.sh
@@ -34,3 +34,8 @@ python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
     --memory_snapshot=True \
     --pipeline="sparse" \
     --name="sparse_data_dist_light"
+
+# Jagged tensor benchmark
+python -m torchrec.sparse.tests.jagged_tensor_benchmark \
+    --pre_gpu_load=1 \
+    --memory_snapshot=True


### PR DESCRIPTION
Summary:
Migrate jagged_tensor_benchmark from the ad-hoc click-based CLI to the standardized torchrec benchmark framework used in distributed benchmarks. This enables consistent benchmarking infrastructure with proper timing, memory stats collection, profiling support, and YAML/JSON config file support.

The refactoring replaces the custom `bench()` function with `benchmark_func()` from `torchrec.distributed.benchmark.base` and uses the `cmd_conf` decorator pattern for CLI argument parsing via dataclasses.

```
# Buck2 (internal):
buck2 run fbcode//mode/opt fbcode//torchrec/sparse/tests:jagged_tensor_benchmark -- --batch_size=1024 --n_dense=20 --n_sparse=1000

# OSS (external):
python -m torchrec.sparse.tests.jagged_tensor_benchmark --batch_size=1024 --n_dense=20 --n_sparse=1000
```

* benchmark

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|torch_generic                      |2.50 ms          |5.77 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.33 GB           |
|kt.regroup                         |2.75 ms          |1.72 ms          |1.52 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.56 GB           |
|regroup_module                     |0.76 ms          |0.15 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.56 GB           |
|permute_multi_embs                 |1.44 ms          |0.83 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.57 GB           |
|regroup_kts                        |1.55 ms          |1.00 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.58 GB           |
|permute_pooled_embs                |2.71 ms          |1.68 ms          |1.52 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.58 GB           |
|torch_generic_dup                  |2.38 ms          |5.29 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.34 GB           |
|kt.regroup_dup                     |2.54 ms          |2.16 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.56 GB           |
|regroup_module_dup                 |0.78 ms          |0.16 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.62 GB           |
|permute_multi_embs_dup             |1.44 ms          |0.83 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.62 GB           |
|regroup_kts_dup                    |1.59 ms          |1.02 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.62 GB           |
|torch_generic_fallback_dup         |2.45 ms          |2.03 ms          |1.01 GB                 |13.82 GB                   |14.33 GB          |0.0 / 0.0 / 0.0              |1.62 GB           |

Differential Revision: D92217936


