### PR TITLE
Migrate estimators and stats to use pre-computed ShardingOption fields (#3847)

### DIFF
--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1731,7 +1731,14 @@ class EmbeddingPerfEstimator(ShardEstimator):
             # (raises ValueError if not supported)
             self._config.validate_sharding_type(sharding_option.sharding_type)
 
-            sharder_key = sharder_name(type(sharding_option.module[1]))
+            from torch._utils_internal import justknobs_check
+
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder_key = sharding_option.module_type_key
+            else:
+                sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
 
             shard_sizes = [shard.size for shard in sharding_option.shards]

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -630,32 +630,47 @@ class ShardPerfContext:
             len(sharding_option.input_lengths) == len(num_poolings) == len(batch_sizes)
         ), "Provided `pooling_factors`, `num_poolings`, and `batch_sizes` constraints must match."
 
-        # Check for feature processor
-        module = sharding_option.module[1]
-        has_feature_processor = False
-        if (
-            hasattr(module, "_feature_processor")
-            and hasattr(module._feature_processor, "feature_processor_modules")
-            and isinstance(
-                module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
-                nn.ModuleDict,
-            )
-            and sharding_option.name
-            in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
-        ):
-            has_feature_processor = True
+        # Check for feature processor and determine is_weighted
+        from torch._utils_internal import justknobs_check
 
-        # Determine is_weighted
-        if isinstance(module, EmbeddingBagCollectionInterface):
-            is_weighted = module.is_weighted()
-        elif (
-            constraints
-            and constraints.get(sharding_option.name)
-            and constraints[sharding_option.name].is_weighted
+        if justknobs_check(
+            "pytorch/torchrec:enable_precomputed_sharding_option_fields"
         ):
-            is_weighted = constraints[sharding_option.name].is_weighted
+            has_feature_processor = sharding_option.has_feature_processor
+            if sharding_option.is_weighted is not None:
+                is_weighted = sharding_option.is_weighted
+            elif (
+                constraints
+                and constraints.get(sharding_option.name)
+                and constraints[sharding_option.name].is_weighted
+            ):
+                is_weighted = constraints[sharding_option.name].is_weighted
+            else:
+                is_weighted = False
         else:
-            is_weighted = False
+            module = sharding_option.module[1]
+            has_feature_processor = False
+            if (
+                hasattr(module, "_feature_processor")
+                and hasattr(module._feature_processor, "feature_processor_modules")
+                and isinstance(
+                    module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
+                    nn.ModuleDict,
+                )
+                and sharding_option.name
+                in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
+            ):
+                has_feature_processor = True
+            if isinstance(module, EmbeddingBagCollectionInterface):
+                is_weighted = module.is_weighted()  # pyre-ignore[29]
+            elif (
+                constraints
+                and constraints.get(sharding_option.name)
+                and constraints[sharding_option.name].is_weighted
+            ):
+                is_weighted = constraints[sharding_option.name].is_weighted
+            else:
+                is_weighted = False
 
         is_weighted = is_weighted or has_feature_processor
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -160,8 +160,15 @@ class EmbeddingStorageEstimator(ShardEstimator):
             assert not sharding_options, "sharder_map not provided for sharding_options"
             return
 
+        from torch._utils_internal import justknobs_check
+
         for sharding_option in sharding_options:
-            sharder_key = sharder_name(type(sharding_option.module[1]))
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder_key = sharding_option.module_type_key
+            else:
+                sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
 
             caching_ratio = sharding_option.cache_load_factor

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -898,7 +898,14 @@ class EmbeddingStats(Stats):
             num_poolings = str(round(sum(num_poolings), 3))
             output = "pooled" if so.is_pooled else "sequence"
             weighted = "weighted" if so.is_weighted else "unweighted"
-            sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
+            from torch._utils_internal import justknobs_check
+
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder = sharder_map.get(so.module_type_key, None)
+            else:
+                sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
             sharder_name = type(sharder).__name__
             num_features = len(so.input_lengths)
             embedding_dim = _get_embedding_dim(so)


### PR DESCRIPTION
Summary:

A pure consumer-side migration. Every place in the codebase that accessed sharding_option.module[1] to do sharder lookup, feature processor detection, or weighted table detection is replaced with the pre-computed properties from D95081452:

- sharder_name(type(so.module[1])) -> so.module_type_key
- hasattr(module, "_feature_processor") ... -> so.has_feature_processor
- isinstance(module, EBC) and module.is_weighted() -> so.is_weighted

After this diff, no estimator or stats class accesses module[1] directly. D95299288 (next) introduces SharderData to handle the remaining dependency on live ModuleSharder objects.

Created this jk in case we missed something and can revert back to the previous behavior: https://www.internalfb.com/intern/justknobs/?name=pytorch%2Ftorchrec#enable_precomputed_sharding_option_fields

JK is currently set to False. I'll set it to True after the land is successful.

Reviewed By: mserturk

Differential Revision: D95081573
