### PR TITLE
implement a train pipeline for sparse operations on CPU

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -163,7 +163,7 @@ def runner(
     with MultiProcessContext(
         rank=rank,
         world_size=world_size,
-        backend="nccl",
+        backend="cpu:gloo,cuda:nccl",
         use_deterministic_algorithms=False,
     ) as ctx:
         unsharded_model = model_config.generate_model(

--- a/torchrec/distributed/benchmark/yaml/eval_sdd_cpu.yml
+++ b/torchrec/distributed/benchmark/yaml/eval_sdd_cpu.yml
@@ -1,0 +1,50 @@
+# this is a very basic sparse data dist config
+# runs on 1 rank, showing traces with reasonable workloads
+RunOptions:
+  world_size: 1
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "eval_sdd_cpu"
+  # export_stacks: True # enable this to export stack traces
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "eval-cpu"
+ModelInputConfig:
+  feature_pooling_avg: 30
+  num_float_features: 10
+  offload_sparse_to_cpu: True
+PlannerConfig:
+  device_group: "cpu"
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 10
+    submodule_kwargs:
+      over_arch_out_size: 2048
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 50
+  num_weighted_features: 50
+  embedding_feature_dim: 128
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -41,6 +41,7 @@ class ModelInput(Pipelineable):
         device: torch.device,
         non_blocking: bool = False,
         data_copy_stream: Optional[torch.cuda.streams.Stream] = None,
+        dense_only: bool = False,
     ) -> "ModelInput":
         """
         Move ModelInput to the specified device.
@@ -51,6 +52,9 @@ class ModelInput(Pipelineable):
             data_copy_stream: Optional CUDA stream for async data copies. When provided,
                 tensors are pre-allocated on the target device and copied within this stream.
                 This enables pipelined data transfers with computation on other streams.
+            dense_only: Whether to only move dense features (float_features, label, dummy)
+                to the target device, keeping sparse features (idlist_features, idscore_features)
+                on their current device.
 
         Returns:
             ModelInput on the target device.
@@ -62,6 +66,9 @@ class ModelInput(Pipelineable):
             # Async transfer with dedicated stream
             copy_stream = torch.cuda.Stream()
             batch_gpu = batch_cpu.to(device="cuda", non_blocking=True, data_copy_stream=copy_stream)
+
+            # Move only dense features to GPU, keep sparse on CPU
+            batch_mixed = batch_cpu.to(device="cuda", dense_only=True)
         """
         if data_copy_stream is None:
             # Standard .to() method
@@ -69,69 +76,90 @@ class ModelInput(Pipelineable):
                 device=device,
                 non_blocking=non_blocking,
             )
-            idlist_features = (
-                self.idlist_features.to(
-                    device=device,
-                    non_blocking=non_blocking,
-                )
-                if self.idlist_features is not None
-                else None
-            )
-            idscore_features = (
-                self.idscore_features.to(
-                    device=device,
-                    non_blocking=non_blocking,
-                )
-                if self.idscore_features is not None
-                else None
-            )
             label = self.label.to(
                 device=device,
                 non_blocking=non_blocking,
             )
             dummy = [d.to(device=device, non_blocking=non_blocking) for d in self.dummy]
+
+            if dense_only:
+                # Keep sparse features on their current device
+                idlist_features = self.idlist_features
+                idscore_features = self.idscore_features
+            else:
+                idlist_features = (
+                    self.idlist_features.to(
+                        device=device,
+                        non_blocking=non_blocking,
+                    )
+                    if self.idlist_features is not None
+                    else None
+                )
+                idscore_features = (
+                    self.idscore_features.to(
+                        device=device,
+                        non_blocking=non_blocking,
+                    )
+                    if self.idscore_features is not None
+                    else None
+                )
         else:
             # Async copy using dedicated stream
             current_stream = torch.cuda.current_stream(device)
 
-            # Pre-allocate tensors on target device
+            # Pre-allocate dense tensors on target device
             float_features = torch.empty_like(self.float_features, device=device)
             label = torch.empty_like(self.label, device=device)
-            idlist_features = (
-                None
-                if self.idlist_features is None
-                else KeyedJaggedTensor.empty_like(self.idlist_features, device=device)
-            )
-            idscore_features = (
-                None
-                if self.idscore_features is None
-                else KeyedJaggedTensor.empty_like(self.idscore_features, device=device)
-            )
             dummy = [torch.empty_like(d, device=device) for d in self.dummy]
+
+            if dense_only:
+                # Keep sparse features on their current device
+                idlist_features = self.idlist_features
+                idscore_features = self.idscore_features
+            else:
+                # Pre-allocate sparse tensors on target device
+                idlist_features = (
+                    None
+                    if self.idlist_features is None
+                    else KeyedJaggedTensor.empty_like(
+                        self.idlist_features, device=device
+                    )
+                )
+                idscore_features = (
+                    None
+                    if self.idscore_features is None
+                    else KeyedJaggedTensor.empty_like(
+                        self.idscore_features, device=device
+                    )
+                )
 
             # Perform async copy in dedicated stream
             with data_copy_stream:
                 # Wait for current stream to finish memory allocation
                 data_copy_stream.wait_stream(current_stream)
 
+                # Copy dense features
                 float_features.copy_(self.float_features, non_blocking=non_blocking)
                 label.copy_(self.label, non_blocking=non_blocking)
-                if idlist_features is not None:
-                    idlist_features.copy_(
-                        # pyrefly: ignore[bad-argument-type]
-                        self.idlist_features,
-                        non_blocking=non_blocking,
-                    )
-                if idscore_features is not None:
-                    idscore_features.copy_(
-                        # pyrefly: ignore[bad-argument-type]
-                        self.idscore_features,
-                        non_blocking=non_blocking,
-                    )
                 dummy = [
                     d.copy_(self.dummy[i], non_blocking=non_blocking)
                     for (i, d) in enumerate(dummy)
                 ]
+
+                # Copy sparse features only if not dense_only
+                if not dense_only:
+                    if idlist_features is not None:
+                        idlist_features.copy_(
+                            # pyrefly: ignore[bad-argument-type]
+                            self.idlist_features,
+                            non_blocking=non_blocking,
+                        )
+                    if idscore_features is not None:
+                        idscore_features.copy_(
+                            # pyrefly: ignore[bad-argument-type]
+                            self.idscore_features,
+                            non_blocking=non_blocking,
+                        )
 
         return ModelInput(
             float_features=float_features,

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -14,19 +14,30 @@ from typing import Any, Callable, cast, Deque, Iterator, Optional, Tuple, Type, 
 import torch
 from torch.autograd.profiler import record_function
 from torchrec.distributed.memory_stashing import MemoryStashingManager
+from torchrec.distributed.model_parallel import ShardedModule
 from torchrec.distributed.train_pipeline.backward_injection import (
     InjectionSite,
     OutputDistSite,
 )
 from torchrec.distributed.train_pipeline.pipeline_context import (
+    CPUEmbeddingTrainPipelineContext,
+    EmbeddingTrainPipelineContext,
     In,
     Out,
     TrainPipelineContext,
 )
-from torchrec.distributed.train_pipeline.runtime_forwards import PipelinedForward
+from torchrec.distributed.train_pipeline.runtime_forwards import (
+    CPUEmbeddingPipelinedForward,
+    PipelinedForward,
+)
 from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
 from torchrec.distributed.train_pipeline.types import PipelineState
-from torchrec.distributed.train_pipeline.utils import _to_device, FutureDeque
+from torchrec.distributed.train_pipeline.utils import (
+    _start_data_dist,
+    _to_device,
+    FutureDeque,
+    use_context_for_postprocs,
+)
 from torchrec.distributed.types import ShardingType
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -193,6 +204,160 @@ class TrainEvalHybridPipelineBase(TrainPipelineSparseDist[In, Out]):
 
         # Remove processed batch from the pipeline
         self.dequeue_batch()
+        return output
+
+
+class EvalPipelineCPUSparseDist(TrainPipelineSparseDist[In, Out]):
+    """
+    Note: this is work in progress
+    This pipeline runs input_dist, forward and output_dist on CPU.
+    This pipeline will process sparse tensors on CPU and other tensors on GPU
+
+    Args:
+        See @TrainPipelineSparseDist args
+        is_sparse_embedding (bool): if True, run input_dist on CPU, else run on GPU
+    """
+
+    # pyrefly: ignore [bad-override]
+    _pipelined_forward_type = CPUEmbeddingPipelinedForward
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        gpu_device: torch.device,
+        apply_jit: bool = False,
+    ) -> None:
+        super().__init__(
+            model,
+            optimizer,
+            gpu_device,
+            apply_jit,
+            context_type=CPUEmbeddingTrainPipelineContext,
+        )
+
+    def get_next_batch(self, dataloader_iter: Iterator[In]) -> None:
+        """
+        load a data batch from dataloader, sparse features remain on CPU, all other features
+        will be copied to GPU
+        """
+        if self._dataloader_iter is not dataloader_iter:
+            self._dataloader_iter = dataloader_iter
+        context = self._create_context()
+        assert isinstance(context, CPUEmbeddingTrainPipelineContext)
+        context.dense_gpu_device = self._device.type
+        with record_function(
+            f"## enqueue_batch_sparse_cpu_other_gpu {context.index} ##"
+        ):
+            batch = self._next_batch(dataloader_iter)
+            if batch is None:
+                return
+
+            batch = batch.to(
+                self._device,
+                non_blocking=True,
+                # pyrefly: ignore[unexpected-keyword]
+                data_copy_stream=self._memcpy_stream,
+                # pyrefly: ignore[unexpected-keyword]
+                dense_only=True,
+            )
+        self.batches.append(cast(In, batch))
+
+        self.contexts.append(context)
+
+    def wait_sparse_data_dist(self, context: TrainPipelineContext) -> None:
+        """
+        Waits on the input dist splits requests to get the input dist tensors requests,
+        and populates the context with them.
+        """
+        with record_function(f"## wait_sparse_data_dist {context.index} on CPU ##"):
+            for names, awaitable in context.fused_splits_awaitables:
+                for name, request in zip(names, awaitable.wait()):
+                    context.input_dist_tensors_requests[name] = request
+        context.input_dist_splits_requests.clear()
+        context.fused_splits_awaitables.clear()
+
+    def start_sparse_data_dist(
+        self, batch: Optional[In], context: TrainPipelineContext
+    ) -> None:
+        """
+        Input distribution
+        """
+        if batch is None:
+            return
+        with record_function(f"## start_sparse_data_dist {context.index} on CPU ##"):
+            # Temporarily set context for next iter to populate cache
+            with use_context_for_postprocs(self._pipelined_postprocs, context):
+                _start_data_dist(self._pipelined_modules, batch, context)
+
+        self.wait_sparse_data_dist(self.contexts[0])
+
+    def _start_embedding_lookup(
+        self, module: ShardedModule, context: EmbeddingTrainPipelineContext
+    ) -> None:
+        """
+        Embedding lookup
+        """
+        # pyrefly: ignore[missing-attribute]
+        module_context = context.module_contexts[module.forward.name]
+        # pyrefly: ignore[missing-attribute]
+        kjt = context.input_dist_tensors_requests[module.forward.name].wait()
+
+        output_dist_out = module.compute_and_output_dist(module_context, kjt)
+        # pyrefly: ignore[missing-attribute]
+        context.embedding_a2a_requests[module.forward.name] = output_dist_out
+
+    def start_embedding_lookup(
+        self,
+        batch: Optional[In],
+        context: CPUEmbeddingTrainPipelineContext,
+    ) -> None:
+        """
+        Do embedding lookup on CPU and then copy the result to GPU
+        """
+        if batch is None:
+            return
+
+        with record_function(f"## start_embedding_lookup {context.index} in CPU ##"):
+            for module in self._pipelined_modules:
+                self._start_embedding_lookup(
+                    module,
+                    context,
+                )
+
+    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+        """
+        For EvalPipelineCPUSparseDist, it will only deal with one batch at a time
+         * batches[0]: i+0 batch, fwd (expecting output_dist)
+        """
+
+        self.get_next_batch(dataloader_iter)
+
+        if len(self.batches) == 0 or self.batches[0] is None:
+            raise StopIteration
+
+        self._init_pipelined_modules(
+            self.batches[0],
+            self.contexts[0],
+            # pyrefly: ignore [bad-argument-type]
+            self._pipelined_forward_type,
+        )
+
+        self.start_embedding_lookup(
+            self.batches[0], cast(CPUEmbeddingTrainPipelineContext, self.contexts[0])
+        )
+
+        # make sure dense copy is done
+        if self._memcpy_stream:
+            self._memcpy_stream.synchronize()
+        # forward
+        with record_function(f"## forward {self.contexts[0].index} ##"):
+            self._state = PipelineState.CALL_FWD
+            with torch.no_grad():
+                _, output = self._model_fwd(self.batches[0])
+
+        self.dequeue_batch()
+
         return output
 
 

--- a/torchrec/distributed/train_pipeline/pipeline_context.py
+++ b/torchrec/distributed/train_pipeline/pipeline_context.py
@@ -99,3 +99,8 @@ class EmbeddingTrainPipelineContext(TrainPipelineContext):
     embedding_tensors: List[List[torch.Tensor]] = field(default_factory=list)
     embedding_features: List[List[Union[str, List[str]]]] = field(default_factory=list)
     detached_embedding_tensors: List[List[torch.Tensor]] = field(default_factory=list)
+
+
+@dataclass
+class CPUEmbeddingTrainPipelineContext(EmbeddingTrainPipelineContext):
+    dense_gpu_device: str = field(default_factory=str)

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -17,6 +17,7 @@ from torch.profiler import record_function
 from torchrec.distributed.embedding_sharding import KJTSplitsAllToAllMeta
 from torchrec.distributed.model_parallel import ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
+    CPUEmbeddingTrainPipelineContext,
     EmbeddingTrainPipelineContext,
     PrefetchTrainPipelineContext,
     TrainPipelineContext,
@@ -206,6 +207,44 @@ class EmbeddingPipelinedForward(BaseForward[EmbeddingTrainPipelineContext]):
             """
             self._context.embedding_features.append([list(embeddings.keys())])
             self._context.detached_embedding_tensors.append(detached_tensors)
+
+
+class CPUEmbeddingPipelinedForward(EmbeddingPipelinedForward):
+    """
+    Pipeline used in CPU eval
+    """
+
+    # pyre-ignore [2, 24]
+    def __call__(self, *input, **kwargs) -> Union[
+        Awaitable[EmbeddingModuleRetType],
+        Tuple[
+            Awaitable[EmbeddingModuleRetType], Awaitable[Optional[KeyedJaggedTensor]]
+        ],
+    ]:
+        ctx = self._context
+        assert isinstance(ctx, CPUEmbeddingTrainPipelineContext)
+        assert (
+            self._name in ctx.embedding_a2a_requests
+        ), f"Invalid PipelinedForward usage, input_dist of {self._name} is not available, probably consumed by others"
+        # we made a basic assumption that an embedding module (EBC, EC, etc.) should only be evoked only
+        # once in the model's forward pass. For more details: https://github.com/meta-pytorch/torchrec/pull/32944
+
+        awaitable = self._context.embedding_a2a_requests.pop(self._name)
+
+        assert isinstance(awaitable, Awaitable)
+        embeddings = awaitable.wait()  # trigger awaitable manually for type checking
+        if isinstance(embeddings, KeyedTensor):
+            embeddings = embeddings.to(
+                device=torch.device(ctx.dense_gpu_device), non_blocking=False
+            )
+        else:
+            assert isinstance(embeddings, dict)
+            for key, jt in embeddings.items():
+                embeddings[key] = jt.to(
+                    device=torch.device(ctx.dense_gpu_device), non_blocking=False
+                )
+
+        return LazyNoWait(embeddings)
 
 
 class InSyncEmbeddingPipelinedForward(EmbeddingPipelinedForward):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -48,6 +48,7 @@ from torchrec.distributed.train_pipeline.pipeline_context import (
 from torchrec.distributed.train_pipeline.postproc import PipelinedPostproc
 from torchrec.distributed.train_pipeline.runtime_forwards import (
     BaseForward,
+    CPUEmbeddingPipelinedForward,
     EmbeddingPipelinedForward,
     InSyncEmbeddingPipelinedForward,
     KJTAllToAllForward,
@@ -170,6 +171,7 @@ def _start_data_dist(
                 PrefetchPipelinedForward,
                 EmbeddingPipelinedForward,
                 InSyncEmbeddingPipelinedForward,
+                CPUEmbeddingPipelinedForward,
             ),
         )
 


### PR DESCRIPTION
Summary:
This diff adds a prototype for CPU eval pipeline that runs input distribution, embedding lookup and output distribution on CPU. After output distribution is done, the result will be copied back to GPU to run forward. This pipeline currently does everything serially

Step 1
Load batch, copy the dense part to GPU
Step 2
Do input distribution, embedding look up and output distribution
Copy the result back to GPU
Step 3
Run forward

Reviewed By: TroyGarden

Differential Revision: D94393600


