### PR TITLE
Add core type definitions for new EmbeddingPerfEstimator (#3711)

### DIFF
--- a/torchrec/distributed/planner/estimator/annotations.py
+++ b/torchrec/distributed/planner/estimator/annotations.py
@@ -1,0 +1,1359 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Purpose:
+This module provides decorator functions to annotate hardware-specific properties and communication patterns on
+HardwarePerfConfig classes, enabling flexible and hardware-aware performance modeling for distributed training in TorchRec.
+
+Key Features:
+Hardware Property Annotations: Use decorators like @hbm_mem_bw, @ddr_mem_bw, and @bwd_compute_multiplier to
+specify hardware characteristics (such as memory bandwidth and compute multipliers) on config classes.
+Sharding-Type Specific Overrides: Communication decorators (@fwd_comms, @bwd_comms, @input_dist_comms) can be
+applied to methods, optionally filtered by sharding type (e.g., TABLE_WISE, ROW_WISE). This enables custom
+performance formulas for specific sharding strategies, while using defaults for others.
+Usage Example: You can annotate a config class with hardware properties and override communication formulas
+for particular sharding types.
+Flexible Method Resolution: When an estimator calls a communication method, it checks for sharding-type-specific
+overrides. If a method is annotated for a specific sharding type and matches the context, it uses the custom method; otherwise, it falls back to the default implementation. This keeps code DRY and allows targeted optimizations.
+
+Typical Use Cases:
+Modeling hardware performance for distributed training.
+Customizing communication cost formulas for different sharding strategies.
+Creating hardware-specific estimators for Meta’s infrastructure.
+
+"""
+
+from typing import Any, Callable, cast, List, Optional, overload, Type, TypeVar, Union
+
+# Type variable for decorator return types
+T = TypeVar("T")
+
+# =============================================================================
+# Helper Functions for Accessing Annotated Methods
+# =============================================================================
+
+
+def _matches_sharding_type(method: Callable[..., float], sharding_type: str) -> bool:
+    """
+    Check if a custom method matches the given sharding type.
+
+    Args:
+        method: The custom method to check
+        sharding_type: The sharding type to match against (e.g., 'table_wise')
+
+    Returns:
+        True if the method applies to this sharding type
+    """
+    custom_sharding_type = getattr(method, "_custom_sharding_type", None)
+    if custom_sharding_type is None:
+        # No sharding type restriction - applies to all
+        return True
+
+    # Handle list/tuple of sharding types
+    if isinstance(custom_sharding_type, (list, tuple)):
+        return sharding_type.lower() in [st.lower() for st in custom_sharding_type]
+
+    # Single sharding type - normalize both to lowercase for comparison
+    return custom_sharding_type.lower() == sharding_type.lower()
+
+
+def _get_annotated_method(
+    config: Any,
+    annotation_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., float]]:
+    """
+    Scan all methods on config for the annotation attribute.
+
+    This function finds any method that has the specified annotation attribute,
+    regardless of the method name. The annotation is the source of truth.
+
+    Args:
+        config: The hardware config to check
+        annotation_attr: The annotation attribute to look for (e.g., '_is_custom_output_write_size')
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+
+    Returns:
+        The annotated method if found and matches sharding type, otherwise None.
+    """
+    for attr_name in dir(config):
+        if attr_name.startswith("_"):
+            continue
+        attr = getattr(config, attr_name, None)
+        if attr and callable(attr) and getattr(attr, annotation_attr, False):
+            # Cast to the expected return type
+            method = cast(Callable[..., float], attr)
+            # Check sharding type if provided
+            if sharding_type is not None:
+                if not _matches_sharding_type(method, sharding_type):
+                    continue
+            return method
+    return None
+
+
+def get_custom_method(
+    obj: Any,
+    method_name: str,
+    annotation_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., float]]:
+    """
+    Get a method from an object if it has the specified annotation attribute
+    and optionally matches the specified sharding type.
+
+    Args:
+        obj: The object to get the method from
+        method_name: Name of the method to retrieve
+        annotation_attr: The annotation attribute to check for
+        sharding_type: Optional sharding type to filter by. If provided, the method
+            must either have no sharding_type restriction or match this sharding_type.
+
+    Returns:
+        The method if it exists, has the annotation, and matches the sharding type
+        (if specified), otherwise None
+    """
+
+    method = getattr(obj, method_name, None)
+    if method and getattr(method, annotation_attr, False):
+        # Check sharding type if provided
+        if sharding_type is not None:
+            if not _matches_sharding_type(method, sharding_type):
+                return None
+        return method
+    return None
+
+
+def get_forward_compute(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom forward compute method if annotated with @forward_compute.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_forward_compute", sharding_type)
+
+
+def get_backward_compute(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom backward compute method if annotated with @backward_compute.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_backward_compute", sharding_type)
+
+
+def get_prefetch_compute(config: Any) -> Optional[Callable[..., float]]:
+    """Get custom prefetch compute method if annotated with @prefetch_compute."""
+    return _get_annotated_method(config, "_is_custom_prefetch_compute")
+
+
+def get_input_dist_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom input dist comms method if annotated with @input_dist_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_input_dist_comms", sharding_type)
+
+
+def get_fwd_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom fwd comms method if annotated with @fwd_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_fwd_comms", sharding_type)
+
+
+def get_bwd_comms(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom bwd comms method if annotated with @bwd_comms.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_bwd_comms", sharding_type)
+
+
+def get_output_write_size(
+    config: Any, sharding_type: Optional[str] = None
+) -> Optional[Callable[..., float]]:
+    """
+    Get custom output write size method if annotated with @output_write_size.
+
+    Scans all methods on the config for the annotation, regardless of method name.
+    The annotation is the source of truth, not the method name.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: Optional sharding type to filter by. If specified, only returns
+            the method if it applies to this sharding type.
+    """
+    return _get_annotated_method(config, "_is_custom_output_write_size", sharding_type)
+
+
+# =============================================================================
+# SECTION 1: Bandwidth Decorators
+# =============================================================================
+
+
+def hbm_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set HBM memory bandwidth for a hardware config.
+
+    HBM High Bandwidth Memory
+
+    Args:
+        value: HBM memory bandwidth in bytes/second
+
+    Example:
+        @hbm_mem_bw(6200 * 1024 * 1024 * 1024)  # 6200 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.hbm_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set DDR memory bandwidth for a hardware config.
+
+    DDR memory is the system/host memory.
+
+    Args:
+        value: DDR memory bandwidth in bytes/second
+
+    Example:
+        @ddr_mem_bw(100 * 1024 * 1024 * 1024)  # 100 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.ddr_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def hbm_to_ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set HBM to DDR memory bandwidth for a hardware config.
+
+    This is the bandwidth for UVM (Unified Virtual Memory) operations
+    that move data between GPU HBM and system DDR memory.
+
+    Args:
+        value: HBM to DDR bandwidth in bytes/second
+
+    Example:
+        @hbm_to_ddr_mem_bw(25.6 * 1024 * 1024 * 1024)  # 25.6 GB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.hbm_to_ddr_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def device_bw(
+    bandwidth: Optional[float] = None,
+    *,
+    device: Optional[str] = None,
+    compute_kernel: Optional[str] = None,
+) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set device bandwidth for a hardware config.
+
+    Usage:
+        # General device bandwidth (existing behavior)
+        @device_bw(3200 * 1024 * 1024 * 1024)
+        class MyConfig(HardwarePerfConfig): pass
+
+        # Specific device + kernel bandwidth (NEW)
+        @device_bw(bandwidth=5000, device='cuda', compute_kernel='fused')
+        @device_bw(bandwidth=3000, device='cuda', compute_kernel='dense')
+        class MyConfig(HardwarePerfConfig): pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        if device is not None and compute_kernel is not None:
+            # Bind to local variables to satisfy type narrowing
+            device_str: str = device
+            compute_kernel_str: str = compute_kernel
+            # Specific device + kernel override
+            # IMPORTANT: Check if kernel_device_bandwidths is inherited from parent class
+            # If so, create a new dictionary for this class to avoid modifying the shared one
+            if (
+                not hasattr(cls, "kernel_device_bandwidths")
+                or cls.kernel_device_bandwidths is None
+            ):
+                cls.kernel_device_bandwidths = {}  # pyre-ignore[16]
+            else:
+                # Check if we're using an inherited dictionary by comparing with parent's
+                # If so, create a new copy for this class
+                for base in cls.__mro__[1:]:
+                    if (
+                        hasattr(base, "kernel_device_bandwidths")
+                        and cls.kernel_device_bandwidths
+                        is base.kernel_device_bandwidths
+                    ):
+                        cls.kernel_device_bandwidths = dict(
+                            cls.kernel_device_bandwidths
+                        )  # pyre-ignore[16]
+                        break
+            # Store with lowercase keys for case-insensitive lookup
+            key = (device_str.lower(), compute_kernel_str.lower())
+            cls.kernel_device_bandwidths[key] = bandwidth  # pyre-ignore[16]
+        else:
+            # General device bandwidth (existing behavior)
+            cls.device_bw = bandwidth  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 4: Communication Bandwidth Decorators
+# =============================================================================
+
+
+def intra_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set intra-host communication bandwidth.
+
+    This is the bandwidth for communication between GPUs within the
+    same host (e.g., NVLink, NVSwitch).
+
+    Args:
+        value: Intra-host bandwidth in bytes/second
+
+    Example:
+        @intra_host_bw(600 * 1024 * 1024 * 1024)  # 600 GB/s (NVLink)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.intra_host_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def inter_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set inter-host communication bandwidth.
+
+    This is the bandwidth for communication between GPUs across
+    different hosts (e.g., InfiniBand, RoCE).
+
+    Args:
+        value: Inter-host bandwidth in bytes/second
+
+    Example:
+        @inter_host_bw(25 * 1024 * 1024 * 1024)  # 25 GB/s (IB HDR)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.inter_host_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 3: Custom Compute Method Decorators
+# =============================================================================
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def forward_compute(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def forward_compute(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def forward_compute(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom forward compute implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing forward pass time instead of the default linear regression model.
+    This is useful for hardware with unique kernel breakdown patterns
+    (e.g., Athena's BCI + IRLE model).
+    Example:
+        class AthenaHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @forward_compute
+            def compute_fwd(self, ctx: ShardPerfContext) -> float:
+                # Custom Athena kernel breakdown logic
+                bci_time = self._compute_bci(ctx)
+                irle_time = self._compute_irle(ctx)
+                return self.bci_coeff * bci_time + self.irle_coeff * irle_time
+
+            # Applies only to TABLE_WISE sharding
+            @forward_compute(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_fwd(self, ctx: ShardPerfContext) -> float:
+                return self._compute_table_wise_fwd(ctx)
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_forward_compute = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @forward_compute (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @forward_compute(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @forward_compute('table_wise') or @forward_compute(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @forward_compute() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def backward_compute(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def backward_compute(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def backward_compute(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom backward compute implementation.
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_backward_compute = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @backward_compute (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @backward_compute(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @backward_compute('table_wise') or @backward_compute(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @backward_compute() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+def prefetch_compute(
+    method: Callable[..., float],
+) -> Callable[..., float]:
+    """
+    Decorator to mark a method as custom prefetch compute implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing prefetch/cache loading time.
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            @prefetch_compute
+            def compute_prefetch(self, ctx: ShardPerfContext, expected_cache_fetches: float) -> float:
+                # Custom prefetch logic
+                return expected_cache_fetches * ctx.shard_embedding_dim / self.custom_prefetch_bw
+    """
+    method._is_custom_prefetch_compute = True  # pyre-ignore[16]
+    return method
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def input_dist_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def input_dist_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def input_dist_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom input distribution communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing input distribution communication time (A2A input dist latency).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @input_dist_comms
+            def compute_input_dist_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.input_read_size / self.custom_input_dist_bw
+
+            # Applies only to TABLE_WISE sharding
+            @input_dist_comms(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_input_dist_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.input_read_size / self.table_wise_input_dist_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_input_dist_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @input_dist_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @input_dist_comms(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @input_dist_comms('table_wise') or @input_dist_comms(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @input_dist_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def fwd_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def fwd_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def fwd_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom forward communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing forward pass communication time (e.g., All-to-all, Reduce-scatter).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @fwd_comms
+            def compute_fwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.fwd_output_write_size / self.custom_fwd_comms_bw
+
+            # Applies only to TABLE_WISE sharding
+            @fwd_comms(sharding_type=ShardingType.TABLE_WISE.value)
+            def compute_fwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.fwd_output_write_size / self.table_wise_fwd_comms_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_fwd_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @fwd_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @fwd_comms(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @fwd_comms('table_wise') or @fwd_comms(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @fwd_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def bwd_comms(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def bwd_comms(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def bwd_comms(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom backward communication implementation.
+
+    Use this decorator when a hardware config needs custom logic for
+    computing backward pass communication time (e.g., All-gather, All-reduce).
+
+    Example:
+        class CustomHardwarePerfConfig(DefaultHardwarePerfConfig):
+            # Applies to all sharding types
+            @bwd_comms
+            def compute_bwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.bwd_output_write_size / self.custom_bwd_comms_bw
+
+            # Applies only to ROW_WISE sharding
+            @bwd_comms(sharding_type=ShardingType.ROW_WISE.value)
+            def compute_bwd_comms(self, ctx: ShardPerfContext) -> float:
+                return ctx.bwd_output_write_size / self.row_wise_bwd_comms_bw
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_bwd_comms = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @bwd_comms (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @bwd_comms(sharding_type='row_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @bwd_comms('row_wise') or @bwd_comms(['row_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @bwd_comms() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: Callable[..., float],
+) -> Callable[..., float]: ...
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def output_write_size(
+    method_or_sharding_type: List[str],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+@overload
+def output_write_size(
+    *,
+    sharding_type: Union[str, List[str]],
+) -> Callable[[Callable[..., float]], Callable[..., float]]: ...
+
+
+def output_write_size(
+    method_or_sharding_type: Optional[
+        Union[Callable[..., float], str, List[str]]
+    ] = None,
+    *,
+    sharding_type: Optional[Union[str, List[str]]] = None,
+) -> Union[
+    Callable[..., float], Callable[[Callable[..., float]], Callable[..., float]]
+]:
+    """
+    Decorator to mark a method as custom output write size implementation.
+
+    Use this decorator when a hardware config needs to use a different data type
+    size for fwd_output_write_size calculation. For example, FB legacy estimators
+    use output_data_type_size instead of fwd_a2a_comm_data_type_size.
+
+    The method should have signature:
+        def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float
+
+    Example:
+        class FBHardwarePerfConfig(HardwarePerfConfig):
+            # Applies to all sharding types
+            @output_write_size
+            def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float:
+                # FB legacy uses output_data_type_size for compute formula
+                return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * ctx.output_data_type_size
+
+            # Applies only to TABLE_WISE sharding
+            @output_write_size(sharding_type=ShardingType.TABLE_WISE.value)
+            def get_output_write_size(self, ctx: ShardPerfContext, is_fwd: bool = True) -> float:
+                return ctx.batch_outputs * ctx.world_size * ctx.emb_dim * ctx.output_data_type_size
+    """
+
+    def _apply_decorator(
+        method: Callable[..., float],
+        target_sharding_type: Optional[Union[str, List[str]]],
+    ) -> Callable[..., float]:
+        method._is_custom_output_write_size = True  # pyre-ignore[16]
+        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        return method
+
+    # Case 1: @output_write_size (no parentheses)
+    if callable(method_or_sharding_type):
+        return _apply_decorator(method_or_sharding_type, None)
+
+    # Case 2: @output_write_size(sharding_type='table_wise')
+    if sharding_type is not None:
+        target_sharding_type = sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 3: @output_write_size('table_wise') or @output_write_size(['table_wise', 'column_wise']) - positional argument
+    if isinstance(method_or_sharding_type, (str, list)):
+        target_sharding_type = method_or_sharding_type
+
+        def decorator(method: Callable[..., float]) -> Callable[..., float]:
+            return _apply_decorator(method, target_sharding_type)
+
+        return decorator
+
+    # Case 4: @output_write_size() - empty parentheses
+    def decorator(method: Callable[..., float]) -> Callable[..., float]:
+        return _apply_decorator(method, None)
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 4: Strategy Hook Decorators
+# =============================================================================
+
+
+def use_min_dim_for_lookup(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to enable/disable min_dim constraint for embedding lookup size.
+
+    When enabled (True), embedding lookup uses max(emb_dim, 32) for kernel
+    efficiency. This is the TABLE_WISE behavior per OSS EmbeddingPerfEstimator.
+
+    Args:
+        value: Whether to use min_dim constraint (default: True)
+
+    Example:
+        @use_min_dim_for_lookup(True)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_min_dim_for_lookup = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def use_block_usage_penalty(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to enable/disable block usage penalty for forward compute.
+
+    When enabled (True), forward compute is multiplied by a penalty factor
+    based on emb_dim alignment with GPU block sizes. This is the TABLE_WISE
+    behavior per OSS EmbeddingPerfEstimator.
+
+    Penalty factors:
+    - emb_dim >= 128: 1.0 (no penalty)
+    - emb_dim >= 64: HALF_BLOCK_PENALTY
+    - emb_dim >= 32: QUARTER_BLOCK_PENALTY
+
+    Args:
+        value: Whether to apply block usage penalty (default: True)
+
+    Example:
+        @use_block_usage_penalty(True)
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_block_usage_penalty = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def use_bytes_for_input_read_size(value: bool = True) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to control whether input_read_size is calculated in bytes or counts.
+
+    When enabled (True, default/OSS behavior):
+        input_read_size = batch_inputs * world_size * input_data_type_size  (BYTES)
+    When disabled (False, FB legacy behavior):
+        input_read_size = batch_inputs * world_size  (COUNT of indices)
+
+    This affects the forward/backward compute formulas where input_read_size is used.
+
+    Args:
+        value: Whether to multiply by input_data_type_size (default: True)
+
+    Example:
+        @use_bytes_for_input_read_size(False)  # FB legacy: use counts, not bytes
+        class GrandTetonHardwarePerfConfig(HardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._use_bytes_for_input_read_size = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def input_data_type_size(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set a custom input_data_type_size for the hardware config.
+
+    This allows hardware configs to override the default BIGINT_DTYPE (8 bytes)
+    used in ShardPerfContext. FB legacy estimators use INT_DTYPE (4 bytes).
+
+    Args:
+        value: The input data type size in bytes (e.g., 4.0 for INT_DTYPE, 8.0 for BIGINT_DTYPE)
+
+    Example:
+        @input_data_type_size(4.0)  # FB legacy uses 4 bytes, not 8
+        class GrandTetonHardwarePerfConfig(HardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls._input_data_type_size = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
+def supported_sharding_types(*sharding_types: str) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to specify which sharding types a HardwarePerfConfig supports.
+
+    If not specified, all sharding types are evaluated (default behavior).
+    If specified, only listed sharding types are evaluated; others raise ValueError.
+
+    The annotation is inherited - child classes get parent's supported types
+    unless they override with their own @supported_sharding_types annotation.
+
+    Args:
+        *sharding_types: Sharding type values (e.g., "table_wise", "row_wise")
+
+    Example:
+        @supported_sharding_types("table_wise", "row_wise")
+        class HeterogeneousHardwarePerfConfig(HardwarePerfConfig):
+            pass
+
+    Raises:
+        ValueError: When attempting to evaluate an unsupported sharding type
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        # Store as a frozenset for O(1) lookup, lowercase for case-insensitive matching
+        cls._supported_sharding_types = frozenset(  # pyre-ignore[16]
+            st.lower() for st in sharding_types
+        )
+        return cls
+
+    return decorator
+
+
+# =============================================================================
+# SECTION 5: Coefficient Decorators
+# =============================================================================
+# These decorators allow defining performance coefficients via annotations
+# instead of manually creating PerfCoefficientConfig objects. The evaluator
+# uses these annotations to discover coefficients for each sharding type.
+#
+# Usage example:
+#     class MyHardwarePerfConfig(HardwarePerfConfig):
+#         @fwd_coefficient(sharding_type=["table_wise", "column_wise"])
+#         def tw_cw_fwd(self) -> PerfCoefficient:
+#             return PerfCoefficient(
+#                 input_read_size_multiplier=100.0,
+#                 lookup_size_multiplier=1.0,
+#                 embedding_output_multiplier=1.0,
+#                 hash_size_multiplier=4.5,
+#             )
+#
+#         @bwd_coefficient(sharding_type=["table_wise", "column_wise"])
+#         def tw_cw_bwd(self) -> PerfCoefficient:
+#             return PerfCoefficient(...)
+#
+#         @prefetch_coefficient()
+#         def prefetch_coeff(self) -> PrefetchCoefficients:
+#             return PrefetchCoefficients(...)
+# =============================================================================
+
+
+def fwd_coefficient(
+    sharding_type: Optional[Union[str, list[str]]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing forward pass performance coefficients.
+
+    The decorated method should return a PerfCoefficient object. Method name is
+    arbitrary - only the annotation matters for discovery.
+
+    Args:
+        sharding_type: Sharding type(s) this coefficient applies to.
+                       Can be a single string or list of strings.
+                       If None, applies to all sharding types.
+
+    Example:
+        @fwd_coefficient(sharding_type=["table_wise", "column_wise"])
+        def compute_tw_cw_fwd(self) -> PerfCoefficient:
+            return PerfCoefficient(
+                input_read_size_multiplier=100.0,
+                lookup_size_multiplier=1.0,
+                embedding_output_multiplier=1.0,
+                hash_size_multiplier=4.5,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_fwd_coefficient = True  # pyre-ignore[16]
+        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+def bwd_coefficient(
+    sharding_type: Optional[Union[str, list[str]]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing backward pass performance coefficients.
+
+    The decorated method should return a PerfCoefficient object. Method name is
+    arbitrary - only the annotation matters for discovery.
+
+    Args:
+        sharding_type: Sharding type(s) this coefficient applies to.
+                       Can be a single string or list of strings.
+                       If None, applies to all sharding types.
+
+    Example:
+        @bwd_coefficient(sharding_type=["table_wise", "column_wise"])
+        def compute_tw_cw_bwd(self) -> PerfCoefficient:
+            return PerfCoefficient(
+                input_read_size_multiplier=600.0,
+                lookup_size_multiplier=3.0,
+                embedding_output_multiplier=3.0,
+                hash_size_multiplier=9.0,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_bwd_coefficient = True  # pyre-ignore[16]
+        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+def prefetch_coefficient() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to mark a method as providing prefetch pipeline coefficients.
+
+    The decorated method should return a PrefetchCoefficients object.
+    Prefetch coefficients are global (no sharding type filter).
+
+    Example:
+        @prefetch_coefficient()
+        def get_prefetch_coeff(self) -> PrefetchCoefficients:
+            return PrefetchCoefficients(
+                expected_num_lookups_coefficient=4.337620774386766e-07,
+                expected_num_unique_lookups_coefficient=1.0654341763287636e-05,
+                expected_size_cache_fetches_coefficient=1.3311586664661257e-07,
+            )
+    """
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        method._is_prefetch_coefficient = True  # pyre-ignore[16]
+        return method
+
+    return decorator
+
+
+# =============================================================================
+# Helper Functions for Coefficient Annotations
+# =============================================================================
+
+
+def _matches_coefficient_sharding_type(
+    method: Callable[..., Any], sharding_type: str
+) -> bool:
+    """
+    Check if a coefficient method matches the given sharding type.
+
+    Args:
+        method: The coefficient method to check
+        sharding_type: The sharding type to match against (e.g., 'table_wise')
+
+    Returns:
+        True if the method applies to this sharding type
+    """
+    method_sharding_type = getattr(method, "_coefficient_sharding_type", None)
+    if method_sharding_type is None:
+        return True  # No filter = matches all
+
+    if isinstance(method_sharding_type, (list, tuple)):
+        return sharding_type.lower() in [st.lower() for st in method_sharding_type]
+
+    return method_sharding_type.lower() == sharding_type.lower()
+
+
+def _get_coefficient_method(
+    config: Any,
+    marker_attr: str,
+    sharding_type: Optional[str] = None,
+) -> Optional[Callable[..., Any]]:
+    """
+    Find a coefficient method on config marked with the given attribute.
+
+    Scans ALL methods by attribute (not by method name). Returns the first
+    method that has the marker attribute and matches the sharding type.
+
+    Args:
+        config: The hardware config to scan
+        marker_attr: The annotation attribute to look for (e.g., '_is_fwd_coefficient')
+        sharding_type: Optional sharding type to filter by
+
+    Returns:
+        The matching method if found, otherwise None
+    """
+    # Skip these attributes to avoid infinite recursion (coefficients property
+    # calls get_fwd_coefficient which calls this function)
+    skip_attrs = {"coefficients", "_coefficients"}
+
+    for attr_name in dir(config):
+        if attr_name.startswith("_") or attr_name in skip_attrs:
+            continue
+        method = getattr(config, attr_name, None)
+        if method and callable(method) and getattr(method, marker_attr, False):
+            if sharding_type is not None:
+                if not _matches_coefficient_sharding_type(method, sharding_type):
+                    continue
+            return method
+    return None
+
+
+def get_fwd_coefficient(
+    config: Any,
+    sharding_type: str,
+) -> Optional[Any]:
+    """
+    Get forward coefficient for the given sharding type from config annotations.
+
+    Scans all methods on the config for @fwd_coefficient annotation.
+    Returns the PerfCoefficient if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: The sharding type to get coefficient for
+
+    Returns:
+        PerfCoefficient if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_fwd_coefficient", sharding_type)
+    if method:
+        return method()
+    return None
+
+
+def get_bwd_coefficient(
+    config: Any,
+    sharding_type: str,
+) -> Optional[Any]:
+    """
+    Get backward coefficient for the given sharding type from config annotations.
+
+    Scans all methods on the config for @bwd_coefficient annotation.
+    Returns the PerfCoefficient if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+        sharding_type: The sharding type to get coefficient for
+
+    Returns:
+        PerfCoefficient if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_bwd_coefficient", sharding_type)
+    if method:
+        return method()
+    return None
+
+
+def get_prefetch_coefficient(
+    config: Any,
+) -> Optional[Any]:
+    """
+    Get prefetch coefficients from config annotations.
+
+    Scans all methods on the config for @prefetch_coefficient annotation.
+    Returns the PrefetchCoefficients if a matching method is found.
+
+    Args:
+        config: The hardware config to check
+
+    Returns:
+        PrefetchCoefficients if annotated method found, otherwise None
+    """
+    method = _get_coefficient_method(config, "_is_prefetch_coefficient")
+    if method:
+        return method()
+    return None

--- a/torchrec/distributed/planner/estimator/tests/test_annotations.py
+++ b/torchrec/distributed/planner/estimator/tests/test_annotations.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the annotations module.
+
+These tests cover the decorators and helper functions used in the estimator package:
+- Coefficient decorators: @fwd_coefficient, @bwd_coefficient, @prefetch_coefficient
+- Helper functions: get_fwd_coefficient, get_bwd_coefficient, get_prefetch_coefficient
+- Other decorators: @device_bw, @output_write_size, @supported_sharding_types
+"""
+
+import unittest
+
+from torchrec.distributed.planner.estimator.annotations import (
+    bwd_coefficient,
+    device_bw,
+    fwd_coefficient,
+    get_bwd_coefficient,
+    get_fwd_coefficient,
+    get_output_write_size,
+    get_prefetch_coefficient,
+    output_write_size,
+    prefetch_coefficient,
+    supported_sharding_types,
+)
+
+
+class FwdCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @fwd_coefficient decorator and get_fwd_coefficient helper."""
+
+    def test_fwd_coefficient_decorator_marks_method(self) -> None:
+        """Test that @fwd_coefficient decorator marks method with correct attributes."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+        method = config.get_table_wise_fwd
+
+        self.assertTrue(hasattr(method, "_is_fwd_coefficient"))
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
+        self.assertEqual(
+            method._coefficient_sharding_type, "table_wise"  # pyre-ignore[16]
+        )
+
+    def test_fwd_coefficient_decorator_with_multiple_sharding_types(self) -> None:
+        """Test @fwd_coefficient decorator with multiple sharding types."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type=["table_wise", "row_wise"])
+            def get_fwd(self) -> object:
+                return {"emb_lookup": 2.0}
+
+        config = TestConfig()
+        method = config.get_fwd
+
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertEqual(
+            method._coefficient_sharding_type,  # pyre-ignore[16]
+            ["table_wise", "row_wise"],
+        )
+
+    def test_fwd_coefficient_decorator_no_sharding_type(self) -> None:
+        """Test @fwd_coefficient decorator with no sharding type (applies to all)."""
+
+        class TestConfig:
+            @fwd_coefficient()
+            def get_fwd_all(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+        method = config.get_fwd_all
+
+        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertIsNone(method._coefficient_sharding_type)  # pyre-ignore[16]
+
+    def test_get_fwd_coefficient_returns_coefficient_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns the coefficient for matching sharding type."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5, "hash_size": 0.1}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "table_wise")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["emb_lookup"], 1.5)  # pyre-ignore[16]
+
+    def test_get_fwd_coefficient_returns_none_for_non_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns None when sharding type doesn't match."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_table_wise_fwd(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "row_wise")
+
+        self.assertIsNone(result)
+
+    def test_get_fwd_coefficient_returns_none_when_no_decorator(self) -> None:
+        """Test get_fwd_coefficient returns None when no @fwd_coefficient decorator."""
+
+        class TestConfig:
+            def some_method(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+        result = get_fwd_coefficient(config, "table_wise")
+
+        self.assertIsNone(result)
+
+    def test_get_fwd_coefficient_matches_any_when_no_sharding_type_specified(
+        self,
+    ) -> None:
+        """Test get_fwd_coefficient returns coefficient when no sharding_type filter."""
+
+        class TestConfig:
+            @fwd_coefficient()  # No sharding_type = matches all
+            def get_fwd_all(self) -> object:
+                return {"emb_lookup": 1.0}
+
+        config = TestConfig()
+
+        # Should match any sharding type
+        result_tw = get_fwd_coefficient(config, "table_wise")
+        result_rw = get_fwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(result_tw)
+        self.assertIsNotNone(result_rw)
+
+
+class BwdCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @bwd_coefficient decorator and get_bwd_coefficient helper."""
+
+    def test_bwd_coefficient_decorator_marks_method(self) -> None:
+        """Test that @bwd_coefficient decorator marks method with correct attributes."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 2.0}
+
+        config = TestConfig()
+        method = config.get_row_wise_bwd
+
+        self.assertTrue(hasattr(method, "_is_bwd_coefficient"))
+        self.assertTrue(method._is_bwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
+        self.assertEqual(
+            method._coefficient_sharding_type, "row_wise"  # pyre-ignore[16]
+        )
+
+    def test_get_bwd_coefficient_returns_coefficient_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_bwd_coefficient returns the coefficient for matching sharding type."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 3.0}
+
+        config = TestConfig()
+        result = get_bwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["emb_lookup"], 3.0)  # pyre-ignore[16]
+
+    def test_get_bwd_coefficient_returns_none_for_non_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_bwd_coefficient returns None when sharding type doesn't match."""
+
+        class TestConfig:
+            @bwd_coefficient(sharding_type="row_wise")
+            def get_row_wise_bwd(self) -> object:
+                return {"emb_lookup": 3.0}
+
+        config = TestConfig()
+        result = get_bwd_coefficient(config, "table_wise")
+
+        self.assertIsNone(result)
+
+
+class PrefetchCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for @prefetch_coefficient decorator and get_prefetch_coefficient helper."""
+
+    def test_prefetch_coefficient_decorator_marks_method(self) -> None:
+        """Test that @prefetch_coefficient decorator marks method correctly."""
+
+        class TestConfig:
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {
+                    "expected_num_lookups_coefficient": 0.5,
+                    "expected_num_unique_lookups_coefficient": 0.3,
+                }
+
+        config = TestConfig()
+        method = config.get_prefetch
+
+        self.assertTrue(hasattr(method, "_is_prefetch_coefficient"))
+        self.assertTrue(method._is_prefetch_coefficient)  # pyre-ignore[16]
+
+    def test_get_prefetch_coefficient_returns_coefficients(self) -> None:
+        """Test get_prefetch_coefficient returns prefetch coefficients."""
+
+        class TestConfig:
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {
+                    "expected_num_lookups_coefficient": 0.5,
+                    "expected_num_unique_lookups_coefficient": 0.3,
+                }
+
+        config = TestConfig()
+        result = get_prefetch_coefficient(config)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+        )
+
+    def test_get_prefetch_coefficient_returns_none_when_no_decorator(self) -> None:
+        """Test get_prefetch_coefficient returns None when no decorator."""
+
+        class TestConfig:
+            def some_method(self) -> object:
+                return {}
+
+        config = TestConfig()
+        result = get_prefetch_coefficient(config)
+
+        self.assertIsNone(result)
+
+
+class DeviceBwDecoratorTest(unittest.TestCase):
+    """Tests for @device_bw class decorator."""
+
+    def test_device_bw_decorator_sets_general_bandwidth(self) -> None:
+        """Test that @device_bw sets general device bandwidth."""
+
+        @device_bw(bandwidth=100.0)
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "device_bw"))
+        self.assertEqual(config.device_bw, 100.0)  # pyre-ignore[16]
+
+    def test_device_bw_decorator_with_specific_device_and_kernel(self) -> None:
+        """Test @device_bw decorator with specific device and compute kernel."""
+
+        @device_bw(bandwidth=200.0, device="cuda", compute_kernel="fused")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "kernel_device_bandwidths"))
+        self.assertIn(
+            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            200.0,
+        )
+
+    def test_device_bw_decorator_stacking(self) -> None:
+        """Test multiple @device_bw decorators can be stacked."""
+
+        @device_bw(bandwidth=200.0, device="cuda", compute_kernel="fused")
+        @device_bw(bandwidth=150.0, device="cuda", compute_kernel="dense")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertIn(
+            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertIn(
+            ("cuda", "dense"), config.kernel_device_bandwidths  # pyre-ignore[16]
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            200.0,
+        )
+        self.assertEqual(
+            config.kernel_device_bandwidths[("cuda", "dense")],  # pyre-ignore[16]
+            150.0,
+        )
+
+
+class OutputWriteSizeDecoratorTest(unittest.TestCase):
+    """Tests for @output_write_size decorator and get_output_write_size helper."""
+
+    def test_output_write_size_decorator_marks_method(self) -> None:
+        """Test that @output_write_size decorator marks method correctly."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = config.custom_output_write
+
+        self.assertTrue(hasattr(method, "_is_custom_output_write_size"))
+        self.assertTrue(method._is_custom_output_write_size)  # pyre-ignore[16]
+
+    def test_get_output_write_size_returns_method_for_matching_sharding_type(
+        self,
+    ) -> None:
+        """Test get_output_write_size returns method for matching sharding type."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = get_output_write_size(config, "table_wise")
+
+        self.assertIsNotNone(method)
+
+    def test_get_output_write_size_returns_none_for_non_matching(self) -> None:
+        """Test get_output_write_size returns None for non-matching sharding type."""
+
+        class TestConfig:
+            @output_write_size(sharding_type="table_wise")
+            def custom_output_write(self, ctx: object) -> float:
+                return 100.0
+
+        config = TestConfig()
+        method = get_output_write_size(config, "row_wise")
+
+        self.assertIsNone(method)
+
+
+class SupportedShardingTypesDecoratorTest(unittest.TestCase):
+    """Tests for @supported_sharding_types class decorator."""
+
+    def test_supported_sharding_types_sets_class_attribute(self) -> None:
+        """Test that @supported_sharding_types sets _supported_sharding_types."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class TestConfig:
+            pass
+
+        config = TestConfig()
+
+        self.assertTrue(hasattr(config, "_supported_sharding_types"))
+        self.assertIn("table_wise", config._supported_sharding_types)  # pyre-ignore[16]
+        self.assertIn("row_wise", config._supported_sharding_types)  # pyre-ignore[16]
+        self.assertNotIn(
+            "column_wise", config._supported_sharding_types  # pyre-ignore[16]
+        )
+
+
+class MultipleCoefficientDecoratorTest(unittest.TestCase):
+    """Tests for configs with multiple coefficient decorators."""
+
+    def test_config_with_both_fwd_and_bwd_coefficients(self) -> None:
+        """Test config that has both fwd and bwd coefficient decorators."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_fwd_table_wise(self) -> object:
+                return {"emb_lookup": 1.0}
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def get_bwd_table_wise(self) -> object:
+                return {"emb_lookup": 2.0}
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def get_fwd_row_wise(self) -> object:
+                return {"emb_lookup": 1.5}
+
+        config = TestConfig()
+
+        # Get fwd coefficients
+        fwd_tw = get_fwd_coefficient(config, "table_wise")
+        fwd_rw = get_fwd_coefficient(config, "row_wise")
+        bwd_tw = get_bwd_coefficient(config, "table_wise")
+        bwd_rw = get_bwd_coefficient(config, "row_wise")
+
+        self.assertIsNotNone(fwd_tw)
+        self.assertEqual(fwd_tw["emb_lookup"], 1.0)  # pyre-ignore[16]
+
+        self.assertIsNotNone(fwd_rw)
+        self.assertEqual(fwd_rw["emb_lookup"], 1.5)  # pyre-ignore[16]
+
+        self.assertIsNotNone(bwd_tw)
+        self.assertEqual(bwd_tw["emb_lookup"], 2.0)  # pyre-ignore[16]
+
+        # No bwd for row_wise
+        self.assertIsNone(bwd_rw)
+
+    def test_config_with_prefetch_and_fwd_coefficients(self) -> None:
+        """Test config that has both fwd and prefetch coefficient decorators."""
+
+        class TestConfig:
+            @fwd_coefficient(sharding_type="table_wise")
+            def get_fwd(self) -> object:
+                return {"emb_lookup": 1.0}
+
+            @prefetch_coefficient()
+            def get_prefetch(self) -> object:
+                return {"expected_num_lookups_coefficient": 0.5}
+
+        config = TestConfig()
+
+        fwd = get_fwd_coefficient(config, "table_wise")
+        prefetch = get_prefetch_coefficient(config)
+
+        self.assertIsNotNone(fwd)
+        self.assertIsNotNone(prefetch)
+        self.assertEqual(fwd["emb_lookup"], 1.0)  # pyre-ignore[16]
+        self.assertEqual(
+            prefetch["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+        )

--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the types module in the estimator package.
+
+Tests the core dataclasses and config classes:
+- PerfCoefficient, EstimatorPerfCoefficients, PrefetchCoefficients
+- PerfCoefficientConfig with get_coefficients() method
+- HardwarePerfConfig with coefficient lookup and validation
+- ShardPerfContext computed properties
+"""
+
+import unittest
+
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.estimator.annotations import (
+    bwd_coefficient,
+    fwd_coefficient,
+    prefetch_coefficient,
+    supported_sharding_types,
+)
+from torchrec.distributed.planner.estimator.types import (
+    EstimatorPerfCoefficients,
+    HardwarePerfConfig,
+    PerfCoefficient,
+    PerfCoefficientConfig,
+    PrefetchCoefficients,
+    ShardPerfContext,
+)
+from torchrec.distributed.types import ShardingType
+
+
+class PerfCoefficientTest(unittest.TestCase):
+    """Tests for the PerfCoefficient frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default coefficient values."""
+        coeff = PerfCoefficient()
+        self.assertEqual(coeff.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeff.lookup_size_multiplier, 1.0)
+        self.assertEqual(coeff.embedding_output_multiplier, 1.0)
+        self.assertEqual(coeff.hash_size_multiplier, 0.0)
+
+    def test_custom_values(self) -> None:
+        """Test creating coefficient with custom values."""
+        coeff = PerfCoefficient(
+            input_read_size_multiplier=2.0,
+            lookup_size_multiplier=1.5,
+            embedding_output_multiplier=0.5,
+            hash_size_multiplier=0.1,
+        )
+        self.assertEqual(coeff.input_read_size_multiplier, 2.0)
+        self.assertEqual(coeff.lookup_size_multiplier, 1.5)
+        self.assertEqual(coeff.embedding_output_multiplier, 0.5)
+        self.assertEqual(coeff.hash_size_multiplier, 0.1)
+
+    def test_frozen(self) -> None:
+        """Test that PerfCoefficient is frozen (immutable)."""
+        coeff = PerfCoefficient()
+        with self.assertRaises(AttributeError):
+            coeff.input_read_size_multiplier = 2.0  # pyre-ignore[41]
+
+
+class EstimatorPerfCoefficientsTest(unittest.TestCase):
+    """Tests for EstimatorPerfCoefficients frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default fwd and bwd coefficients."""
+        coeffs = EstimatorPerfCoefficients()
+        self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+
+    def test_custom_fwd_bwd(self) -> None:
+        """Test creating with custom forward and backward coefficients."""
+        fwd = PerfCoefficient(lookup_size_multiplier=2.0)
+        bwd = PerfCoefficient(lookup_size_multiplier=3.0)
+        coeffs = EstimatorPerfCoefficients(fwd=fwd, bwd=bwd)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 3.0)
+
+
+class PrefetchCoefficientsTest(unittest.TestCase):
+    """Tests for PrefetchCoefficients frozen dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default prefetch coefficient values."""
+        prefetch = PrefetchCoefficients()
+        self.assertEqual(prefetch.expected_num_lookups_coefficient, 0.0)
+        self.assertEqual(prefetch.expected_num_unique_lookups_coefficient, 0.0)
+        self.assertEqual(prefetch.expected_size_cache_fetches_coefficient, 0.0)
+
+    def test_custom_values(self) -> None:
+        """Test creating prefetch coefficients with custom values."""
+        prefetch = PrefetchCoefficients(
+            expected_num_lookups_coefficient=1.5,
+            expected_num_unique_lookups_coefficient=2.0,
+            expected_size_cache_fetches_coefficient=0.8,
+        )
+        self.assertEqual(prefetch.expected_num_lookups_coefficient, 1.5)
+        self.assertEqual(prefetch.expected_num_unique_lookups_coefficient, 2.0)
+        self.assertEqual(prefetch.expected_size_cache_fetches_coefficient, 0.8)
+
+
+class PerfCoefficientConfigTest(unittest.TestCase):
+    """Tests for PerfCoefficientConfig with get_coefficients() method."""
+
+    def test_get_coefficients_returns_default_when_no_specific(self) -> None:
+        """Test that get_coefficients returns default when no specific coefficients."""
+        config = PerfCoefficientConfig()
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
+        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+
+    def test_get_coefficients_returns_sharding_specific(self) -> None:
+        """Test that get_coefficients returns sharding-specific coefficients."""
+        table_wise_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=2.0),
+            bwd=PerfCoefficient(lookup_size_multiplier=3.0),
+        )
+        config = PerfCoefficientConfig(table_wise=table_wise_coeffs)
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 3.0)
+
+    def test_get_coefficients_kernel_override_takes_priority(self) -> None:
+        """Test that kernel-specific overrides take priority over sharding type."""
+        table_wise_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=2.0),
+        )
+        kernel_coeffs = EstimatorPerfCoefficients(
+            fwd=PerfCoefficient(lookup_size_multiplier=5.0),
+        )
+        config = PerfCoefficientConfig(
+            table_wise=table_wise_coeffs,
+            by_kernel={("table_wise", "fused"): kernel_coeffs},
+        )
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value, "fused")
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 5.0)
+        coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+
+    def test_get_coefficients_all_sharding_types(self) -> None:
+        """Test get_coefficients works for all standard sharding types."""
+        config = PerfCoefficientConfig(
+            table_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=1.0)
+            ),
+            row_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=2.0)
+            ),
+            table_row_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=3.0)
+            ),
+            column_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=4.0)
+            ),
+            data_parallel=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=5.0)
+            ),
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.TABLE_WISE.value
+            ).fwd.lookup_size_multiplier,
+            1.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.ROW_WISE.value
+            ).fwd.lookup_size_multiplier,
+            2.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.TABLE_ROW_WISE.value
+            ).fwd.lookup_size_multiplier,
+            3.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.COLUMN_WISE.value
+            ).fwd.lookup_size_multiplier,
+            4.0,
+        )
+        self.assertEqual(
+            config.get_coefficients(
+                ShardingType.DATA_PARALLEL.value
+            ).fwd.lookup_size_multiplier,
+            5.0,
+        )
+
+    def test_get_coefficients_case_insensitive(self) -> None:
+        """Test that sharding type lookup is case-insensitive."""
+        config = PerfCoefficientConfig(
+            table_wise=EstimatorPerfCoefficients(
+                fwd=PerfCoefficient(lookup_size_multiplier=2.0)
+            ),
+        )
+        coeffs = config.get_coefficients("TABLE_WISE")
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 2.0)
+
+
+class HardwarePerfConfigTest(unittest.TestCase):
+    """Tests for HardwarePerfConfig class."""
+
+    def test_default_name(self) -> None:
+        """Test default hardware config name."""
+        config = HardwarePerfConfig()
+        self.assertEqual(config.name, "default")
+
+    def test_is_sharding_type_supported_all_by_default(self) -> None:
+        """Test that all sharding types are supported by default."""
+        config = HardwarePerfConfig()
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.TABLE_WISE.value)
+        )
+        self.assertTrue(config.is_sharding_type_supported(ShardingType.ROW_WISE.value))
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.COLUMN_WISE.value)
+        )
+
+    def test_is_sharding_type_supported_with_restriction(self) -> None:
+        """Test sharding type support with explicit restrictions."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class RestrictedConfig(HardwarePerfConfig):
+            name = "restricted"
+
+        config = RestrictedConfig()
+        self.assertTrue(
+            config.is_sharding_type_supported(ShardingType.TABLE_WISE.value)
+        )
+        self.assertTrue(config.is_sharding_type_supported(ShardingType.ROW_WISE.value))
+        self.assertFalse(
+            config.is_sharding_type_supported(ShardingType.COLUMN_WISE.value)
+        )
+
+    def test_validate_sharding_type_raises_for_unsupported(self) -> None:
+        """Test validate_sharding_type raises ValueError for unsupported types."""
+
+        @supported_sharding_types("table_wise")
+        class LimitedConfig(HardwarePerfConfig):
+            name = "limited"
+
+        config = LimitedConfig()
+        config.validate_sharding_type(ShardingType.TABLE_WISE.value)
+        with self.assertRaises(ValueError) as ctx:
+            config.validate_sharding_type(ShardingType.ROW_WISE.value)
+        self.assertIn("row_wise", str(ctx.exception))
+
+    def test_get_coefficients_for_sharding_with_annotations(self) -> None:
+        """Test get_coefficients_for_sharding uses annotation-based coefficients."""
+
+        class AnnotatedConfig(HardwarePerfConfig):
+            name = "annotated"
+
+            @fwd_coefficient(sharding_type="table_wise")
+            def table_wise_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=5.0)
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def table_wise_bwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=6.0)
+
+        config = AnnotatedConfig()
+        coeffs = config.get_coefficients_for_sharding(ShardingType.TABLE_WISE.value)
+        self.assertEqual(coeffs.fwd.lookup_size_multiplier, 5.0)
+        self.assertIsNotNone(coeffs.bwd)
+        self.assertEqual(coeffs.bwd.lookup_size_multiplier, 6.0)
+
+    def test_coefficients_property_builds_from_annotations(self) -> None:
+        """Test that coefficients property builds config from annotations."""
+
+        class ConfigWithAnnotations(HardwarePerfConfig):
+            name = "with_annotations"
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def row_wise_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=3.0)
+
+            @prefetch_coefficient()
+            def get_prefetch(self) -> PrefetchCoefficients:
+                return PrefetchCoefficients(expected_num_lookups_coefficient=1.0)
+
+        config = ConfigWithAnnotations()
+        perf_config = config.coefficients
+        self.assertIsNotNone(perf_config.row_wise)
+        self.assertEqual(
+            perf_config.row_wise.fwd.lookup_size_multiplier,  # pyre-ignore[16]
+            3.0,
+        )
+        self.assertIsNotNone(perf_config.prefetch)
+        self.assertEqual(perf_config.prefetch.expected_num_lookups_coefficient, 1.0)
+
+    def test_get_device_bw_priority_kernel_specific(self) -> None:
+        """Test get_device_bw priority: kernel-specific takes precedence."""
+
+        class ConfigWithKernelBW(HardwarePerfConfig):
+            name = "kernel_bw"
+            kernel_device_bandwidths = {("cuda", "fused"): 1000.0}
+            device_bw = 500.0
+
+        config = ConfigWithKernelBW()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel="fused",
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 1000.0)
+
+    def test_get_device_bw_priority_device_bw_override(self) -> None:
+        """Test get_device_bw priority: device_bw override when no kernel match."""
+
+        class ConfigWithDeviceBW(HardwarePerfConfig):
+            name = "device_bw"
+            device_bw = 500.0
+
+        config = ConfigWithDeviceBW()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel="dense",
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 500.0)
+
+    def test_get_device_bw_uses_kernel_bw_lookup_fallback(self) -> None:
+        """Test get_device_bw falls back to kernel_bw_lookup."""
+        config = HardwarePerfConfig()
+        bw = config.get_device_bw(
+            compute_device="cuda",
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            hbm_mem_bw=900.0,
+            ddr_mem_bw=100.0,
+            hbm_to_ddr_mem_bw=200.0,
+        )
+        self.assertEqual(bw, 900.0)
+
+    def test_get_device_bw_invalid_kernel_raises(self) -> None:
+        """Test get_device_bw raises for invalid compute kernel."""
+        config = HardwarePerfConfig()
+        with self.assertRaises(ValueError) as ctx:
+            config.get_device_bw(
+                compute_device="cuda",
+                compute_kernel="invalid_kernel",
+                hbm_mem_bw=900.0,
+                ddr_mem_bw=100.0,
+                hbm_to_ddr_mem_bw=200.0,
+            )
+        self.assertIn("invalid_kernel", str(ctx.exception))
+
+    def test_post_process_perfs_returns_unchanged_by_default(self) -> None:
+        """Test post_process_perfs returns input unchanged by default."""
+        from torchrec.distributed.planner.types import Perf
+
+        config = HardwarePerfConfig()
+        perfs = [
+            Perf(fwd_compute=1.0, fwd_comms=2.0, bwd_compute=3.0, bwd_comms=4.0),
+            Perf(fwd_compute=5.0, fwd_comms=6.0, bwd_compute=7.0, bwd_comms=8.0),
+        ]
+        shard_sizes = [[100, 64], [200, 64]]
+        result = config.post_process_perfs(
+            perfs, shard_sizes, ShardingType.TABLE_WISE.value
+        )
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].fwd_compute, 1.0)
+        self.assertEqual(result[1].fwd_compute, 5.0)
+
+
+class ShardPerfContextTest(unittest.TestCase):
+    """Tests for ShardPerfContext dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test ShardPerfContext default values."""
+        ctx = ShardPerfContext()
+        self.assertEqual(ctx.sharding_type, "")
+        self.assertEqual(ctx.compute_kernel, "")
+        self.assertEqual(ctx.hash_size, 0)
+        self.assertEqual(ctx.emb_dim, 0)
+        self.assertEqual(ctx.world_size, 1)
+        self.assertEqual(ctx.local_world_size, 1)
+        self.assertFalse(ctx.is_inference)
+        self.assertFalse(ctx.is_weighted)
+        self.assertTrue(ctx.is_pooled)
+
+    def test_num_hosts_property(self) -> None:
+        """Test num_hosts computed property."""
+        ctx = ShardPerfContext(world_size=8, local_world_size=4)
+        self.assertEqual(ctx.num_hosts, 2)
+        ctx2 = ShardPerfContext(world_size=4, local_world_size=4)
+        self.assertEqual(ctx2.num_hosts, 1)
+
+    def test_batch_inputs_property(self) -> None:
+        """Test batch_inputs computed property."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+        )
+        self.assertEqual(ctx.batch_inputs, 1600.0)
+
+    def test_batch_outputs_property_pooled(self) -> None:
+        """Test batch_outputs for pooled embeddings."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+            is_pooled=True,
+        )
+        self.assertEqual(ctx.batch_outputs, 96.0)
+
+    def test_batch_outputs_property_unpooled(self) -> None:
+        """Test batch_outputs for unpooled embeddings (same as batch_inputs)."""
+        ctx = ShardPerfContext(
+            input_lengths=[10.0, 20.0],
+            num_poolings=[1.0, 2.0],
+            batch_sizes=[32, 32],
+            is_pooled=False,
+        )
+        self.assertEqual(ctx.batch_outputs, ctx.batch_inputs)
+
+    def test_is_uvm_caching_property(self) -> None:
+        """Test is_uvm_caching computed property."""
+        ctx = ShardPerfContext(compute_kernel=EmbeddingComputeKernel.FUSED.value)
+        self.assertFalse(ctx.is_uvm_caching)
+        ctx2 = ShardPerfContext(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        )
+        self.assertTrue(ctx2.is_uvm_caching)
+
+    def test_custom_initialization(self) -> None:
+        """Test ShardPerfContext with custom initialization."""
+        ctx = ShardPerfContext(
+            sharding_type=ShardingType.TABLE_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            hash_size=10000,
+            emb_dim=128,
+            batch_sizes=[64],
+            num_poolings=[1.0],
+            input_lengths=[50.0],
+            world_size=8,
+            local_world_size=4,
+            is_inference=True,
+            is_weighted=True,
+            is_pooled=False,
+        )
+        self.assertEqual(ctx.sharding_type, ShardingType.TABLE_WISE.value)
+        self.assertEqual(ctx.compute_kernel, EmbeddingComputeKernel.FUSED.value)
+        self.assertEqual(ctx.hash_size, 10000)
+        self.assertEqual(ctx.emb_dim, 128)
+        self.assertEqual(ctx.world_size, 8)
+        self.assertTrue(ctx.is_inference)
+        self.assertTrue(ctx.is_weighted)
+        self.assertFalse(ctx.is_pooled)
+
+
+class HardwarePerfConfigIntegrationTest(unittest.TestCase):
+    """Integration tests for HardwarePerfConfig with annotations."""
+
+    def test_full_config_with_all_annotation_types(self) -> None:
+        """Test a full config class with all annotation types."""
+
+        @supported_sharding_types("table_wise", "row_wise")
+        class FullConfig(HardwarePerfConfig):
+            name = "full_config"
+
+            @fwd_coefficient(sharding_type="table_wise")
+            def tw_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=1.5)
+
+            @bwd_coefficient(sharding_type="table_wise")
+            def tw_bwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=2.0)
+
+            @fwd_coefficient(sharding_type="row_wise")
+            def rw_fwd(self) -> PerfCoefficient:
+                return PerfCoefficient(lookup_size_multiplier=1.2)
+
+            @prefetch_coefficient()
+            def prefetch(self) -> PrefetchCoefficients:
+                return PrefetchCoefficients(
+                    expected_num_lookups_coefficient=0.5,
+                    expected_num_unique_lookups_coefficient=0.3,
+                )
+
+        config = FullConfig()
+
+        self.assertTrue(config.is_sharding_type_supported("table_wise"))
+        self.assertTrue(config.is_sharding_type_supported("row_wise"))
+        self.assertFalse(config.is_sharding_type_supported("column_wise"))
+
+        tw_coeffs = config.get_coefficients_for_sharding("table_wise")
+        self.assertEqual(tw_coeffs.fwd.lookup_size_multiplier, 1.5)
+        self.assertIsNotNone(tw_coeffs.bwd)
+        self.assertEqual(tw_coeffs.bwd.lookup_size_multiplier, 2.0)
+
+        rw_coeffs = config.get_coefficients_for_sharding("row_wise")
+        self.assertEqual(rw_coeffs.fwd.lookup_size_multiplier, 1.2)
+
+        perf_config = config.coefficients
+        self.assertIsNotNone(perf_config.prefetch)
+        self.assertEqual(perf_config.prefetch.expected_num_lookups_coefficient, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+"""
+Performance Estimator Types.
+
+This module contains the core dataclasses  performance estimator:
+- Coefficient classes: PerfCoefficient, EstimatorPerfCoefficients, PerfCoefficientConfig
+- Context class: ShardPerfContext
+- Config class: HardwarePerfConfig
+
+Evaluator classes and factory are in estimator.py.
+"""
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+from torch import nn
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.planner.constants import (
+    BIGINT_DTYPE,
+    BWD_COMPUTE_MULTIPLIER,
+    DDR_MEM_BW,
+    HBM_MEM_BW,
+    kernel_bw_lookup,
+    WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
+    WEIGHTED_KERNEL_MULTIPLIER,
+)
+from torchrec.distributed.planner.estimator.annotations import (
+    get_bwd_coefficient,
+    get_fwd_coefficient,
+    get_prefetch_coefficient,
+)
+from torchrec.distributed.planner.types import (
+    GeneralizedCommsBandwidth,
+    ParameterConstraints,
+    Perf,
+    PlannerError,
+    ShardingOption,
+    Topology,
+)
+from torchrec.distributed.planner.utils import (
+    extract_comm_data_type_size,
+    get_num_poolings,
+    is_prefetch_pipelined,
+)
+from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
+from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Coefficient Dataclasses
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PerfCoefficient:
+    # Multiplier for number of indices to lookup.
+    input_read_size_multiplier: float = 1.0
+
+    # Multiplier for lookup size.
+    lookup_size_multiplier: float = 1.0
+
+    # Multiplier after pooled operation,basically the size of the output.
+    embedding_output_multiplier: float = 1.0
+
+    # Multiplier for table size
+    hash_size_multiplier: float = 0.0
+
+
+@dataclass(frozen=True)
+class EstimatorPerfCoefficients:
+    # Coefficients for forward pass
+    fwd: PerfCoefficient = field(default_factory=PerfCoefficient)
+    # Coefficients for backward pass
+    bwd: PerfCoefficient = field(default_factory=PerfCoefficient)
+
+
+@dataclass(frozen=True)
+class PrefetchCoefficients:
+    """
+    Prefetch pipeline per estimation coefficients.
+    """
+
+    # Multiplier for number of lookups
+    expected_num_lookups_coefficient: float = 0.0
+    # Multipliers for number of unique lookups
+    expected_num_unique_lookups_coefficient: float = 0.0
+    # Multiplier for number of cache fetches
+    expected_size_cache_fetches_coefficient: float = 0.0
+
+
+@dataclass
+class PerfCoefficientConfig:
+    """
+    Each sharding type has a set of coefficients for forward and backward passes., If these coefficients are need to be specified for
+    a specific sharding type,for a particular compute kernel, then they can be specified in the by_kernel dictionary.
+    Priority order:
+    1. by_kernel[(sharding_type, compute_kernel)] if compute_kernel provided
+    2. Sharding-type specific attribute
+    3. default
+    """
+
+    table_wise: Optional[EstimatorPerfCoefficients] = None
+    row_wise: Optional[EstimatorPerfCoefficients] = None
+    table_row_wise: Optional[EstimatorPerfCoefficients] = None
+    data_parallel: Optional[EstimatorPerfCoefficients] = None
+    column_wise: Optional[EstimatorPerfCoefficients] = None
+
+    # Kernel-specific overrides: (sharding_type, compute_kernel) -> coefficients
+    by_kernel: Dict[Tuple[str, str], EstimatorPerfCoefficients] = field(
+        default_factory=dict
+    )
+
+    # Default fallback
+    default: EstimatorPerfCoefficients = field(
+        default_factory=lambda: EstimatorPerfCoefficients()
+    )
+
+    # Compute multipliers (imported from constants)
+    bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER
+    weighted_kernel_multiplier: float = WEIGHTED_KERNEL_MULTIPLIER
+    weighted_feature_bwd_compute_multiplier: float = (
+        WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER
+    )
+
+    # Prefetch coefficients (optional, for FB hardware estimators)
+    # When set and use_linear_regression=True, enables extended prefetch formula
+    prefetch: Optional[PrefetchCoefficients] = None
+
+    def get_coefficients(
+        self, sharding_type: str, compute_kernel: Optional[str] = None
+    ) -> EstimatorPerfCoefficients:
+        """
+        Get coefficients for a sharding type and optional compute kernel.
+
+        Priority order:
+        1. by_kernel[(sharding_type, compute_kernel)] if compute_kernel provided
+        2. Sharding-type specific attribute
+        3. default
+        """
+        # Priority 1: Check kernel-specific override
+        if compute_kernel:
+            key = (sharding_type.lower(), compute_kernel.lower())
+            if key in self.by_kernel:
+                return self.by_kernel[key]
+
+        # Priority 2: Check sharding-type specific
+        sharding_type_lower = sharding_type.lower()
+
+        if sharding_type_lower == ShardingType.TABLE_WISE.value:
+            coeff = self.table_wise
+        elif sharding_type_lower == ShardingType.ROW_WISE.value:
+            coeff = self.row_wise
+        elif sharding_type_lower == ShardingType.TABLE_ROW_WISE.value:
+            coeff = self.table_row_wise
+        elif sharding_type_lower == ShardingType.DATA_PARALLEL.value:
+            coeff = self.data_parallel
+        elif sharding_type_lower == ShardingType.COLUMN_WISE.value:
+            coeff = self.column_wise
+        elif sharding_type_lower == ShardingType.TABLE_COLUMN_WISE.value:
+            coeff = self.column_wise
+        elif sharding_type_lower == ShardingType.GRID_SHARD.value:
+            coeff = self.default
+        else:
+            coeff = None
+
+        if coeff is not None:
+            return coeff
+
+        # Priority 3: Default
+        return self.default
+
+
+# =============================================================================
+# HardwarePerfConfig
+# =============================================================================
+
+
+class HardwarePerfConfig:
+    """
+    Hardware-specific performance configuration.
+
+    This class contains hardware-specific coefficients and compute methods.
+    It is used by the EmbeddingPerfEstimator to estimate performance for a given hardware.
+
+    Args:
+        name: Name of the hardware (e.g. "H100", "A100", "V100").
+        coefficients: Coefficients for each sharding type.
+    """
+
+    # Internal storage for coefficients (populated lazily from annotations)
+    _coefficients: Optional[PerfCoefficientConfig] = None
+
+    name: str = "default"
+
+    @property
+    def coefficients(self) -> PerfCoefficientConfig:
+        """
+        Get coefficients config, populated from annotations.
+
+        This property dynamically builds the PerfCoefficientConfig from
+        annotation-based coefficients (@fwd_coefficient, @bwd_coefficient, @prefetch_coefficient).
+        The result is cached for subsequent accesses.
+
+        Returns:
+            PerfCoefficientConfig with coefficients populated from annotations.
+        """
+        if self._coefficients is not None:
+            return self._coefficients
+
+        # Build coefficients from annotations for each sharding type
+        sharding_types = [
+            ShardingType.TABLE_WISE,
+            ShardingType.ROW_WISE,
+            ShardingType.TABLE_ROW_WISE,
+            ShardingType.COLUMN_WISE,
+            ShardingType.DATA_PARALLEL,
+        ]
+
+        config_kwargs: Dict[str, Optional[EstimatorPerfCoefficients]] = {}
+
+        for sharding_type in sharding_types:
+            fwd_coeff = get_fwd_coefficient(self, sharding_type.value)
+            bwd_coeff = get_bwd_coefficient(self, sharding_type.value)
+
+            if fwd_coeff is not None or bwd_coeff is not None:
+                config_kwargs[sharding_type.value] = EstimatorPerfCoefficients(
+                    fwd=fwd_coeff if fwd_coeff is not None else PerfCoefficient(),
+                    bwd=bwd_coeff if bwd_coeff is not None else PerfCoefficient(),
+                )
+
+        # Get prefetch coefficients
+        prefetch = get_prefetch_coefficient(self)
+
+        self._coefficients = PerfCoefficientConfig(
+            table_wise=config_kwargs.get(ShardingType.TABLE_WISE.value),
+            row_wise=config_kwargs.get(ShardingType.ROW_WISE.value),
+            table_row_wise=config_kwargs.get(ShardingType.TABLE_ROW_WISE.value),
+            column_wise=config_kwargs.get(ShardingType.COLUMN_WISE.value),
+            data_parallel=config_kwargs.get(ShardingType.DATA_PARALLEL.value),
+            prefetch=prefetch,
+        )
+
+        return self._coefficients
+
+    # Hardware bandwidth defaults (can be overridden by decorators)
+    hbm_mem_bw: float = HBM_MEM_BW
+    ddr_mem_bw: float = DDR_MEM_BW
+
+    # Optional bandwidth overrides (None = use ctx/topology values)
+    device_bw: Optional[float] = None
+    hbm_to_ddr_mem_bw: Optional[float] = None
+    intra_host_bw: Optional[float] = None
+    inter_host_bw: Optional[float] = None
+
+    kernel_device_bandwidths: Dict[Tuple[str, str], float] = {}
+
+    # Supported sharding types (None = all supported, set via @supported_sharding_types)
+    _supported_sharding_types: Optional[FrozenSet[str]] = None
+
+    # Configurable data type defaults (can be overridden by subclasses)
+    # FB legacy uses INT_DTYPE (4.0) as default output_data_type_size when output_dtype is None
+    # OSS uses tensor.element_size() (can be 2.0 for FP16)
+    # Set to 4.0 in FBHardwarePerfConfig to match FB legacy behavior, None for OSS default
+    _default_output_data_type_size: Optional[float] = None
+
+    def get_coefficients_for_sharding(
+        self, sharding_type: str, compute_kernel: Optional[str] = None
+    ) -> EstimatorPerfCoefficients:
+        """
+        Get coefficients for a specific sharding type.
+
+        Priority order:
+        1. Annotation-based coefficients (@fwd_coefficient, @bwd_coefficient)
+        2. Explicit self.coefficients attribute (PerfCoefficientConfig)
+        3. Default coefficients
+
+        Args:
+            sharding_type: The sharding type to get coefficients for
+            compute_kernel: Optional compute kernel for kernel-specific overrides
+
+        Returns:
+            EstimatorPerfCoefficients with fwd and bwd coefficients
+        """
+        # Priority 1: Check for annotation-based coefficients
+        fwd_coeff = get_fwd_coefficient(self, sharding_type)
+        bwd_coeff = get_bwd_coefficient(self, sharding_type)
+
+        if fwd_coeff is not None or bwd_coeff is not None:
+            return EstimatorPerfCoefficients(
+                fwd=fwd_coeff if fwd_coeff is not None else PerfCoefficient(),
+                bwd=bwd_coeff if bwd_coeff is not None else PerfCoefficient(),
+            )
+
+        # Priority 2 & 3: Use explicit coefficients attribute (falls back to default)
+        return self.coefficients.get_coefficients(sharding_type, compute_kernel)
+
+    def is_sharding_type_supported(self, sharding_type: str) -> bool:
+        """
+        Check if a sharding type is supported by this config.
+
+        If _supported_sharding_types is None, all types are supported.
+        If set (via @supported_sharding_types decorator), only listed types are supported.
+
+        Args:
+            sharding_type: The sharding type to check
+
+        Returns:
+            True if supported, False otherwise
+        """
+        if self._supported_sharding_types is None:
+            return True  # All supported by default
+        return sharding_type.lower() in self._supported_sharding_types
+
+    def validate_sharding_type(self, sharding_type: str) -> None:
+        """
+        Validate that a sharding type is supported, raise ValueError if not.
+
+        Args:
+            sharding_type: The sharding type to validate
+
+        Raises:
+            ValueError: If sharding type is not supported
+        """
+        if not self.is_sharding_type_supported(sharding_type):
+            supported = self._supported_sharding_types or "all"
+            raise ValueError(
+                f"Sharding type '{sharding_type}' is not supported by {self.__class__.__name__}. "
+                f"Supported types: {supported}"
+            )
+
+    def post_process_perfs(
+        self,
+        shard_perfs: List[Perf],
+        shard_sizes: List[List[int]],
+        sharding_type: str,
+        uneven_sharding_perf_multiplier: float = 1.0,
+    ) -> List[Perf]:
+        """
+        Optional post-processing hook for adjusting shard perfs after computation.
+
+        This method is called after all shards have been computed individually.
+        Override in subclasses for custom cross-shard adjustments (e.g., uneven sharding).
+
+        Default implementation: returns shard_perfs unchanged.
+
+        Args:
+            shard_perfs: List of computed Perf objects, one per shard
+            shard_sizes: List of [hash_size, emb_dim] for each shard
+            sharding_type: The sharding type being evaluated
+            uneven_sharding_perf_multiplier: Multiplier for uneven sharding adjustment
+
+        Returns:
+            List of (potentially adjusted) Perf objects
+        """
+        return shard_perfs
+
+    def get_device_bw(
+        self,
+        compute_device: str,
+        compute_kernel: str,
+        hbm_mem_bw: float,
+        ddr_mem_bw: float,
+        hbm_to_ddr_mem_bw: float,
+        caching_ratio: Optional[float] = None,
+        prefetch_pipeline: bool = False,
+    ) -> Optional[float]:
+        """
+        Get device bandwidth with priority-based lookup.
+
+        Priority order:
+        1. kernel_device_bandwidths (specific device+kernel overrides)
+        2. device_bw (general device bandwidth override)
+        3. kernel_bw_lookup() (computed from memory bandwidth)
+
+        Args:
+            compute_device: The compute device (e.g., "cuda", "cpu", "mtia")
+            compute_kernel: The embedding compute kernel (e.g., "fused", "dense")
+            hbm_mem_bw: HBM memory bandwidth
+            ddr_mem_bw: DDR memory bandwidth
+            hbm_to_ddr_mem_bw: HBM to DDR bandwidth
+            caching_ratio: Optional caching ratio for UVM caching
+            prefetch_pipeline: Whether prefetch pipeline is enabled
+
+        Returns:
+            The device bandwidth in bytes/ms, or None if not found
+        """
+        # Following same logic as kernel_bw_lookup
+        effective_compute_kernel = compute_kernel
+        if (
+            prefetch_pipeline
+            and compute_device.lower() == "cuda"
+            and compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        ):
+            effective_compute_kernel = EmbeddingComputeKernel.FUSED.value
+
+        # Priority 1: Check kernel-specific overrides (case-insensitive lookup)
+        key = (compute_device.lower(), effective_compute_kernel.lower())
+        if key in self.kernel_device_bandwidths:
+            return self.kernel_device_bandwidths[key]
+
+        # Priority 2: Check general device_bw override
+        if self.device_bw is not None:
+            return self.device_bw
+
+        # Priority 3: Use kernel_bw_lookup (returns None for invalid kernels)
+        bw = kernel_bw_lookup(
+            compute_device=compute_device,
+            compute_kernel=compute_kernel,
+            hbm_mem_bw=hbm_mem_bw,
+            ddr_mem_bw=ddr_mem_bw,
+            hbm_to_ddr_mem_bw=hbm_to_ddr_mem_bw,
+            caching_ratio=caching_ratio,
+            prefetch_pipeline=prefetch_pipeline,
+        )
+        if bw is None:
+            raise ValueError(
+                f"Unrecognized or unsupported compute kernel: {compute_kernel} for hardware aware perf estimators."
+            )
+        return bw
+
+
+# =============================================================================
+# ShardPerfContext
+# =============================================================================
+
+
+@dataclass
+class ShardPerfContext:
+    """
+    Raw data container for shard performance estimation.
+
+    This is a pure data container - all computation logic is in the evaluator classes.
+    Evaluators use the raw data fields to compute sizes and performance metrics.
+    """
+
+    # Identifiers
+    sharding_type: str = ""
+    compute_kernel: str = ""
+
+    # Shard dimensions
+    hash_size: int = 0
+    emb_dim: int = 0
+
+    # Raw inputs
+    batch_sizes: List[int] = field(default_factory=list)
+    num_poolings: List[float] = field(default_factory=list)
+    input_lengths: List[float] = field(default_factory=list)
+
+    # Topology info
+    world_size: int = 1
+    local_world_size: int = 1
+
+    # Data type sizes
+    input_data_type_size: float = BIGINT_DTYPE
+    table_data_type_size: float = 4.0
+    output_data_type_size: float = 4.0
+    fwd_a2a_comm_data_type_size: float = 4.0
+    bwd_a2a_comm_data_type_size: float = 4.0
+    fwd_sr_comm_data_type_size: float = 4.0
+    bwd_sr_comm_data_type_size: float = 4.0
+
+    # Bandwidth values
+    device_bw: float = HBM_MEM_BW
+    hbm_to_ddr_mem_bw: float = HBM_MEM_BW
+    intra_host_bw: float = 0.0
+    inter_host_bw: float = 0.0
+
+    # Communication bandwidths
+    comms_bandwidths: Optional[GeneralizedCommsBandwidth] = None
+
+    # Flags
+    is_inference: bool = False
+    is_weighted: bool = False
+    is_pooled: bool = True
+    has_feature_processor: bool = False
+
+    # Multipliers from topology
+    bwd_compute_multiplier: float = BWD_COMPUTE_MULTIPLIER
+    weighted_feature_bwd_compute_multiplier: float = (
+        WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER
+    )
+
+    # Cache-related
+    expected_cache_fetches: float = 0.0
+
+    # Extended prefetch fields (used by FB hardware estimators for linear regression)
+    # These are optional and only populated when cache stats are available
+    expected_lookups: Optional[float] = None
+    expected_unique_lookups: Optional[float] = None
+
+    # =========================================================================
+    # Class method to build from ShardingOption
+    # =========================================================================
+
+    @classmethod
+    def build_shard_perf_contexts(
+        cls,
+        config: HardwarePerfConfig,
+        shard_sizes: List[List[int]],
+        sharding_option: ShardingOption,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        sharder: ModuleSharder[nn.Module],
+        is_inference: bool = False,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> List["ShardPerfContext"]:
+        """
+        Build list of ShardPerfContexts from ShardingOption and Topology.
+
+        This follows the exact logic from OSS EmbeddingPerfEstimator.estimate.
+
+        Args:
+            config: Hardware performance configuration
+            shard_sizes: List of [hash_size, emb_dim] for each shard
+            sharding_option: The sharding option being evaluated
+            topology: Device topology with bandwidth and world size info
+            constraints: Optional parameter constraints
+            sharder: Module sharder for this option
+            is_inference: Whether this is for inference
+            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+                If False (default), uses expected_miss_rate * expected_unique_lookups.
+            use_linear_regression_prefetch_estimate: If True, clamps num_unique_lookups
+                to min(num_unique_lookups, batch_inputs, hash_size) before computing
+                prefetch time.
+
+        Returns:
+            List of ShardPerfContext instances, one per shard.
+        """
+        # Get caching ratio
+        caching_ratio = sharding_option.cache_load_factor
+        if caching_ratio is None:
+            caching_ratio = (
+                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                if hasattr(sharder, "fused_params") and sharder.fused_params
+                else None
+            )
+
+        # Get num_poolings and batch_sizes
+        num_poolings = get_num_poolings(constraints, sharding_option)
+        batch_sizes = (
+            list(constraints[sharding_option.name].batch_sizes or [])
+            if constraints
+            and constraints.get(sharding_option.name)
+            and constraints[sharding_option.name].batch_sizes
+            else [sharding_option.batch_size] * sharding_option.num_inputs
+        )
+
+        assert (
+            len(sharding_option.input_lengths) == len(num_poolings) == len(batch_sizes)
+        ), "Provided `pooling_factors`, `num_poolings`, and `batch_sizes` constraints must match."
+
+        # Check for feature processor
+        module = sharding_option.module[1]
+        has_feature_processor = False
+        if (
+            hasattr(module, "_feature_processor")
+            and hasattr(module._feature_processor, "feature_processor_modules")
+            and isinstance(
+                module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
+                nn.ModuleDict,
+            )
+            and sharding_option.name
+            in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
+        ):
+            has_feature_processor = True
+
+        # Determine is_weighted
+        if isinstance(module, EmbeddingBagCollectionInterface):
+            is_weighted = module.is_weighted()
+        elif (
+            constraints
+            and constraints.get(sharding_option.name)
+            and constraints[sharding_option.name].is_weighted
+        ):
+            is_weighted = constraints[sharding_option.name].is_weighted
+        else:
+            is_weighted = False
+
+        is_weighted = is_weighted or has_feature_processor
+
+        # Get data type sizes
+        table_data_type_size = sharding_option.tensor.element_size()
+        (
+            fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size,
+        ) = extract_comm_data_type_size(sharder, sharding_option)
+
+        # Check prefetch pipeline
+        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder)
+
+        # Output data type size - fetch default from config if output_dtype not specified
+        # FB legacy uses INT_DTYPE (4.0), OSS uses tensor.element_size()
+        default_output_data_type_size = getattr(
+            config, "_default_output_data_type_size", None
+        )
+        output_data_type_size: float = (
+            DATA_TYPE_NUM_BITS[sharding_option.output_dtype] / 8
+            if sharding_option.output_dtype
+            else (
+                default_output_data_type_size
+                if default_output_data_type_size is not None
+                else sharding_option.tensor.element_size()
+            )
+        )
+
+        # Calculate expected cache fetches and extended prefetch fields
+        expected_cache_fetches = 0.0
+        expected_lookups: Optional[float] = None
+        expected_unique_lookups: Optional[float] = None
+
+        # Calculate batch_inputs for all features
+        batch_inputs = math.ceil(
+            topology.world_size
+            * sum(
+                x * y * z
+                for x, y, z in zip(
+                    sharding_option.input_lengths, num_poolings, batch_sizes
+                )
+            )
+        )
+
+        if (
+            caching_ratio is not None
+            and sharding_option.cache_params is not None
+            and sharding_option.cache_params.stats is not None
+            and sharding_option.compute_kernel
+            == EmbeddingComputeKernel.FUSED_UVM_CACHING.value
+        ):
+            _stats = sharding_option.cache_params.stats
+
+            # Get num_unique_lookups from cache stats
+            num_unique_lookups = float(_stats.expected_lookups)
+
+            # If linear regression prefetch estimate is enabled, clamp num_unique_lookups
+            if use_linear_regression_prefetch_estimate:
+                num_unique_lookups = min(
+                    num_unique_lookups,
+                    batch_inputs,
+                    sharding_option.tensor.shape[0],  # hash size
+                )
+                logger.info(
+                    "Since use_linear_regression_prefetch_estimate is enabled, "
+                    "adjusting num_unique_lookups to be min(estimated_num_unique_lookups, batch_input_count, hash_size)."
+                )
+
+            expected_miss_rate = _stats.expected_miss_rate(caching_ratio)
+
+            # Calculate expected_cache_fetches based on flag
+            if use_batch_inputs_for_expected_cache_fetches:
+                expected_cache_fetches = expected_miss_rate * batch_inputs
+                logger.info(
+                    f"Since use_batch_inputs_for_expected_cache_fetches is enabled, "
+                    f"computing expected_cache_fetches = expected_miss_rate * batch_inputs. "
+                    f"For example, [expected_cache_fetches] table={sharding_option.name} "
+                    f"using batch_inputs: expected_miss_rate={expected_miss_rate} * "
+                    f"batch_inputs={batch_inputs} = {expected_cache_fetches}"
+                )
+            else:
+                expected_cache_fetches = expected_miss_rate * num_unique_lookups
+                logger.info(
+                    f"Computing expected_cache_fetches = expected_miss_rate * expected_unique_lookups. "
+                    f"For example, [expected_cache_fetches] table={sharding_option.name} "
+                    f"using expected_unique_lookups: expected_miss_rate={expected_miss_rate} * "
+                    f"expected_unique_lookups={num_unique_lookups} = {expected_cache_fetches}"
+                )
+
+            # Extended prefetch fields for FB hardware estimators (linear regression)
+            expected_unique_lookups = num_unique_lookups
+            # expected_lookups is total lookups (batch_inputs)
+            expected_lookups = float(batch_inputs)
+
+        # Get device bandwidth
+        device_bw = config.get_device_bw(
+            topology.compute_device,
+            sharding_option.compute_kernel,
+            topology.hbm_mem_bw,
+            topology.ddr_mem_bw,
+            topology.hbm_to_ddr_mem_bw,
+            caching_ratio,
+            prefetch_pipeline,
+        )
+
+        if device_bw is None:
+            raise PlannerError(
+                f"No kernel bandwidth for compute device: {topology.compute_device}, "
+                f"compute kernel: {sharding_option.compute_kernel}"
+            )
+
+        # Get input_data_type_size from config annotation (if set) or use default BIGINT_DTYPE
+        input_data_type_size = getattr(config, "_input_data_type_size", BIGINT_DTYPE)
+
+        # Build contexts
+        contexts = []
+        for hash_size, emb_dim in shard_sizes:
+            # Calculate expected_lookups for this shard (based on input_read_size formula)
+            # This matches FB hardware estimator's usage: expected_lookups=input_read_size
+            shard_expected_lookups = expected_lookups
+            if expected_unique_lookups is not None:
+                # batch_inputs * world_size * input_data_type_size
+                batch_inputs = sum(
+                    x * y * z
+                    for x, y, z in zip(
+                        sharding_option.input_lengths, num_poolings, batch_sizes
+                    )
+                )
+                shard_expected_lookups = (
+                    batch_inputs * topology.world_size * BIGINT_DTYPE
+                )
+
+            ctx = cls(
+                sharding_type=sharding_option.sharding_type,
+                compute_kernel=sharding_option.compute_kernel,
+                hash_size=hash_size,
+                emb_dim=emb_dim,
+                batch_sizes=batch_sizes,
+                num_poolings=num_poolings,
+                input_lengths=sharding_option.input_lengths,
+                world_size=topology.world_size,
+                local_world_size=topology.local_world_size,
+                input_data_type_size=input_data_type_size,
+                table_data_type_size=table_data_type_size,
+                output_data_type_size=output_data_type_size,
+                fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
+                bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
+                fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
+                bwd_sr_comm_data_type_size=bwd_sr_comm_data_type_size,
+                device_bw=device_bw,
+                hbm_to_ddr_mem_bw=topology.hbm_to_ddr_mem_bw,
+                comms_bandwidths=topology.comms_bandwidths,
+                is_inference=is_inference,
+                is_weighted=is_weighted,
+                is_pooled=sharding_option.is_pooled,
+                has_feature_processor=has_feature_processor,
+                bwd_compute_multiplier=topology.bwd_compute_multiplier,
+                weighted_feature_bwd_compute_multiplier=topology.weighted_feature_bwd_compute_multiplier,
+                expected_cache_fetches=expected_cache_fetches,
+                expected_lookups=shard_expected_lookups,
+                expected_unique_lookups=expected_unique_lookups,
+            )
+            contexts.append(ctx)
+
+        return contexts
+
+    # =========================================================================
+    # Computed properties - raw derived values only
+    # =========================================================================
+
+    @property
+    def num_hosts(self) -> int:
+        """Number of hosts in the topology."""
+        return max(1, self.world_size // self.local_world_size)
+
+    @property
+    def batch_inputs(self) -> float:
+        """Raw batch inputs: sum of input_lengths * num_poolings * batch_sizes."""
+        return sum(
+            x * y * z
+            for x, y, z in zip(self.input_lengths, self.num_poolings, self.batch_sizes)
+        )
+
+    @property
+    def batch_outputs(self) -> float:
+        """
+        Raw batch outputs.
+
+        For pooled: sum of num_poolings * batch_sizes.
+        For unpooled: same as batch_inputs.
+        """
+        if self.is_pooled:
+            return sum(x * y for x, y in zip(self.num_poolings, self.batch_sizes))
+        return self.batch_inputs
+
+    @property
+    def is_uvm_caching(self) -> bool:
+        """Check if using UVM caching."""
+        return self.compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING.value


### PR DESCRIPTION
Summary:

### Context
This effort is to refactor existing Perf estimators for better scalability ,reduce code duplication,  improve code reusability, and provide single source of  debugability with increasing number of  hetrogenouse hardware .
https://docs.google.com/document/d/15_IyINeZBPslqabrUnGxbR7rGsWdiG5eZlhWojDAHZU/edit?usp=sharing

## TorchRec Performance Estimator Module - Class Summary

### `types.py` - Core Data Types

| Class | Purpose |
|-------|---------|
| `ComputeDeviceType` | Enum for supported compute device types (CUDA, CPU, MTIA) |
| `PerfCoefficient` | Frozen dataclass holding multipliers for input read, lookup, embedding output, and hash size |
| `EstimatorPerfCoefficients` | Groups forward and backward `PerfCoefficient` together |
| `PrefetchCoefficients` | Coefficients for prefetch pipeline estimation (lookups, unique lookups, cache fetches) |
| `PerfCoefficientConfig` | Config containing coefficients per sharding type with kernel-specific overrides, prefetch coefficients, and fallback defaults |
| `HardwarePerfConfig` | Base class for hardware-specific configs. Holds coefficients, bandwidth settings, supported sharding types, data type defaults, and hooks for custom compute |
| `ShardPerfContext` | Data container with all raw inputs needed for shard performance estimation (dimensions, batch sizes, bandwidths, data type sizes, flags). Includes `build_shard_perf_contexts` class method |

Differential Revision: D92558018


