### PR TITLE
Add Claude skills: docstring, pr-review, skill-writer

### DIFF
--- a/torchrec/.claude/skills/docstring/SKILL.md
+++ b/torchrec/.claude/skills/docstring/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: docstring
+description: Write docstrings for TorchRec functions and methods following PyTorch conventions. Use when writing or updating docstrings in TorchRec code.
+---
+
+# TorchRec Docstring Writing Guide
+
+This skill describes how to write docstrings for functions and methods in the TorchRec project, following PyTorch conventions.
+
+## General Principles
+
+- Use **raw strings** (`r"""..."""`) for all docstrings to avoid issues with LaTeX/math backslashes
+- Follow **Sphinx/reStructuredText** (reST) format for documentation
+- Be **concise but complete** - include all essential information
+- Always include **examples** when possible
+- Use **cross-references** to related functions/classes
+
+## Docstring Structure
+
+### 1. Function Signature (First Line)
+
+Start with the function signature showing all parameters:
+
+```python
+r"""function_name(param1, param2, *, kwarg1=default1, kwarg2=default2) -> ReturnType
+```
+
+**Notes:**
+- Include the function name
+- Show positional and keyword-only arguments (use `*` separator)
+- Include default values
+- Show return type annotation
+- This line should NOT end with a period
+
+### 2. Brief Description
+
+Provide a one-line description of what the function does:
+
+```python
+r"""apply_optimizer_in_backward(optimizer_class, params, optimizer_kwargs) -> None
+
+Applies optimizer to parameters in backward pass for memory efficiency.
+```
+
+### 3. Mathematical Formulas (if applicable)
+
+Use Sphinx math directives for mathematical expressions:
+
+```python
+.. math::
+    \text{output} = \text{input} \cdot \text{weight}^T
+```
+
+Or inline math: `:math:\`x^2\``
+
+### 4. Cross-References
+
+Link to related classes and functions using Sphinx roles:
+
+- `:class:\`~torchrec.modules.EmbeddingBagCollection\`` - Link to a class
+- `:func:\`torchrec.distributed.sharding.shard\`` - Link to a function
+- `:meth:\`~Module.forward\`` - Link to a method
+- `:attr:\`attribute_name\`` - Reference an attribute
+- The `~` prefix shows only the last component
+
+**Example:**
+```python
+See :class:`~torchrec.distributed.DistributedModelParallel` for details.
+```
+
+### 5. Notes and Warnings
+
+Use admonitions for important information:
+
+```python
+.. note::
+    This function requires CUDA to be available.
+
+.. warning::
+    This API is experimental and may change without notice.
+```
+
+### 6. Args Section
+
+Document all parameters with type annotations and descriptions:
+
+```python
+Args:
+    module (nn.Module): Module to be sharded across devices.
+    device (torch.device, optional): Device to place the module. Default: ``None``
+    sharders (List[ModuleSharder], optional): List of sharders to use for sharding.
+        Default: ``None``
+    plan (ShardingPlan, optional): Explicit sharding plan. If not provided, will be
+        generated automatically. Default: ``None``
+```
+
+**Formatting rules:**
+- Parameter name in **lowercase**
+- Type in parentheses: `(Type)`, `(Type, optional)` for optional parameters
+- Description follows the type
+- For optional parameters, include "Default: ``value``" at the end
+- Use double backticks for inline code: ``` ``None`` ```
+- Indent continuation lines by 4 spaces
+
+### 7. Returns Section
+
+Document the return value:
+
+```python
+Returns:
+    ShardedModule: The sharded module ready for distributed training.
+        The module will have its parameters distributed according to
+        the sharding plan.
+```
+
+### 8. Raises Section (if applicable)
+
+Document exceptions that may be raised:
+
+```python
+Raises:
+    ValueError: If the sharding plan is invalid for the given module.
+    RuntimeError: If CUDA is not available when GPU sharding is requested.
+```
+
+### 9. Examples Section
+
+Always include examples when possible:
+
+```python
+Examples::
+
+    >>> import torchrec
+    >>> from torchrec.modules import EmbeddingBagCollection
+    >>> ebc = EmbeddingBagCollection(
+    ...     tables=[
+    ...         EmbeddingBagConfig(
+    ...             name="product",
+    ...             embedding_dim=64,
+    ...             num_embeddings=1000,
+    ...             feature_names=["product_id"],
+    ...         ),
+    ...     ],
+    ... )
+    >>> # Shard the module
+    >>> sharded_ebc = shard(ebc, plan=plan)
+```
+
+**Formatting rules:**
+- Use `Examples::` with double colon
+- Use `>>>` prompt for Python code
+- Include comments with `#` when helpful
+- Show actual output when it helps understanding
+
+## TorchRec-Specific Patterns
+
+### Embedding Configuration
+
+```python
+Args:
+    tables (List[EmbeddingBagConfig]): List of embedding table configurations.
+        Each config specifies the table name, embedding dimension, number of
+        embeddings, and feature names.
+    device (Optional[torch.device]): Device to place embeddings. Default: ``None``
+```
+
+### Sharding-Related
+
+```python
+Args:
+    sharding_type (ShardingType): How to shard the embedding table. Options are:
+        - ``TABLE_WISE``: Each table on a single device
+        - ``ROW_WISE``: Rows distributed across devices
+        - ``COLUMN_WISE``: Columns distributed across devices
+        - ``TABLE_ROW_WISE``: Combination of table and row sharding
+```
+
+### KeyedJaggedTensor
+
+```python
+Args:
+    kjt (KeyedJaggedTensor): Sparse features in KeyedJaggedTensor format.
+        Contains keys (feature names), values (embedding indices), and
+        lengths/offsets for variable-length sequences.
+```
+
+## Complete Example
+
+```python
+def shard_modules(
+    module: nn.Module,
+    plan: ShardingPlan,
+    env: ShardingEnv,
+    device: Optional[torch.device] = None,
+) -> nn.Module:
+    r"""
+    Shard a module's embedding tables according to a sharding plan.
+
+    This function takes a module containing embedding tables and distributes
+    them across multiple devices according to the provided sharding plan.
+    It supports various sharding strategies including table-wise, row-wise,
+    and column-wise sharding.
+
+    Args:
+        module (nn.Module): The module containing embedding tables to shard.
+        plan (ShardingPlan): The sharding plan specifying how each table
+            should be distributed.
+        env (ShardingEnv): The sharding environment containing process group
+            information and device topology.
+        device (torch.device, optional): Target device for local shards.
+            Default: ``None`` (uses current device)
+
+    Returns:
+        nn.Module: The sharded module with distributed embedding tables.
+
+    Raises:
+        ValueError: If the plan references tables not present in the module.
+        RuntimeError: If the sharding environment is not properly initialized.
+
+    .. note::
+        This function modifies the module in-place for efficiency.
+
+    .. warning::
+        This is an experimental API and may change in future releases.
+
+    Examples::
+
+        >>> from torchrec.distributed import shard_modules
+        >>> from torchrec.distributed.planner import EmbeddingShardingPlanner
+        >>>
+        >>> # Create a sharding plan
+        >>> planner = EmbeddingShardingPlanner()
+        >>> plan = planner.plan(module, sharders)
+        >>>
+        >>> # Shard the module
+        >>> sharded_module = shard_modules(module, plan, env)
+    """
+    # implementation
+```
+
+## Quick Checklist
+
+When writing a TorchRec docstring, ensure:
+
+- [ ] Use raw string (`r"""`)
+- [ ] Include function signature on first line
+- [ ] Provide brief description
+- [ ] Document all parameters in Args section with types
+- [ ] Include default values for optional parameters
+- [ ] Use Sphinx cross-references (`:func:`, `:class:`, `:meth:`)
+- [ ] Add mathematical formulas if applicable
+- [ ] Include at least one example in Examples section
+- [ ] Add warnings/notes for experimental APIs
+- [ ] Document any exceptions in Raises section
+- [ ] Use proper math notation for tensor shapes

--- a/torchrec/.claude/skills/pr-review/SKILL.md
+++ b/torchrec/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: pr-review
+description: Review TorchRec pull requests and diffs for code quality, test coverage, security, and backward compatibility. Use when reviewing PRs, diffs, or when asked to review code changes.
+---
+
+# TorchRec PR/Diff Review Skill
+
+Review TorchRec pull requests and diffs focusing on what CI cannot check: code quality, test coverage adequacy, security vulnerabilities, and backward compatibility. Linting, formatting, type checking, and import ordering are handled by CI.
+
+## Usage Modes
+
+### No Argument
+
+If the user invokes `/pr-review` with no arguments, use `get_local_changes` to review uncommitted changes or the current commit.
+
+### Diff ID Mode
+
+The user provides a Phabricator diff ID:
+
+```
+/pr-review D12345678
+```
+
+Use the `get_phabricator_diff_details` tool to fetch diff information.
+
+### Local Changes Mode
+
+Review uncommitted changes or the current commit:
+
+```
+/pr-review local
+/pr-review branch
+```
+
+Use `get_local_changes` to get the diff data.
+
+## Review Workflow
+
+### Step 1: Fetch Information
+
+1. For Phabricator diffs: Use `get_phabricator_diff_details` with `include_raw_diff=true`
+2. For local changes: Use `get_local_changes`
+3. Read related files for context using `read_file`
+
+### Step 2: Analyze Changes
+
+Read through the diff systematically:
+1. Identify the purpose of the change from title/description
+2. Group changes by type (new code, tests, config, docs)
+3. Note the scope of changes (files affected, lines changed)
+
+### Step 3: Deep Review
+
+Perform thorough line-by-line analysis focusing on:
+
+#### Code Quality
+- Proper abstractions and design patterns
+- Appropriate complexity levels
+- Clear naming and documentation
+- No code duplication
+
+#### TorchRec-Specific Patterns
+- Proper use of `KeyedJaggedTensor` and sparse tensors
+- Correct sharding strategies (table-wise, row-wise, column-wise)
+- Appropriate use of `DistributedModelParallel`
+- Correct embedding table configurations
+- Proper use of `EmbeddingBagCollection` and `EmbeddingCollection`
+
+#### Testing
+- Tests exist for new functionality
+- Edge cases covered (empty tensors, single-device, multi-device)
+- Tests follow TorchRec patterns (multi-process tests for distributed)
+- Proper mocking of distributed primitives when needed
+
+#### Performance
+- No unnecessary tensor copies
+- Efficient use of collectives
+- Proper device placement
+- Memory-efficient implementations
+
+#### Backward Compatibility
+- No breaking changes to public APIs
+- Proper deprecation warnings if changing behavior
+- Version compatibility considerations
+
+### Step 4: Check BC Implications
+
+For TorchRec, pay special attention to:
+- Changes to `ShardingPlan` format
+- Changes to `EmbeddingBagConfig` or `EmbeddingConfig`
+- Changes to `KeyedJaggedTensor` structure
+- Changes to distributed communication patterns
+- Changes to serialization/deserialization
+
+## Review Areas
+
+| Area | Focus |
+|------|-------|
+| Code Quality | Abstractions, patterns, complexity |
+| TorchRec Patterns | Sharding, embeddings, sparse tensors |
+| Testing | Coverage, distributed tests, edge cases |
+| Performance | Memory, communication, device handling |
+| BC | Breaking changes, deprecation |
+
+## Output Format
+
+Structure your review as follows:
+
+```markdown
+## Review: D<number> / Local Changes
+
+### Summary
+Brief overall assessment of the changes (1-2 sentences).
+
+### Code Quality
+[Issues and suggestions, or "No concerns" if none]
+
+### TorchRec Patterns
+[Check for proper use of TorchRec APIs and patterns]
+
+### Testing
+- [ ] Tests exist for new functionality
+- [ ] Edge cases covered
+- [ ] Distributed scenarios tested (if applicable)
+[Additional testing feedback]
+
+### Performance
+[Performance concerns if any, or "No performance concerns"]
+
+### Backward Compatibility
+[BC concerns if any, or "No BC-breaking changes"]
+
+### Recommendation
+**Approve** / **Request Changes** / **Needs Discussion**
+
+[Brief justification for recommendation]
+```
+
+### Specific Comments (Detailed Review Only)
+
+When requested, add file-specific feedback with line references:
+
+```markdown
+### Specific Comments
+- `torchrec/distributed/sharding.py:42` - Consider using table-wise sharding for small tables
+- `torchrec/modules/embedding.py:100-105` - Missing test for empty input case
+```
+
+## Key Principles
+
+1. **Focus on what CI cannot check** - Don't comment on formatting, linting, or type errors
+2. **Be specific** - Reference file paths and line numbers
+3. **Be actionable** - Provide concrete suggestions, not vague concerns
+4. **Be proportionate** - Minor issues shouldn't block, but note them
+5. **TorchRec expertise** - Apply knowledge of distributed embeddings and recommendation systems
+
+## TorchRec Code Patterns to Check
+
+### Embedding Configuration
+```python
+# Good: Explicit configuration
+EmbeddingBagConfig(
+    name="product",
+    embedding_dim=64,
+    num_embeddings=1000,
+    feature_names=["product_id"],
+    pooling=PoolingType.SUM,
+)
+
+# Check: Is pooling type appropriate?
+# Check: Are feature names correct?
+# Check: Is embedding_dim reasonable for the use case?
+```
+
+### Sharding Plans
+```python
+# Check: Is the sharding strategy appropriate for table size?
+# Small tables -> TABLE_WISE
+# Large tables -> ROW_WISE or COLUMN_WISE
+# Check: Are compute kernels specified correctly?
+```
+
+### Distributed Tests
+```python
+# Check: Are multi-process tests using correct world_size?
+# Check: Is cleanup handled properly?
+# Check: Are results verified across all ranks?
+```
+
+## Files to Reference
+
+When reviewing TorchRec code, consult:
+- `torchrec/CLAUDE.md` - Coding style and testing patterns
+- `torchrec/distributed/test_utils/` - Test utilities and patterns
+- `torchrec/modules/` - Core module implementations
+- `torchrec/distributed/planner/` - Sharding planner reference

--- a/torchrec/.claude/skills/skill-writer/SKILL.md
+++ b/torchrec/.claude/skills/skill-writer/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: skill-writer
+description: Guide users through creating Agent Skills for Claude Code. Use when the user wants to create, write, author, or design a new Skill for TorchRec, or needs help with SKILL.md files.
+---
+
+# TorchRec Skill Writer
+
+This Skill helps you create well-structured Agent Skills for Claude Code specifically for the TorchRec project.
+
+## When to use this Skill
+
+Use this Skill when:
+- Creating a new Agent Skill for TorchRec
+- Writing or updating SKILL.md files
+- Designing skill structure and frontmatter
+- Converting existing TorchRec workflows into Skills
+
+## Instructions
+
+### Step 1: Determine Skill scope
+
+First, understand what the Skill should do:
+
+1. **Ask clarifying questions**:
+   - What specific TorchRec capability should this Skill provide?
+   - When should Claude use this Skill?
+   - What tools or resources does it need?
+
+2. **Keep it focused**: One Skill = one capability
+   - Good: "sharding-optimizer", "embedding-config-validator"
+   - Too broad: "distributed-training", "model-tools"
+
+### Step 2: Choose Skill location
+
+TorchRec Skills should be placed in:
+```
+fbcode/torchrec/.claude/skills/<skill-name>/SKILL.md
+```
+
+### Step 3: Create Skill structure
+
+Create the directory and files:
+
+```bash
+mkdir -p fbcode/torchrec/.claude/skills/skill-name
+```
+
+For multi-file Skills:
+```
+skill-name/
+├── SKILL.md (required)
+├── reference.md (optional)
+├── examples.md (optional)
+└── templates/ (optional)
+```
+
+### Step 4: Write SKILL.md frontmatter
+
+Create YAML frontmatter with required fields:
+
+```yaml
+---
+name: skill-name
+description: Brief description of what this does and when to use it
+---
+```
+
+**Field requirements**:
+
+- **name**:
+  - Lowercase letters, numbers, hyphens only
+  - Max 64 characters
+  - Must match directory name
+  - Good: `sharding-optimizer`, `kjt-validator`
+  - Bad: `Sharding_Optimizer`, `KJT Validator!`
+
+- **description**:
+  - Max 1024 characters
+  - Include BOTH what it does AND when to use it
+  - Use specific trigger words users would say
+  - Mention TorchRec concepts (embeddings, sharding, KJT, etc.)
+
+**Optional frontmatter fields**:
+
+- **allowed-tools**: Restrict tool access (comma-separated list)
+  ```yaml
+  allowed-tools: Read, Grep, Glob
+  ```
+
+- **argument-hint**: Hint for expected arguments
+  ```yaml
+  argument-hint: [feature or task description]
+  ```
+
+### Step 5: Write effective descriptions
+
+The description is critical for Claude to discover your Skill.
+
+**Formula**: `[What it does] + [When to use it] + [TorchRec keywords]`
+
+**Examples**:
+
+✅ **Good**:
+```yaml
+description: Optimize sharding plans for TorchRec embedding tables. Use when configuring DistributedModelParallel, analyzing sharding strategies, or tuning embedding performance.
+```
+
+✅ **Good**:
+```yaml
+description: Validate KeyedJaggedTensor (KJT) configurations and debug sparse tensor issues. Use when working with KJT, debugging embedding lookups, or validating feature configurations.
+```
+
+❌ **Too vague**:
+```yaml
+description: Helps with TorchRec
+description: For distributed training
+```
+
+### Step 6: Structure the Skill content
+
+Use clear Markdown sections:
+
+```markdown
+# Skill Name
+
+Brief overview of what this Skill does for TorchRec.
+
+## Quick start
+
+Provide a simple example to get started immediately.
+
+## Instructions
+
+Step-by-step guidance for Claude:
+1. First step with clear action
+2. Second step with expected outcome
+3. Handle edge cases
+
+## TorchRec-Specific Patterns
+
+Document TorchRec-specific patterns and conventions.
+
+## Examples
+
+Show concrete usage examples with TorchRec code.
+
+## Best practices
+
+- Key conventions to follow
+- Common pitfalls to avoid
+- When to use vs. not use
+
+## Files to Reference
+
+List important TorchRec files for context:
+- `torchrec/distributed/` - Distributed training code
+- `torchrec/modules/` - Core modules
+```
+
+### Step 7: Validate the Skill
+
+Check these requirements:
+
+✅ **File structure**:
+- [ ] SKILL.md exists in correct location
+- [ ] Directory name matches frontmatter `name`
+
+✅ **YAML frontmatter**:
+- [ ] Opening `---` on line 1
+- [ ] Closing `---` before content
+- [ ] Valid YAML (no tabs, correct indentation)
+- [ ] `name` follows naming rules
+- [ ] `description` is specific and < 1024 chars
+
+✅ **Content quality**:
+- [ ] Clear instructions for Claude
+- [ ] TorchRec-specific examples provided
+- [ ] Edge cases handled
+- [ ] References to relevant TorchRec code
+
+## TorchRec Skill Ideas
+
+Here are some useful Skills to consider creating:
+
+| Skill Name | Purpose |
+|------------|---------|
+| `sharding-optimizer` | Analyze and optimize embedding sharding plans |
+| `kjt-validator` | Validate KeyedJaggedTensor configurations |
+| `distributed-debug` | Debug distributed training issues |
+| `embedding-benchmark` | Benchmark embedding performance |
+| `migration-helper` | Help migrate to newer TorchRec APIs |
+
+## Example: Complete TorchRec Skill
+
+```yaml
+---
+name: sharding-analyzer
+description: Analyze TorchRec sharding plans and suggest optimizations. Use when reviewing ShardingPlan, DistributedModelParallel configuration, or optimizing embedding distribution across devices.
+---
+
+# Sharding Analyzer
+
+Analyze TorchRec sharding plans and suggest optimizations for embedding tables.
+
+## Quick start
+
+Run `/sharding-analyzer` on a file containing a ShardingPlan to get optimization suggestions.
+
+## Instructions
+
+1. Read the sharding plan configuration
+2. Analyze table sizes and sharding strategies
+3. Check for common anti-patterns:
+   - Large tables with TABLE_WISE sharding
+   - Small tables with ROW_WISE sharding
+   - Unbalanced memory distribution
+4. Suggest optimizations
+
+## TorchRec Sharding Strategies
+
+| Strategy | Best For | Avoid When |
+|----------|----------|------------|
+| TABLE_WISE | Small tables, < 1M rows | Large tables |
+| ROW_WISE | Large tables, uniform access | Small tables |
+| COLUMN_WISE | Wide embeddings, > 256 dim | Narrow embeddings |
+
+## Files to Reference
+
+- `torchrec/distributed/planner/` - Sharding planner
+- `torchrec/distributed/sharding/` - Sharding implementations
+```
+
+## Output format
+
+When creating a Skill, I will:
+
+1. Ask clarifying questions about scope and requirements
+2. Suggest a Skill name and location
+3. Create the SKILL.md file with proper frontmatter
+4. Include TorchRec-specific instructions and examples
+5. Add references to relevant TorchRec code
+6. Provide validation checklist

--- a/torchrec/utils/experimental.py
+++ b/torchrec/utils/experimental.py
@@ -51,8 +51,8 @@ def experimental(
         >>> fancy_new_op(3)  # first call triggers a warning
         6
 
-        >>> @experimental(feature="Hybird 2D Parallel", since="1.2.0")
-        ... class HybirdDistributedModelParallel:
+        >>> @experimental(feature="Hybrid 2D Parallel", since="1.2.0")
+        ... class HybridDistributedModelParallel:
         ...     ...
     """
     tag: str = feature or obj.__name__  # pyre-ignore[16]

--- a/torchrec/utils/tests/__init__.py
+++ b/torchrec/utils/tests/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/utils/tests/test_experimental.py
+++ b/torchrec/utils/tests/test_experimental.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import functools
+import unittest
+import warnings
+from typing import Any
+
+from torchrec.utils.experimental import experimental
+
+
+class ExperimentalDecoratorTest(unittest.TestCase):
+    """Tests for the experimental decorator."""
+
+    def test_experimental_function_returns_correct_value(self) -> None:
+        """Test that a decorated function returns the correct value."""
+
+        @experimental
+        def multiply(x: int, y: int) -> int:
+            return x * y
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = multiply(3, 4)
+
+        self.assertEqual(result, 12)
+
+    def test_experimental_function_emits_warning_on_first_call(self) -> None:
+        """Test that a decorated function emits a UserWarning on first call."""
+
+        @experimental
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            add(1, 2)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertIn("add", str(w[0].message))
+            self.assertIn("experimental", str(w[0].message))
+
+    def test_experimental_function_emits_warning_only_once(self) -> None:
+        """Test that a decorated function emits warning only on the first call."""
+
+        @experimental
+        def subtract(x: int, y: int) -> int:
+            return x - y
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            subtract(5, 3)
+            subtract(10, 4)
+            subtract(100, 50)
+
+            self.assertEqual(len(w), 1)
+
+    def test_experimental_function_with_feature_name(self) -> None:
+        """Test that custom feature name appears in the warning message."""
+
+        def dummy_func() -> None:
+            pass
+
+        wrapped = experimental(dummy_func, feature="Custom Feature Name")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrapped()
+
+            self.assertEqual(len(w), 1)
+            self.assertIn("Custom Feature Name", str(w[0].message))
+
+    def test_experimental_function_with_since_version(self) -> None:
+        """Test that since version appears in the warning message."""
+
+        def versioned_func() -> None:
+            pass
+
+        wrapped = experimental(versioned_func, since="1.2.0")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrapped()
+
+            self.assertEqual(len(w), 1)
+            self.assertIn("[since 1.2.0]", str(w[0].message))
+
+    def test_experimental_function_with_feature_and_since(self) -> None:
+        """Test that both feature name and since version appear in warning."""
+
+        def full_feature_func() -> None:
+            pass
+
+        wrapped = experimental(
+            full_feature_func, feature="Hybrid 2D Parallel", since="1.2.0"
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrapped()
+
+            self.assertEqual(len(w), 1)
+            message = str(w[0].message)
+            self.assertIn("Hybrid 2D Parallel", message)
+            self.assertIn("[since 1.2.0]", message)
+
+    def test_experimental_class_returns_instance(self) -> None:
+        """Test that a decorated class can be instantiated correctly."""
+
+        @experimental
+        class ExperimentalClass:
+            def __init__(self, value: int) -> None:
+                self.value = value
+
+            def get_value(self) -> int:
+                return self.value
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = ExperimentalClass(42)
+
+        self.assertIsInstance(obj, ExperimentalClass)
+        self.assertEqual(obj.get_value(), 42)
+
+    def test_experimental_class_emits_warning_on_instantiation(self) -> None:
+        """Test that a decorated class emits warning when instantiated."""
+
+        @experimental
+        class WarningClass:
+            def __init__(self) -> None:
+                pass
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            WarningClass()
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertIn("WarningClass", str(w[0].message))
+
+    def test_experimental_class_emits_warning_only_once(self) -> None:
+        """Test that a decorated class emits warning only on first instantiation."""
+
+        @experimental
+        class SingleWarningClass:
+            __slots__ = ("value",)
+
+            def __init__(self, value: int = 0) -> None:
+                self.value = value
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            SingleWarningClass(1)
+            SingleWarningClass(2)
+            SingleWarningClass(3)
+
+            self.assertEqual(len(w), 1)
+
+    def test_experimental_class_with_feature_name(self) -> None:
+        """Test that custom feature name appears in class warning."""
+
+        class FeatureClass:
+            pass
+
+        WrappedClass = experimental(FeatureClass, feature="Feature Class")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            WrappedClass()
+
+            self.assertEqual(len(w), 1)
+            self.assertIn("Feature Class", str(w[0].message))
+
+    def test_experimental_preserves_function_name(self) -> None:
+        """Test that the decorated function preserves its __name__ attribute."""
+
+        @experimental
+        def named_function() -> None:
+            pass
+
+        self.assertEqual(named_function.__name__, "named_function")
+
+    def test_experimental_preserves_function_docstring(self) -> None:
+        """Test that the decorated function preserves its docstring."""
+
+        @experimental
+        def documented_function() -> None:
+            """This is a docstring."""
+            pass
+
+        self.assertEqual(documented_function.__doc__, "This is a docstring.")
+
+    def test_experimental_function_with_kwargs(self) -> None:
+        """Test that decorated function handles keyword arguments correctly."""
+
+        @experimental
+        def func_with_kwargs(a: int, b: int = 10, **kwargs: Any) -> int:
+            return a + b + kwargs.get("c", 0)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = func_with_kwargs(1, b=2, c=3)
+
+        self.assertEqual(result, 6)
+
+    def test_experimental_function_with_args(self) -> None:
+        """Test that decorated function handles *args correctly."""
+
+        @experimental
+        def sum_all(*args: int) -> int:
+            return sum(args)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = sum_all(1, 2, 3, 4, 5)
+
+        self.assertEqual(result, 15)
+
+    def test_experimental_class_with_inheritance(self) -> None:
+        """Test that decorated class can be subclassed."""
+
+        @experimental
+        class BaseExperimental:
+            __slots__ = ("x",)
+
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+        class DerivedClass(BaseExperimental):
+            __slots__ = ("y",)
+
+            def __init__(self, x: int, y: int) -> None:
+                super().__init__(x)
+                self.y = y
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            obj = DerivedClass(10, 20)
+
+        self.assertEqual(obj.x, 10)
+        self.assertEqual(obj.y, 20)
+
+    def test_warning_message_format(self) -> None:
+        """Test that warning message has the expected format."""
+
+        def formatted_func() -> None:
+            pass
+
+        wrapped = experimental(formatted_func, feature="Test Feature", since="2.0.0")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrapped()
+
+            self.assertEqual(len(w), 1)
+            message = str(w[0].message)
+            self.assertIn("[since 2.0.0]", message)
+            self.assertIn("`Test Feature`", message)
+            self.assertIn("*experimental*", message)
+            self.assertIn("may change or be removed without notice", message)
+
+    def test_experimental_uses_functools_partial_correctly(self) -> None:
+        """Test using functools.partial for decorator-style with arguments."""
+
+        def my_func() -> str:
+            return "result"
+
+        custom_experimental = functools.partial(
+            experimental, feature="Partial Feature", since="3.0.0"
+        )
+        wrapped = custom_experimental(my_func)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = wrapped()
+
+            self.assertEqual(result, "result")
+            self.assertEqual(len(w), 1)
+            self.assertIn("Partial Feature", str(w[0].message))
+            self.assertIn("[since 3.0.0]", str(w[0].message))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add three new Claude skills to torchrec adapted from the PyTorch/caffe2 project:

1. **docstring** - Guide for writing PyTorch-style docstrings in TorchRec code
2. **pr-review** - Skill for reviewing TorchRec pull requests and diffs
3. **skill-writer** - Guide for creating new Agent Skills for TorchRec

These skills will help improve code quality and documentation consistency in TorchRec.

Differential Revision: D92989271


