### PR TITLE
Relax numerical tolerances for EC 2D parallel sharding tests

### DIFF
--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -678,6 +678,8 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
+            atol=1e-4,
+            rtol=1e-4,
         )
 
     @unittest.skipIf(
@@ -749,6 +751,8 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
             },
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
+            atol=1e-4,
+            rtol=1e-4,
         )
 
     @unittest.skipIf(
@@ -820,6 +824,8 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
             },
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
             variable_batch_size=variable_batch_size,
+            atol=1e-4,
+            rtol=1e-4,
         )
 
     def _test_sharding(
@@ -838,6 +844,8 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         ] = None,
         variable_batch_size: bool = False,
         variable_batch_per_feature: bool = False,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
     ) -> None:
         self._run_multi_process_test(
             callable=sharding_single_rank_test,
@@ -856,6 +864,8 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
             variable_batch_size=variable_batch_size,
             variable_batch_per_feature=variable_batch_per_feature,
             global_constant_batch=True,
+            atol=atol,
+            rtol=rtol,
         )
 
 


### PR DESCRIPTION
Summary:
## Problem

The test `test_sharding_ec_cw_2D` (and related EC 2D parallel sharding tests) in `TestEmbeddingCollection2DParallel` intermittently fails due to numerical precision mismatches when comparing sharded vs unsharded model predictions.

With 2D parallelism (world_size=8, world_size_2D=4), `DMPCollection.sync()` performs `allreduce_coalesced(ReduceOp.AVG)` on model weights. This allreduce averaging introduces floating-point rounding errors that can exceed the default tight tolerances of `torch.testing.assert_close` (atol=1e-5, rtol=1.3e-6 for float32).

The `ModelParallelTestShared._test_sharding` (used by EBC tests) already supports `atol`/`rtol` parameters, but `TestEmbeddingCollection2DParallel._test_sharding` did not plumb these through.

## Fix

1. Added `atol` and `rtol` parameters to `TestEmbeddingCollection2DParallel._test_sharding` and pass them through to `sharding_single_rank_test` via `_run_multi_process_test`.
2. Set `atol=1e-4, rtol=1e-4` for all three EC 2D parallel test methods (`test_sharding_ec_rw_2D`, `test_sharding_ec_cw_2D`, `test_sharding_ec_tw_2D`) to account for numerical noise from allreduce averaging.

These tolerances are deliberately conservative (much tighter than qcomms tolerance of 0.003) but relaxed enough to absorb allreduce floating-point noise.

Task: T258576940

---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=2e691844-1bda-11f1-80bc-a582e6284152&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=2e691844-1bda-11f1-80bc-a582e6284152&tab=Trace)

Differential Revision: D95832911


