### PR TITLE
fix bug in fused_params parsing for benchmark_train_pipeline

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
@@ -20,7 +20,7 @@ ModelSelectionConfig:
     num_float_features: 100
 EmbeddingTablesConfig:
   num_unweighted_features: 70
-  num_weighted_features: 70
+  num_weighted_features: 0
   embedding_feature_dim: 256
   additional_tables:
     # First list: unweighted tables (EBC + EC mixed)
@@ -46,6 +46,6 @@ EmbeddingTablesConfig:
     # Second list: weighted tables (empty for this config)
     - []
 PlannerConfig:
-  pooling_factors: [30.0]
+  pooling_factors: [10.0]
   hardware:  # A100
     hbm_cap: 85899345920  # 80GB

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
@@ -7,15 +7,11 @@ RunOptions:
   num_batches: 10
   num_benchmarks: 1
   num_profiles: 1
-  sharding_type: table_wise
+  memory_snapshot: True
   profile_dir: "."
   name: "sparse_data_dist_shampoo"
   # export_stacks: True # enable this to export stack traces
   loglevel: "info"
-  dense_optimizer: "Shampoo"
-  dense_lr: 0.01
-  sparse_optimizer: "EXACT_ROWWISE_ADAGRAD"
-  sparse_lr: 0.01
 PipelineConfig:
   pipeline: "sparse"
 ModelInputConfig:
@@ -50,6 +46,13 @@ EmbeddingTablesConfig:
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
+  sharding_type: table_wise
   additional_constraints:
     large_table:
       sharding_types: [column_wise]
+ShardingConfig:
+  dense_optimizer: "Shampoo"
+  dense_lr: 0.01
+  fused_params:
+    optimizer: EXACT_ROWWISE_ADAGRAD
+    learning_rate: 0.01


### PR DESCRIPTION
## Overview
Refactored sharding and optimizer configuration into a new `ShardingConfig` dataclass, following the same pattern as `PlannerConfig`. This consolidates sharding-related parameters and simplifies the benchmark CLI interface.

## Changes

### `fbcode/torchrec/distributed/test_utils/sharding_config.py`
- Added new `ShardingConfig` dataclass with the following fields:
  - `fused_params: Optional[Dict[str, Any]] = None` - sparse optimizer parameters
  - `dense_optimizer: str = "SGD"` - optimizer type for dense parameters
  - `dense_lr: float = 0.1` - learning rate for dense parameters
  - `dense_momentum: Optional[float] = None`
  - `dense_weight_decay: Optional[float] = None`
- Added `generate_sharded_model_and_optimizer()` method to `ShardingConfig`
- Added `_get_sharders()` helper function that returns default sharders when `fused_params` is `None`, otherwise returns sharders configured with fused parameters
- Added necessary imports for the new functionality

### `fbcode/torchrec/distributed/benchmark/benchmark_train_pipeline.py`
- Removed redundant parameters from `RunOptions` that are now in `ShardingConfig` or `PlannerConfig`:
  - `sharding_type`, `num_poolings` (already in `PlannerConfig`)
  - `dense_optimizer`, `dense_lr`, `dense_momentum`, `dense_weight_decay` (now in `ShardingConfig`)
  - `sparse_optimizer`, `sparse_lr`, `sparse_momentum`, `sparse_weight_decay` (now via `fused_params` in `ShardingConfig`)
- Updated `main()` to accept `sharding_config: ShardingConfig` as a CLI argument
- Updated `runner()` and `run_pipeline()` to use `ShardingConfig`

### `fbcode/torchrec/distributed/test_utils/model_config.py`
- Removed `generate_sharded_model_and_optimizer()` function (moved to `ShardingConfig`)
- Removed `get_sharders_with_fused_params()` helper function (moved to `sharding_config.py`)
- Cleaned up unused imports

### results
* sharding plan
```
INFO:torchrec.distributed.planner.stats:#############################################################################################################################################################################################################################################################################################################
INFO:torchrec.distributed.planner.stats:#                                                                                                                                        --- Planner Statistics ---                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                                                                                                 --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.03s ---                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
INFO:torchrec.distributed.planner.stats:#      Rank       HBM (GB)     DDR (GB)               Perf (ms)     Input (MB)     Output (MB)     Shards                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#    ------     ----------   ----------             -----------   ------------   -------------   --------                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#         0   19.723 (29%)     0.0 (0%)   115.936 (33,8,67,8,0)          185.0          4864.0     TW: 37                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#         1   15.813 (23%)     0.0 (0%)   115.936 (33,8,67,8,0)          185.0          4864.0     TW: 37                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Parameter Info:                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                FQN     Sharding     Compute Kernel                 Perf (ms)     Storage (HBM, DDR)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size     Ranks   #
INFO:torchrec.distributed.planner.stats:#              -----   ----------   ----------------               -----------   --------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------   -------   #
INFO:torchrec.distributed.planner.stats:#      ec.ec_table_0           TW              fused       25.072 (6,4,11,4,0)      (6.32 GB, 0.0 GB)                  None                   10.0                  1.0            10.0   sequence   unweighted      EmbeddingCollectionSharder            1                 1024       1000000         1   #
INFO:torchrec.distributed.planner.stats:#      ec.ec_table_1           TW              fused       25.072 (6,4,11,4,0)    (10.134 GB, 0.0 GB)                  None                   10.0                  1.0            10.0   sequence   unweighted      EmbeddingCollectionSharder            1                 1024       2000000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_0           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_1           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_2           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_3           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_4           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_5           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_6           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_7           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_8           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_9           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_10           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_11           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_12           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_13           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_14           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_15           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_16           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_17           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_18           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_19           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_20           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_21           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_22           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_23           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_24           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_25           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_26           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_27           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_28           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_29           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_30           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_31           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_32           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_33           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_34           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_35           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_36           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_37           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_38           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_39           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_40           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_41           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_42           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_43           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_44           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_45           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_46           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_47           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_48           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_49           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_50           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_51           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_52           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_53           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_54           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_55           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_56           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_57           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_58           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_59           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_60           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_61           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_62           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_63           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_64           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_65           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_66           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_67           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_68           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_69           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#    ebc.ebc_table_0           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.163 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#    ebc.ebc_table_1           TW              fused   2.524 (0.8,0.1,2,0.1,0)     (0.258 GB, 0.0 GB)                  None                   10.0                  1.0            10.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        200000         0   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Batch Size: 32768                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Count:                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:#    fused: 74                                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Storage:                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#    fused: HBM: 28.267 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.000                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.000                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.055                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.110                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.012                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.009                                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Total Perf: 115.936 ms on ranks 0-1                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Mean Total Perf: 115.936 ms                                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:# Max Total Perf is 0% greater than the mean                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Compute: 33.368 ms on ranks 0-1                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Comms: 7.917 ms on ranks 0-1                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Compute: 66.735 ms on ranks 0-1                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Comms: 7.917 ms on ranks 0-1                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Sum of Maxima: 115.936 ms                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Estimated Sharding Distribution                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Sparse only Max HBM: 16.089 GB on rank [0]                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Sparse only Min HBM: 12.179 GB on rank [1]                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Max HBM: 19.723 GB on rank [0]                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Min HBM: 15.813 GB on rank [1]                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Mean HBM: 17.768 GB on rank []                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Low Median HBM: 15.813 GB on rank [1]                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# High Median HBM: 19.723 GB on rank [0]                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms): 15.833                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Critical Path (compute): 100.103                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms + compute): 115.936                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:# Max HBM is 11% greater than the mean                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Top HBM Memory Usage Estimation: 19.723 GB                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Top Tier #2 Estimated Peak HBM Pressure: 15.813 GB on rank 0                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Top Tier #1 Estimated Peak HBM Pressure: 19.723 GB on rank 0                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Reserved Memory:                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    HBM: 12.0 GB                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 15%                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Planning Memory:                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    HBM: 68.0 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 85%                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Dense Storage (per rank):                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#    HBM: 0.021 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# KJT Storage (per rank):                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#    HBM: 3.613 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#    ec_table_1: 10.134 GB on rank [0]                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#    ebc_table_1: 0.258 GB on rank [0]                                                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:#    table_1: 0.163 GB on rank [0]                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    table_3: 0.163 GB on rank [0]                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    table_5: 0.163 GB on rank [0]                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#############################################################################################################################################################################################################################################################################################################
```

*  Benchmark: sparse_data_dist_seq

  Runtime:
    GPU (P90):              7831.16 ms
    CPU (P90):              5855.36 ms

  GPU Memory:
    Peak Allocated (P90):   47.37 GB
    Peak Reserved (P90):    69.30 GB
    Used (P90):             70.32 GB
    Malloc Retries:         P50=0  P90=0  P100=0

  CPU Memory:
    Peak RSS (P90):         58.48 GB

* benchmark
|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base              |13406.91 ms      |12479.27 ms      |49.04 GB                |70.68 GB                   |71.73 GB          |0.0 / 0.0 / 0.0              |30.32 GB          |
|sdd_ebc_ems                        |56713.10 ms      |52738.21 ms      |37.73 GB                |57.50 GB                   |58.58 GB          |0.0 / 0.0 / 0.0              |45.58 GB          |
|sparse_data_dist_seq               |7831.16 ms       |5855.36 ms       |47.37 GB                |69.30 GB                   |70.32 GB          |0.0 / 0.0 / 0.0              |58.48 GB          |
|sdd_seq_ems                        |40999.66 ms      |37811.72 ms      |43.75 GB                |76.72 GB                   |77.76 GB          |0.0 / 0.0 / 0.0              |62.28 GB          |

Differential Revision: D93310544


