### PR TITLE
Handle empty tensors in infinity norm computation

### DIFF
--- a/torchrec/optim/tests/test_clipping.py
+++ b/torchrec/optim/tests/test_clipping.py
@@ -317,6 +317,36 @@ class TestBatchCalNorm(unittest.TestCase):
 
         self.assertTrue(torch.allclose(result, torch.tensor(expected_result)))
 
+    def test_batch_cal_norm_inf_with_empty_tensor(self) -> None:
+        """Test that infinity norm handles empty tensors without erroring."""
+        grad_1 = torch.tensor([1.0, 5.0])
+        grad_2 = torch.tensor([])  # empty tensor
+
+        result = _batch_cal_norm(
+            grad_list=[grad_1, grad_2],
+            max_norm=1.0,
+            norm_type=torch.inf,
+        )
+
+        # The empty tensor should be filtered out, so the result should be max of grad_1
+        expected_result = 5.0
+
+        self.assertTrue(torch.allclose(result, torch.tensor(expected_result)))
+
+    def test_batch_cal_norm_inf_all_empty_tensors(self) -> None:
+        """Test that infinity norm returns -inf when all tensors are empty."""
+        grad_1 = torch.tensor([])
+        grad_2 = torch.tensor([])
+
+        result = _batch_cal_norm(
+            grad_list=[grad_1, grad_2],
+            max_norm=1.0,
+            norm_type=torch.inf,
+        )
+
+        # When all tensors are empty, return -inf (identity for max operation)
+        self.assertEqual(result.item(), float("-inf"))
+
 
 class TestComputeTotalNorm(unittest.TestCase):
     def test_compute_total_norm_replicate_only_l2(self) -> None:


### PR DESCRIPTION
Summary:
When using infinity norm in `GradientClippingOptimizer`, if a tensor in the gradient list is empty (numel=0), `torch._foreach_norm` would error out with:

```
_foreach_norm cannot compute the infinity norm on an empty tensor because the operation does not have an identity
```

This happens because the `max` operation used for infinity norm has no identity value for empty sets.

This diff fixes the issue by filtering out empty tensors before computing the infinity norm in `_batch_cal_norm`. When all tensors are empty after filtering, we return `-inf` which is the identity element for the `max` operation, ensuring correct behavior when combining norms across shards.

Reviewed By: jialun-zhang

Differential Revision: D94430621


