### PR TITLE
Implementing hardware capabilites detection module (#3832)

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -189,6 +189,19 @@ class StorageUsageType(Enum):
     DEFAULT = "ModuleSharder"
 
 
+class ComputeDevice(Enum):
+    """
+    Well-known compute devices, which can be used as constraints by ShardingPlanner.
+    """
+
+    # GPU compute device
+    CUDA = "cuda"
+    # CPU compute device
+    CPU = "cpu"
+    # MTIA compute device
+    MTIA = "mtia"
+
+
 @unique
 class ComputeKernel(Enum):
     DEFAULT = "default"


### PR DESCRIPTION
Summary:

### Overview
This diff introduces a new **Hardware Utility Module (HUM)** that consolidates hardware detection logic previously scattered across Pyper, APF, and MVAI trainer frameworks into a unified location for TorchRec Planner Topology creation.

### Key Components

**1. New `ComputeDevice` Enum** (`torchrec/distributed/types.py`)
- Defines well-known compute devices: `CUDA`, `CPU`, `MTIA`
- Used as constraints by ShardingPlanner

**2. Hardware Detection Module** (`torchrec/fb/distributed/hardware_utilities/`)
- **`types.py`**: Defines `TrainerFramework` enum (PYPER, APF, MVAI, UNIFIED)
- **`detection.py`**: Core detection functions:
  - `get_training_hardware()`: Auto-detects hardware via LLST (Logical Server SubType) from Serf
  - `detect_hbm_cap_bytes()`: Detects HBM (GPU memory) capacity
  - `detect_ddr_cap_bytes()`: Detects DDR (host memory) capacity with framework-specific behavior
  - `create_hardware_config()`: Factory function that creates `HardwareConfig` with all detected values

**3. Hardware-Specific Bandwidth Mappings** (Moved from Planner/Utils)
- `LLST_TO_TRAINING_HW`: Maps Logical Server SubTypes to TrainingHardware enums
- `CAPABILITY_INTRA_NODE_BANDWIDTH`: NVLink/NVSwitch bandwidths per hardware type
- `CAPABILITY_CROSS_NODE_BANDWIDTH`: InfiniBand/RoCE bandwidths per hardware type
- `CAPABILITY_HBM_MEM_BANDWIDTH`: HBM memory bandwidths from FBGEMM benchmarking

**4. Framework-Specific Behavior (Backward Compatibility)**
- **PYPER**: Total host memory (not divided)
- **APF/UNIFIED**: Total / local_world_size (per-rank)
- **MVAI**: Hardcoded 1536 GB DDR

### Hardware Detection Flow
1. Detect `TrainingHardware` via LLST from Serf
2. Look up bandwidth values from `CAPABILITY_*` dicts
3. Detect HBM/DDR capacity from hardware APIs
4. Create `HardwareConfig` with all values

Reviewed By: kausv

Differential Revision: D94731447
