### PR TITLE
add cuda13.0 to GPU unittest and skip certain jobs to save capacity

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda-tag: ["cu126", "cu128", "cu129"]
+        cuda-tag: ["cu126", "cu128", "cu129", "cu130"]
         os:
           - linux.g5.12xlarge.nvidia.gpu
         python:
@@ -63,6 +63,8 @@ jobs:
             free_threaded: true
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
+        is_main_push:  # for main branch
+          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         exclude:
           - is_pr: true
             cuda-tag: "cu126"
@@ -70,20 +72,59 @@ jobs:
             cuda-tag: "cu128"
           - is_pr: true
             cuda-tag: "cu129"
+          - is_pr: true
+            cuda-tag: "cu130"
             python:
               version: "3.10"
           - is_pr: true
-            cuda-tag: "cu129"
+            cuda-tag: "cu130"
             python:
               version: "3.11"
           - is_pr: true
-            cuda-tag: "cu129"
+            cuda-tag: "cu130"
             python:
               version: "3.12"
           - is_pr: true
+            cuda-tag: "cu130"
+            python:
+              version: "3.13"
+          - is_main_push: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.11"
+          - is_main_push: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.12"
+          - is_main_push: true
+            cuda-tag: "cu126"
+            python:
+              version: "3.13"
+          - is_main_push: true
+            cuda-tag: "cu128"
+            python:
+              version: "3.10"
+          - is_main_push: true
+            cuda-tag: "cu128"
+            python:
+              version: "3.12"
+          - is_main_push: true
+            cuda-tag: "cu128"
+            python:
+              version: "3.14"
+          - is_main_push: true
+            cuda-tag: "cu129"
+            python:
+              version: "3.11"
+          - is_main_push: true
             cuda-tag: "cu129"
             python:
               version: "3.13"
+          - is_main_push: true
+            cuda-tag: "cu129"
+            python:
+              version: "3.14"
+              free_threaded: true
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Summary:
## 1. Context
The TorchRec OSS GPU CI matrix currently tests against CUDA 12.6, 12.8, and 12.9. With CUDA 13.0 now available, the CI needs to include it for compatibility validation. However, the full cross-product of 4 CUDA versions × 6 Python versions generates too many jobs, consuming excessive CI capacity on main branch push runs.

## 2. Approach
1. **Add CUDA 13.0 to the test matrix**: Added `cu130` to the `cuda-tag` matrix so GPU unit tests run against CUDA 13.0.
2. **Shift PR exclusions from cu129 to cu130**: PR runs previously excluded extra Python versions for `cu129`; these exclusions now apply to `cu130` instead, keeping PR CI lean on the newest CUDA version.
3. **Add `is_main_push` matrix variable**: Introduced an `is_main_push` matrix flag (`github.event_name == 'push' && github.ref == 'refs/heads/main'`) to target excludes specifically at main branch pushes, leaving nightly pushes and `workflow_dispatch` runs with the full matrix.
4. **Skip redundant CUDA × Python combinations on main push only**: Added targeted exclude rules scoped to `is_main_push: true` to drop specific Python versions for `cu126`, `cu128`, and `cu129`. Each CUDA version still tests at least 3 Python versions on main push, and each Python version is tested on at least 2 CUDA versions.

## 3. Results
No benchmark results — CI configuration change only.

## 4. Analysis
1. **Coverage**: Despite the main-push-scoped excludes, every CUDA version (cu126–cu130) and every Python version (3.10–3.14, including free-threaded 3.14) is still tested on at least two main push configurations, preserving compatibility signal. Nightly pushes and manual `workflow_dispatch` runs get the full unfiltered matrix for comprehensive validation.
2. **Risk**: Low. This only modifies the GitHub Actions CI workflow for OSS. No changes to library code or internal CI.
3. **Capacity**: The main-push-scoped exclude rules reduce the main branch matrix from ~24 jobs to ~15 jobs, saving roughly 40% of GPU CI capacity on automated main branch runs.

## 5. Changes
1. **`github/.github/workflows/unittest_ci.yml`**: Added `cu130` to `cuda-tag` matrix, added `is_main_push` matrix variable, shifted PR Python-version excludes from `cu129` to `cu130`, and added main-push-scoped capacity-saving exclude rules for `cu126`, `cu128`, and `cu129` on specific Python versions.

Differential Revision: D95153219


