### PR TITLE
Add Python enum configs and KJT builder for enrichment (#3850)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -536,6 +536,8 @@ def _populate_zero_collision_tbe_params(
         optimizer_state_dtypes_for_st = kvzch_tbe_config.optimizer_state_dtypes_for_st
         load_ckpt_without_opt = True
 
+    enrichment_policy = kvzch_tbe_config.enrichment_policy if kvzch_tbe_config else None
+
     tbe_params["kv_zch_params"] = KVZCHParams(
         bucket_offsets=bucket_offsets,
         bucket_sizes=bucket_sizes,
@@ -546,6 +548,7 @@ def _populate_zero_collision_tbe_params(
         load_ckpt_without_opt=load_ckpt_without_opt,
         optimizer_type_for_st=optimizer_type_for_st,
         optimizer_state_dtypes_for_st=optimizer_state_dtypes_for_st,
+        enrichment_policy=enrichment_policy,
     )
 
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5464


X-link: https://github.com/facebookresearch/FBGEMM/pull/2439

CONTEXT: The enrichment configuration in EnrichmentPolicy uses raw strings for enrichment_type and response_format, which is error-prone and lacks type safety. Additionally, there is no utility to extract unhashed IDs from KJT features for enrichment queries.

WHAT: Strengthen enrichment configuration with Python enums and add a KJT builder utility.
- Added EnrichmentType enum (IGR_LASER_EMBEDDING, IGR_LASER_SID) and EnrichmentResponseFormat enum (JSON, THRIFT_FLOAT, THRIFT_INT64) in split_table_batched_embeddings_ops_common.py
- Updated EnrichmentPolicy to use enum types instead of strings
- Added enrichment_policy field to KVZCHTBEConfig for config propagation
- Convert enum values to int when passing to C++ TorchScript layer in training.py
- Added build_embedding_cache_write_kjt() in kvzch_utils.py to extract hashed/unhashed feature pairs from KJT and encode unhashed IDs as float32 weights for enrichment queries
- Wired enrichment_policy through batched_embedding_kernel.py to KVZCHParams

Reviewed By: zlzhao1104

Differential Revision: D95883280
