### PR TITLE
Add batch input size logging to benchmark_train_pipeline

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -185,6 +185,23 @@ def runner(
             weighted_tables=weighted_tables,
         )
 
+        total_bytes = 0
+        for i, batch in enumerate(bench_inputs):
+            batch_bytes = batch.size_in_bytes()
+            total_bytes += batch_bytes
+            if batch_bytes >= 1024 * 1024 * 1024:
+                batch_size_str = f"{batch_bytes / 1024 / 1024 / 1024:.2f} GB"
+            else:
+                batch_size_str = f"{batch_bytes / 1024 / 1024:.2f} MB"
+            logger.info(f"Rank {rank} batch {i} input size: {batch_size_str}")
+        if total_bytes >= 1024 * 1024 * 1024:
+            total_size_str = f"{total_bytes / 1024 / 1024 / 1024:.2f} GB"
+        else:
+            total_size_str = f"{total_bytes / 1024 / 1024:.2f} MB"
+        logger.info(
+            f"Rank {rank} total input size: {total_size_str} ({len(bench_inputs)} batches)"
+        )
+
         sharded_model, optimizer = sharding_config.generate_sharded_model_and_optimizer(
             model=unsharded_model,
             # pyrefly: ignore[bad-argument-type]


### PR DESCRIPTION
Summary:
## 1. Context
When running benchmark_train_pipeline, there is no visibility into how large the generated model inputs are in memory. This makes it difficult to reason about memory consumption, correlate input sizes with GPU memory stats, or diagnose OOM issues. The `ModelInput` class already provides a `size_in_bytes()` API, but it was not being used in the benchmark runner.

## 2. Approach
1. **Per-batch and total size logging**: After `input_config.generate_batches()` returns, iterate over all batches, call `size_in_bytes()` on each, and log both per-batch and total sizes with human-readable formatting (MB or GB).
2. **All-rank logging**: Log on every rank (not just rank 0) since each rank generates its own inputs independently and sizes could theoretically differ with variable-batch configurations.
3. **Human-readable formatting**: Sizes are displayed in GB when >= 1 GB, otherwise in MB, with 2 decimal places.

## 3. Results
* benchmark

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base              |3230.91 ms       |3068.12 ms       |49.06 GB                |66.50 GB                   |68.97 GB          |0.0 / 0.0 / 0.0              |31.07 GB          |

New logging output (per rank):
```
Rank 0 batch 0 input size: 1.58 GB
...
Rank 0 total input size: 15.81 GB (10 batches)
Rank 1 batch 0 input size: 1.58 GB
...
Rank 1 total input size: 15.81 GB (10 batches)
```

* repro commands
```bash
# sparse_data_dist_base
buck2 run $GB200 fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
```

## 4. Analysis
1. **No behavioral impact**: This is a logging-only change. It does not modify any model inputs, sharding, or pipeline behavior. Zero risk to training correctness.
2. **Performance**: The `size_in_bytes()` calls are lightweight (summing `element_size() * numel()` over tensors). Negligible overhead compared to the benchmark itself.
3. **Observability**: With `sparse_data_dist_base.yml` config (batch_size=32768, 90 unweighted + 80 weighted features, pooling_avg=30), each batch is 1.58 GB. Total input across 10 batches is 15.81 GB per rank — this context is valuable when interpreting the 49 GB peak GPU memory allocation.

## 5. Changes
1. **`benchmark_train_pipeline.py`**: Added 17 lines after `generate_batches()` to log per-batch and total input sizes in human-readable format (MB/GB) for all ranks.

Differential Revision: D95741625


