### PR TITLE
Unified non-blocking DtoH transfer in DeferrableMetrics (#3813)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -12,7 +12,7 @@ import queue
 import threading
 import time
 import traceback
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 import torch
 from torch import distributed as dist
@@ -20,7 +20,11 @@ from torch.profiler import record_function
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.logging_utils import EventType
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
-from torchrec.metrics.deferrable_metrics import DeferrableMetrics
+from torchrec.metrics.deferrable_metrics import (
+    DeferrableMetrics,
+    device_supports_async,
+    transfer_tensors_to_cpu,
+)
 from torchrec.metrics.metric_job_types import (
     MetricComputeJob,
     MetricUpdateJob,
@@ -213,41 +217,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
             raise RecMetricException("update metric queue is full.")
 
-    def _transfer_to_cpu(
-        self,
-        model_out: Dict[str, torch.Tensor],
-    ) -> Tuple[Dict[str, torch.Tensor], torch.cuda.Event]:
-        """
-        Create a copy of model_out on CPU and return the copy. A cuda event
-        is created to track when the copy is completed.
-
-
-        Args:
-            model_out: intermediate model outputs to be used for metric updates
-        """
-
-        transfer_completed_event = torch.cuda.Event()
-        cpu_model_out = self._move_output_to_cpu(model_out)
-        transfer_completed_event.record()
-
-        return (
-            cpu_model_out,
-            transfer_completed_event,
-        )
-
-    def _move_output_to_cpu(
-        self, output: Dict[str, torch.Tensor]
-    ) -> Dict[str, torch.Tensor]:
-        """
-        Move all tensors in output to CPU and preserve dictionary structure.
-        Args:
-            output: tensors to be moved to CPU
-        """
-        return {
-            k: tensor.to(device="cpu", non_blocking=True)
-            for k, tensor in output.items()
-        }
-
     @EventLoggingHandler.event_logger(
         TorchrecComponent.REC_METRICS, n=1000, add_wait_counter=True
     )
@@ -264,8 +233,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         with record_function("## CPUOffloadedRecMetricModule:update ##"):
             start_time = time.time()
             cpu_model_out, transfer_completed_event = (
-                self._transfer_to_cpu(metric_update_job.model_out)
-                if self._model_out_device.type == "cuda"
+                transfer_tensors_to_cpu(metric_update_job.model_out)
+                if device_supports_async(self._model_out_device)
                 else (metric_update_job.model_out, None)
             )
             if transfer_completed_event is not None:

--- a/torchrec/metrics/deferrable_metrics.py
+++ b/torchrec/metrics/deferrable_metrics.py
@@ -23,7 +23,47 @@ from collections.abc import Iterator, Mapping
 from concurrent.futures import Future
 from typing import Any, Callable
 
+import torch
+
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def device_supports_async(device: torch.device) -> bool:
+    """Check if a device supports non-blocking async transfers (CUDA events)."""
+    return device.type == "cuda"
+
+
+def transfer_tensors_to_cpu(
+    tensors: dict[str, Any],
+) -> tuple[dict[str, Any], torch.cuda.Event | None]:
+    """Transfer GPU tensors to CPU using non-blocking copies.
+
+    Returns the CPU tensor dict and a CUDA event that tracks completion.
+    For CPU-only inputs, returns the dict as-is with None event.
+    Non-tensor values are preserved unchanged.
+
+    Records the CUDA event on the source tensor's device stream (not the
+    default device) to avoid metric corruption on non-rank-0 processes.
+    All tensors are assumed to be on the same device.
+    """
+    source_device: torch.device | None = None
+    for v in tensors.values():
+        if isinstance(v, torch.Tensor) and v.device.type == "cuda":
+            source_device = v.device
+            break
+    if source_device is None:
+        return tensors, None
+
+    cpu_tensors = {
+        k: v.to(device="cpu", non_blocking=True) if isinstance(v, torch.Tensor) else v
+        for k, v in tensors.items()
+    }
+
+    with torch.cuda.device(source_device):
+        event = torch.cuda.Event()
+        event.record()
+
+    return cpu_tensors, event
 
 
 class DeferrableMetrics(Mapping[str, Any]):

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -23,6 +23,7 @@ from torchrec.metrics.cpu_offloaded_metric_module import (
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
 )
+from torchrec.metrics.deferrable_metrics import transfer_tensors_to_cpu
 from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
 from torchrec.metrics.metrics_config import DefaultMetricsConfig
 from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
@@ -108,7 +109,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             "task1-weight": torch.tensor([5.0, 1.0, 0.0]).to("cuda:0"),
         }
 
-        cpu_output, transfer_event = self.cpu_module._transfer_to_cpu(output)
+        cpu_output, transfer_event = transfer_tensors_to_cpu(output)
+        self.assertIsNotNone(transfer_event)
+        assert transfer_event is not None
         wait_until_true(transfer_event.query)
 
         self.assertEqual(len(cpu_output), 3)
@@ -522,6 +525,59 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
         cpu_module_indexed.shutdown()
 
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_transfer_tensors_to_cpu_event_on_source_device_stream(self) -> None:
+        """
+        Regression test for ZORM metric corruption on non-rank-0 processes.
+
+        Bug: transfer_tensors_to_cpu recorded the CUDA event on cuda:0 (default)
+        instead of the source tensor's device (cuda:N), making event.synchronize()
+        a no-op on non-rank-0 processes.
+
+        Verifies the event tracks cuda:1's stream via event.query(): with the bug,
+        the event on idle cuda:0 completes immediately; with the fix, it stays
+        pending behind cuda:1's queued work.
+        """
+        with torch.cuda.device(0):
+            source_tensors = {
+                "predictions": torch.ones(1024, device="cuda:1") * 3.14,
+                "labels": torch.ones(1024, device="cuda:1"),
+                "weights": torch.ones(1024, device="cuda:1") * 2.0,
+            }
+
+            busy = torch.randn(8192, 8192, device="cuda:1")
+            for _ in range(50):
+                busy = busy @ busy
+
+            cpu_tensors, event = transfer_tensors_to_cpu(source_tensors)
+            self.assertIsNotNone(event)
+            assert event is not None
+
+            self.assertFalse(
+                event.query(),
+                "CUDA event completed immediately — it was recorded on the "
+                "wrong stream (cuda:0 instead of cuda:1).",
+            )
+
+            event.synchronize()
+            torch.testing.assert_close(
+                cpu_tensors["predictions"],
+                torch.ones(1024) * 3.14,
+            )
+            torch.testing.assert_close(
+                cpu_tensors["labels"],
+                torch.ones(1024),
+            )
+            torch.testing.assert_close(
+                cpu_tensors["weights"],
+                torch.ones(1024) * 2.0,
+            )
+
+    # pyre-ignore[56]
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -565,11 +621,13 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         )
 
         transfer_call_info: list = []
-        original_transfer_to_cpu = offloaded_module._transfer_to_cpu
+        original_transfer = transfer_tensors_to_cpu
 
-        def tracking_transfer_to_cpu(model_out: dict) -> tuple:
+        def tracking_transfer(
+            tensors: dict,
+        ) -> tuple:
             transfer_call_info.append(threading.current_thread().name)
-            return original_transfer_to_cpu(model_out)
+            return original_transfer(tensors)
 
         model_out = {
             "task1-prediction": torch.tensor([0.5, 0.7]),
@@ -581,10 +639,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             for tensor in model_out.values():
                 self.assertEqual(tensor.device.type, "cuda")
 
-        with patch.object(
-            offloaded_module,
-            "_transfer_to_cpu",
-            side_effect=tracking_transfer_to_cpu,
+        with patch(
+            "torchrec.metrics.cpu_offloaded_metric_module.transfer_tensors_to_cpu",
+            side_effect=tracking_transfer,
         ):
             offloaded_module.update(model_out)
             wait_until_true(offloaded_metric.update_called)
@@ -593,7 +650,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.assertEqual(
                 len(transfer_call_info),
                 1,
-                "_transfer_to_cpu should be called exactly once for CUDA device",
+                "transfer_tensors_to_cpu should be called exactly once for CUDA device",
             )
             self.assertEqual(
                 transfer_call_info[0],
@@ -605,7 +662,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.assertEqual(
                 len(transfer_call_info),
                 0,
-                "_transfer_to_cpu should NOT be called when device is CPU",
+                "transfer_tensors_to_cpu should NOT be called when device is CPU",
             )
 
         self.assertTrue(offloaded_metric.predictions_update_calls is not None)

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -12,7 +12,12 @@ from collections.abc import Mapping
 from concurrent.futures import Future
 from unittest.mock import patch
 
-from torchrec.metrics.deferrable_metrics import DeferrableMetrics
+import torch
+from torchrec.metrics.deferrable_metrics import (
+    DeferrableMetrics,
+    device_supports_async,
+    transfer_tensors_to_cpu,
+)
 
 
 class TestDeferrableMetrics(unittest.TestCase):
@@ -255,3 +260,58 @@ class TestDeferrableMetrics(unittest.TestCase):
         with self.assertRaises(ValueError):
             dm.resolve()
         self.assertFalse(dm.is_resolved())
+
+    def test_future_backed_update_dict_merges(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        dm.update({"cpu_val": "extra"})
+        f.set_result({"original": "data"})
+        received: list[dict] = []
+        dm.subscribe(lambda d: received.append(d))
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["original"], "data")
+        self.assertEqual(received[0]["cpu_val"], "extra")
+
+
+class TransferTensorsToCpuTest(unittest.TestCase):
+
+    def test_cpu_tensors_passthrough(self) -> None:
+        tensors: dict[str, torch.Tensor] = {
+            "predictions": torch.tensor([1.0, 2.0]),
+            "labels": torch.tensor([0.0, 1.0]),
+        }
+        cpu_tensors, event = transfer_tensors_to_cpu(tensors)
+        self.assertEqual(len(cpu_tensors), 2)
+        self.assertIsNone(event)
+        for key, tensor in cpu_tensors.items():
+            self.assertEqual(tensor.device.type, "cpu")
+            torch.testing.assert_close(tensor, tensors[key])
+
+    def test_non_tensor_values_preserved(self) -> None:
+        # pyre-ignore[6]
+        tensors: dict[str, torch.Tensor] = {
+            "predictions": torch.tensor([1.0]),
+            "name": "task1",
+            "count": 42,
+        }
+        cpu_tensors, event = transfer_tensors_to_cpu(tensors)
+        self.assertEqual(cpu_tensors["name"], "task1")
+        self.assertEqual(cpu_tensors["count"], 42)
+        torch.testing.assert_close(cpu_tensors["predictions"], torch.tensor([1.0]))
+
+    def test_empty_dict(self) -> None:
+        cpu_tensors, event = transfer_tensors_to_cpu({})
+        self.assertEqual(len(cpu_tensors), 0)
+        self.assertIsNone(event)
+
+
+class DeviceSupportsAsyncTest(unittest.TestCase):
+
+    def test_cuda_device_supported(self) -> None:
+        self.assertTrue(device_supports_async(torch.device("cuda")))
+
+    def test_cuda_indexed_device_supported(self) -> None:
+        self.assertTrue(device_supports_async(torch.device("cuda:1")))
+
+    def test_cpu_device_not_supported(self) -> None:
+        self.assertFalse(device_supports_async(torch.device("cpu")))


### PR DESCRIPTION
Summary:

Unifies GPU->CPU tensor transfer helpers into `deferrable_metrics.py` and integrates non-blocking DtoH into `DeferrableMetrics.update()`.

Key changes:
- Add `transfer_tensors_to_cpu()` and `device_supports_async()` as public functions in `deferrable_metrics.py` with correct CUDA event device detection (fixes metric corruption on non-rank-0 processes where events were recorded on cuda:0 instead of the source tensor's device)
- Integrate non-blocking DtoH into `DeferrableMetrics.update()` for Future-backed instances: GPU tensors are transferred immediately, CUDA event is synchronized in the callback before merging

Reviewed By: TroyGarden

Differential Revision: D92434318


