### PR TITLE
add pooling factor and hardware config for benchmark

### DIFF
--- a/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
+++ b/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
@@ -39,6 +39,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [10.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
@@ -60,6 +60,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [60.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -44,6 +44,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base_vbe.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base_vbe.yml
@@ -35,6 +35,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emo.yml
@@ -30,6 +30,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [1.0]  # Default pooling factor (no ModelInputConfig.feature_pooling_avg specified)
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       compute_kernels: [fused_uvm_caching]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
@@ -36,6 +36,9 @@ EmbeddingTablesConfig:
         feature_names: ["additional_0_0"]
         data_type: FP16
 PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   # MP-ZCH only works with row-wise sharding
   additional_constraints:
     FP16_table:

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
@@ -33,6 +33,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -58,6 +58,9 @@ EmbeddingTablesConfig:
             single_ttl: 1
           disable_fallback: False
 PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   # MP-ZCH only works with row-wise sharding
   additional_constraints:
     FP16_table:

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
@@ -32,6 +32,9 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  pooling_factors: [10.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       compute_kernels: [key_value]


### PR DESCRIPTION
Summary:
This diff adds configurable pooling factors and hardware configuration to the benchmark framework to ensure planner stats are calculated correctly.

**Problem:**
The benchmark planner was using default pooling factors and hardware capacity values, which didn't match the actual benchmark configuration. This resulted in incorrect planner memory estimations.

**Changes:**

1. **`sharding_config.py`**: Added `PlannerConfig` support for:
   1. `pooling_factors`: List of pooling factors passed to `ParameterConstraints`
   2. `num_poolings` and `batch_sizes`: Optional parameters for planner constraints
   3. `storage_reservation_percentage`: Configurable memory reservation (default 10%)
   4. `hardware`: Dict-based hardware configuration for `Topology` (hbm_cap, ddr_cap, bandwidth params)
2. **All YAML benchmark configs**: Added `PlannerConfig` section with:
   1. `pooling_factors` matching each config's `ModelInputConfig.feature_pooling_avg`
   2. `hardware` section with A100 GPU specs (`hbm_cap: 85899345920` = 80GB)
3. run command
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline --config torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
```
* sharding plan makes more sense
```
INFO:torchrec.distributed.planner.stats:###########################################################################################################################################################################################################################################################################################################################################################
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                               --- Planner Statistics ---                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                        --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.06s ---                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
INFO:torchrec.distributed.planner.stats:#      Rank       HBM (GB)     DDR (GB)                 Perf (ms)     Input (MB)     Output (MB)         Shards                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    ------     ----------   ----------               -----------   ------------   -------------       --------                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#         0    45.39 (63%)     0.0 (0%)   704.985 (197,9,490,9,0)         1410.0          5760.0   CW: 8 TW: 86                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#         1   45.218 (63%)     0.0 (0%)   698.248 (194,9,485,9,0)         1395.0          5696.0   CW: 8 TW: 85                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Parameter Info:                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                      FQN     Sharding     Compute Kernel                 Perf (ms)     Storage (HBM, DDR)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size                             Ranks   #
INFO:torchrec.distributed.planner.stats:#                                    -----   ----------   ----------------               -----------   --------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------                           -------   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_0           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_1           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_2           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_3           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_4           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_5           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_6           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_7           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_8           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_9           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_10           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_11           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_12           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_13           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_14           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_15           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_16           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_17           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_18           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_19           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_20           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_21           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_22           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_23           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_24           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_25           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_26           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_27           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_28           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_29           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_30           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_31           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_32           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_33           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_34           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_35           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_36           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_37           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_38           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_39           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_40           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_41           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_42           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_43           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_44           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_45           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_46           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_47           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_48           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_49           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_50           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_51           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_52           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_53           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_54           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_55           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_56           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_57           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_58           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_59           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_60           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_61           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_62           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_63           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_64           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_65           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_66           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_67           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_68           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_69           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_70           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_71           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_72           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_73           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_74           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_75           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_76           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_77           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_78           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_79           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_0           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_1           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_2           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_3           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_4           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_5           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_6           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_7           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_8           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_9           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_10           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_11           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_12           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_13           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_14           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_15           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_16           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_17           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_18           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_19           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_20           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_21           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_22           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_23           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_24           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_25           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_26           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_27           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_28           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_29           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_30           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_31           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_32           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_33           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_34           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_35           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_36           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_37           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_38           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_39           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_40           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_41           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_42           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_43           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_44           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_45           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_46           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_47           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_48           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_49           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_50           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_51           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_52           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_53           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_54           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_55           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_56           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_57           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_58           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_59           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_60           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_61           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_62           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_63           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_64           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_65           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_66           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_67           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_68           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_69           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_70           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_71           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_72           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_73           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_74           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_75           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_76           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_77           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_78           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_79           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_80           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_81           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_82           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_83           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_84           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_85           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_86           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_87           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_88           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_89           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                    sparse.ebc.FP16_table           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  512        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                   sparse.ebc.large_table           CW              fused   54.29 (18,0.8,35,0.8,0)     (8.364 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1           2048 (128)       1000000   0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Batch Size: 32768                                                                                                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Count:                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#    fused: 172                                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Storage:                                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#    fused: HBM: 37.864 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.002                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.005                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.001                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.002                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Maximum of Total Perf: 704.985 ms on rank 0                                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Mean Total Perf: 701.616 ms                                                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Max Total Perf is 0.48% greater than the mean                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Compute: 196.586 ms on rank 0                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Compute: 489.649 ms on rank 0                                                                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Sum of Maxima: 704.985 ms                                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Estimated Sharding Distribution                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Sparse only Max HBM: 19.018 GB on rank [0]                                                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Sparse only Min HBM: 18.846 GB on rank [1]                                                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Max HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Min HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Mean HBM: 45.304 GB on rank []                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Low Median HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# High Median HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms): 18.75                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Critical Path (compute): 686.235                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms + compute): 704.985                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Max HBM is 0.19% greater than the mean                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Top HBM Memory Usage Estimation: 45.39 GB                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:# Top Tier #2 Estimated Peak HBM Pressure: 45.218 GB on rank 0                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Top Tier #1 Estimated Peak HBM Pressure: 45.39 GB on rank 0                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Reserved Memory:                                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#    HBM: 8.0 GB                                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 10%                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Planning Memory:                                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#    HBM: 72.0 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 90%                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Dense Storage (per rank):                                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    HBM: 1.177 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# KJT Storage (per rank):                                                                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#    HBM: 25.195 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    weighted_table_0                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_2                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_4                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_6                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_8                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    large_table: 0.523 GB on ranks [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#    weighted_table_0: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_2: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_4: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_6: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:###########################################################################################################################################################################################################################################################################################################################################################
```

Differential Revision: D92604043


