### PR TITLE
[detailed][memory] Add `permute_2D_sparse_preallocated_out` with pre-allocated output buffers (#3846)

### DIFF
--- a/torchrec/sparse/tests/permute_2d_benchmark.py
+++ b/torchrec/sparse/tests/permute_2d_benchmark.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Benchmark for permute_2D_sparse_data with and without pre-allocated output tensors.
+
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark
+    buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark -- --num_features=170 --batch_size=256 --device_type=cuda
+"""
+
+import logging
+import random
+import sys
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import torch
+
+torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    BenchmarkResult,
+    cmd_conf,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(message)s", stream=sys.stdout)
+logger.setLevel(logging.DEBUG)
+
+
+def _generate_sparse_data(
+    num_features: int,
+    batch_size: int,
+    mean_pooling_factor: int,
+    device: torch.device,
+    has_weight: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Generate sparse data for permute_2D_sparse_data benchmarking."""
+    lengths = torch.randint(
+        low=0,
+        high=2 * mean_pooling_factor,
+        size=(num_features, batch_size),
+        dtype=torch.int32,
+        device=device,
+    )
+    total = int(lengths.sum().item())
+    indices = torch.randint(
+        low=0,
+        high=int(1e5),
+        size=(total,),
+        dtype=torch.int32,
+        device=device,
+    )
+    permute = torch.tensor(
+        random.sample(range(num_features), k=num_features),
+        dtype=torch.int32,
+        device=device,
+    )
+    weights = (
+        torch.rand(total, dtype=torch.float32, device=device) if has_weight else None
+    )
+    return permute, lengths, indices, weights
+
+
+@dataclass
+class RunOptions(BenchFuncConfig):
+    """Configuration for permute_2D_sparse_data benchmark."""
+
+    ALL_NAMES: List[str] = field(
+        default_factory=lambda: [
+            "permute_2d_default",
+            "permute_2d_preallocated",
+        ],
+        repr=False,
+    )
+
+    name: str = "all"
+    num_features: int = 170
+    batch_size: int = 128
+    mean_pooling_factor: int = 50
+    has_weight: bool = False
+
+    # Override defaults from BenchFuncConfig
+    world_size: int = 1
+    num_benchmarks: int = 100
+    num_profiles: int = 10
+    device_type: str = "cuda"
+    debug_mode: bool = False
+    profile_dir: str = "."
+    memory_snapshot: bool = True
+
+    _iter_index: int = field(default=0, repr=False)
+
+    def __iter__(self) -> "RunOptions":
+        self._iter_index = 0
+        return self
+
+    def __next__(self) -> "RunOptions":
+        if self.name != "all":
+            if self._iter_index == 0:
+                self._iter_index += 1
+                return self
+            raise StopIteration
+
+        if self._iter_index >= len(self.ALL_NAMES):
+            raise StopIteration
+
+        import copy
+
+        name = self.ALL_NAMES[self._iter_index]
+        self._iter_index += 1
+        new_option = copy.copy(self)
+        new_option.name = name
+        return new_option
+
+
+def runner(
+    run_option: RunOptions,
+) -> BenchmarkResult:
+    """Run benchmark for a single configuration."""
+    device = torch.device(run_option.device_type)
+
+    permute, lengths, indices, weights = _generate_sparse_data(
+        run_option.num_features,
+        run_option.batch_size,
+        run_option.mean_pooling_factor,
+        device,
+        run_option.has_weight,
+    )
+
+    total = int(lengths.sum().item())
+    T = permute.numel()
+    B = lengths.size(1)
+
+    use_preallocated = run_option.name == "permute_2d_preallocated"
+
+    # Only pre-allocate output tensors for the preallocated path
+    permuted_lengths_out: Optional[torch.Tensor] = None
+    permuted_indices_out: Optional[torch.Tensor] = None
+    permuted_weights_out: Optional[torch.Tensor] = None
+    if use_preallocated:
+        permuted_lengths_out = torch.empty(T, B, dtype=lengths.dtype, device=device)
+        permuted_indices_out = torch.empty(total, dtype=indices.dtype, device=device)
+        permuted_weights_out = (
+            torch.empty(total, dtype=torch.float32, device=device)
+            if run_option.has_weight
+            else None
+        )
+
+    # Warmup
+    if use_preallocated:
+        torch.ops.fbgemm.permute_2D_sparse_data(
+            permute,
+            lengths,
+            indices,
+            weights,
+            total,
+            permuted_lengths_out,
+            permuted_indices_out,
+            permuted_weights_out,
+        )
+    else:
+        torch.ops.fbgemm.permute_2D_sparse_data(
+            permute,
+            lengths,
+            indices,
+            weights,
+            total,
+        )
+
+    def _func_to_benchmark(
+        _bench_inputs: List[Any],
+    ) -> None:
+        if use_preallocated:
+            torch.ops.fbgemm.permute_2D_sparse_data(
+                permute,
+                lengths,
+                indices,
+                weights,
+                total,
+                permuted_lengths_out,
+                permuted_indices_out,
+                permuted_weights_out,
+            )
+        else:
+            torch.ops.fbgemm.permute_2D_sparse_data(
+                permute,
+                lengths,
+                indices,
+                weights,
+                total,
+            )
+
+    result = benchmark_func(
+        rank=0,
+        func_to_benchmark=_func_to_benchmark,
+        bench_inputs=[{}],
+        prof_inputs=[{}] * run_option.num_profiles,
+        benchmark_func_kwargs={},
+        **run_option.benchmark_func_kwargs(),
+    )
+
+    logger.info(result.prettify())
+    logger.info("\nMarkdown format:\n%s", result)
+
+    return result
+
+
+@cmd_conf
+def main(
+    run_option: RunOptions,
+) -> None:
+    """Main entry point for the permute_2D_sparse_data benchmark."""
+    run_option.set_log_level()
+
+    results: List[BenchmarkResult] = []
+    for option in run_option:
+        results.append(runner(option))
+
+    print(BenchmarkResult.print_table(results))
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[not-callable]
+    main()

--- a/torchrec/sparse/tests/permute_2d_benchmark.py
+++ b/torchrec/sparse/tests/permute_2d_benchmark.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Benchmark for permute_2D_sparse_data with and without pre-allocated output tensors.
+
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark
+    buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark -- --num_features=170 --batch_size=256 --device_type=cuda
+"""
+
+import logging
+import random
+import sys
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import torch
+
+torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    BenchmarkResult,
+    cmd_conf,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(message)s", stream=sys.stdout)
+logger.setLevel(logging.DEBUG)
+
+
+def _generate_sparse_data(
+    num_features: int,
+    batch_size: int,
+    mean_pooling_factor: int,
+    device: torch.device,
+    has_weight: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Generate sparse data for permute_2D_sparse_data benchmarking."""
+    lengths = torch.randint(
+        low=0,
+        high=2 * mean_pooling_factor,
+        size=(num_features, batch_size),
+        dtype=torch.int32,
+        device=device,
+    )
+    total = int(lengths.sum().item())
+    indices = torch.randint(
+        low=0,
+        high=int(1e5),
+        size=(total,),
+        dtype=torch.int32,
+        device=device,
+    )
+    permute = torch.tensor(
+        random.sample(range(num_features), k=num_features),
+        dtype=torch.int32,
+        device=device,
+    )
+    weights = (
+        torch.rand(total, dtype=torch.float32, device=device) if has_weight else None
+    )
+    return permute, lengths, indices, weights
+
+
+@dataclass
+class RunOptions(BenchFuncConfig):
+    """Configuration for permute_2D_sparse_data benchmark."""
+
+    ALL_NAMES: List[str] = field(
+        default_factory=lambda: [
+            "permute_2d_default",
+            "permute_2d_preallocated",
+        ],
+        repr=False,
+    )
+
+    name: str = "all"
+    num_features: int = 170
+    batch_size: int = 128
+    mean_pooling_factor: int = 50
+    has_weight: bool = False
+
+    # Override defaults from BenchFuncConfig
+    world_size: int = 1
+    num_benchmarks: int = 100
+    num_profiles: int = 10
+    device_type: str = "cuda"
+    debug_mode: bool = False
+    profile_dir: str = "."
+    memory_snapshot: bool = True
+
+    _iter_index: int = field(default=0, repr=False)
+
+    def __iter__(self) -> "RunOptions":
+        self._iter_index = 0
+        return self
+
+    def __next__(self) -> "RunOptions":
+        if self.name != "all":
+            if self._iter_index == 0:
+                self._iter_index += 1
+                return self
+            raise StopIteration
+
+        if self._iter_index >= len(self.ALL_NAMES):
+            raise StopIteration
+
+        import copy
+
+        name = self.ALL_NAMES[self._iter_index]
+        self._iter_index += 1
+        new_option = copy.copy(self)
+        new_option.name = name
+        return new_option
+
+
+def runner(
+    run_option: RunOptions,
+) -> BenchmarkResult:
+    """Run benchmark for a single configuration."""
+    device = torch.device(run_option.device_type)
+
+    permute, lengths, indices, weights = _generate_sparse_data(
+        run_option.num_features,
+        run_option.batch_size,
+        run_option.mean_pooling_factor,
+        device,
+        run_option.has_weight,
+    )
+
+    total = int(lengths.sum().item())
+    T = permute.numel()
+    B = lengths.size(1)
+
+    use_preallocated = run_option.name == "permute_2d_preallocated"
+
+    # Only pre-allocate output tensors for the preallocated path
+    permuted_lengths_out: Optional[torch.Tensor] = None
+    permuted_indices_out: Optional[torch.Tensor] = None
+    permuted_weights_out: Optional[torch.Tensor] = None
+    if use_preallocated:
+        permuted_lengths_out = torch.empty(T, B, dtype=lengths.dtype, device=device)
+        permuted_indices_out = torch.empty(total, dtype=indices.dtype, device=device)
+        permuted_weights_out = (
+            torch.empty(total, dtype=torch.float32, device=device)
+            if run_option.has_weight
+            else None
+        )
+
+    # Warmup
+    if use_preallocated:
+        torch.ops.fbgemm.permute_2D_sparse_preallocated_out(
+            permute,
+            lengths,
+            indices,
+            weights,
+            total,
+            permuted_lengths_out,
+            permuted_indices_out,
+            permuted_weights_out,
+        )
+    else:
+        torch.ops.fbgemm.permute_2D_sparse_data(
+            permute,
+            lengths,
+            indices,
+            weights,
+            total,
+        )
+
+    def _func_to_benchmark(
+        _bench_inputs: List[Any],
+    ) -> None:
+        if use_preallocated:
+            torch.ops.fbgemm.permute_2D_sparse_preallocated_out(
+                permute,
+                lengths,
+                indices,
+                weights,
+                total,
+                permuted_lengths_out,
+                permuted_indices_out,
+                permuted_weights_out,
+            )
+        else:
+            torch.ops.fbgemm.permute_2D_sparse_data(
+                permute,
+                lengths,
+                indices,
+                weights,
+                total,
+            )
+
+    result = benchmark_func(
+        rank=0,
+        func_to_benchmark=_func_to_benchmark,
+        bench_inputs=[{}],
+        prof_inputs=[{}] * run_option.num_profiles,
+        benchmark_func_kwargs={},
+        **run_option.benchmark_func_kwargs(),
+    )
+
+    logger.info(result.prettify())
+    logger.info("\nMarkdown format:\n%s", result)
+
+    return result
+
+
+@cmd_conf
+def main(
+    run_option: RunOptions,
+) -> None:
+    """Main entry point for the permute_2D_sparse_data benchmark."""
+    run_option.set_log_level()
+
+    results: List[BenchmarkResult] = []
+    for option in run_option:
+        results.append(runner(option))
+
+    print(BenchmarkResult.print_table(results))
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[not-callable]
+    main()


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5461


X-link: https://github.com/facebookresearch/FBGEMM/pull/2435

## 1. Context

In TrainPipelineSparseDist, input distribution runs on a separate data_dist_stream. Memory snapshot analysis revealed that KJT allocations happen inside `permute_2D_sparse_data` (called from jagged_tensor.py). These allocations on data_dist_stream require record_stream when the tensors are later consumed on the default stream, which delays memory reclamation by the CUDA caching allocator.

By letting callers pass in pre-allocated output buffers (allocated on the main stream before switching to data_dist_stream), we eliminate the cross-stream allocation and the need for record_stream, so the output's memory can be reused by other ops on the main stream.

<img width="1862" height="918" alt="image" src="https://github.com/user-attachments/assets/c16b55f2-7b1c-47d9-8f17-93649e9e2ed7" />

## 2. Approach

The zero-copy path needs the operator's returned tensors to alias the caller's pre-allocated buffers. That aliasing cannot be added to `permute_2D_sparse_data` itself: it has a registered autograd formula, and register_autograd requires a functional (non-mutating, non-aliasing) operator -- declaring Tensor(a!) aliasing on it fails at import. So instead of overloading the existing differentiable op, this diff adds a separate, non-differentiable operator.

1. **New op `permute_2D_sparse_preallocated_out`**: takes three optional buffers (permuted_lengths_out, permuted_indices_out, permuted_weights_out). When provided, the op writes into them and returns tensors aliasing them; when omitted it allocates as usual. The schema declares the aliasing honestly with Tensor(a!) / Tensor(b!) / Tensor(c!) annotations on both the optional buffers and the corresponding returns. No autograd formula is registered.
2. **The existing op is unchanged**: `permute_2D_sparse_data` keeps the same functional 5-arg schema, autograd, and behavior as before.
3. **Shared implementation (no duplicated logic)**: the existing kernel bodies (CPU, CUDA, meta) were renamed to the preallocated-out variants and now hold the use-buffer-if-provided logic. The original entry points became thin wrappers that delegate to them with no buffers, so the permutation logic lives in exactly one place.
4. **No torch.compile support for the new op**: functionalization (AOTAutograd) does not support custom ops whose outputs carry alias annotations, so its aot dispatch opcheck is marked xfail (the new op targets the eager input-distribution path, consistent with many other FBGEMM ops). The schema opcheck passes for real.
5. **CPU only / CUDA only**: the new op is registered for CPU and CUDA; no MTIA backend is added.

## 3. Results

* benchmark (H100, num_features=170, batch_size=128, mean_pooling_factor=50): the microbenchmark runs single-stream, so it does not exercise the multi-stream data_dist_stream scenario where the memory saving materializes; run-to-run runtime variation is also too large to draw a runtime conclusion. It confirms the new op produces the same results as the existing op, and the memory snapshots below show the allocation-pattern difference.

* repro command
```
buck2 run @fbcode//mode/opt fbcode//torchrec/sparse/tests:permute_2d_benchmark -- \
  --num_features=170 --batch_size=128 --mean_pooling_factor=50
```

<img width="4782" height="1948" alt="image" src="https://github.com/user-attachments/assets/b446f44b-0105-4274-a546-4372abc5459a" />

Top: `permute_2D_sparse_data`; bottom: `permute_2D_sparse_preallocated_out`. The traces are intentionally identical -- the GPU kernel is unchanged. The optimization is host-side allocation and cross-stream memory lifetime (dropping record_stream), which a single-stream kernel trace does not capture.

<img width="5078" height="1630" alt="image" src="https://github.com/user-attachments/assets/cb5a65dd-20a4-4477-a28f-d01822285d18" />

<img width="5098" height="1638" alt="image" src="https://github.com/user-attachments/assets/1eab8366-b2a0-42be-adad-47c012d623bf" />

Memory snapshots over the 10 benchmark iterations (single-stream). Top (`permute_2D_sparse_data`): the output buffer is allocated and freed on every iteration -- the repeated transient blocks. Bottom (`permute_2D_sparse_preallocated_out`): the buffer is allocated once and persists, reused across all iterations -- no per-iteration allocation. Single-stream peak memory is comparable; in the multi-stream path the per-iteration allocation is what forces record_stream and blocks reuse, which the persistent buffer avoids.

## 4. Analysis

1. **Backward compatibility**: `permute_2D_sparse_data` (and its legacy alias, the input1D variant, permute_sequence_embeddings, and all TorchRec call sites) are untouched. The optimization is purely additive via the new op.
2. **Why a separate op**: aliasing plus mutation on an op that has a registered autograd formula is rejected by PyTorch (autograd registration requires a functional schema). The buffers are write-only outputs that never participate in gradients, so a dedicated non-differentiable op is the correct model rather than a compromise.
3. **Refactor is autograd-safe**: `permute_2D_sparse_data` now delegates to the shared implementation, but its autograd is registered at the op level (unchanged) and its forward is verified by the existing tests. A new backward test additionally checks that gradients still flow correctly to the weights on CPU and GPU, against an independent inverse-permute reference.
4. **GPU runtime unchanged**: the CUDA kernel is identical -- only the host-side allocation is skipped.
5. **No validation on pre-allocated buffers**: the op trusts callers to provide correctly sized buffers, consistent with other out-variant patterns in PyTorch/FBGEMM, avoiding runtime overhead.

## 5. Changes

1. **sparse_ops_cpu.cpp**: Added the `permute_2D_sparse_preallocated_out` schema (with the alias annotations) and CPU dispatch. Renamed the implementation body to the preallocated-out variant; the original CPU entry point is now a thin wrapper that delegates with no buffers.
2. **sparse_permute_2d.cu**: Same split on the CUDA side -- the preallocated-out variant holds the logic, the original entry point delegates; added the CUDA dispatch for the new op.
3. **sparse_ops.h**: Added declarations for the new CPU/CUDA entry points; the original declarations are back to the 5-arg form.
4. **sparse_ops.py**: Added the meta implementation for the new op (conditional allocation) and registered its fake impl; the original meta delegates to it. No autograd registered for the new op.
5. **permute_indices_test.py**: Added test_permute_indices_with_preallocated_output (correctness + zero-copy verification on CPU/GPU against the new op) and test_permute_indices_backward (gradient check for `permute_2D_sparse_data` on CPU/GPU against an independent inverse-permute reference).
6. **failures_dict.json**: two entries -- (a) xfail for the new op's aot dispatch opcheck (functionalization does not support alias-annotated custom-op outputs); (b) skip for the backward test's aot dispatch opcheck. The latter is not an op bug: the aot_autograd_check harness builds its loss by summing all outputs, so the op's leading int64 outputs make the accumulator int64 and the trailing add of the float weights raises "result type Float can't be cast to Long"; the op's backward is never reached and real torch.compile/autograd is unaffected. Skip (not xfail) is used so it does not falsely flag the forward-PT2-compliant op.
7. **permute_2d_benchmark.py** (new) and **torchrec/sparse/tests/BUCK**: benchmark comparing default vs pre-allocated paths (calls the new op), plus its python_binary target.

Reviewed By: q10

Differential Revision: D95757955


