### PR TITLE
Pre-compute module-derived fields on ShardingOption during enumerate()

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -318,6 +318,10 @@ class EmbeddingEnumerator(Enumerator):
         return None
 
     @property
+    def sharder_map(self) -> Dict[str, ModuleSharder[nn.Module]]:
+        return self._sharder_map
+
+    @property
     def last_stored_search_space(self) -> Optional[List[ShardingOption]]:
         # NOTE: This is the last search space stored by enumerate(...), do not use
         # this field in place of actually calling enumerate(...) as it will varie for each

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -12,6 +12,7 @@ from typing import cast, List, Optional, Type
 from unittest.mock import MagicMock
 
 import torch
+from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE, DEFAULT_PERF_ESTIMATOR
@@ -116,8 +117,7 @@ def make_sharding_option(
     return ShardingOption(
         name=name,
         tensor=torch.zeros(1),
-        # pyrefly: ignore[bad-argument-type]
-        module=("model", None),
+        module=("model", nn.Module()),
         input_lengths=[],
         batch_size=8,
         sharding_type="row_wise",
@@ -927,8 +927,7 @@ class TestProposers(unittest.TestCase):
                 ShardingOption(
                     name=name,
                     tensor=torch.zeros(1),
-                    # pyrefly: ignore[bad-argument-type]
-                    module=("model", None),
+                    module=("model", nn.Module()),
                     input_lengths=[],
                     batch_size=8,
                     sharding_type="row_wise",

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -40,7 +40,10 @@ from torchrec.distributed.types import (
     ShardingPlan,
 )
 from torchrec.modules.embedding_configs import DataType
-from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollectionInterface,
+    EmbeddingCollectionInterface,
+)
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
 
 
@@ -1062,12 +1065,43 @@ class ShardingOption:
         self.stochastic_rounding = stochastic_rounding
         self.bounds_check_mode = bounds_check_mode
         self.dependency = dependency
-        self._is_pooled = is_pooled
+        self._is_pooled: bool = (
+            is_pooled
+            if is_pooled is not None
+            else ShardingOption.module_pooled(module[1], name)
+        )
         self.is_weighted: Optional[bool] = None
         self.feature_names: Optional[List[str]] = feature_names
         self.output_dtype: Optional[DataType] = output_dtype
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
+
+        child_module = module[1]
+        self._module_type_key: str = (
+            type(child_module).__module__ + "." + type(child_module).__name__
+        )
+        _module_has_fp = (
+            hasattr(child_module, "_feature_processor")
+            and hasattr(
+                child_module._feature_processor,
+                "feature_processor_modules",
+            )
+            and isinstance(
+                # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+                child_module._feature_processor.feature_processor_modules,
+                nn.ModuleDict,
+            )
+        )
+        self._has_feature_processor: bool = (
+            _module_has_fp
+            and name
+            # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+            in child_module._feature_processor.feature_processor_modules.keys()
+        )
+        if hasattr(child_module, "is_weighted") and callable(child_module.is_weighted):
+            if isinstance(child_module, EmbeddingBagCollectionInterface):
+                # pyre-ignore[29]: `Module` has no attribute `is_weighted`
+                self.is_weighted = child_module.is_weighted()
 
     @property
     def tensor(self) -> torch.Tensor:
@@ -1116,8 +1150,6 @@ class ShardingOption:
 
     @property
     def is_pooled(self) -> bool:
-        if self._is_pooled is None:
-            self._is_pooled = ShardingOption.module_pooled(self.module[1], self.name)
         return self._is_pooled
 
     @staticmethod
@@ -1137,6 +1169,14 @@ class ShardingOption:
                         return False
 
         return True
+
+    @property
+    def module_type_key(self) -> str:
+        return self._module_type_key
+
+    @property
+    def has_feature_processor(self) -> bool:
+        return self._has_feature_processor
 
     def get_shards_assignment(self) -> List[Optional[int]]:
         return [shard.rank for shard in self.shards]


### PR DESCRIPTION
Summary:
The `ShardingOption` constructor now extracts everything it needs from the `nn.Module` at construction time instead of letting consumers reach into `module[1]` later. Four fields are pre-computed:

- `module_type_key`: the sharder lookup key, previously computed as `sharder_name(type(module[1]))` by every estimator and stats class
- `has_feature_processor`: whether the module has a feature processor for this table, previously checked via a chain of `hasattr` calls on `module[1]._feature_processor`
- `is_weighted`: whether the module is a weighted EBC, previously checked via `isinstance(module, EmbeddingBagCollectionInterface)` + `module.is_weighted()`
- `is_pooled`: was already a property but lazily resolved; now eagerly computed via `module_pooled()` in the constructor

All four handle `module[1] == None` gracefully (for test/mock contexts). Also adds a sharder_map property on EmbeddingEnumerator for external access.

This is the first diff in a 7-diff stack that makes planner inputs serializable for offline replay. D95081573 migrates all consumers to use these pre-computed fields.

Differential Revision: D95081452


