### PR TITLE
Add DeferrableMetrics class (#3812)

### DIFF
--- a/torchrec/metrics/deferrable_metrics.py
+++ b/torchrec/metrics/deferrable_metrics.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Unified metrics type for sync and async metric access.
+
+Thread safety: This class relies on CPython's GIL for safe mutation of
+_data and _resolved from Future callback threads. The GIL ensures that
+attribute assignment is atomic, so concurrent reads of is_resolved() or
+resolve() will see a consistent state. If used outside CPython (e.g.,
+free-threaded Python 3.13t), a threading.Lock would be needed.
+"""
+
+from concurrent.futures import Future
+from typing import Any, Callable
+
+
+class DeferrableMetrics:
+    """
+    Metrics container that wraps either a resolved dict or a pending Future.
+
+    Provides a unified interface for both sync and async metric access:
+    - subscribe(callback): async access, always works
+    - resolve(): sync access, fails fast if backed by Future
+    - update(other): deferred merge
+    - is_resolved(): check without blocking
+
+    Does NOT implement Mapping. Callers must use subscribe() or resolve()
+    to access metric values. This prevents silent blocking in the training
+    path when backed by a Future.
+    """
+
+    def __init__(
+        self,
+        inner: dict[str, Any] | Future[dict[str, Any]],
+    ) -> None:
+        if isinstance(inner, Future):
+            self._future: Future[dict[str, Any]] | None = inner
+            self._data: dict[str, Any] = {}
+            self._resolved: bool = False
+        else:
+            self._future = None
+            self._data = dict(inner)
+            self._resolved = True
+
+    def subscribe(
+        self,
+        callback: Callable[[dict[str, Any]], None],
+        on_error: Callable[[Exception], None] | None = None,
+    ) -> None:
+        """Register a callback for when metrics are available.
+
+        If already resolved, callback fires immediately (synchronously).
+        If backed by Future, callback fires when Future completes.
+        """
+        if self._resolved:
+            callback(self._data)
+        elif self._future is not None:
+
+            def _on_complete(f: Future[dict[str, Any]]) -> None:
+                try:
+                    result = f.result()
+                    self._data = result
+                    self._resolved = True
+                    callback(self._data)
+                except Exception as e:
+                    if on_error:
+                        on_error(e)
+                    else:
+                        raise
+
+            self._future.add_done_callback(_on_complete)
+
+    def resolve(self) -> dict[str, Any]:
+        """Synchronously return the resolved metrics dict.
+
+        Fails fast with RuntimeError if backed by a Future.
+        Only use in contexts where CPU-offloaded metrics are disabled
+        (eval, inference, tests).
+        """
+        if not self._resolved:
+            raise RuntimeError(
+                "Cannot synchronously resolve DeferrableMetrics backed by a "
+                "Future. Use subscribe() for async access, or ensure "
+                "CPU-offloaded metrics are disabled for this code path."
+            )
+        return self._data
+
+    def update(self, other: "dict[str, Any] | DeferrableMetrics") -> None:
+        """Merge additional key-value pairs.
+
+        If already resolved, merges immediately.
+        If backed by Future, defers the merge until Future resolves.
+        If other is a DeferrableMetrics, subscribes to it for deferred merge.
+
+        Ordering constraint: when backed by a Future, update() replaces the
+        internal Future with a new merged Future. Any subscribe() callbacks
+        registered *before* update() are attached to the original Future and
+        will receive un-merged data. Call update() before subscribe() to
+        ensure callbacks see the merged result.
+        """
+        if isinstance(other, DeferrableMetrics):
+            if other.is_resolved():
+                self.update(other.resolve())
+            else:
+
+                target_future = self._future
+
+                def _propagate_error(e: Exception) -> None:
+                    if target_future is not None and not target_future.done():
+                        target_future.set_exception(e)
+
+                other.subscribe(
+                    lambda data: self.update(data),
+                    on_error=_propagate_error,
+                )
+            return
+
+        assert isinstance(other, dict)
+        dict_other: dict[str, Any] = other
+
+        if self._resolved:
+            self._data.update(dict_other)
+        elif self._future is not None:
+            original_future = self._future
+            merged_future: Future[dict[str, Any]] = Future()
+
+            def _on_complete(f: Future[dict[str, Any]]) -> None:
+                try:
+                    result = dict(f.result())
+                    result.update(dict_other)
+                    merged_future.set_result(result)
+                except Exception as e:
+                    merged_future.set_exception(e)
+
+            original_future.add_done_callback(_on_complete)
+            self._future = merged_future
+
+    def is_resolved(self) -> bool:
+        """Check if metrics are available without blocking."""
+        return self._resolved
+
+    def __bool__(self) -> bool:
+        """Always True. Prevents ``metrics or {}`` from replacing DeferrableMetrics."""
+        return True
+
+    def __repr__(self) -> str:
+        if self._resolved:
+            return f"DeferrableMetrics(resolved, {len(self._data)} keys)"
+        return "DeferrableMetrics(pending)"

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from concurrent.futures import Future
+
+from torchrec.metrics.deferrable_metrics import DeferrableMetrics
+
+
+class TestDeferrableMetrics(unittest.TestCase):
+    def test_resolved_basic(self) -> None:
+        data = {"a": 1, "b": 2}
+        dm = DeferrableMetrics(data)
+        self.assertTrue(dm.is_resolved())
+        self.assertEqual(dm.resolve(), {"a": 1, "b": 2})
+
+    def test_resolved_subscribe(self) -> None:
+        data = {"x": 10}
+        dm = DeferrableMetrics(data)
+        received: list[dict] = []
+        dm.subscribe(lambda d: received.append(d))
+        self.assertEqual(received, [{"x": 10}])
+
+    def test_resolved_update_dict(self) -> None:
+        dm = DeferrableMetrics({"a": 1})
+        dm.update({"b": 2, "c": 3})
+        self.assertEqual(dm.resolve(), {"a": 1, "b": 2, "c": 3})
+
+    def test_resolved_update_deferrable(self) -> None:
+        dm1 = DeferrableMetrics({"a": 1})
+        dm2 = DeferrableMetrics({"b": 2})
+        dm1.update(dm2)
+        self.assertEqual(dm1.resolve(), {"a": 1, "b": 2})
+
+    def test_future_backed_is_not_resolved(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        self.assertFalse(dm.is_resolved())
+
+    def test_future_backed_resolve_raises(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        with self.assertRaisesRegex(RuntimeError, "Cannot synchronously resolve"):
+            dm.resolve()
+
+    def test_future_backed_subscribe(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        received: list[dict] = []
+        dm.subscribe(lambda d: received.append(d))
+        self.assertEqual(received, [])
+        f.set_result({"val": 42})
+        self.assertEqual(received, [{"val": 42}])
+        self.assertTrue(dm.is_resolved())
+
+    def test_future_backed_subscribe_error(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        errors: list[Exception] = []
+        dm.subscribe(
+            lambda d: None,
+            on_error=lambda e: errors.append(e),
+        )
+        f.set_exception(ValueError("boom"))
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], ValueError)
+        self.assertEqual(str(errors[0]), "boom")
+
+    def test_future_backed_update_deferred(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        dm.update({"extra": 99})
+        self.assertFalse(dm.is_resolved())
+        f.set_result({"original": 1})
+        received: list[dict] = []
+        dm.subscribe(lambda d: received.append(d))
+        self.assertEqual(received, [{"original": 1, "extra": 99}])
+
+    def test_bool_always_true(self) -> None:
+        self.assertTrue(bool(DeferrableMetrics({})))
+        self.assertTrue(bool(DeferrableMetrics({"a": 1})))
+        f: Future[dict] = Future()
+        self.assertTrue(bool(DeferrableMetrics(f)))
+
+    def test_or_pattern(self) -> None:
+        dm = DeferrableMetrics({})
+        result = dm or {}
+        self.assertIsInstance(result, DeferrableMetrics)
+        self.assertIs(result, dm)
+
+    def test_not_a_mapping(self) -> None:
+        dm = DeferrableMetrics({"a": 1})
+        with self.assertRaisesRegex(TypeError, ""):
+            _ = dm["a"]  # pyrefly: ignore
+        with self.assertRaisesRegex(TypeError, ""):
+            len(dm)  # pyrefly: ignore
+        with self.assertRaisesRegex(TypeError, ""):
+            list(dm)  # pyrefly: ignore
+
+    def test_repr(self) -> None:
+        dm_resolved = DeferrableMetrics({"a": 1, "b": 2})
+        self.assertEqual(repr(dm_resolved), "DeferrableMetrics(resolved, 2 keys)")
+        f: Future[dict] = Future()
+        dm_pending = DeferrableMetrics(f)
+        self.assertEqual(repr(dm_pending), "DeferrableMetrics(pending)")
+
+    def test_empty_resolved(self) -> None:
+        dm = DeferrableMetrics({})
+        self.assertTrue(dm.is_resolved())
+        self.assertEqual(dm.resolve(), {})
+
+    def test_update_deferrable_to_deferrable(self) -> None:
+        f1: Future[dict] = Future()
+        f2: Future[dict] = Future()
+        dm1 = DeferrableMetrics(f1)
+        dm2 = DeferrableMetrics(f2)
+        dm1.update(dm2)
+        f1.set_result({"a": 1})
+        received_1: list[dict] = []
+        dm1.subscribe(lambda d: received_1.append(d))
+        self.assertEqual(received_1[0], {"a": 1})
+        f2.set_result({"b": 2})
+        self.assertIn("b", dm1.resolve())
+
+    def test_update_deferrable_error_propagation(self) -> None:
+        f1: Future[dict] = Future()
+        f2: Future[dict] = Future()
+        dm1 = DeferrableMetrics(f1)
+        dm2 = DeferrableMetrics(f2)
+        dm1.update(dm2)
+        f1.set_result({"a": 1})
+        errors: list[Exception] = []
+        dm1.subscribe(lambda d: None, on_error=lambda e: errors.append(e))
+        f2.set_exception(ValueError("upstream failed"))
+        self.assertEqual(len(errors), 0)
+
+    def test_update_deferrable_error_propagation_pending(self) -> None:
+        f1: Future[dict] = Future()
+        f2: Future[dict] = Future()
+        dm1 = DeferrableMetrics(f1)
+        dm2 = DeferrableMetrics(f2)
+        dm1.update(dm2)
+        errors: list[Exception] = []
+        dm1.subscribe(lambda d: None, on_error=lambda e: errors.append(e))
+        f2.set_exception(ValueError("upstream failed"))
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], ValueError)
+
+    def test_defensive_copy(self) -> None:
+        original = {"a": 1}
+        dm = DeferrableMetrics(original)
+        original["a"] = 999
+        self.assertEqual(dm.resolve()["a"], 1)


### PR DESCRIPTION
Summary:

Add DeferrableMetrics, a unified metrics container that wraps either a resolved
dict or a pending Future. Provides subscribe()/resolve()/update()/is_resolved()
APIs for async-safe metric access.

Reviewed By: sahshah-meta

Differential Revision: D94254756


