### PR TITLE
Rename inplace_copy_batch_to_gpu to enable_inplace_copy_batch

### DIFF
--- a/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
@@ -15,7 +15,7 @@ RunOptions:
   num_float_features: 1000
 PipelineConfig:
   pipeline: "prefetch"
-  # inplace_copy_batch_to_gpu: True
+  # enable_inplace_copy_batch: True
 ModelInputConfig:
   num_float_features: 1000
   feature_pooling_avg: 60

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -52,7 +52,7 @@ class PipelineConfig:
 
     pipeline: str = "base"
     emb_lookup_stream: str = "data_dist"
-    inplace_copy_batch_to_gpu: bool = False
+    enable_inplace_copy_batch: bool = False
     apply_jit: bool = False
 
     def generate_pipeline(
@@ -121,7 +121,7 @@ class PipelineConfig:
                 device=device,
                 emb_lookup_stream=self.emb_lookup_stream,
                 apply_jit=self.apply_jit,
-                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
+                enable_inplace_copy_batch=self.enable_inplace_copy_batch,
             )
         elif self.pipeline == "base":
             assert self.apply_jit is False, "JIT is not supported for base pipeline"
@@ -130,7 +130,7 @@ class PipelineConfig:
                 model=model,
                 optimizer=opt,
                 device=device,
-                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
+                enable_inplace_copy_batch=self.enable_inplace_copy_batch,
             )
         else:
             Pipeline = _pipeline_cls[self.pipeline]
@@ -140,5 +140,5 @@ class PipelineConfig:
                 device=device,
                 # pyrefly: ignore[unexpected-keyword]
                 apply_jit=self.apply_jit,
-                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
+                enable_inplace_copy_batch=self.enable_inplace_copy_batch,
             )


### PR DESCRIPTION
## Context

* The `inplace_copy_batch_to_gpu` argument name on train pipeline classes is overly specific — it describes the implementation mechanism ("copy batch to GPU") rather than the intent ("enable in-place copy behavior").
* This is inconsistent with the naming convention of other boolean pipeline flags (e.g., `enqueue_batch_after_forward`, `execute_all_batches`) which describe what feature is being toggled rather than the underlying operation.
* Renaming to `enable_inplace_copy_batch` makes the argument self-documenting as a feature toggle and decouples the name from the specific device transfer direction.


## benchmark
* run commands
```
# baseline (default)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True

# inplace copy enabled
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --memory_snapshot=True \
    --name=sparse_data_dist_base_inplace_copy \
    --enable_inplace_copy_batch=True
```

* table of results

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base              |3263.71 ms       |3085.04 ms       |49.06 GB                |67.47 GB                   |69.90 GB          |0.0 / 0.0 / 0.0              |30.95 GB          |
|sparse_data_dist_base_inplace_copy |3254.66 ms       |3068.03 ms       |49.06 GB                |64.29 GB                   |66.72 GB          |0.0 / 0.0 / 0.0              |30.91 GB          |

* traces
<img width="3378" height="1402" alt="image" src="https://github.com/user-attachments/assets/110e0057-93a5-416c-b0e3-9f8583f4a964" />
<img width="3380" height="1356" alt="image" src="https://github.com/user-attachments/assets/c6bce6c1-2799-4204-bbcd-4c5d7c3556ea" />

* snapshot
<img width="3430" height="1270" alt="image" src="https://github.com/user-attachments/assets/09bffa67-cb70-49e7-ba63-ecc4ef45e1b7" />
<img width="3424" height="1222" alt="image" src="https://github.com/user-attachments/assets/dd627515-bd1c-4ae3-9eb7-6e088315db92" />

## takeaways
* **No runtime regression**: GPU P90 runtime is nearly identical (3254.66 ms vs 3263.71 ms), confirming the rename is behavior-preserving.
* **Memory improvement with inplace copy**: GPU Peak Reserved drops by 3.18 GB (64.29 vs 67.47 GB) and GPU Mem Used drops by 3.18 GB (66.72 vs 69.90 GB) when `enable_inplace_copy_batch=True`, since in-place copy avoids allocating new GPU tensors during H2D transfer.
* **Peak Allocated unchanged**: 49.06 GB in both cases — expected, as the model size is the same.
* **Inplace label in trace**: The inplace copy variant shows `## inplace_copy_batch_to_gpu ##` labels in the trace (method name preserved), confirming the inplace copy codepath is correctly exercised.

Differential Revision: D93958723


