### PR TITLE
test-gen claude skill

### DIFF
--- a/torchrec/.claude/skills/pr-review/bc-guidelines.md
+++ b/torchrec/.claude/skills/pr-review/bc-guidelines.md
@@ -1,0 +1,171 @@
+# TorchRec Backward Compatibility Guidelines
+
+TorchRec is an open-source PyTorch domain library with external users. Any change to user-visible behavior is potentially BC-breaking and must be evaluated carefully.
+
+## What Is a Public API in TorchRec
+
+An API is **public** if:
+- It lives outside the `fb/` directory
+- Its name does not start with `_`
+- It is exported via `__init__.py`
+- It appears in public documentation or examples (`github/examples/`)
+
+**Key public surfaces:**
+- `torchrec.modules` - `EmbeddingBagCollection`, `EmbeddingCollection`, configs
+- `torchrec.sparse` - `KeyedJaggedTensor`, `KeyedTensor`, `JaggedTensor`
+- `torchrec.distributed` - `DistributedModelParallel`, sharders, `TrainPipelineSparseDist`, planner
+- `torchrec.distributed.types` - `ShardingType`, `LazyAwaitable`, `ParameterSharding`
+- `torchrec.optim` - `KeyedOptimizer`, fused optimizers
+- `torchrec.metrics` - All `RecMetric` subclasses
+
+**Note:** Code in `torchrec/fb/` is Meta-internal and not subject to OSS BC requirements, but still affects internal users.
+
+## What Constitutes a BC-Breaking Change
+
+### API Changes
+
+| Change Type | BC Impact | Action Required |
+|-------------|-----------|-----------------|
+| Removing a public class/function | Breaking | Deprecation period required |
+| Renaming a public API | Breaking | Deprecation period required |
+| Removing/reordering function arguments | Breaking | Deprecation period required |
+| Adding required arguments without defaults | Breaking | Add default value instead |
+| Changing argument defaults | Potentially breaking | Document in release notes |
+| Changing return type | Breaking | Deprecation period required |
+| Changing `ShardingType` enum values | Breaking | Never change existing values; only add new ones |
+| Modifying `EmbeddingBagConfig` fields | Potentially breaking | New fields must have defaults |
+
+### Behavioral Changes
+
+| Change Type | BC Impact | Action Required |
+|-------------|-----------|-----------------|
+| Changing KJT construction semantics | Breaking | KJT is the primary input format; changes affect all users |
+| Changing default sharding strategy | Potentially breaking | May change performance characteristics silently |
+| Changing embedding output layout | Breaking | Downstream models depend on output tensor shapes |
+| New exceptions from existing APIs | Potentially breaking | Document and ensure it's expected |
+| Changing planner heuristics | Potentially breaking | May produce different sharding plans for same inputs |
+
+## Common BC Pitfalls in TorchRec
+
+### 1. KeyedJaggedTensor Changes
+
+KJT is the most widely used data structure. Changes are high-risk.
+
+**Bad:**
+```python
+# Changing the meaning of lengths
+# Before: lengths per feature per batch
+# After: cumulative offsets
+kjt = KeyedJaggedTensor(keys=keys, values=values, lengths=offsets)  # BREAKING
+```
+
+**Good:**
+```python
+# Add new parameter with default that preserves old behavior
+kjt = KeyedJaggedTensor(
+    keys=keys, values=values, lengths=lengths,
+    offsets=offsets,  # New optional parameter
+)
+```
+
+### 2. EmbeddingBagConfig Changes
+
+**Bad:**
+```python
+# Adding a required field
+@dataclass
+class EmbeddingBagConfig:
+    name: str
+    embedding_dim: int
+    num_embeddings: int
+    new_required_field: str  # BREAKING - no default
+```
+
+**Good:**
+```python
+@dataclass
+class EmbeddingBagConfig:
+    name: str
+    embedding_dim: int
+    num_embeddings: int
+    new_field: str = ""  # Has default, backward compatible
+```
+
+### 3. Sharding Type Additions
+
+**Safe:** Adding a new `ShardingType` enum value is safe IF all switch/match statements have a default case or raise `NotImplementedError`.
+
+**Unsafe:** If code uses exhaustive matching (explicit check for each variant), adding a new variant can cause runtime errors in user code.
+
+### 4. DistributedModelParallel Signature
+
+**Bad:**
+```python
+# Reordering args breaks positional callers
+class DistributedModelParallel:
+    def __init__(self, module, sharders, device):  # Was: module, device, sharders
+```
+
+**Good:**
+```python
+# New args at end with defaults
+class DistributedModelParallel:
+    def __init__(self, module, device, sharders=None, new_param=None):
+```
+
+### 5. Changing Module State Dict Keys
+
+**Bad:**
+```python
+# Renaming internal parameters changes state_dict keys
+# Before: model.embedding.weight
+# After: model._embedding.weight  # BREAKING - saved models can't load
+```
+
+Changing state dict keys breaks model loading for all saved checkpoints. This requires explicit migration support.
+
+## Deprecation Pattern
+
+```python
+import warnings
+
+def old_function(x, old_arg=None, new_arg=None):
+    if old_arg is not None:
+        warnings.warn(
+            "old_arg is deprecated and will be removed in a future release. "
+            "Use new_arg instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        new_arg = old_arg
+    # ... rest of implementation
+```
+
+Use `FutureWarning` (not `DeprecationWarning`) for user-facing APIs so warnings are visible by default.
+
+## When BC Breaks Are Acceptable
+
+### With Deprecation
+1. Deprecation warning added for at least one release
+2. Migration path documented
+3. Release notes updated
+
+### Without Deprecation (Rare)
+- Security vulnerabilities
+- Serious bugs making the API unusable
+- APIs explicitly marked experimental
+
+## Review Checklist for BC
+
+When reviewing a TorchRec diff, check:
+
+- [ ] **No removed public APIs** - Or proper deprecation path exists
+- [ ] **No changed signatures** - Or new args have defaults and are appended at the end
+- [ ] **No changed defaults** - Or deprecation warning added
+- [ ] **No changed return types/shapes** - Especially embedding output tensors
+- [ ] **No changed KJT semantics** - Construction, splitting, permutation behavior preserved
+- [ ] **No changed state dict keys** - Module parameter names unchanged
+- [ ] **No changed ShardingType behavior** - Existing sharding types produce same results
+- [ ] **No changed planner output** - Same inputs produce same sharding plans (or change is intentional and documented)
+- [ ] **Deprecation uses FutureWarning** - Not `DeprecationWarning`
+- [ ] **Deprecation has stacklevel=2** - Points to user code, not library internals

--- a/torchrec/.claude/skills/pr-review/review-checklist.md
+++ b/torchrec/.claude/skills/pr-review/review-checklist.md
@@ -1,0 +1,118 @@
+# TorchRec Review Checklist
+
+This checklist covers areas that CI and linters cannot check. Skip items related to formatting, import ordering, and type checking (handled by `arc lint` and `arc pyre`).
+
+## Distributed Correctness
+
+### Collective Operations
+
+- [ ] **Matching collectives** - Every `all_reduce`, `all_gather`, `reduce_scatter`, `all_to_all` is called by ALL ranks in the process group. Missing a collective on any rank causes a hang.
+- [ ] **Consistent arguments** - Collective tensor shapes, dtypes, and op types match across ranks. Mismatches cause silent data corruption or NCCL errors.
+- [ ] **Correct process group** - Operations use the intended process group, not the default. Check for `pg` vs `ctx.pg` vs `dist.group.WORLD` confusion.
+- [ ] **Async ops completed** - Any `async_op=True` collective has a corresponding `.wait()` before the result is consumed.
+- [ ] **No rank-conditional collectives** - Code like `if rank == 0: dist.all_reduce(...)` is almost always wrong. All ranks must participate.
+
+### Sharding Safety
+
+- [ ] **All ShardingType variants handled** - When switching on `ShardingType`, all 7 variants are covered: `TABLE_WISE`, `ROW_WISE`, `COLUMN_WISE`, `TABLE_ROW_WISE`, `TABLE_COLUMN_WISE`, `GRID_SHARD`, `DATA_PARALLEL`. Missing a variant causes silent fallthrough or runtime errors.
+- [ ] **Shard metadata consistency** - `ShardedTensorMetadata` (sizes, offsets, placements) is consistent across ranks. Inconsistencies cause incorrect lookups.
+- [ ] **Correct device placement** - Tensors created during sharding are on the expected device. Watch for accidental CPU tensors in GPU sharding paths.
+- [ ] **LazyAwaitable usage** - `_wait_impl` returns the correct tensor. The awaitable is not `.wait()`'d prematurely (which defeats pipelining).
+- [ ] **Input distribution correctness** - `KJT` splitting/redistribution preserves feature keys ordering and lengths-values correspondence.
+
+### Pipeline Safety
+
+- [ ] **Pipeline stage ordering** - `TrainPipelineSparseDist` stages (sparse data dist, forward, backward) maintain correct data flow dependencies.
+- [ ] **No eager waits in pipeline** - Operations that should be deferred via `LazyAwaitable` are not eagerly awaited, which would serialize communication and computation.
+- [ ] **Fused optimizer consistency** - Fused optimizer parameters match the sharded embedding tables. Adding/removing tables without updating the optimizer causes silent training bugs.
+
+## FBGEMM Integration
+
+- [ ] **Correct kernel selection** - `SplitTableBatchedEmbeddingBagsCodegen` for training, `IntNBitTableBatchedEmbeddingBagsCodegen` for quantized inference. Using the wrong one causes incorrect results.
+- [ ] **Op loading guards** - FBGEMM ops loaded with try/except: `torch.ops.load_library(...)` wrapped in `try/except OSError`.
+- [ ] **Config alignment** - `EmbeddingLocation`, `ComputeDevice`, `PoolingMode`, `SparseType` values are consistent between TorchRec configs and FBGEMM kernel configs.
+- [ ] **Batch size handling** - FBGEMM kernels have specific requirements for batch size alignment. Verify batch dimensions are correct.
+
+## Code Quality
+
+### TorchRec Patterns
+
+- [ ] **Match existing patterns** - Code follows architectural patterns already in TorchRec (ABC interfaces, dataclass configs, enum patterns)
+- [ ] **Config via dataclass** - Configuration uses `@dataclass` with typed fields and defaults, not dicts or kwargs
+- [ ] **Enum for variants** - Enumerated options use `@unique class MyEnum(Enum)`, not string constants
+- [ ] **ABC for interfaces** - Module interfaces inherit from both `abc.ABC` and `nn.Module`
+- [ ] **No dynamic attribute access** - Avoid `setattr`/`getattr` for state management; use explicit class members
+
+### Code Clarity
+
+- [ ] **Self-explanatory code** - Variable and function names convey intent
+- [ ] **Useful comments only** - Comments explain non-obvious context (e.g., why a specific sharding order matters), not what the code does
+- [ ] **No backward-compatibility hacks** - Unused code is deleted, not renamed with underscores
+- [ ] **Appropriate complexity** - Solutions are as simple as possible for the current requirements
+
+### Common Issues to Flag
+
+- Magic numbers without explanation (especially embedding dimensions, batch sizes, world sizes)
+- Copy-pasted sharding logic that should be a shared helper
+- Overly defensive error handling for impossible cases
+- `Optional` parameters that are never actually `None` in practice
+
+## Testing
+
+### Test Existence
+
+- [ ] **Tests exist** - New functionality has corresponding tests
+- [ ] **Tests in correct location** - Tests are at `$(dirname)/test(s)/` following TorchRec convention
+- [ ] **Distributed code has distributed tests** - Any change to distributed/ requires `MultiProcessTestBase` tests
+
+### Distributed Test Patterns
+
+- [ ] **Uses MultiProcessTestBase** - Distributed tests inherit from `MultiProcessTestBase` and use `_run_multi_process_test`
+- [ ] **Test function signature** - Test callable follows `_test_func(rank: int, world_size: int, **kwargs) -> None` pattern
+- [ ] **MultiProcessContext** - Test function uses `with MultiProcessContext(rank, world_size, backend="gloo") as ctx:` for setup
+- [ ] **Multiple world sizes** - Tests cover at least `world_size=2`; ideally also `world_size=4` for sharding strategies that behave differently
+- [ ] **Backend selection** - Tests use `gloo` backend (not `nccl`) unless specifically testing GPU collective behavior
+
+### Test Quality
+
+- [ ] **Edge cases covered** - Empty KJT (no features), single-rank world, zero-length embeddings, single-feature tables
+- [ ] **Error conditions tested** - Expected exceptions tested with `assertRaises` or `assertRaisesRegex`
+- [ ] **Sharding type coverage** - If testing a sharder, relevant `ShardingType` variants are tested
+- [ ] **Deterministic** - Tests set seeds via `seed_and_log` from `torchrec.test_utils`, no flaky assertions on floating point equality without tolerance
+
+### Common Testing Issues
+
+- Tests that only check `world_size=2` for sharding strategies that partition differently at higher world sizes
+- Distributed tests missing cleanup (process group destruction)
+- Tests that hardcode CUDA device without checking availability
+- Missing tests for the interaction between pipeline stages
+
+## Performance
+
+### Memory
+
+- [ ] **No unnecessary tensor copies** - Avoid `.clone()`, `.contiguous()`, or `.to(device)` in hot paths when not needed
+- [ ] **Gradient memory** - Proper use of `torch.no_grad()` and `.detach()` to avoid retaining computation graphs
+- [ ] **Embedding table memory** - New tables or increased dimensions accounted for in memory estimates
+- [ ] **KJT materialization** - Avoid materializing dense tensors from sparse KJT representations unnecessarily
+
+### GPU Utilization
+
+- [ ] **Overlap communication and compute** - Pipelined operations use `async_op=True` where possible
+- [ ] **No unnecessary synchronization** - Avoid `torch.cuda.synchronize()` or `.item()` in training loops
+- [ ] **Batch size efficiency** - FBGEMM kernels perform best with specific batch size alignments
+
+### Common Performance Issues
+
+- Creating new tensors inside training loops instead of pre-allocating
+- Synchronous collective operations where async would work
+- Redundant `all_to_all` operations that could be batched
+- KJT permutation/splitting done eagerly when it could be deferred
+
+## OSS Boundary
+
+- [ ] **No public-to-internal imports** - Code outside `fb/` must NOT import from `torchrec/fb/` or any `fb/` subdirectory
+- [ ] **License headers** - Public files use BSD license header, not Meta confidential
+- [ ] **`# pyre-strict`** - All Python files include `# pyre-strict` after the copyright header
+- [ ] **Internal features gated** - If a public module has internal extensions, they are registered via the `fb/` module's `__init__.py`, not hard-coded in public code
+- [ ] **No internal dependencies in public BUCK targets** - Public build targets should not depend on `//torchrec/fb/...` targets

--- a/torchrec/.claude/skills/test-gen/SKILL.md
+++ b/torchrec/.claude/skills/test-gen/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: test-gen
+argument-hint: [file-path or "local"]
+description: Generate tests for TorchRec source files with correct patterns (unit, distributed, hypothesis), proper BUCK targets, and test utilities. Use when asked to generate tests, add test coverage, or write tests for a module.
+allowed-tools: Read, Write, Edit, Bash(sl:*), Bash(buck2:*), Grep, Glob, Task
+---
+
+# TorchRec Test Generator
+
+Generate idiomatic TorchRec tests by reading source files, detecting the appropriate test type, scaffolding test code with correct patterns, and creating/updating BUCK targets.
+
+## Usage Modes
+
+### File Path Mode
+
+```
+/test-gen torchrec/distributed/sharding/my_sharder.py
+/test-gen torchrec/modules/new_module.py
+```
+
+Generate tests for the specified source file.
+
+### Auto-Detect Mode
+
+```
+/test-gen local
+/test-gen
+```
+
+Detect changed files via `sl status` and generate tests for new/modified source files that lack test coverage.
+
+## Workflow
+
+### Phase 1: Identify Source Files
+
+**File path mode:** Read the specified file.
+
+**Auto-detect mode:**
+1. Run `sl status` to find changed files
+2. Filter to `.py` source files in `torchrec/` (exclude test files, `__init__.py`, BUCK files)
+3. For each source file, check if a corresponding test file exists at `$(dirname)/test(s)/test_$(basename)`
+4. Present the list of untested files and ask the user which to generate tests for
+
+### Phase 2: Analyze Source Code
+
+Read the source file and classify it:
+
+**Detection rules (in priority order):**
+
+1. **Distributed test** if ANY of:
+   - File is under `torchrec/distributed/`
+   - Imports from `torch.distributed`, `torchrec.distributed`, or uses `ProcessGroup`
+   - Defines sharders, sharded modules, or uses `ShardingType`
+   - Uses `LazyAwaitable`, `all_to_all`, `all_reduce`, `all_gather`
+
+2. **Hypothesis-parameterized test** if ANY of:
+   - Source defines enums, configs, or strategies with multiple variants
+   - Source handles multiple `ShardingType` or `EmbeddingComputeKernel` values
+   - Source has branching behavior based on config parameters
+
+3. **Unit test** (default) if:
+   - File is under `torchrec/modules/`, `torchrec/sparse/`, `torchrec/optim/`, `torchrec/metrics/`
+   - No distributed primitives used
+
+A file can be **both** distributed AND hypothesis-parameterized.
+
+Extract from the source file:
+- Public classes and their methods
+- Public functions
+- Constructor signatures and required arguments
+- Key data types (KJT, EBC, KeyedTensor, etc.)
+- Dependencies and imports needed for tests
+
+### Phase 3: Determine Test Location
+
+Follow TorchRec convention:
+- Source: `torchrec/foo/bar/my_module.py`
+- Test: `torchrec/foo/bar/tests/test_my_module.py`
+
+If a `tests/` directory doesn't exist, create it.
+If a test file already exists, **add new test methods** rather than overwriting.
+
+### Phase 4: Generate Test Code
+
+Generate tests following the patterns below. See [test-patterns.md](test-patterns.md) for complete templates.
+
+**For all test types:**
+- BSD license header + `# pyre-strict`
+- Type hints on all methods (return `-> None` for test methods)
+- Use `self.assertEqual`, `self.assertTrue`, `torch.testing.assert_close` for assertions
+- Cover: happy path, edge cases (empty inputs, single element), error conditions
+- Name tests descriptively: `test_<what>_<condition>`
+
+**For unit tests:**
+- Inherit from `unittest.TestCase`
+- Test each public method/function independently
+- For modules: test `forward()` with representative inputs, verify output shapes and types
+
+**For distributed tests:**
+- Inherit from `MultiProcessTestBase`
+- Use `@staticmethod` or module-level `_test_func(rank, world_size, **kwargs)` pattern
+- Wrap per-rank logic in `with MultiProcessContext(rank, world_size, backend) as ctx:`
+- Default `world_size=2`, add `world_size=4` for sharding tests
+- Use `backend="gloo"` unless testing GPU-specific behavior
+- Add `@unittest.skipIf(torch.cuda.device_count() < N, "Not enough GPUs...")` for CUDA tests
+
+**For hypothesis tests:**
+- Add `@given(...)` with `st.sampled_from([...])` for enum/config parameters
+- Add `@settings(verbosity=Verbosity.verbose, max_examples=N, deadline=None)`
+- Use `assume()` to filter invalid parameter combinations
+- Keep `max_examples` reasonable (4-8 for distributed tests, 10-20 for unit tests)
+
+### Phase 5: Create/Update BUCK Target
+
+Read the existing BUCK file in the `tests/` directory (or create one if it doesn't exist).
+
+**For CPU-only unit tests:**
+```python
+python_unittest(
+    name = "test_my_module",
+    srcs = ["test_my_module.py"],
+    deps = [
+        "//caffe2:_torch",
+        # ... source deps ...
+    ],
+)
+```
+
+**For GPU/distributed tests:**
+```python
+python_unittest(
+    name = "test_my_module",
+    srcs = ["test_my_module.py"],
+    remote_execution = re_test_utils.remote_execution(
+        mig = "false",
+        platform = "gpu-remote-execution",
+        resource_units = 2,
+    ),
+    deps = [
+        "//caffe2:_torch",
+        "//torchrec/distributed/test_utils:multi_process",
+        # ... source deps ...
+    ],
+)
+```
+
+**If hypothesis is used, add:**
+```python
+    supports_static_listing = False,
+```
+and add to deps:
+```python
+    "fbsource//third-party/pypi/hypothesis:hypothesis",
+```
+
+**BUCK rules:**
+- Use `load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")` for standard tests
+- Add `load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")` for GPU tests
+- Include `oncall("torchrec")` if already present in the BUCK file
+- Derive deps from the test file's imports — map each `torchrec.*` import to its BUCK target by checking the source directory's BUCK file
+
+### Phase 6: Verify
+
+1. Ask the user to review the generated test file
+2. Suggest running the test:
+   ```
+   buck2 test fbcode//torchrec/path/to/tests:test_my_module
+   ```
+3. If hypothesis is used, suggest running with more examples:
+   ```
+   buck2 test fbcode//torchrec/path/to/tests:test_my_module -- -s
+   ```
+
+## Test Utilities Reference
+
+Use these utilities when generating tests:
+
+| Utility | Import | When to Use |
+|---------|--------|-------------|
+| `MultiProcessTestBase` | `torchrec.distributed.test_utils.multi_process` | All distributed tests |
+| `MultiProcessContext` | `torchrec.distributed.test_utils.multi_process` | Per-rank setup/teardown |
+| `ModelInput` | `torchrec.distributed.test_utils.test_model` | Generating test inputs for models |
+| `TestSparseNN` | `torchrec.distributed.test_utils.test_model` | Test model with embedding tables |
+| `sharding_single_rank_test` | `torchrec.distributed.test_utils.test_sharding` | Testing sharders |
+| `create_test_sharder` | `torchrec.distributed.test_utils.test_sharding` | Creating test sharder instances |
+| `skip_if_asan_class` | `torchrec.test_utils` | Skip entire class under ASAN |
+| `seed_and_log` | `torchrec.test_utils` | Deterministic seeding with logging |
+| `get_free_port` | `torchrec.test_utils` | Getting available port for dist init |
+
+## Constraints
+
+- NEVER overwrite existing test methods. Add new methods to existing test classes or create new classes.
+- NEVER add tests for private methods (starting with `_`) unless they contain complex logic that's critical to test.
+- ALWAYS match the import style of the source file (modern `list[str]` vs `List[str]`).
+- ALWAYS check if similar tests already exist before generating duplicates.
+- Keep generated tests focused and minimal — don't test framework behavior or trivial getters/setters.
+
+## Instructions from User
+
+<instructions>$ARGUMENTS</instructions>

--- a/torchrec/.claude/skills/test-gen/test-patterns.md
+++ b/torchrec/.claude/skills/test-gen/test-patterns.md
@@ -1,0 +1,382 @@
+# TorchRec Test Patterns Reference
+
+Complete templates for each test type. Use these as scaffolding when generating tests.
+
+## File Header (All Test Files)
+
+```python
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+```
+
+## Unit Test Template
+
+For non-distributed code in `torchrec/modules/`, `torchrec/sparse/`, `torchrec/optim/`, `torchrec/metrics/`.
+
+```python
+import unittest
+
+import torch
+# Import the module under test
+from torchrec.modules.my_module import MyModule, MyConfig
+
+
+class TestMyModule(unittest.TestCase):
+    def setUp(self) -> None:
+        self.device = torch.device("cpu")
+        self.config = MyConfig(
+            # ... representative config ...
+        )
+
+    def test_forward_basic(self) -> None:
+        """Test forward pass with standard inputs."""
+        module = MyModule(config=self.config)
+        input_tensor = torch.randn(4, 64)
+        output = module(input_tensor)
+        self.assertEqual(output.shape, (4, 128))
+
+    def test_forward_empty_input(self) -> None:
+        """Test forward pass with empty input."""
+        module = MyModule(config=self.config)
+        input_tensor = torch.randn(0, 64)
+        output = module(input_tensor)
+        self.assertEqual(output.shape, (0, 128))
+
+    def test_forward_single_element(self) -> None:
+        """Test forward pass with single-element batch."""
+        module = MyModule(config=self.config)
+        input_tensor = torch.randn(1, 64)
+        output = module(input_tensor)
+        self.assertEqual(output.shape, (1, 128))
+
+    def test_invalid_config_raises(self) -> None:
+        """Test that invalid config raises ValueError."""
+        with self.assertRaises(ValueError):
+            MyModule(config=MyConfig(invalid_param=-1))
+```
+
+## Unit Test with KJT Inputs
+
+For modules that consume `KeyedJaggedTensor`:
+
+```python
+import unittest
+
+import torch
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class TestMyEmbeddingModule(unittest.TestCase):
+    def _create_kjt(self, batch_size: int = 2) -> KeyedJaggedTensor:
+        """Helper to create a representative KJT for testing."""
+        return KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5]),
+            lengths=torch.tensor([2, 1, 1, 2]),  # batch_size * num_features
+        )
+
+    def _create_ebc(self) -> EmbeddingBagCollection:
+        """Helper to create an EBC for testing."""
+        return EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    name="table_0",
+                    embedding_dim=8,
+                    num_embeddings=100,
+                    feature_names=["feature_0"],
+                ),
+                EmbeddingBagConfig(
+                    name="table_1",
+                    embedding_dim=8,
+                    num_embeddings=100,
+                    feature_names=["feature_1"],
+                ),
+            ],
+        )
+
+    def test_forward(self) -> None:
+        ebc = self._create_ebc()
+        kjt = self._create_kjt()
+        output = ebc(kjt)
+        # KeyedTensor output: batch_size x total_embedding_dim
+        self.assertEqual(output.values().shape, (2, 16))
+
+    def test_empty_kjt(self) -> None:
+        ebc = self._create_ebc()
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([], dtype=torch.long),
+            lengths=torch.tensor([0, 0, 0, 0]),
+        )
+        output = ebc(kjt)
+        self.assertEqual(output.values().shape, (2, 16))
+```
+
+## Distributed Test Template
+
+For code in `torchrec/distributed/` using collectives, sharding, or process groups.
+
+```python
+import unittest
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.test_utils import skip_if_asan_class
+
+# Module-level test function: runs once per rank
+def _test_my_sharding(
+    rank: int,
+    world_size: int,
+    backend: str = "gloo",
+) -> None:
+    with MultiProcessContext(rank, world_size, backend) as ctx:
+        device = ctx.device
+        pg = ctx.pg
+
+        # Setup: create module, inputs, etc.
+        # ...
+
+        # Run the operation under test
+        # ...
+
+        # Assert results are correct on this rank
+        # torch.testing.assert_close(actual, expected)
+
+
+@skip_if_asan_class
+class TestMySharding(MultiProcessTestBase):
+    def test_sharding_world_size_2(self) -> None:
+        self._run_multi_process_test(
+            callable=_test_my_sharding,
+            world_size=2,
+            backend="gloo",
+        )
+
+    def test_sharding_world_size_4(self) -> None:
+        self._run_multi_process_test(
+            callable=_test_my_sharding,
+            world_size=4,
+            backend="gloo",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_sharding_nccl(self) -> None:
+        self._run_multi_process_test(
+            callable=_test_my_sharding,
+            world_size=2,
+            backend="nccl",
+        )
+```
+
+## Distributed Test with Static Method Pattern
+
+Alternative pattern using `@staticmethod` on the test class:
+
+```python
+@skip_if_asan_class
+class TestMyDistributedModule(MultiProcessTestBase):
+    @staticmethod
+    def _test_forward(rank: int, world_size: int) -> None:
+        with MultiProcessContext(rank, world_size, "gloo") as ctx:
+            # ... test logic ...
+            pass
+
+    def test_forward(self) -> None:
+        self._run_multi_process_test(
+            callable=self._test_forward,
+            world_size=2,
+        )
+```
+
+## Hypothesis-Parameterized Test Template
+
+For tests that need to cover multiple configurations (sharding types, kernels, pooling modes).
+
+```python
+import unittest
+
+import torch
+from hypothesis import given, settings, Verbosity
+from hypothesis import strategies as st
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import ShardingType
+from torchrec.test_utils import skip_if_asan_class
+
+
+def _test_sharding_type(
+    rank: int,
+    world_size: int,
+    sharding_type: str,
+    kernel_type: str,
+) -> None:
+    with MultiProcessContext(rank, world_size, "gloo") as ctx:
+        # ... test with the given sharding_type and kernel_type ...
+        pass
+
+
+@skip_if_asan_class
+class TestShardingVariants(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+            ]
+        ),
+        kernel_type=st.sampled_from(
+            [
+                EmbeddingComputeKernel.FUSED.value,
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
+    def test_sharding(self, sharding_type: str, kernel_type: str) -> None:
+        self._run_multi_process_test(
+            callable=_test_sharding_type,
+            world_size=2,
+            sharding_type=sharding_type,
+            kernel_type=kernel_type,
+        )
+```
+
+## Hypothesis Unit Test Template
+
+For parameterized unit tests (non-distributed):
+
+```python
+import unittest
+
+import torch
+from hypothesis import given, settings, Verbosity
+from hypothesis import strategies as st
+from torchrec.modules.my_module import MyModule
+
+
+class TestMyModuleParameterized(unittest.TestCase):
+    @given(
+        batch_size=st.sampled_from([1, 4, 32]),
+        use_weights=st.booleans(),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=10, deadline=None)
+    def test_forward_variants(self, batch_size: int, use_weights: bool) -> None:
+        module = MyModule(use_weights=use_weights)
+        input_tensor = torch.randn(batch_size, 64)
+        output = module(input_tensor)
+        self.assertEqual(output.shape[0], batch_size)
+```
+
+## BUCK Target Templates
+
+### CPU-Only Unit Test
+```python
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+
+python_unittest(
+    name = "test_my_module",
+    srcs = ["test_my_module.py"],
+    deps = [
+        "//caffe2:_torch",
+        "//torchrec/modules:my_module",
+    ],
+)
+```
+
+### GPU Distributed Test
+```python
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
+
+python_unittest(
+    name = "test_my_sharding",
+    srcs = ["test_my_sharding.py"],
+    remote_execution = re_test_utils.remote_execution(
+        mig = "false",
+        platform = "gpu-remote-execution",
+        resource_units = 2,
+    ),
+    deps = [
+        "//caffe2:_torch",
+        "//torchrec/distributed/test_utils:multi_process",
+        "//torchrec/test_utils:test_utils",
+        "//torchrec/distributed:types",
+    ],
+)
+```
+
+### Test with Hypothesis
+```python
+python_unittest(
+    name = "test_my_sharding",
+    srcs = ["test_my_sharding.py"],
+    remote_execution = re_test_utils.remote_execution(
+        mig = "false",
+        platform = "gpu-remote-execution",
+        resource_units = 2,
+    ),
+    supports_static_listing = False,
+    deps = [
+        "//caffe2:_torch",
+        "//torchrec/distributed/test_utils:multi_process",
+        "//torchrec/test_utils:test_utils",
+        "fbsource//third-party/pypi/hypothesis:hypothesis",
+    ],
+)
+```
+
+## Common Assertions
+
+| Assertion | When to Use |
+|-----------|-------------|
+| `self.assertEqual(a, b)` | Exact equality (shapes, counts, string values) |
+| `self.assertTrue(condition)` | Boolean conditions |
+| `self.assertIsInstance(obj, cls)` | Type checking |
+| `torch.testing.assert_close(a, b)` | Tensor value comparison with tolerance |
+| `torch.equal(a, b)` | Exact tensor equality (use inside `assertTrue`) |
+| `self.assertRaises(ErrorType)` | Expected exceptions |
+| `self.assertRaisesRegex(ErrorType, "msg")` | Expected exceptions with message matching |
+
+## Edge Cases to Always Cover
+
+For **KJT-based code:**
+- Empty KJT (no values, all-zero lengths)
+- Single feature, single batch element
+- Variable-length sequences (some lengths = 0)
+
+For **distributed code:**
+- `world_size=2` (minimum)
+- `world_size=4` for sharding strategies that partition differently
+- Single rank (`world_size=1`) if the code should support it
+
+For **embedding modules:**
+- Single table, single feature
+- Multiple tables with different embedding dimensions
+- Zero `num_embeddings` if applicable
+
+For **metrics:**
+- Empty predictions/labels
+- All-zero weights
+- Single task vs multi-task


### PR DESCRIPTION
Summary:
New Claude skill that generates idiomatic TorchRec tests with BUCK targets. It maintains the style of testing we have in TorchRec and uses the common test utilities to reduce code duplication and ensure well tested code is used.

**Key Features**

  - Auto-detects test type from source code: unit, distributed (MultiProcessTestBase), or hypothesis-parameterized — no manual specification needed
  - Two invocation modes: file path (/test-gen torchrec/modules/foo.py) or auto-detect from local changes (/test-gen local)
  - Generates BUCK targets with correct rules — handles remote_execution for GPU tests, supports_static_listing = False for hypothesis, proper deps
  - Templates for all TorchRec patterns: standard unit tests, KJT-based tests, distributed tests (both module-level _test_func and staticmethod patterns), hypothesis with given/st.sampled_from
  - Edge case coverage guidance: empty KJT, single rank, variable-length sequences, multi-world-size for sharding tests

Differential Revision: D94264316


