### PR TITLE
[detailed][memory] Prototype Long-Sequence Activation Stashing

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml
@@ -1,0 +1,57 @@
+# Mixed EBC + EC (EmbeddingCollection) benchmark config
+# Demonstrates benchmarking with both EmbeddingBagConfig and EmbeddingConfig tables
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sdd_activation_stashing"
+  memory_snapshot: True
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "mixed_embedding"
+  model_config:
+    num_float_features: 100
+    over_arch_clazz: "large_activation"
+    enable_activation_stashing: true
+    dense_arch_hidden_sizes: [8192, 8192, 8192]
+    over_arch_kwargs:
+      large_activation_dim: 8192
+EmbeddingTablesConfig:
+  num_unweighted_features: 70
+  num_weighted_features: 0
+  embedding_feature_dim: 256
+  additional_tables:
+    # First list: unweighted tables (EBC + EC mixed)
+    - - name: ebc_table_0
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["ebc_feature_0"]
+      - name: ebc_table_1
+        embedding_dim: 256
+        num_embeddings: 200_000
+        feature_names: ["ebc_feature_1"]
+      # EC tables - use config_class to specify EmbeddingConfig
+      - name: ec_table_0
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["ec_feature_0"]
+        config_class: EmbeddingConfig
+      - name: ec_table_1
+        embedding_dim: 1024
+        num_embeddings: 2_000_000
+        feature_names: ["ec_feature_1"]
+        config_class: EmbeddingConfig
+    # Second list: weighted tables (empty for this config)
+    - []
+PlannerConfig:
+  pooling_factors: [10.0]
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB


### PR DESCRIPTION
Summary:
## 1. Context

In long-sequence embedding models (using `EmbeddingCollection`), EC output tensors can be very large (e.g., 7+ GB each) because they retain full sequence-length dimensions. These activations remain in HBM throughout the forward pass and must be kept alive for backward, creating significant memory pressure that limits model scale. See previous posts for background:
- [Embedding Memory Stashing: Overall Design and Embedding Table Stashing](https://fb.workplace.com/groups/811751593969209/permalink/1380163167128046/) [#3807, #3745]

- [Embedding Memory Stashing: Optimizer State Stashing](https://fb.workplace.com/groups/429376538334034/permalink/1569024167702593/) [#3800]

This diff prototypes activation stashing for EC outputs: after the sparse forward completes, EC result tensors are asynchronously copied to pinned CPU memory and their HBM storage is freed. During backward, a `register_hook` callback restores the tensors from CPU back to HBM just before they are needed for gradient computation. With proper tuning of the restore timing, the H2D transfer can fully overlap with dense backward compute, making the QPS impact minimal.

## 2. Approach

1. **Activation stashing integration in `TestMixedEmbeddingSparseArch`**: After the sequence embedding (EC result) is used in sparse_forward, the model calls `MemoryStashingManager._stash_tensors` on the raw EC result to stash the seq emb. `await_restore` is registered on `ec_embeddings` (fires in backward, blocks until H2D completes). The `restore` callback is saved to `self._restore_callback` and registered on `dense_r` in `forward`, so it fires during dense backward -- initiating the async H2D copy early enough to overlap with dense gradient computation.

2. **FX tracing compatibility**: `_stash_tensors` is not FX-traceable (it uses control flow on tensor values). The stashing code path is guarded with `torch.fx._symbolic_trace.is_fx_tracing()` so it is skipped during pipeline model rewriting. The `torch.fx._symbolic_trace` variant is used (rather than `torchrec.fx.tracer.is_fx_tracing`) because the pipeline's `_rewrite_model` uses `torch.fx.Tracer`.

3. **Shared-storage fix in `_stash_tensors`**: EC tensors can be views into the same underlying storage (e.g., slices of an all-to-all output buffer). The previous implementation copied and freed tensors one-by-one, which would invalidate sibling views when the first tensor's storage was freed. Fixed with a two-pass approach:
   - **Stash phase**: Copy all tensors to CPU first, then free HBM storage with deduplication by `data_ptr()`.
   - **Restore phase**: Resize to the original storage size (not individual tensor size) so sibling views share the same allocation. Use `hbm_ref.storage_offset()` instead of hardcoded `0` to place data at the correct position within shared storage.

## 3. Results

* benchmark

| name | per-iter time | GPU peak alloc | GPU peak reserved | GPU total used | CPU peak RSS |
|--|--|--|--|--|--|
| sdd_large_seq | 2.723 s | 68.41 GB | 118.90 GB | 121.34 GB | 65.15 GB |
| sdd_activation_stashing | 2.728 s | 60.85 GB | 115.27 GB | 117.71 GB | 73.77 GB |

* repro commands
```bash
# baseline (no activation stashing)
# Set enable_activation_stashing: false in sparse_data_dist_act_stash.yml before running
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml \
  --name=sdd_large_seq

# activation stashing
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml
```

* trace

**baseline** (2.723 s per iteration):
<img width="4654" height="1612" alt="image" src="https://github.com/user-attachments/assets/c468ce38-babe-4fee-ab98-df3e00f3725e" />

**activation stashing** (2.728 s per iteration, +0.2%): stashing and restoring are fully overlapped
<img width="4652" height="1714" alt="image" src="https://github.com/user-attachments/assets/b561e5ef-bfb4-4ffd-80e2-d2636c804d0f" />
<img width="1090" height="259" alt="image" src="https://github.com/user-attachments/assets/307cd72f-883e-4d7e-8f6b-cafd40ea55ea" />
<img width="1277" height="242" alt="image" src="https://github.com/user-attachments/assets/9e045b94-f9d0-45b8-8189-d8881db6499f" />


* memory snapshot

**baseline**: 7.4 GB sequence embedding allocated in `sparse_forward` remains in HBM throughout forward and backward, freed only at the end of backward.
<img width="1817" height="804" alt="image" src="https://github.com/user-attachments/assets/ba263a73-8719-4f5b-8b47-5493c18b8129" />

**activation stashing**: Same 7.4 GB allocation in `sparse_forward`, but stashed to CPU and freed from HBM immediately after use. Restored back to HBM during backward just before gradient computation needs it.
<img width="1813" height="830" alt="image" src="https://github.com/user-attachments/assets/e68efdc4-f4b8-40e8-b5d6-8855d4271d2e" />

## 4. Analysis

1. **GPU peak alloc savings**: Activation stashing reduces GPU peak allocated memory from 68.41 GB to 60.85 GB, a savings of ~7.56 GB (11%). As shown in the memory snapshots, the 7.4 GB sequence embedding created in `sparse_forward` normally stays in HBM until late in the backward pass; with stashing, it is freed shortly after creation and restored only when needed during backward.

2. **Runtime overhead**: Per-iteration runtime measured from traces: baseline 2.723 s vs activation stashing 2.728 s (+0.2%), showing that the H2D restore effectively overlaps with dense backward compute.

3. **CPU memory tradeoff**: CPU peak RSS increases from 65.15 GB to 73.77 GB (+8.62 GB) to hold the pinned CPU buffers for stashed EC tensors.

4. **GPU reserved memory**: GPU peak reserved decreases from 118.90 GB to 115.27 GB (-3.63 GB), and total reserved from 121.34 GB to 117.71 GB (-3.63 GB). The smaller reduction in reserved vs. allocated suggests some fragmentation overhead from the stash/restore cycle.

5. **Backward compatibility**: All new parameters have default values that preserve existing behavior (`enable_activation_stashing=False`). The shared-storage fix in `_stash_tensors` is a correctness improvement that also benefits the existing embedding weight and optimizer state stashing use cases.

## 5. How to Use Activation Stashing
<img width="1367" height="606" alt="image" src="https://github.com/user-attachments/assets/06d475ba-aca8-4945-9c18-2dc42366ef2a" />

To add activation stashing to your model, follow these steps:

1. **Initialize streams**: Call `MemoryStashingManager.set_streams(torch.cuda.Stream(device=device))` during model `__init__`.

2. **Stash in sparse forward**: After computing the activations you want to offload, call `_stash_tensors` on the raw tensors that stay in the memory for backward:
   ```python
   await_restore, restore = MemoryStashingManager._stash_tensors(
       [tensor_to_stash_0, tensor_to_stash_1, ...]
   )
   ```

3. **Register backward hooks**: Register hooks so that restore happens before the stashed tensors are needed in backward:
   - Register `await_restore` on a tensor whose backward runs **after** the stashed tensors are needed (e.g., the downstream output that depends on them). This blocks the current stream until H2D completes.
   - Save `restore` and register it on a tensor whose backward runs **before** the stashed tensors are needed (e.g., the dense arch output). This initiates the async H2D copy early so it can overlap with other backward compute.
   ```python
   # In sparse_forward:
   ec_embeddings.register_hook(await_restore)
   self._restore_callback = restore

   # In forward:
   dense_r.register_hook(self._restore_callback)
   ```

4. **Guard for FX tracing**: Wrap the stashing logic with `torch.fx._symbolic_trace.is_fx_tracing()` to skip it during pipeline model rewriting:
   ```python
   if not torch.fx._symbolic_trace.is_fx_tracing():
       # stashing logic here
   ```

5. **Maximize overlap**: To hide the H2D restore latency, register the `restore` callback on a tensor whose backward precedes a significant amount of compute (e.g., dense arch backward). This way the H2D transfer runs concurrently with that compute, and `await_restore` only blocks if the transfer hasn't finished yet.

## 6. Changes

1. **`memory_stashing.py`**: Fixed `_stash_tensors` to handle tensors with shared underlying storage. Changed `stash_data` tuple to include `orig_storage_size`. Stash phase uses two-pass approach (copy all, then free with dedup). Restore phase resizes to original storage size and uses `storage_offset()` for correct placement.

2. **`test_model.py`**: Added `TestMixedSequenceOverArchLargeActivation` over-arch with configurable `large_activation_dim` and `over_arch_hidden_layers`. Added `enable_activation_stashing`, `dense_arch_hidden_sizes`, and `over_arch_kwargs` params to `TestMixedEmbeddingSparseArch`. Integrated `MemoryStashingManager._stash_tensors` in `sparse_forward` with `is_fx_tracing()` guard. Added `MemoryStashingManager` import and BUCK dependency.

3. **`model_config.py`**: Added `MIXED_OVER_ARCH_CLASSES` registry. Added `over_arch_clazz`, `enable_activation_stashing`, `dense_arch_hidden_sizes`, and `over_arch_kwargs` fields to `MixedEmbeddingConfig` with `__post_init__` for string-to-class resolution. Passed all new params through `generate_model()`.

4. **`sparse_data_dist_act_stash.yml`**: New benchmark config (copied from `sparse_data_dist_seq.yml`) with activation stashing enabled, large dense arch (`[8192, 8192, 8192]`), and large over-arch (`large_activation_dim: 8192`).

Differential Revision: D94588410
