### PR TITLE
add eval sdd cpu pipeline to benchmark

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -163,7 +163,7 @@ def runner(
     with MultiProcessContext(
         rank=rank,
         world_size=world_size,
-        backend="nccl",
+        backend="cpu:gloo,cuda:nccl",
         use_deterministic_algorithms=False,
     ) as ctx:
         unsharded_model = model_config.generate_model(

--- a/torchrec/distributed/benchmark/yaml/eval_sdd_cpu.yml
+++ b/torchrec/distributed/benchmark/yaml/eval_sdd_cpu.yml
@@ -1,0 +1,50 @@
+# this is a very basic sparse data dist config
+# runs on 1 rank, showing traces with reasonable workloads
+RunOptions:
+  world_size: 1
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "eval_sdd_cpu"
+  # export_stacks: True # enable this to export stack traces
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "eval-cpu"
+ModelInputConfig:
+  feature_pooling_avg: 30
+  num_float_features: 10
+  offload_sparse_to_cpu: True
+PlannerConfig:
+  device_group: "cpu"
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 10
+    submodule_kwargs:
+      over_arch_out_size: 2048
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 50
+  num_weighted_features: 50
+  embedding_feature_dim: 128
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]


### PR DESCRIPTION
Summary: We are working on offloading eval sparse embedding load/lookup/distribution to CPU. This diff adds the yaml file for benchmark

Reviewed By: TroyGarden

Differential Revision: D94393603


