### PR TITLE
use reserved slots to support always-on table

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -505,9 +505,13 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     else (None, -1)
                 )
 
+                # self._opt_in_prob == 100 means reserved slots are used as always-on table
+                # we do not need to generate opt_in_rands, and assign it to None
                 opt_in_rands = (
                     (torch.rand_like(values, dtype=torch.float) * 100).to(torch.int32)
-                    if self._opt_in_prob != -1 and self.training
+                    if self._opt_in_prob > 0
+                    and self._opt_in_prob < 100
+                    and self.training
                     else None
                 )
 


### PR DESCRIPTION
Summary:
feature is requested from [doc](https://docs.google.com/document/d/11hFqQTDeCy8P47lAOonvyOlovjRU1lBTPLnWT7Q8_Vw/edit?tab=t.0#bookmark=id.qa1fb2m23dwc)

change the logic so when
`opt_in_prob==100 && opt_in_rands=nullptr`

 the kernel always use opt-in.
In the meantime keep the kernel backward compatible.

Reviewed By: zlzhao1104

Differential Revision: D91915902


