### PR TITLE
2D-Sharding Enablement For MP-ZCH (#3836)

### DIFF
--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -8,9 +8,10 @@
 # pyre-strict
 
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, Union
 
 import torch
+import torch.distributed as dist
 from torch.autograd.profiler import record_function
 from torchrec.distributed.embedding import (
     EmbeddingCollectionSharder,
@@ -273,6 +274,98 @@ class BaseShardedManagedCollisionEmbeddingCollection(
             yield append_prefix(prefix, fqn)
         for fqn, _ in self.named_buffers():
             yield append_prefix(prefix, fqn)
+
+    def sync_hash_zch_weights(
+        self,
+        table_name: str,
+        rank_to_global: torch.Tensor,
+        survived: torch.Tensor,
+        include_optimizer_state: bool,
+        allreduce_fn: Callable[
+            [
+                Dict[torch.dtype, List[torch.Tensor]],
+                str,
+                dist.AllreduceCoalescedOptions,
+            ],
+            None,
+        ],
+        indices_slots: Optional[torch.Tensor] = None,
+    ) -> None:
+        """
+        Sync the embedding weights and optimizers states.
+
+        Embedding weights that are still in the sync, are re-arranged to match the
+        global ordering. The weights of the identites that aren't found in
+        global are zeroed out. Certain replica may have identites that others don't,
+        the count of which replica has the that row is recorded, and then used when
+        doing the allreduce averaging. The rows for the reserved slots are averaged
+        out.
+
+        Args:
+            table_name (str): the name of the table to get tbe.
+            survived: Which local identities survived the sync/merging
+            rank_to_global: Mapping from this rank i to the global identity for syncing
+            include_optimizer_state (bool): whether to include optimizer state in the sync.
+            allreduce_fn (Callable): the function to perform allreduce.
+            indices_slots (Optional[torch.Tensor]): the indices of the reserved slots
+        """
+        # Grab tbe/optimizers
+        tbe, table_idx = self._table_to_tbe_and_index[table_name]
+        emb_t = tbe.split_embedding_weights()[table_idx]  # pyre-ignore[29]
+        optimizer = tbe.get_optimizer_state()  # pyre-ignore[29]
+        optim = optimizer[table_idx]["sum"] if optimizer else None
+
+        # Re-arrange embedding tables, align all tables to global hash identities
+        #  We use clone here because kernel async
+        emb_t[rank_to_global[survived]] = emb_t[survived].clone()
+        if optim is not None:
+            optim[rank_to_global[survived]] = optim[survived].clone()
+
+        # Zero out those that didn't survive global merge.
+        #  This shouldn't zero out the reserved slots of the identities
+        indices_zeroed = torch.where(rank_to_global == -1)[0]
+        emb_t[indices_zeroed] = 0.0
+        if optim is not None:
+            optim[indices_zeroed] = 0.0
+
+        # Do all reduce of tables/optimizers based on sums rather than Avg
+        #    because later we divide by count to be the right 'Avg'
+        opts = dist.AllreduceCoalescedOptions()
+        opts.reduceOp = dist.ReduceOp.SUM
+        allreduce_fn({emb_t.dtype: [emb_t]}, "## 2d_hash_weight_sync ##", opts)
+        if include_optimizer_state and optim is not None:
+            allreduce_fn({optim.dtype: [optim]}, "## 2d_hash_optimizer_sync ##", opts)
+
+        # Broadcast the counts of non-zero rows
+        emb_t_size = emb_t.shape[0]
+        nonzero_counts = torch.zeros(
+            (emb_t_size, 1),
+            device=emb_t.device,
+            requires_grad=False,
+            dtype=torch.int32,
+        )
+        nonzero_counts[rank_to_global[survived]] = 1
+
+        # Set the indices of the reserved slots to 1
+        #   this causes all embedding weights of reserved slots to be averaged
+        if indices_slots is not None:
+            nonzero_counts[indices_slots] = 1
+
+        # Allreduce the counts to get number of non-zero
+        opts = dist.AllreduceCoalescedOptions()
+        opts.reduceOp = dist.ReduceOp.SUM
+        allreduce_fn(
+            {nonzero_counts.dtype: [nonzero_counts]}, "## 2d_hash_counts_sync ##", opts
+        )
+        nonzero_counts[nonzero_counts == 0] = 1  # Handle division by zero
+
+        # Divide the embedding tables by the number of non-zero rows
+        emb_t /= nonzero_counts.to(emb_t.dtype)
+        if include_optimizer_state and optim is not None:
+            if optim.ndim == 2:
+                optim /= nonzero_counts.to(optim.dtype)
+            else:
+                optim /= nonzero_counts.to(optim.dtype).squeeze()
 
 
 M = TypeVar("M", bound=BaseManagedCollisionEmbeddingCollection)

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -65,6 +65,7 @@ from torchrec.distributed.types import (
     ShardedModule,
     ShardedTensor,
     ShardingEnv,
+    ShardingEnv2D,
     ShardingType,
 )
 from torchrec.distributed.utils import append_prefix
@@ -264,11 +265,17 @@ class ShardedManagedCollisionCollection(
         ] = None
 
     def _initialize_torch_state(self) -> None:
+        # Creates ShardedTensor using self._env_rank.
         self._model_parallel_mc_buffer_name_to_sharded_tensor = OrderedDict()
         shardable_params = set(
             self.sharded_parameter_names(prefix="_managed_collision_modules")
         )
-
+        # 2D-Sharding: Use global rank since process_group is based on global rank
+        global_rank = (
+            self._env.global_rank
+            if isinstance(self._env, ShardingEnv2D)
+            else self._env.rank
+        )
         for fqn, tensor in self.state_dict().items():
             if fqn not in shardable_params:
                 continue
@@ -293,12 +300,16 @@ class ShardedManagedCollisionCollection(
                             metadata=ShardMetadata(
                                 shard_offsets=shard_offsets,
                                 shard_sizes=sharded_sizes,
-                                placement=(f"rank:{self._env.rank}/{tensor.device}"),
+                                placement=f"rank:{global_rank}/{tensor.device}",
                             ),
                         )
                     ],
                     torch.Size(global_sizes),
-                    process_group=self._env.process_group,
+                    process_group=(
+                        self._env.sharding_pg
+                        if isinstance(self._env, ShardingEnv2D)
+                        else self._env.process_group
+                    ),
                 )
             )
 
@@ -417,7 +428,11 @@ class ShardedManagedCollisionCollection(
                             torch.tensor(
                                 [zch_size], dtype=torch.int64, device=self._device
                             ),
-                            group=self._env.process_group,
+                            group=(
+                                self._env.sharding_pg
+                                if isinstance(self._env, ShardingEnv2D)
+                                else self._env.process_group
+                            ),
                         )
                     else:
                         zch_size_by_rank[0] = torch.tensor(

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -32,6 +32,9 @@ from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.collective_utils import create_on_rank_and_share_result
 from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.mc_embedding_modules import (
+    BaseShardedManagedCollisionEmbeddingCollection,
+)
 from torchrec.distributed.model_tracker.model_delta_tracker import (
     ModelDeltaTracker,
     ModelDeltaTrackerTrec,
@@ -180,12 +183,12 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
             ),
         )
         if self._allreduce_comm_precision == "fp16":
-            # pyrefly: ignore[not-callable]
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             dmp._dmp_wrapped_module.register_comm_hook(
                 None, ddp_default_hooks.fp16_compress_hook
             )
         elif self._allreduce_comm_precision == "bf16":
-            # pyrefly: ignore[not-callable]
+            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             dmp._dmp_wrapped_module.register_comm_hook(
                 None, ddp_default_hooks.bf16_compress_hook
             )
@@ -328,7 +331,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             if pg is not None:
                 plan = planner.collective_plan(module, self.sharders, pg)
             else:
-                # pyrefly: ignore[bad-argument-type, missing-argument]
                 plan = planner.plan(module, self.sharders)
         self._plan: ShardingPlan = plan
         self._writable_sharded_modules: list[ShardedEmbeddingCollection] = []
@@ -373,6 +375,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         else:
             self._dmp_wrapped_module = value
 
+    # pyre-ignore [2, 3]
     def forward(self, *args, **kwargs) -> Any:
         for tracker in self.model_trackers.values():
             # The step() call advances the internal batch counter so that subsequent ID tracking and delta
@@ -424,9 +427,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         ):
             module_id_cache: Dict[int, ShardedModule] = {}
         else:
-            # pyrefly: ignore[bad-assignment]
             module_id_cache = None
-        # pyrefly: ignore[bad-argument-type]
         return self._shard_modules_impl(module, module_id_cache=module_id_cache)
 
     def _init_delta_tracker(
@@ -457,10 +458,9 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         ):
             module_id_cache: Dict[int, KeyedOptimizer] = {}
         else:
-            # pyrefly: ignore[bad-assignment]
             module_id_cache = None
+        # pyre-ignore [6]
         return CombinedOptimizer(
-            # pyrefly: ignore[bad-argument-type]
             self._fused_optim_impl(module, [], module_id_cache=module_id_cache)
         )
 
@@ -483,7 +483,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                         f"(module ID {module_id} at different path)"
                     )
                     return fused_optims
-                # pyrefly: ignore[unsupported-operation]
                 module_id_cache[module_id] = module.fused_optimizer
             fused_optims.append((path, module.fused_optimizer))
             return fused_optims
@@ -522,7 +521,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                 logger.error(
                     f"Module {path} is already in cache (replaced by sharded module already)"
                 )
-                # pyrefly: ignore[bad-index]
                 return module_id_cache[module_id]
 
         # shardable module
@@ -531,14 +529,12 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             sharder_key = type(module)
             sharded_module = self._sharder_map[sharder_key].shard(
                 module,
-                # pyrefly: ignore[bad-argument-type]
                 module_sharding_plan,
                 self._env,
                 self.device,
                 path,
             )
             if module_id_cache is not None:
-                # pyrefly: ignore[unbound-name, unsupported-operation]
                 module_id_cache[module_id] = sharded_module
             return sharded_module
 
@@ -570,7 +566,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
             # Init parameters if at least one parameter is over 'meta' device.
             if has_meta_param and hasattr(module, "reset_parameters"):
-                # pyrefly: ignore[not-callable]
+                # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
                 module.reset_parameters()
 
         module.apply(init_parameters)
@@ -621,26 +617,24 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                 )
         return destination
 
-    # pyrefly: ignore[bad-override]
+    # pyre-ignore [14]
     def state_dict(
         self,
         destination: Optional[Dict[str, Any]] = None,
         prefix: str = "",
         keep_vars: bool = False,
     ) -> Dict[str, Any]:
-        # pyrefly: ignore[no-matching-overload]
         state_dict = get_module(self).state_dict(
             destination=destination, prefix=prefix, keep_vars=keep_vars
         )
-        # pyrefly: ignore[implicit-import]
         torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
             state_dict, prefix + _DDP_STATE_DICT_PREFIX
         )
         add_prefix_to_state_dict(state_dict, prefix)
         return state_dict
 
+    # pyre-fixme[14]: `load_state_dict` overrides method defined in `Module`
     #  inconsistently.
-    # pyrefly: ignore[bad-override]
     def load_state_dict(
         self,
         state_dict: "OrderedDict[str, torch.Tensor]",
@@ -672,7 +666,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         unexpected_keys = []
         module = get_module(module)
         if isinstance(module, DistributedDataParallel):
-            # pyrefly: ignore[implicit-import]
             torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
                 state_dict, prefix
             )
@@ -864,7 +857,6 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
         if sharded_module_fqn is None:
             named_modules_queue = [("", self.module)]
-            # pyrefly: ignore[bad-assignment]
             while named_modules_queue:
                 child_path, child_module = named_modules_queue.pop(0)
                 if isinstance(child_module, ShardedModule):
@@ -904,8 +896,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         ), "Could not find sharded_module to reshard"
         data_volume, delta_plan = changed_shard_to_params[sharded_module_fqn]
 
-        # pyrefly: ignore[missing-attribute]
-        sharded_module = sharder.reshard(
+        sharded_module = sharder.reshard(  # pyre-ignore
             sharded_module,
             delta_plan,
             self._env,
@@ -914,8 +905,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
         # Need to use .module to maintain FQN consistency
         self._optim: CombinedOptimizer = self._init_optim(
-            # pyrefly: ignore[bad-argument-type]
-            self._dmp_wrapped_module.module
+            self._dmp_wrapped_module.module  # pyre-ignore
         )
         self._plan.plan[sharded_module_fqn] = sharded_module.module_sharding_plan
         return data_volume
@@ -1136,6 +1126,7 @@ class DMPCollection(DistributedModelParallel):
         assert (
             device.type == "cuda" or device.type == "mtia"
         ), "DMPCollection only supports CUDA or MTIA"
+        # TODO: Add assertion that world_size != sharding_group_size
         self._device = device
         self._pg: dist.ProcessGroup = global_pg
         self._global_rank: int = dist.get_rank(global_pg)
@@ -1150,8 +1141,7 @@ class DMPCollection(DistributedModelParallel):
         # Create the default context for modules without submodule configs
         self._default_ctx: DMPCollectionContext = DMPCollectionContext(
             # default context has module type None
-            # pyrefly: ignore[bad-argument-type]
-            module=None,
+            module=None,  # pyre-ignore[6]
             plan=plan,
             sharding_group_size=sharding_group_size,
             node_group_size=node_group_size,
@@ -1203,7 +1193,7 @@ class DMPCollection(DistributedModelParallel):
             )
 
             if ctx.module:
-                # pyrefly: ignore[missing-attribute]
+                # pyre-ignore[16]
                 ctx.sharded_module = self._sharder_map[ctx.module].sharded_module_type
 
         consolidated_plan = self._default_ctx.plan
@@ -1245,7 +1235,6 @@ class DMPCollection(DistributedModelParallel):
         ):
             self._register_sparse_arch_forward_hook(rs_awaitable_hook_module)
 
-    # pyrefly: ignore[bad-override]
     def _shard_modules_impl(
         self,
         module: nn.Module,
@@ -1294,14 +1283,12 @@ class DMPCollection(DistributedModelParallel):
 
             sharded_module = self._sharder_map[sharder_key].shard(
                 module,
-                # pyrefly: ignore[bad-argument-type]
                 module_sharding_plan,
                 env,
                 self.device,
                 path,
             )
             if module_id_cache is not None:
-                # pyrefly: ignore[unbound-name]
                 module_id_cache[module_id] = sharded_module
             return sharded_module
 
@@ -1330,7 +1317,58 @@ class DMPCollection(DistributedModelParallel):
         """
         # we sync per context to use the right all reduce process group
         for ctx in self._ctxs:
+            if len(ctx.hash_zch_modules) > 0:
+                # Do syncing of managed collision modules.
+                self._sync_mcc_modules(ctx, include_optimizer_state)
+
             self._sync(ctx, include_optimizer_state)
+
+    def _sync_mcc_modules(
+        self,
+        ctx: DMPCollectionContext,
+        include_optimizer_state: bool = True,
+    ) -> None:
+        """
+        Syncs the DMP identites/metadata/weights of ManagedCollisionModule across process group.
+
+        It syncs the hash identities across replica by taking merging them all together.
+        The weights of the identities that did not exist in the final merge are zeroed out.
+        The weights of the identities that are in final merge are averaged across those replica
+        that have them.
+        """
+        mesh = ctx.device_mesh.mesh
+        # The list of root nodes that all identities get sent to
+        replica_gp_root = mesh[0]
+        is_root_node = self._global_rank in replica_gp_root
+        # The index of replica_gp_root to send all identities/metadata to
+        index_root = torch.where(mesh == self._global_rank)
+        replica_ranks = mesh[:, index_root[1][0]].tolist()
+
+        for emb_kernel, table_name in ctx.hash_zch_modules:
+            mpzch = emb_kernel._managed_collision_collection._managed_collision_modules[
+                table_name
+            ]
+            reserved_indices = mpzch.get_indices_of_reserved_slots_per_bucket()
+
+            # Sync hash identities and metadata and get information about mapping
+            survived, rank_to_global = mpzch.sync_identities(
+                is_root_node,
+                num_replica_gp=len(mesh),
+                replica_ranks=replica_ranks,
+                replica_pg=ctx.replica_pg,
+            )
+
+            # Sync the weights and optimizers of the table
+            emb_kernel.sync_hash_zch_weights(
+                table_name,
+                rank_to_global,
+                survived,
+                include_optimizer_state,
+                allreduce_fn=lambda dict_tensors, annotation, opts: self._allreduce_tensors(
+                    ctx.replica_pg, dict_tensors, annotation, opts
+                ),
+                indices_slots=reserved_indices,
+            )
 
     def _sync(
         self,
@@ -1387,7 +1425,6 @@ class DMPCollection(DistributedModelParallel):
 
             def _all_reduce(tensors: List[torch.Tensor]) -> None:
                 with record_function(f"{annotation}_custom_hook"):
-                    # pyrefly: ignore[not-callable]
                     custom_all_reduce(tensors)
 
         else:
@@ -1449,7 +1486,6 @@ class DMPCollection(DistributedModelParallel):
         for ctx in self._ctxs:
             if ctx.sharding_strategy == ShardingStrategy.FULLY_SHARDED:
                 for _, sharded_module in ctx.modules_to_sync:
-                    # pyrefly: ignore[not-callable]
                     sharded_module.ensure_reduce_scatter_complete()
 
     def _register_sparse_arch_forward_hook(self, rs_awaitable_hook_module) -> None:
@@ -1560,7 +1596,7 @@ class DMPCollection(DistributedModelParallel):
         """
         group_start = rank % step
         for key in plan.plan:
-            # pyrefly: ignore[missing-attribute]
+            # pyre-ignore[16]
             for _, param_sharding in plan.plan[key].items():
                 new_ranks = []
                 if use_inter_host_allreduce:
@@ -1579,12 +1615,10 @@ class DMPCollection(DistributedModelParallel):
                     if shards is not None:
                         for shard in shards:
                             if use_inter_host_allreduce:
-                                # pyrefly: ignore[missing-attribute]
                                 shard_rank = shard.placement._rank + (
                                     (rank // sharding_group_size) * sharding_group_size
                                 )
                             else:
-                                # pyrefly: ignore[missing-attribute]
                                 shard_rank = shard.placement._rank * step + group_start
                             shard.placement = _remote_device(
                                 f"rank:{shard_rank}/{self._device.type}:{shard_rank % get_local_size()}"
@@ -1604,11 +1638,12 @@ class DMPCollection(DistributedModelParallel):
         """
         # Process submodule-specific contexts first (contexts[1:])
         for context in contexts[1:]:
-            # pyrefly: ignore[bad-argument-type]
-            context.modules_to_sync = self._group_sharded_module(context.sharded_module)
+            context.modules_to_sync = self._group_sharded_module(
+                context.sharded_module  # pyre-ignore[6]
+            )
 
         # Group leftover embedding kernels, with respect to default context
-        # pyrefly: ignore[bad-assignment]
+        # pyre-ignore[9]
         modules_to_skip: List[nn.Module] = [c.sharded_module for c in contexts[1:]]
         sharded_modules: List[Tuple[nn.Module, nn.Module]] = []
 
@@ -1618,18 +1653,19 @@ class DMPCollection(DistributedModelParallel):
         ) -> None:
             if isinstance(module, SplitTableBatchedEmbeddingBagsCodegen):
                 sharded_modules.append((module, prev_module))
-            # pyrefly: ignore[invalid-argument]
-            if not isinstance(module, tuple(modules_to_skip)) and hasattr(
-                module, "_lookups"
-            ):
-                # pyrefly: ignore[not-iterable]
-                for lookup in module._lookups:
+            if isinstance(module, BaseShardedManagedCollisionEmbeddingCollection):
+                sharded_modules.append((module, prev_module))
+                return  # Stop here don't go to the children
+            if not isinstance(
+                module, tuple(modules_to_skip)  # pyre-ignore[6]
+            ) and hasattr(module, "_lookups"):
+                for lookup in module._lookups:  # pyre-ignore[29]
                     _find_sharded_modules(lookup, module)
 
             for _, child in module.named_children():
                 _find_sharded_modules(child, module)
 
-        # pyrefly: ignore[bad-argument-type]
+        # pyre-ignore[6]
         _find_sharded_modules(self._dmp_wrapped_module, None)
         contexts[0].modules_to_sync = sharded_modules
 
@@ -1647,16 +1683,13 @@ class DMPCollection(DistributedModelParallel):
         ) -> None:
             if isinstance(module, SplitTableBatchedEmbeddingBagsCodegen):
                 sharded_modules.append((module, prev_module))
-            # pyrefly: ignore[invalid-argument]
-            if isinstance(module, sharded_module):
-                # pyrefly: ignore[not-iterable]
-                for lookup in module._lookups:
+            if isinstance(module, sharded_module):  # pyre-ignore[6]
+                for lookup in module._lookups:  # pyre-ignore[29]
                     _find_sharded_modules(lookup, module)
 
             for _, child in module.named_children():
                 _find_sharded_modules(child, module)
 
-        # pyrefly: ignore[bad-argument-type]
         _find_sharded_modules(self._dmp_wrapped_module, None)
         return sharded_modules
 
@@ -1676,18 +1709,26 @@ class DMPCollection(DistributedModelParallel):
             optimizer_by_dtype: Dict[torch.dtype, List[torch.Tensor]] = defaultdict(
                 list
             )
+            hash_zch_modules: List[Tuple[nn.Module, str]] = []
             for emb_kernel, _ in context.modules_to_sync:
-                # pyrefly: ignore[not-callable]
-                for w in emb_kernel.split_embedding_weights():
-                    weights_by_dtype[w.dtype].append(w)
+                if isinstance(emb_kernel, SplitTableBatchedEmbeddingBagsCodegen):
+                    # If kernel is TBE, then cache the weights and optimizer tensors
+                    for w in emb_kernel.split_embedding_weights():  # pyre-ignore[29]
+                        weights_by_dtype[w.dtype].append(w)
+                    for state in emb_kernel.get_optimizer_state():
+                        opt_tensor = state["sum"]
+                        optimizer_by_dtype[opt_tensor.dtype].append(opt_tensor)
 
-                # pyrefly: ignore[not-callable]
-                for state in emb_kernel.get_optimizer_state():
-                    opt_tensor = state["sum"]
-                    optimizer_by_dtype[opt_tensor.dtype].append(opt_tensor)
+                elif isinstance(
+                    emb_kernel, BaseShardedManagedCollisionEmbeddingCollection
+                ):
+                    # If kernel is MP-ZCH, then cache the kernel and table name
+                    for table_name in emb_kernel._table_to_tbe_and_index.keys():
+                        hash_zch_modules.append((emb_kernel, table_name))
 
             context.weights_by_dtype = dict(weights_by_dtype)
             context.optimizer_tensors_by_dtype = dict(optimizer_by_dtype)
+            context.hash_zch_modules = hash_zch_modules
 
     @property
     def device_mesh(self) -> DeviceMesh:

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -9,21 +9,27 @@
 
 import copy
 import unittest
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.mc_embedding import (
     KJTList,
     ManagedCollisionEmbeddingCollectionSharder,
     ShardedManagedCollisionEmbeddingCollection,
 )
+from torchrec.distributed.mc_embedding_modules import (
+    BaseShardedManagedCollisionEmbeddingCollection,
+)
 from torchrec.distributed.mc_modules import (
     ManagedCollisionCollectionContext,
     ShardedManagedCollisionCollection,
 )
+from torchrec.distributed.model_parallel import DMPCollection
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.shard import _shard_modules
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.sharding_plan import (
@@ -35,6 +41,7 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
+from torchrec.distributed.test_utils.test_model import ModelInput
 from torchrec.distributed.types import (
     ModuleSharder,
     ShardedTensor,
@@ -43,16 +50,23 @@ from torchrec.distributed.types import (
 )
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.embedding_modules import EmbeddingCollection
+from torchrec.modules.hash_mc_evictions import (
+    HashZchEvictionConfig,
+    HashZchEvictionPolicyName,
+)
+from torchrec.modules.hash_mc_modules import HashZchManagedCollisionModule
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
 from torchrec.modules.mc_modules import (
     DistanceLFU_EvictionPolicy,
     ManagedCollisionCollection,
+    ManagedCollisionModule,
     MCHManagedCollisionModule,
 )
 from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
 from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class
+from torchrec.types import DataType
 
 
 class SparseArch(nn.Module):
@@ -63,26 +77,54 @@ class SparseArch(nn.Module):
         return_remapped: bool = False,
         input_hash_size: int = 4000,
         allow_in_place_embed_weight_update: bool = False,
+        use_mpzch: bool = False,
     ) -> None:
         super().__init__()
         self._return_remapped = return_remapped
 
-        mc_modules = {}
-        mc_modules["table_0"] = MCHManagedCollisionModule(
-            zch_size=(tables[0].num_embeddings),
-            input_hash_size=input_hash_size,
-            device=device,
-            eviction_interval=2,
-            eviction_policy=DistanceLFU_EvictionPolicy(),
-        )
+        mc_modules: dict[str, ManagedCollisionModule] = {}
+        if use_mpzch:
+            # Parameters hard-coded from test_quant_mc_embedding
+            mc_modules["table_0"] = HashZchManagedCollisionModule(
+                zch_size=(tables[0].num_embeddings),
+                input_hash_size=input_hash_size,
+                device=device,
+                total_num_buckets=4,
+                eviction_policy_name=HashZchEvictionPolicyName.LRU_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=["feature_0"],
+                    single_ttl=1,
+                ),
+                max_probe=5,
+            )
 
-        mc_modules["table_1"] = MCHManagedCollisionModule(
-            zch_size=(tables[1].num_embeddings),
-            device=device,
-            input_hash_size=input_hash_size,
-            eviction_interval=2,
-            eviction_policy=DistanceLFU_EvictionPolicy(),
-        )
+            mc_modules["table_1"] = HashZchManagedCollisionModule(
+                zch_size=(tables[1].num_embeddings),
+                device=device,
+                input_hash_size=input_hash_size,
+                total_num_buckets=4,
+                eviction_policy_name=HashZchEvictionPolicyName.LRU_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=["feature_1"],
+                    single_ttl=1,
+                ),
+                max_probe=5,
+            )
+        else:
+            mc_modules["table_0"] = MCHManagedCollisionModule(
+                zch_size=(tables[0].num_embeddings),
+                input_hash_size=input_hash_size,
+                device=device,
+                eviction_interval=2,
+                eviction_policy=DistanceLFU_EvictionPolicy(),
+            )
+            mc_modules["table_1"] = MCHManagedCollisionModule(
+                zch_size=(tables[1].num_embeddings),
+                device=device,
+                input_hash_size=input_hash_size,
+                eviction_interval=2,
+                eviction_policy=DistanceLFU_EvictionPolicy(),
+            )
 
         self._mc_ec: ManagedCollisionEmbeddingCollection = (
             ManagedCollisionEmbeddingCollection(
@@ -660,6 +702,284 @@ def _test_sharding_dedup(  # noqa C901
         # deduping is not being used right now
         # assert torch.allclose(remapped_1.values(), dedup_remapped_1.values())
         # assert torch.allclose(remapped_1.lengths(), dedup_remapped_1.lengths())
+
+
+def _test_2d_mc_sharding_syncing_identical_identities_and_tables(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    world_size_2D: int,
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    kjt_input_per_rank: List[torch.Tensor],
+    local_size: Optional[int] = None,
+    use_inter_host_allreduce: bool = False,
+    apply_optimizer_in_backward_config: Optional[
+        Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
+    ] = None,
+) -> None:  # noqa: C901
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        num_tables = 2
+        num_replica = world_size // world_size_2D
+
+        sparse_arch = SparseArch(
+            tables,
+            torch.device("meta"),
+            use_mpzch=True,
+            input_hash_size=80,
+        )
+
+        if apply_optimizer_in_backward_config is not None:
+            for apply_optim_name, (
+                optimizer_type,
+                optimizer_kwargs,
+            ) in apply_optimizer_in_backward_config.items():
+                for name, param in sparse_arch.named_parameters():
+                    if apply_optim_name not in name:
+                        continue
+                    apply_optimizer_in_backward(
+                        optimizer_type,
+                        [param],
+                        optimizer_kwargs,
+                    )
+
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size=world_size_2D,
+                compute_device=ctx.device.type,
+                local_world_size=None,
+            ),
+        )
+        plan = planner.collective_plan(sparse_arch, [sharder], ctx.pg)
+        assert ctx.pg is not None
+
+        dmp = DMPCollection(
+            module=sparse_arch,
+            device=ctx.device,
+            plan=plan,
+            sharding_group_size=world_size_2D,
+            world_size=world_size,
+            global_pg=ctx.pg,
+            sharders=[sharder],
+            use_inter_host_allreduce=use_inter_host_allreduce,
+        )
+
+        # Test that "HashZch" modules are in `modules_to_sync`
+        for module, _ in dmp._ctxs[0].modules_to_sync:
+            # The first module is SplitTable, but the second/third should be HashZch
+            if type(module).__name__ != "SplitTableBatchedEmbeddingBagsCodegen":
+                assert isinstance(
+                    module, BaseShardedManagedCollisionEmbeddingCollection
+                ), f"Modules {module} should be 'BaseShardedManagedCollisionEmbeddingCollection'"
+
+        # Test that hash_identities and hash_metadata is inside the context
+        assert hasattr(dmp._ctxs[0], "hash_zch_modules")
+        assert len(dmp._ctxs[0].hash_zch_modules) == num_tables
+
+        # pyrefly: ignore[missing-attribute]
+        mc_collection = dmp.module._mc_ec._managed_collision_collection  # ShardedMCC
+
+        # Test that sharding metadata is identical across replicas, this is created from
+        #   _create_managed_collision_modules
+        metadata = torch.tensor(
+            [
+                mc_collection._mc_module_name_shard_metadata[f"table_{i_table}"]
+                for i_table in range(num_tables)
+            ],
+            device=ctx.device,
+            dtype=torch.int32,
+        )
+        other_metadata = [torch.empty_like(metadata) for _ in range(num_replica)]
+        dist.all_gather(
+            other_metadata,
+            metadata,
+            group=dmp._default_ctx.replica_pg,
+        )
+        for m in other_metadata[1:]:
+            assert torch.equal(other_metadata[0], m)
+
+        # Do a forward pass
+        kjt_input = kjt_input_per_rank[rank]
+        loss, _ = dmp(kjt_input.to(ctx.device))
+        loss.backward()
+
+        # Randomize the metadata to get realistic scenario
+        for t in ["table_0", "table_1"]:
+            m = mc_collection._managed_collision_modules[t]._hash_zch_metadata
+            m.copy_(torch.randint_like(m, low=10, high=100))
+
+        # Perform syncing
+        dmp.sync()
+
+        # Test that identities/metadata is identical across replicas
+        for i_table in range(num_tables):
+            # Grab the sharded tensors for this rank
+            identities = (
+                mc_collection._model_parallel_mc_buffer_name_to_sharded_tensor[
+                    f"_managed_collision_modules.table_{i_table}._hash_zch_identities"
+                ]
+                ._local_shards[0]
+                .tensor
+            )
+            metadata = (
+                mc_collection._model_parallel_mc_buffer_name_to_sharded_tensor[
+                    f"_managed_collision_modules.table_{i_table}._hash_zch_metadata"
+                ]
+                ._local_shards[0]
+                .tensor
+            )
+
+            # Assert that it is unique elements after removing -1, tests buckets/local_sizes
+            torch.testing.assert_close(
+                torch.unique(identities[identities != -1]).numel(),
+                identities[identities != -1].numel(),
+            )
+
+            # Grab the other sharded tensors from other ranks
+            identities_other_ranks = [
+                torch.empty_like(identities) for _ in range(num_replica)
+            ]
+            dist.all_gather(
+                identities_other_ranks,
+                identities,
+                group=dmp._default_ctx.replica_pg,
+            )
+            metadata_other_ranks = [
+                torch.empty_like(metadata) for _ in range(num_replica)
+            ]
+            dist.all_gather(
+                metadata_other_ranks,
+                metadata,
+                group=dmp._default_ctx.replica_pg,
+            )
+
+            # Make sure identities/metadata are identical across ranks after syncing
+            for i in range(1, num_replica):
+                torch.testing.assert_allclose(
+                    identities_other_ranks[0], identities_other_ranks[i]
+                )
+                torch.testing.assert_allclose(
+                    metadata_other_ranks[0], metadata_other_ranks[i]
+                )
+
+            # Test that embedding table are equal too.
+            # pyrefly: ignore[missing-attribute]
+            tbe, table_id = dmp.module._mc_ec._table_to_tbe_and_index[
+                f"table_{i_table}"
+            ]
+            emb_table = tbe.split_embedding_weights()[table_id.item()]
+            embedding_tables_other_ranks = [
+                torch.empty_like(emb_table) for _ in range(num_replica)
+            ]
+            dist.all_gather(
+                embedding_tables_other_ranks,
+                emb_table,
+                group=dmp._default_ctx.replica_pg,
+            )
+            for rank_emb in embedding_tables_other_ranks[1:]:
+                torch.testing.assert_allclose(rank_emb, embedding_tables_other_ranks[0])
+
+            # Test optimizers are equal too.
+            optim = tbe.get_optimizer_state()
+            if len(optim) > 0:
+                optim = optim[table_id.item()]["sum"]
+                optimizers_other_ranks = [
+                    torch.empty_like(optim) for _ in range(num_replica)
+                ]
+                dist.all_gather(
+                    optimizers_other_ranks, optim, group=dmp._default_ctx.replica_pg
+                )
+                for rank_optim in optimizers_other_ranks[1:]:
+                    torch.testing.assert_allclose(rank_optim, optimizers_other_ranks[0])
+
+
+def _test_2d_mc_syncing_preserves_top_indices(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    world_size_2D: int,
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    kjt_input_per_rank: List[torch.Tensor],
+    local_size: Optional[int] = None,
+) -> None:
+
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        sparse_arch = SparseArch(
+            tables,
+            torch.device("meta"),
+            use_mpzch=True,
+            input_hash_size=80,
+        )
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size=world_size_2D,
+                compute_device=ctx.device.type,
+                local_world_size=None,
+            ),
+        )
+        assert ctx.pg is not None
+
+        dmp = DMPCollection(
+            module=sparse_arch,
+            device=ctx.device,
+            plan=planner.collective_plan(sparse_arch, [sharder], ctx.pg),
+            sharding_group_size=world_size_2D,
+            world_size=world_size,
+            global_pg=ctx.pg,
+            sharders=[sharder],
+        )
+
+        # pyrefly: ignore[missing-attribute]
+        mc_collection = dmp.module._mc_ec._managed_collision_collection
+
+        kjt_input = kjt_input_per_rank[rank]
+        loss, _ = dmp(kjt_input.to(ctx.device))
+        loss.backward()
+
+        # Randomize metadata to simulate realistic situation
+        for t in ["table_0", "table_1"]:
+            m = mc_collection._managed_collision_modules[t]._hash_zch_metadata
+            m.copy_(torch.randint_like(m, low=10, high=100))
+
+        # Find root of this replica group
+        mesh = dmp._default_ctx.device_mesh.mesh
+        is_root_node = rank in mesh[0]
+        index_root = torch.where(mesh == rank)
+        replica_ranks = mesh[:, index_root[1][0]].tolist()
+
+        # Force high metadata only on the root node
+        # it survives the merge (they have the highest metadata values)
+        indices_preserved = {}
+        if is_root_node:
+            for t in ["table_0", "table_1"]:
+                model = mc_collection._managed_collision_modules[t]
+                m = model._hash_zch_metadata
+                # This is higher than original metadata values of 100
+                m = mc_collection._managed_collision_modules[t]._hash_zch_metadata
+                m.copy_(torch.randint_like(m, low=101, high=200))
+                indices_preserved[t] = model._hash_zch_identities.clone()
+
+        dmp.sync()
+
+        # Send preserved indices from root to all replica
+        for t in ["table_0", "table_1"]:
+            model = mc_collection._managed_collision_modules[t]
+            preserved = torch.empty_like(model._hash_zch_identities)
+            if is_root_node:
+                preserved = indices_preserved[t]
+
+            dist.broadcast(
+                preserved,
+                src=replica_ranks[0],
+                group=dmp._default_ctx.replica_pg,
+            )
+
+            # Verify all elements match replica 0 after sync
+            final_identities = model._hash_zch_identities.squeeze()
+            preserved = preserved.squeeze()
+            nonempty = preserved != -1
+            torch.testing.assert_close(preserved[nonempty], final_identities[nonempty])
 
 
 @skip_if_asan_class
@@ -1436,4 +1756,118 @@ class ComputeOutputLengthTest(unittest.TestCase):
         self.assertTrue(
             torch.equal(result[0].lengths(), input_lengths),
             f"Expected lengths {input_lengths}, got {result[0].lengths()}.",
+        )
+
+
+@skip_if_asan_class
+class ShardedMCECWith2DSharding(MultiProcessTestBase):
+    """Tests for 2D parallelism of MCEC tables"""
+
+    WORLD_SIZE = 8
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.embedding_config = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=80,
+            ),
+            EmbeddingConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=60,
+                data_type=DataType.FP16,
+            ),
+        ]
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 7,
+        "Not enough GPUs, this test requires at least 8 GPUs",
+    )
+    # pyre-ignore
+    @given(
+        backend=st.sampled_from(["nccl"]),
+        use_inter_host_allreduce=st.booleans(),
+        world_size_2D=st.sampled_from([2, 4]),
+        apply_optimizer_in_backward_config=st.sampled_from(
+            [
+                None,
+                {
+                    "embeddings": (torch.optim.Adagrad, {"lr": 0.2}),
+                },
+            ]
+        ),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    def test_2d_mc_zch_sharding_syncing_is_correct(
+        self,
+        backend: str,
+        use_inter_host_allreduce: bool,
+        world_size_2D: int,
+        apply_optimizer_in_backward_config: Optional[
+            Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
+        ],
+    ) -> None:
+        _, local_inputs = ModelInput.generate(
+            batch_size=40,
+            world_size=self.WORLD_SIZE,
+            num_float_features=0,
+            tables=self.embedding_config,
+            weighted_tables=[],
+            pooling_avg=5,
+            random_seed=100,
+        )
+        # Extract global and local KJT from ModelInput
+        kjt_input_per_rank = [mi.idlist_features for mi in local_inputs]
+
+        self._run_multi_process_test(
+            callable=_test_2d_mc_sharding_syncing_identical_identities_and_tables,
+            world_size=self.WORLD_SIZE,
+            tables=self.embedding_config,
+            world_size_2D=world_size_2D,
+            sharder=ManagedCollisionEmbeddingCollectionSharder(),
+            backend=backend,
+            kjt_input_per_rank=kjt_input_per_rank,
+            use_inter_host_allreduce=use_inter_host_allreduce,
+            apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 7,
+        "Not enough GPUs, this test requires at least 8 GPUs",
+    )
+    @given(
+        backend=st.sampled_from(["nccl"]),
+        world_size_2D=st.sampled_from([2, 4]),
+    )
+    @settings(verbosity=Verbosity.verbose, deadline=None)
+    def test_2d_mc_zch_syncing_preserves_top_indices(
+        self,
+        backend: str,
+        world_size_2D: int,
+    ) -> None:
+        """One rank has all largest metadata, and so checks it didn't get evicted."""
+        _, local_inputs = ModelInput.generate(
+            batch_size=40,
+            world_size=self.WORLD_SIZE,
+            num_float_features=0,
+            tables=self.embedding_config,
+            weighted_tables=[],
+            pooling_avg=5,
+            random_seed=100,
+        )
+        kjt_input_per_rank = [mi.idlist_features for mi in local_inputs]
+
+        self._run_multi_process_test(
+            callable=_test_2d_mc_syncing_preserves_top_indices,
+            world_size=self.WORLD_SIZE,
+            tables=self.embedding_config,
+            world_size_2D=world_size_2D,
+            sharder=ManagedCollisionEmbeddingCollectionSharder(),
+            backend=backend,
+            kjt_input_per_rank=kjt_input_per_rank,
         )

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -1038,6 +1038,7 @@ class DMPCollectionContext(DMPCollectionConfig):
     sharded_module: Optional[nn.Module]
     weights_by_dtype: Dict["torch.dtype", List["torch.Tensor"]]
     optimizer_tensors_by_dtype: Dict["torch.dtype", List["torch.Tensor"]]
+    hash_zch_modules: List[Tuple[nn.Module, str]]
 
     def __init__(
         self,
@@ -1056,6 +1057,7 @@ class DMPCollectionContext(DMPCollectionConfig):
         optimizer_tensors_by_dtype: Optional[
             Dict["torch.dtype", List["torch.Tensor"]]
         ] = None,
+        hash_zch_modules: Optional[List[Tuple[nn.Module, nn.Module, str]]] = None,
     ) -> None:
         super().__init__(
             module=module,
@@ -1080,6 +1082,9 @@ class DMPCollectionContext(DMPCollectionConfig):
         )
         self.optimizer_tensors_by_dtype: Dict["torch.dtype", List["torch.Tensor"]] = (
             optimizer_tensors_by_dtype if optimizer_tensors_by_dtype is not None else {}
+        )
+        self.hash_zch_modules: List[Tuple[nn.Module, nn.Module, str]] = (
+            hash_zch_modules if hash_zch_modules is not None else []
         )
 
 

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import fbgemm_gpu  # @manual = "//deeplearning/fbgemm/fbgemm_gpu:fbgemm_gpu"
 import torch
+import torch.distributed as dist
 from torchrec.modules.hash_mc_evictions import (
     get_kernel_from_policy,
     HashZchEvictionConfig,
@@ -282,6 +283,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._eviction_policy_name: Optional[HashZchEvictionPolicyName] = (
             eviction_policy_name
         )
+        self._eviction_flag: int = get_kernel_from_policy(self._eviction_policy_name)
         self._eviction_config: Optional[HashZchEvictionConfig] = eviction_config
         self._eviction_module: Optional[HashZchEvictionModule] = (
             HashZchEvictionModule(
@@ -457,6 +459,18 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
     @property
     def device(self) -> torch.device:
         return _get_device(self._hash_zch_identities)
+
+    @property
+    def max_probe(self) -> int:
+        return self._max_probe
+
+    @property
+    def disable_fallback(self) -> bool:
+        return self._disable_fallback
+
+    @property
+    def eviction_flag(self) -> int:
+        return self._eviction_flag
 
     def buckets(self) -> int:
         return self._buckets
@@ -639,7 +653,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     output_offset=self._output_global_offset_tensor,
                 )
 
-                num_reserved_slots = self.get_reserved_slots_per_bucket()
+                num_reserved_slots: int = self.get_reserved_slots_per_bucket()
                 remapped_ids, evictions = self._zero_collision_hash(
                     input=values,
                     identities=self._hash_zch_identities,
@@ -657,7 +671,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     _modulo_identity_DPRECATED=False,  # deprecated, always False
                     input_metadata=input_metadata,
                     eviction_threshold=eviction_threshold,
-                    eviction_policy=get_kernel_from_policy(self._eviction_policy_name),
+                    eviction_policy=self._eviction_flag,
                     opt_in_prob=self._opt_in_prob,
                     num_reserved_slots=num_reserved_slots,
                     opt_in_rands=opt_in_rands,
@@ -796,6 +810,186 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             # force the counter to be 0 for the ids not found in emb table.
             metadata[not_hit_indices_mask] = 0
             return metadata.reshape(-1)
+
+    def get_indices_of_reserved_slots_per_bucket(self) -> Optional[torch.Tensor]:
+        """Get the range of indices of reserved slots per bucket of identities."""
+        num_slots = self.get_reserved_slots_per_bucket()
+
+        if num_slots == -1:
+            # If reserved slots isn't used.
+            return None
+
+        size = self.input_mapper._zch_size_per_training_rank  # length of buckets
+        off = self.input_mapper._train_rank_offsets  # offsets of buckets
+        indices = torch.cat(
+            [
+                # pyre-ignore[6]: ignore[no-matching-overload]
+                torch.arange(
+                    off[i] + size[i] - num_slots,  # pyre-ignore[26]
+                    off[i] + size[i],  # pyre-ignore[26]
+                    device=self.device,
+                )
+                for i in range(self._start_bucket, self._end_bucket)
+            ]
+        )
+        if self._output_global_offset_tensor is not None:
+            indices -= self._output_global_offset_tensor
+        return indices
+
+    def sync_identities(
+        self,
+        is_root_node: bool,
+        num_replica_gp: int,
+        replica_ranks: List[int],
+        replica_pg: dist.ProcessGroup,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Syncs identities/metadata for 2D-sharding from all other replica nodes to root node.
+        The root node then finds the best top K global indices for each rank and
+        broadcasts them back to all other replica nodes. The local identities are then
+        updated to be global identities.
+
+        Args:
+            is_root_node (bool): whether the current node is the root replica node
+            num_replica_gp (int): number of replica groups
+            replica_ranks (List[int]): list of global ranks in the replica group
+            replica_pg (ProcessGroup): process group for the replica group
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                survived: Which local identities survived the sync/merging
+                rank_to_global: Mapping from identities in rank i to the best identites_global
+        """
+        # Get all necessary tensors for ZCH
+        identity_table = self._hash_zch_identities
+        meta_table = self._hash_zch_metadata
+        assert meta_table is not None
+
+        # Gather all identities/metadata from all other replicas
+        gathered_identities = None
+        gathered_metadata = None
+        if is_root_node:
+            # If root-node, then gather all of the identities and metadata from all other replica nodes.
+            gathered_identities = [
+                torch.full_like(identity_table, -1) for _ in range(num_replica_gp)
+            ]
+            gathered_metadata = [
+                torch.full_like(meta_table, -1) for _ in range(num_replica_gp)
+            ]
+
+        dist.gather(
+            identity_table,
+            gather_list=gathered_identities,
+            dst=replica_ranks[0],
+            group=replica_pg,
+        )
+        dist.gather(
+            meta_table,
+            gather_list=gathered_metadata,
+            dst=replica_ranks[0],
+            group=replica_pg,
+        )
+
+        # X_global are the 'final' identities/metadata after merging.
+        identity_global = torch.full_like(identity_table, -1)
+        metadata_global = torch.full_like(meta_table, -1)
+        # num_reserved_slots needed to get correct hash positions.
+        num_reserved_slots: int = self.get_reserved_slots_per_bucket()
+
+        # The root node should grab the best top items from all other replica nodes
+        if is_root_node:
+            identity_global = identity_table.clone()
+            metadata_global = meta_table.clone()
+            for i in range(1, num_replica_gp):
+                # Remove -1 due to potential insertion
+                identities = gathered_identities[i].squeeze()  # pyre-ignore[58]
+                indices = torch.where(identities != -1)[0]
+                identities = identities[indices]
+                metadata = gathered_metadata[i].squeeze()[indices]  # pyre-ignore[58]
+
+                # Compute the local sizes and offsets for correct hash position!
+                inds, local_sizes, offsets = self.input_mapper(
+                    values=identities,
+                    output_offset=self._output_global_offset_tensor,
+                )
+
+                # Grab the best top items by running `process_item_zch` onto root node identites
+                _ = torch.ops.fbgemm.zero_collision_hash(
+                    input=inds,
+                    input_metadata=metadata,
+                    identities=identity_global,
+                    metadata=metadata_global,
+                    max_probe=self.max_probe,
+                    local_sizes=local_sizes,
+                    offsets=offsets,
+                    circular_probe=True,
+                    output_on_uvm=False,
+                    _modulo_identity_DPRECATED=False,
+                    exp_hours=-1,
+                    disable_fallback=True,
+                    eviction_threshold=2**31 - 1,  # Always ensures eviction
+                    eviction_policy=self.eviction_flag,
+                    opt_in_prob=self._opt_in_prob,
+                    num_reserved_slots=num_reserved_slots,  # Needed to get correct hash position
+                )
+
+        # All ranks waits until their corresponding root node finshes the syncing
+        dist.barrier(group=replica_pg)
+
+        # Perform broadcast from root node to all other replica nodes
+        dist.broadcast(
+            tensor=identity_global,
+            src=replica_ranks[0],
+            group=replica_pg,
+        )
+        dist.broadcast(
+            tensor=metadata_global,
+            src=replica_ranks[0],
+            group=replica_pg,
+        )
+
+        # Remove -1
+        inds = identity_table.squeeze()
+        nonzero_ids = inds != -1
+        inds = inds[nonzero_ids]
+
+        # Compute local sizes and offsets for correct hash position
+        inds, local_sizes, offsets = self.input_mapper(
+            values=inds,
+            output_offset=self._output_global_offset_tensor,
+        )
+
+        # Find mapping from rank i to the best top K global indices
+        rank_to_global_exist, _ = torch.ops.fbgemm.zero_collision_hash(
+            input=inds,
+            identities=identity_global,
+            max_probe=self.max_probe,
+            local_sizes=local_sizes,
+            offsets=offsets,
+            circular_probe=True,
+            output_on_uvm=False,
+            _modulo_identity_DPRECATED=False,
+            readonly=True,
+            exp_hours=-1,
+            disable_fallback=True,  # must be True here
+            opt_in_prob=self._opt_in_prob,  # Needed to get correct hash position
+            num_reserved_slots=num_reserved_slots,
+        )
+        rank_to_global = torch.full_like(identity_table.squeeze(), -1)
+        rank_to_global[nonzero_ids] = rank_to_global_exist
+
+        # If both identity_table and identity_global have -1, then
+        #   rank_to_global will map all -1 to the same slot in identity_global
+        #   that has -1. We ignore these by masking with `nonzero_ids` below,
+        #   as they represent empty rows with no embedding data to move.
+        found_in_global = rank_to_global != -1
+        survived = nonzero_ids & found_in_global
+
+        # Update the local table and its metadata
+        identity_table.copy_(identity_global)
+        meta_table.copy_(metadata_global)
+
+        return survived, rank_to_global
 
 
 @torch.fx.wrap

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -1518,6 +1518,31 @@ class TestMCH(unittest.TestCase):
         )
         self.assertFalse(m2.is_sharded)
 
+    def test_reserved_indices_for_buckets(self) -> None:
+        """Test getting reserved indices for each bucket over 4 ranks."""
+        # table_size = 80
+        # 4 ranks, so each rank holds 20 rows
+        # 8 buckets, so each rank gets two buckets and each bucket holds 10 rows.
+        # each bucket has size 10, and 10 percent of them are reserved so 1 row.
+        m = HashZchManagedCollisionModule(
+            zch_size=80,
+            device=torch.device("cpu"),
+            total_num_buckets=8,
+            percent_reserved_slots=10.0,
+            opt_in_prob=1,
+        )
+        # Since the buckets are all the same size, then local reserved indices
+        #  are all the same, so forloop over all 4 shards.
+        for shard_id_range in [(0, 20), (20, 40), (40, 60), (60, 80)]:
+            m1 = m.rebuild_with_output_id_range(shard_id_range)
+            reserved_indices = m1.get_indices_of_reserved_slots_per_bucket()
+            torch.testing.assert_close(
+                reserved_indices,
+                torch.tensor([9, 19]),
+                rtol=0,
+                atol=0,
+            )
+
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",


### PR DESCRIPTION
Summary:

Context
---------
Part of the diff-stack to enable 2D-sharding with MP-ZCH. This diff implements the full syncing procedure.
It is a two step process:

1. Gather all hash identities from all replica, and pick out the best/most recent from them, call this the global identities.
2. Re-arrange all embedding tables to match the order in global identities, and zero out rows that didn't survive.

Implementation
------------------

- `distributed/mc_modules.py` change self._env to utilize 2D sharding when appropriate, and make sure that ShardedTensors have the correct global rank
- `model_parallel`:
    - DMP class
        - DMP context variable now stores `BaseShardedManagedCollisionEmbeddingCollection` stored as variable `hash_zch_modules`.
        - Then when syncing is called it checks if `ctx.hash_zch_modules` isn't empty.
        - Add a `_sync_mcc_modules` method that does the syncing of the managed collision modules.
- `modules/hash_mc_modules`:
    - Added `sync_identities` method to syncs every table, by gathering all identity/metadata from all replica to the root node, then it merges them together using `zero_colleision_hash` so that it preserves the highest-metadata entries, then broadcasts the merged result back
- `distributed/mc_embedding_modules`:
    - `sync_hash_zch_weights`
        - Rearranges the embedding/optimizer rows to match this new global identity layout, zeroes out evicted rows and then performs allreduce across replica. It takes number of times the row exist in each replica and uses that to properly divide the weights.


NOTE: Design choices, decided to include the functions that does syncing of hash identities and allreduce of the weights/optimizers inside MCC/MP-ZCH classes instead of DMP, due to how large DMP was getting.

NOTE: `reset_embedding_weights` isn't used due to big QPS hits, and resorted to just doing how 2D-sharding zeroes out embedding weights, and optimizers.

NOTE: `opt_in_prob` and reserved slots is **only** used to get the correct hash positions. An avg allreduce is done over the reserved slots.

Reviewed By: kausv

Differential Revision: D94684746


