### PR TITLE
Add SSD-related argument with default value 0 to Storage

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -24,8 +24,10 @@ BIGINT_DTYPE: int = 8
 
 HBM_CAP: int = 32 * 1024 * 1024 * 1024  # 32 GB
 DDR_CAP: int = 128 * 1024 * 1024 * 1024  # 128 GB
+SSD_CAP: int = 2 * 1024 * 1024 * 1024 * 1024  # 2 TB
 DDR_MEM_BW: float = 51 * 1024 * 1024 * 1024 / 1000  # bytes/ms
 HBM_MEM_BW: float = 897 * 1024 * 1024 * 1024 / 1000  # bytes/ms
+SSD_MEM_BW: float = 100 * 1024 * 1024 / 1000  # bytes/ms
 # This can be smaller than DDR_MEM_BW because the PCI channel maybe shared
 # with other devices such as the FE NIC.
 HBM_TO_DDR_MEM_BW: float = 32 * 1024 * 1024 * 1024 / 1000  # bytes/ms
@@ -57,6 +59,7 @@ def kernel_bw_lookup(
     hbm_to_ddr_mem_bw: float,
     caching_ratio: Optional[float] = None,
     prefetch_pipeline: bool = False,
+    ssd_mem_bw: float = SSD_MEM_BW,
 ) -> Optional[float]:
     """
     Calculates the device bandwidth based on given compute device, compute kernel, and
@@ -71,6 +74,9 @@ def kernel_bw_lookup(
         caching_ratio (Optional[float]): caching ratio used to determine device bandwidth
             if UVM caching is enabled.
         prefetch_pipeline (bool): whether prefetch pipeline is enabled.
+        ssd_mem_bw (float): the bandwidth of SSD storage. Added at the end of the
+            parameter list (with a default value) to maintain backward compatibility
+            with existing callers.
 
     Returns:
         Optional[float]: the device bandwidth.
@@ -102,7 +108,7 @@ def kernel_bw_lookup(
         )
         / 10,
         # TODO: revisit whether this estimation makes sense
-        ("cuda", EmbeddingComputeKernel.KEY_VALUE.value): hbm_to_ddr_mem_bw,
+        ("cuda", EmbeddingComputeKernel.KEY_VALUE.value): ssd_mem_bw,
         ("cuda", EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
         ("cuda", EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
     }

--- a/torchrec/distributed/planner/estimator/__init__.py
+++ b/torchrec/distributed/planner/estimator/__init__.py
@@ -25,6 +25,7 @@ from torchrec.distributed.planner.estimator.annotations import (
     fwd_coefficient as fwd_coefficient,  # noqa: F401
     output_write_size as output_write_size,  # noqa: F401
     prefetch_coefficient as prefetch_coefficient,  # noqa: F401
+    ssd_mem_bw as ssd_mem_bw,  # noqa: F401
     supported_sharding_types as supported_sharding_types,  # noqa: F401
 )
 from torchrec.distributed.planner.estimator.config import (

--- a/torchrec/distributed/planner/estimator/annotations.py
+++ b/torchrec/distributed/planner/estimator/annotations.py
@@ -282,6 +282,28 @@ def ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     return decorator
 
 
+def ssd_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
+    """
+    Decorator to set SSD memory bandwidth for a hardware config.
+
+    SSD storage is used for SSD offloading (KEY_VALUE compute kernel).
+
+    Args:
+        value: SSD memory bandwidth in bytes/second
+
+    Example:
+        @ssd_mem_bw(100 * 1024 * 1024)  # 100 MB/s
+        class MyHardwarePerfConfig(DefaultHardwarePerfConfig):
+            pass
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        cls.ssd_mem_bw = value  # pyre-ignore[16]
+        return cls
+
+    return decorator
+
+
 def hbm_to_ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
     Decorator to set HBM to DDR memory bandwidth for a hardware config.

--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -317,6 +317,7 @@ class HardwarePerfConfigTest(unittest.TestCase):
             compute_kernel="fused",
             hbm_mem_bw=900.0,
             ddr_mem_bw=100.0,
+            ssd_mem_bw=50.0,
             hbm_to_ddr_mem_bw=200.0,
         )
         self.assertEqual(bw, 1000.0)
@@ -334,6 +335,7 @@ class HardwarePerfConfigTest(unittest.TestCase):
             compute_kernel="dense",
             hbm_mem_bw=900.0,
             ddr_mem_bw=100.0,
+            ssd_mem_bw=50.0,
             hbm_to_ddr_mem_bw=200.0,
         )
         self.assertEqual(bw, 500.0)
@@ -346,6 +348,7 @@ class HardwarePerfConfigTest(unittest.TestCase):
             compute_kernel=EmbeddingComputeKernel.FUSED.value,
             hbm_mem_bw=900.0,
             ddr_mem_bw=100.0,
+            ssd_mem_bw=50.0,
             hbm_to_ddr_mem_bw=200.0,
         )
         self.assertEqual(bw, 900.0)
@@ -359,6 +362,7 @@ class HardwarePerfConfigTest(unittest.TestCase):
                 compute_kernel="invalid_kernel",
                 hbm_mem_bw=900.0,
                 ddr_mem_bw=100.0,
+                ssd_mem_bw=50.0,
                 hbm_to_ddr_mem_bw=200.0,
             )
         self.assertIn("invalid_kernel", str(ctx.exception))

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -30,6 +30,7 @@ from torchrec.distributed.planner.constants import (
     DDR_MEM_BW,
     HBM_MEM_BW,
     kernel_bw_lookup,
+    SSD_MEM_BW,
     WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
     WEIGHTED_KERNEL_MULTIPLIER,
 )
@@ -257,6 +258,7 @@ class HardwarePerfConfig:
     # Hardware bandwidth defaults (can be overridden by decorators)
     hbm_mem_bw: float = HBM_MEM_BW
     ddr_mem_bw: float = DDR_MEM_BW
+    ssd_mem_bw: float = SSD_MEM_BW
 
     # Optional bandwidth overrides (None = use ctx/topology values)
     device_bw: Optional[float] = None
@@ -421,6 +423,7 @@ class HardwarePerfConfig:
         compute_kernel: str,
         hbm_mem_bw: float,
         ddr_mem_bw: float,
+        ssd_mem_bw: float,
         hbm_to_ddr_mem_bw: float,
         caching_ratio: Optional[float] = None,
         prefetch_pipeline: bool = False,
@@ -438,6 +441,7 @@ class HardwarePerfConfig:
             compute_kernel: The embedding compute kernel (e.g., "fused", "dense")
             hbm_mem_bw: HBM memory bandwidth
             ddr_mem_bw: DDR memory bandwidth
+            ssd_mem_bw: SSD memory bandwidth
             hbm_to_ddr_mem_bw: HBM to DDR bandwidth
             caching_ratio: Optional caching ratio for UVM caching
             prefetch_pipeline: Whether prefetch pipeline is enabled
@@ -472,6 +476,7 @@ class HardwarePerfConfig:
             hbm_to_ddr_mem_bw=hbm_to_ddr_mem_bw,
             caching_ratio=caching_ratio,
             prefetch_pipeline=prefetch_pipeline,
+            ssd_mem_bw=ssd_mem_bw,
         )
         if bw is None:
             raise ValueError(
@@ -711,6 +716,7 @@ class ShardPerfContext:
             sharding_option.compute_kernel,
             topology.hbm_mem_bw,
             topology.ddr_mem_bw,
+            topology.ssd_mem_bw,
             topology.hbm_to_ddr_mem_bw,
             caching_ratio,
             prefetch_pipeline,

--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -261,7 +261,11 @@ class GreedyPerfPartitioner(Partitioner):
         devices = [
             DeviceHardware(
                 rank=d.rank,
-                storage=Storage(hbm=hbm_per_device or d.storage.hbm, ddr=d.storage.ddr),
+                storage=Storage(
+                    hbm=hbm_per_device or d.storage.hbm,
+                    ddr=d.storage.ddr,
+                    ssd=d.storage.ssd,
+                ),
                 perf=copy.deepcopy(d.perf),
             )
             for d in storage_constraint.devices
@@ -599,7 +603,7 @@ class GreedyPerfPartitioner(Partitioner):
         sorted_host_level_devices = _sort_devices_by_perf(_host_level_devices)
         for devices in sorted_host_level_devices:
             host_devices = copy.deepcopy(devices)
-            host_storage = Storage(hbm=0, ddr=0)
+            host_storage = Storage(hbm=0, ddr=0, ssd=0)
             for device in host_devices:
                 host_storage += device.storage
             if not sharding_option_group.storage_sum.fits_in(host_storage):

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -542,7 +542,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         self._num_plans = 0
         start_time = perf_counter()
         best_plan = None
-        lowest_storage = Storage(MAX_SIZE, MAX_SIZE)
+        lowest_storage = Storage(MAX_SIZE, MAX_SIZE, MAX_SIZE)
         last_planner_error: Optional[PlannerError] = None
         last_proposal: List[ShardingOption] = []
         best_perf_rating = MAX_SIZE
@@ -959,7 +959,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             self._num_plans = 0
             start_time = perf_counter()
             best_plan = None
-            lowest_storage = Storage(MAX_SIZE, MAX_SIZE)
+            lowest_storage = Storage(MAX_SIZE, MAX_SIZE, MAX_SIZE)
             last_planner_error: Optional[PlannerError] = None
             last_proposal: List[ShardingOption] = []
             best_perf_rating = MAX_SIZE

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -79,6 +79,7 @@ def _reserve_dense_storage(
     dense_tensor_storage = Storage(
         hbm=dense_tensor_size if topology.compute_device in {"cuda", "mtia"} else 0,
         ddr=dense_tensor_size if topology.compute_device == "cpu" else 0,
+        ssd=0,
     )
 
     for device in topology.devices:
@@ -97,6 +98,7 @@ def _get_kjt_storage(
     return Storage(
         hbm=kjt_size if topology.compute_device in {"cuda", "mtia"} else 0,
         ddr=kjt_size if topology.compute_device == "cpu" else 0,
+        ssd=0,
     )
 
 

--- a/torchrec/distributed/planner/tests/test_constants.py
+++ b/torchrec/distributed/planner/tests/test_constants.py
@@ -16,6 +16,7 @@ from torchrec.distributed.planner.constants import (
     HBM_MEM_BW,
     HBM_TO_DDR_MEM_BW,
     kernel_bw_lookup,
+    SSD_MEM_BW,
 )
 
 
@@ -34,6 +35,7 @@ class TestKernelBWLookup(unittest.TestCase):
                 DDR_MEM_BW,
                 HBM_TO_DDR_MEM_BW,
                 caching_ratio,
+                ssd_mem_bw=SSD_MEM_BW,
             )
             for caching_ratio in caching_ratios
         ]
@@ -62,6 +64,7 @@ class TestKernelBWLookup(unittest.TestCase):
                 HBM_TO_DDR_MEM_BW,
                 caching_ratio,
                 prefetch_pipeline,
+                ssd_mem_bw=SSD_MEM_BW,
             )
             for caching_ratio in caching_ratios
         ]


### PR DESCRIPTION
Summary:
This diff is the first step in the SSD offloading diff stack. It adds SSD storage infrastructure to the TorchRec planner system (OSS Planner, LP Planner, and new config-based estimator) without auto-enabling SSD offloading. SSD offloading can still be enabled manually via config, but the planner does not automatically enable it in this diff. This foundational change allows the planner to track SSD capacity and bandwidth, preparing for automatic SSD offloading enablement in a follow-up diff.

## Changes

### Constants (`constants.py`):
- Add `SSD_CAP`: 2 TB default SSD capacity
- Add `SSD_MEM_BW`: 100 MB/s SSD memory bandwidth
- Add `ssd_mem_bw` parameter to `kernel_bw_lookup()` at the end for backward compatibility, and use it for `KEY_VALUE` compute kernel

### Storage Type (`types.py`):
- Extend `Storage` dataclass with `ssd: int = 0` field
- Update `__add__`, `__sub__`, `__hash__`, and `fits_in()` methods to include SSD

### Topology (`types.py`):
- Add `ssd_cap` and `ssd_mem_bw` parameters to `Topology` class
- Add `ssd_mem_bw` property to Topology
- Support custom `ssd_cap` per rank via `custom_topology_data`
- Include `ssd` storage and `ssd_mem_bw` in `Topology._hash()` and `hash_planner_context_inputs()` to prevent stale plan cache hits when SSD configuration changes

### Shard Estimators (`shard_estimators.py`):
- Pass `ssd_mem_bw` through performance estimation pipeline
- Calculate `ssd_specific_sizes` as HBM + DDR (total table size for offloading)
- Compute SSD storage only for `KEY_VALUE` compute kernel; other kernels get 0

### New Config-Based Estimator System (`estimator/`):
- Add `ssd_mem_bw` class-level default to `HardwarePerfConfig` (`estimator/types.py`)
- Plumb `ssd_mem_bw` through `HardwarePerfConfig.get_device_bw()` to `kernel_bw_lookup()` (`estimator/types.py`)
- Pass `topology.ssd_mem_bw` in `ShardPerfContext.build_shard_perf_contexts()` (`estimator/types.py`)
- Add `ssd_mem_bw` decorator for hardware configs to override SSD bandwidth (`estimator/annotations.py`)
- Export `ssd_mem_bw` decorator from `estimator/__init__.py`
- Update tests to pass `ssd_mem_bw` to `get_device_bw()` calls (`estimator/tests/test_estimator_types.py`)

### Partitioners & Planners:
- Update `Storage()` instantiations to include `ssd` parameter
- Update `lowest_storage` initialization to include SSD in `EmbeddingShardingPlanner`, `HeteroEmbeddingShardingPlanner`, and `LinearProgrammingPlanner`

### Sharding Plan Logger (`fb/distributed/planner/sharding_plan_logger.py`):
- Update `Storage()` instantiations to include `ssd` parameter

### Stats & Display (`stats.py`, `fb/distributed/planner/utils.py`):
- Update storage format from `(HBM, DDR)` to `(HBM, DDR, SSD)`
- Add `ssd_gb` field to embedding stats parsing

### Tests:
- Update test assertions to match new storage format with SSD

## Notes
- SSD offloading is NOT auto-enabled in this diff. This diff only adds the infrastructure (Storage, Topology, constants, etc.). SSD offloading can still be manually enabled via config, but automatic enablement is in a separate follow-up diff.
- SSD storage is calculated as HBM + DDR because we offload the entire embedding table to SSD

Differential Revision: D91522803


