### PR TITLE
Add INTERPOLATE policy to WarmupPolicy

### DIFF
--- a/torchrec/optim/tests/test_warmup.py
+++ b/torchrec/optim/tests/test_warmup.py
@@ -72,3 +72,54 @@ class TestWarmupOptimizer(unittest.TestCase):
             warmup_optimizer_1.state_dict()["state"]["__warmup"],
             warmup_optimizer_2.state_dict()["state"]["__warmup"],
         )
+
+    def test_interpolate_policy(self) -> None:
+        param_1_t = torch.tensor([1.0, 2.0])
+        param_1 = Variable(param_1_t)
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, defaultdict(dict), [{"params": [param_1], "lr": 1.0}]
+        )
+        warmup_optimizer = WarmupOptimizer(
+            keyed_optimizer,
+            stages=[
+                WarmupStage(
+                    WarmupPolicy.INTERPOLATE,
+                    max_iters=200,
+                    start_interpolating_iters=100,
+                    value=0.01,
+                    end_value=0.1,
+                    lr_scale=1,
+                ),
+            ],
+            lr=1.0,
+        )
+
+        # At iter 0 (before start_interpolating_iters=100), the formula gives:
+        # multiplier = 0.01 + (0.1 - 0.01) * (0 - 100) / (200 - 100) = 0.01 - 0.09 = -0.08
+        # But typically INTERPOLATE is used starting from start_interpolating_iters
+        # Let's step to iteration 100 and verify
+        for _ in range(100):
+            warmup_optimizer.zero_grad()
+            warmup_optimizer.step()
+
+        # At iter 100: multiplier = 0.01 + (0.1 - 0.01) * (100 - 100) / (200 - 100) = 0.01
+        lr_at_100 = list(warmup_optimizer.param_groups)[0]["lr"]
+        self.assertAlmostEqual(lr_at_100, 0.01, places=5)
+
+        # Step 50 more times to iter 150
+        for _ in range(50):
+            warmup_optimizer.zero_grad()
+            warmup_optimizer.step()
+
+        # At iter 150: multiplier = 0.01 + (0.1 - 0.01) * (150 - 100) / (200 - 100) = 0.01 + 0.045 = 0.055
+        lr_at_150 = list(warmup_optimizer.param_groups)[0]["lr"]
+        self.assertAlmostEqual(lr_at_150, 0.055, places=5)
+
+        # Step 50 more times to iter 200
+        for _ in range(50):
+            warmup_optimizer.zero_grad()
+            warmup_optimizer.step()
+
+        # At iter 200: multiplier = 0.01 + (0.1 - 0.01) * (200 - 100) / (200 - 100) = 0.1
+        lr_at_200 = list(warmup_optimizer.param_groups)[0]["lr"]
+        self.assertAlmostEqual(lr_at_200, 0.1, places=5)

--- a/torchrec/optim/warmup.py
+++ b/torchrec/optim/warmup.py
@@ -11,7 +11,7 @@ import logging
 import math
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Any, List, Tuple
+from typing import Any, cast, List, Optional, Tuple
 
 import torch
 from torchrec.optim.keyed import KeyedOptimizer, OptimizerWrapper
@@ -28,6 +28,7 @@ class WarmupPolicy(Enum):
     STEP = "step"
     INVSQRT = "inv_sqrt"  # inverse square root
     COSINE_ANNEALING_WARM_RESTARTS = "cosine_annealing_warm_restarts"
+    INTERPOLATE = "interpolate"
 
 
 @dataclass
@@ -42,6 +43,9 @@ class WarmupStage:
     # default to 1 if not set to value > 0
     decay_iters: int = -1
     sgdr_period: int = 1
+    # the following are used in INTERPOLATE policy only
+    start_interpolating_iters: Optional[int] = None
+    end_value: Optional[float] = None
 
 
 def _lr_stages(stages: List[WarmupStage]) -> List[WarmupStage]:
@@ -55,6 +59,18 @@ def _lr_stages(stages: List[WarmupStage]) -> List[WarmupStage]:
             f"Max iter of the stage {stage} must be greater than the previous "
             f"max iter {start_iter}"
         )
+        if stage.policy == WarmupPolicy.INTERPOLATE:
+            assert (
+                stage.start_interpolating_iters is not None
+            ), "start_interpolating_iters must be set for INTERPOLATE policy"
+            assert (
+                stage.end_value is not None
+            ), "end_value must be set for INTERPOLATE policy"
+            assert stage.max_iters > stage.start_interpolating_iters, (
+                f"max_iters ({stage.max_iters}) must be greater than "
+                f"start_interpolating_iters ({stage.start_interpolating_iters}) "
+                "for INTERPOLATE policy to avoid division by zero"
+            )
         start_iter = stage.max_iters
         if stage.decay_iters <= 0:
             if stage.policy == WarmupPolicy.STEP:
@@ -86,6 +102,12 @@ def _get_multiplier(stage: WarmupStage, iter: int) -> float:
         t_cur = iter % t_0
         cos_iter = 0.5 * (1 + math.cos(math.pi * t_cur / t_0))
         multiplier = eta_min + (1.0 - eta_min) * cos_iter
+    elif stage.policy == WarmupPolicy.INTERPOLATE:
+        end_value = cast(float, stage.end_value)
+        start_interpolating_iters = cast(float, stage.start_interpolating_iters)
+        multiplier = stage.value + (end_value - stage.value) * (
+            iter - start_interpolating_iters
+        ) / (stage.max_iters - start_interpolating_iters)
     return multiplier * stage.lr_scale
 
 


### PR DESCRIPTION
Summary:
Add INTERPOLATE policy support to torchrec's WarmupOptimizer to enable
flexible learning rate scheduling that can start interpolation at any
iteration point.

This mirrors the INTERPOLATE policy added to apf/optim/parameter_schedule
in D79498274, allowing MVAI to use the same interpolation-based LR
scheduling.

The interpolation formula:
`value + (end_value - value) * (iter - start_interpolating_iters) / (max_iters - start_interpolating_iters)`

This is useful for variable batch size scheduling tuning where LR needs
to change after some training iterations, rather than from the start.

Differential Revision: D93950744


