### PR TITLE
enable feature score auto collection in EBC (#3841)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -396,6 +396,7 @@ def _populate_zero_collision_tbe_params(
         if not isinstance(table.virtual_table_eviction_policy, NoEvictionPolicy):
             enabled = True
     kvzch_tbe_config = None
+    fs_eviction_enabled: bool = False
     if enabled:
         counter_thresholds = [0] * len(config.embedding_tables)
         ttls_in_mins = [0] * len(config.embedding_tables)
@@ -458,6 +459,7 @@ def _populate_zero_collision_tbe_params(
                         raise ValueError(
                             f"Do not support multiple eviction strategy in one tbe {eviction_strategy} and 5 for tables {table_names}"
                         )
+                    fs_eviction_enabled = True
                 elif isinstance(policy_t, TimestampBasedEvictionPolicy):
                     training_id_eviction_trigger_count[i] = (
                         policy_t.training_id_eviction_trigger_count
@@ -549,6 +551,7 @@ def _populate_zero_collision_tbe_params(
         optimizer_type_for_st=optimizer_type_for_st,
         optimizer_state_dtypes_for_st=optimizer_state_dtypes_for_st,
         enrichment_policy=enrichment_policy,
+        feature_score_collection_enabled=fs_eviction_enabled,
     )
 
 
@@ -3338,6 +3341,7 @@ class ZeroCollisionKeyValueEmbeddingBag(
         _populate_zero_collision_tbe_params(
             ssd_tbe_params, self._bucket_spec, config, backend_type
         )
+        self._kv_zch_params: KVZCHParams = ssd_tbe_params["kv_zch_params"]
         compute_kernel = config.embedding_tables[0].compute_kernel
         embedding_location = compute_kernel_to_embedding_location(compute_kernel)
 
@@ -3634,9 +3638,62 @@ class ZeroCollisionKeyValueEmbeddingBag(
         self._split_weights_res = None
         self._optim.set_sharded_embedding_weight_ids(sharded_embedding_weight_ids=None)
 
-        return super().forward(
-            features, vbe_output=vbe_output, vbe_output_offsets=vbe_output_offsets
-        )
+        forward_args: Dict[str, Any] = {}
+        identities_and_metadata = self._get_hash_zch_identities_and_metadata(features)
+        if identities_and_metadata is not None:
+            hash_zch_identities, hash_zch_runtime_meta = identities_and_metadata
+            forward_args["hash_zch_identities"] = hash_zch_identities
+            if hash_zch_runtime_meta is not None:
+                forward_args["hash_zch_runtime_meta"] = hash_zch_runtime_meta
+
+        weights = features.weights_or_none()
+        if weights is not None and not torch.is_floating_point(weights):
+            weights = None
+        per_sample_weights = None
+        score_weights = None
+        if weights is not None and weights.dtype == torch.float64:
+            fp32_weights = weights.view(torch.float32)
+            per_sample_weights = fp32_weights[:, 0]
+            score_weights = fp32_weights[:, 1]
+        elif weights is not None and weights.dtype == torch.float32:
+            if self._kv_zch_params.feature_score_collection_enabled:
+                score_weights = weights.view(-1)
+            else:
+                per_sample_weights = weights.view(-1)
+        if features.variable_stride_per_key():
+            if isinstance(self.emb_module, DenseTableBatchedEmbeddingBagsCodegen):
+                forward_args.update(
+                    {
+                        "batch_size_per_feature_per_rank": features.stride_per_key_per_rank(),
+                        "weights": score_weights,
+                    }
+                )
+            if isinstance(
+                self.emb_module,
+                (SplitTableBatchedEmbeddingBagsCodegen, SSDTableBatchedEmbeddingBags),
+            ):
+                forward_args.update(
+                    {
+                        "batch_size_per_feature_per_rank": features.stride_per_key_per_rank(),
+                        "vbe_output": vbe_output,
+                        "vbe_output_offsets": vbe_output_offsets,
+                        "weights": score_weights,
+                    }
+                )
+
+        if len(forward_args) == 0:
+            return self.emb_module(
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_index_type),
+                per_sample_weights=per_sample_weights,
+            )
+        else:
+            return self.emb_module(
+                indices=features.values().to(self._embedding_table_index_type),
+                offsets=features.offsets().to(self._embedding_table_index_type),
+                per_sample_weights=per_sample_weights,
+                **forward_args,
+            )
 
 
 class BatchedFusedEmbeddingBag(

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -79,6 +79,7 @@ from torchrec.distributed.types import (
     ShardingStrategy,
     ShardingType,
 )
+from torchrec.modules.embedding_configs import FeatureScoreBasedEvictionPolicy
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -570,6 +571,22 @@ class GroupedPooledEmbeddingsLookup(
         env: Optional[ShardingEnv] = None,
     ) -> None:
         super().__init__()
+        self._feature_score_auto_collections: List[bool] = []
+        for config in grouped_configs:
+            collection = False
+            for table in config.embedding_tables:
+                if table.use_virtual_table and isinstance(
+                    table.virtual_table_eviction_policy, FeatureScoreBasedEvictionPolicy
+                ):
+                    if (
+                        table.virtual_table_eviction_policy.enable_auto_feature_score_collection
+                    ):
+                        collection = True
+            self._feature_score_auto_collections.append(collection)
+
+        logger.info(
+            f"GroupedPooledEmbeddingsLookup: {self._feature_score_auto_collections=}"
+        )
         self._env = env
         self._emb_modules: nn.ModuleList = nn.ModuleList()
         for config in grouped_configs:
@@ -887,6 +904,7 @@ class GroupedPooledEmbeddingsLookup(
         self,
         features: KeyedJaggedTensor,
         config: GroupedEmbeddingConfig,
+        fs_auto_collection: bool = False,
     ) -> KeyedJaggedTensor:
         if (
             config.has_feature_processor
@@ -896,9 +914,22 @@ class GroupedPooledEmbeddingsLookup(
             features = self._feature_processor(features)
 
         if config.is_weighted:
-            features._weights = CommOpGradientScaling.apply(
-                features._weights, self._scale_gradient_factor
-            )
+            if fs_auto_collection and features.weights_or_none() is not None:
+                feature_weights = CommOpGradientScaling.apply(
+                    features._weights, self._scale_gradient_factor
+                ).float()
+                score_weights = features.weights().float()
+                assert (
+                    feature_weights.numel() == score_weights.numel()
+                ), f"feature_weights.numel() {feature_weights.numel()} != score_weights.numel() {score_weights.numel()}"
+                cat_weights = torch.cat(
+                    [feature_weights.unsqueeze(1), score_weights.unsqueeze(1)], dim=1
+                ).view(torch.float64)
+                features._weights = cat_weights
+            else:
+                features._weights = CommOpGradientScaling.apply(
+                    features._weights, self._scale_gradient_factor
+                )
         return features
 
     def _forward(
@@ -907,13 +938,14 @@ class GroupedPooledEmbeddingsLookup(
     ) -> List[torch.Tensor]:
         embeddings: List[torch.Tensor] = []
 
-        for config, emb_op, features in zip(
+        for config, emb_op, features, fs_auto_collection in zip(
             self.grouped_configs,
             self._emb_modules,
             features_by_group,
+            self._feature_score_auto_collections,
         ):
             features = self._apply_fearture_processor_and_gradient_scaling(
-                features, config
+                features, config, fs_auto_collection
             )
             lookup = emb_op(features)
             embeddings.append(lookup)

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -51,6 +51,10 @@ from torchrec.distributed.embedding_types import (
     KJTList,
     ShardedEmbeddingModule,
 )
+from torchrec.distributed.feature_score_utils import (
+    create_sharding_type_to_feature_score_mapping,
+    may_collect_feature_scores,
+)
 from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
@@ -743,6 +747,23 @@ class ShardedEmbeddingBagCollection(
         self._has_uninitialized_input_dist: bool = True
         self._has_features_permute: bool = True
         self._free_features_storage_early: bool = False
+        self._enable_feature_score_weight_accumulation: bool = False
+        self._enabled_feature_score_auto_collection: bool = False
+        self._sharding_type_feature_score_mapping: Dict[str, Dict[str, float]] = {}
+        (
+            self._enable_feature_score_weight_accumulation,
+            self._enabled_feature_score_auto_collection,
+            self._sharding_type_feature_score_mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            self._embedding_bag_configs, self.sharding_type_to_sharding_infos
+        )
+
+        logger.info(
+            f"EBC feature score weight accumulation enabled: {self._enable_feature_score_weight_accumulation}, "
+            f"auto collection enabled: {self._enabled_feature_score_auto_collection}, "
+            f"sharding type to feature score mapping: {self._sharding_type_feature_score_mapping}"
+        )
+
         # Get all fused optimizers and combine them.
         optims = []
         for lookup in self._lookups:
@@ -1765,6 +1786,11 @@ class ShardedEmbeddingBagCollection(
 
             features_by_shards = features.split(
                 self._feature_splits,
+            )
+            features_by_shards = may_collect_feature_scores(
+                features_by_shards,
+                self._enabled_feature_score_auto_collection,
+                self._sharding_type_feature_score_mapping,
             )
             awaitables = []
             for input_dist, features_by_shard, sharding_type in zip(

--- a/torchrec/distributed/feature_score_utils.py
+++ b/torchrec/distributed/feature_score_utils.py
@@ -14,7 +14,7 @@ from torch.autograd.profiler import record_function
 from torchrec.distributed.embedding_sharding import EmbeddingShardingInfo
 from torchrec.distributed.embedding_types import ShardingType
 from torchrec.modules.embedding_configs import (
-    EmbeddingConfig,
+    BaseEmbeddingConfig,
     FeatureScoreBasedEvictionPolicy,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -23,7 +23,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 
 def create_sharding_type_to_feature_score_mapping(
-    embedding_configs: Sequence[EmbeddingConfig],
+    embedding_configs: Sequence[BaseEmbeddingConfig],
     sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]],
 ) -> Tuple[bool, bool, Dict[str, Dict[str, float]]]:
     enable_feature_score_weight_accumulation = False

--- a/torchrec/distributed/tests/test_feature_score_utils.py
+++ b/torchrec/distributed/tests/test_feature_score_utils.py
@@ -55,6 +55,237 @@ def _convert_to_table_config(
     )
 
 
+class EmbeddingBagConfigTest(unittest.TestCase):
+    def test_embedding_bag_config_with_auto_collection_enabled(self) -> None:
+        # Setup: create EmbeddingBagConfig with auto collection enabled
+        mock_embedding_bag_config = EmbeddingBagConfig(
+            name="table_0",
+            embedding_dim=64,
+            num_embeddings=100,
+            feature_names=["feature_0", "feature_1"],
+            use_virtual_table=True,
+            virtual_table_eviction_policy=FeatureScoreBasedEvictionPolicy(
+                feature_score_mapping={"feature_0": 1.5, "feature_1": 2.0},
+                enable_auto_feature_score_collection=True,
+            ),
+        )
+
+        mock_param = torch.nn.Parameter(torch.randn(100, 64))
+        mock_param_sharding = Mock(spec=ParameterSharding)
+
+        sharding_info = EmbeddingShardingInfo(
+            embedding_config=_convert_to_table_config(mock_embedding_bag_config),
+            param_sharding=mock_param_sharding,
+            param=mock_param,
+        )
+
+        embedding_configs = [mock_embedding_bag_config]
+        sharding_type_to_sharding_infos = {
+            ShardingType.TABLE_WISE.value: [sharding_info],
+        }
+
+        # Execute: run create_sharding_type_to_feature_score_mapping
+        (
+            enable_weight_acc,
+            enable_auto_collection,
+            mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            embedding_configs, sharding_type_to_sharding_infos
+        )
+
+        # Assert: both flags are enabled and mapping contains feature scores
+        self.assertTrue(enable_weight_acc)
+        self.assertTrue(enable_auto_collection)
+        self.assertIn(ShardingType.TABLE_WISE.value, mapping)
+        self.assertEqual(
+            mapping[ShardingType.TABLE_WISE.value],
+            {"feature_0": 1.5, "feature_1": 2.0},
+        )
+
+    def test_embedding_bag_config_with_default_value(self) -> None:
+        # Setup: create EmbeddingBagConfig with default value for missing features
+        mock_embedding_bag_config = EmbeddingBagConfig(
+            name="table_0",
+            embedding_dim=64,
+            num_embeddings=100,
+            feature_names=["feature_0", "feature_1", "feature_2"],
+            use_virtual_table=True,
+            virtual_table_eviction_policy=FeatureScoreBasedEvictionPolicy(
+                feature_score_mapping={"feature_0": 1.5, "feature_1": 2.0},
+                feature_score_default_value=0.5,
+                enable_auto_feature_score_collection=True,
+            ),
+        )
+
+        mock_param = torch.nn.Parameter(torch.randn(100, 64))
+        mock_param_sharding = Mock(spec=ParameterSharding)
+
+        sharding_info = EmbeddingShardingInfo(
+            embedding_config=_convert_to_table_config(mock_embedding_bag_config),
+            param_sharding=mock_param_sharding,
+            param=mock_param,
+        )
+
+        embedding_configs = [mock_embedding_bag_config]
+        sharding_type_to_sharding_infos = {
+            ShardingType.TABLE_WISE.value: [sharding_info],
+        }
+
+        # Execute: run create_sharding_type_to_feature_score_mapping
+        (
+            enable_weight_acc,
+            enable_auto_collection,
+            mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            embedding_configs, sharding_type_to_sharding_infos
+        )
+
+        # Assert: mapping contains explicit scores and default for feature_2
+        self.assertTrue(enable_weight_acc)
+        self.assertTrue(enable_auto_collection)
+        self.assertEqual(
+            mapping[ShardingType.TABLE_WISE.value],
+            {"feature_0": 1.5, "feature_1": 2.0, "feature_2": 0.5},
+        )
+
+    def test_mixed_embedding_config_and_bag_config(self) -> None:
+        # Setup: create both EmbeddingConfig and EmbeddingBagConfig with auto collection
+        embedding_config = EmbeddingConfig(
+            name="table_0",
+            embedding_dim=64,
+            num_embeddings=100,
+            feature_names=["feature_0"],
+            use_virtual_table=True,
+            virtual_table_eviction_policy=FeatureScoreBasedEvictionPolicy(
+                feature_score_mapping={"feature_0": 1.0},
+                enable_auto_feature_score_collection=True,
+            ),
+        )
+
+        embedding_bag_config = EmbeddingBagConfig(
+            name="table_1",
+            embedding_dim=32,
+            num_embeddings=50,
+            feature_names=["feature_1"],
+            use_virtual_table=True,
+            virtual_table_eviction_policy=FeatureScoreBasedEvictionPolicy(
+                feature_score_mapping={"feature_1": 2.0},
+                enable_auto_feature_score_collection=True,
+            ),
+        )
+
+        mock_param_0 = torch.nn.Parameter(torch.randn(100, 64))
+        mock_param_1 = torch.nn.Parameter(torch.randn(50, 32))
+        mock_param_sharding = Mock(spec=ParameterSharding)
+
+        sharding_info_0 = EmbeddingShardingInfo(
+            embedding_config=_convert_to_table_config(embedding_config),
+            param_sharding=mock_param_sharding,
+            param=mock_param_0,
+        )
+
+        sharding_info_1 = EmbeddingShardingInfo(
+            embedding_config=_convert_to_table_config(embedding_bag_config),
+            param_sharding=mock_param_sharding,
+            param=mock_param_1,
+        )
+
+        embedding_configs = [embedding_config, embedding_bag_config]
+        sharding_type_to_sharding_infos = {
+            ShardingType.TABLE_WISE.value: [sharding_info_0, sharding_info_1],
+        }
+
+        # Execute: run create_sharding_type_to_feature_score_mapping
+        (
+            enable_weight_acc,
+            enable_auto_collection,
+            mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            embedding_configs, sharding_type_to_sharding_infos
+        )
+
+        # Assert: mapping contains scores from both config types
+        self.assertTrue(enable_weight_acc)
+        self.assertTrue(enable_auto_collection)
+        self.assertIn(ShardingType.TABLE_WISE.value, mapping)
+        self.assertEqual(
+            mapping[ShardingType.TABLE_WISE.value],
+            {"feature_0": 1.0, "feature_1": 2.0},
+        )
+
+    def test_embedding_bag_config_without_virtual_table(self) -> None:
+        # Setup: create EmbeddingBagConfig without virtual table
+        embedding_bag_configs = [
+            EmbeddingBagConfig(
+                name="table_0",
+                embedding_dim=64,
+                num_embeddings=100,
+                feature_names=["feature_0"],
+            ),
+        ]
+        sharding_type_to_sharding_infos: Dict[str, List[EmbeddingShardingInfo]] = {}
+
+        # Execute: run create_sharding_type_to_feature_score_mapping
+        (
+            enable_weight_acc,
+            enable_auto_collection,
+            mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            embedding_bag_configs, sharding_type_to_sharding_infos
+        )
+
+        # Assert: both flags should be False and mapping should be empty
+        self.assertFalse(enable_weight_acc)
+        self.assertFalse(enable_auto_collection)
+        self.assertEqual(mapping, {})
+
+    def test_embedding_bag_config_with_eviction_ttl_mins(self) -> None:
+        # Setup: create EmbeddingBagConfig with positive eviction_ttl_mins
+        mock_embedding_bag_config = EmbeddingBagConfig(
+            name="table_0",
+            embedding_dim=64,
+            num_embeddings=100,
+            feature_names=["feature_0", "feature_1"],
+            use_virtual_table=True,
+            virtual_table_eviction_policy=FeatureScoreBasedEvictionPolicy(
+                feature_score_mapping={},
+                eviction_ttl_mins=60,
+                enable_auto_feature_score_collection=True,
+            ),
+        )
+
+        mock_param = torch.nn.Parameter(torch.randn(100, 64))
+        mock_param_sharding = Mock(spec=ParameterSharding)
+
+        sharding_info = EmbeddingShardingInfo(
+            embedding_config=_convert_to_table_config(mock_embedding_bag_config),
+            param_sharding=mock_param_sharding,
+            param=mock_param,
+        )
+
+        embedding_configs = [mock_embedding_bag_config]
+        sharding_type_to_sharding_infos = {
+            ShardingType.TABLE_WISE.value: [sharding_info],
+        }
+
+        # Execute: run create_sharding_type_to_feature_score_mapping
+        (
+            enable_weight_acc,
+            enable_auto_collection,
+            mapping,
+        ) = create_sharding_type_to_feature_score_mapping(
+            embedding_configs, sharding_type_to_sharding_infos
+        )
+
+        # Assert: all features get 0.0 score when eviction_ttl_mins is positive
+        self.assertTrue(enable_weight_acc)
+        self.assertTrue(enable_auto_collection)
+        self.assertEqual(
+            mapping[ShardingType.TABLE_WISE.value],
+            {"feature_0": 0.0, "feature_1": 0.0},
+        )
+
+
 class CreateShardingTypeToFeatureScoreMappingTest(unittest.TestCase):
     def test_no_virtual_tables(self) -> None:
         # Setup: create embedding configs without virtual tables


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2436

X-link: https://github.com/pytorch/FBGEMM/pull/5459


This diff is a redo of D85017179 which was reverted due to test failure

**Summary**
This diff enables automatic feature score collection in EmbeddingBagCollection (EBC) for virtual table eviction policies. It integrates the existing feature score utilities into the EBC forward pass, allowing automatic collection of feature scores during inference.

Reviewed By: kausv

Differential Revision: D95503524
