### PR TITLE
Implement a write method in DMP

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -74,7 +74,6 @@ from torchrec.distributed.embedding_types import (
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
-from torchrec.distributed.model_tracker.types import IndexedLookup
 from torchrec.distributed.shards_wrapper import LocalShardsWrapper
 from torchrec.distributed.types import (
     LazyAwaitable,

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -498,6 +498,7 @@ class ShardedEmbeddingCollection(
         self._write_splits: List[int] = []
         self._feature_splits: List[int] = []
         self._features_order: List[int] = []
+        self._writable_embedding_names: set[str] = set()
 
         self._has_uninitialized_input_dist: bool = True
         logger.info(f"EC index dedup enabled: {self._use_index_dedup}.")
@@ -1685,6 +1686,7 @@ class ShardedEmbeddingCollection(
             if sharding.enable_embedding_update:
                 self._write_dists.append(sharding.create_write_dist())
                 self._write_splits.append(sharding._get_num_writable_features())
+                self._writable_embedding_names.update(sharding.embedding_names())
 
     # pyrefly: ignore[bad-override]
     def write_dist(
@@ -1694,6 +1696,10 @@ class ShardedEmbeddingCollection(
             raise ValueError("enable_embedding_update is False for this collection")
         if not self._write_dists:
             self._create_write_dist()
+        if set(embeddings.keys()) != self._writable_embedding_names:
+            raise ValueError(
+                f"write_dist feature names {embeddings.keys()} do not match expected {self._writable_embedding_names}"
+            )
         with torch.no_grad():
             embeddings_by_shards = embeddings.split(self._write_splits)
             awaitables = []

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -11,6 +11,7 @@ import abc
 import copy
 import logging as logger
 from collections import defaultdict, OrderedDict
+from functools import wraps
 from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Set, Tuple, Type
 
 import torch
@@ -30,6 +31,7 @@ from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.collective_utils import create_on_rank_and_share_result
 from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.model_tracker.model_delta_tracker import (
     ModelDeltaTracker,
     ModelDeltaTrackerTrec,
@@ -40,7 +42,6 @@ from torchrec.distributed.model_tracker.types import (
     ModelTrackerConfigs,
     RawIdTrackerConfig,
     Trackers,
-    UniqueRows,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.sharding_plan import get_default_sharders
@@ -61,7 +62,6 @@ from torchrec.distributed.utils import (
     append_prefix,
     copy_to_device,
     filter_state_dict,
-    none_throws,
     sharded_model_copy,
 )
 from torchrec.optim.fused import FusedOptimizerModule
@@ -75,6 +75,40 @@ except OSError:
 
 
 _DDP_STATE_DICT_PREFIX = "module."
+
+
+def _populate_updatable_modules(
+    func: Callable[..., nn.Module],
+) -> Callable[..., nn.Module]:
+    """
+    Decorator that populates the list of modules that can be updated with kjt.
+    Specifically, modules with enable_embedding_update flag set to True.
+
+    Applied to _shard_modules_impl to automatically process returned modules.
+    """
+
+    @wraps(func)
+    def wrapper(
+        self: "DistributedModelParallel",
+        module: nn.Module,
+        path: str = "",
+        module_id_cache: Optional[Dict[str, "ShardedModule"]] = None,
+    ) -> nn.Module:
+        result = func(self, module, path, module_id_cache)
+
+        module_id = id(result)
+        if module_id_cache and module_id in module_id_cache:
+            # skip adding duplicate one
+            return result
+
+        if isinstance(result, ShardedEmbeddingCollection) and getattr(
+            result, "enable_embedding_update", False
+        ):
+            self._writable_sharded_modules.append(result)
+
+        return result
+
+    return wrapper
 
 
 class DataParallelWrapper(abc.ABC):
@@ -297,6 +331,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                 # pyrefly: ignore[bad-argument-type, missing-argument]
                 plan = planner.plan(module, self.sharders)
         self._plan: ShardingPlan = plan
+        self._writable_sharded_modules: list[ShardedEmbeddingCollection] = []
         self._dmp_wrapped_module: nn.Module = self._init_dmp(module)
         self._optim: CombinedOptimizer = self._init_optim(self._dmp_wrapped_module)
 
@@ -462,6 +497,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             )
         return fused_optims
 
+    @_populate_updatable_modules
     def _shard_modules_impl(
         self,
         module: nn.Module,
@@ -612,6 +648,18 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         strict: bool = True,
     ) -> _IncompatibleKeys:
         return self._load_state_dict(self, state_dict, prefix, strict)
+
+    def write(self, *input, **kwargs) -> None:
+        """
+        Write features to the sharded module if it has enable_embedding_update flag.
+        """
+        if len(self._writable_sharded_modules) == 0:
+            raise RuntimeError(
+                "No writable sharded modules found. Please check `enable_embedding_update` flag in your embedding config"
+            )
+
+        for module in self._writable_sharded_modules:
+            module.write(*input, **kwargs)
 
     def _load_state_dict(
         self,

--- a/torchrec/distributed/tests/test_embedding_update.py
+++ b/torchrec/distributed/tests/test_embedding_update.py
@@ -41,57 +41,74 @@ class TestECModel(nn.Module):
         return self.ec(features)
 
 
+class ExpectedMsgNotFoundException(Exception):
+    pass
+
+
 class TestEmbeddingUpdate(MultiProcessTestBase):
+    # Note all tests are disabled on OSS due to incompatibility
+
+    def _gpu_check(self, world_size: int) -> None:
+        if torch.cuda.device_count() < world_size:
+            self.skipTest(
+                f"Not enough GPUs, this test requires at least {world_size} GPUs"
+            )
+
+    def _get_example_configs_and_input(
+        self,
+    ) -> tuple[list[EmbeddingConfig], list[KeyedJaggedTensor]]:
+        return (
+            [
+                EmbeddingConfig(
+                    num_embeddings=8000,
+                    embedding_dim=64,
+                    name="table_0",
+                    feature_names=["feature_0", "feature_1"],
+                    total_num_buckets=20,
+                    use_virtual_table=True,
+                    enable_embedding_update=True,
+                    virtual_table_eviction_policy=NoEvictionPolicy(),
+                ),
+                EmbeddingConfig(
+                    num_embeddings=8000,
+                    embedding_dim=64,
+                    name="table_1",
+                    feature_names=["feature_2"],
+                    total_num_buckets=40,
+                    use_virtual_table=True,
+                    enable_embedding_update=True,
+                    virtual_table_eviction_policy=NoEvictionPolicy(),
+                ),
+                EmbeddingConfig(
+                    num_embeddings=8000,
+                    embedding_dim=64,
+                    name="table_2",
+                    feature_names=["feature_3"],
+                ),
+            ],
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1", "feature_2", "feature_3"],
+                    values=torch.randint(0, 8000, (13,)),
+                    lengths=torch.LongTensor([2, 1, 1, 1, 1, 1, 2, 0, 1, 1, 2, 0]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1", "feature_2", "feature_3"],
+                    values=torch.randint(0, 8000, (12,)),
+                    lengths=torch.LongTensor([1, 1, 1, 1, 1, 1, 0, 0, 3, 1, 0, 2]),
+                ),
+            ],
+        )
 
     def test_sharded_embedding_update_disabled_in_oss_compatibility(
         self,
         # sharding_type: str,
         # kernel_type: str,
     ) -> None:
-        if torch.cuda.device_count() <= 1:
-            self.skipTest("Not enough GPUs, this test requires at least two GPUs")
         WORLD_SIZE = 2
-        tables = [
-            EmbeddingConfig(
-                num_embeddings=8000,
-                embedding_dim=64,
-                name="table_0",
-                feature_names=["feature_0", "feature_1"],
-                total_num_buckets=20,
-                use_virtual_table=True,
-                enable_embedding_update=True,
-                virtual_table_eviction_policy=NoEvictionPolicy(),
-            ),
-            EmbeddingConfig(
-                num_embeddings=8000,
-                embedding_dim=64,
-                name="table_1",
-                feature_names=["feature_2"],
-                total_num_buckets=40,
-                use_virtual_table=True,
-                enable_embedding_update=True,
-                virtual_table_eviction_policy=NoEvictionPolicy(),
-            ),
-            EmbeddingConfig(
-                num_embeddings=8000,
-                embedding_dim=64,
-                name="table_2",
-                feature_names=["feature_3"],
-            ),
-        ]
+        self._gpu_check(WORLD_SIZE)
+        tables, inputs_per_rank = self._get_example_configs_and_input()
         backend = "nccl"
-        inputs_per_rank = [  # noqa
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=["feature_0", "feature_1", "feature_2", "feature_3"],
-                values=torch.randint(0, 8000, (13,)),
-                lengths=torch.LongTensor([2, 1, 1, 1, 1, 1, 2, 0, 1, 1, 2, 0]),
-            ),
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=["feature_0", "feature_1", "feature_2", "feature_3"],
-                values=torch.randint(0, 8000, (12,)),
-                lengths=torch.LongTensor([1, 1, 1, 1, 1, 1, 0, 0, 3, 1, 0, 2]),
-            ),
-        ]
         embeddings_per_rank = [
             KeyedJaggedTensor.from_lengths_sync(
                 keys=["feature_0", "feature_1", "feature_2"],
@@ -124,6 +141,137 @@ class TestEmbeddingUpdate(MultiProcessTestBase):
             embeddings_per_rank=embeddings_per_rank,
         )
 
+    def test_embedding_update_through_dmp_success_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
+        WORLD_SIZE = 2
+        self._gpu_check(WORLD_SIZE)
+        tables, inputs_per_rank = self._get_example_configs_and_input()
+        embeddings_per_rank = [
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1", "feature_2"],
+                values=torch.cat(
+                    (
+                        input["feature_0"].values(),
+                        input["feature_1"].values(),
+                        input["feature_2"].values(),
+                    )
+                ),
+                lengths=input.lengths()[: -input["feature_3"].lengths().size(0)],
+                weights=torch.rand(
+                    int(
+                        torch.sum(
+                            input.lengths()[: -input["feature_3"].lengths().size(0)]
+                        ).item()
+                    ),
+                    64,
+                    dtype=torch.float32,
+                ),
+            )
+            for input in inputs_per_rank
+        ]
+        self._run_multi_process_test(
+            callable=sharded_embedding_update,
+            world_size=WORLD_SIZE,
+            tables=tables,
+            backend="nccl",
+            inputs_per_rank=inputs_per_rank,
+            embeddings_per_rank=embeddings_per_rank,
+            update_through_dmp=True,
+        )
+
+    def test_embedding_update_through_dmp_fail_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
+        WORLD_SIZE = 2
+        self._gpu_check(WORLD_SIZE)
+        tables, inputs_per_rank = self._get_example_configs_and_input()
+        # feature 2 doesn't exist, should error out
+        embeddings_per_rank = [
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.cat(
+                    (
+                        input["feature_0"].values(),
+                        input["feature_1"].values(),
+                    )
+                ),
+                lengths=input.lengths()[
+                    : -(
+                        input["feature_3"].lengths().size(0)
+                        + input["feature_2"].lengths().size(0)
+                    )
+                ],
+                weights=torch.rand(
+                    int(
+                        torch.sum(
+                            input.lengths()[
+                                : -(
+                                    input["feature_2"].lengths().size(0)
+                                    + input["feature_3"].lengths().size(0)
+                                )
+                            ]
+                        ).item()
+                    ),
+                    64,
+                    dtype=torch.float32,
+                ),
+            )
+            for input in inputs_per_rank
+        ]
+        self._run_multi_process_test(
+            callable=sharded_embedding_update,
+            world_size=WORLD_SIZE,
+            tables=tables,
+            backend="nccl",
+            inputs_per_rank=inputs_per_rank,
+            embeddings_per_rank=embeddings_per_rank,
+            update_through_dmp=True,
+            expected_failure_msg="write_dist feature names",
+        )
+
+    def test_embedding_update_config_not_enabled_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
+        WORLD_SIZE = 2
+        self._gpu_check(WORLD_SIZE)
+        tables, inputs_per_rank = self._get_example_configs_and_input()
+        for table in tables:
+            table.enable_embedding_update = False
+        embeddings_per_rank = [
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1", "feature_2"],
+                values=torch.cat(
+                    (
+                        input["feature_0"].values(),
+                        input["feature_1"].values(),
+                        input["feature_2"].values(),
+                    )
+                ),
+                lengths=input.lengths()[: -input["feature_3"].lengths().size(0)],
+                weights=torch.rand(
+                    int(
+                        torch.sum(
+                            input.lengths()[: -input["feature_3"].lengths().size(0)]
+                        ).item()
+                    ),
+                    64,
+                    dtype=torch.float32,
+                ),
+            )
+            for input in inputs_per_rank
+        ]
+        self._run_multi_process_test(
+            callable=sharded_embedding_update,
+            world_size=WORLD_SIZE,
+            tables=tables,
+            backend="nccl",
+            inputs_per_rank=inputs_per_rank,
+            embeddings_per_rank=embeddings_per_rank,
+            update_through_dmp=True,
+            expected_failure_msg="No writable sharded modules found",
+        )
+
 
 def sharded_embedding_update(
     rank: int,
@@ -133,6 +281,10 @@ def sharded_embedding_update(
     embeddings_per_rank: List[KeyedJaggedTensor],
     inputs_per_rank: List[KeyedJaggedTensor],
     local_size: Optional[int] = None,
+    update_through_dmp: bool = False,  # update through DMP or ShardedEmbeddingCollection
+    expected_failure_msg: (
+        str | None
+    ) = None,  # a string that will appear in the error message if the test fails
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         assert ctx.pg is not None
@@ -174,10 +326,31 @@ def sharded_embedding_update(
         kjts = inputs_per_rank[rank]
         sharded_model(kjts.to(ctx.device))
         torch.cuda.synchronize()
-        # pyrefly: ignore[missing-attribute]
-        sharded_model._dmp_wrapped_module.ec.write(
-            embeddings_per_rank[rank].to(ctx.device)
-        )
+        failure_raised = False
+        try:
+            if update_through_dmp:
+                sharded_model.write(embeddings_per_rank[rank].to(ctx.device))
+            else:
+                # pyrefly: ignore[missing-attribute]
+                sharded_model._dmp_wrapped_module.ec.write(
+                    embeddings_per_rank[rank].to(ctx.device)
+                )
+        except Exception as e:
+            failure_raised = True
+            if expected_failure_msg is None:
+                raise ExpectedMsgNotFoundException(
+                    f"Expected failure message is None but an exception was raised: {e}"
+                )
+            if expected_failure_msg not in str(e):
+                raise ExpectedMsgNotFoundException(
+                    f"Expected failure message {expected_failure_msg} not found in the actual exception: {e}"
+                )
+            return
+
+        assert (
+            expected_failure_msg is None and not failure_raised
+        ), "Expected the run to fail but it succeeded"
+
         torch.cuda.synchronize()
         expected_embeddings = {
             key: embeddings_per_rank[rank][key].weights()


### PR DESCRIPTION
Summary:
TorchRec allows users to create embeddings with custom input. This was done in D78749760.
In this diff I expose this method to DistributedDataParallel (DMP), so that for modules with config enable_embedding_update = True, DMP will be able to update the embeddings with custom input.

Differential Revision: D93914739


