### PR TITLE
Simplified hardware specific estimators with config based approach

### DIFF
--- a/torchrec/distributed/benchmark/embedding_collection_wrappers.py
+++ b/torchrec/distributed/benchmark/embedding_collection_wrappers.py
@@ -44,11 +44,10 @@ from torchrec.distributed.benchmark.base import (
 from torchrec.distributed.embedding_types import ShardingType
 from torchrec.distributed.global_settings import set_propogate_device
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.multi_process import MultiProcessContext
 from torchrec.distributed.test_utils.test_model import ModelInput
@@ -306,7 +305,9 @@ def _transform_module(
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -45,7 +45,8 @@ DP_ELEMENTWISE_KERNELS_PERF_FACTOR: float = 9.22  # empirical studies
 # For rounding memory hashing to nearest 100GB (10^11 bytes):
 HUNDRED_GB = 100 * 1024**3  # 107,374,182,400
 
-DEFAULT_PERF_ESTIMATOR: str = "oss_estimator"
+# Default perf estimator name - use this constant when creating estimators
+DEFAULT_PERF_ESTIMATOR: str = "default_estimator"
 
 
 def kernel_bw_lookup(

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -18,7 +18,14 @@ from torchrec.distributed.planner.constants import (
     DEFAULT_PERF_ESTIMATOR,
     POOLING_FACTOR,
 )
-from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+
+# Explicit import to ensure default estimator config is registered before factory use.
+# This is required for spawned subprocesses where module-level registration
+# decorators may not execute before EmbeddingPerfEstimatorFactory.create() is called.
+from torchrec.distributed.planner.estimator import (  # noqa: F401
+    config as _config_module,
+    EmbeddingPerfEstimatorFactory,
+)
 from torchrec.distributed.planner.shard_estimators import (
     EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,

--- a/torchrec/distributed/planner/estimator/config.py
+++ b/torchrec/distributed/planner/estimator/config.py
@@ -41,6 +41,7 @@ from torchrec.distributed.planner.estimator.types import (  # noqa: F401
 # =============================================================================
 
 # Shared coefficients for sharding types with block usage penalty (TABLE_WISE, COLUMN_WISE)
+# bwd=None means use fwd_compute * bwd_compute_multiplier (OSS legacy behavior)
 _TABLE_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
     fwd=PerfCoefficient(
         input_read_size_multiplier=1.0,
@@ -48,15 +49,11 @@ _TABLE_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
         embedding_output_multiplier=1.0,
         hash_size_multiplier=0.0,  #  doesn't use hash_size
     ),
-    bwd=PerfCoefficient(
-        input_read_size_multiplier=1.0,
-        lookup_size_multiplier=1.0,
-        embedding_output_multiplier=1.0,
-        hash_size_multiplier=0.0,
-    ),
+    bwd=None,  # Use fwd_compute * bwd_compute_multiplier for backward compatibility
 )
 
 # Shared coefficients for sharding types without block usage penalty (ROW_WISE, TABLE_ROW_WISE)
+# bwd=None means use fwd_compute * bwd_compute_multiplier (OSS legacy behavior)
 _ROW_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
     fwd=PerfCoefficient(
         input_read_size_multiplier=1.0,
@@ -64,12 +61,7 @@ _ROW_WISE_COEFFICIENTS = EstimatorPerfCoefficients(
         embedding_output_multiplier=1.0,
         hash_size_multiplier=0.0,
     ),
-    bwd=PerfCoefficient(
-        input_read_size_multiplier=1.0,
-        lookup_size_multiplier=1.0,
-        embedding_output_multiplier=0.0,
-        hash_size_multiplier=0.0,
-    ),
+    bwd=None,  # Use fwd_compute * bwd_compute_multiplier for backward compatibility
 )
 
 

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -38,6 +38,7 @@ from torchrec.distributed.planner.types import (
     CollectiveType,
     ParameterConstraints,
     Perf,
+    ShardEstimator,
     ShardingOption,
     Topology,
 )
@@ -1731,7 +1732,7 @@ def get_embedding_perf_sharding_evaluator(
 # =============================================================================
 
 
-class EmbeddingPerfEstimatorV2:  # TODO rename this later
+class EmbeddingPerfEstimatorV2(ShardEstimator):  # TODO rename this later
     """
     Embedding Performance Estimator using HardwarePerfConfig.
     This estimator uses :

--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -72,10 +72,11 @@ class EstimatorPerfCoefficientsTest(unittest.TestCase):
     """Tests for EstimatorPerfCoefficients frozen dataclass."""
 
     def test_default_values(self) -> None:
-        """Test default fwd and bwd coefficients."""
+        """Test default fwd coefficient and bwd is None (for FB estimator compatibility)."""
         coeffs = EstimatorPerfCoefficients()
         self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
-        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+        # bwd is None by default to support FB estimators using fwd_compute * bwd_compute_multiplier
+        self.assertIsNone(coeffs.bwd)
 
     def test_custom_fwd_bwd(self) -> None:
         """Test creating with custom forward and backward coefficients."""
@@ -117,7 +118,8 @@ class PerfCoefficientConfigTest(unittest.TestCase):
         config = PerfCoefficientConfig()
         coeffs = config.get_coefficients(ShardingType.TABLE_WISE.value)
         self.assertEqual(coeffs.fwd.input_read_size_multiplier, 1.0)
-        self.assertEqual(coeffs.bwd.input_read_size_multiplier, 1.0)
+        # bwd is None by default - estimator will use fwd_compute * bwd_compute_multiplier approach
+        self.assertIsNone(coeffs.bwd)
 
     def test_get_coefficients_returns_sharding_specific(self) -> None:
         """Test that get_coefficients returns sharding-specific coefficients."""

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -14,8 +14,9 @@ from unittest.mock import MagicMock
 import torch
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
-from torchrec.distributed.planner.constants import BATCH_SIZE
+from torchrec.distributed.planner.constants import BATCH_SIZE, DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
 from torchrec.distributed.planner.proposers import (
     DynamicProgrammingProposer,
     EmbeddingOffloadScaleupProposer,
@@ -26,7 +27,6 @@ from torchrec.distributed.planner.proposers import (
 )
 from torchrec.distributed.planner.shard_estimators import (
     _calculate_storage_specific_sizes,
-    EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.planner.types import (
@@ -685,8 +685,10 @@ class TestProposers(unittest.TestCase):
             batch_size=BATCH_SIZE,
             constraints=constraints,
             estimator=[
-                EmbeddingPerfEstimator(
-                    topology=storage_constraint, constraints=constraints
+                EmbeddingPerfEstimatorFactory.create(
+                    DEFAULT_PERF_ESTIMATOR,
+                    topology=storage_constraint,
+                    constraints=constraints,
                 ),
                 EmbeddingStorageEstimator(
                     topology=storage_constraint,
@@ -863,8 +865,10 @@ class TestProposers(unittest.TestCase):
             batch_size=BATCH_SIZE,
             constraints=constraints,
             estimator=[
-                EmbeddingPerfEstimator(
-                    topology=storage_constraint, constraints=constraints
+                EmbeddingPerfEstimatorFactory.create(
+                    DEFAULT_PERF_ESTIMATOR,
+                    topology=storage_constraint,
+                    constraints=constraints,
                 ),
                 EmbeddingStorageEstimator(
                     topology=storage_constraint,

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -25,13 +25,14 @@ from torchrec.distributed.fbgemm_qcomm_codec import (
 from torchrec.distributed.planner.constants import (
     BATCH_SIZE,
     CROSS_NODE_BANDWIDTH,
+    DEFAULT_PERF_ESTIMATOR,
     INTRA_NODE_BANDWIDTH,
 )
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
 from torchrec.distributed.planner.shard_estimators import (
     _calculate_storage_specific_sizes,
     EmbeddingOffloadStats,
-    EmbeddingPerfEstimator,
     EmbeddingStorageEstimator,
 )
 from torchrec.distributed.planner.types import (
@@ -63,7 +64,9 @@ from torchrec.modules.embedding_configs import (
 class TestEmbeddingPerfEstimator(unittest.TestCase):
     def setUp(self) -> None:
         self.topology = Topology(world_size=2, compute_device="cuda")
-        self.estimator = EmbeddingPerfEstimator(topology=self.topology)
+        self.estimator = EmbeddingPerfEstimatorFactory.create(
+            DEFAULT_PERF_ESTIMATOR, topology=self.topology
+        )
         self.enumerator = EmbeddingEnumerator(
             topology=self.topology, batch_size=BATCH_SIZE, estimator=self.estimator
         )
@@ -800,8 +803,8 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
         model = TestSparseNN(tables=tables, weighted_tables=[])
         quant_model = quantize(model, inplace=True)
 
-        inference_estimator = EmbeddingPerfEstimator(
-            topology=self.topology, is_inference=True
+        inference_estimator = EmbeddingPerfEstimatorFactory.create(
+            DEFAULT_PERF_ESTIMATOR, topology=self.topology, is_inference=True
         )
         inference_enumerator = EmbeddingEnumerator(
             topology=self.topology, batch_size=BATCH_SIZE, estimator=inference_estimator
@@ -964,7 +967,9 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
                 compute_device="cuda",
                 weighted_feature_bwd_compute_multiplier=weighted_feature_bwd_compute_multiplier,
             )
-            estimator = EmbeddingPerfEstimator(topology=topology)
+            estimator = EmbeddingPerfEstimatorFactory.create(
+                DEFAULT_PERF_ESTIMATOR, topology=topology
+            )
             enumerator = EmbeddingEnumerator(
                 topology=topology, batch_size=BATCH_SIZE, estimator=estimator
             )
@@ -1091,7 +1096,9 @@ class TestEmbeddingPerfEstimatorWithGeneralizedComms(unittest.TestCase):
             inter_host_bw=40.0 * 1024**3 / 1000,
             intra_host_bw=300.0 * 1024**3 / 1000,
         )
-        self.estimator = EmbeddingPerfEstimator(topology=self.topology)
+        self.estimator = EmbeddingPerfEstimatorFactory.create(
+            DEFAULT_PERF_ESTIMATOR, topology=self.topology
+        )
         self.enumerator = EmbeddingEnumerator(
             topology=self.topology, batch_size=BATCH_SIZE, estimator=self.estimator
         )
@@ -1105,7 +1112,9 @@ class TestEmbeddingPerfEstimatorWithGeneralizedComms(unittest.TestCase):
                 intra_host_bw=300.0 * 1024**3 / 1000,
             ),
         )
-        self.estimator2 = EmbeddingPerfEstimator(topology=self.topology2)
+        self.estimator2 = EmbeddingPerfEstimatorFactory.create(
+            DEFAULT_PERF_ESTIMATOR, topology=self.topology2
+        )
         self.enumerator2 = EmbeddingEnumerator(
             topology=self.topology2, batch_size=BATCH_SIZE, estimator=self.estimator2
         )

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -43,11 +43,10 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_REGISTER_TBE_BOOL,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.planner.types import ParameterConstraints
 from torchrec.distributed.quant_embedding import (
     QuantEmbeddingCollectionSharder,
@@ -663,7 +662,9 @@ def create_test_model(
             topology=topology,
             batch_size=batch_size,
             estimator=[
-                EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                EmbeddingPerfEstimatorFactory.create(
+                    DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                ),
                 EmbeddingStorageEstimator(topology=topology),
             ],
             constraints=constraints,
@@ -752,7 +753,9 @@ def create_test_model_ebc_only_no_quantize(
             topology=topology,
             batch_size=batch_size,
             estimator=[
-                EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                EmbeddingPerfEstimatorFactory.create(
+                    DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                ),
                 EmbeddingStorageEstimator(topology=topology),
             ],
         ),

--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -27,11 +27,10 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.infer_utils import (
     assert_close,
@@ -241,7 +240,9 @@ class ModelTraceScriptTest(unittest.TestCase):
                 topology=topology,
                 batch_size=1,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -289,7 +290,9 @@ class ModelTraceScriptTest(unittest.TestCase):
                     topology=topology,
                     batch_size=1,
                     estimator=[
-                        EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                        EmbeddingPerfEstimatorFactory.create(
+                            DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                        ),
                         EmbeddingStorageEstimator(topology=topology),
                     ],
                 ),

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -29,11 +29,10 @@ from torchrec.distributed.infer_utils import (
     get_tbes_from_sharded_module,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.quant_embedding import QuantEmbeddingCollectionSharder
 from torchrec.distributed.quant_embeddingbag import (
     QuantEmbeddingBagCollectionSharder,
@@ -1045,7 +1044,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -1158,7 +1159,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -1279,7 +1282,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -1388,7 +1393,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -1590,7 +1597,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -1701,7 +1710,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -2146,7 +2157,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -2222,7 +2235,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -2322,7 +2337,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -2401,7 +2418,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -2540,7 +2559,9 @@ class InferShardingsTest(unittest.TestCase):
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),

--- a/torchrec/distributed/tests/test_pt2_multiprocess.py
+++ b/torchrec/distributed/tests/test_pt2_multiprocess.py
@@ -33,11 +33,10 @@ from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import QCommsConfig
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.planner.types import ShardingPlan
 from torchrec.distributed.sharding_plan import EmbeddingBagCollectionSharder
 from torchrec.distributed.test_utils.infer_utils import TestModelInfo
@@ -273,7 +272,9 @@ def _test_compile_rank_fn(
                 topology=topology,
                 batch_size=batch_size,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -566,7 +567,9 @@ def _test_compile_fake_pg_fn(
             topology=topology,
             batch_size=batch_size,
             estimator=[
-                EmbeddingPerfEstimator(topology=topology),
+                EmbeddingPerfEstimatorFactory.create(
+                    DEFAULT_PERF_ESTIMATOR, topology=topology
+                ),
                 EmbeddingStorageEstimator(topology=topology),
             ],
         ),

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -17,11 +17,10 @@ from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel, ModuleSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.planner.constants import DEFAULT_PERF_ESTIMATOR
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
-from torchrec.distributed.planner.shard_estimators import (
-    EmbeddingPerfEstimator,
-    EmbeddingStorageEstimator,
-)
+from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
+from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.test_utils.infer_utils import quantize, TestQuantEBCSharder
 from torchrec.distributed.test_utils.test_model import (
@@ -509,7 +508,9 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 topology=topology,
                 batch_size=1,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -598,7 +599,9 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 topology=topology,
                 batch_size=1,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -682,7 +685,9 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                 topology=topology,
                 batch_size=1,
                 estimator=[
-                    EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                    EmbeddingPerfEstimatorFactory.create(
+                        DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                    ),
                     EmbeddingStorageEstimator(topology=topology),
                 ],
             ),
@@ -773,7 +778,9 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
                     topology=topology,
                     batch_size=1,
                     estimator=[
-                        EmbeddingPerfEstimator(topology=topology, is_inference=True),
+                        EmbeddingPerfEstimatorFactory.create(
+                            DEFAULT_PERF_ESTIMATOR, topology=topology, is_inference=True
+                        ),
                         EmbeddingStorageEstimator(topology=topology),
                     ],
                 ),


### PR DESCRIPTION
Summary:
## Summary
Migrates FB hardware performance estimators (GrandTeton, ZIONEX_80G, T20B200, Athena) to new declarative config-based approach.

Key changes:
- Created hardware_perf_configs.py with 4 hardware config classes replacing legacy code.
- Introduce annotations based registration customization.

Benefits:
- Reduced FB hardware estimator code from ~2,034 lines to ~234 lines (~88% reduction)
- Each hardware config is now ~60 lines vs ~450-500 lines per legacy estimator class
- Declarative bandwidth configuration via device_bw(bandwidth=..., device=..., compute_kernel=...)
- Typed PerfCoefficientConfig for performance coefficients grouped by sharding type
- Custom compute methods via forward_compute/backward_compute decorators (used by Athena)
- Plugin architecture: add new hardware by registering ~60-line config class
- Tests validate backward compatibility with legacy expected bandwidth values


# =============================================================================
# Example 1: Basic Hardware Config with Linear Regression Coefficients
# =============================================================================
```
EmbeddingPerfEstimatorFactory.register("basic_gpu")
device_bw(bandwidth=2000 * 1024 * 1024 * 1024 / 1000, device="cuda", compute_kernel="fused")
device_bw(bandwidth=1000 * 1024 * 1024 * 1024 / 1000, device="cuda", compute_kernel="dense")
class BasicGPUHardwarePerfConfig(HardwarePerfConfig):
    """
    Basic GPU hardware configuration with linear regression coefficients.

    Performance formula:
        perf = (input_read_size_multiplier * input_read_size +
                lookup_size_multiplier * embedding_lookup_size +
                embedding_output_multiplier * output_write_size +
                hash_size_multiplier * hash_size) / device_bandwidth
    """

    name = "basic_gpu"

    coefficients = PerfCoefficientConfig(
        table_wise=EstimatorPerfCoefficients(
            fwd=PerfCoefficient(
                input_read_size_multiplier=100.0,
                lookup_size_multiplier=1.0,
                embedding_output_multiplier=1.0,
                hash_size_multiplier=4.5,
            ),
            bwd=PerfCoefficient(
                input_read_size_multiplier=600.0,
                lookup_size_multiplier=3.0,
                embedding_output_multiplier=3.0,
                hash_size_multiplier=9.0,
            ),
        ),
        row_wise=EstimatorPerfCoefficients(
            fwd=PerfCoefficient(
                input_read_size_multiplier=50.0,
                lookup_size_multiplier=0.5,
                embedding_output_multiplier=0.5,
                hash_size_multiplier=2.0,
            ),
            bwd=PerfCoefficient(
                input_read_size_multiplier=200.0,
                lookup_size_multiplier=1.5,
                embedding_output_multiplier=1.5,
                hash_size_multiplier=4.0,
            ),
        ),
    )

```
# =============================================================================
# Example 2: Advanced Config with Kernel-Specific Coefficient Overrides
# =============================================================================
```
EmbeddingPerfEstimatorFactory.register("advanced_gpu")
device_bw(bandwidth=3000 * 1024 * 1024 * 1024 / 1000, device="cuda", compute_kernel="fused")
device_bw(bandwidth=800 * 1024 * 1024 * 1024 / 1000, device="cuda", compute_kernel="fused_uvm_caching")
hbm_mem_bw(3000 * 1024 * 1024 * 1024)
intra_host_bw(600 * 1024 * 1024 * 1024)
inter_host_bw(25 * 1024 * 1024 * 1024)
class AdvancedGPUHardwarePerfConfig(HardwarePerfConfig):
    """
    Advanced config with by_kernel overrides for specific (sharding_type, compute_kernel) pairs.

    Priority: by_kernel > sharding-type specific > default
    """

    name = "advanced_gpu"

    coefficients = PerfCoefficientConfig(
        table_wise=EstimatorPerfCoefficients(
            fwd=PerfCoefficient(input_read_size_multiplier=80.0, lookup_size_multiplier=0.8, embedding_output_multiplier=0.8, hash_size_multiplier=40.0),
            bwd=PerfCoefficient(input_read_size_multiplier=400.0, lookup_size_multiplier=2.0, embedding_output_multiplier=2.0, hash_size_multiplier=100.0),
        ),
        # Kernel-specific overrides
        by_kernel={
            (ShardingType.TABLE_WISE.value, "fused_uvm_caching"): EstimatorPerfCoefficients(
                fwd=PerfCoefficient(input_read_size_multiplier=120.0, lookup_size_multiplier=1.2, embedding_output_multiplier=1.2, hash_size_multiplier=60.0),
                bwd=PerfCoefficient(input_read_size_multiplier=600.0, lookup_size_multiplier=3.0, embedding_output_multiplier=3.0, hash_size_multiplier=150.0),
            ),
        },
        prefetch=PrefetchCoefficients(
            expected_num_lookups_coefficient=0.001,
            expected_num_unique_lookups_coefficient=0.002,
            expected_size_cache_fetches_coefficient=0.0001,
        ),
    )

```
# =============================================================================
# Example 3: Custom Compute Methods for Non-Linear Models
# =============================================================================
```
EmbeddingPerfEstimatorFactory.register("custom_accelerator")
device_bw(bandwidth=5000 * 1024 * 1024 * 1024 / 1000, device="cuda", compute_kernel="fused")
class CustomAcceleratorHardwarePerfConfig(HardwarePerfConfig):
    """
    Custom accelerator with non-linear performance models using forward_compute/backward_compute.
    """

    name = "custom_accelerator"

    # Hardware-specific kernel coefficients
    bci_coeff: float = 1.0 / 1e9
    irle_coeff: float = 1.0 / 46e9
    rs_coeff: float = 1.0 / 20e9
    rle_coeff: float = 1.0 / 71e9
    cache_reuse_factor: float = 0.166

    # Fallback coefficients for non-TABLE_WISE sharding
    coefficients = PerfCoefficientConfig(
        row_wise=EstimatorPerfCoefficients(
            fwd=PerfCoefficient(input_read_size_multiplier=30.0, lookup_size_multiplier=0.3, embedding_output_multiplier=0.3, hash_size_multiplier=15.0),
            bwd=PerfCoefficient(input_read_size_multiplier=150.0, lookup_size_multiplier=1.5, embedding_output_multiplier=1.5, hash_size_multiplier=75.0),
        ),
    )

    forward_compute(sharding_type=ShardingType.TABLE_WISE.value)
    def compute_fwd(self, ctx: ShardPerfContext) -> float:
        """Custom kernel breakdown: BCI + GVM + TBE forward"""
        batch_inputs_elems = ctx.batch_inputs * ctx.world_size
        batch_outputs_elems = ctx.batch_outputs * ctx.world_size

        perf_bci = self.bci_coeff * batch_inputs_elems
        embedding_lookup_bytes = batch_inputs_elems * ctx.emb_dim * ctx.table_data_type_size
        output_write_bytes = batch_outputs_elems * ctx.emb_dim * ctx.output_data_type_size
        perf_fwd = (embedding_lookup_bytes + output_write_bytes) / ctx.device_bw

        return perf_bci + perf_fwd

    backward_compute(sharding_type=ShardingType.TABLE_WISE.value)
    def compute_bwd(self, ctx: ShardPerfContext) -> float:
        """Custom kernel breakdown: IRLE + RS + RLE + TBE backward"""
        batch_inputs_elems = ctx.batch_inputs * ctx.world_size

        perf_irle = self.irle_coeff * batch_inputs_elems
        perf_rs = self.rs_coeff * batch_inputs_elems
        perf_rle = self.rle_coeff * batch_inputs_elems

        bwd_read_bytes = batch_inputs_elems * ctx.emb_dim * ctx.output_data_type_size
        bwd_opt_bytes = 2 * self.cache_reuse_factor * batch_inputs_elems * ctx.emb_dim * ctx.table_data_type_size
        perf_bwd = (bwd_read_bytes + bwd_opt_bytes) / ctx.device_bw

        return perf_irle + perf_rs + perf_rle + perf_bwd

```

## FB vs OSS Estimator Equation  Differences

### Configuration Differences

| Property | OSS Default | FB Default | Effect |
|----------|-------------|------------|--------|
| `input_data_type_size` | 8.0 (BIGINT) | 4.0 (INT) | Size of indices in bytes |
| `use_bytes_for_input_read_size` | True | False | Bytes vs count for input_read_size |
| `use_min_dim_for_lookup` | True | False | Apply `max(emb_dim, 32)` for kernel alignment |
| `use_block_usage_penalty` | True | False | Apply penalty based on emb_dim |

### Equation Differences

**Input Read Size:**

| | OSS | FB |
|---|-----|-----|
| Formula | `batch_inputs × world_size × input_data_type_size` | `batch_inputs × world_size` |
| Units | Bytes | Count |

**Embedding Lookup Size:**

| | OSS | FB |
|---|-----|-----|
| Formula | `batch_inputs × world_size × max(emb_dim, 32) × dtype_size` | `batch_inputs × world_size × emb_dim × dtype_size` |

**Block Usage Penalty:**

| | OSS | FB |
|---|-----|-----|
| Applied | Yes | No |
| Formula | `128 / (emb_dim × dtype_size)` capped at 1.0 | 1.0 (none) |

### Implementation

Created `FBHardwarePerfConfig` base class that all FB hardware configs (GrandTeton, ZIONEX, T20B200, Athena) inherit from, providing FB legacy defaults automatically.

Differential Revision: D91949346


