### PR TITLE
Add SharderData dataclass and extraction functions

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -318,6 +318,10 @@ class EmbeddingEnumerator(Enumerator):
         return None
 
     @property
+    def sharder_map(self) -> Dict[str, ModuleSharder[nn.Module]]:
+        return self._sharder_map
+
+    @property
     def last_stored_search_space(self) -> Optional[List[ShardingOption]]:
         # NOTE: This is the last search space stored by enumerate(...), do not use
         # this field in place of actually calling enumerate(...) as it will varie for each

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -62,24 +62,6 @@ except Exception:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _is_prefetch_pipelined(
-    sharding_option: ShardingOption, sharder: ModuleSharder[nn.Module]
-) -> bool:
-    prefetch_pipeline = (
-        sharding_option.cache_params.prefetch_pipeline
-        if sharding_option.cache_params
-        else None
-    )
-    # TODO: remove after deprecating fused_params in sharder
-    if not prefetch_pipeline:
-        prefetch_pipeline = (
-            sharder.fused_params.get("prefetch_pipeline", False)
-            if hasattr(sharder, "fused_params") and sharder.fused_params
-            else False
-        )
-    return prefetch_pipeline
-
-
 class EmbeddingPerfEstimator(ShardEstimator):
     """
     Embedding Wall Time Perf Estimator. This estimator estimates the wall time

--- a/torchrec/distributed/planner/tests/test_proposers.py
+++ b/torchrec/distributed/planner/tests/test_proposers.py
@@ -12,6 +12,7 @@ from typing import cast, List, Optional, Type
 from unittest.mock import MagicMock
 
 import torch
+from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE, DEFAULT_PERF_ESTIMATOR
@@ -116,8 +117,7 @@ def make_sharding_option(
     return ShardingOption(
         name=name,
         tensor=torch.zeros(1),
-        # pyrefly: ignore[bad-argument-type]
-        module=("model", None),
+        module=("model", nn.Module()),
         input_lengths=[],
         batch_size=8,
         sharding_type="row_wise",
@@ -927,8 +927,7 @@ class TestProposers(unittest.TestCase):
                 ShardingOption(
                     name=name,
                     tensor=torch.zeros(1),
-                    # pyrefly: ignore[bad-argument-type]
-                    module=("model", None),
+                    module=("model", nn.Module()),
                     input_lengths=[],
                     batch_size=8,
                     sharding_type="row_wise",

--- a/torchrec/distributed/planner/tests/test_utils.py
+++ b/torchrec/distributed/planner/tests/test_utils.py
@@ -13,14 +13,24 @@ from typing import Callable, List, Optional
 from unittest.mock import MagicMock
 
 import torch
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    BaseQuantEmbeddingSharder,
+)
 from torchrec.distributed.planner.types import Perf, Shard, ShardingOption, Storage
 from torchrec.distributed.planner.utils import (
     _find_imbalance_tables,
     BinarySearchPredicate,
+    build_sharder_data,
     LuusJaakolaSearch,
     reset_shard_rank,
 )
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import (
+    CommOp,
+    ModuleSharder,
+    ShardingType,
+    StorageUsageType,
+)
 
 
 class TestFindImbalanceTables(unittest.TestCase):
@@ -381,3 +391,77 @@ class TestLuusJaakolaSearch(unittest.TestCase):
             ],
         )
         torch.testing.assert_close(results, want)
+
+
+class TestBuildSharderData(unittest.TestCase):
+    def test_base_embedding_sharder(self) -> None:
+        sharder = MagicMock(spec=BaseEmbeddingSharder)
+        sharder.fused_params = {"cache_load_factor": 0.5}
+        sharder.qcomm_codecs_registry = None
+
+        result = build_sharder_data(sharder)
+
+        self.assertEqual(result.storage_usage_type, StorageUsageType.BASE)
+        self.assertEqual(result.fused_params, {"cache_load_factor": 0.5})
+        self.assertEqual(result.qcomm_dtype_sizes, {})
+
+    def test_base_quant_embedding_sharder(self) -> None:
+        sharder = MagicMock(spec=BaseQuantEmbeddingSharder)
+        sharder.fused_params = {}
+        sharder.qcomm_codecs_registry = None
+
+        result = build_sharder_data(sharder)
+
+        self.assertEqual(result.storage_usage_type, StorageUsageType.BASE_QUANT)
+
+    def test_generic_module_sharder(self) -> None:
+        sharder = MagicMock(spec=ModuleSharder)
+        sharder.fused_params = {}
+        sharder.qcomm_codecs_registry = None
+
+        result = build_sharder_data(sharder)
+
+        self.assertEqual(result.storage_usage_type, StorageUsageType.DEFAULT)
+
+    def test_no_fused_params(self) -> None:
+        sharder = MagicMock(spec=BaseEmbeddingSharder)
+        sharder.fused_params = None
+        sharder.qcomm_codecs_registry = None
+
+        result = build_sharder_data(sharder)
+
+        self.assertEqual(result.fused_params, {})
+
+    def test_qcomm_codecs_extraction(self) -> None:
+        sharder = MagicMock(spec=BaseEmbeddingSharder)
+        sharder.fused_params = {}
+
+        forward_codec = MagicMock()
+        forward_codec.quantized_dtype = torch.float16
+        backward_codec = MagicMock()
+        backward_codec.quantized_dtype = torch.bfloat16
+
+        codec = MagicMock()
+        codec.forward = forward_codec
+        codec.backward = backward_codec
+
+        sharder.qcomm_codecs_registry = {
+            CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name: codec,
+        }
+
+        result = build_sharder_data(sharder)
+
+        fwd_size = torch.tensor([], dtype=torch.float16).element_size()
+        bwd_size = torch.tensor([], dtype=torch.bfloat16).element_size()
+        self.assertEqual(
+            result.qcomm_dtype_sizes[CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name],
+            (fwd_size, bwd_size),
+        )
+        self.assertNotIn(
+            CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name,
+            result.qcomm_dtype_sizes,
+        )
+        self.assertNotIn(
+            CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name,
+            result.qcomm_dtype_sizes,
+        )

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -40,7 +40,10 @@ from torchrec.distributed.types import (
     ShardingPlan,
 )
 from torchrec.modules.embedding_configs import DataType
-from torchrec.modules.embedding_modules import EmbeddingCollectionInterface
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollectionInterface,
+    EmbeddingCollectionInterface,
+)
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
 
 
@@ -1062,12 +1065,43 @@ class ShardingOption:
         self.stochastic_rounding = stochastic_rounding
         self.bounds_check_mode = bounds_check_mode
         self.dependency = dependency
-        self._is_pooled = is_pooled
+        self._is_pooled: bool = (
+            is_pooled
+            if is_pooled is not None
+            else ShardingOption.module_pooled(module[1], name)
+        )
         self.is_weighted: Optional[bool] = None
         self.feature_names: Optional[List[str]] = feature_names
         self.output_dtype: Optional[DataType] = output_dtype
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
+
+        child_module = module[1]
+        self._module_type_key: str = (
+            type(child_module).__module__ + "." + type(child_module).__name__
+        )
+        _module_has_fp = (
+            hasattr(child_module, "_feature_processor")
+            and hasattr(
+                child_module._feature_processor,
+                "feature_processor_modules",
+            )
+            and isinstance(
+                # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+                child_module._feature_processor.feature_processor_modules,
+                nn.ModuleDict,
+            )
+        )
+        self._has_feature_processor: bool = (
+            _module_has_fp
+            and name
+            # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+            in child_module._feature_processor.feature_processor_modules.keys()
+        )
+        if hasattr(child_module, "is_weighted") and callable(child_module.is_weighted):
+            if isinstance(child_module, EmbeddingBagCollectionInterface):
+                # pyre-ignore[29]: `Module` has no attribute `is_weighted`
+                self.is_weighted = child_module.is_weighted()
 
     @property
     def tensor(self) -> torch.Tensor:
@@ -1116,8 +1150,6 @@ class ShardingOption:
 
     @property
     def is_pooled(self) -> bool:
-        if self._is_pooled is None:
-            self._is_pooled = ShardingOption.module_pooled(self.module[1], self.name)
         return self._is_pooled
 
     @staticmethod
@@ -1137,6 +1169,14 @@ class ShardingOption:
                         return False
 
         return True
+
+    @property
+    def module_type_key(self) -> str:
+        return self._module_type_key
+
+    @property
+    def has_feature_processor(self) -> bool:
+        return self._has_feature_processor
 
     def get_shards_assignment(self) -> List[Optional[int]]:
         return [shard.rank for shard in self.shards]

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -38,6 +38,7 @@ from torchrec.distributed.types import (
     KeyValueParams,
     ModuleSharder,
     ShardingPlan,
+    StorageUsageType,
 )
 from torchrec.modules.embedding_configs import DataType
 from torchrec.modules.embedding_modules import (
@@ -1245,6 +1246,22 @@ class PartitionByType(Enum):
     UNIFORM = "uniform"
     # Partitioning based on multiple hosts
     MULTI_HOST = "multi_host"
+
+
+@dataclass
+class SharderData:
+    """Picklable snapshot of sharder data needed by estimators.
+
+    Captures fused_params, quantized comm codec dtype sizes, and storage
+    usage dispatch info so estimators can work without live sharder objects.
+    """
+
+    fused_params: Dict[str, Any]
+    qcomm_dtype_sizes: Dict[str, Tuple[float, float]]
+    storage_usage_type: StorageUsageType
+
+
+SharderDataMap = Dict[str, SharderData]
 
 
 @dataclass

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -14,14 +14,65 @@ from typing import Any, cast, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import torch
 from torch import nn
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    BaseQuantEmbeddingSharder,
+)
 from torchrec.distributed.planner.constants import NUM_POOLINGS
 from torchrec.distributed.planner.types import (
     ParameterConstraints,
     Perf,
+    SharderData,
+    SharderDataMap,
     ShardingOption,
     Storage,
+    StorageUsageType,
 )
 from torchrec.distributed.types import CommOp, ModuleSharder, ShardingType
+
+
+def build_sharder_data(sharder: ModuleSharder[nn.Module]) -> SharderData:
+    fused_params = (
+        dict(sharder.fused_params)
+        if hasattr(sharder, "fused_params") and sharder.fused_params
+        else {}
+    )
+
+    qcomm_dtype_sizes: Dict[str, Tuple[float, float]] = {}
+    if sharder.qcomm_codecs_registry is not None:
+        for comm_op_name in [
+            CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name,
+            CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name,
+            CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name,
+        ]:
+            if comm_op_name in sharder.qcomm_codecs_registry:
+                codecs = sharder.qcomm_codecs_registry[comm_op_name]
+                fwd_size = torch.tensor(
+                    [], dtype=codecs.forward.quantized_dtype
+                ).element_size()
+                bwd_size = torch.tensor(
+                    [], dtype=codecs.backward.quantized_dtype
+                ).element_size()
+                qcomm_dtype_sizes[comm_op_name] = (fwd_size, bwd_size)
+
+    if isinstance(sharder, BaseQuantEmbeddingSharder):
+        storage_usage_type = StorageUsageType.BASE_QUANT
+    elif isinstance(sharder, BaseEmbeddingSharder):
+        storage_usage_type = StorageUsageType.BASE
+    else:
+        storage_usage_type = StorageUsageType.DEFAULT
+
+    return SharderData(
+        fused_params=fused_params,
+        qcomm_dtype_sizes=qcomm_dtype_sizes,
+        storage_usage_type=storage_usage_type,
+    )
+
+
+def build_sharder_data_map(
+    sharder_map: Dict[str, ModuleSharder[nn.Module]],
+) -> SharderDataMap:
+    return {key: build_sharder_data(sharder) for key, sharder in sharder_map.items()}
 
 
 def sharder_name(t: Type[Any]) -> str:

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -183,6 +183,12 @@ class ParameterStorage(Enum):
     DDR = "ddr"
 
 
+class StorageUsageType(Enum):
+    BASE_QUANT = "BaseQuantEmbeddingSharder"
+    BASE = "BaseEmbeddingSharder"
+    DEFAULT = "ModuleSharder"
+
+
 @unique
 class ComputeKernel(Enum):
     DEFAULT = "default"
@@ -1329,6 +1335,41 @@ def get_tensor_size_bytes(t: torch.Tensor) -> int:
         b = b // 4
 
     return b
+
+
+def compute_storage_usage(
+    tensor: torch.Tensor,
+    compute_device_type: str,
+    compute_kernel: str,
+    storage_usage_type: StorageUsageType,
+) -> Dict[str, int]:
+    tensor_bytes = get_tensor_size_bytes(tensor)
+    if storage_usage_type == StorageUsageType.BASE_QUANT:
+        tensor_bytes += tensor.shape[0] * 4
+        if compute_kernel in {"quant_uvm", "quant_uvm_caching"}:
+            return {ParameterStorage.DDR.value: tensor_bytes}
+        storage_map = {
+            "cuda": ParameterStorage.HBM,
+            "cpu": ParameterStorage.DDR,
+            "mtia": ParameterStorage.DDR,
+        }
+    elif storage_usage_type == StorageUsageType.BASE:
+        if compute_kernel in {"fused_uvm", "fused_uvm_caching"}:
+            return {ParameterStorage.DDR.value: tensor_bytes}
+        storage_map = {
+            "cuda": ParameterStorage.HBM,
+            "cpu": ParameterStorage.DDR,
+            "mtia": ParameterStorage.HBM,
+        }
+    else:
+        storage_map = {
+            "cuda": ParameterStorage.HBM,
+            "cpu": ParameterStorage.DDR,
+            "mtia": ParameterStorage.HBM,
+        }
+    return {
+        storage_map.get(compute_device_type, ParameterStorage.HBM).value: tensor_bytes
+    }
 
 
 class ModuleSharder(abc.ABC, Generic[M]):


### PR DESCRIPTION
Summary:
Introduces the serialization layer for sharder data. D95081452 and D95081573 removed the dependency on module[1], but estimators still need data from live ModuleSharder objects (fused_params, qcomm codecs, storage usage type). This diff captures that data in a picklable form:

- `StorageUsageType` enum in distributed/types.py: `BASE_QUANT`, `BASE`, `DEFAULT` for type-safe storage dispatch
- `SharderData` dataclass in planner/types.py: captures `fused_params`, `qcomm_dtype_sizes`, and `storage_usage_type`
- `build_sharder_data()` / `build_sharder_data_map()` in planner/utils.py: extracts `SharderData` from live sharders during `enumerate()`

Also refactors `extract_comm_data_type_size()` and `is_prefetch_pipelined()` to accept `SharderData` instead of live `ModuleSharder` objects. Updates the `ShardEstimator.estimate()` ABC and `Enumerator` ABC to accept `sharder_data_map`.

D95315153 (next) migrates all estimators to use `SharderData` exclusively.

Differential Revision: D95299288


