### PR TITLE
Pass batch_size_stages to RecMetrics via _generate_rec_metrics

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -402,6 +402,11 @@ class RecMetric(nn.Module, abc.ABC):
         if "should_clone_update_inputs" in kwargs:
             del kwargs["should_clone_update_inputs"]
 
+        # Pop batch_size_stages from kwargs so it doesn't cause type conflicts
+        # when subclasses pass **kwargs: Dict[str, Any] to super().__init__().
+        # TowerQPSMetric declares its own explicit batch_size_stages parameter.
+        kwargs.pop("batch_size_stages", None)
+
         if self._window_size < self._batch_size:
             raise ValueError(
                 f"Local window size must be larger than batch size. Got local window size {self._window_size} and batch size {self._batch_size}."


### PR DESCRIPTION
Summary:
TowerQPSMetric supports variable batch sizes via its batch_size_stages parameter, and the training framework already derives and passes batch_size_stages to generate_metric_module(). However, generate_metric_module() only forwarded batch_size_stages to ThroughputMetric, not to _generate_rec_metrics() which creates TowerQPSMetric. This caused TowerQPSMetric to use the configured final batch_size (e.g. 4096) during batch size warmup when the actual batch size is smaller (e.g. 2048), leading to RuntimeError in labels.view(-1, batch_size) when num_tasks * actual_batch_size is not divisible by configured batch_size.

This change passes batch_size_stages through _generate_rec_metrics() to all RecMetrics via kwargs. TowerQPSMetric consumes it to track the correct batch size at each training iteration. Other metrics silently accept and ignore it via **kwargs.

Differential Revision: D93789002


