### PR TITLE
Implement mean pooling with MP-ZCH

### DIFF
--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -14,6 +14,7 @@ from typing import Any, cast, Dict, List, Optional, Type, TypeVar
 import torch
 from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.embeddingbag import (
+    _create_mean_pooling_divisor,
     EmbeddingBagCollectionContext,
     EmbeddingBagCollectionSharder,
     ShardedEmbeddingBagCollection,
@@ -118,11 +119,52 @@ class ShardedManagedCollisionEmbeddingBagCollection(
                     # pyrefly: ignore[missing-attribute]
                     ctx.inverse_indices
                 )
+            # For mean pooling
+            if self._embedding_module._has_mean_pooling_callback:
+                self._embedding_module._init_mean_pooling_callback(
+                    features.keys(),
+                    # pyrefly: ignore[missing-attribute]
+                    ctx.inverse_indices,
+                )
+
+        with torch.no_grad():
+            skip_permute = False
+            if self._managed_collision_collection._features_order:
+                skip_permute = True
+                features = features.permute(
+                    self._managed_collision_collection._features_order,
+                    # pyrefly: ignore[bad-argument-type]
+                    self._managed_collision_collection._features_order_tensor,
+                )
+
+            # TODO: Consider turning this into a hook inside mc_modules and remove skip_permute
+            #   from mc_modules, and fix all the private methods to be public.
+            if self._embedding_module._has_mean_pooling_callback:
+                emb_mod = self._embedding_module
+                # pyrefly: ignore[missing-attribute]
+                ctx.divisor = _create_mean_pooling_divisor(
+                    lengths=features.lengths(),
+                    stride=features.stride(),
+                    keys=features.keys(),
+                    offsets=features.offsets(),
+                    pooling_type_to_rs_features=emb_mod._pooling_type_to_rs_features,
+                    stride_per_key=features.stride_per_key(),
+                    dim_per_key=emb_mod._dim_per_key,
+                    embedding_names=emb_mod._embedding_names,
+                    embedding_dims=emb_mod._embedding_dims,
+                    variable_batch_per_feature=ctx.variable_batch_per_feature,
+                    kjt_inverse_order=emb_mod._kjt_inverse_order,
+                    kjt_key_indices=emb_mod._kjt_key_indices,
+                    kt_key_ordering=emb_mod._kt_key_ordering,
+                    inverse_indices=ctx.inverse_indices,
+                    weights=features.weights_or_none(),
+                )
 
         return self._managed_collision_collection.input_dist(
             # pyrefly: ignore[bad-argument-type]
             ctx,
             features,
+            skip_permute,
         )
 
 

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -625,13 +625,16 @@ class ShardedManagedCollisionCollection(
         self,
         ctx: ManagedCollisionCollectionContext,
         features: KeyedJaggedTensor,
+        skip_permute: bool = False,
     ) -> Awaitable[Awaitable[KJTList]]:
         if self._has_uninitialized_input_dists:
             self._create_input_dists(input_feature_names=features.keys())
             self._has_uninitialized_input_dists = False
 
+        # TODO: Refactor mc_modules to make it generic with mc_embeddingbag/mc_embedding
         with torch.no_grad():
-            if self._features_order:
+            # skip_permute added since these were used earlier in `mc_embeddingbag`
+            if not skip_permute and self._features_order:
                 features = features.permute(
                     #  `Union[Module, Tensor]`.
                     self._features_order,

--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -31,7 +31,7 @@ from torchrec.distributed.test_utils.multi_process import (
 )
 from torchrec.distributed.test_utils.test_model import ModelInput
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
-from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.modules.hash_mc_evictions import (
     HashZchEvictionConfig,
@@ -597,6 +597,7 @@ def _run_single_rank_training_step(
 
 @skip_if_asan_class
 class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
+
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -649,9 +650,29 @@ class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @given(backend=st.sampled_from(["nccl"]))
+    @given(
+        backend=st.sampled_from(["nccl"]),
+        pooling_type=st.sampled_from([PoolingType.SUM, PoolingType.MEAN]),
+    )
     @settings(deadline=None)
-    def test_sharding_zch_mc_ebc(self, backend: str) -> None:
+    def test_sharding_zch_mc_ebc(self, backend: str, pooling_type: PoolingType) -> None:
+        embedding_bag_config: Final[List[EmbeddingBagConfig]] = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+                pooling=pooling_type,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=32,
+                pooling=pooling_type,
+            ),
+        ]
+
         self._run_multi_process_test(
             callable=_test_sharding_and_remapping,
             output_keys=["feature_0", "feature_1"],
@@ -699,10 +720,11 @@ class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
                 EmbeddingComputeKernel.FUSED.value,
             ]
         ),
+        pooling_type=st.sampled_from([PoolingType.SUM, PoolingType.MEAN]),
     )
     @settings(deadline=None)
     def test_mc_zch_with_sharded_versus_unsharded_vbe(
-        self, backend: str, kernel_type: str
+        self, backend: str, kernel_type: str, pooling_type: PoolingType
     ) -> None:
         WORLD_SIZE = 2
         embedding_bag_config: Final[List[EmbeddingBagConfig]] = [
@@ -712,12 +734,14 @@ class ShardedMCEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
                 embedding_dim=64,
                 num_embeddings=1000,
                 data_type=DataType.FP16,
+                pooling=pooling_type,
             ),
             EmbeddingBagConfig(
                 name="table_1",
                 feature_names=["feature_1"],
                 embedding_dim=8,
                 num_embeddings=32,
+                pooling=pooling_type,
             ),
         ]
 


### PR DESCRIPTION
Summary:
Context
---------
Implements mean-pooling with MC-EBC (for RW and TWRW).

Implementation
------------------
- Moved many of the mean pooling features inside `mc_embeddingbag`.
- Added a no_permute to mc_modules, since I had to lift the feature permutation towards mc_embeddingbag (See notes below).


Note: Rather than adding a hook function inside mc_modules, decided to go with moving many of the features inside mc_embeddingbag. This is due to the potential future refactoring of mc_modules to make it compatible with MC-EC, and MC-EBC with VBE.  Added two TODO along these lines.

Differential Revision: D94698873


