### PR TITLE
include offsets calculation when exporting for PT2 (#3769)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -99,7 +99,10 @@ def _maybe_compute_lengths(
 def _maybe_compute_offsets(
     lengths: Optional[torch.Tensor], offsets: Optional[torch.Tensor]
 ) -> torch.Tensor:
-    if offsets is None:
+    if not torch.jit.is_scripting() and torch.compiler.is_compiling():
+        assert lengths is not None
+        offsets = _to_offsets(lengths)
+    elif offsets is None:
         assert lengths is not None
         offsets = _to_offsets(lengths)
     return offsets


### PR DESCRIPTION
Summary:

Fix offset computation for torch.export in JaggedTensor
When using torch.export, the _maybe_compute_offsets function
now always computes offsets from lengths during the compilation phase, regardless
of whether offsets are already provided. This ensures that the offset computation
graph is included in the exported model.
This change addresses an issue where offsets calculation was being skipped during
torch compilation when offsets were pre-computed, which could cause problems in
the exported model.

Reviewed By: TroyGarden

Differential Revision: D93186325
