### PR TITLE
[detailed][memory] Embedding Memory Stashing — Onboarding Guide

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -1,0 +1,65 @@
+# Embedding weight stashing benchmark config
+# Based on sparse_data_dist_base.yml with stash_weights on selected tables.
+# large_table has stash_weights: true, FP16_table does not — verifies
+# that only marked tables have weights moved from HBM to CPU after forward.
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_emb_stash"
+  memory_snapshot: True
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse-emb-stash"
+  kwargs:
+    site_fqn: "over.overarch.0"  # dense
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  stash_weights: true
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+      - name: large_table_no_stash
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_2"]
+        stash_weights: false
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]
+    large_table_no_stash:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -54,6 +54,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sequence_sharding import (
     CwSequenceEmbeddingSharding,
 )
@@ -1623,6 +1624,11 @@ class ShardedEmbeddingCollection(
                 EmbeddingEvent.LOOKUP, self._module_fqn, sharding_type
             ):
                 embs = lookup(features)
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore[not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -55,6 +55,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sharding import CwPooledEmbeddingSharding
 from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
 from torchrec.distributed.sharding.dynamic_sharding import (
@@ -1864,6 +1865,11 @@ class ShardedEmbeddingBagCollection(
                 if hasattr(lookup, "wait_for_forward"):
                     # pyre-ignore[29]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.logger import capped_logger, one_time_rank0_logger
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ class MemoryStashingManager:
         return cls._device_to_host_stream
 
     @classmethod
+    def is_enabled(cls) -> bool:
+        """Return whether memory stashing streams have been initialized."""
+        return cls._device_to_host_stream is not None
+
+    @classmethod
     def set_streams(
         cls,
         host_to_device_stream: Optional[torch.cuda.Stream] = None,
@@ -79,11 +85,13 @@ class MemoryStashingManager:
             cls._device_to_host_stream = host_to_device_stream
         else:
             cls._device_to_host_stream = device_to_host_stream
+        logger.info("MemoryStashingManager: streams initialized")
         one_time_rank0_logger.info("MemoryStashingManager: streams initialized")
 
     @classmethod
     def reset(cls) -> None:
         """Release all resources."""
+        logger.info("MemoryStashingManager: resetting all resources")
         cls._host_to_device_stream = None
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
@@ -270,9 +278,11 @@ class MemoryStashingManager:
     def stash_embedding_weights(
         cls,
         lookup: nn.Module,
-    ) -> Tuple[
-        Callable[[Optional[torch.Tensor]], None],
-        Callable[[Optional[torch.Tensor]], None],
+    ) -> Optional[
+        Tuple[
+            Callable[[Optional[torch.Tensor]], None],
+            Callable[[Optional[torch.Tensor]], None],
+        ]
     ]:
         """
         Stash embedding weights from HBM to CPU asynchronously.
@@ -288,7 +298,7 @@ class MemoryStashingManager:
                 embedding modules with weights to stash.
 
         Returns:
-            A tuple of two callback functions:
+            A tuple of two callback functions, or None if no tensors were stashed:
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
 
@@ -314,13 +324,24 @@ class MemoryStashingManager:
             capped_logger.info(
                 "stash_embedding_weights: no _emb_modules found, skipping"
             )
-            return lambda _grad: None, lambda _grad: None
+            return None
 
-        # Collect CUDA embedding weight tensors
+        # Collect CUDA embedding weight tensors from TBE groups marked for stashing
         tensors: List[torch.Tensor] = []
         for emb_module in module._emb_modules:
             if not hasattr(emb_module, "_emb_module"):
                 continue
+            # Check if this TBE group is marked for stashing via per-table config.
+            # If _config is a GroupedEmbeddingConfig, only stash TBEs where at
+            # least one table has stash_weights=True. Otherwise (e.g., in tests
+            # with mock objects), stash all TBEs.
+            config = getattr(emb_module, "_config", None)
+            if isinstance(config, GroupedEmbeddingConfig):
+                should_stash = any(
+                    getattr(t, "stash_weights", False) for t in config.embedding_tables
+                )
+                if not should_stash:
+                    continue
             inner = emb_module._emb_module
             if not hasattr(inner, "weights_dev"):
                 continue
@@ -334,6 +355,9 @@ class MemoryStashingManager:
             f"module={type(module).__name__}, "
             f"collected {len(tensors)} weight tensors"
         )
+
+        if not tensors:
+            return None
 
         await_restore, restore = cls._stash_tensors(tensors, label="embedding")
         cls._embedding_weight_restore_callbacks.append(restore)

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -143,6 +143,10 @@ class EmbeddingTablesConfig:
     table_data_type: DataType = DataType.FP32
     total_num_buckets: Optional[int] = None
     additional_tables: List[List[Dict[str, Any]]] = field(default_factory=list)
+
+    # Default for all tables; per-table overrides in additional_tables
+    stash_weights: bool = False
+
     # ManagedCollision configs for all tables
     mc_config: Optional[ManagedCollisionConfig] = None  # Default for all tables
     mc_configs_per_table: Dict[str, ManagedCollisionConfig] = field(
@@ -180,6 +184,10 @@ class EmbeddingTablesConfig:
 
         # Remove all keys that are not part of EmbeddingBagConfig
         kwargs.pop("location", None)
+
+        # Apply global stash_weights default if not set per-table
+        if "stash_weights" not in kwargs:
+            kwargs["stash_weights"] = self.stash_weights
 
         # Support EmbeddingConfig via config_class field
         if "config_class" in kwargs:
@@ -221,6 +229,7 @@ class EmbeddingTablesConfig:
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_unweighted_features)
         ]
@@ -231,6 +240,7 @@ class EmbeddingTablesConfig:
                 name="weighted_table_" + str(i),
                 feature_names=["weighted_feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_weighted_features)
         ]

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -9,7 +9,7 @@
 
 import unittest
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
 import torch
@@ -132,7 +132,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify HBM is freed
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -157,7 +159,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([weights_1, weights_2, weights_3])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify all are stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)
@@ -186,7 +190,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify stash worked
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -210,7 +216,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         output = torch.matmul(x, weights.t())
 
         # Stash and restore
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
@@ -250,7 +258,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Only CUDA weights should be stashed
         self.assertEqual(cuda_weights.untyped_storage().size(), 0)
@@ -286,7 +296,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Valid weights should be stashed
         self.assertEqual(valid_weights.untyped_storage().size(), 0)
@@ -308,7 +320,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         x = torch.randn(3, 5, device=self.device, requires_grad=True)
         output = torch.matmul(x, weights.t())
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Register restore via class method and await_restore as backward hook
         output.register_hook(
@@ -323,6 +337,12 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         self.assertTrue(torch.allclose(weights, original_values))
+
+    def test_is_enabled(self) -> None:
+        """Test is_enabled reflects stream initialization state."""
+        self.assertTrue(MemoryStashingManager.is_enabled())
+        MemoryStashingManager.reset()
+        self.assertFalse(MemoryStashingManager.is_enabled())
 
 
 class TestStashOptimizerState(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -63,6 +63,7 @@ class InjectionSite:
     """
 
     fqn: str
+    use_output_tensor: bool = True
 
     def find_target_module(self, model: nn.Module) -> Optional[nn.Module]:
         """
@@ -140,7 +141,10 @@ def register_backward_hook(
         input: Any,
         output: Any,
     ) -> None:
-        tensor = site.find_grad_tensor(output)
+        if site.use_output_tensor:
+            tensor = site.find_grad_tensor(output)
+        else:
+            tensor = site.find_grad_tensor(input)
         if tensor is None:
             raise RuntimeError(
                 f"register_hook: no grad-requiring tensor in "

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -367,6 +367,8 @@ class BaseEmbeddingConfig:
             for number embedding memory for virtual table is dynamic and only materialized when
             id is trained this needs to be paired with SSD/DRAM Virtual talbe in EmbeddingComputeKernel
         virtual_table_eviction_policy (Optional[VirtualTableEvictionPolicy]): eviction policy for virtual table.
+        enable_embedding_update (bool): whether to enable embedding update.
+        stash_weights (bool): whether to stash weights.
     """
 
     num_embeddings: int
@@ -389,6 +391,7 @@ class BaseEmbeddingConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
 
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:

--- a/torchrec/schema/api_tests/test_embedding_config_schema.py
+++ b/torchrec/schema/api_tests/test_embedding_config_schema.py
@@ -43,6 +43,7 @@ class StableEmbeddingBagConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
     pooling: PoolingType = PoolingType.SUM
 
 


### PR DESCRIPTION
Summary:
# Embedding Memory Stashing — Onboarding Guide

Embedding Memory Stashing (EMS) asynchronously offloads embedding table weights from GPU HBM to pinned CPU memory after the forward-pass lookup, then restores them before the backward pass. This temporarily frees HBM for activations and dense computation, enabling larger model sizes or batch sizes.

For design details and benchmark results, see:
- [Embedding Memory Stashing](https://fb.workplace.com/groups/429376538334034/permalink/1569024167702593/)
- [Optimizer State Stashing](https://fb.workplace.com/groups/811751593969209/permalink/1380163167128046/)
- [Activation Stashing](https://fb.workplace.com/groups/811751593969209/permalink/1382593183551711/)
- [Multithreading Copy-Batch](https://fb.workplace.com/groups/811751593969209/permalink/1377479830729713/)

Gated behind `MemoryStashingManager.is_enabled()`, which returns `False` unless a pipeline explicitly calls `set_streams()`. Zero production impact when not enabled.

---

## 1. How to Enable

NOTE: Per-table stashing control requires D92586272 [#3745], which adds `stash_weights` to `EmbeddingBagConfig` and propagates it through sharding.

### 1.1 Use the Stashing Pipeline

```python
from torchrec.distributed.train_pipeline.experimental_pipelines import (
    TrainPipelineSparseDistEmbStash,
)

pipeline = TrainPipelineSparseDistEmbStash(
    model=dmp_model,
    optimizer=optimizer,
    device=device,
    site_fqn="over.overarch.0",  # injection site for restore hook
)
```

The pipeline calls `MemoryStashingManager.set_streams()` in `__init__`, which enables stash guards in the sharded embedding forward path.

### 1.2 Mark Tables for Stashing

```python
tables = [
    EmbeddingBagConfig(
        name="large_user_embedding",
        num_embeddings=10_000_000,
        embedding_dim=256,
        feature_names=["user_id"],
        stash_weights=True,        # stash this table
    ),
    EmbeddingBagConfig(
        name="small_item_embedding",
        num_embeddings=50_000,
        embedding_dim=64,
        feature_names=["item_id"],
        # stash_weights defaults to False
    ),
]
```

Tables with `stash_weights=True` are grouped into separate TBEs during sharding. `stash_embedding_weights()` checks each TBE group's config and only stashes groups with marked tables.

`stash_weights` is defined on `BaseEmbeddingConfig`, so it is available on both `EmbeddingBagConfig` (pooled) and `EmbeddingConfig` (sequence). The forward guard is present in both `embeddingbag.py` and `embedding.py`.

### 1.3 Choose an Injection Site

The **injection site** is the module whose backward hook triggers the CPU→GPU restore. Requirements:

1. Runs after embedding lookup in forward (stash needs time to complete)
2. Its backward runs before EBC/EC backward (weights must be restored in time)
3. Has a `requires_grad=True` output tensor

In a typical model (`sparse_arch → over_arch → task_arch`), use an early over-arch layer.

FQN is relative to the unwrapped model. Find valid FQNs with:
```python
for name, _ in model.module.named_modules():
    print(name)
```

---

## 2. How It Works

<img width="2638" height="1662" alt="image" src="https://github.com/user-attachments/assets/d86a43fd-47f2-46b0-9e0d-3c42ebf03cc6" />

### 2.1 Stash (during forward, automatic)

After each sharded embedding lookup:

```python
embs = lookup(features)
if MemoryStashingManager.is_enabled():
    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
    if stash_result is not None:
        await_restore, _ = stash_result
        embs.register_hook(await_restore)
```

1. Iterates TBE groups, checks `stash_weights` config
2. Async copies `weights_dev` → pinned CPU buffer on D2H stream
3. Frees HBM with `untyped_storage().resize_(0)`

### 2.2 Restore (triggered by injection site)

When backward reaches the injection site:

```python
MemoryStashingManager.restore_embedding_weights()
```

Re-allocates HBM, async copies CPU → GPU on H2D stream, records a CUDA event.

### 2.3 Await (during EBC backward, automatic)

The `await_restore` hook on the embedding output tensor blocks the compute stream until H2D completes.

---

## 3. Benchmark
|short name                         |Per-Iteration (trace)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|
|sparse_data_dist_base              |~269 ms              |49.06 GB                |65.91 GB                   |68.40 GB          |0.0 / 0.0 / 0.0              |30.48 GB          |
|embedding_stashing_over_arch       |~271 ms              |49.06 GB                |61.32 GB                   |63.81 GB          |0.0 / 0.0 / 0.0              |46.34 GB          |
|embedding_stashing_dense           |~312 ms              |49.06 GB                |61.31 GB                   |63.80 GB          |0.0 / 0.0 / 0.0              |46.34 GB          |


```bash
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
```

| | Trace | Memory snapshot |
|--|--|--|
| Baseline | <img width="4624" height="1616" alt="image" src="https://github.com/user-attachments/assets/8df04b65-1941-494c-b97e-eaeaff051b43" /> | <img width="5092" height="1642" alt="image" src="https://github.com/user-attachments/assets/8f9fb232-d2ae-4439-84fd-caf13aa757d8" /> |
| Over-arch restore | <img width="4610" height="1542" alt="image" src="https://github.com/user-attachments/assets/8ec782a0-d80e-4e8c-a324-45e223721a95" /> | <img width="5092" height="1630" alt="image" src="https://github.com/user-attachments/assets/8ae19279-bc4e-46b9-9016-1ba06d86cbe6" /> |
| Dense restore | <img width="4652" height="1574" alt="image" src="https://github.com/user-attachments/assets/ed8f9d07-3cc2-4578-9a32-0537d76df338" /> | <img width="5092" height="1640" alt="image" src="https://github.com/user-attachments/assets/d14e0204-1405-45a9-a661-dbecae846e83" /> |

Dense restore site reduces GPU reserved memory by ~5 GB vs baseline; over-arch site restores later, so peak alloc is higher due to activation overlap.

---

## 4. API Reference

### 4.1 MemoryStashingManager

| Method | Description |
|--------|-------------|
| `set_streams(h2d, d2h=None)` | Initialize CUDA streams. Enables stashing. |
| `is_enabled() → bool` | Whether streams are initialized. |
| `stash_embedding_weights(lookup) → Optional[Tuple]` | Stash weights. Returns `None` if nothing to stash. |
| `restore_embedding_weights()` | Execute all queued restore callbacks. |
| `reset()` | Tear down all resources. |

### 4.2 EmbeddingBagConfig / EmbeddingConfig

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `stash_weights` | `bool` | `False` | Stash this table's weights to CPU after forward |

### 4.3 TrainPipelineSparseDistEmbStash

| Parameter | Type | Description |
|-----------|------|-------------|
| `site_fqn` | `str` or `InjectionSite` | Module FQN where restore triggers during backward |

---

## 5. Files Changed

| File | Change |
|------|--------|
| distributed/memory_stashing.py | Config-aware filtering, is_enabled(), Optional return |
| distributed/embeddingbag.py | Forward guard: stash after lookup |
| distributed/embedding.py | Forward guard: stash after lookup |
| distributed/variable_length_embedding_arch.py | Forward guard for VLE arch |
| distributed/test_utils/table_config.py | Global stash_weights option for benchmark/test |
| distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml | Benchmark config |
| distributed/tests/test_memory_stashing.py | Fix Optional unpacking, add test_is_enabled |

Differential Revision: D94770461


