### PR TITLE
Auto-detect GPU HBM capacity instead of hardcoding A100 values

### DIFF
--- a/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
+++ b/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
@@ -40,8 +40,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [10.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_kvzch.yml
@@ -61,8 +61,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [60.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_act_stash.yml
@@ -53,5 +53,3 @@ EmbeddingTablesConfig:
     - []
 PlannerConfig:
   pooling_factors: [10.0]
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -50,8 +50,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base_vbe.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base_vbe.yml
@@ -36,8 +36,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emo.yml
@@ -31,8 +31,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [1.0]  # Default pooling factor (no ModelInputConfig.feature_pooling_avg specified)
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       compute_kernels: [fused_uvm_caching]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
@@ -37,8 +37,6 @@ EmbeddingTablesConfig:
         data_type: FP16
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   # MP-ZCH only works with row-wise sharding
   additional_constraints:
     FP16_table:

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_ga.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_ga.yml
@@ -46,8 +46,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
@@ -34,8 +34,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -59,8 +59,6 @@ EmbeddingTablesConfig:
           disable_fallback: False
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   # MP-ZCH only works with row-wise sharding
   additional_constraints:
     FP16_table:

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
@@ -47,5 +47,3 @@ EmbeddingTablesConfig:
     - []
 PlannerConfig:
   pooling_factors: [10.0]
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_shampoo.yml
@@ -50,8 +50,6 @@ EmbeddingTablesConfig:
 PlannerConfig:
   sharding_type: table_wise
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
@@ -33,8 +33,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [10.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       compute_kernels: [key_value]

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 import copy
+import logging
 from dataclasses import dataclass, field
 from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
@@ -39,6 +40,22 @@ from torchrec.distributed.types import (
 )
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _detect_hbm_cap(compute_device: str) -> Optional[int]:
+    """Auto-detect HBM capacity from the current CUDA device.
+
+    Returns the total GPU memory in bytes, or None if detection is not
+    possible (e.g., no CUDA device available or compute_device is not cuda).
+    """
+    if compute_device != "cuda" or not torch.cuda.is_available():
+        return None
+    try:
+        return torch.cuda.get_device_properties(torch.device("cuda")).total_memory
+    except Exception:
+        return None
+
 
 @dataclass
 class PlannerConfig:
@@ -56,6 +73,49 @@ class PlannerConfig:
     storage_reservation_percentage: float = 0.15
     # Hardware configuration for topology (dict with keys: hbm_cap, ddr_cap, etc.)
     hardware: Optional[Dict[str, Any]] = None
+
+    def _apply_hardware_config(
+        self,
+        topology_kwargs: Dict[str, Any],
+        device_type: str,
+    ) -> None:
+        """Apply hardware config to topology kwargs, with hbm_cap fact-checking."""
+        if self.hardware is None:
+            return
+
+        # Passthrough keys from hardware config to topology kwargs
+        _HARDWARE_KEYS = [
+            "hbm_cap",
+            "ddr_cap",
+            "hbm_mem_bw",
+            "ddr_mem_bw",
+            "hbm_to_ddr_mem_bw",
+            "intra_host_bw",
+            "inter_host_bw",
+            "pod_size",
+            "local_world_size",
+        ]
+        for key in _HARDWARE_KEYS:
+            if key in self.hardware:
+                topology_kwargs[key] = self.hardware[key]
+
+        # Fact-check user-provided hbm_cap against detected value
+        if "hbm_cap" in self.hardware:
+            detected_hbm = _detect_hbm_cap(device_type)
+            if detected_hbm is not None:
+                user_hbm = self.hardware["hbm_cap"]
+                ratio = user_hbm / detected_hbm if detected_hbm else 0.0
+                if ratio < 0.5 or ratio > 2.0:
+                    logger.warning(
+                        "Hardware config hbm_cap=%d (%.1f GB) differs significantly "
+                        "from detected GPU memory %d (%.1f GB), ratio=%.2fx. "
+                        "Using configured value.",
+                        user_hbm,
+                        user_hbm / (1024**3),
+                        detected_hbm,
+                        detected_hbm / (1024**3),
+                        ratio,
+                    )
 
     def generate_topology(self, device_type: str) -> Topology:
         """
@@ -81,34 +141,18 @@ class PlannerConfig:
             "compute_device": device_type,
         }
 
-        if self.hardware is not None:
-            if "hbm_cap" in self.hardware:
-                topology_kwargs["hbm_cap"] = self.hardware["hbm_cap"]
-            if "ddr_cap" in self.hardware:
-                topology_kwargs["ddr_cap"] = self.hardware["ddr_cap"]
-            if "hbm_mem_bw" in self.hardware:
-                topology_kwargs["hbm_mem_bw"] = self.hardware["hbm_mem_bw"]
-            if "ddr_mem_bw" in self.hardware:
-                topology_kwargs["ddr_mem_bw"] = self.hardware["ddr_mem_bw"]
-            if "hbm_to_ddr_mem_bw" in self.hardware:
-                topology_kwargs["hbm_to_ddr_mem_bw"] = self.hardware[
-                    "hbm_to_ddr_mem_bw"
-                ]
-            if "intra_host_bw" in self.hardware:
-                topology_kwargs["intra_host_bw"] = self.hardware["intra_host_bw"]
-            if "inter_host_bw" in self.hardware:
-                topology_kwargs["inter_host_bw"] = self.hardware["inter_host_bw"]
+        self._apply_hardware_config(topology_kwargs, device_type)
 
-            # GB200 NVLink domain topology support
-            # pod_size represents topology_domain_multiple (hosts per NVLink domain)
-            # This enables proper intra_group_size calculation for multi-host NVLink domains
-            if "pod_size" in self.hardware:
-                topology_kwargs["pod_size"] = self.hardware["pod_size"]
-
-            # Override local_world_size if explicitly specified in hardware config
-            # Useful for GB200 (2 GPUs/host) vs A100 (8 GPUs/host)
-            if "local_world_size" in self.hardware:
-                topology_kwargs["local_world_size"] = self.hardware["local_world_size"]
+        # Auto-detect hbm_cap when not provided in hardware config
+        if "hbm_cap" not in topology_kwargs:
+            detected_hbm = _detect_hbm_cap(device_type)
+            if detected_hbm is not None:
+                topology_kwargs["hbm_cap"] = detected_hbm
+                logger.info(
+                    "Auto-detected hbm_cap=%d (%.1f GB) from GPU.",
+                    detected_hbm,
+                    detected_hbm / (1024**3),
+                )
 
         return Topology(**topology_kwargs)
 


### PR DESCRIPTION
Summary:
## 1. Context
All benchmark YAML configs hardcode `hbm_cap: 85899345920` (80 GB), which assumes an A100 GPU. When running benchmarks on different hardware (H100, GB200, etc.), the planner uses incorrect memory constraints, leading to suboptimal or broken sharding plans. This makes the benchmark suite non-portable across GPU types.

## 2. Approach
1. **Auto-detect HBM at runtime**: Added `_detect_hbm_cap()` that queries `torch.cuda.get_device_properties()` to get the actual GPU memory, returning `None` when CUDA is unavailable.
2. **Remove hardcoded values from YAML configs**: Removed the `hardware.hbm_cap` field from all 13 benchmark YAML configs so the planner falls through to auto-detection.
3. **Fact-check user-provided values**: When a user explicitly sets `hbm_cap` in the hardware config, the new `_apply_hardware_config()` method compares it against the detected value and logs a warning if they differ by more than 2x, helping catch stale or copy-pasted configs.
4. **Refactor hardware passthrough**: Replaced the verbose per-key if-chain in `generate_topology()` with a declarative `_HARDWARE_KEYS` list and a loop in `_apply_hardware_config()`, reducing duplication and making it easier to add new hardware keys.

## 3. Results
N/A — no benchmark runs included in this change.

## 4. Analysis
1. **Backward compatibility**: The `hardware.hbm_cap` field in YAML configs is still fully supported. Existing configs that set it explicitly will continue to work unchanged; the only difference is they now get a warning if the value is far from reality.
2. **Fallback behavior**: When `hbm_cap` is not set and CUDA is unavailable (e.g., CPU-only tests), no `hbm_cap` is injected into `Topology`, preserving the existing default from `torchrec.distributed.planner.Topology`.
3. **Risk (Low)**: This change only affects benchmark config parsing and planner topology construction. No changes to sharding logic, collective patterns, or training pipelines. The refactored `_apply_hardware_config()` method passes through the exact same keys as before.

## 5. Changes
1. **`distributed/test_utils/sharding_config.py`**: Added `_detect_hbm_cap()` function for runtime GPU memory detection. Added `_apply_hardware_config()` method to `PlannerConfig` that replaces the per-key if-chain with a loop and adds hbm_cap fact-checking. Updated `generate_topology()` to call the new method and auto-detect hbm_cap when not configured.
2. **`distributed/benchmark/yaml/*.yml`** (13 files): Removed hardcoded `hardware.hbm_cap: 85899345920` from all benchmark configs (`base_pipeline_light`, `prefetch_kvzch`, `sparse_data_dist_{act_stash,base,base_vbe,emo,eval,ga,lite,mpzch,seq,shampoo,ssd}`).

Differential Revision: D95072024


