### PR TITLE
Add TrainPipelineSparseDistEmbStash with configurable restore injection site

### DIFF
--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -20,6 +20,7 @@ from torchrec.distributed.train_pipeline import (
 from torchrec.distributed.train_pipeline.experimental_pipelines import (
     TrainEvalHybridPipelineBase,
     TrainPipelineSparseDistBwdOpt,
+    TrainPipelineSparseDistEmbStash,
     TrainPipelineSparseDistOptStash,
     TrainPipelineSparseDistT,
 )
@@ -67,6 +68,8 @@ class PipelineConfig:
             for key in ("site_fqn", "sharding_type"):
                 if key in kwargs:
                     kwargs.pop(key)
+        if self.pipeline in ("sparse-emb-stash",):
+            kwargs.pop("sharding_type", None)
         return kwargs
 
     def generate_pipeline(
@@ -120,6 +123,7 @@ class PipelineConfig:
             "sparse-threading": TrainPipelineSparseDistT,
             "sparse-bwd-opt": TrainPipelineSparseDistBwdOpt,
             "sparse-opt-stash": TrainPipelineSparseDistOptStash,
+            "sparse-emb-stash": TrainPipelineSparseDistEmbStash,
         }
 
         match self.pipeline:


### PR DESCRIPTION
Summary:
## 1. Context

Embedding Memory Stashing (EMS) offloads embedding weights from HBM to pinned CPU memory after the forward lookup, restoring them before backward reaches the sparse modules. The previous prototype (D93945917) demonstrated this with optimizer state stashing and a fixed `OutputDistSite` restore trigger tied to the backward all-to-all.

However, the optimal point to trigger the restore depends on the model architecture and memory/compute tradeoffs. Restoring earlier (e.g., at the dense layer or over-arch) gives more time for the H2D transfer to overlap with backward compute, but also means the weights occupy HBM for a longer portion of backward. Restoring later (e.g., at the sparse all-to-all) minimizes HBM residency but risks delaying backward if the transfer isn't complete.

This diff adds support for triggering restore at different injection sites in the backward pass, enabling benchmarking of the tradeoff between restore latency hiding and HBM savings.

## 2. Approach

1. **New pipeline class `TrainPipelineSparseDistEmbStash`**: Extends `TrainPipelineSparseDist` to add embedding weight restore during backward. The stash (HBM → CPU) is handled by the sharded embedding modules in the parent diff stack — it runs automatically inside `EmbeddingBagCollection.forward()` immediately after the TBE lookup. This pipeline is only responsible for the restore (CPU → HBM) side.

2. **Configurable injection site**: The pipeline registers a backward hook at a user-specified `InjectionSite` (via `site_fqn`) that calls `MemoryStashingManager.restore_embedding_weights()` to copy weights back before backward reaches the sparse modules. Unlike `TrainPipelineSparseDistOptStash` which uses `OutputDistSite` (tied to a specific sharding type's backward all-to-all awaitable), this uses the base `InjectionSite` so it can hook any module in the model by FQN — `dense`, `over.overarch.0`, `sparse.weighted_ebc`, etc. — enabling experimentation with different restore trigger points.

3. **Stream initialization**: `__init__` takes a `site_fqn` parameter and initializes `MemoryStashingManager` with two CUDA streams: the pipeline's existing `_memcpy_stream` for D2H transfers and a new stream for H2D transfers.

4. **`_pipeline_model` override**: Calls `super()._pipeline_model()` (which runs the pipelined forward including the stash), then registers the restore backward hook at the injection site via `self.register_backward_hook()`. The pipeline does not override `progress()` — it uses the standard `TrainPipelineSparseDist` training loop since no special synchronization (like optimizer state futures) is needed.

5. **Pipeline config integration**: Added `"sparse-emb-stash"` as a new pipeline type in `PipelineConfig`, with `sharding_type` excluded from kwargs since `InjectionSite` doesn't need it. The `site_fqn` kwarg controls which module's backward triggers the restore.

## 3. Results

### Benchmark metrics

|short name                         |Per-Iteration (trace)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|
|sparse_data_dist_base              |~269 ms              |49.06 GB                |65.91 GB                   |68.40 GB          |0.0 / 0.0 / 0.0              |30.48 GB          |
|embedding_stashing_over_arch       |~271 ms              |49.06 GB                |61.32 GB                   |63.81 GB          |0.0 / 0.0 / 0.0              |46.34 GB          |
|embedding_stashing_dense           |~312 ms              |49.06 GB                |61.31 GB                   |63.80 GB          |0.0 / 0.0 / 0.0              |46.34 GB          |
|embedding_stashing_sparse          |~309 ms              |41.98 GB                |55.36 GB                   |57.85 GB          |0.0 / 0.0 / 0.0              |46.22 GB          |

### Traces

**Baseline**: ~269 ms
<img width="4624" height="1616" alt="image" src="https://github.com/user-attachments/assets/ff17415e-5373-453d-ab08-74cdebb860ba" />

**Restore at over-arch**: ~271 ms
<img width="4610" height="1542" alt="image" src="https://github.com/user-attachments/assets/4f96a4fd-bf59-4c26-bc23-a9739b4303f9" />

**Restore at bwd_all2all**: ~309 ms
<img width="4654" height="1596" alt="image" src="https://github.com/user-attachments/assets/8cb11410-37e4-4bb3-8421-5b4106f6bab3" />

**Restore at dense**: ~312 ms
<img width="4652" height="1574" alt="image" src="https://github.com/user-attachments/assets/9d155b0a-2e0d-4735-995f-7a009ccc0227" />

### Memory snapshots

**Baseline**: ~55 GB
<img width="5092" height="1642" alt="image" src="https://github.com/user-attachments/assets/0bb97fd4-9943-4c4f-982f-dd1a1e9d8f1d" />

**Restore at over-arch**: ~55 GB
<img width="5092" height="1630" alt="image" src="https://github.com/user-attachments/assets/d8cfbff2-6d78-4a79-b64d-a7206296e800" />

**Restore at dense**: ~50 GB
<img width="5092" height="1640" alt="image" src="https://github.com/user-attachments/assets/365629cc-41e5-4a0b-8912-4df7ee6bf92b" />

**Restore at bwd_all2all**: ~45 GB
<img width="5088" height="1632" alt="image" src="https://github.com/user-attachments/assets/984569ff-06b1-47ae-8862-67c66a1a2fdf" />

## 4. Analysis

1. **Stashed memory matches CPU increase**: The stashed embedding weights are ~16 GB, consistent with the CPU RSS increase across all variants (~46 GB vs 30 GB baseline). This is the amount of HBM that stashing should theoretically free up.

2. **HBM savings are less than 16 GB in this toy model**: The toy model's peak HBM occurs at the beginning of the over-arch (concat), which partially overlaps with the stashing process. Because stashing runs during the forward embedding lookup and the peak happens shortly after, not all weights have been fully offloaded by the time peak memory is measured. The memory snapshots confirm this: over-arch restores too early and shows the same peak as baseline (~55 GB), dense restores slightly later and sees a partial reduction (~50 GB), and bwd_all2all restores latest and achieves the largest reduction (~45 GB). The later the restore, the less overlap with the peak, and the more savings observed.

3. **Production models should see full savings**: In production models, the forward pass is much more complex and peak memory typically occurs in the early phase of backward, well after stashing completes. The HBM savings should match the full stashed memory (~16 GB).

4. **Over-arch restore site fully overlaps with compute**: Restoring early at the over-arch backward hook gives the H2D transfer enough time to fully overlap with the compute stream, resulting in the same runtime as baseline (~271 ms vs ~269 ms). Restoring later at dense or bwd_all2all leaves insufficient compute to hide the H2D copy, exposing some restore latency and adding ~15–16% overhead (~309–312 ms).

5. **Restore timing is a tradeoff**: The ideal restore site must be early enough in backward to fully overlap the H2D transfer with compute, but not so early that the restored weights are back in HBM before the memory peak. Restoring too early negates the HBM savings; restoring too late adds runtime overhead. The optimal site depends on the model's peak memory profile and backward compute duration.

6. **Prototype status**: This is a prototype for benchmarking the injection site tradeoff. The stashing itself is triggered inside the sharded embedding modules (in the parent diff stack), and only the restore trigger point is configurable here.

## 5. Changes

1. **`experimental_pipelines.py`**: Added `TrainPipelineSparseDistEmbStash` pipeline class. Uses base `InjectionSite` (not `OutputDistSite`) so any module FQN can serve as the restore trigger. Registers a backward hook via `self.register_backward_hook()` that calls `MemoryStashingManager.restore_embedding_weights()`. Initializes `MemoryStashingManager` streams in `__init__`.
2. **`pipeline_config.py`**: Added `"sparse-emb-stash"` pipeline type mapped to `TrainPipelineSparseDistEmbStash`. Strips `sharding_type` from kwargs for this pipeline since `InjectionSite` doesn't use it.

## 6. How to Run

The restore injection site is configured via `PipelineConfig.kwargs.site_fqn` in the YAML config. To test different sites, copy the base YAML and edit `site_fqn`:

```yaml
PipelineConfig:
  pipeline: "sparse-emb-stash"
  kwargs:
    site_fqn: "over.overarch.0"   # change to: "dense" or "over.overarch.0"
    sharding_type: "table_wise"
```

For the bwd_all2all restore site, use the `"sparse-opt-stash"` pipeline instead, which uses `OutputDistSite` (hooks into the backward all-to-all awaitable rather than a module FQN):

```yaml
PipelineConfig:
  pipeline: "sparse-opt-stash"
  kwargs:
    site_fqn: "sparse.weighted_ebc"
    sharding_type: "table_wise"
```

run command:
```bash
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse-emb-stash \
  --name=embedding_stashing_sparse
```

* sharding stats
```
#################################################################################################################################################################################################################################################################################################################################################################
#                                                                                                                                                                  --- Planner Statistics ---                                                                                                                                                                   #
#                                                                                                                                           --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.04s ---                                                                                                                                            #
# ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
#      Rank       HBM (GB)     DDR (GB)                 Perf (ms)     Input (MB)     Output (MB)         Shards                                                                                                                                                                                                                                                 #
#    ------     ----------   ----------               -----------   ------------   -------------       --------                                                                                                                                                                                                                                                 #
#         0    45.39 (67%)     0.0 (0%)   704.985 (197,9,490,9,0)         1410.0          5760.0   CW: 8 TW: 86                                                                                                                                                                                                                                                 #
#         1   45.218 (66%)     0.0 (0%)   698.248 (194,9,485,9,0)         1395.0          5696.0   CW: 8 TW: 85                                                                                                                                                                                                                                                 #
#                                                                                                                                                                                                                                                                                                                                                               #
# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                                                                         #
# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                                                                           #
# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                                                                                #
#                                                                                                                                                                                                                                                                                                                                                               #
# Parameter Info:                                                                                                                                                                                                                                                                                                                                               #
#                                      FQN     Sharding     Compute Kernel                 Perf (ms)      Storage (HBM, DDR, SSD)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size                             Ranks   #
#                                    -----   ----------   ----------------               -----------    -------------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------                           -------   #
#     sparse.weighted_ebc.weighted_table_0           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_1           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_2           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_3           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_4           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_5           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_6           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_7           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_8           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_9           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_10           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_11           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_12           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_13           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_14           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_15           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_16           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_17           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_18           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_19           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_20           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_21           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_22           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_23           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_24           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_25           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_26           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_27           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_28           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_29           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_30           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_31           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_32           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_33           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_34           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_35           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_36           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_37           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_38           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_39           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_40           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_41           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_42           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_43           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_44           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_45           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_46           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_47           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_48           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_49           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_50           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_51           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_52           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_53           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_54           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_55           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_56           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_57           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_58           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_59           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_60           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_61           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_62           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_63           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_64           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_65           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_66           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_67           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_68           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_69           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_70           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_71           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_72           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_73           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_74           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_75           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_76           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_77           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_78           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_79           TW              fused     9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_0           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_1           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_2           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_3           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_4           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_5           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_6           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_7           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_8           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_9           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_10           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_11           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_12           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_13           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_14           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_15           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_16           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_17           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_18           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_19           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_20           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_21           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_22           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_23           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_24           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_25           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_26           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_27           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_28           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_29           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_30           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_31           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_32           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_33           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_34           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_35           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_36           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_37           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_38           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_39           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_40           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_41           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_42           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_43           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_44           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_45           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_46           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_47           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_48           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_49           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_50           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_51           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_52           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_53           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_54           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_55           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_56           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_57           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_58           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_59           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_60           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_61           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_62           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_63           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_64           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_65           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_66           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_67           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_68           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_69           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_70           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_71           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_72           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_73           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_74           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_75           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_76           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_77           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_78           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_79           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_80           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_81           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_82           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_83           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_84           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_85           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_86           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_87           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_88           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_89           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                    sparse.ebc.FP16_table           TW              fused     6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  512        100000                                 0   #
#                   sparse.ebc.large_table           CW              fused   54.29 (18,0.8,35,0.8,0)   (8.364 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1           2048 (128)       1000000   0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1   #
#                                                                                                                                                                                                                                                                                                                                                               #
# Batch Size: 32768                                                                                                                                                                                                                                                                                                                                             #
#                                                                                                                                                                                                                                                                                                                                                               #
# Compute Kernels Count:                                                                                                                                                                                                                                                                                                                                        #
#    fused: 172                                                                                                                                                                                                                                                                                                                                                 #
#                                                                                                                                                                                                                                                                                                                                                               #
# Compute Kernels Storage:                                                                                                                                                                                                                                                                                                                                      #
#    fused: HBM: 37.864 GB, DDR: 0.0 GB, SSD: 0.0 GB                                                                                                                                                                                                                                                                                                            #
#                                                                                                                                                                                                                                                                                                                                                               #
# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                                                                               #
# Total Variation: 0.002                                                                                                                                                                                                                                                                                                                                        #
# Total Distance: 0.005                                                                                                                                                                                                                                                                                                                                         #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                         #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                          #
#                                                                                                                                                                                                                                                                                                                                                               #
# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                                                                      #
# Total Variation: 0.001                                                                                                                                                                                                                                                                                                                                        #
# Total Distance: 0.002                                                                                                                                                                                                                                                                                                                                         #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                         #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                          #
#                                                                                                                                                                                                                                                                                                                                                               #
# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                                                                       #
#                                                                                                                                                                                                                                                                                                                                                               #
# Maximum of Total Perf: 704.985 ms on rank 0                                                                                                                                                                                                                                                                                                                   #
# Mean Total Perf: 701.616 ms                                                                                                                                                                                                                                                                                                                                   #
# Max Total Perf is 0.48% greater than the mean                                                                                                                                                                                                                                                                                                                 #
# Maximum of Forward Compute: 196.586 ms on rank 0                                                                                                                                                                                                                                                                                                              #
# Maximum of Forward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                                  #
# Maximum of Backward Compute: 489.649 ms on rank 0                                                                                                                                                                                                                                                                                                             #
# Maximum of Backward Comms: 9.375 ms on rank 0                                                                                                                                                                                                                                                                                                                 #
# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                                                                              #
# Sum of Maxima: 704.985 ms                                                                                                                                                                                                                                                                                                                                     #
#                                                                                                                                                                                                                                                                                                                                                               #
# Estimated Sharding Distribution                                                                                                                                                                                                                                                                                                                                #
# Sparse only Max HBM: 19.018 GB on rank [0]                                                                                                                                                                                                                                                                                                                    #
# Sparse only Min HBM: 18.846 GB on rank [1]                                                                                                                                                                                                                                                                                                                    #
# Max HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                                 #
# Min HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                                #
# Mean HBM: 45.304 GB on rank []                                                                                                                                                                                                                                                                                                                                #
# Low Median HBM: 45.218 GB on rank [1]                                                                                                                                                                                                                                                                                                                         #
# High Median HBM: 45.39 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
# Critical Path (comms): 18.75                                                                                                                                                                                                                                                                                                                                  #
# Critical Path (compute): 686.235                                                                                                                                                                                                                                                                                                                              #
# Critical Path (comms + compute): 704.985                                                                                                                                                                                                                                                                                                                      #
# Max HBM is 0.19% greater than the mean                                                                                                                                                                                                                                                                                                                        #
#                                                                                                                                                                                                                                                                                                                                                               #
#                                                                                                                                                                                                                                                                                                                                                               #
# Top HBM Memory Usage Estimation: 45.39 GB                                                                                                                                                                                                                                                                                                                     #
# Top Tier #2 Estimated Peak HBM Pressure: 45.218 GB on rank 0                                                                                                                                                                                                                                                                                                  #
# Top Tier #1 Estimated Peak HBM Pressure: 45.39 GB on rank 0                                                                                                                                                                                                                                                                                                   #
#                                                                                                                                                                                                                                                                                                                                                               #
# Reserved Memory:                                                                                                                                                                                                                                                                                                                                              #
#    HBM: 12.0 GB                                                                                                                                                                                                                                                                                                                                               #
#    Percent of Total HBM: 15%                                                                                                                                                                                                                                                                                                                                  #
# Planning Memory:                                                                                                                                                                                                                                                                                                                                              #
#    HBM: 68.0 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                                                                                #
#    Percent of Total HBM: 85%                                                                                                                                                                                                                                                                                                                                  #
#                                                                                                                                                                                                                                                                                                                                                               #
# Dense Storage (per rank):                                                                                                                                                                                                                                                                                                                                     #
#    HBM: 1.177 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                                 #
#                                                                                                                                                                                                                                                                                                                                                               #
# KJT Storage (per rank):                                                                                                                                                                                                                                                                                                                                       #
#    HBM: 25.195 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                                #
#                                                                                                                                                                                                                                                                                                                                                               #
# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                                                                                #
#    weighted_table_0                                                                                                                                                                                                                                                                                                                                           #
#    weighted_table_2                                                                                                                                                                                                                                                                                                                                           #
#    weighted_table_4                                                                                                                                                                                                                                                                                                                                           #
#    weighted_table_6                                                                                                                                                                                                                                                                                                                                           #
#    weighted_table_8                                                                                                                                                                                                                                                                                                                                           #
# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                                                                                 #
#    large_table: 0.523 GB on ranks [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]                                                                                                                                                                                                                                                                            #
#    weighted_table_0: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                                     #
#    weighted_table_2: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                                     #
#    weighted_table_4: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                                     #
#    weighted_table_6: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                                                                     #
#################################################################################################################################################################################################################################################################################################################################################################
```

Differential Revision: D94184432
