### PR TITLE
Backward injection framework for SDD & variants

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Backward hook injection utilities for training pipelines.
+
+This module provides utilities for injecting work functions into the backward
+pass of EC (EmbeddingCollection) and EBC (EmbeddingBagCollection) modules.
+Work functions are registered at specific injection sites and executed during
+the backward all-to-all communication phase.
+
+Example usage:
+    from torchrec.distributed.train_pipeline.backward_injection import (
+        BackwardHookRegistry,
+        InjectionSite,
+        register_hooks,
+    )
+    from torchrec.distributed.types import ShardingType
+
+    # Create registry and add hooks
+    registry = BackwardHookRegistry()
+    registry.add_hook(
+        InjectionSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE),
+        lambda p: p._optimizer.step(),
+    )
+
+    # In pipeline progress():
+    register_hooks(registry, pipeline, context.output_dist_embeddings_requests)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, TYPE_CHECKING
+
+import torch
+from torch.autograd.profiler import record_function
+from torchrec.distributed.comm_ops import Request
+from torchrec.distributed.embedding import EmbeddingCollectionAwaitable
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionAwaitable
+from torchrec.distributed.types import Awaitable, NoWait, ShardingType
+
+
+if TYPE_CHECKING:
+    from torchrec.distributed.train_pipeline.train_pipelines import (  # @manual
+        TrainPipeline,
+    )
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# Type alias for work function that receives pipeline reference
+BackwardHookWork = Callable[["TrainPipeline"], None]
+
+
+@dataclass(frozen=True)
+class InjectionSite:
+    """
+    Injection site specification for backward hooks.
+
+    Attributes:
+        fqn: Fully qualified name of the module (e.g., "sparse_arch.ebc")
+        sharding_type: The sharding type to target (e.g., ShardingType.TABLE_WISE)
+    """
+
+    fqn: str
+    sharding_type: ShardingType
+
+
+@dataclass
+class BackwardHookRegistry:
+    """Registry mapping injection sites to their work functions."""
+
+    hooks: Dict[InjectionSite, List[BackwardHookWork]] = field(default_factory=dict)
+
+    def add_hook(
+        self,
+        site: InjectionSite,
+        work: BackwardHookWork,
+    ) -> None:
+        """Adds a work function at the specified injection site."""
+        if site not in self.hooks:
+            self.hooks[site] = []
+        self.hooks[site].append(work)
+
+    def work(self, site: InjectionSite) -> List[BackwardHookWork]:
+        """Gets all work functions for a site."""
+        return self.hooks.get(site, [])
+
+
+def _filter_awaitables(
+    odist_awaitable: Any,
+) -> Dict[ShardingType, Awaitable[torch.Tensor]] | None:
+    """
+    Extracts valid (non-DP) awaitables from an EC/EBC awaitable.
+
+    Args:
+        odist_awaitable: The EC/EBC awaitable (may be MC tuple-wrapped)
+
+    Returns:
+        Dict mapping ShardingType to awaitable, or None if not a valid
+        EC/EBC awaitable. DP sharding (NoWait) awaitables are filtered out.
+    """
+    # Handle MC EC/EBC tuple wrapping
+    if isinstance(odist_awaitable, tuple):
+        odist_awaitable = odist_awaitable[0]
+
+    # NOTE: We avoid importing VariableBatchEmbeddingBagCollectionAwaitable directly
+    # due to torch.package compatibility issues with repackaging. Instead, we use
+    # hasattr to detect EBC-like awaitables (including VB-EBC).
+    match odist_awaitable:
+        case EmbeddingBagCollectionAwaitable():
+            awaitables = odist_awaitable._awaitables
+            sharding_types = odist_awaitable._sharding_types
+        case EmbeddingCollectionAwaitable():
+            awaitables = odist_awaitable._awaitables_per_sharding
+            sharding_types = odist_awaitable._sharding_types
+        case _ if hasattr(odist_awaitable, "_awaitables") and hasattr(
+            odist_awaitable, "_sharding_types"
+        ):
+            awaitables = odist_awaitable._awaitables
+            sharding_types = odist_awaitable._sharding_types
+        case _:
+            logger.warning(
+                f"Unsupported awaitable type: {type(odist_awaitable).__name__}. "
+            )
+            return None
+
+    # Filter out DP (NoWait) and build dict mapping sharding type to awaitable
+    valid_awaitables: Dict[str, Awaitable[torch.Tensor]] = {}
+    for w, sharding_type in zip(awaitables, sharding_types):
+        if isinstance(w, NoWait):
+            continue
+
+        valid_awaitables[ShardingType(sharding_type)] = w
+
+    return valid_awaitables
+
+
+def _find_awaitable_for_site(
+    site: InjectionSite,
+    output_dist_embeddings_requests: Dict[str, Any],
+) -> Awaitable[torch.Tensor] | None:
+    """
+    Finds the specific awaitable matching the injection site.
+
+    Args:
+        site: The injection site specification
+        output_dist_embeddings_requests: Dict mapping FQN to EC/EBC awaitables
+
+    Returns:
+        The matching awaitable, or None if not found
+    """
+    # Find the FQN for this site
+    if site.fqn not in output_dist_embeddings_requests:
+        logger.warning(f"Could not find module FQN for site: {site}")
+        return None
+
+    # Get valid (non-DP) awaitables
+    valid_awaitables = _filter_awaitables(output_dist_embeddings_requests[site.fqn])
+    if valid_awaitables is None or site.sharding_type not in valid_awaitables:
+        logger.warning(
+            f"Could not find awaitable for module {site.fqn} "
+            f"with sharding type: {site.sharding_type}"
+        )
+        return None
+
+    return valid_awaitables[site.sharding_type]
+
+
+def _register_hook_on_tensor(
+    awaitable: Awaitable[torch.Tensor],
+    hook_fn: Callable[[torch.Tensor], None],
+) -> bool:
+    """
+    Registers a hook on the awaitable's dummy tensor.
+
+    Returns True if successful, False otherwise.
+    """
+    tensor_awaitable = getattr(awaitable, "_tensor_awaitable", None)
+    if tensor_awaitable is None:
+        return False
+
+    if isinstance(tensor_awaitable, Request):
+        dummy_tensor = tensor_awaitable.dummy_tensor
+        dummy_tensor.register_hook(hook_fn)
+        return True
+
+    return False
+
+
+def _create_backward_hook(
+    pipeline: "TrainPipeline",
+    work_list: List[BackwardHookWork],
+    site_name: str,
+) -> Callable[[torch.Tensor], None]:
+    """
+    Creates a backward hook function that executes the given work list.
+
+    Args:
+        pipeline: The pipeline instance to pass to work functions
+        work_list: List of work functions to execute
+        site_name: Name of the injection site (for profiling)
+
+    Returns:
+        Hook function to register on a tensor
+    """
+
+    def hook_fn(grad: torch.Tensor) -> None:
+        with record_function(f"## backward_hook {site_name} ##"):
+            for work in work_list:
+                work(pipeline)
+
+    return hook_fn
+
+
+def register_hooks(
+    registry: BackwardHookRegistry,
+    pipeline: "TrainPipeline",
+    output_dist_embeddings_requests: Dict[str, Any],
+) -> None:
+    """
+    Registers all configured backward hooks on output dist tensors.
+
+    This function iterates through all registered hooks in the registry and
+    attaches them to the appropriate output dist tensors. The hooks will be
+    executed during the backward pass when gradients flow through the tensors.
+
+    Args:
+        registry: The backward hook registry containing hook configurations
+        pipeline: The pipeline instance to pass to work functions
+        output_dist_embeddings_requests: Dict mapping FQN to EC/EBC awaitables
+            (typically context.output_dist_embeddings_requests)
+
+    Example:
+        register_hooks(
+            registry=self._backward_hook_registry,
+            pipeline=self,
+            output_dist_embeddings_requests=self.contexts[0].output_dist_embeddings_requests,
+        )
+    """
+    if len(registry.hooks) == 0:
+        return
+
+    if len(output_dist_embeddings_requests) == 0:
+        logger.warning(
+            "No output dist requests found. Skipping backward hook registration."
+        )
+        return
+
+    for site, work_list in registry.hooks.items():
+        # Find the specific awaitable matching the site
+        awaitable = _find_awaitable_for_site(site, output_dist_embeddings_requests)
+        if awaitable is None:
+            logger.warning(f"Could not find awaitable for site: {site}")
+            continue
+
+        # Register hook on the dummy tensor
+        registered = _register_hook_on_tensor(
+            awaitable,
+            _create_backward_hook(pipeline, work_list, str(site)),
+        )
+
+        if registered:
+            logger.info(f"Registered backward hook for site: {site} ")

--- a/torchrec/distributed/train_pipeline/pipeline_context.py
+++ b/torchrec/distributed/train_pipeline/pipeline_context.py
@@ -35,6 +35,9 @@ class TrainPipelineContext:
         input_dist_tensors_requests (Dict[str, Awaitable[Any]]): Stores input dist
             requests in the tensors awaitable stage, which occurs after calling `wait()`
             on the splits awaitable.
+        output_dist_embeddings_requests (Dict[str, Awaitable[Any]]): Stores output dist
+            awaitables for pipelined modules, keyed by module FQN. Used for registering
+            backward hooks on the output dist tensors during the backward pass.
         module_contexts (Dict[str, Multistreamable]): Stores module contexts from the
             input dist for the current batch.
         module_contexts_next_batch (Dict[str, Multistreamable]): Stores module contexts
@@ -51,6 +54,9 @@ class TrainPipelineContext:
     input_dist_splits_requests: Dict[str, Awaitable[Any]] = field(default_factory=dict)
     # pyre-ignore [4]
     input_dist_tensors_requests: Dict[str, Awaitable[Any]] = field(default_factory=dict)
+    output_dist_embeddings_requests: Dict[str, Awaitable[Any]] = field(
+        default_factory=dict
+    )
     module_contexts: Dict[str, Multistreamable] = field(default_factory=dict)
     module_contexts_next_batch: Dict[str, Multistreamable] = field(
         default_factory=dict

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -100,7 +100,9 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
             data.record_stream(cur_stream)
             ctx.record_stream(cur_stream)
 
-        return self._module.compute_and_output_dist(ctx, data)
+        awaitable = self._module.compute_and_output_dist(ctx, data)
+        self._context.output_dist_embeddings_requests[self._name] = awaitable
+        return awaitable
 
 
 class EmbeddingPipelinedForward(BaseForward[EmbeddingTrainPipelineContext]):

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import copy
+import unittest
+from typing import Callable, cast, List
+from unittest.mock import patch
+
+import torch
+from hypothesis import given, settings, strategies as st
+from torch import nn, optim
+from torchrec.distributed import DistributedModelParallel
+from torchrec.distributed.comm_ops import All2All_Pooled_Req, ReduceScatterBase_Req
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.emb_sharder import TestEBCSharder
+from torchrec.distributed.test_utils.model_input import ModelInput
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.train_pipeline.backward_injection import (
+    BackwardHookRegistry,
+    InjectionSite,
+)
+from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+# TestCase instance for assertions in test runner functions
+tc = unittest.TestCase()
+tc.maxDiff = None
+
+
+class BackwardHookRegistryTest(unittest.TestCase):
+    """Unit tests for BackwardHookRegistry."""
+
+    def test_add_hook_and_work(self) -> None:
+        """Verifies add_hook stores hook and work returns it."""
+        registry = BackwardHookRegistry()
+        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+
+        def work_fn(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        registry.add_hook(site, work_fn)
+
+        self.assertEqual(registry.work(site), [work_fn])
+
+    def test_multiple_hooks_same_site(self) -> None:
+        """Verifies multiple hooks at same site are returned in order."""
+        registry = BackwardHookRegistry()
+        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+
+        def work_fn_1(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        def work_fn_2(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        registry.add_hook(site, work_fn_1)
+        registry.add_hook(site, work_fn_2)
+
+        self.assertEqual(registry.work(site), [work_fn_1, work_fn_2])
+
+    def test_different_sites_isolated(self) -> None:
+        """Verifies hooks at different sites are isolated."""
+        registry = BackwardHookRegistry()
+        site_1 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+        site_2 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.ROW_WISE)
+
+        def work_fn_1(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        def work_fn_2(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        registry.add_hook(site_1, work_fn_1)
+        registry.add_hook(site_2, work_fn_2)
+
+        self.assertEqual(registry.work(site_1), [work_fn_1])
+        self.assertEqual(registry.work(site_2), [work_fn_2])
+
+    def test_work_unknown_site_returns_empty(self) -> None:
+        """Verifies work returns empty list for unregistered site."""
+        registry = BackwardHookRegistry()
+        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+
+        self.assertEqual(registry.work(site), [])
+
+    def test_add_same_hook_to_multiple_sites(self) -> None:
+        """Verifies same hook can be added to multiple sites."""
+        registry = BackwardHookRegistry()
+        site_1 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+        site_2 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.ROW_WISE)
+
+        def work_fn(_p: TrainPipelineSparseDist) -> None:
+            pass
+
+        registry.add_hook(site_1, work_fn)
+        registry.add_hook(site_2, work_fn)
+
+        self.assertEqual(registry.work(site_1), [work_fn])
+        self.assertEqual(registry.work(site_2), [work_fn])
+
+    def test_hooks_dict_empty_by_default(self) -> None:
+        """Verifies hooks dict is empty when registry is created."""
+        registry = BackwardHookRegistry()
+        self.assertEqual(registry.hooks, {})
+
+
+def _create_pipeline(
+    ctx: MultiProcessContext,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    sharding_type: str = ShardingType.TABLE_WISE.value,
+) -> TrainPipelineSparseDist:
+    """Helper to create a TrainPipelineSparseDist for testing."""
+    unsharded_model = TestSparseNN(
+        tables=tables,
+        weighted_tables=weighted_tables,
+        dense_device=ctx.device,
+        sparse_device=torch.device("meta"),
+    )
+
+    sharder = TestEBCSharder(
+        sharding_type=sharding_type,
+        kernel_type=EmbeddingComputeKernel.FUSED.value,
+    )
+
+    sharded_model = DistributedModelParallel(
+        module=copy.deepcopy(unsharded_model),
+        env=ShardingEnv.from_process_group(ctx.pg),
+        device=ctx.device,
+        sharders=[cast(ModuleSharder[nn.Module], sharder)],
+    )
+
+    optimizer = optim.SGD(sharded_model.parameters(), lr=0.1)
+
+    return TrainPipelineSparseDist(
+        model=sharded_model,
+        optimizer=optimizer,
+        device=ctx.device,
+    )
+
+
+def _run_backward_hook_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[ModelInput],
+    sharding_type: str,
+    site_fqn: str,
+    backend: str = "nccl",
+    local_size: int | None = None,
+    num_hooks: int = 1,
+) -> None:
+    """Test runner for backward hook execution with multi-GPU setup."""
+    operation_order: List[str] = []
+
+    # Different sharding types use different backward comm ops
+    if sharding_type in [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value]:
+        original_backward = All2All_Pooled_Req.backward
+        backward_cls = All2All_Pooled_Req
+    else:  # ROW_WISE uses reduce-scatter
+        original_backward = ReduceScatterBase_Req.backward
+        backward_cls = ReduceScatterBase_Req
+
+    def wrapper_func(*args, **kwargs):
+        operation_order.append("comm_op")
+        return original_backward(*args, **kwargs)
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        tc.assertIsNotNone(ctx.pg)
+        pipeline = _create_pipeline(ctx, tables, weighted_tables, sharding_type)
+
+        # Register hook(s)
+        def make_work_fn(idx: int) -> Callable[[TrainPipelineSparseDist], None]:
+            def work_fn(_p: TrainPipelineSparseDist) -> None:
+                operation_order.append(f"hook_{idx}")
+
+            return work_fn
+
+        for i in range(num_hooks):
+            pipeline.register_backward_hook(
+                site=InjectionSite(
+                    fqn=site_fqn, sharding_type=ShardingType(sharding_type)
+                ),
+                work=make_work_fn(i),
+            )
+
+        dataloader = iter(data)
+        with patch.object(backward_cls, "backward", side_effect=wrapper_func):
+            pipeline.progress(dataloader)
+
+        # Verify hooks were executed in order
+        hook_entries = [f"hook_{i}" for i in range(num_hooks)]
+        if site_fqn == "sparse.ebc":
+            expected = ["comm_op"] + hook_entries + ["comm_op"]
+        elif site_fqn == "sparse.weighted_ebc":
+            expected = hook_entries + ["comm_op", "comm_op"]
+        else:
+            raise ValueError(f"Unknown site_fqn: {site_fqn}")
+
+        tc.assertEqual(operation_order, expected)
+
+
+def _run_nonexistent_site_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[ModelInput],
+    backend: str = "nccl",
+    local_size: int | None = None,
+) -> None:
+    """Test runner to verify warning is logged for non-existent site."""
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        tc.assertIsNotNone(ctx.pg)
+        pipeline = _create_pipeline(ctx, tables, weighted_tables)
+
+        hook_executed: List[bool] = []
+        pipeline.register_backward_hook(
+            site=InjectionSite(
+                fqn="nonexistent.module", sharding_type=ShardingType.TABLE_WISE
+            ),
+            work=lambda _p: hook_executed.append(True),
+        )
+
+        dataloader = iter(data)
+        with tc.assertLogs(
+            "torchrec.distributed.train_pipeline.backward_injection", level="WARNING"
+        ) as cm:
+            pipeline.progress(dataloader)
+
+        tc.assertTrue(
+            any("nonexistent.module" in msg for msg in cm.output),
+            f"Expected warning about non-existent site. Log output: {cm.output}",
+        )
+        tc.assertEqual(
+            len(hook_executed), 0, "Hook should not execute for non-existent site"
+        )
+
+
+def _run_repeated_calls_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[ModelInput],
+    backend: str = "nccl",
+    local_size: int | None = None,
+    num_progress_calls: int = 3,
+) -> None:
+    """Test runner to verify hooks work across multiple pipeline.progress() calls."""
+    hook_call_count: List[int] = [0]
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        tc.assertIsNotNone(ctx.pg)
+        pipeline = _create_pipeline(ctx, tables, weighted_tables)
+
+        pipeline.register_backward_hook(
+            site=InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE),
+            work=lambda _p: hook_call_count.__setitem__(0, hook_call_count[0] + 1),
+        )
+
+        dataloader = iter(data)
+        for _ in range(num_progress_calls):
+            pipeline.progress(dataloader)
+
+        tc.assertEqual(
+            hook_call_count[0],
+            num_progress_calls,
+            f"Hook should be called {num_progress_calls} times, "
+            f"but was called {hook_call_count[0]} times",
+        )
+
+
+class RegisterHooksTest(MultiProcessTestBase):
+    """Integration tests for register_hooks with real pipeline."""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        num_features = 4
+        num_weighted_features = 2
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(num_features)
+        ]
+        self.weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(num_weighted_features)
+        ]
+
+    def _generate_data(
+        self,
+        num_batches: int = 5,
+        batch_size: int = 1,
+    ) -> List[ModelInput]:
+        return [
+            ModelInput.generate(
+                tables=self.tables,
+                weighted_tables=self.weighted_tables,
+                batch_size=batch_size,
+                num_float_features=10,
+            )
+            for _ in range(num_batches)
+        ]
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    @settings(max_examples=6, deadline=None)
+    # pyre-ignore[56]
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+            ]
+        ),
+        site_fqn=st.sampled_from(["sparse.ebc", "sparse.weighted_ebc"]),
+    )
+    def test_backward_hook_executed_during_backward(
+        self,
+        sharding_type: str,
+        site_fqn: str,
+    ) -> None:
+        """Verifies registered hooks are executed during backward pass."""
+        data = self._generate_data(num_batches=5, batch_size=2)
+        self._run_multi_process_test(
+            callable=_run_backward_hook_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=sharding_type,
+            site_fqn=site_fqn,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_multiple_hooks_executed_in_order(self) -> None:
+        """Verifies multiple hooks at the same site are executed in registration order."""
+        data = self._generate_data(num_batches=5, batch_size=2)
+        self._run_multi_process_test(
+            callable=_run_backward_hook_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            site_fqn="sparse.ebc",
+            num_hooks=3,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_hook_on_nonexistent_site_logs_warning(self) -> None:
+        """Verifies warning is logged when hook registered for site that doesn't exist."""
+        data = self._generate_data(num_batches=5, batch_size=2)
+        self._run_multi_process_test(
+            callable=_run_nonexistent_site_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_hooks_work_across_repeated_progress_calls(self) -> None:
+        """Verifies hooks continue to work correctly across multiple pipeline.progress() calls."""
+        data = self._generate_data(num_batches=10, batch_size=2)
+        self._run_multi_process_test(
+            callable=_run_repeated_calls_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            num_progress_calls=5,
+        )


### PR DESCRIPTION
Summary:
# Context

* In backward pass, we almost always observe bubbles where GPU is idle and waiting for output dist backward to finish.
* The root cause can be traced back to the forward pass: the model is waiting for the results of output dist while doing no or little compute work to overlap, so the same issue occurs in the backward pass in a reversed order.
* It is usually difficult to make model side change to completely hide this latency for two reasons:
  * Cannot find enough embedding independent compute while waiting for the output dist comms
  * The output dist comms can be very long, especially for ECs whose sequence length is getting much larger these days.
* There is a need to create a framework to inject extra work in the backward bubbles to further improve training efficiency

# How Does the Injection Work
Every output dist of EC & EBCs have two stages:
* Req (Request) stage that initiates collective calls
* Wait stage that wait for the req stage to finish and retrieve the embeddings.

There is a [*"dummy_tensor"*](https://www.internalfb.com/code/fbsource/[7e2cdd561cc532512a9c856aefdb7a44dd4e6aa8]/fbcode/torchrec/distributed/comm_ops.py?lines=146) that connects the two stages for gradient propagation. We can hook to this tensor and inject the gradient independent work before gradients passed in.

# Where Should I inject the Work?
You need to identify the injection sites from an existing trace. The `InjectionSite` requires:
* FQN of the EC/EBC
* Sharding type of the output dist

# Use Cases
* `optimizer.step()`
  * It cannot be directly moved in because weights need to be synced via all-reduce in DDP. It is pretty common that a DDP all-reduce is triggered after the sparse backward. We'll address this in follow-ups.
  * Distributed optimizers like Shampoo have comms in critical path, so it will take longer time than usual if injected.
* Metrics collection
* Early lookups

# Limitations

* Users need to run the training first to figure out the bubble location & size. It is difficult to accurately predict which output dist backward has bubbles from CPU side.
* It's possible to inject comms into the bubble, but that is eventually a competition of bandwidth so both comms will become longer than non-overlap scenario.
* Need to support the intra-node dist of TWRW sharding
* Un-pipelined modules currently don't have sharding types populated to output dist awaitables.
* Only support pipelines that rewrite models with FX tracing, e.g. SDD variants.

# Benchmark

In a SDD benchmark, as a quick test we moved the optimizer.step() into the backward of EBC. Before the change, there is a bubble in the output dist backward:
 {F1982600813}

With the backward injection framework, we move optimizer to the bubble:
 {F1982600823}

Reviewed By: TroyGarden

Differential Revision: D83789518


