### PR TITLE
[detailed][pipeline] Refactor backward injection and add TrainPipelineSparseDistBWDOpt

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -8,10 +8,14 @@ RunOptions:
   sharding_type: table_wise
   profile_dir: "."
   name: "sparse_data_dist_base"
+  memory_snapshot: True
   # export_stacks: True # enable this to export stack traces
   loglevel: "info"
 PipelineConfig:
-  pipeline: "sparse"
+  pipeline: "sparse" # "sparse-bwd-opt"
+  kwargs:
+    site_fqn: "sparse.weighted_ebc"
+    sharding_type: "table_wise"
 ModelInputConfig:
   num_float_features: 100
   feature_pooling_avg: 30

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
@@ -1,7 +1,7 @@
-# Benchmark configuration using Shampoo optimizer for dense parameters
-# Shampoo is a second-order optimizer that can improve convergence
-# runs on 2 ranks with Shampoo optimizer for dense layers
-# Note: Sparse embeddings use EXACT_ROWWISE_ADAGRAD (Shampoo not supported in fbgemm_gpu)
+# Benchmark config for TrainPipelineSparseDistBWDOpt with Shampoo optimizer
+# Based on sparse_data_dist_bwd_opt, with Shampoo for dense parameters.
+# Shampoo's expensive second-order optimizer step should benefit more from
+# being overlapped with backward all-to-all communication.
 RunOptions:
   world_size: 2
   num_batches: 10
@@ -10,10 +10,12 @@ RunOptions:
   memory_snapshot: True
   profile_dir: "."
   name: "sparse_data_dist_shampoo"
-  # export_stacks: True # enable this to export stack traces
   loglevel: "info"
 PipelineConfig:
-  pipeline: "sparse"
+  pipeline: "sparse" # "sparse-bwd-opt"
+  kwargs:
+    site_fqn: "sparse.weighted_ebc"
+    sharding_type: "table_wise"
 ModelInputConfig:
   num_float_features: 100
   feature_pooling_avg: 30
@@ -22,10 +24,10 @@ ModelSelectionConfig:
   model_config:
     num_float_features: 100
     submodule_kwargs:
-      dense_arch_out_size: 128
-      over_arch_out_size: 1024
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
       over_arch_hidden_layers: 5
-      dense_arch_hidden_sizes: [128, 128, 128]
+      dense_arch_hidden_sizes: [1024, 1024, 1024]
 EmbeddingTablesConfig:
   num_unweighted_features: 90
   num_weighted_features: 80
@@ -47,6 +49,9 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   sharding_type: table_wise
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, cast, Deque, Iterator, Optional, Tuple, Type
+
+import torch
+from torch.autograd.profiler import record_function
+from torchrec.distributed.train_pipeline.backward_injection import OutputDistSite
+from torchrec.distributed.train_pipeline.pipeline_context import (
+    In,
+    Out,
+    TrainPipelineContext,
+)
+from torchrec.distributed.train_pipeline.runtime_forwards import PipelinedForward
+from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
+from torchrec.distributed.train_pipeline.types import PipelineState
+from torchrec.distributed.train_pipeline.utils import _to_device, FutureDeque
+from torchrec.distributed.types import ShardingType
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class TrainEvalHybridPipelineBase(TrainPipelineSparseDist[In, Out]):
+    """
+    A hybrid pipeline that supports both training and evaluation modes in a single
+    pipelined execution flow.
+
+    This class extends `TrainPipelineSparseDist` to enable seamless switching between
+    training and evaluation within the same pipeline. It is particularly useful for
+    scenarios where you need to interleave training and evaluation batches without
+    the overhead of switching between separate pipelines.
+
+    Key Features:
+        - Supports both training and evaluation modes via the `is_training` flag.
+        - Conditionally executes backward pass and optimizer step only during training.
+        - Maintains the same pipelining benefits (overlapping data transfer, sparse
+          data distribution, and forward pass) for both modes.
+
+    Pipeline Stages (inherited from TrainPipelineSparseDist):
+        - Stage 3: Forward/Backward/Optimizer (current batch)
+        - Stage 2: Sparse data distribution (next batch)
+        - Stage 1: Device transfer (batch i+2)
+
+    Note:
+        The `is_training` flag is set per-batch via the context, allowing fine-grained
+        control over which batches trigger gradient computation and weight updates.
+    """
+
+    def _next_batch(self, dataloader_iter: Iterator[In]) -> Optional[In]:
+        if self._state == PipelineState.UNKNOWN:
+            return super()._next_batch(dataloader_iter)
+        return self._next_batch_on_cpu
+
+    def progress(self, dataloader_iter: Iterator[In], is_training: bool = True) -> Out:
+        """
+        Execute one step of the pipelined train/eval loop.
+
+        This method processes one batch through the full pipeline while overlapping
+        operations for subsequent batches. It conditionally executes backward pass
+        and optimizer step based on both the model's training mode and the per-batch
+        `is_training` flag.
+
+        For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
+            - batches[0]: current batch, for emb_lookup, output_dist, and fwd/bwd/opt
+                          (expecting input_dist completed)
+            - batches[1]: next batch, for input_dist (expecting copied to device)
+            - batches[2]: i+2 batch, for copy_batch_to_gpu
+                          (expecting non-exhausted dataloader iter)
+
+        Args:
+            dataloader_iter: Iterator yielding input batches from the dataloader.
+            is_training: Whether the *newly enqueued* batch (batch i+2) should be
+                processed in training mode. Defaults to True.
+
+        Returns:
+            Out: The output from the forward pass of the current batch (batches[0]).
+
+        Raises:
+            StopIteration: When all batches have been processed (pipeline is empty).
+
+        Note:
+            The backward/optimizer execution depends on BOTH:
+            1. `self._model.training` - the model's overall training mode
+            2. `self.contexts[0].is_training` - the per-batch training flag set during enqueue
+
+            This allows fine-grained control where the model can be in training mode
+            but specific batches can skip gradient computation (e.g., for evaluation batches
+            interleaved with training batches).
+        """
+
+        self._state = PipelineState.UNKNOWN
+        # Attach the model just in case the user forgets to call it, especially when the user
+        # pauses the pipeline.progress and detaches the model for other purposes.
+        if not self._model_attached:
+            self.attach(self._model)
+
+        # Fill the pipeline is only needed for the beginning when the pipeline (batches) is empty
+        self.fill_pipeline(dataloader_iter)
+        self._state = PipelineState.IDLE
+
+        self._next_batch_on_cpu = TrainPipelineSparseDist._next_batch(
+            self, dataloader_iter
+        )
+        if self._next_batch_on_cpu is None and not is_training:
+            # stop current progress if eval iter is exhausted
+            # training iter will continue
+            raise StopIteration
+
+        for context in self.contexts:
+            # this only fills the context loaded from fill_pipeline
+            if not hasattr(context, "is_training"):
+                logger.info(
+                    f"initial fill batch-{context.index} with {'train' if is_training else 'eval'}"
+                )
+                # pyrefly: ignore [missing-attribute]
+                context.is_training = is_training
+
+        # Here is the expected stop after exhausting all batches
+        if not self.batches:
+            raise StopIteration
+
+        # TODO: Remove once Bulk Eval migrated (needed for bwd compat, this class only)
+        self._set_module_context(self.contexts[0])
+
+        # Zero gradients only when model is in training mode
+        if self._model.training:
+            with record_function("## zero_grad ##"):
+                self._optimizer.zero_grad()
+
+        # Wait for batches[0] being available on device, this should always be completed since
+        # the input_dist of batches[0] has been invoked in previous iter. TODO: fact check
+        self._wait_for_batch()
+
+        # Start sparse data distribution for the next batch (overlapped with current forward)
+        if len(self.batches) >= 2:
+            # Invoke splits all_to_all comms (first part of input_dist)
+            self.start_sparse_data_dist(self.batches[1], self.contexts[1])
+
+        # pyrefly: ignore [missing-attribute]
+        is_curr_training = self._model.training and self.contexts[0].is_training
+
+        # Batch i+2: load data and copy to GPU, the dataloader iter will first exhaust here
+        if self.enqueue_batch(dataloader_iter):
+            # pyrefly: ignore [missing-attribute]
+            self.contexts[-1].is_training = is_training
+
+        # Forward pass for current batch
+        if is_curr_training:
+            with record_function(f"## forward {self.contexts[0].index} ##"):
+                self._state = PipelineState.CALL_FWD
+                losses, output = self._model_fwd(self.batches[0])
+        else:
+            with record_function(f"## eval {self.contexts[0].index} ##"):
+                with torch.no_grad():
+                    self._state = PipelineState.CALL_FWD
+                    losses, output = self._model_fwd(self.batches[0])
+
+        # Complete sparse data distribution for the next batch
+        if len(self.batches) >= 2:
+            # Invoke data (values, lengths, etc.) all_to_all comms (second part of input_dist)
+            self.wait_sparse_data_dist(self.contexts[1])
+
+        # Execute backward and optimizer step only if:
+        # 1. Model is in training mode (self._model.training)
+        # 2. Current batch is marked for training (self.contexts[0].is_training)
+        if is_curr_training:
+            # Backward pass
+            self._state = PipelineState.CALL_BWD
+            self._backward(losses)
+
+            # Sync embeddings if configured (for distributed model parallel)
+            self.sync_embeddings(
+                self._model,
+                self._dmp_collection_sync_interval_batches,
+                self.contexts[0],
+            )
+
+            # Optimizer step (weight update)
+            with record_function(f"## optimizer {self.contexts[0].index} ##"):
+                self._optimizer.step()
+
+        # Remove processed batch from the pipeline
+        self.dequeue_batch()
+        return output
+
+
+class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
+    """
+    Extends TrainPipelineSparseDist by running the inplace H2D copy (_to_device) in a
+    background thread so the CPU is not blocked while submitting non-blocking copy
+    operations to the memcpy stream.
+
+    The background result is resolved lazily before the batch is actually consumed
+    (in fill_pipeline before _init_pipelined_modules, and in progress before
+    start_sparse_data_dist).
+
+    All other pipeline behaviour is identical to TrainPipelineSparseDist.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        execute_all_batches: bool = True,
+        apply_jit: bool = False,
+        context_type: Type[TrainPipelineContext] = TrainPipelineContext,
+        pipeline_postproc: bool = False,
+        custom_model_fwd: Optional[
+            Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
+        ] = None,
+        dmp_collection_sync_interval_batches: Optional[int] = 1,
+        enable_inplace_copy_batch: bool = False,
+    ) -> None:
+        super().__init__(
+            model=model,
+            optimizer=optimizer,
+            device=device,
+            execute_all_batches=execute_all_batches,
+            apply_jit=apply_jit,
+            context_type=context_type,
+            pipeline_postproc=pipeline_postproc,
+            custom_model_fwd=custom_model_fwd,
+            dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
+            enqueue_batch_after_forward=False,
+            enable_inplace_copy_batch=enable_inplace_copy_batch,
+        )
+        self._copy_executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=1)
+        self.batches: Deque[Optional[In]] = cast(Deque[Optional[In]], FutureDeque())
+
+    def copy_batch_to_gpu(
+        self, dataloader_iter: Iterator[In]
+    ) -> Tuple[Optional[In], Optional[TrainPipelineContext]]:
+        context = self._create_context()
+        with record_function(f"## copy_batch_to_gpu {context.index} ##"):
+            batch = self._next_batch(dataloader_iter)
+            if batch is not None:
+
+                def _copy_work() -> In:
+                    # pyrefly: ignore [bad-argument-type]
+                    with self._stream_context(self._memcpy_stream):
+                        return _to_device(cast(In, batch), self._device, True)
+
+                future_batch = self._copy_executor.submit(_copy_work)
+                return cast(In, future_batch), context
+            elif not self._execute_all_batches:
+                logger.info(
+                    "copy_batch_to_gpu: raising StopIteration for None Batch (execute_all_batches=False)"
+                )
+                raise StopIteration
+            else:
+                logger.info(
+                    "copy_batch_to_gpu: returning None batch (execute_all_batches=True)"
+                )
+            return batch, context
+
+    def inplace_copy_batch_to_gpu(
+        self,
+        dataloader_iter: Iterator[In],
+    ) -> Tuple[Optional[In], Optional[TrainPipelineContext]]:
+        context = self._create_context()
+        with record_function(f"## inplace_copy_batch_to_gpu {context.index} ##"):
+            batch = self._next_batch(dataloader_iter)
+            if batch is not None:
+                future_batch = self._copy_executor.submit(
+                    _to_device,
+                    batch,
+                    self._device,
+                    True,
+                    self._memcpy_stream,
+                )
+                # Return the CPU batch as placeholder; _resolve_copy_future
+                # will replace it in self.batches before consumption.
+                return cast(In, future_batch), context
+            elif not self._execute_all_batches:
+                logger.info(
+                    "inplace_copy_batch_to_gpu: raising StopIteration for None Batch (execute_all_batches=False)"
+                )
+                raise StopIteration
+            else:
+                logger.info(
+                    "inplace_copy_batch_to_gpu: returning None batch (execute_all_batches=True)"
+                )
+            return batch, context
+
+
+class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
+    """
+    Extends TrainPipelineSparseDist by moving the optimizer step into the backward
+    pass via OutputDistSite backward hook injection. This overlaps the optimizer
+    computation with backward all-to-all communication, improving training throughput.
+
+    The explicit optimizer.step() in progress() is removed; instead, the optimizer
+    fires during backward when the output distribution tensor's gradient is computed.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        site_fqn: str,
+        sharding_type: ShardingType = ShardingType.TABLE_WISE,
+        execute_all_batches: bool = True,
+        apply_jit: bool = False,
+        context_type: Type[TrainPipelineContext] = TrainPipelineContext,
+        pipeline_postproc: bool = False,
+        custom_model_fwd: Optional[
+            Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
+        ] = None,
+        dmp_collection_sync_interval_batches: Optional[int] = 1,
+        enqueue_batch_after_forward: bool = False,
+        enable_inplace_copy_batch: bool = False,
+    ) -> None:
+        super().__init__(
+            model=model,
+            optimizer=optimizer,
+            device=device,
+            execute_all_batches=execute_all_batches,
+            apply_jit=apply_jit,
+            context_type=context_type,
+            pipeline_postproc=pipeline_postproc,
+            custom_model_fwd=custom_model_fwd,
+            dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
+            enqueue_batch_after_forward=enqueue_batch_after_forward,
+            enable_inplace_copy_batch=enable_inplace_copy_batch,
+        )
+        self._output_dist_site = OutputDistSite(
+            fqn=site_fqn, sharding_type=sharding_type
+        )
+
+    def _pipeline_model(
+        self,
+        batch: Optional[In],
+        context: TrainPipelineContext,
+        pipelined_forward: Type[PipelinedForward] = PipelinedForward,
+    ) -> None:
+        super()._pipeline_model(batch, context, pipelined_forward)
+
+        def work(pipeline: Any) -> None:
+            with record_function(f"## optimizer {pipeline.contexts[0].index} ##"):
+                pipeline._optimizer.step()
+
+        self.register_backward_hook(self._output_dist_site, work)
+
+    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+        """
+        For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
+            batches[0]: current batch, for emb_lookup, output_dist, and fwd/bwd/opt (expecting input_dist)
+            batches[1]: next batch, for input_dist (expecting copied to device)
+            batches[2]: i+2 batch, for copy_batch_to_gpu (expecting non-exhausted dataloader iter)
+        """
+
+        self._state = PipelineState.IDLE
+        # attach the model just in case the user forgets to call it, especially when the user
+        # pauses the pipeline.progress and detach the model for other purpose.
+        if not self._model_attached:
+            self.attach(self._model)
+
+        # fill the pipeline is only needed for the beginning when the pipeline (batches) is empty
+        self.fill_pipeline(dataloader_iter)
+
+        # here is the expected stop after exhausting all batches
+        if not self.batches:
+            raise StopIteration
+
+        # TODO: Remove once Bulk Eval migrated (needed for bwd compat, this class only)
+        self._set_module_context(self.contexts[0])
+
+        if self._model.training:
+            with record_function("## zero_grad ##"):
+                self._optimizer.zero_grad()
+
+        # wait for batches[0] being available on device, this should always be completed since
+        # the input_dist of batches[0] has be invoked in previous iter. TODO: fact check
+        self._wait_for_batch()
+
+        if len(self.batches) >= 2:
+            # invoke splits all_to_all comms (first part of input_dist)
+            self.start_sparse_data_dist(self.batches[1], self.contexts[1])
+
+        if not self._enqueue_batch_after_forward:
+            # batch i+2: load data and copy to gpu, the dataload iter will first exhaust here
+            self.enqueue_batch(dataloader_iter)
+
+        # forward
+        with record_function(f"## forward {self.contexts[0].index} ##"):
+            self._state = PipelineState.CALL_FWD
+            losses, output = self._model_fwd(self.batches[0])
+
+        if self._enqueue_batch_after_forward:
+            # batch i+2: load data and copy to gpu, the dataload iter will first exhaust here.
+            # Start this step after the forward of batch i, so that the H2D copy doesn't compete
+            # for pcie bandwidth with embedding lookup from UVM/UVM_CACHING.
+            self.enqueue_batch(dataloader_iter)
+
+        if len(self.batches) >= 2:
+            # invoke data (values, lengths, etc.) all_to_all comms (second part of input_dist)
+            self.wait_sparse_data_dist(self.contexts[1])
+
+        if self._model.training:
+            # backward
+            self._state = PipelineState.CALL_BWD
+            self._backward(losses)
+
+            self.sync_embeddings(
+                self._model,
+                self._dmp_collection_sync_interval_batches,
+                self.contexts[0],
+            )
+
+        self.dequeue_batch()
+        return output

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -7,403 +7,157 @@
 
 # pyre-strict
 
-import copy
 import unittest
-from typing import Callable, cast, List
-from unittest.mock import patch
+from typing import Any, List
+from unittest.mock import MagicMock
 
 import torch
-from hypothesis import given, settings, strategies as st
-from torch import nn, optim
-from torchrec.distributed import DistributedModelParallel
-from torchrec.distributed.comm_ops import All2All_Pooled_Req, ReduceScatterBase_Req
-from torchrec.distributed.embedding_types import EmbeddingComputeKernel
-from torchrec.distributed.test_utils.emb_sharder import TestEBCSharder
-from torchrec.distributed.test_utils.model_input import ModelInput
-from torchrec.distributed.test_utils.multi_process import (
-    MultiProcessContext,
-    MultiProcessTestBase,
-)
-from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torch import nn
+from torchrec.distributed.comm_ops import Request
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionAwaitable
 from torchrec.distributed.train_pipeline.backward_injection import (
-    BackwardHookRegistry,
     InjectionSite,
+    OutputDistSite,
+    register_backward_hook,
 )
-from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
-from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
-from torchrec.modules.embedding_configs import EmbeddingBagConfig
-
-# TestCase instance for assertions in test runner functions
-tc = unittest.TestCase()
-tc.maxDiff = None
+from torchrec.distributed.types import ShardingType
 
 
-class BackwardHookRegistryTest(unittest.TestCase):
-    """Unit tests for BackwardHookRegistry."""
+class SimpleModel(nn.Module):
+    """Simple nested model for testing InjectionSite."""
 
-    def test_add_hook_and_work(self) -> None:
-        """Verifies add_hook stores hook and work returns it."""
-        registry = BackwardHookRegistry()
-        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer_a = nn.Linear(4, 4)
+        self.layer_b = nn.Sequential(
+            nn.Linear(4, 4),
+            nn.ReLU(),
+        )
 
-        def work_fn(_p: TrainPipelineSparseDist) -> None:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layer_b(self.layer_a(x))
+
+
+class InjectionSiteTest(unittest.TestCase):
+    """Unit tests for InjectionSite (no GPU/distributed required)."""
+
+    def test_find_target_module(self) -> None:
+        model = SimpleModel()
+        self.assertIs(
+            InjectionSite(fqn="layer_a").find_target_module(model), model.layer_a
+        )
+        self.assertIsNone(InjectionSite(fqn="nonexistent").find_target_module(model))
+
+    def test_find_grad_tensor_nested(self) -> None:
+        site = InjectionSite(fqn="")
+        grad = torch.tensor([1.0], requires_grad=True)
+        nested = (torch.tensor([0.0]), {"k": [torch.tensor([0.0]), grad]})
+        self.assertIs(site.find_grad_tensor(nested), grad)
+        self.assertIsNone(site.find_grad_tensor(torch.tensor([1.0])))
+
+    def test_register_hook_nonexistent_raises(self) -> None:
+        site = InjectionSite(fqn="nonexistent.module")
+        with self.assertRaises(ValueError):
+            register_backward_hook(site, SimpleModel(), lambda grad: None)
+
+    def test_register_hook_persists_and_removable(self) -> None:
+        """Hook fires every iteration; removing it stops firing."""
+        model = SimpleModel()
+        site = InjectionSite(fqn="layer_a")
+        call_count: List[int] = [0]
+
+        handle = register_backward_hook(
+            site,
+            model,
+            lambda grad: call_count.__setitem__(0, call_count[0] + 1),
+        )
+
+        for _ in range(3):
+            model.zero_grad()
+            model(torch.randn(2, 4)).sum().backward()
+        self.assertEqual(call_count[0], 3)
+
+        handle.remove()
+        model.zero_grad()
+        model(torch.randn(2, 4)).sum().backward()
+        self.assertEqual(call_count[0], 3)
+
+
+def _make_request_with_dummy_tensor() -> Request:
+    """Create a mock Request with a dummy_tensor that requires grad."""
+    req = MagicMock(spec=Request)
+    req.dummy_tensor = torch.tensor([1.0], requires_grad=True)
+    return req
+
+
+def _make_ebc_awaitable(
+    sharding_types: List[str],
+    awaitables: List[Any] | None = None,
+) -> EmbeddingBagCollectionAwaitable:
+    """Create a mock EBC awaitable with given sharding types."""
+    mock = MagicMock(spec=EmbeddingBagCollectionAwaitable)
+    mock._sharding_types = sharding_types
+    if awaitables is None:
+        awaitables = []
+        for _ in sharding_types:
+            w = MagicMock()
+            w._tensor_awaitable = _make_request_with_dummy_tensor()
+            awaitables.append(w)
+    mock._awaitables = awaitables
+    return mock
+
+
+class OutputDistSiteTest(unittest.TestCase):
+    """Unit tests for OutputDistSite.find_grad_tensor."""
+
+    def test_ebc_awaitable(self) -> None:
+        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
+        result = site.find_grad_tensor(
+            _make_ebc_awaitable([ShardingType.TABLE_WISE.value])
+        )
+        self.assertIsNotNone(result)
+        self.assertTrue(result.requires_grad)
+
+    def test_selects_correct_sharding_type(self) -> None:
+        """With multiple sharding types, returns tensor for the matching one."""
+        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.COLUMN_WISE)
+
+        tw_req = _make_request_with_dummy_tensor()
+        cw_req = _make_request_with_dummy_tensor()
+
+        tw_awaitable = MagicMock()
+        tw_awaitable._tensor_awaitable = tw_req
+        cw_awaitable = MagicMock()
+        cw_awaitable._tensor_awaitable = cw_req
+
+        ebc = _make_ebc_awaitable(
+            [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value],
+            [tw_awaitable, cw_awaitable],
+        )
+        self.assertIs(site.find_grad_tensor(ebc), cw_req.dummy_tensor)
+
+    def test_sharding_type_mismatch_raises(self) -> None:
+        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.COLUMN_WISE)
+        with self.assertRaises(RuntimeError):
+            site.find_grad_tensor(_make_ebc_awaitable([ShardingType.TABLE_WISE.value]))
+
+    def test_unsupported_type_raises(self) -> None:
+        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
+        with self.assertRaises(RuntimeError):
+            site.find_grad_tensor("not_an_awaitable")
+
+    def test_hasattr_fallback(self) -> None:
+        """Objects with _awaitables/_sharding_types but not EBC/EC use hasattr fallback."""
+        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
+
+        class FakeAwaitable:
             pass
 
-        registry.add_hook(site, work_fn)  # pyrefly: ignore[bad-argument-type]
+        w = MagicMock()
+        w._tensor_awaitable = _make_request_with_dummy_tensor()
 
-        self.assertEqual(registry.work(site), [work_fn])
+        fake = FakeAwaitable()
+        fake._awaitables = [w]  # pyre-ignore[16]
+        fake._sharding_types = [ShardingType.TABLE_WISE.value]  # pyre-ignore[16]
 
-    def test_multiple_hooks_same_site(self) -> None:
-        """Verifies multiple hooks at same site are returned in order."""
-        registry = BackwardHookRegistry()
-        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
-
-        def work_fn_1(_p: TrainPipelineSparseDist) -> None:
-            pass
-
-        def work_fn_2(_p: TrainPipelineSparseDist) -> None:
-            pass
-
-        registry.add_hook(site, work_fn_1)  # pyrefly: ignore[bad-argument-type]
-        registry.add_hook(site, work_fn_2)  # pyrefly: ignore[bad-argument-type]
-
-        self.assertEqual(registry.work(site), [work_fn_1, work_fn_2])
-
-    def test_different_sites_isolated(self) -> None:
-        """Verifies hooks at different sites are isolated."""
-        registry = BackwardHookRegistry()
-        site_1 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
-        site_2 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.ROW_WISE)
-
-        def work_fn_1(_p: TrainPipelineSparseDist) -> None:
-            pass
-
-        def work_fn_2(_p: TrainPipelineSparseDist) -> None:
-            pass
-
-        registry.add_hook(site_1, work_fn_1)  # pyrefly: ignore[bad-argument-type]
-        registry.add_hook(site_2, work_fn_2)  # pyrefly: ignore[bad-argument-type]
-
-        self.assertEqual(registry.work(site_1), [work_fn_1])
-        self.assertEqual(registry.work(site_2), [work_fn_2])
-
-    def test_work_unknown_site_returns_empty(self) -> None:
-        """Verifies work returns empty list for unregistered site."""
-        registry = BackwardHookRegistry()
-        site = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
-
-        self.assertEqual(registry.work(site), [])
-
-    def test_add_same_hook_to_multiple_sites(self) -> None:
-        """Verifies same hook can be added to multiple sites."""
-        registry = BackwardHookRegistry()
-        site_1 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE)
-        site_2 = InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.ROW_WISE)
-
-        def work_fn(_p: TrainPipelineSparseDist) -> None:
-            pass
-
-        registry.add_hook(site_1, work_fn)  # pyrefly: ignore[bad-argument-type]
-        registry.add_hook(site_2, work_fn)  # pyrefly: ignore[bad-argument-type]
-
-        self.assertEqual(registry.work(site_1), [work_fn])
-        self.assertEqual(registry.work(site_2), [work_fn])
-
-    def test_hooks_dict_empty_by_default(self) -> None:
-        """Verifies hooks dict is empty when registry is created."""
-        registry = BackwardHookRegistry()
-        self.assertEqual(registry.hooks, {})
-
-
-def _create_pipeline(
-    ctx: MultiProcessContext,
-    tables: List[EmbeddingBagConfig],
-    weighted_tables: List[EmbeddingBagConfig],
-    sharding_type: str = ShardingType.TABLE_WISE.value,
-) -> TrainPipelineSparseDist:
-    """Helper to create a TrainPipelineSparseDist for testing."""
-    unsharded_model = TestSparseNN(
-        tables=tables,
-        weighted_tables=weighted_tables,
-        dense_device=ctx.device,
-        sparse_device=torch.device("meta"),
-    )
-
-    sharder = TestEBCSharder(
-        sharding_type=sharding_type,
-        kernel_type=EmbeddingComputeKernel.FUSED.value,
-    )
-
-    sharded_model = DistributedModelParallel(
-        module=copy.deepcopy(unsharded_model),
-        env=ShardingEnv.from_process_group(
-            ctx.pg  # pyrefly: ignore[bad-argument-type]
-        ),
-        device=ctx.device,
-        sharders=[cast(ModuleSharder[nn.Module], sharder)],
-    )
-
-    optimizer = optim.SGD(sharded_model.parameters(), lr=0.1)
-
-    return TrainPipelineSparseDist(
-        model=sharded_model,
-        optimizer=optimizer,
-        device=ctx.device,
-    )
-
-
-def _run_backward_hook_test(
-    rank: int,
-    world_size: int,
-    tables: List[EmbeddingBagConfig],
-    weighted_tables: List[EmbeddingBagConfig],
-    data: List[ModelInput],
-    sharding_type: str,
-    site_fqn: str,
-    backend: str = "nccl",
-    local_size: int | None = None,
-    num_hooks: int = 1,
-) -> None:
-    """Test runner for backward hook execution with multi-GPU setup."""
-    operation_order: List[str] = []
-
-    # Different sharding types use different backward comm ops
-    if sharding_type in [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value]:
-        original_backward = All2All_Pooled_Req.backward
-        backward_cls = All2All_Pooled_Req
-    else:  # ROW_WISE uses reduce-scatter
-        original_backward = ReduceScatterBase_Req.backward
-        backward_cls = ReduceScatterBase_Req
-
-    def wrapper_func(*args, **kwargs):
-        operation_order.append("comm_op")
-        return original_backward(*args, **kwargs)
-
-    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        tc.assertIsNotNone(ctx.pg)
-        pipeline = _create_pipeline(ctx, tables, weighted_tables, sharding_type)
-
-        # Register hook(s)
-        def make_work_fn(idx: int) -> Callable[[TrainPipelineSparseDist], None]:
-            def work_fn(_p: TrainPipelineSparseDist) -> None:
-                operation_order.append(f"hook_{idx}")
-
-            return work_fn
-
-        for i in range(num_hooks):
-            pipeline.register_backward_hook(
-                site=InjectionSite(
-                    fqn=site_fqn, sharding_type=ShardingType(sharding_type)
-                ),
-                work=make_work_fn(i),  # pyrefly: ignore[bad-argument-type]
-            )
-
-        dataloader = iter(data)
-        with patch.object(backward_cls, "backward", side_effect=wrapper_func):
-            pipeline.progress(dataloader)
-
-        # Verify hooks were executed in order
-        hook_entries = [f"hook_{i}" for i in range(num_hooks)]
-        if site_fqn == "sparse.ebc":
-            expected = ["comm_op"] + hook_entries + ["comm_op"]
-        elif site_fqn == "sparse.weighted_ebc":
-            expected = hook_entries + ["comm_op", "comm_op"]
-        else:
-            raise ValueError(f"Unknown site_fqn: {site_fqn}")
-
-        tc.assertEqual(operation_order, expected)
-
-
-def _run_nonexistent_site_test(
-    rank: int,
-    world_size: int,
-    tables: List[EmbeddingBagConfig],
-    weighted_tables: List[EmbeddingBagConfig],
-    data: List[ModelInput],
-    backend: str = "nccl",
-    local_size: int | None = None,
-) -> None:
-    """Test runner to verify warning is logged for non-existent site."""
-    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        tc.assertIsNotNone(ctx.pg)
-        pipeline = _create_pipeline(ctx, tables, weighted_tables)
-
-        hook_executed: List[bool] = []
-        pipeline.register_backward_hook(
-            site=InjectionSite(
-                fqn="nonexistent.module", sharding_type=ShardingType.TABLE_WISE
-            ),
-            work=lambda _p: hook_executed.append(True),
-        )
-
-        dataloader = iter(data)
-        with tc.assertLogs(
-            "torchrec.distributed.train_pipeline.backward_injection", level="WARNING"
-        ) as cm:
-            pipeline.progress(dataloader)
-
-        tc.assertTrue(
-            any("nonexistent.module" in msg for msg in cm.output),
-            f"Expected warning about non-existent site. Log output: {cm.output}",
-        )
-        tc.assertEqual(
-            len(hook_executed), 0, "Hook should not execute for non-existent site"
-        )
-
-
-def _run_repeated_calls_test(
-    rank: int,
-    world_size: int,
-    tables: List[EmbeddingBagConfig],
-    weighted_tables: List[EmbeddingBagConfig],
-    data: List[ModelInput],
-    backend: str = "nccl",
-    local_size: int | None = None,
-    num_progress_calls: int = 3,
-) -> None:
-    """Test runner to verify hooks work across multiple pipeline.progress() calls."""
-    hook_call_count: List[int] = [0]
-
-    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        tc.assertIsNotNone(ctx.pg)
-        pipeline = _create_pipeline(ctx, tables, weighted_tables)
-
-        pipeline.register_backward_hook(
-            site=InjectionSite(fqn="sparse.ebc", sharding_type=ShardingType.TABLE_WISE),
-            work=lambda _p: hook_call_count.__setitem__(0, hook_call_count[0] + 1),
-        )
-
-        dataloader = iter(data)
-        for _ in range(num_progress_calls):
-            pipeline.progress(dataloader)
-
-        tc.assertEqual(
-            hook_call_count[0],
-            num_progress_calls,
-            f"Hook should be called {num_progress_calls} times, "
-            f"but was called {hook_call_count[0]} times",
-        )
-
-
-class RegisterHooksTest(MultiProcessTestBase):
-    """Integration tests for register_hooks with real pipeline."""
-
-    def setUp(self) -> None:
-        super().setUp()
-
-        num_features = 4
-        num_weighted_features = 2
-        self.tables = [
-            EmbeddingBagConfig(
-                num_embeddings=(i + 1) * 100,
-                embedding_dim=(i + 1) * 4,
-                name="table_" + str(i),
-                feature_names=["feature_" + str(i)],
-            )
-            for i in range(num_features)
-        ]
-        self.weighted_tables = [
-            EmbeddingBagConfig(
-                num_embeddings=(i + 1) * 100,
-                embedding_dim=(i + 1) * 4,
-                name="weighted_table_" + str(i),
-                feature_names=["weighted_feature_" + str(i)],
-            )
-            for i in range(num_weighted_features)
-        ]
-
-    def _generate_data(
-        self,
-        num_batches: int = 5,
-        batch_size: int = 1,
-    ) -> List[ModelInput]:
-        return [
-            ModelInput.generate(
-                tables=self.tables,
-                weighted_tables=self.weighted_tables,
-                batch_size=batch_size,
-                num_float_features=10,
-            )
-            for _ in range(num_batches)
-        ]
-
-    @unittest.skipIf(
-        torch.cuda.device_count() < 2,
-        "Not enough GPUs, this test requires at least 2 GPUs",
-    )
-    @settings(max_examples=6, deadline=None)
-    @given(
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.TABLE_WISE.value,
-                ShardingType.ROW_WISE.value,
-                ShardingType.COLUMN_WISE.value,
-            ]
-        ),
-        site_fqn=st.sampled_from(["sparse.ebc", "sparse.weighted_ebc"]),
-    )
-    def test_backward_hook_executed_during_backward(
-        self,
-        sharding_type: str,
-        site_fqn: str,
-    ) -> None:
-        """Verifies registered hooks are executed during backward pass."""
-        data = self._generate_data(num_batches=5, batch_size=2)
-        self._run_multi_process_test(
-            callable=_run_backward_hook_test,
-            world_size=2,
-            tables=self.tables,
-            weighted_tables=self.weighted_tables,
-            data=data,
-            sharding_type=sharding_type,
-            site_fqn=site_fqn,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() < 2,
-        "Not enough GPUs, this test requires at least 2 GPUs",
-    )
-    def test_multiple_hooks_executed_in_order(self) -> None:
-        """Verifies multiple hooks at the same site are executed in registration order."""
-        data = self._generate_data(num_batches=5, batch_size=2)
-        self._run_multi_process_test(
-            callable=_run_backward_hook_test,
-            world_size=2,
-            tables=self.tables,
-            weighted_tables=self.weighted_tables,
-            data=data,
-            sharding_type=ShardingType.TABLE_WISE.value,
-            site_fqn="sparse.ebc",
-            num_hooks=3,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() < 2,
-        "Not enough GPUs, this test requires at least 2 GPUs",
-    )
-    def test_hook_on_nonexistent_site_logs_warning(self) -> None:
-        """Verifies warning is logged when hook registered for site that doesn't exist."""
-        data = self._generate_data(num_batches=5, batch_size=2)
-        self._run_multi_process_test(
-            callable=_run_nonexistent_site_test,
-            world_size=2,
-            tables=self.tables,
-            weighted_tables=self.weighted_tables,
-            data=data,
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() < 2,
-        "Not enough GPUs, this test requires at least 2 GPUs",
-    )
-    def test_hooks_work_across_repeated_progress_calls(self) -> None:
-        """Verifies hooks continue to work correctly across multiple pipeline.progress() calls."""
-        data = self._generate_data(num_batches=10, batch_size=2)
-        self._run_multi_process_test(
-            callable=_run_repeated_calls_test,
-            world_size=2,
-            tables=self.tables,
-            weighted_tables=self.weighted_tables,
-            data=data,
-            num_progress_calls=5,
-        )
+        self.assertIsNotNone(site.find_grad_tensor(fake))

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -11,7 +11,6 @@ import abc
 import contextlib
 import logging
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -39,12 +38,11 @@ from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionAwaitable,  # noqa: F401
 )
 from torchrec.distributed.logger import one_time_rank0_logger
-from torchrec.distributed.model_parallel import ShardedModule
+from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.backward_injection import (
-    BackwardHookRegistry,
     BackwardHookWork,
     InjectionSite,
-    register_hooks,
+    register_backward_hook,
 )
 from torchrec.distributed.train_pipeline.pipeline_context import (
     EmbeddingTrainPipelineContext,
@@ -78,7 +76,6 @@ from torchrec.distributed.train_pipeline.utils import (
     _wait_for_batch,
     _wait_for_events,
     DataLoadingThread,
-    FutureDeque,
     use_context_for_postprocs,
 )
 from torchrec.distributed.types import Awaitable, NoWait, ShardingType  # noqa: F401
@@ -523,7 +520,6 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
-        backward_hook_registry: Optional[BackwardHookRegistry] = None,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -595,9 +591,6 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 f"{self.__class__.__name__}: [Sparse 2D] DMP collection will sync every "
                 f"{self._dmp_collection_sync_interval_batches} batches"
             )
-
-        # Backward hook registry for injecting work during backward comms
-        self._backward_hook_registry = backward_hook_registry or BackwardHookRegistry()
 
         super().__init__()
 
@@ -801,12 +794,6 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             self._state = PipelineState.CALL_FWD
             losses, output = self._model_fwd(self.batches[0])
 
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:killswitch_enable_sdd_backward_injection"
-        ):
-            # Register all user-configured backward hooks
-            self._register_output_dist_hooks(self.contexts[0])
-
         if self._enqueue_batch_after_forward:
             # batch i+2: load data and copy to gpu, the dataload iter will first exhaust here.
             # Start this step after the forward of batch i, so that the H2D copy doesn't compete
@@ -904,30 +891,37 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         """
         Registers work to execute during backward pass of an EC/EBC.
 
+        Installs a persistent forward hook on the target module via
+        ``register_backward_hook``. Each forward pass, the hook finds the
+        appropriate output tensor and registers a backward hook that
+        executes all work functions for the site.
+
         Args:
-            site: Injection site specification with fqn and sharding_type.
-                  e.g., InjectionSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE)
+            site: Injection site specification.
+                  e.g., OutputDistSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE)
             work: Callable that receives the pipeline instance.
                   Executed sequentially with other work at same site.
 
         Example:
             pipeline.register_backward_hook(
-                site=InjectionSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE),
+                site=OutputDistSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE),
                 work=lambda p: p._optimizer.step(),
             )
         """
-        self._backward_hook_registry.add_hook(site, work)
 
-    def _register_output_dist_hooks(
-        self,
-        context: TrainPipelineContext,
-    ) -> None:
-        """Registers all configured backward hooks on output dist tensors."""
-        register_hooks(
-            registry=self._backward_hook_registry,
-            pipeline=self,
-            output_dist_embeddings_requests=context.output_dist_embeddings_requests,
-        )
+        # DMP doesn't override named_modules(), so FQNs include the
+        # _dmp_wrapped_module (and possibly DDP .module) prefix.
+        # Unwrap to the inner model so find_target_module can match
+        # user-facing FQNs like "sparse.ebc" directly.
+        model = self._model
+        if isinstance(model, DistributedModelParallel):
+            model = model.module
+
+        def hook_fn(grad: torch.Tensor) -> None:
+            with record_function(f"## backward_hook {site} ##"):
+                work(self)
+
+        register_backward_hook(site, model, hook_fn)
 
     def copy_batch_to_gpu(
         self,
@@ -2072,170 +2066,6 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
                     )
 
 
-class TrainEvalHybridPipelineBase(TrainPipelineSparseDist[In, Out]):
-    """
-    A hybrid pipeline that supports both training and evaluation modes in a single
-    pipelined execution flow.
-
-    This class extends `TrainPipelineSparseDist` to enable seamless switching between
-    training and evaluation within the same pipeline. It is particularly useful for
-    scenarios where you need to interleave training and evaluation batches without
-    the overhead of switching between separate pipelines.
-
-    Key Features:
-        - Supports both training and evaluation modes via the `is_training` flag.
-        - Conditionally executes backward pass and optimizer step only during training.
-        - Maintains the same pipelining benefits (overlapping data transfer, sparse
-          data distribution, and forward pass) for both modes.
-
-    Pipeline Stages (inherited from TrainPipelineSparseDist):
-        - Stage 3: Forward/Backward/Optimizer (current batch)
-        - Stage 2: Sparse data distribution (next batch)
-        - Stage 1: Device transfer (batch i+2)
-
-    Note:
-        The `is_training` flag is set per-batch via the context, allowing fine-grained
-        control over which batches trigger gradient computation and weight updates.
-    """
-
-    def _next_batch(self, dataloader_iter: Iterator[In]) -> Optional[In]:
-        if self._state == PipelineState.UNKNOWN:
-            return super()._next_batch(dataloader_iter)
-        return self._next_batch_on_cpu
-
-    def progress(self, dataloader_iter: Iterator[In], is_training: bool = True) -> Out:
-        """
-        Execute one step of the pipelined train/eval loop.
-
-        This method processes one batch through the full pipeline while overlapping
-        operations for subsequent batches. It conditionally executes backward pass
-        and optimizer step based on both the model's training mode and the per-batch
-        `is_training` flag.
-
-        For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
-            - batches[0]: current batch, for emb_lookup, output_dist, and fwd/bwd/opt
-                          (expecting input_dist completed)
-            - batches[1]: next batch, for input_dist (expecting copied to device)
-            - batches[2]: i+2 batch, for copy_batch_to_gpu
-                          (expecting non-exhausted dataloader iter)
-
-        Args:
-            dataloader_iter: Iterator yielding input batches from the dataloader.
-            is_training: Whether the *newly enqueued* batch (batch i+2) should be
-                processed in training mode. Defaults to True.
-
-        Returns:
-            Out: The output from the forward pass of the current batch (batches[0]).
-
-        Raises:
-            StopIteration: When all batches have been processed (pipeline is empty).
-
-        Note:
-            The backward/optimizer execution depends on BOTH:
-            1. `self._model.training` - the model's overall training mode
-            2. `self.contexts[0].is_training` - the per-batch training flag set during enqueue
-
-            This allows fine-grained control where the model can be in training mode
-            but specific batches can skip gradient computation (e.g., for evaluation batches
-            interleaved with training batches).
-        """
-
-        self._state = PipelineState.UNKNOWN
-        # Attach the model just in case the user forgets to call it, especially when the user
-        # pauses the pipeline.progress and detaches the model for other purposes.
-        if not self._model_attached:
-            self.attach(self._model)
-
-        # Fill the pipeline is only needed for the beginning when the pipeline (batches) is empty
-        self.fill_pipeline(dataloader_iter)
-        self._state = PipelineState.IDLE
-
-        self._next_batch_on_cpu = TrainPipelineSparseDist._next_batch(
-            self, dataloader_iter
-        )
-        if self._next_batch_on_cpu is None and not is_training:
-            # stop current progress if eval iter is exhausted
-            # training iter will continue
-            raise StopIteration
-
-        for context in self.contexts:
-            # this only fills the context loaded from fill_pipeline
-            if not hasattr(context, "is_training"):
-                logger.info(
-                    f"initial fill batch-{context.index} with {'train' if is_training else 'eval'}"
-                )
-                # pyrefly: ignore [missing-attribute]
-                context.is_training = is_training
-
-        # Here is the expected stop after exhausting all batches
-        if not self.batches:
-            raise StopIteration
-
-        # TODO: Remove once Bulk Eval migrated (needed for bwd compat, this class only)
-        self._set_module_context(self.contexts[0])
-
-        # Zero gradients only when model is in training mode
-        if self._model.training:
-            with record_function("## zero_grad ##"):
-                self._optimizer.zero_grad()
-
-        # Wait for batches[0] being available on device, this should always be completed since
-        # the input_dist of batches[0] has been invoked in previous iter. TODO: fact check
-        self._wait_for_batch()
-
-        # Start sparse data distribution for the next batch (overlapped with current forward)
-        if len(self.batches) >= 2:
-            # Invoke splits all_to_all comms (first part of input_dist)
-            self.start_sparse_data_dist(self.batches[1], self.contexts[1])
-
-        # pyrefly: ignore [missing-attribute]
-        is_curr_training = self._model.training and self.contexts[0].is_training
-
-        # Batch i+2: load data and copy to GPU, the dataloader iter will first exhaust here
-        if self.enqueue_batch(dataloader_iter):
-            # pyrefly: ignore [missing-attribute]
-            self.contexts[-1].is_training = is_training
-
-        # Forward pass for current batch
-        if is_curr_training:
-            with record_function(f"## forward {self.contexts[0].index} ##"):
-                self._state = PipelineState.CALL_FWD
-                losses, output = self._model_fwd(self.batches[0])
-        else:
-            with record_function(f"## eval {self.contexts[0].index} ##"):
-                with torch.no_grad():
-                    self._state = PipelineState.CALL_FWD
-                    losses, output = self._model_fwd(self.batches[0])
-
-        # Complete sparse data distribution for the next batch
-        if len(self.batches) >= 2:
-            # Invoke data (values, lengths, etc.) all_to_all comms (second part of input_dist)
-            self.wait_sparse_data_dist(self.contexts[1])
-
-        # Execute backward and optimizer step only if:
-        # 1. Model is in training mode (self._model.training)
-        # 2. Current batch is marked for training (self.contexts[0].is_training)
-        if is_curr_training:
-            # Backward pass
-            self._state = PipelineState.CALL_BWD
-            self._backward(losses)
-
-            # Sync embeddings if configured (for distributed model parallel)
-            self.sync_embeddings(
-                self._model,
-                self._dmp_collection_sync_interval_batches,
-                self.contexts[0],
-            )
-
-            # Optimizer step (weight update)
-            with record_function(f"## optimizer {self.contexts[0].index} ##"):
-                self._optimizer.step()
-
-        # Remove processed batch from the pipeline
-        self.dequeue_batch()
-        return output
-
-
 class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
     """
     This pipeline overlaps device transfer, and `ShardedModule.input_dist()` with
@@ -2848,106 +2678,3 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
 
         self.dequeue_batch()
         return output
-
-
-class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
-    """
-    Extends TrainPipelineSparseDist by running the inplace H2D copy (_to_device) in a
-    background thread so the CPU is not blocked while submitting non-blocking copy
-    operations to the memcpy stream.
-
-    The background result is resolved lazily before the batch is actually consumed
-    (in fill_pipeline before _init_pipelined_modules, and in progress before
-    start_sparse_data_dist).
-
-    All other pipeline behaviour is identical to TrainPipelineSparseDist.
-    """
-
-    def __init__(
-        self,
-        model: torch.nn.Module,
-        optimizer: torch.optim.Optimizer,
-        device: torch.device,
-        execute_all_batches: bool = True,
-        apply_jit: bool = False,
-        context_type: Type[TrainPipelineContext] = TrainPipelineContext,
-        pipeline_postproc: bool = False,
-        custom_model_fwd: Optional[
-            Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
-        ] = None,
-        dmp_collection_sync_interval_batches: Optional[int] = 1,
-        enqueue_batch_after_forward: bool = False,
-        enable_inplace_copy_batch: bool = False,
-        backward_hook_registry: Optional[BackwardHookRegistry] = None,
-    ) -> None:
-        super().__init__(
-            model=model,
-            optimizer=optimizer,
-            device=device,
-            execute_all_batches=execute_all_batches,
-            apply_jit=apply_jit,
-            context_type=context_type,
-            pipeline_postproc=pipeline_postproc,
-            custom_model_fwd=custom_model_fwd,
-            dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
-            enqueue_batch_after_forward=False,
-            enable_inplace_copy_batch=enable_inplace_copy_batch,
-            backward_hook_registry=backward_hook_registry,
-        )
-        self._copy_executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=1)
-        self.batches: Deque[Optional[In]] = cast(Deque[Optional[In]], FutureDeque())
-
-    def copy_batch_to_gpu(
-        self, dataloader_iter: Iterator[In]
-    ) -> Tuple[Optional[In], Optional[TrainPipelineContext]]:
-        context = self._create_context()
-        with record_function(f"## copy_batch_to_gpu {context.index} ##"):
-            batch = self._next_batch(dataloader_iter)
-            if batch is not None:
-
-                def _copy_work() -> In:
-                    # pyrefly: ignore [bad-argument-type]
-                    with self._stream_context(self._memcpy_stream):
-                        return _to_device(cast(In, batch), self._device, True)
-
-                future_batch = self._copy_executor.submit(_copy_work)
-                return cast(In, future_batch), context
-            elif not self._execute_all_batches:
-                logger.info(
-                    "copy_batch_to_gpu: raising StopIteration for None Batch (execute_all_batches=False)"
-                )
-                raise StopIteration
-            else:
-                logger.info(
-                    "copy_batch_to_gpu: returning None batch (execute_all_batches=True)"
-                )
-            return batch, context
-
-    def inplace_copy_batch_to_gpu(
-        self,
-        dataloader_iter: Iterator[In],
-    ) -> Tuple[Optional[In], Optional[TrainPipelineContext]]:
-        context = self._create_context()
-        with record_function(f"## inplace_copy_batch_to_gpu {context.index} ##"):
-            batch = self._next_batch(dataloader_iter)
-            if batch is not None:
-                future_batch = self._copy_executor.submit(
-                    _to_device,
-                    batch,
-                    self._device,
-                    True,
-                    self._memcpy_stream,
-                )
-                # Return the CPU batch as placeholder; _resolve_copy_future
-                # will replace it in self.batches before consumption.
-                return cast(In, future_batch), context
-            elif not self._execute_all_batches:
-                logger.info(
-                    "inplace_copy_batch_to_gpu: raising StopIteration for None Batch (execute_all_batches=False)"
-                )
-                raise StopIteration
-            else:
-                logger.info(
-                    "inplace_copy_batch_to_gpu: returning None batch (execute_all_batches=True)"
-                )
-            return batch, context


### PR DESCRIPTION
# Refactor backward injection to support persistent forward-hook-based registration and add TrainPipelineSparseDistBWDOpt

## 1. Context

The backward hook injection system previously used a registry-based approach (`BackwardHookRegistry`) that re-registered hooks on output dist tensors every iteration via `register_hooks()` called from `progress()`. This required access to `context.output_dist_embeddings_requests` each iteration and was gated behind a JustKnobs killswitch (`killswitch_enable_sdd_backward_injection`).

This diff refactors the injection mechanism to use persistent forward hooks (`nn.Module.register_forward_hook`) that automatically attach backward hooks on each forward pass, eliminating the per-iteration re-registration overhead. It also introduces `TrainPipelineSparseDistBWDOpt`, a new pipeline that moves the optimizer step into the backward pass to overlap it with backward all-to-all communication. Additionally, experimental pipeline classes (`TrainEvalHybridPipelineBase`, `TrainPipelineSparseDistT`) are moved out of `train_pipelines.py` into a new `experimental_pipelines.py` module to reduce file size and improve code organization.

## 2. Approach

1. **Persistent forward-hook-based injection**: `InjectionSite.register_hook()` installs a `register_forward_hook` on the target module. Each forward pass, the hook finds the first grad-requiring output tensor and attaches the backward hook on it. This persists across iterations — no per-iteration re-registration needed.

2. **OutputDistSite specialization**: `OutputDistSite` extends `InjectionSite` with sharding-type-aware tensor extraction. It overrides `find_first_grad_tensor()` to locate the `dummy_tensor` from the EC/EBC output dist awaitable matching the configured `ShardingType`, which is the tensor involved in backward all-to-all communication.

3. **DMP model unwrapping for FQN resolution**: `DistributedModelParallel` does not override `named_modules()`, so module FQNs include the `_dmp_wrapped_module` prefix (and `.module` if DDP-wrapped). `TrainPipelineSparseDistBWDOpt._pipeline_model()` unwraps the DMP model via `model.module` before calling `register_hook()`, matching how `_rewrite_model` handles this internally.

4. **PipelineConfig refactoring**: Replaced per-pipeline fields (`emb_lookup_stream`, `apply_jit`) with a generic `kwargs: Dict[str, Any]` that gets forwarded to pipeline constructors via `get_kwargs()`. This allows pipeline-specific parameters (like `site_fqn`, `sharding_type`) to be configured in YAML without modifying `PipelineConfig`. Uses `match/case` with only `semi` and `fused` as special cases, all others go through a unified default path.

5. **Module reorganization**: Moved `TrainEvalHybridPipelineBase`, `TrainPipelineSparseDistT`, and the new `TrainPipelineSparseDistBWDOpt` into `experimental_pipelines.py`. This keeps `train_pipelines.py` focused on production pipeline classes.

## 3. Results

* benchmark

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base              |3248.67 ms       |3064.18 ms       |49.06 GB                |66.38 GB                   |68.82 GB          |0.0 / 0.0 / 0.0              |30.75 GB          |
|sparse_data_dist_bwd_opt           |3230.54 ms       |3043.00 ms       |49.06 GB                |67.12 GB                   |69.56 GB          |0.0 / 0.0 / 0.0              |30.68 GB          |
|sparse_data_dist_shampoo           |3505.08 ms       |3324.14 ms       |50.26 GB                |71.52 GB                   |73.95 GB          |0.0 / 0.0 / 0.0              |30.79 GB          |
|sparse_data_dist_bwd_opt_shampoo   |3420.16 ms       |3250.52 ms       |50.17 GB                |71.25 GB                   |73.69 GB          |0.0 / 0.0 / 0.0              |30.95 GB          |

* repro commands
```bash
# baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml

# bwd-opt
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse-bwd-opt \
  --name=sparse_data_dist_bwd_opt

# shampoo baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml

# shampoo bwd-opt
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml \
  --pipeline=sparse-bwd-opt \
  --name=sparse_data_dist_bwd_opt_shampoo
```

* trace
In baseline the shampoo optimizer is after all TBE_BWD
<img width="4806" height="1850" alt="image" src="https://github.com/user-attachments/assets/eac0950b-cba8-41bf-a20e-f2e93e9939e5" />

In BWD Opt the shampoo optimizer starts with the first backward_all_to_all comms (grad all2all)
<img width="4680" height="1836" alt="image" src="https://github.com/user-attachments/assets/5686d22c-ef7b-49ef-bf25-1b2f4bd7b7dc" />

## 4. Analysis

1. **Backward injection effectiveness**: The BWD Opt pipeline successfully overlaps the dense optimizer step with backward all-to-all communication. With the default optimizer (SGD), the optimizer step is cheap and the overlap saves ~18 ms per iteration (~0.6%). With Shampoo (`precondition_frequency=100`), the more expensive optimizer step provides more computation to overlap, yielding ~85 ms savings per iteration (~2.4%). This confirms the backward hook fires at the correct point in the backward pass — during the output dist tensor's gradient computation, which coincides with the backward all-to-all.

2. **Overlap verification via trace**: The Perfetto traces confirm that `optimizer.step()` executes concurrently with the backward all-to-all NCCL kernels in the BWD Opt variant, whereas in the baseline it runs sequentially after backward completes.

   *(trace screenshots to be added)*

3. **Memory**: Peak allocated memory is nearly identical across configurations (~49 GB default, ~50 GB Shampoo). Reserved memory increases slightly in BWD Opt variants (~0.7-1.1 GB), likely due to the additional forward hook infrastructure. No malloc retries in any configuration.

4. **Scaling expectation**: The benefit scales with (a) the cost of `optimizer.step()` relative to backward all-to-all duration, and (b) the size of the dense model. In this benchmark, the dense arch is small (`[128, 128, 128]` + 5 over_arch layers), so the overlap potential is limited. Production models with larger dense components and expensive optimizers (Shampoo, LAMB) should see proportionally greater gains.
## 5. Changes

1. **`backward_injection.py`**: Replaced `BackwardHookRegistry`/`register_hooks`/`_filter_awaitables`/`_find_awaitable_for_site`/`_register_hook_on_tensor`/`_create_backward_hook` with two classes: `InjectionSite` (base, with `find_target_module`, `find_first_grad_tensor`, `register_hook`) and `OutputDistSite` (extends `InjectionSite` with sharding-type-aware `find_first_grad_tensor` for EC/EBC awaitables).

2. **`experimental_pipelines.py`** (new): Houses `TrainEvalHybridPipelineBase` (moved from train_pipelines.py), `TrainPipelineSparseDistT` (moved), and `TrainPipelineSparseDistBWDOpt` (new). The BWD Opt pipeline overrides `_pipeline_model()` to register a backward hook that calls `optimizer.step()` during backward, and overrides `progress()` to remove the explicit `optimizer.step()` call.

3. **`train_pipelines.py`**: Removed `BackwardHookRegistry` parameter, `_register_output_dist_hooks()`, JustKnobs-gated hook registration in `progress()`, and the moved experimental classes. Updated `register_backward_hook()` to directly call `site.register_hook()`.

4. **`pipeline_config.py`**: Replaced `emb_lookup_stream`/`apply_jit` fields with `kwargs: Dict[str, Any]`. Added `get_kwargs()` method with `ShardingType` auto-conversion. Added `sparse-bwd-opt` pipeline entry. Refactored `generate_pipeline()` to use `match/case` with unified default path.

5. **`sparse_data_dist_bwd_opt.yml`** (new): Benchmark config for `TrainPipelineSparseDistBWDOpt`, identical to `sparse_data_dist_base.yml` except pipeline type and kwargs (`site_fqn: "sparse.ebc"`, `sharding_type: "table_wise"`).

6. **`sparse_data_dist_bwd_opt_shampoo.yml`** (new): Benchmark config combining `TrainPipelineSparseDistBWDOpt` with Shampoo dense optimizer, for measuring overlap benefit with an expensive optimizer step. Uses existing `sparse_data_dist_shampoo.yml` as the Shampoo baseline.

7. **`test_backward_injection.py`**: Updated tests to use `OutputDistSite` instead of `InjectionSite`/`BackwardHookRegistry`. Removed `BackwardHookRegistryTest` unit tests. Updated nonexistent-site test to expect warning from `train_pipelines` logger.

8. **`sharding_config.py`**: Added `dense_optimizer_kwargs` field to `ShardingConfig` for forwarding extra kwargs to the dense optimizer constructor. Defaults Shampoo's `precondition_frequency` to 100 to amortize the expensive preconditioner computation.

9. **BUCK files**: Added `experimental_pipelines` target in `train_pipeline/BUCK`. Updated `test_utils/BUCK` with new deps.

Differential Revision: D94011313


