### PR TITLE
Config-driven int32 embedding indices and offsets support

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -74,6 +74,10 @@ from torchrec.distributed.embedding_types import (
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
+from torchrec.distributed.fused_params import (
+    get_embedding_table_index_type,
+    get_embedding_table_offset_type,
+)
 from torchrec.distributed.shards_wrapper import LocalShardsWrapper
 from torchrec.distributed.types import (
     LazyAwaitable,
@@ -1735,6 +1739,12 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
         self._feature_table_map: List[int] = []
         self.table_name_to_count: Dict[str, int] = {}
         self._param_per_table: Dict[str, TableBatchedEmbeddingSlice] = {}
+        self._embedding_table_index_type: torch.dtype = get_embedding_table_index_type(
+            config.fused_params
+        )
+        self._embedding_table_offset_type: torch.dtype = (
+            get_embedding_table_offset_type(config.fused_params)
+        )
 
         for idx, table_config in enumerate(self._config.embedding_tables):
             self._local_rows.append(table_config.local_rows)
@@ -1806,13 +1816,13 @@ class BaseBatchedEmbedding(BaseEmbedding, Generic[SplitWeightType]):
 
         if len(forward_args) == 0:
             return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_offset_type),
             )
         else:
             return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_offset_type),
                 **forward_args,
             )
 
@@ -2893,6 +2903,12 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
         self._lengths_per_emb: List[int] = []
         self.table_name_to_count: Dict[str, int] = {}
         self._param_per_table: Dict[str, TableBatchedEmbeddingSlice] = {}
+        self._embedding_table_index_type: torch.dtype = get_embedding_table_index_type(
+            config.fused_params
+        )
+        self._embedding_table_offset_type: torch.dtype = (
+            get_embedding_table_offset_type(config.fused_params)
+        )
 
         for idx, table_config in enumerate(self._config.embedding_tables):
             self._local_rows.append(table_config.local_rows)
@@ -2988,14 +3004,14 @@ class BaseBatchedEmbeddingBag(BaseEmbedding, Generic[SplitWeightType]):
 
         if len(forward_args) == 0:
             return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_offset_type),
                 per_sample_weights=weights,
             )
         else:
             return self.emb_module(
-                indices=features.values().long(),
-                offsets=features.offsets().long(),
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_offset_type),
                 per_sample_weights=weights,
                 **forward_args,
             )

--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -33,6 +33,12 @@ FUSED_PARAM_SSD_TABLE_LIST: str = "__register_ssd_table_list"
 # Bool fused param per table to check if the table is offloaded to SSD
 FUSED_PARAM_IS_SSD_TABLE: str = "__register_is_ssd_table"
 
+# Embedding table index type for int32 support. Defaults to torch.int64 if not specified.
+FUSED_PARAM_EMBEDDING_TABLE_INDEX_TYPE: str = "embedding_table_index_type"
+
+# Embedding table offset type for int32 support. Defaults to torch.int64 if not specified.
+FUSED_PARAM_EMBEDDING_TABLE_OFFSET_TYPE: str = "embedding_table_offset_type"
+
 
 class TBEToRegisterMixIn:
     def get_tbes_to_register(
@@ -122,3 +128,33 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_SSD_TABLE_LIST)
 
     return fused_params_for_tbe
+
+
+def get_embedding_table_index_type(
+    fused_params: Optional[Dict[str, Any]],
+) -> torch.dtype:
+    """Get embedding table index type from fused_params.
+
+    Defaults to torch.int64 if not specified.
+    """
+    if (
+        fused_params is None
+        or FUSED_PARAM_EMBEDDING_TABLE_INDEX_TYPE not in fused_params
+    ):
+        return torch.int64
+    return fused_params[FUSED_PARAM_EMBEDDING_TABLE_INDEX_TYPE]
+
+
+def get_embedding_table_offset_type(
+    fused_params: Optional[Dict[str, Any]],
+) -> torch.dtype:
+    """Get embedding table offset type from fused_params.
+
+    Defaults to torch.int64 if not specified.
+    """
+    if (
+        fused_params is None
+        or FUSED_PARAM_EMBEDDING_TABLE_OFFSET_TYPE not in fused_params
+    ):
+        return torch.int64
+    return fused_params[FUSED_PARAM_EMBEDDING_TABLE_OFFSET_TYPE]


### PR DESCRIPTION
Summary:
Add config-driven int32 index/offset support to TorchRec's batched
embedding kernels, without JustKnobs gating.

This adds `embedding_table_index_type` and `embedding_table_offset_type`
to fused_params, defaulting to torch.int64. When a model sets these to
torch.int32, BaseBatchedEmbedding and BaseBatchedEmbeddingBag will cast
indices/offsets to int32 in forward(), halving radix-sort key width for
~2x speedup on CUB DeviceRadixSort kernels.

Unlike D77843259 which gates this behind JustKnobs, this approach is
purely config-driven: the default (int64) preserves existing behavior,
and only models that explicitly opt in via fused_params get int32. To
disable, simply revert the model config to int64.

Differential Revision: D94414603


