### PR TITLE
Guard NE metric against out-of-range labels

### DIFF
--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -27,6 +27,8 @@ def compute_cross_entropy(
 ) -> torch.Tensor:
     predictions = predictions.double()
     predictions.clamp_(min=eta, max=1 - eta)
+    labels = labels.double()
+    labels.clamp_(min=0.0, max=1.0)
     cross_entropy = -weights * labels * torch.log2(predictions) - weights * (
         1.0 - labels
     ) * torch.log2(1.0 - predictions)
@@ -79,6 +81,7 @@ def compute_logloss(
 def get_ne_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
 ) -> Dict[str, torch.Tensor]:
+    labels = labels.double().clamp(min=0.0, max=1.0)
     cross_entropy = compute_cross_entropy(
         labels,
         predictions,


### PR DESCRIPTION
Summary:
The NE (Normalized Entropy) metric in torchrec computes binary cross-entropy but has no validation on label values. If upstream label transforms produce values outside [0, 1] (e.g., subtraction yielding -1 when label1=0 and label2=1), the NE computation could silently produce garbage: negative pos_labels, doubled neg_labels, and corrupted cross-entropy.

This diff adds label clamping to [0, 1] in two places, mirroring how predictions are already clamped:
- `compute_cross_entropy()`: clamps labels before the BCE formula (this is a public standalone function)
- `get_ne_states()`: clamps labels before they're used for both cross-entropy AND the pos_labels/neg_labels accumulation

Differential Revision: D93818562


