### PR TITLE
Guard reduce_scatter with self.training to prevent inference deadlock (#3849)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -2735,9 +2735,10 @@ class ShardedBatchedFusedEmbedding(BatchedFusedEmbedding):
 
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
         embs = super().forward(features)
-        self._async_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(self._async_stream):
-            self._rs_awaitable = self._reduce_scatter_weights_async()
+        if self.training:
+            self._async_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(self._async_stream):
+                self._rs_awaitable = self._reduce_scatter_weights_async()
         return embs
 
     def _reduce_scatter_weights_async(self) -> ReduceScatterResizeAwaitable:
@@ -4618,9 +4619,10 @@ class ShardedBatchedFusedEmbeddingBag(BatchedFusedEmbeddingBag):
     # pyrefly: ignore [bad-override]
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
         embs = super().forward(features)
-        self._async_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(self._async_stream):
-            self._rs_awaitable = self._reduce_scatter_weights_async()
+        if self.training:
+            self._async_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(self._async_stream):
+                self._rs_awaitable = self._reduce_scatter_weights_async()
         return embs
 
     def _reduce_scatter_weights_async(self) -> ReduceScatterResizeAwaitable:

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -360,10 +360,11 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
     def get_resize_awaitables(self) -> List[LazyAwaitable[torch.Tensor]]:
         # TODO - we can probably do some smart grouping to make this more efficient
         return [
-            # pyrefly: ignore[not-callable]
-            emb_module.get_rs_awaitable()
+            awaitable
             for emb_module in self._emb_modules
             if hasattr(emb_module, "get_rs_awaitable")
+            # pyrefly: ignore[not-callable]
+            and (awaitable := emb_module.get_rs_awaitable()) is not None
         ]
 
     # pyrefly: ignore[bad-override]
@@ -1017,10 +1018,11 @@ class GroupedPooledEmbeddingsLookup(
     def get_resize_awaitables(self) -> List[LazyAwaitable[torch.Tensor]]:
         # TODO - we can probably do some smart grouping to make this more efficient
         return [
-            # pyrefly: ignore[not-callable]
-            emb_module.get_rs_awaitable()
+            awaitable
             for emb_module in self._emb_modules
             if hasattr(emb_module, "get_rs_awaitable")
+            # pyrefly: ignore[not-callable]
+            and (awaitable := emb_module.get_rs_awaitable()) is not None
         ]
 
     # pyrefly: ignore[bad-override]


### PR DESCRIPTION
Summary:

Within a single forward pass of a 2D FULLY_SHARDED embedding module, two NCCL collectives are active on different CUDA streams:

- Default stream: collectives on sharding_pg (feature distribution via the outer ShardedModule)
- Async stream: reduce_scatter on replica_pg (weight averaging across replicas)

The reduce_scatter is intentionally async (launched on self._async_stream, forward returns immediately) so it can overlap with downstream computation. During training, the backward pre-hook (_all_gather_table_weights) calls ensure_reduce_scatter_complete() to wait on it before performing the next all-gather. During inference (model.eval()), there is no backward pass, so the reduce_scatter is both unnecessary (no weight modifications to sync) and orphaned (never waited on). But it still fires, and with both streams submitting NCCL operations to different communicators on the same GPU, NCCL's internal cross-communicator serialization can create a circular dependency.

NCCL serializes operations from different communicators sharing a GPU. Each GPU picks one to execute first. When different GPUs pick different operations, a circular dependency forms across the overlapping process groups. With 6 GPUs and world_size_2D=2 (sharding PGs {0,3},{1,4},{2,5}, replica PGs {0,1,2},{3,4,5}):

  GPU 0: NCCL runs sharding_pg collective  -> barrier waiting for GPU 3
  GPU 3: NCCL runs reduce_scatter({3,4,5}) -> barrier waiting for GPU 4
  GPU 4: NCCL runs sharding_pg collective  -> barrier waiting for GPU 1
  GPU 1: NCCL runs reduce_scatter({0,1,2}) -> barrier waiting for GPU 0
  -> DEADLOCK

Technically a race condition (depends on NCCL's cross-communicator scheduling order), but near-deterministic with small PG sizes.

The fix adds `if self.training:` guard so reduce_scatter only fires during training, where it's needed for weight sync after gradient updates. Also adds a None filter to get_resize_awaitables() since get_rs_awaitable() returns None during inference when reduce_scatter is skipped.

Reviewed By: kausv, TroyGarden

Differential Revision: D91254757


