### PR TITLE
Refactor test models and add dummy tensors to ModelInput

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -24,6 +24,7 @@ ModelSelectionConfig:
       over_arch_out_size: 1024
       over_arch_hidden_layers: 5
       dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
 EmbeddingTablesConfig:
   num_unweighted_features: 90
   num_weighted_features: 80


### PR DESCRIPTION
Summary:
## 1. Context
This is prep work for benchmarking multi-threaded host-to-device tensor copies. Production recommendation models often have 500+ tensors per batch, and the existing benchmark infrastructure cannot simulate this tensor count to measure CPU-side overhead from issuing individual H2D copy calls. The test model over-arch classes also had duplicated code making it harder to add new variants.

## 2. Approach
1. **Dummy tensors on ModelInput**: A new `dummy: List[torch.Tensor]` field allows injecting an arbitrary number of additional tensors into the batch, handled in both the standard `.to()` and async `data_copy_stream` paths.
2. **Over-arch refactoring**: `TestOverArchRegroupModule` is refactored to inherit from `TestOverArch` via a `sparse_grouped()` method override, eliminating duplicated init/forward logic.
3. **Skip regroup option**: `TestOverArchLarge` gains a `skip_regroup: bool` parameter to bypass `KTRegroupAsDict`, isolating copy performance from regroup overhead in benchmarks.
4. **YAML-driven over-arch selection**: An `OVER_ARCH_CLASSES` registry and `__post_init__` on `TestSparseNNConfig` allow specifying the over-arch class as a string in YAML benchmark configs.

## 3. Results
* benchmark

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base              |12129.08 ms      |11228.53 ms      |49.06 GB                |67.10 GB                   |68.14 GB          |0.0 / 0.0 / 0.0              |30.79 GB          |
|sparse_data_dist_base_inplace_copy |12223.75 ms      |11291.58 ms      |49.06 GB                |64.46 GB                   |65.50 GB          |0.0 / 0.0 / 0.0              |30.37 GB          |

* repro commands
```
# baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True

# inplace copy
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True \
    --inplace_copy_batch_to_gpu=True \
    --name=sparse_data_dist_base_inplace_copy
```

* trace
<img width="4580" height="1540" alt="image" src="https://github.com/user-attachments/assets/5ebd575b-abc5-4756-9977-822501c96458" />
<img width="4584" height="1548" alt="image" src="https://github.com/user-attachments/assets/f65ef45c-1d30-4ab9-b0d2-d6dfb157ac7f" />


## 4. Analysis
1. **BC for test model callers**: `TestOverArchRegroupModule` now inherits from `TestOverArch` with a different `__init__` signature (added `dense_arch_out_size`, `over_arch_out_size`, `**_kwargs`). Existing callers should still work since the new params have defaults.
2. **`dummy` not populated by `generate()`**: `ModelInput.generate()` and `generate_global_and_local_batches()` don't populate `dummy` — it defaults to `[]`. This is intentional (user fills it for benchmarks).
3. **Inplace copy reduces GPU memory with no runtime regression**: The inplace copy path uses ~2.6 GB less reserved GPU memory (64.46 vs 67.10 GB) and ~2.6 GB less total GPU memory (65.50 vs 68.14 GB), with runtime within noise (~0.8% difference). This is expected since inplace copies reuse pre-allocated pinned buffers rather than allocating new GPU tensors per batch.
4. **Peak allocated memory is identical**: Both paths show 49.06 GB peak allocated, confirming the memory savings come from reduced fragmentation in the CUDA caching allocator rather than from smaller model/data footprint.

## 5. Changes
1. **`model_input.py`**: Added `dummy: List[torch.Tensor]` field to `ModelInput`. Updated `.to()` to copy dummy tensors in both standard and async `data_copy_stream` paths.
2. **`test_model.py`**: Refactored `TestOverArchRegroupModule` to subclass `TestOverArch` with `sparse_grouped()` override. Added `**_kwargs` to `TestOverArch.__init__`. Added `skip_regroup: bool` to `TestOverArchLarge` to optionally bypass `KTRegroupAsDict`.
3. **`model_config.py`**: Added `OVER_ARCH_CLASSES` string-to-class mapping. Added `__post_init__` on `TestSparseNNConfig` to resolve string `over_arch_clazz` from YAML configs.
4. **`sparse_data_dist_base.yml`**: Added `skip_regroup: true` to benchmark config's `submodule_kwargs`.

Differential Revision: D93779801


