### PR TITLE
LRU + opt-in support

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -272,10 +272,6 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             assert (
                 self._percent_reserved_slots > 0
             ), "percent_reserved_slots must be positive when opt_in_prob is positive"
-            assert (
-                self._eviction_policy_name is None
-                or self._eviction_policy_name != HashZchEvictionPolicyName.LRU_EVICTION
-            ), "LRU eviction is not compatible with opt-in at this time"
         self._disable_fallback: bool = disable_fallback
         self._track_id_freq: bool = track_id_freq
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5439

X-link: https://github.com/facebookresearch/FBGEMM/pull/2412


currently the opt-in option only works with single_ttl eviction, not LRU eviction. 
This diff is to enable LRU eviction for opt-in and always-on.


Overall flowchart, generated by Claude:
  New ID arrives → Hash to initial slot
    │
    ▼
  Pre-check: Does this ID already exist in probing range?
    ├─ YES → Update existing slot's metadata, done (no eviction needed)
    └─ NO  → Start probing loop
                │
                ▼
           For each probed slot:
                ├─ Slot has matching ID?  → Claim it, done
                ├─ Slot is empty (-1)?    → Claim it, done
                └─ Slot occupied by other ID
                     │
                     ▼
                    Is slot expired? (eviction_threshold > metadata[slot])
                     ├─ YES → Track as LRU candidate if it's the oldest so far
                     └─ NO  → Skip, continue probing
                │
                ▼
           Probing exhausted (max_probe reached)
                │
                ▼
           Did we find any expired LRU candidate?
                ├─ YES (min_index != -1) → Evict that slot, insert new ID
                └─ NO  (all slots unexpired!)
                     ├─ DISABLE_FALLBACK=true  → Return -1 (insertion failure)
                     └─ DISABLE_FALLBACK=false → Collision fallback
                          ├─ opt_in_prob == -1 → hash % modulo (original position)
                          └─ opt_in_prob != -1 → hash % num_reserved_slots (reserved block)

Reviewed By: MengjiaoZhou, xinyuanzzz

Differential Revision: D94587946


