### PR TITLE
[detailed][memory] prototype embedding stashing for EBC

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -1,0 +1,65 @@
+# Embedding weight stashing benchmark config
+# Based on sparse_data_dist_base.yml with stash_weights on selected tables.
+# large_table has stash_weights: true, FP16_table does not — verifies
+# that only marked tables have weights moved from HBM to CPU after forward.
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_emb_stash"
+  memory_snapshot: True
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse-emb-stash"
+  kwargs:
+    site_fqn: "over.overarch.0"  # dense
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  stash_weights: true
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+      - name: large_table_no_stash
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_2"]
+        stash_weights: false
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]
+    large_table_no_stash:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -54,6 +54,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sequence_sharding import (
     CwSequenceEmbeddingSharding,
 )
@@ -1623,6 +1624,11 @@ class ShardedEmbeddingCollection(
                 EmbeddingEvent.LOOKUP, self._module_fqn, sharding_type
             ):
                 embs = lookup(features)
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore[not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -255,6 +255,7 @@ def create_sharding_infos_by_sharding_device_group(
                         total_num_buckets=config.total_num_buckets,
                         use_virtual_table=config.use_virtual_table,
                         virtual_table_eviction_policy=config.virtual_table_eviction_policy,
+                        stash_weights=getattr(config, "stash_weights", False),
                     ),
                     param_sharding=parameter_sharding,
                     param=param,

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -567,6 +567,7 @@ def group_tables(
                 _prefetch_and_cached(table),
                 table.use_virtual_table if is_inference else None,
                 table.enable_embedding_update,
+                table.stash_weights,
             )
             # micromanage the order of we traverse the groups to ensure backwards compatibility
             if grouping_key not in groups:
@@ -584,6 +585,7 @@ def group_tables(
                 _,
                 use_virtual_table,
                 enable_embedding_update,
+                _,
             ) = grouping_key
             grouped_tables = groups[grouping_key]
             # remove non-native fused params

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -314,6 +314,7 @@ def create_sharding_infos_by_sharding_device_group(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
+                    stash_weights=getattr(config, "stash_weights", False),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,
@@ -896,6 +897,7 @@ class ShardedEmbeddingBagCollection(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
+                    stash_weights=getattr(config, "stash_weights", False),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -55,6 +55,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sharding import CwPooledEmbeddingSharding
 from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
 from torchrec.distributed.sharding.dynamic_sharding import (
@@ -1864,6 +1865,11 @@ class ShardedEmbeddingBagCollection(
                 if hasattr(lookup, "wait_for_forward"):
                     # pyre-ignore[29]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.logger import capped_logger, one_time_rank0_logger
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ class MemoryStashingManager:
         return cls._device_to_host_stream
 
     @classmethod
+    def is_enabled(cls) -> bool:
+        """Return whether memory stashing streams have been initialized."""
+        return cls._device_to_host_stream is not None
+
+    @classmethod
     def set_streams(
         cls,
         host_to_device_stream: Optional[torch.cuda.Stream] = None,
@@ -79,11 +85,13 @@ class MemoryStashingManager:
             cls._device_to_host_stream = host_to_device_stream
         else:
             cls._device_to_host_stream = device_to_host_stream
+        logger.info("MemoryStashingManager: streams initialized")
         one_time_rank0_logger.info("MemoryStashingManager: streams initialized")
 
     @classmethod
     def reset(cls) -> None:
         """Release all resources."""
+        logger.info("MemoryStashingManager: resetting all resources")
         cls._host_to_device_stream = None
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
@@ -270,9 +278,11 @@ class MemoryStashingManager:
     def stash_embedding_weights(
         cls,
         lookup: nn.Module,
-    ) -> Tuple[
-        Callable[[Optional[torch.Tensor]], None],
-        Callable[[Optional[torch.Tensor]], None],
+    ) -> Optional[
+        Tuple[
+            Callable[[Optional[torch.Tensor]], None],
+            Callable[[Optional[torch.Tensor]], None],
+        ]
     ]:
         """
         Stash embedding weights from HBM to CPU asynchronously.
@@ -288,7 +298,7 @@ class MemoryStashingManager:
                 embedding modules with weights to stash.
 
         Returns:
-            A tuple of two callback functions:
+            A tuple of two callback functions, or None if no tensors were stashed:
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
 
@@ -314,13 +324,24 @@ class MemoryStashingManager:
             capped_logger.info(
                 "stash_embedding_weights: no _emb_modules found, skipping"
             )
-            return lambda _grad: None, lambda _grad: None
+            return None
 
-        # Collect CUDA embedding weight tensors
+        # Collect CUDA embedding weight tensors from TBE groups marked for stashing
         tensors: List[torch.Tensor] = []
         for emb_module in module._emb_modules:
             if not hasattr(emb_module, "_emb_module"):
                 continue
+            # Check if this TBE group is marked for stashing via per-table config.
+            # If _config is a GroupedEmbeddingConfig, only stash TBEs where at
+            # least one table has stash_weights=True. Otherwise (e.g., in tests
+            # with mock objects), stash all TBEs.
+            config = getattr(emb_module, "_config", None)
+            if isinstance(config, GroupedEmbeddingConfig):
+                should_stash = any(
+                    getattr(t, "stash_weights", False) for t in config.embedding_tables
+                )
+                if not should_stash:
+                    continue
             inner = emb_module._emb_module
             if not hasattr(inner, "weights_dev"):
                 continue
@@ -334,6 +355,9 @@ class MemoryStashingManager:
             f"module={type(module).__name__}, "
             f"collected {len(tensors)} weight tensors"
         )
+
+        if not tensors:
+            return None
 
         await_restore, restore = cls._stash_tensors(tensors, label="embedding")
         cls._embedding_weight_restore_callbacks.append(restore)

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -230,6 +230,7 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         num_embeddings_post_pruning=info.embedding_config.num_embeddings_post_pruning,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -93,6 +93,7 @@ class BaseDpEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
         return tables_per_rank

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -277,6 +277,7 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -231,6 +231,7 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         use_virtual_table=info.embedding_config.use_virtual_table,
                         virtual_table_eviction_policy=info.embedding_config.virtual_table_eviction_policy,
                         enable_embedding_update=info.embedding_config.enable_embedding_update,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
         return tables_per_rank

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -185,6 +185,7 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     fused_params=info.fused_params,
                     num_embeddings_post_pruning=info.embedding_config.num_embeddings_post_pruning,
                     use_virtual_table=info.embedding_config.use_virtual_table,
+                    stash_weights=info.embedding_config.stash_weights,
                 )
             )
         return tables_per_rank

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -202,6 +202,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
                         use_virtual_table=info.embedding_config.use_virtual_table,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -143,6 +143,10 @@ class EmbeddingTablesConfig:
     table_data_type: DataType = DataType.FP32
     total_num_buckets: Optional[int] = None
     additional_tables: List[List[Dict[str, Any]]] = field(default_factory=list)
+
+    # Default for all tables; per-table overrides in additional_tables
+    stash_weights: bool = False
+
     # ManagedCollision configs for all tables
     mc_config: Optional[ManagedCollisionConfig] = None  # Default for all tables
     mc_configs_per_table: Dict[str, ManagedCollisionConfig] = field(
@@ -180,6 +184,10 @@ class EmbeddingTablesConfig:
 
         # Remove all keys that are not part of EmbeddingBagConfig
         kwargs.pop("location", None)
+
+        # Apply global stash_weights default if not set per-table
+        if "stash_weights" not in kwargs:
+            kwargs["stash_weights"] = self.stash_weights
 
         # Support EmbeddingConfig via config_class field
         if "config_class" in kwargs:
@@ -221,6 +229,7 @@ class EmbeddingTablesConfig:
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_unweighted_features)
         ]
@@ -231,6 +240,7 @@ class EmbeddingTablesConfig:
                 name="weighted_table_" + str(i),
                 feature_names=["weighted_feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_weighted_features)
         ]

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -14,7 +14,13 @@ from unittest.mock import Mock
 
 import torch
 from torch import nn
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
 from torchrec.distributed.memory_stashing import MemoryStashingManager
+from torchrec.modules.embedding_configs import DataType, PoolingType
 
 
 class TestStashTensors(unittest.TestCase):
@@ -111,14 +117,49 @@ class TestStashEmbeddingWeights(unittest.TestCase):
     def tearDown(self) -> None:
         MemoryStashingManager.reset()
 
-    def _create_mock_lookup(self, weights_list: List[torch.Tensor]) -> Mock:
-        """Helper to create a mock lookup with multiple embedding modules."""
+    def _create_mock_lookup(
+        self,
+        weights_list: List[torch.Tensor],
+        stash_weights_list: Optional[List[bool]] = None,
+    ) -> Mock:
+        """Helper to create a mock lookup with multiple embedding modules.
+
+        Args:
+            weights_list: List of weight tensors, one per TBE group.
+            stash_weights_list: If provided, sets _config to a
+                GroupedEmbeddingConfig with a single ShardedEmbeddingTable
+                per group whose stash_weights matches this list. If None,
+                no _config is set (backward-compatible: stash everything).
+        """
         emb_modules = []
-        for weights in weights_list:
+        for i, weights in enumerate(weights_list):
             inner = Mock()
             inner.weights_dev = weights
             emb_module = Mock()
             emb_module._emb_module = inner
+            if stash_weights_list is not None:
+                emb_module._config = GroupedEmbeddingConfig(
+                    data_type=DataType.FP32,
+                    pooling=PoolingType.SUM,
+                    is_weighted=False,
+                    has_feature_processor=False,
+                    compute_kernel=EmbeddingComputeKernel.FUSED,
+                    embedding_tables=[
+                        ShardedEmbeddingTable(
+                            num_embeddings=weights.shape[0],
+                            embedding_dim=weights.shape[1],
+                            name=f"table_{i}",
+                            feature_names=[f"feature_{i}"],
+                            pooling=PoolingType.SUM,
+                            is_weighted=False,
+                            has_feature_processor=False,
+                            compute_kernel=EmbeddingComputeKernel.FUSED,
+                            local_rows=weights.shape[0],
+                            local_cols=weights.shape[1],
+                            stash_weights=stash_weights_list[i],
+                        ),
+                    ],
+                )
             emb_modules.append(emb_module)
 
         lookup = Mock(spec=["_emb_modules"])
@@ -337,6 +378,100 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         self.assertTrue(torch.allclose(weights, original_values))
+
+    def test_stash_weights_config_filters_tbe_groups(self) -> None:
+        """Test that only TBE groups with stash_weights=True are stashed."""
+        stash_weights = torch.ones((50, 32), device=self.device)
+        no_stash_weights = torch.ones((80, 64), device=self.device) * 2
+
+        stash_original = stash_weights.clone()
+        no_stash_original = no_stash_weights.clone()
+
+        lookup = self._create_mock_lookup(
+            [stash_weights, no_stash_weights],
+            stash_weights_list=[True, False],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
+
+        # Only the stash_weights=True group should be stashed
+        self.assertEqual(stash_weights.untyped_storage().size(), 0)
+        # The stash_weights=False group should NOT be stashed
+        self.assertGreater(no_stash_weights.untyped_storage().size(), 0)
+        self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
+
+        # Restore
+        MemoryStashingManager.restore_embedding_weights()
+        await_restore(None)
+
+        # Stashed weights should be restored correctly
+        self.assertTrue(torch.allclose(stash_weights, stash_original))
+        # Non-stashed weights should remain unchanged
+        self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
+
+    def test_stash_weights_all_false_returns_none(self) -> None:
+        """Test that stash_embedding_weights returns None when all tables have stash_weights=False."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device)
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=[False, False],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNone(result)
+
+        # No weights should be stashed
+        self.assertGreater(weights_1.untyped_storage().size(), 0)
+        self.assertGreater(weights_2.untyped_storage().size(), 0)
+
+    def test_stash_weights_all_true_stashes_all(self) -> None:
+        """Test that all TBE groups are stashed when all have stash_weights=True."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device) * 2
+
+        original_1 = weights_1.clone()
+        original_2 = weights_2.clone()
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=[True, True],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
+
+        # Both should be stashed
+        self.assertEqual(weights_1.untyped_storage().size(), 0)
+        self.assertEqual(weights_2.untyped_storage().size(), 0)
+
+        # Restore
+        MemoryStashingManager.restore_embedding_weights()
+        await_restore(None)
+
+        self.assertTrue(torch.allclose(weights_1, original_1))
+        self.assertTrue(torch.allclose(weights_2, original_2))
+
+    def test_stash_weights_no_config_stashes_all(self) -> None:
+        """Test backward compat: without _config, all TBE groups are stashed."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device)
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=None,  # No config set
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+
+        # Both should be stashed (no config = stash everything)
+        self.assertEqual(weights_1.untyped_storage().size(), 0)
+        self.assertEqual(weights_2.untyped_storage().size(), 0)
 
     def test_is_enabled(self) -> None:
         """Test is_enabled reflects stream initialization state."""

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -9,7 +9,7 @@
 
 import unittest
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
 import torch
@@ -132,7 +132,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify HBM is freed
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -157,7 +159,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([weights_1, weights_2, weights_3])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify all are stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)
@@ -186,7 +190,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify stash worked
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -210,7 +216,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         output = torch.matmul(x, weights.t())
 
         # Stash and restore
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
@@ -250,7 +258,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Only CUDA weights should be stashed
         self.assertEqual(cuda_weights.untyped_storage().size(), 0)
@@ -286,7 +296,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Valid weights should be stashed
         self.assertEqual(valid_weights.untyped_storage().size(), 0)
@@ -308,7 +320,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         x = torch.randn(3, 5, device=self.device, requires_grad=True)
         output = torch.matmul(x, weights.t())
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Register restore via class method and await_restore as backward hook
         output.register_hook(
@@ -323,6 +337,12 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         self.assertTrue(torch.allclose(weights, original_values))
+
+    def test_is_enabled(self) -> None:
+        """Test is_enabled reflects stream initialization state."""
+        self.assertTrue(MemoryStashingManager.is_enabled())
+        MemoryStashingManager.reset()
+        self.assertFalse(MemoryStashingManager.is_enabled())
 
 
 class TestStashOptimizerState(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -63,6 +63,7 @@ class InjectionSite:
     """
 
     fqn: str
+    use_output_tensor: bool = True
 
     def find_target_module(self, model: nn.Module) -> Optional[nn.Module]:
         """
@@ -140,7 +141,10 @@ def register_backward_hook(
         input: Any,
         output: Any,
     ) -> None:
-        tensor = site.find_grad_tensor(output)
+        if site.use_output_tensor:
+            tensor = site.find_grad_tensor(output)
+        else:
+            tensor = site.find_grad_tensor(input)
         if tensor is None:
             raise RuntimeError(
                 f"register_hook: no grad-requiring tensor in "

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -367,6 +367,8 @@ class BaseEmbeddingConfig:
             for number embedding memory for virtual table is dynamic and only materialized when
             id is trained this needs to be paired with SSD/DRAM Virtual talbe in EmbeddingComputeKernel
         virtual_table_eviction_policy (Optional[VirtualTableEvictionPolicy]): eviction policy for virtual table.
+        enable_embedding_update (bool): whether to enable embedding update.
+        stash_weights (bool): whether to stash weights.
     """
 
     num_embeddings: int
@@ -389,6 +391,7 @@ class BaseEmbeddingConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
 
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:

--- a/torchrec/schema/api_tests/test_embedding_config_schema.py
+++ b/torchrec/schema/api_tests/test_embedding_config_schema.py
@@ -43,6 +43,7 @@ class StableEmbeddingBagConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
     pooling: PoolingType = PoolingType.SUM
 
 


### PR DESCRIPTION
Summary:
# Design: Embedding Memory Stashing (EMS)

## 1. Overview

The massive embedding tables used in modern RecSys models often strain GPU High Bandwidth Memory (HBM). While sharding is now common for embedding tables, models still frequently exceed single-device HBM capacity, with the activation and dense parts increasingly contributing to memory usage, limiting batch size or complexity.

To overcome this, the HBM-to-CPU Embedding Table Weights Stashing design proposes asynchronously offloading embedding weights from HBM to high-speed pinned CPU memory **after** the forward pass lookup, and restoring them before the backward pass (fused embedding grad compute and optimize). This temporarily frees substantial HBM for other operations (like intermediate activations), maximizing GPU utilization and enabling larger effective model sizes.

The goal is:
1. **After lookup**: Async copy weights from HBM (GPU) → CPU (pinned memory)
2. **Before lookup backward**: Restore weights from CPU → HBM
3. **Impact**: Reduce peak HBM memory without QPS regression

---

## 2. Background

### 2.1 Distributed Embedding in TorchRec

TorchRec provides distributed embedding infrastructure for RecSys. At its core, embedding operations in TorchRec are split into three phases:
1. **Input Distribution (input_dist)**: Sparse features (user IDs, item IDs, etc.) are redistributed across GPUs via all-to-all communication so each GPU receives the features it needs for its local embedding tables.
2. **Embedding Lookup**: Each GPU performs lookups on its local embedding tables. The embedding weights (`weights_dev`) are stored in GPU HBM and accessed by FBGEMM's Table Batched Embedding (TBE) kernels.
3. **Output Distribution (output_dist)**: The resulting embeddings are redistributed back via all-to-all so each GPU has the embeddings needed for its batch.

```
┌─────────────┐     ┌─────────────┐     ┌─────────────┐
│  input_dist │ ──► │   lookup    │ ──► │ output_dist │
│  (all2all)  │     │ (TBE kernel)│     │  (all2all)  │
└─────────────┘     └─────────────┘     └─────────────┘
                           │
                    weights_dev (HBM)
```

### 2.2 Memory Characteristics

The key insight for EMS is that **embedding weights are only accessed at specific points** in the training loop:
- **Forward**: During the lookup phase (beginning of forward pass)
- **Backward**: During gradient computation and optimizer update (end of backward pass)

Between these points—during dense model forward/backward computation—the embedding weights sit idle in HBM while activations compete for memory. The HBM peak typically occurs at the forward→backward transition when activations are at maximum.

This access pattern creates an opportunity: **stash embedding weights to CPU during the idle window** to free HBM for activations, then restore before backward.

---

## 3. Why Now?

This Embedding Memory Stashing (EMS) approach only becomes practically feasible and highly effective with the advent of modern hardware architectures, especially NVIDIA's GB200/GB300 series, which provide significantly increased host-to-device (CPU-to-HBM) bandwidth, exceeding 400 GB/s. The high bandwidth is crucial because the embedding table weights must be stashed to CPU memory after the forward pass and restored before the backward pass.

Given that the embedding table is utilized only at the beginning of the model's forward computation and updated at the very end of the backward pass, there is a considerable time window (headroom) during the intermediate computations where this data transfer (stashing and restoring) can occur, leveraging the high-speed interconnect.

Furthermore, this method is especially beneficial because the HBM memory peak, driven by intermediate activations, typically occurs right at the transition from forward to backward; by offloading the weights during this critical period, EMS effectively reduces the memory requirements in the late forward and early backward phases, maximizing the available HBM for activations and enabling larger model complexity or batch sizes.

---

## 4. Preliminary Estimation

### 4.1 GB200 Key Memory and Interconnect Specifications
1. CPU-to-GPU Interconnect (NVLink-C2C): 900 GB/s (bidirectional)
2. CPU Memory Bandwidth (LPDDR5X): Up to 512 GB/s
3. GPU Memory Bandwidth (HBM3e): Up to 16 TB/s per Blackwell GPU
4. GPU-to-GPU Interconnect (NVLink 5): 1.8 TB/s per GPU

<img width="4822" height="1756" alt="image" src="https://github.com/user-attachments/assets/9579ae85-9308-408e-8142-b18beb290c4c" />

### 4.2 Transfer Time Estimation
- Typical train cycle: 800 ms ~ 1,600 ms
- Assuming 60 ms for stashing/restoring with 450 GB/s NVLink-C2C
- **~27 GB HBM saving per rank** (theoretical)

---

## 5. Architecture

### 5.1 Training Loop with EMS

The diagram below shows how EMS integrates into the training loop. The key insight is that stash/restore operations run on a separate `memcpy_stream`, allowing them to overlap with compute on the default stream.

```
                              Forward Pass                         │             Backward Pass
                                                                   │
 ┌─────────┐   ┌────────┐   ┌───────────┐   ┌─────────────────┐    │    ┌─────────────────┐   ┌───────────┐   ┌───────────┐
 │ input   │──►│ lookup │──►│  output   │──►│  dense forward  │    │    │  dense backward │──►│  EBC BWD  │──►│ optimizer │
 │  dist   │   │  (TBE) │   │   dist    │   │  (MLP, etc.)    │────┼───►│                 │   │ + update  │   │   step    │
 └─────────┘   └────────┘   └───────────┘   └─────────────────┘    │    └─────────────────┘   └───────────┘   └───────────┘
                   │             │                                 │              │                 ▲
                   │             │                                 │              │                 │
                   ▼             │                                 │              ▼                 │
              weights_dev        │                                 │         ┌─────────┐            │
              accessed           │                                 │         │ restore │────────────┘
                                 │                                 │         │ (async) │
                                 ▼                                 │         └─────────┘
                           ┌──────────┐                            │              ▲
                           │  stash   │                            │              │
                           │ (async)  │                            │         CPU buffer
                           └──────────┘                            │         (pinned)
                                 │                                 │              │
                                 ▼                                                │
                            CPU buffer ───────────────────────────────────────────┘
                            (pinned)
```

### 5.2 API Design: Three Callbacks

The `stash_embedding_weights()` function returns **three separate callback functions** for fine-grained control over the stash/restore lifecycle:

```python
free_hbm, restore, await_restore = stash_embedding_weights(lookup, memcpy_stream)
```

| Callback | Signature | Purpose | When to Call |
|----------|-----------|---------|--------------|
| `free_hbm` | `() -> None` | Frees HBM storage after stash copy completes | After stash copy is done (CPU-blocking) |
| `restore` | `(grad: torch.Tensor) -> None` | Starts async restore from CPU to HBM | Registered as backward hook on output tensor |
| `await_restore` | `(grad: torch.Tensor) -> None` | Waits for restore to complete | Registered as backward hook before TBE backward |

**Why three callbacks?**
1. **Separation of concerns**: Decouples stash completion (CPU-blocking) from restore (GPU-async) from synchronization (GPU-stream blocking)
2. **Flexibility**: Allows different injection points in the training pipeline
3. **Backward hook compatibility**: `restore` and `await_restore` accept a `grad` tensor parameter for registration as autograd backward hooks

### 5.3 Stash Phase (HBM → CPU)

Triggered immediately after embedding lookup completes:

1. **Allocate pinned CPU buffer**: Create a CPU tensor with `pin_memory=True` matching the shape of `weights_dev`. Pinned memory enables DMA transfers without CPU involvement.
2. **Async copy on memcpy stream**:
    1. `stream.wait_stream(current_stream)` ensures lookup is complete
    2. `cpu_buffer.copy_(weights_dev, non_blocking=True)` initiates async DMA transfer
    3. CPU thread returns immediately while GPU handles the copy
3. **Free HBM storage**: The `free_hbm()` callback is called separately to free GPU memory. After copy completes, `weights_dev.untyped_storage().resize_(0)` releases GPU memory immediately.

```python
# stash_embedding_weights returns three callbacks
free_hbm, restore, await_restore = stash_embedding_weights(lookup, memcpy_stream)

# Inside stash_embedding_weights - stash starts immediately:
cpu_buffer = torch.empty(weights_dev.shape, pin_memory=True)

with torch.cuda.stream(memcpy_stream):
    memcpy_stream.wait_stream(main_stream)  # Wait for lookup to complete
    cpu_buffer.copy_(weights_dev, non_blocking=True)
    stash_event.record()

# free_hbm() is called separately when ready to free HBM:
def free_hbm():
    stash_event.synchronize()  # CPU-blocking wait for copy to complete
    weights_dev.untyped_storage().resize_(0)  # Free HBM
```

### 5.4 Restore Phase (CPU → HBM)

The `restore` and `await_restore` callbacks are registered as backward hooks:

1. **`restore(grad)`**: Re-allocates HBM storage and starts async copy back
    - `weights_dev.untyped_storage().resize_(storage_size)` allocates fresh GPU memory
    - Creates a temporary tensor viewing the same storage to avoid autograd version counter issues
    - `tmp.copy_(cpu_buffer, non_blocking=True)` initiates async DMA transfer
2. **`await_restore(grad)`**: Ensures backward doesn't start until restore completes
    - `current_stream.wait_event(restore_event)` blocks GPU stream until restore is done

```python
def restore(_grad: torch.Tensor) -> None:
    """Restore weights from CPU to HBM asynchronously."""
    weights_dev.untyped_storage().resize_(storage_size)

    with torch.cuda.stream(memcpy_stream):
        # Create temp tensor to avoid autograd version counter issues
        tmp = torch.tensor([], dtype=weights_dev.dtype, device=weights_dev.device)
        tmp.set_(weights_dev.untyped_storage(), 0, weights_dev.shape, weights_dev.stride())
        tmp.copy_(cpu_buffer, non_blocking=True)
        restore_event.record()
        restore_events.append(restore_event)

def await_restore(_grad: torch.Tensor) -> None:
    """Pause current stream awaiting restore completion."""
    for restore_event in restore_events:
        torch.cuda.current_stream().wait_event(restore_event)
```

### 5.5 Autograd Hook Integration

The `restore` and `await_restore` functions are registered as backward hooks on tensors in the computation graph. This ensures they are triggered at the right points in the backward pass:

```python
# In compute_and_output_dist:
free_hbm, restore, await_restore = stash_embedding_weights(lookup, memcpy_stream)

# Register restore to start when grad_dist begins
dist_awaitable._tensor_awaitable.dummy_tensor.register_hook(restore)

# Register await_restore to ensure weights are ready before TBE backward
dist_awaitable._tensor_awaitable.dummy_tensor.register_hook(await_restore)

# Call free_hbm when stash is complete (can be called immediately or deferred)
free_hbm()
```

When autograd traverses the computation graph during backward:
1. `restore` is called when starting the backward all-to-all communication (grad_dist)
2. `await_restore` ensures weights are ready before EBC backward

### 5.6 Stream Management

CUDA operations on the same stream execute sequentially, while operations on different streams can execute concurrently. By using a dedicated `memcpy_stream` for stash/restore operations, we can overlap data transfers with compute operations on the default stream.
1. The data transfer happens "in the background" without blocking the GPU for dense computation, effectively hiding the transfer latency.
2. It occupies the same host-to-device IO resource which copy-batch-to-gpu also uses, so it's better to use the same stream, and the operations can run sequentially to avoid the overhead of context switching.
3. However, depending on how NVLink-C2C operates, it may be beneficial to use a separate stream for host-to-device transfers and device-to-host transfers if they are not interfering with each other.

Re-use/Freeing HBM memory is a tricky topic. CUDA caching allocator (CCA) runs on the host side, so it's not a GPU stream operation. The current implementation uses stash_event.synchronize() to block the CPU thread until the copy completes, which is a major performance gap in the prototype.
1. The CCA runs in ahead of the GPU stream, so it doesn't know if the stashing is done or not when the next operation comes to allocate memory.
2. If the CCA decides to reuse this particular HBM memory, the GPU stream will need to wait for the stashing stream.



**Timeline Diagram**

```
Time ────────────────────────────────────────────────────────────────────────────────────────────────►

                    Forward                                              Backward
    ┌────────────────────────────────────────┐        ┌────────────────────────────────────────┐

Compute Stream:
    ┌────────┐                ┌─────────────────┐  ┌─────────────────┐                 ┌─────────┐
    │ lookup │                │  dense forward  │  │  dense backward │                 │ TBE BWD │
    └────────┘                └─────────────────┘  └─────────────────┘                 └─────────┘
             │                                                   |                        ▲
             │                                                   |                        │
D2D Comm     │                                                   |                        │
Stream:      │  ┌────────────┐                                   |   ┌────────────┐       │
             └─►│ output_dist│                                   └─► │  grad_dist │───────┤
                └────────────┘                                       └────────────┘       │
                                                                          │               │
                                                                          │ restore()     │ await_restore()
            |                                                    |        ▼               │
H2D Memcpy  |                                                    |                        │
Stream:     |  ┌─────────────────┐                               |   ┌─────────────────┐  │
            └─►│  stash (D2H)    │                               └─► │  restore (H2D)  │──┘
               └─────────────────┘                                   └─────────────────┘
                        │
                        │ free_hbm()
                        ▼
                  (HBM freed)
```

- **Stash** starts right after lookup ends
- **free_hbm()** is called after stash completes to free HBM
- **restore()** starts when grad_dist begins (triggered by autograd hook)
- **await_restore()** ensures TBE BWD waits for restore to complete

**Synchronization Points**

| Sync Point | Mechanism | Purpose |
|------------|-----------|---------|
| Lookup → Stash | `memcpy_stream.wait_stream(compute_stream)` | Ensure weights are fully written before copying to CPU |
| Stash → Free HBM | `stash_event.synchronize()` in `free_hbm()` (CPU-blocking) | Ensure data is safely on CPU before freeing GPU memory |
| HBM Alloc → Restore | `memcpy_stream.wait_stream(compute_stream)` in `restore()` | Ensure HBM storage is allocated on main stream before copying from CPU |
| Restore → TBE BWD | `compute_stream.wait_event(restore_event)` in `wait_for_restore()` | Ensure weights are restored before backward uses them |

---

## 6. Prototype & Benchmark Results

### 6.1 Implementation Summary

**Core API**: `stash_embedding_weights()` in `embeddingbag.py`

The function takes a lookup module and an optional CUDA stream, then returns **three callback functions** (`free_hbm`, `restore`, `await_restore`). Key implementation choices:

- **Three-callback design**: Separates HBM freeing (CPU-blocking), restore initiation (async), and restore synchronization (GPU-stream blocking) for maximum flexibility
- **Backward hook compatibility**: `restore` and `await_restore` accept a `grad: torch.Tensor` parameter for registration as autograd backward hooks
- **Pinned memory for CPU buffers**: Allocates CPU tensors with `pin_memory=True`, enabling async DMA transfers where the GPU can access CPU memory directly without intermediate staging buffers.
- **Async copy with dedicated stream**: Uses a separate `memcpy_stream` to perform HBM↔CPU transfers, allowing overlap with compute operations on the default stream.
- **`resize_(0)` for immediate HBM release**: After stashing completes, `free_hbm()` calls `weights_dev.untyped_storage().resize_(0)` to immediately free GPU memory while keeping the tensor metadata intact for later restoration.
- **Temporary tensor trick for restore**: During restore, creates a temporary tensor viewing the same storage to perform the copy. This avoids incrementing the original tensor's autograd version counter, which would otherwise cause "modified by in-place operation" errors during backward.

**Function Signature**:

```python
def stash_embedding_weights(
    lookup: nn.Module,
    stash_stream: Optional[torch.cuda.Stream] = None,
) -> Tuple[Callable[[], None], Callable[[torch.Tensor], None], Callable[[torch.Tensor], None]]:
    """
    Returns:
        A tuple of three callback functions:
        - free_hbm: Frees HBM storage from CPU side (call after stash copy completes)
        - restore: Retrieves stashed data from CPU back to HBM asynchronously
        - await_restore: Pauses current stream awaiting restore completion
    """
```

**Integration**: Modified `TrainPipelineSparseDist`

- Added `memcpy_stream` parameter for stash/restore operations
- **Autograd hooks for restore/wait**: The `restore` and `await_restore` callbacks are registered as backward hooks on the output distribution tensor. This ensures they are triggered at exactly the right points during backward pass.

**Diffs**:
- D92585742: Core stashing implementation [#3744]
- D92655860: Refactoring to three callbacks [#3746]
- D92586272: Pipeline integration and benchmarks [#3745]

### 6.2 Benchmark Setup

The benchmark uses a basic sparse data distribution pipeline with a sparse NN model (embedding tables + MLP). This setup isolates the embedding memory behavior without interference from complex model architectures.

**Sharding Plan**
See below

**Traces**
<img width="2532" height="716" alt="image" src="https://github.com/user-attachments/assets/748a9d7c-b4f1-4f94-834a-64810a6d347d" />
<img width="2541" height="812" alt="image" src="https://github.com/user-attachments/assets/889456fd-8ff3-490f-b11c-05b705eed919" />

**Memory Snapshot**
<img width="2554" height="816" alt="image" src="https://github.com/user-attachments/assets/fd6f6d98-68b3-4c13-bbe3-125d56a4996a" />
<img width="2545" height="811" alt="image" src="https://github.com/user-attachments/assets/73eab4bd-5b65-4217-942e-4b0710ae2142" />


**Run Script:**

```bash
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True \
    --name=sdd_embedding_stash
```

**Run Script (OSS):**
```bash
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True \
    --name=sdd_embedding_stash
  ```

### 6.3 Benchmark Results

| Metric | Baseline | With EMS | Delta |
|--------|----------|----------|-------|
| GPU Peak Mem Alloc | [43.28 GB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D92585742/memory-sparse_data_dist_base-rank0.pickle) | [31.97 GB](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D92585742/memory-sdd_embedding_stash-rank0.pickle) | **-11.31 GB** |
| GPU Peak Mem Reserved | 66.51 GB | 53.89 GB | **-12.62 GB** |
| GPU Runtime | [14.5s](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92585742/trace-sparse_data_dist_base-rank0.json.gz&bucket=torchrec_benchmark_traces) | [59.6s](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92585742/trace-sdd_embedding_stash-rank0.json.gz&bucket=torchrec_benchmark_traces) | +45s (see gaps) |
| CPU Peak RSS | 30.66 GB | 45.51 GB | +14.85 GB (expected) |

**Key Observation**: Memory savings validated (~12GB), but significant runtime overhead in prototype due to slow host-to-device copy (~45s).

---

## 7. Gaps & Solutions

### 7.1 Timing of Freeing HBM

As discussed in Section 5.6, the current implementation uses `stash_event.synchronize()` in `free_hbm()` to block the CPU thread until the D2H copy completes before freeing HBM, resulting in ~4x slowdown.

**Proposed Solutions**

1. **Deferred `free_hbm()` with stream synchronization**: Call `free_hbm()` at a later point in the forward pass (e.g., via a hook or FSDP integration). Before any operation that might reuse this HBM, insert `main_stream.wait(stash_event)` to ensure the D2H transfer has completed. This approach is simpler but requires careful placement of the sync point.
 {F1985328852}
2. **AsyncIO thread for completion monitoring**: Spawn a separate asyncIO thread that polls for stash completion. Once the D2H transfer finishes, the thread triggers `free_hbm()` to free HBM. This allows the main CPU thread to continue issuing GPU operations without blocking, maximizing overlap between compute and memory transfer.
 {F1985328853}

### 7.2 When to Trigger Restore

The current implementation triggers `restore()` at the start of `all2all_bwd` (grad_dist). However, on GB200/GB300 hardware, the all-to-all communication is significantly faster than the host-to-device copy—even accounting for potential straggler effects.

This timing mismatch means the restore may not complete before TBE backward needs the weights. To address this, we may need to trigger `restore()` earlier in the backward pass. Finding the optimal injection point in the autograd engine will require experimentation and tuning based on actual transfer and computation timings.
### 7.3 Functionality Gaps

| Gap | Current State | Solution |
|-----|---------------|----------|
| EC support | Only EBC supported | Extend `stash_embedding_weights` to support EmbeddingCollection |
| Sharding type coverage | Untested for all types | Verify and test all sharding types (CW, RW, TWRW, GRID, 2D, etc.) |
| TBE kernel variants | Unknown compatibility with EMO, SSD-TBE, etc. | Investigate interaction with different TBE kernel types; may require kernel-specific handling |
| Checkpointing compatibility | Unclear behavior during save/load | Verify stashed weights are properly restored before checkpointing; handle in-flight transfers |
| Multi-GPU coordination | Unknown behavior with FSDP/DDP | Test and document interaction with FSDP/DDP wrappers |

---

## 8. Other HBM Reduction Techniques

### 8.1 Embedding Memory Offloading (EMO)

EMO offloads embedding weights to CPU memory and fetches only the required rows during lookup. Unlike EMS, which temporarily stashes entire tables, EMO keeps weights on CPU permanently and only brings accessed rows to GPU.

- **Pros**: Significant HBM reduction; no need for frequent full-table transfers
- **Cons**: Not applicable to all tables (e.g., high-frequency tables); still consumes HBM for cached rows
- **Compatibility**: Theoretically compatible with EMS; requires verification

### 8.2 Activation Checkpointing and Offloading (AC/AO)

AC/AO reduces HBM usage by checkpointing or offloading activations during forward pass, then recomputing or reloading them during backward. Activations are often the dominant contributor to HBM peak.

- **Pros**: Targets activations, which are a major component of HBM peak
- **Cons**: Requires recomputation (AC) or additional data transfer (AO); more tuning needed; shorter idle window for offloading
- **Compatibility**: Theoretically compatible with EMS; AO may compete for host-device bandwidth during stash/restore

### 8.3 Fully Sharded Data Parallel (FSDP)

FSDP shards model parameters across GPUs and gathers them on-demand during forward/backward passes. It primarily targets dense layer weights rather than embeddings.

- **Pros**: Reduces HBM usage for dense layers by sharding weights across devices
- **Cons**: Requires careful tuning of prefetch timing to avoid stalls
- **Compatibility**: Theoretically compatible with EMS; both can operate on different parts of the model (FSDP on dense, EMS on embeddings)

---

## 9. Discussion

### 9.1 Risks & Mitigations

| Risk | Impact | Mitigation |
|------|--------|------------|
| Host-device bandwidth dependency | Slower transfers on older hardware | Reduce stash size; selectively stash large tables/modules |
| Pinned memory exhaustion | OOM on CPU side | Reduce stash size; selectively stash large tables/modules |
| Tuning complexity | Hard to onboard; slows production adoption | Provide tooling; integrate with TorchRec planner |

### 9.2 Open Questions

- What is the optimal sync strategy to minimize overhead while ensuring correctness?
- Where and how should we inject/hook the callbacks within a training step?
- How can the TorchRec planner help determine stashing configuration automatically?
- How do we ensure reliability and handle edge cases (e.g., failed transfers, timeouts)?
- What metrics and logging are needed for production debugging and monitoring?

---

## 10. Appendix

**Prototype Diffs**
- [D92585742](https://www.internalfb.com/diff/D92585742): Core `stash_embedding_weights` implementation
- [D92586272](https://www.internalfb.com/diff/D92586272): Pipeline integration and benchmarks

**References**
- [GB200 Key Memory and Interconnect Specifications](link)
- [TorchRec Train Pipeline Documentation](link)
- [FBGEMM TBE Documentation](link)

**Benchmark Artifacts**
- [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D92585742)
- Sharding Plan
```
INFO:torchrec.distributed.planner.stats:###########################################################################################################################################################################################################################################################################################################################################################
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                               --- Planner Statistics ---                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                        --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.06s ---                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
INFO:torchrec.distributed.planner.stats:#      Rank       HBM (GB)     DDR (GB)                 Perf (ms)     Input (MB)     Output (MB)         Shards                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    ------     ----------   ----------               -----------   ------------   -------------       --------                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#         0    45.39 (63%)     0.0 (0%)   704.985 (197,9,490,9,0)         1410.0          5760.0   CW: 8 TW: 86                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#         1   45.218 (63%)     0.0 (0%)   698.248 (194,9,485,9,0)         1395.0          5696.0   CW: 8 TW: 85                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Parameter Info:                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                      FQN     Sharding     Compute Kernel                 Perf (ms)     Storage (HBM, DDR)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size                             Ranks   #
INFO:torchrec.distributed.planner.stats:#                                    -----   ----------   ----------------               -----------   --------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------                           -------   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_0           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_1           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_2           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_3           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_4           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_5           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_6           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_7           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_8           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#     sparse.weighted_ebc.weighted_table_9           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_10           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_11           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_12           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_13           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_14           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_15           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_16           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_17           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_18           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_19           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_20           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_21           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_22           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_23           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_24           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_25           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_26           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_27           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_28           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_29           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_30           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_31           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_32           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_33           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_34           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_35           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_36           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_37           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_38           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_39           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_40           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_41           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_42           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_43           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_44           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_45           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_46           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_47           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_48           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_49           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_50           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_51           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_52           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_53           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_54           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_55           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_56           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_57           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_58           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_59           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_60           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_61           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_62           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_63           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_64           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_65           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_66           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_67           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_68           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_69           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_70           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_71           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_72           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_73           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_74           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_75           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_76           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_77           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_78           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#    sparse.weighted_ebc.weighted_table_79           TW              fused     9.198 (2,0.1,7,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_0           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_1           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_2           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_3           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_4           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_5           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_6           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_7           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_8           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                       sparse.ebc.table_9           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_10           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_11           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_12           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_13           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_14           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_15           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_16           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_17           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_18           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_19           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_20           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_21           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_22           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_23           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_24           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_25           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_26           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_27           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_28           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_29           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_30           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_31           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_32           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_33           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_34           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_35           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_36           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_37           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_38           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_39           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_40           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_41           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_42           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_43           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_44           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_45           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_46           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_47           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_48           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_49           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_50           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_51           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_52           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_53           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_54           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_55           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_56           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_57           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_58           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_59           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_60           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_61           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_62           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_63           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_64           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_65           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_66           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_67           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_68           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_69           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_70           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_71           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_72           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_73           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_74           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_75           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_76           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_77           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_78           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_79           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_80           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_81           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_82           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_83           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_84           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_85           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_86           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_87           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_88           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                      sparse.ebc.table_89           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
INFO:torchrec.distributed.planner.stats:#                    sparse.ebc.FP16_table           TW              fused     6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  512        100000                                 0   #
INFO:torchrec.distributed.planner.stats:#                   sparse.ebc.large_table           CW              fused   54.29 (18,0.8,35,0.8,0)     (8.364 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1           2048 (128)       1000000   0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Batch Size: 32768                                                                                                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Count:                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#    fused: 172                                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Storage:                                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#    fused: HBM: 37.864 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.002                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.005                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.001                                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.002                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Maximum of Total Perf: 704.985 ms on rank 0                                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Mean Total Perf: 701.616 ms                                                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Max Total Perf is 0.48% greater than the mean                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Compute: 196.586 ms on rank 0                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Compute: 489.649 ms on rank 0                                                                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Sum of Maxima: 704.985 ms                                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Estimated Sharding Distribution                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Sparse only Max HBM: 19.018 GB on rank [0]                                                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Sparse only Min HBM: 18.846 GB on rank [1]                                                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Max HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Min HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Mean HBM: 45.304 GB on rank []                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Low Median HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# High Median HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms): 18.75                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Critical Path (compute): 686.235                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms + compute): 704.985                                                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Max HBM is 0.19% greater than the mean                                                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Top HBM Memory Usage Estimation: 45.39 GB                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:# Top Tier #2 Estimated Peak HBM Pressure: 45.218 GB on rank 0                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Top Tier #1 Estimated Peak HBM Pressure: 45.39 GB on rank 0                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Reserved Memory:                                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#    HBM: 8.0 GB                                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 10%                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Planning Memory:                                                                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#    HBM: 72.0 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 90%                                                                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Dense Storage (per rank):                                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    HBM: 1.177 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# KJT Storage (per rank):                                                                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#    HBM: 25.195 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    weighted_table_0                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_2                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_4                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_6                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    weighted_table_8                                                                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    large_table: 0.523 GB on ranks [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#    weighted_table_0: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_2: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_4: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    weighted_table_6: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#################################################################################
```
Differential Revision: D92586272


