### PR TITLE
Fix storage estimation for SSD Offloading

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -1297,7 +1297,7 @@ def calculate_shard_storages(
     if (
         compute_kernel
         in {
-            EmbeddingComputeKernel.KEY_VALUE.value,
+            # EmbeddingComputeKernel.KEY_VALUE.value,
             EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
             EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
         }
@@ -1324,6 +1324,30 @@ def calculate_shard_storages(
         ddr_specific_sizes = [
             # TODO: revisit the logic for SSD virtual table
             0
+            for _ in ddr_specific_sizes
+        ]
+    elif compute_kernel == EmbeddingComputeKernel.KEY_VALUE.value:
+        key_value_params = key_value_params or KeyValueParams()
+
+        hbm_specific_sizes = [
+            int(
+                min(
+                    (key_value_params.max_l1_cache_size or float("inf")) * 1024**2,
+                    math.ceil(
+                        tensor.shape[0]  # num_embeddings
+                        * kv_cache_load_factor
+                        * tensor.element_size()  # size of one column
+                        * tensor.shape[1],  # number of columns in embedding
+                    ),
+                )
+            )
+            for _ in hbm_specific_sizes
+        ]
+        ddr_specific_sizes = [
+            (
+                (key_value_params.l2_cache_size or 0) * 1024**3
+                + (key_value_params.ssd_rocksdb_write_buffer_size or 2 * 1024**3)
+            )
             for _ in ddr_specific_sizes
         ]
 


### PR DESCRIPTION
Summary:
Change the default value of max_l1_cache_size from `0` to `inf` when `key_value_param` or `max_l1_cache_size` is missing to fix the issue that the L1 cache size is not counted during the estimation when `max_l1_cache_size` is missing.

Also wrap the `min()` result with `int()` to fix a type error: `min(float, int)` returns `float | int`, which is not assignable to `hbm_specific_sizes: List[int]`. This is safe because when `max_l1_cache_size` is missing, `min(inf, ceil(...))` always selects the `int` side, and when it is set, truncating the float byte size to `int` is appropriate.

In `KeyValueEmbeddingBag`, the arguments for `SSDTableBatchedEmbeddingBags` is generated by `_populate_ssd_tbe_params` function:

https://www.internalfb.com/code/fbsource/[94951d5dc2d9]/fbcode/torchrec/distributed/batched_embedding_kernel.py?lines=1871-1882

Inside `_populate_ssd_tbe_params`, the argument `cache_sets` is added if not exist based on `cache_load_factor` (default: 0.2):

https://www.internalfb.com/code/fbsource/[94951d5dc2d9]/fbcode/torchrec/distributed/batched_embedding_kernel.py?lines=237-251

Then this argument is limited by `max_l1_cache_size` if `max_l1_cache_size` exist. And if `max_l1_cache_size` is missing, the L1 cache will not be touched.

https://www.internalfb.com/code/fbsource/[94951d5dc2d9]/fbcode/torchrec/distributed/batched_embedding_kernel.py?lines=287-300

In the estimator, if `key_value_params` is missing or `max_l1_cache_size` is missing, the `max_l1_cache_size` is initialized to `0`. And the `hbm_specific_sizes` is the minimal of the `max_l1_cache_size` and `table_size * load_factor`. When `max_l1_cache_size` is missing, the actual HBM usage is the `table_size * load_factor` in `SSDTableBatchedEmbeddingBags`, but is estimated as `0` here.

https://www.internalfb.com/code/fbsource/[56b1e0fb955f]/fbcode/torchrec/distributed/planner/shard_estimators.py?lines=1318-1333

Differential Revision: D91623467


