### PR TITLE
Fix pyrefly type error in test_quant_utils.py

### DIFF
--- a/torchrec/quant/tests/test_quant_utils.py
+++ b/torchrec/quant/tests/test_quant_utils.py
@@ -44,6 +44,7 @@ class QuantUtilsTest(unittest.TestCase):
         ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
 
         # test forward
+        # pyrefly: ignore[bad-argument-type]
         ebc.qconfig = torch.quantization.QConfig(
             activation=torch.quantization.PlaceholderObserver.with_args(
                 dtype=output_type


### PR DESCRIPTION
Summary:
Fix pyrefly type checking test [844425223348599](https://www.internalfb.com/intern/test/844425223348599).

Added `# pyrefly: ignore[bad-argument-type]` before 1 `.qconfig = torch.quantization.QConfig(...)` assignment. Pyrefly types `nn.Module.__setattr__` as accepting `Module | Tensor`, so assigning a `QConfig` triggers a type error.

Differential Revision: D93962819


