### PR TITLE
Fix pyrefly type errors in test_stats.py

### DIFF
--- a/torchrec/distributed/planner/tests/test_stats.py
+++ b/torchrec/distributed/planner/tests/test_stats.py
@@ -14,7 +14,6 @@ from typing import List
 import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings
-from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.planners import EmbeddingShardingPlanner
@@ -32,12 +31,11 @@ from torchrec.distributed.planner.stats import (
 )
 from torchrec.distributed.planner.types import Topology
 from torchrec.distributed.test_utils.test_model import TestSparseNN
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
-# pyrefly: ignore[inconsistent-inheritance]
-class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+class TWvsRWSharder(EmbeddingBagCollectionSharder):
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return [ShardingType.ROW_WISE.value, ShardingType.TABLE_WISE.value]
 


### PR DESCRIPTION
Summary:
Fix pyrefly type checking test [281475269893214](https://www.internalfb.com/intern/test/281475269893214).

The `TWvsRWSharder` class had redundant `ModuleSharder[nn.Module]` in its inheritance alongside `EmbeddingBagCollectionSharder`, which already inherits from `ModuleSharder[EmbeddingBagCollection]`. This caused an `inconsistent-inheritance` error due to invariant generic type parameters.

**Fixes:**
- Remove `ModuleSharder[nn.Module]` from `TWvsRWSharder` class
  definition and its `# pyrefly: ignore` comment
- Remove unused `ModuleSharder` import and `from torch import nn`

Differential Revision: D93956588


