### PR TITLE
Harden shutdown and fix compute_count double-increment (#3814)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import atexit
 import concurrent
 import logging
 import queue
@@ -88,6 +89,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         super().__init__(*args, **kwargs)
         self._model_out_device = model_out_device
         self._shutdown_event: threading.Event = threading.Event()
+        self._compute_shutdown_event: threading.Event = threading.Event()
+        self._shutdown_complete: bool = False
         self._captured_exception_event: threading.Event = threading.Event()
         self._captured_exception: Optional[Exception] = None
 
@@ -140,6 +143,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         self.update_thread.start()
         self.compute_thread.start()
+
+        atexit.register(self.shutdown)
 
         logger.info(
             f"CPUOffloadedRecMetricModule initialization complete with {model_out_device.type=}, {update_queue_size=}, {compute_queue_size=}."
@@ -239,11 +244,13 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
             if transfer_completed_event is not None:
                 transfer_completed_event.synchronize()
+
             labels, predictions, weights, required_inputs = parse_task_model_outputs(
                 self.rec_tasks,
                 cpu_model_out,
                 self.get_required_inputs(),
             )
+
             if required_inputs:
                 metric_update_job.kwargs["required_inputs"] = required_inputs
 
@@ -264,16 +271,37 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     @override
     def shutdown(self) -> None:
         """
-        Stop the worker thread gracefully, processing all remaining queue items.
+        Two-phase shutdown: stop the update thread first so its flush can
+        enqueue any final compute jobs, then stop the compute thread.
+        Idempotent — safe under explicit call + atexit.
         """
 
-        logger.info("Gracefully shutting down CPUOffloadedRecMetricModule...")
-        self._shutdown_event.set()
+        if self._shutdown_complete:
+            return
 
+        shutdown_timeout = 300.0
+
+        logger.info(
+            f"Gracefully shutting down CPUOffloadedRecMetricModule... "
+            f"update_queue={self.update_queue.qsize()}, "
+            f"compute_queue={self.compute_queue.qsize()}"
+        )
+
+        self._shutdown_event.set()
         if self.update_thread.is_alive():
-            self.update_thread.join(timeout=30.0)
+            self.update_thread.join(timeout=shutdown_timeout)
+        logger.info(
+            f"Update thread: alive={self.update_thread.is_alive()}, "
+            f"update_queue_remaining={self.update_queue.qsize()}"
+        )
+
+        self._compute_shutdown_event.set()
         if self.compute_thread.is_alive():
-            self.compute_thread.join(timeout=30.0)
+            self.compute_thread.join(timeout=shutdown_timeout)
+        logger.info(
+            f"Compute thread: alive={self.compute_thread.is_alive()}, "
+            f"compute_queue_remaining={self.compute_queue.qsize()}"
+        )
 
         self.update_job_time_logger.log_percentiles()
         self.update_queue_size_logger.log_percentiles()
@@ -328,12 +356,19 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
             )
 
+        # Surface a worker thread crash that happened before shutdown() ran;
+        # is_alive() checks above pass for already-dead threads.
+        if self._captured_exception_event.is_set():
+            assert self._captured_exception is not None
+            raise self._captured_exception
+
         self._log_event("shutdown", EventType.SUCCESS, correctness_metadata)
         logger.info(
             f"CPUOffloadedRecMetricModule shutdown complete. "
             f"updates={self._total_updates_processed}/{self._total_updates_enqueued}, "
             f"computes={self._total_computes_processed}/{self._total_computes_enqueued}"
         )
+        self._shutdown_complete = True
 
     @override
     def compute(self) -> DeferrableMetrics:
@@ -393,7 +428,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         """
 
         with record_function("## CPUOffloadedRecMetricModule:sync_marker ##"):
-            self.compute_count += 1
             if not self.rec_metrics:
                 raise RecMetricException("No metrics to compute.")
 
@@ -480,10 +514,18 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 )
                 self._captured_exception = e
                 self._captured_exception_event.set()
-                raise e
+                return
+
+        try:
+            # pyrefly: ignore[implicit-import]
+            self.update_queue.put_nowait(
+                SynchronizationMarker(concurrent.futures.Future())
+            )
+        except queue.Full:
+            logger.warning("Could not enqueue final SyncMarker: update queue full")
 
         remaining = self._flush_remaining_work(self.update_queue)
-        logger.info(f"Flushed {remaining} remaining items during shutdown.")
+        logger.info(f"Flushed {remaining} remaining update items during shutdown.")
 
     def _compute_loop(self) -> None:
         """
@@ -492,7 +534,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         torch.multiprocessing._set_thread_name(metric_compute_thread_name)
         logger.info(f"Started thread {torch.multiprocessing._get_thread_name()}")
 
-        while not self._shutdown_event.is_set():
+        while not self._compute_shutdown_event.is_set():
             try:
                 self._do_work(self.compute_queue)
             except Exception as e:
@@ -510,12 +552,25 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 )
                 self._captured_exception = e
                 self._captured_exception_event.set()
-                raise e
+                # Subsequent compute jobs all hit the same collective and would
+                # fail identically — fail their futures and exit.
+                self._fail_remaining_compute_jobs(e)
+                return
 
         remaining = self._flush_remaining_work(self.compute_queue)
         logger.info(
             f"Compute thread flushed {remaining} remaining items during shutdown."
         )
+
+    def _fail_remaining_compute_jobs(self, error: Exception) -> None:
+        while not self.compute_queue.empty():
+            try:
+                job = self.compute_queue.get_nowait()
+            except queue.Empty:
+                break
+            if isinstance(job, MetricComputeJob) and not job.future.done():
+                job.future.set_exception(error)
+            self.compute_queue.task_done()
 
     def _do_work(
         self,
@@ -533,6 +588,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         try:
             job = metric_job_queue.get(timeout=5.0)
+        except queue.Empty:
+            return
+        # try/finally guarantees task_done() so queue.join() can't deadlock.
+        try:
             if isinstance(job, MetricUpdateJob):
                 self._process_metric_update_job(job)
             elif isinstance(job, SynchronizationMarker):
@@ -540,9 +599,13 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             elif isinstance(job, MetricComputeJob):
                 computed_metrics = self._process_metric_compute_job(job)
                 job.future.set_result(computed_metrics)
+        except Exception as e:
+            # Fail the future so DeferrableMetrics.resolve() doesn't block forever.
+            if isinstance(job, (SynchronizationMarker, MetricComputeJob)):
+                job.future.set_exception(e)
+            raise
+        finally:
             metric_job_queue.task_done()
-        except queue.Empty:
-            pass
 
     def _flush_remaining_work(
         self,
@@ -563,13 +626,21 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         items_processed = 0
         while not metric_job_queue.empty():
             job = metric_job_queue.get_nowait()
-            if isinstance(job, MetricUpdateJob):
-                self._process_metric_update_job(job)
-            elif isinstance(job, SynchronizationMarker):
-                self._process_synchronization_marker(job)
-            elif isinstance(job, MetricComputeJob):
-                computed_metrics = self._process_metric_compute_job(job)
-                job.future.set_result(computed_metrics)
+            try:
+                if isinstance(job, MetricUpdateJob):
+                    self._process_metric_update_job(job)
+                elif isinstance(job, SynchronizationMarker):
+                    self._process_synchronization_marker(job)
+                elif isinstance(job, MetricComputeJob):
+                    computed_metrics = self._process_metric_compute_job(job)
+                    job.future.set_result(computed_metrics)
+            except Exception as e:
+                logger.warning(f"Ignoring error during shutdown flush: {e}")
+                if (
+                    isinstance(job, (SynchronizationMarker, MetricComputeJob))
+                    and not job.future.done()
+                ):
+                    job.future.set_exception(e)
             items_processed += 1
             metric_job_queue.task_done()
         return items_processed

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -259,6 +259,59 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         self.assertFalse(self.cpu_module.update_thread.is_alive())
         self.assertFalse(self.cpu_module.compute_thread.is_alive())
 
+    def test_shutdown_is_idempotent(self) -> None:
+        self.cpu_module.shutdown()
+        self.assertTrue(self.cpu_module._shutdown_complete)
+
+        # Second call must be a no-op (no exception, no re-logging).
+        with patch.object(self.cpu_module, "_log_event") as mock_log_event:
+            self.cpu_module.shutdown()
+            mock_log_event.assert_not_called()
+
+    def test_shutdown_reraises_captured_exception(self) -> None:
+        """If a worker thread crashed before shutdown(), shutdown() must
+        re-raise the captured exception so the training job fails properly."""
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_update_job",
+            side_effect=RuntimeError("worker died"),
+        ):
+            self.cpu_module.update(
+                {
+                    "task1-prediction": torch.tensor([0.5]),
+                    "task1-label": torch.tensor([0.5]),
+                    "task1-weight": torch.tensor([1.0]),
+                }
+            )
+            self.assertTrue(
+                self.cpu_module._captured_exception_event.wait(timeout=5.0),
+                "update thread did not capture exception",
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "worker died"):
+            self.cpu_module.shutdown()
+
+    def test_shutdown_processes_final_sync_marker_in_compute_thread(self) -> None:
+        """Two-phase shutdown: the SyncMarker enqueued during update-thread
+        flush must be processed by the compute thread before it stops."""
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.5]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+        for _ in range(3):
+            self.cpu_module.update(model_out)
+
+        computes_before = self.cpu_module._total_computes_processed
+        self.cpu_module.shutdown()
+
+        self.assertGreater(
+            self.cpu_module._total_computes_processed,
+            computes_before,
+            "compute thread did not process the final SyncMarker enqueued "
+            "during update-thread flush",
+        )
+
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -690,6 +743,28 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
     def test_no_dtoh_transfer_for_cpu_device(self) -> None:
         self._run_dtoh_transfer_test(use_cuda=False)
 
+    def test_compute_count_increments_once_per_async_compute(self) -> None:
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        self.assertEqual(self.cpu_module.compute_count, 0)
+
+        for expected_count in range(1, 4):
+            for _ in range(3):
+                self.cpu_module.update(model_out)
+
+            deferrable = self.cpu_module.async_compute()
+            result_event = threading.Event()
+            deferrable.subscribe(callback=lambda _, e=result_event: e.set())
+            self.assertTrue(
+                result_event.wait(timeout=15.0),
+                f"async_compute #{expected_count} did not complete",
+            )
+            self.assertEqual(self.cpu_module.compute_count, expected_count)
+
     def test_generate_metric_module_creates_cpu_offloaded_module(self) -> None:
         module_kwargs = {
             "model_out_device": torch.device("cpu"),
@@ -804,6 +879,79 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
             self.cpu_module._captured_exception_event.wait(timeout=5.0)
             self.assertEqual(self.cpu_module._compute_errors, 1)
+
+    def test_queue_join_does_not_deadlock_after_processing_failure(self) -> None:
+        """Regression: if _do_work skips task_done() on processing failure,
+        queue.join() in sync()/wait_until_queue_is_empty() would deadlock.
+        The fix wraps processing in try/finally so task_done() always runs.
+        """
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.5]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_update_job",
+            side_effect=RuntimeError("processing failed"),
+        ):
+            self.cpu_module._update_rec_metrics(model_out)
+            # Wait for the update thread to die
+            self.assertTrue(
+                self.cpu_module._captured_exception_event.wait(timeout=5.0),
+                "update thread did not capture exception",
+            )
+
+        # queue.join() has no timeout — run in a thread and detect deadlock via Event
+        join_completed = threading.Event()
+
+        def join_queue() -> None:
+            self.cpu_module.update_queue.join()
+            join_completed.set()
+
+        threading.Thread(target=join_queue, daemon=True).start()
+        self.assertTrue(
+            join_completed.wait(timeout=5.0),
+            "queue.join() deadlocked — task_done() was not called after processing failure",
+        )
+
+    def test_compute_job_failure_propagates_to_future(self) -> None:
+        """Regression: _process_metric_compute_job failure must set the future's
+        exception so DeferrableMetrics.resolve() doesn't block forever."""
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_compute_job",
+            side_effect=RuntimeError("compute failed"),
+        ):
+            deferrable = self.cpu_module.async_compute()
+
+            self.assertTrue(
+                self.cpu_module._captured_exception_event.wait(timeout=5.0),
+                "compute thread did not capture exception",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "compute failed"):
+                deferrable.resolve()
+
+    def test_sync_marker_failure_propagates_to_future(self) -> None:
+        """SynchronizationMarker.future is the same future returned via
+        DeferrableMetrics from async_compute(). A failure in
+        _process_synchronization_marker must surface through resolve()."""
+        with patch.object(
+            self.cpu_module,
+            "_process_synchronization_marker",
+            side_effect=RuntimeError("sync marker failed"),
+        ):
+            deferrable = self.cpu_module.async_compute()
+
+            self.assertTrue(
+                self.cpu_module._captured_exception_event.wait(timeout=5.0),
+                "update thread did not capture exception",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "sync marker failed"):
+                deferrable.resolve()
 
     def test_enqueue_update_logs_failure_on_queue_full(self) -> None:
         """Verify FAILURE event is logged when update queue is full."""


### PR DESCRIPTION
Summary:

Several reliability fixes for CPUOffloadedRecMetricModule:

- **Two-phase shutdown**: stop the update thread first so its flush can enqueue final compute jobs, then stop the compute thread. Idempotent and atexit-registered.
- **Surface worker-thread crashes**: shutdown() re-raises any exception captured by a worker thread that died before shutdown() ran. Without this, is_alive() checks pass silently and the training job mis-reports success.
- **Fail-fast compute loop**: on processing error, fail all queued compute futures and exit the thread. Subsequent jobs share the same collective (e.g. all_gather) and would fail identically — draining is wasted work.
- **Future propagation**: SynchronizationMarker and MetricComputeJob futures are now set with the exception on processing failure, so DeferrableMetrics.resolve() does not block forever.
- **task_done() guarantee**: try/finally in both _do_work and _flush_remaining_work prevents queue.join() from deadlocking after a crash.
- **compute_count double-increment fix**: removed the duplicate increment from _process_synchronization_marker. compute_count now grows by 1 per cycle, restoring _adjust_compute_interval()'s behavior (it gates on compute_count == 1).

Differential Revision: D94276131


