### PR TITLE
Add event logging handler (#3779)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -5,8 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import contextlib
 import logging
 from collections import defaultdict
+from typing import Dict, Generator, Optional
+
+from torchrec.distributed.logging_utils import EventLoggingHandlerBase, EventType
 
 
 __all__: list[str] = []
@@ -18,5 +22,63 @@ CappedLogger = "CappedLogger"
 Cap1Logger = "Cap1Logger"
 Cap01Logger = "Cap01Logger"
 MethodLogger = "MethodLogger"
+
+
+class EventLoggingHandler(EventLoggingHandlerBase):
+    """No-op event logging handler for open-source builds.
+
+    This class can be used to add event logging implementation to Torchrec Components
+    """
+
+    @classmethod
+    def log_event(
+        cls,
+        component: str,
+        event_name: str,
+        event_type: EventType,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None:
+        pass
+
+    @classmethod
+    @contextlib.contextmanager
+    def log_event_context(
+        cls,
+        component: str,
+        event_name: str,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+    ) -> Generator[None, None, None]:
+        yield
+
+    @classmethod
+    def n_batch_log_event(
+        cls,
+        component: str,
+        event_name: str,
+        event_type: EventType,
+        n: int = 1,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None:
+        pass
+
+    @classmethod
+    @contextlib.contextmanager
+    def n_batch_log_event_context(
+        cls,
+        component: str,
+        event_name: str,
+        n: int = 1,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+    ) -> Generator[None, None, None]:
+        yield
+
 
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import contextlib
+from enum import Enum, unique
+from typing import Dict, Generator, Optional
+
+
+@unique
+class EventType(Enum):
+    """Type of lifecycle event being logged."""
+
+    START = "START"
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    INFO = "INFO"
+
+
+class EventLoggingHandlerBase(abc.ABC):
+    """Abstract base class for event logging handlers.
+
+    Defines the interface that both the internal (Scuba-backed) and
+    open-source (no-op) ``EventLoggingHandler`` implementations must satisfy.
+    Functions that accept an event logging handler should type-hint against
+    this base class.
+    """
+
+    batches_processed: int = 0
+
+    @classmethod
+    def update_batches_processed(cls, batches_processed: int) -> None:
+        """Update the class-level batches processed counter."""
+        cls.batches_processed = batches_processed
+
+    @classmethod
+    @abc.abstractmethod
+    def log_event(
+        cls,
+        component: str,
+        event_name: str,
+        event_type: EventType,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None: ...
+
+    @classmethod
+    @abc.abstractmethod
+    @contextlib.contextmanager
+    def log_event_context(
+        cls,
+        component: str,
+        event_name: str,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+    ) -> Generator[None, None, None]:
+        """Context manager that logs START on entry and SUCCESS/FAILURE on exit.
+
+        On entry, logs a START event. If the wrapped code block completes
+        without raising, logs a SUCCESS event. If an exception is raised,
+        logs a FAILURE event with the error message and stack trace
+        extracted from the exception, then re-raises it.
+
+        Args:
+            component: Component name (e.g. ``"torchrec"``).
+            event_name: Name identifying the event (e.g. ``"train_step"``).
+            metadata: Optional key-value pairs to attach to the event records.
+            add_wait_counter: If ``True``, a ``_WaitCounter`` is managed
+                for the duration of the context.
+        """
+        ...
+
+    @classmethod
+    @abc.abstractmethod
+    def n_batch_log_event(
+        cls,
+        component: str,
+        event_name: str,
+        event_type: EventType,
+        n: int = 1,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None: ...
+
+    @classmethod
+    @abc.abstractmethod
+    @contextlib.contextmanager
+    def n_batch_log_event_context(
+        cls,
+        component: str,
+        event_name: str,
+        n: int = 1,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+    ) -> Generator[None, None, None]: ...


### PR DESCRIPTION
Summary:

Detailed Tech Plan: https://fburl.com/gdoc/byi33d3o

Add EventLoggingHandler to Torchrec.

EventLoggingHandler supports two usage patterns for logging training lifecycle events to Scuba:
1. Context manager (preferred) -- log_event_context / n_batch_log_event_context
Wrap a code block to automatically log START on entry and SUCCESS or FAILURE on exit. FAILURE events include the error message and stack trace, extracted automatically from the exception. This is the preferred pattern because it guarantees│
errors are always captured without the caller needing to add explicit error-handling logic.
```
with EventLoggingHandler.log_event_context("torchrec", "train_step"):
     do_training()  # FAILURE auto-logged if this raises
```
```
with EventLoggingHandler.n_batch_log_event_context("torchrec", "train_step", n=1000):
     do_training()  # START/SUCCESS sampled every n batches, FAILURE always logged
```
2. Explicit log_event calls -- for cases where the start and end of an event do not surround a single code block (e.g.
the START and SUCCESS/FAILURE are in different callbacks or methods). This method is the less preferred method as this requires manual capture of all errors that will happen between START and SUCCESS to make sure FAILURE events are correctly captured.
```
EventLoggingHandler.log_event("torchrec", "init", EventType.START)
# ... across multiple methods/callbacks ...
EventLoggingHandler.log_event("torchrec", "init", EventType.SUCCESS)
```

Reviewed By: TroyGarden, aschhabra

Differential Revision: D93489964
