### PR TITLE
Fix pyrefly type errors in test_planners.py

### DIFF
--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -42,7 +42,6 @@ from torchrec.distributed.types import (
     DataType,
     EmbeddingModuleShardingPlan,
     KeyValueParams,
-    ModuleSharder,
     ShardingPlan,
     ShardingType,
 )
@@ -50,8 +49,7 @@ from torchrec.distributed.utils import none_throws
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
-# pyrefly: ignore[inconsistent-inheritance]
-class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+class TWvsRWSharder(EmbeddingBagCollectionSharder):
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return [ShardingType.ROW_WISE.value, ShardingType.TABLE_WISE.value]
 
@@ -61,8 +59,7 @@ class TWvsRWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
         return [EmbeddingComputeKernel.FUSED.value]
 
 
-# pyrefly: ignore[inconsistent-inheritance]
-class TWSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+class TWSharder(EmbeddingBagCollectionSharder):
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return [ShardingType.TABLE_WISE.value]
 
@@ -440,8 +437,7 @@ class TestEmbeddingShardingHashPlannerContextInputs(unittest.TestCase):
         )
 
 
-# pyrefly: ignore[inconsistent-inheritance]
-class AutoSharder(EmbeddingBagCollectionSharder, ModuleSharder[nn.Module]):
+class AutoSharder(EmbeddingBagCollectionSharder):
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return [ShardingType.ROW_WISE.value, ShardingType.TABLE_WISE.value]
 


### PR DESCRIPTION
Summary:
Fix pyrefly type checking test [562950246651223](https://www.internalfb.com/intern/test/562950246651223).

Removed redundant `ModuleSharder[nn.Module]` from `TWvsRWSharder`, `TWSharder`, and `AutoSharder` class definitions. `EmbeddingBagCollectionSharder` already inherits from `ModuleSharder[EmbeddingBagCollection]`, so adding `ModuleSharder[nn.Module]` caused `inconsistent-inheritance` errors due to invariant generic type parameters. Also removed associated `# pyrefly: ignore` comments and unused `ModuleSharder` import.

Differential Revision: D93962731


