### PR TITLE
Add forward kernel sync before NCCL collectives

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -2577,6 +2577,22 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
     def purge(self) -> None:
         self._emb_module.reset_cache_states()
 
+    def wait_for_forward(self) -> None:
+        """
+        Wait for any pending Triton forward kernel to complete.
+
+        This should be called before collective operations (e.g., ALLTOALL for
+        output distribution) to ensure the forward kernel has completed on all
+        ranks. Without this synchronization, NCCL collectives may time out
+        because different ranks reach the collective at different times (since
+        Triton kernels run asynchronously).
+
+        The underlying TritonTableBatchedEmbeddingBags records a CUDA event after
+        the forward kernel completes, and this method waits on that event.
+        """
+        if hasattr(self._emb_module, "wait_for_forward"):
+            self._emb_module.wait_for_forward()
+
 
 class ShardedBatchedFusedEmbedding(BatchedFusedEmbedding):
     """
@@ -3817,6 +3833,18 @@ class TritonBatchedFusedEmbeddingBag(
     @property
     def fused_optimizer(self) -> FusedOptimizer:
         return self._optim
+
+    def wait_for_forward(self) -> None:
+        """
+        Wait for any pending Triton forward kernel to complete on the current stream.
+
+        This is called before NCCL collectives (e.g., AllToAll in output_dist) to ensure
+        the embedding lookup has fully completed. While Triton kernels run on the same
+        stream as PyTorch operations, NCCL collectives may run on a separate NCCL stream.
+        This method ensures proper synchronization via CUDA events.
+        """
+        if hasattr(self._emb_module, "wait_for_forward"):
+            self._emb_module.wait_for_forward()
 
     def forward(
         self,

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -981,6 +981,23 @@ class GroupedPooledEmbeddingsLookup(
             dim=1,
         )
 
+    def wait_for_forward(self) -> None:
+        """
+        Wait for any pending Triton forward kernels to complete.
+
+        This should be called before NCCL collectives (e.g., AllToAll in output_dist)
+        to ensure all embedding lookups have fully completed. While Triton kernels run
+        on the same CUDA stream as PyTorch operations, NCCL collectives may run on a
+        separate NCCL stream. This method ensures proper synchronization via CUDA events.
+
+        For non-Triton embedding modules (e.g., SplitTBE), this is a no-op since they
+        don't require explicit event-based synchronization.
+        """
+        for emb_module in self._emb_modules:
+            if hasattr(emb_module, "wait_for_forward"):
+                # pyre-ignore[16]: `wait_for_forward` is dynamically checked above
+                emb_module.wait_for_forward()
+
     def get_resize_awaitables(self) -> List[LazyAwaitable[torch.Tensor]]:
         # TODO - we can probably do some smart grouping to make this more efficient
         return [

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1857,6 +1857,13 @@ class ShardedEmbeddingBagCollection(
             ):
                 # with fully sharded 2D enabled, it returns an awaitable for the reduce scatter and resize operation
                 embs = lookup(features)
+                # Ensure Triton kernels complete before NCCL collectives.
+                # This is needed because Triton kernels run asynchronously and NCCL may
+                # use a separate stream. The wait_for_forward() method synchronizes via
+                # CUDA events recorded after the Triton kernel completes.
+                if hasattr(lookup, "wait_for_forward"):
+                    # pyre-ignore[29]: `wait_for_forward` is dynamically checked
+                    lookup.wait_for_forward()
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())


### PR DESCRIPTION
Summary:
## Problem

Triton TBE causes NCCL timeouts and collective sequence mismatches (e.g., ranks stuck on ALLREDUCE #658 while others are on ALLTOALL_BASE #659) in distributed training. Setting `CUDA_LAUNCH_BLOCKING=1` fixes the issue, indicating a stream synchronization problem.

## Root Cause Analysis

### Why SplitTBE works but TritonTBE doesn't

The fundamental difference is how PyTorch tracks tensor-stream associations:

**SplitTBE (C++ CUDA Extension):**
```cpp
Tensor split_embedding_codegen_lookup_function(...) {
    output = at::empty({B, total_D}, dev_weights.options());
    kernel<<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(output, ...);
    return output;
}
```
- Everything happens inside a single C++ function call
- PyTorch's C++ runtime knows this tensor was created and modified on the current stream
- The caching allocator tracks stream dependencies automatically
- Any subsequent operation on this tensor will be ordered after the kernel

**TritonTBE (Python/Triton JIT):**
```python
def forward(ctx, indices, offsets, weight, ...):
    output = torch.empty((B, total_D), device=weight.device)  # Python allocation
    triton_kernel[(B * T,)](output, ...)  # Triton JIT dispatch
    return output
```
- `torch.empty()` allocates on current stream ✓
- Triton kernel launches on current stream ✓
- BUT: Python interpreter returns immediately after kernel launch
- **PyTorch's caching allocator doesn't know Triton modified this tensor**

### Why this causes NCCL issues

When NCCL performs AllToAll after embedding lookup:
1. For SplitTBE: PyTorch knows the tensor has pending work, `.copy_()` naturally waits
2. For TritonTBE: PyTorch only knows about `torch.empty()` allocation, not Triton's writes
3. NCCL might start before Triton finishes, causing timeouts or data corruption

### Why `CUDA_LAUNCH_BLOCKING=1` fixes it

With `CUDA_LAUNCH_BLOCKING=1`, every CUDA kernel becomes synchronous - CPU waits for Triton kernel to complete before returning. By the time NCCL runs, Triton is definitely finished.

## Solution

Add explicit CUDA event-based synchronization since PyTorch's internal stream tracking doesn't automatically capture Triton kernel dependencies:

1. **TritonTableBatchedEmbeddingBags**: Records CUDA event after forward kernel via callback
2. **TritonBatchedFusedEmbeddingBag**: Exposes `wait_for_forward()` method
3. **GroupedPooledEmbeddingsLookup**: Exposes `wait_for_forward()` to iterate over all embedding modules
4. **ShardedEmbeddingBagCollection.compute_and_output_dist()**: Calls `lookup.wait_for_forward()` after lookup and before output_dist (NCCL AllToAll)

The fix uses `stream.wait_event()` which is GPU-side synchronization - CPU returns immediately, only GPU waits. This preserves pipelining benefits unlike `torch.cuda.synchronize()`.

## Key Insight

Triton bypasses PyTorch's internal tensor-stream association mechanism that C++ extensions naturally participate in. This requires explicit event-based synchronization when Triton outputs feed into NCCL collectives.

Differential Revision: D92662715


