### PR TITLE
Remove key_value from GUARDED_COMPUTE_KERNEL

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from torch import nn
+from torch._utils_internal import justknobs_check
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     DEFAULT_PERF_ESTIMATOR,
@@ -58,12 +59,31 @@ from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerColle
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+
 # compute kernels that should only be used if users specified them
-GUARDED_COMPUTE_KERNELS: Set[EmbeddingComputeKernel] = {
-    EmbeddingComputeKernel.KEY_VALUE,
-    EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
-    EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
-}
+def get_guarded_compute_kernels() -> Set[EmbeddingComputeKernel]:
+    """
+    Returns the set of guarded compute kernels.
+
+    When pytorch/torchrec:enable_ssd_offloading is enabled, KEY_VALUE is removed
+    from the guarded set, allowing SSD offloading to be considered by default.
+
+    NOTE: This is a temporary function for the SSD offloading rollout. It exists
+    because justknobs_check cannot be called at module import time (not fork-safe).
+    This function will be removed once the rollout is complete and the JustKnob
+    is cleaned up.
+    """
+    if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+        return {
+            EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
+            EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
+        }
+    return {
+        EmbeddingComputeKernel.KEY_VALUE,
+        EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
+        EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
+    }
+
 
 # sharding types that require explicit user specification for feature-processed modules
 # row wise sharding uses a different pipelined configuration for feature processing
@@ -409,7 +429,7 @@ class EmbeddingEnumerator(Enumerator):
             constrained_compute_kernels: List[str] = [
                 compute_kernel.value
                 for compute_kernel in EmbeddingComputeKernel
-                if compute_kernel not in GUARDED_COMPUTE_KERNELS
+                if compute_kernel not in get_guarded_compute_kernels()
             ]
 
         # setup filtered_compute_kernels

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -12,6 +12,7 @@ from typing import cast, List, Optional, Type
 from unittest.mock import MagicMock
 
 import torch
+from torch._utils_internal import justknobs_check
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE, DEFAULT_PERF_ESTIMATOR
@@ -420,7 +421,11 @@ class TestProposers(unittest.TestCase):
         So the total number of pruned options will be:
             (num_sharding_types - 1) * 3 + 1 = 19
         """
-        num_pruned_options = (len(ShardingType) - 1) * 3 + 1
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            num_pruned_options = (len(ShardingType) - 1) * 4 + 1
+            self.grid_search_proposer = GridSearchProposer(max_proposals=int(1e5))
+        else:
+            num_pruned_options = (len(ShardingType) - 1) * 3 + 1
         self.grid_search_proposer.load(search_space)
         for (
             sharding_options

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import torch
 import torchrec.optim as trec_optim
+from torch._utils_internal import justknobs_check
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
@@ -364,6 +365,96 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         }
 
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            expected_perfs.update(
+                {
+                    ("key_value", "column_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=6.015625,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "grid_shard"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "row_wise"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_column_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=6.015625,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "table_row_wise"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=6.015625,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                }
+            )
+
         perfs = {
             (
                 sharding_option.compute_kernel,
@@ -650,6 +741,96 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         }
 
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            expected_perfs.update(
+                {
+                    ("key_value", "column_wise"): [
+                        Perf(
+                            fwd_compute=3.14453125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=9.748046875,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "grid_shard"): [
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "row_wise"): [
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_column_wise"): [
+                        Perf(
+                            fwd_compute=3.14453125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=9.748046875,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "table_row_wise"): [
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.6640625,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=2.05859375,
+                            bwd_comms=0.9590479532877604,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_wise"): [
+                        Perf(
+                            fwd_compute=3.14453125,
+                            fwd_comms=6.357828776041667e-05,
+                            bwd_compute=9.748046875,
+                            bwd_comms=6.357828776041667e-05,
+                            input_dist_comms=1.2715657552083334e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                }
+            )
+
         perfs = {
             (
                 sharding_option.compute_kernel,
@@ -732,6 +913,24 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
             ],
         }
 
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            expected_total_perfs.update(
+                {
+                    ("key_value", "column_wise"): [7.485383351643881],
+                    ("key_value", "grid_shard"): [
+                        1.7686182657877603,
+                        1.7686182657877603,
+                    ],
+                    ("key_value", "row_wise"): [1.7686182657877603, 1.7686182657877603],
+                    ("key_value", "table_column_wise"): [7.485383351643881],
+                    ("key_value", "table_row_wise"): [
+                        1.7686182657877603,
+                        1.7686182657877603,
+                    ],
+                    ("key_value", "table_wise"): [7.485383351643881],
+                }
+            )
+
         total_perfs = {
             (
                 sharding_option.compute_kernel,
@@ -780,6 +979,15 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
                 0.025934979198424798,
             ],
         }
+
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            expected_total_perfs.update(
+                {
+                    ("key_value", "column_wise"): [13.535563151041668],
+                    ("key_value", "row_wise"): [5.401765950520833, 5.401765950520833],
+                    ("key_value", "table_wise"): [13.535563151041668],
+                }
+            )
 
         total_perfs = {
             (
@@ -1400,6 +1608,96 @@ class TestEmbeddingPerfEstimatorWithGeneralizedComms(unittest.TestCase):
                 ),
             ],
         }
+
+        if justknobs_check("pytorch/torchrec:enable_ssd_offloading"):
+            expected_perfs.update(
+                {
+                    ("key_value", "column_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=6.015625,
+                            bwd_comms=0.00012715657552083334,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "grid_shard"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "row_wise"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_column_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=6.015625,
+                            bwd_comms=0.00012715657552083334,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                    ("key_value", "table_row_wise"): [
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                        Perf(
+                            fwd_compute=0.625,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=1.25,
+                            bwd_comms=0.9591115315755209,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        ),
+                    ],
+                    ("key_value", "table_wise"): [
+                        Perf(
+                            fwd_compute=3.0078125,
+                            fwd_comms=0.00012715657552083334,
+                            bwd_compute=6.015625,
+                            bwd_comms=0.00012715657552083334,
+                            input_dist_comms=2.5431315104166668e-05,
+                            prefetch_compute=0.0,
+                        )
+                    ],
+                }
+            )
 
         perfs = {
             (


### PR DESCRIPTION
Summary:
Enable SSD offloading in the OSS planner behind the `pytorch/torchrec:enable_ssd_offloading` JustKnobs flag. This provides a controlled rollout mechanism for making the `KEY_VALUE` compute kernel available by default in sharding enumeration.

## Changes

### Enumerators (`enumerators.py`):
- Replace `GUARDED_COMPUTE_KERNELS` module-level constant with `get_guarded_compute_kernels()` function (justknobs_check is not fork-safe at module import time)
- When `pytorch/torchrec:enable_ssd_offloading` is enabled, remove `KEY_VALUE` from the guarded set, allowing the planner to automatically consider SSD offloading for embedding tables without requiring explicit user constraints

### Tests:
- `test_proposers.py`: Update `test_grid_search_pruning` to expect 4 compute kernels per sharding type (instead of 3) when the flag is enabled, using an explicit `max_proposals=int(1e5)` in the test to accommodate the expanded search space
- `test_shard_estimators.py`: Add expected performance values for `KEY_VALUE` compute kernel across all sharding types (table_wise, row_wise, column_wise, grid_shard, table_row_wise, table_column_wise) when the flag is enabled

## Notes
- The JustKnobs flag `pytorch/torchrec:enable_ssd_offloading` defaults to on. When off, behavior is identical to before this diff.
- `get_guarded_compute_kernels()` is a temporary function for the rollout. It will be replaced with a constant once the JustKnob is cleaned up.
- This diff does NOT change any performance estimation logic — it only controls whether `KEY_VALUE` is included in the default enumeration.

Differential Revision: D92094216


