### PR TITLE
Add Muon optimizer support to MVAI trainer

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -69,6 +69,7 @@ class OptimType(Enum):
     ADAMW = "ADAMW"
     SHAMPOO_V2_MRS = "SHAMPOO_V2_MRS"
     SHAMPOO_MRS = "SHAMPOO_MRS"
+    MUON = "MUON"
 
 
 @unique


### PR DESCRIPTION
Summary:
Wire torch.optim.Muon into MVAI's optimizer infrastructure as a new OptimType.MUON.
Muon uses Newton-Schulz orthogonalization on gradients and is designed for 2D weight
matrices, so the integration automatically splits params by ndim: 2D params use Muon
while non-2D params (biases, norms, embeddings) fall back to AdamW.

- Add MUON to OptimType enum
- Add MuonConfig dataclass with NS iteration params and fallback AdamW overrides
- Add factory branches in _get_optimizer_factory for CUDA and CPU paths
- Add 2D/non-2D param splitting in create_dense_optimizer_by_config
- Add MUON to FSDP2 allowlist; reject FSDP1 (flattens params to 1D)
- Add unit tests for factory, config defaults, auto-creation, and custom configs

Reviewed By: yunjiangster

Differential Revision: D95662805


