### PR TITLE
refactor embedding memory stashing API to add free/wait callbacks

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -730,6 +730,9 @@ def _run_benchmark_core(
         export_stacks: Whether to export flamegraph-compatible stack files.
         reset_accumulated_memory_stats: Whether to reset accumulated memory
             stats in addition to peak memory stats.
+        all_rank_traces: Whether to export traces for all ranks or just rank 0.
+        memory_snapshot: Whether to capture memory snapshot during the profiling
+            usage: https://docs.pytorch.org/memory_viz
     """
 
     def _reset_memory_stats() -> None:
@@ -1030,6 +1033,7 @@ def benchmark_func(
         export_stacks: Whether to export flamegraph-compatible stack files.
         all_rank_traces: Whether to export traces from all ranks.
         memory_snapshot: Whether to capture memory snapshot during the profiling
+            usage: https://docs.pytorch.org/memory_viz
     """
     if benchmark_func_kwargs is None:
         benchmark_func_kwargs = {}


### PR DESCRIPTION
Summary:
This diff implements a prototype for **Embedding Memory Stashing (EMS)** in TorchRec's EmbeddingBagCollection (EBC). EMS asynchronously offloads embedding weights from GPU HBM to pinned CPU memory after the forward pass lookup, then restores them before the backward pass. This temporarily frees substantial HBM during dense model computation, enabling larger effective model sizes or batch sizes on modern hardware like GB200/GB300 with high host-to-device bandwidth (400+ GB/s).

## Key Changes

- **embeddingbag.py**: Added `stash_embedding_weights()` API that returns three callbacks (`free_hbm`, `restore`, `await_restore`) for fine-grained control over the stash/restore lifecycle
- **train_pipelines.py**: Integrated EMS into `TrainPipelineSparseDist` with a new `memcpy_stream` parameter for stash/restore operations
- **runtime_forwards.py**: Added autograd hook registration for `restore` and `await_restore` callbacks during output distribution
- **utils.py**: Added utility support for the stashing pipeline
- **embedding_memory_stashing_design.md**: Added comprehensive design documentation

## API Design

```python
free_hbm, restore, await_restore = stash_embedding_weights(lookup, memcpy_stream)
```

| Callback | Purpose |
|----------|---------|
| `free_hbm` | Frees HBM storage after stash copy completes (CPU-blocking) |
| `restore` | Starts async restore from CPU to HBM (registered as backward hook) |
| `await_restore` | Waits for restore to complete before TBE backward |

## Known Gaps

This is an RFC/prototype. Future work includes optimizing HBM freeing timing, tuning restore trigger points, and extending support to EmbeddingCollection and additional sharding types.

Differential Revision: D92655860


