### PR TITLE
Migrate estimators to use SharderData and wire enumerators (#3852)

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -35,6 +35,7 @@ from torch.distributed._tensor.placement_types import Placement
 from torch.nn.modules.module import _addindent
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.types import (
+    compute_storage_usage,
     get_tensor_size_bytes,
     ModuleSharder,
     ParameterStorage,
@@ -43,6 +44,7 @@ from torchrec.distributed.types import (
     ShardedTensorMetadata,
     ShardingType,
     ShardMetadata,
+    StorageUsageType,
 )
 from torchrec.modules.embedding_configs import (
     DataType,
@@ -587,6 +589,12 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
+        from torch._utils_internal import justknobs_check
+
+        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
+            return compute_storage_usage(
+                tensor, compute_device_type, compute_kernel, StorageUsageType.BASE
+            )
         tensor_bytes = get_tensor_size_bytes(tensor)
         if compute_kernel in {
             EmbeddingComputeKernel.FUSED_UVM.value,
@@ -690,6 +698,12 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
+        from torch._utils_internal import justknobs_check
+
+        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
+            return compute_storage_usage(
+                tensor, compute_device_type, compute_kernel, StorageUsageType.BASE_QUANT
+            )
         tensor_bytes = get_tensor_size_bytes(tensor) + tensor.shape[0] * 4
         if compute_kernel in {
             EmbeddingComputeKernel.QUANT_UVM.value,

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -31,11 +31,12 @@ from torchrec.distributed.planner.types import (
     ParameterConstraints,
     PartitionByType,
     Shard,
+    SharderDataMap,
     ShardEstimator,
     ShardingOption,
     Topology,
 )
-from torchrec.distributed.planner.utils import sharder_name
+from torchrec.distributed.planner.utils import build_sharder_data_map, sharder_name
 from torchrec.distributed.sharding_plan import calculate_shard_sizes_and_offsets
 from torchrec.distributed.types import (
     BoundsCheckMode,
@@ -99,6 +100,7 @@ class EmbeddingEnumerator(Enumerator):
         self._batch_size: int = batch_size
         self._constraints = constraints
         self._sharder_map: Dict[str, ModuleSharder[nn.Module]] = {}
+        self._sharder_data_map: SharderDataMap = {}
         self._use_exact_enumerate_order: bool = (
             use_exact_enumerate_order if use_exact_enumerate_order else False
         )
@@ -159,6 +161,10 @@ class EmbeddingEnumerator(Enumerator):
         self._sharder_map = {
             sharder_name(sharder.module_type): sharder for sharder in sharders
         }
+        from torch._utils_internal import justknobs_check
+
+        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
+            self._sharder_data_map = build_sharder_data_map(self._sharder_map)
         sharding_options: List[ShardingOption] = []
 
         named_modules_queue = [("", module)]
@@ -329,8 +335,19 @@ class EmbeddingEnumerator(Enumerator):
         return self._last_stored_search_space
 
     def populate_estimates(self, sharding_options: List[ShardingOption]) -> None:
+        from torch._utils_internal import justknobs_check
+
         for estimator in self._estimators:
-            estimator.estimate(sharding_options, self._sharder_map)
+            if justknobs_check("pytorch/torchrec:enable_sharder_data"):
+                estimator.estimate(
+                    sharding_options,
+                    sharder_data_map=self._sharder_data_map,
+                )
+            else:
+                estimator.estimate(
+                    sharding_options,
+                    sharder_map=self._sharder_map,
+                )
 
     def _filter_sharding_types(
         self, name: str, allowed_sharding_types: List[str], sharder_key: str = ""

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1731,7 +1731,14 @@ class EmbeddingPerfEstimator(ShardEstimator):
             # (raises ValueError if not supported)
             self._config.validate_sharding_type(sharding_option.sharding_type)
 
-            sharder_key = sharder_name(type(sharding_option.module[1]))
+            from torch._utils_internal import justknobs_check
+
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder_key = sharding_option.module_type_key
+            else:
+                sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
 
             shard_sizes = [shard.size for shard in sharding_option.shards]

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -47,6 +47,7 @@ from torchrec.distributed.planner.types import (
     CollectiveType,
     ParameterConstraints,
     Perf,
+    SharderDataMap,
     ShardEstimator,
     ShardingOption,
     Topology,
@@ -1711,19 +1712,29 @@ class EmbeddingPerfEstimator(ShardEstimator):
         self,
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: Optional[SharderDataMap] = None,
     ) -> None:
         """
         Estimates the wall time of given sharding options
         Args:
             sharding_options: List of sharding options to estimate
-            sharder_map: Map of sharder names to sharder instances
+            sharder_map: Optional map of sharder names to ModuleSharder instances
+            sharder_data_map: Optional map of sharder names to SharderData instances
+                (used when enable_sharder_data killswitch is on)
         """
-
-        if not sharder_map:
-            assert not sharding_options, "sharder_map not provided for sharding_options"
-            return
-
         assert self._topology is not None, "Topology must be set to use estimate method"
+
+        from torch._utils_internal import justknobs_check
+
+        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
+        if use_sharder_data:
+            assert (
+                sharder_data_map is not None
+            ), "sharder_data_map required when enable_sharder_data is on"
+        else:
+            assert (
+                sharder_map is not None
+            ), "sharder_map required when enable_sharder_data is off"
 
         num_feature_processors = 0
         for sharding_option in sharding_options:
@@ -1731,31 +1742,43 @@ class EmbeddingPerfEstimator(ShardEstimator):
             # (raises ValueError if not supported)
             self._config.validate_sharding_type(sharding_option.sharding_type)
 
-            from torch._utils_internal import justknobs_check
-
             if justknobs_check(
                 "pytorch/torchrec:enable_precomputed_sharding_option_fields"
             ):
                 sharder_key = sharding_option.module_type_key
             else:
                 sharder_key = sharder_name(type(sharding_option.module[1]))
-            sharder = sharder_map[sharder_key]
 
             shard_sizes = [shard.size for shard in sharding_option.shards]
 
-            # Build all contexts at once using shard_sizes list
-            # This follows OSS pattern: extract common params ONCE per sharding_option
-            contexts = ShardPerfContext.build_shard_perf_contexts(
-                config=self._config,
-                shard_sizes=shard_sizes,
-                sharding_option=sharding_option,
-                topology=self._topology,
-                constraints=self._constraints,
-                sharder=sharder,
-                is_inference=self._is_inference,
-                use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
-                use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
-            )
+            # Build contexts using the appropriate version based on killswitch
+            contexts: List[ShardPerfContext] = []
+            if sharder_data_map is not None:
+                sharder_data = sharder_data_map[sharder_key]
+                contexts = ShardPerfContext.build_shard_perf_contexts_v2(
+                    config=self._config,
+                    shard_sizes=shard_sizes,
+                    sharding_option=sharding_option,
+                    topology=self._topology,
+                    constraints=self._constraints,
+                    sharder_data=sharder_data,
+                    is_inference=self._is_inference,
+                    use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
+                    use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
+                )
+            elif sharder_map is not None:
+                sharder = sharder_map[sharder_key]
+                contexts = ShardPerfContext.build_shard_perf_contexts(
+                    config=self._config,
+                    shard_sizes=shard_sizes,
+                    sharding_option=sharding_option,
+                    topology=self._topology,
+                    constraints=self._constraints,
+                    sharder=sharder,
+                    is_inference=self._is_inference,
+                    use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
+                    use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
+                )
 
             # Update is_weighted from first context (common across all shards)
             if contexts:

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -44,13 +44,16 @@ from torchrec.distributed.planner.types import (
     ParameterConstraints,
     Perf,
     PlannerError,
+    SharderData,
     ShardingOption,
     Topology,
 )
 from torchrec.distributed.planner.utils import (
     extract_comm_data_type_size,
+    extract_comm_data_type_size_v2,
     get_num_poolings,
     is_prefetch_pipelined,
+    is_prefetch_pipelined_v2,
 )
 from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
@@ -585,9 +588,8 @@ class ShardPerfContext:
         use_linear_regression_prefetch_estimate: bool = False,
     ) -> List["ShardPerfContext"]:
         """
-        Build list of ShardPerfContexts from ShardingOption and Topology.
-
-        This follows the exact logic from OSS EmbeddingPerfEstimator.estimate.
+        Build list of ShardPerfContexts from ShardingOption and Topology using a live
+        ModuleSharder.
 
         Args:
             config: Hardware performance configuration
@@ -616,6 +618,121 @@ class ShardPerfContext:
                 else None
             )
 
+        # Get data type sizes
+        (
+            fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size,
+        ) = extract_comm_data_type_size(sharder, sharding_option)
+
+        # Check prefetch pipeline
+        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder)
+
+        return cls._build_contexts(
+            config=config,
+            shard_sizes=shard_sizes,
+            sharding_option=sharding_option,
+            topology=topology,
+            constraints=constraints,
+            caching_ratio=caching_ratio,
+            fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size=bwd_sr_comm_data_type_size,
+            prefetch_pipeline=prefetch_pipeline,
+            is_inference=is_inference,
+            use_batch_inputs_for_expected_cache_fetches=use_batch_inputs_for_expected_cache_fetches,
+            use_linear_regression_prefetch_estimate=use_linear_regression_prefetch_estimate,
+        )
+
+    @classmethod
+    def build_shard_perf_contexts_v2(
+        cls,
+        config: HardwarePerfConfig,
+        shard_sizes: List[List[int]],
+        sharding_option: ShardingOption,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        sharder_data: SharderData,
+        is_inference: bool = False,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> List["ShardPerfContext"]:
+        """
+        Build list of ShardPerfContexts from ShardingOption and Topology using a
+        SharderData snapshot.
+
+        Args:
+            config: Hardware performance configuration
+            shard_sizes: List of [hash_size, emb_dim] for each shard
+            sharding_option: The sharding option being evaluated
+            topology: Device topology with bandwidth and world size info
+            constraints: Optional parameter constraints
+            sharder_data: SharderData snapshot for this option
+            is_inference: Whether this is for inference
+            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
+                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
+                If False (default), uses expected_miss_rate * expected_unique_lookups.
+            use_linear_regression_prefetch_estimate: If True, clamps num_unique_lookups
+                to min(num_unique_lookups, batch_inputs, hash_size) before computing
+                prefetch time.
+
+        Returns:
+            List of ShardPerfContext instances, one per shard.
+        """
+        # Get caching ratio
+        caching_ratio = sharding_option.cache_load_factor
+        if caching_ratio is None:
+            caching_ratio = sharder_data.fused_params.get("cache_load_factor")
+
+        # Get data type sizes
+        (
+            fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size,
+        ) = extract_comm_data_type_size_v2(sharding_option, sharder_data)
+
+        # Check prefetch pipeline
+        prefetch_pipeline = is_prefetch_pipelined_v2(sharding_option, sharder_data)
+
+        return cls._build_contexts(
+            config=config,
+            shard_sizes=shard_sizes,
+            sharding_option=sharding_option,
+            topology=topology,
+            constraints=constraints,
+            caching_ratio=caching_ratio,
+            fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
+            bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
+            fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
+            bwd_sr_comm_data_type_size=bwd_sr_comm_data_type_size,
+            prefetch_pipeline=prefetch_pipeline,
+            is_inference=is_inference,
+            use_batch_inputs_for_expected_cache_fetches=use_batch_inputs_for_expected_cache_fetches,
+            use_linear_regression_prefetch_estimate=use_linear_regression_prefetch_estimate,
+        )
+
+    @classmethod
+    def _build_contexts(
+        cls,
+        config: HardwarePerfConfig,
+        shard_sizes: List[List[int]],
+        sharding_option: ShardingOption,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        caching_ratio: Optional[float],
+        fwd_a2a_comm_data_type_size: float,
+        bwd_a2a_comm_data_type_size: float,
+        fwd_sr_comm_data_type_size: float,
+        bwd_sr_comm_data_type_size: float,
+        prefetch_pipeline: bool,
+        is_inference: bool = False,
+        use_batch_inputs_for_expected_cache_fetches: bool = False,
+        use_linear_regression_prefetch_estimate: bool = False,
+    ) -> List["ShardPerfContext"]:
+        """Shared context-building logic for both build_shard_perf_contexts variants."""
         # Get num_poolings and batch_sizes
         num_poolings = get_num_poolings(constraints, sharding_option)
         batch_sizes = (
@@ -676,15 +793,6 @@ class ShardPerfContext:
 
         # Get data type sizes
         table_data_type_size = sharding_option.tensor.element_size()
-        (
-            fwd_a2a_comm_data_type_size,
-            bwd_a2a_comm_data_type_size,
-            fwd_sr_comm_data_type_size,
-            bwd_sr_comm_data_type_size,
-        ) = extract_comm_data_type_size(sharder, sharding_option)
-
-        # Check prefetch pipeline
-        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder)
 
         # Get input_data_type_size from config annotation (if set) or use default BIGINT_DTYPE
         input_data_type_size = getattr(config, "_input_data_type_size", BIGINT_DTYPE)

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -630,32 +630,47 @@ class ShardPerfContext:
             len(sharding_option.input_lengths) == len(num_poolings) == len(batch_sizes)
         ), "Provided `pooling_factors`, `num_poolings`, and `batch_sizes` constraints must match."
 
-        # Check for feature processor
-        module = sharding_option.module[1]
-        has_feature_processor = False
-        if (
-            hasattr(module, "_feature_processor")
-            and hasattr(module._feature_processor, "feature_processor_modules")
-            and isinstance(
-                module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
-                nn.ModuleDict,
-            )
-            and sharding_option.name
-            in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
-        ):
-            has_feature_processor = True
+        # Check for feature processor and determine is_weighted
+        from torch._utils_internal import justknobs_check
 
-        # Determine is_weighted
-        if isinstance(module, EmbeddingBagCollectionInterface):
-            is_weighted = module.is_weighted()
-        elif (
-            constraints
-            and constraints.get(sharding_option.name)
-            and constraints[sharding_option.name].is_weighted
+        if justknobs_check(
+            "pytorch/torchrec:enable_precomputed_sharding_option_fields"
         ):
-            is_weighted = constraints[sharding_option.name].is_weighted
+            has_feature_processor = sharding_option.has_feature_processor
+            if sharding_option.is_weighted is not None:
+                is_weighted = sharding_option.is_weighted
+            elif (
+                constraints
+                and constraints.get(sharding_option.name)
+                and constraints[sharding_option.name].is_weighted
+            ):
+                is_weighted = constraints[sharding_option.name].is_weighted
+            else:
+                is_weighted = False
         else:
-            is_weighted = False
+            module = sharding_option.module[1]
+            has_feature_processor = False
+            if (
+                hasattr(module, "_feature_processor")
+                and hasattr(module._feature_processor, "feature_processor_modules")
+                and isinstance(
+                    module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
+                    nn.ModuleDict,
+                )
+                and sharding_option.name
+                in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
+            ):
+                has_feature_processor = True
+            if isinstance(module, EmbeddingBagCollectionInterface):
+                is_weighted = module.is_weighted()  # pyre-ignore[29]
+            elif (
+                constraints
+                and constraints.get(sharding_option.name)
+                and constraints[sharding_option.name].is_weighted
+            ):
+                is_weighted = constraints[sharding_option.name].is_weighted
+            else:
+                is_weighted = False
 
         is_weighted = is_weighted or has_feature_processor
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -27,6 +27,8 @@ from torchrec.distributed.planner.estimator.estimator import (
 )
 from torchrec.distributed.planner.types import (
     ParameterConstraints,
+    SharderData,
+    SharderDataMap,
     ShardEstimator,
     ShardingOption,
     Storage,
@@ -35,6 +37,7 @@ from torchrec.distributed.planner.types import (
 from torchrec.distributed.planner.utils import prod, sharder_name
 from torchrec.distributed.types import (
     CacheStatistics,
+    compute_storage_usage,
     KeyValueParams,
     ModuleSharder,
     PipelineType,
@@ -94,6 +97,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
         self,
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: Optional[SharderDataMap] = None,
     ) -> None:
         """
         Estimates the wall time of a given sharding option.
@@ -101,8 +105,28 @@ class EmbeddingPerfEstimator(ShardEstimator):
         Args:
             sharding_options (List[ShardingOption]): list of sharding options.
             sharder_map (Optional[Dict[str, ModuleSharder[nn.Module]]]): sharder map.
+            sharder_data_map (Optional[SharderDataMap]): sharder data map
+                (used when enable_sharder_data killswitch is on).
         """
-        return self._estimator.estimate(sharding_options, sharder_map)
+        from torch._utils_internal import justknobs_check
+
+        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
+        if use_sharder_data:
+            assert (
+                sharder_data_map is not None
+            ), "sharder_data_map required when enable_sharder_data is on"
+            return self._estimator.estimate(
+                sharding_options,
+                sharder_data_map=sharder_data_map,
+            )
+        else:
+            assert (
+                sharder_map is not None
+            ), "sharder_map required when enable_sharder_data is off"
+            return self._estimator.estimate(
+                sharding_options,
+                sharder_map=sharder_map,
+            )
 
 
 class EmbeddingStorageEstimator(ShardEstimator):
@@ -147,20 +171,28 @@ class EmbeddingStorageEstimator(ShardEstimator):
         self,
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: Optional[SharderDataMap] = None,
     ) -> None:
         """
         Estimate the storage cost of each sharding option.
 
         Args:
             sharding_options (List[ShardingOption]): list of sharding options.
-            sharder_map (Optional[Dict[str, ModuleSharder[nn.Module]]]): map from module
-                type to sharder.
+            sharder_map (Optional[Dict[str, ModuleSharder[nn.Module]]]): sharder map.
+            sharder_data_map (Optional[SharderDataMap]): sharder data map
+                (used when enable_sharder_data killswitch is on).
         """
-        if not sharder_map:
-            assert not sharding_options, "sharder_map not provided for sharding_options"
-            return
-
         from torch._utils_internal import justknobs_check
+
+        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
+        if use_sharder_data:
+            assert (
+                sharder_data_map is not None
+            ), "sharder_data_map required when enable_sharder_data is on"
+        else:
+            assert (
+                sharder_map is not None
+            ), "sharder_map required when enable_sharder_data is off"
 
         for sharding_option in sharding_options:
             if justknobs_check(
@@ -169,16 +201,25 @@ class EmbeddingStorageEstimator(ShardEstimator):
                 sharder_key = sharding_option.module_type_key
             else:
                 sharder_key = sharder_name(type(sharding_option.module[1]))
-            sharder = sharder_map[sharder_key]
+
+            sharder_data: Optional[SharderData] = None
+            sharder: Optional[ModuleSharder[nn.Module]] = None
+            if sharder_data_map is not None:
+                sharder_data = sharder_data_map[sharder_key]
+            elif sharder_map is not None:
+                sharder = sharder_map[sharder_key]
 
             caching_ratio = sharding_option.cache_load_factor
             # TODO: remove after deprecating fused_params in sharder
             if caching_ratio is None:
-                caching_ratio = (
-                    sharder.fused_params.get("cache_load_factor")
-                    if hasattr(sharder, "fused_params") and sharder.fused_params
-                    else None
-                )
+                if sharder_data is not None:
+                    caching_ratio = sharder_data.fused_params.get("cache_load_factor")
+                elif sharder is not None:
+                    caching_ratio = (
+                        sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                        if hasattr(sharder, "fused_params") and sharder.fused_params
+                        else None
+                    )
             constraints: Optional[ParameterConstraints] = (
                 self._constraints.get(sharding_option.name, None)
                 if self._constraints
@@ -197,13 +238,20 @@ class EmbeddingStorageEstimator(ShardEstimator):
                 if constraints and constraints.key_value_params
                 else None
             )
-            kv_cache_load_factor: float = (
-                # pyrefly: ignore[missing-attribute]
-                sharder.fused_params.get("cache_load_factor", KV_CACHING_RATIO)
-                # pyrefly: ignore[missing-attribute]
-                if sharder.fused_params
-                else KV_CACHING_RATIO
-            )
+            if sharder_data is not None:
+                kv_cache_load_factor: float = sharder_data.fused_params.get(
+                    "cache_load_factor", KV_CACHING_RATIO
+                )
+            elif sharder is not None:
+                kv_cache_load_factor: float = (
+                    # pyrefly: ignore[missing-attribute]
+                    sharder.fused_params.get("cache_load_factor", KV_CACHING_RATIO)
+                    # pyrefly: ignore[missing-attribute]
+                    if sharder.fused_params
+                    else KV_CACHING_RATIO
+                )
+            else:
+                kv_cache_load_factor = KV_CACHING_RATIO
             use_virtual_table: bool = (
                 constraints.use_virtual_table if constraints else False
             )
@@ -225,35 +273,71 @@ class EmbeddingStorageEstimator(ShardEstimator):
             )
             # TODO: remove after deprecating fused_params in sharder
             if mpp_conf is None:
-                mpp_conf = (
-                    sharder.fused_params.get("multipass_prefetch_config", None)
-                    if hasattr(sharder, "fused_params") and sharder.fused_params
-                    else None
+                if sharder_data is not None:
+                    mpp_conf = sharder_data.fused_params.get(
+                        "multipass_prefetch_config"
+                    )
+                elif sharder is not None:
+                    mpp_conf = (
+                        sharder.fused_params.get("multipass_prefetch_config", None)
+                        if hasattr(sharder, "fused_params") and sharder.fused_params
+                        else None
+                    )
+            if sharder_data is not None:
+                shard_storages = calculate_shard_storages_v2(
+                    sharder_data=sharder_data,
+                    sharding_type=sharding_option.sharding_type,
+                    tensor=sharding_option.tensor,
+                    compute_device=self._topology.compute_device,
+                    compute_kernel=sharding_option.compute_kernel,
+                    shard_sizes=[shard.size for shard in sharding_option.shards],
+                    batch_sizes=batch_sizes,
+                    world_size=self._topology.world_size,
+                    local_world_size=self._topology.intra_group_size,
+                    input_lengths=sharding_option.input_lengths,
+                    num_poolings=num_poolings,
+                    caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
+                    is_pooled=sharding_option.is_pooled,
+                    input_data_type_size=input_data_type_size,
+                    output_data_type_size=output_data_type_size,
+                    pipeline_type=self._pipeline_type,
+                    count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
+                    is_inference=self._is_inference,
+                    multipass_prefetch_max_pass=(
+                        mpp_conf.num_passes if mpp_conf else None
+                    ),
+                    key_value_params=key_value_params,
+                    kv_cache_load_factor=kv_cache_load_factor,
+                    use_virtual_table=use_virtual_table,
                 )
-            shard_storages = calculate_shard_storages(
-                sharder=sharder,
-                sharding_type=sharding_option.sharding_type,
-                tensor=sharding_option.tensor,
-                compute_device=self._topology.compute_device,
-                compute_kernel=sharding_option.compute_kernel,
-                shard_sizes=[shard.size for shard in sharding_option.shards],
-                batch_sizes=batch_sizes,
-                world_size=self._topology.world_size,
-                local_world_size=self._topology.intra_group_size,
-                input_lengths=sharding_option.input_lengths,
-                num_poolings=num_poolings,
-                caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
-                is_pooled=sharding_option.is_pooled,
-                input_data_type_size=input_data_type_size,
-                output_data_type_size=output_data_type_size,
-                pipeline_type=self._pipeline_type,
-                count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
-                is_inference=self._is_inference,
-                multipass_prefetch_max_pass=mpp_conf.num_passes if mpp_conf else None,
-                key_value_params=key_value_params,
-                kv_cache_load_factor=kv_cache_load_factor,
-                use_virtual_table=use_virtual_table,
-            )
+            else:
+                assert sharder is not None
+                shard_storages = calculate_shard_storages(
+                    sharder=sharder,
+                    sharding_type=sharding_option.sharding_type,
+                    tensor=sharding_option.tensor,
+                    compute_device=self._topology.compute_device,
+                    compute_kernel=sharding_option.compute_kernel,
+                    shard_sizes=[shard.size for shard in sharding_option.shards],
+                    batch_sizes=batch_sizes,
+                    world_size=self._topology.world_size,
+                    local_world_size=self._topology.intra_group_size,
+                    input_lengths=sharding_option.input_lengths,
+                    num_poolings=num_poolings,
+                    caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
+                    is_pooled=sharding_option.is_pooled,
+                    input_data_type_size=input_data_type_size,
+                    output_data_type_size=output_data_type_size,
+                    pipeline_type=self._pipeline_type,
+                    count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
+                    is_inference=self._is_inference,
+                    multipass_prefetch_max_pass=(
+                        mpp_conf.num_passes if mpp_conf else None
+                    ),
+                    key_value_params=key_value_params,
+                    kv_cache_load_factor=kv_cache_load_factor,
+                    use_virtual_table=use_virtual_table,
+                )
             for shard, storage in zip(sharding_option.shards, shard_storages):
                 shard.storage = storage
 
@@ -451,6 +535,184 @@ def calculate_shard_storages(
             0
             for _ in ddr_specific_sizes
         ]
+
+    hbm_sizes: List[int] = [
+        (
+            hbm_specific_size
+            + calculate_pipeline_io_cost(
+                input_size=input_size,
+                output_size=output_size,
+                prefetch_size=input_size if table_cached else 0,
+                pipeline_type=pipeline_type,
+                multipass_prefetch_max_pass=multipass_prefetch_max_pass,
+                count_ephemeral_storage_cost=count_ephemeral_storage_cost,
+                is_inference=is_inference,
+            )
+            if compute_device in {"cuda", "mtia"}
+            else 0
+        )
+        for input_size, output_size, hbm_specific_size in zip(
+            input_sizes,
+            output_sizes,
+            hbm_specific_sizes,
+        )
+    ]
+    ddr_sizes: List[int] = [
+        (
+            input_size + output_size + ddr_specific_size
+            if compute_device == "cpu" and not is_inference
+            else ddr_specific_size
+        )
+        for input_size, output_size, ddr_specific_size in zip(
+            input_sizes,
+            output_sizes,
+            ddr_specific_sizes,
+        )
+    ]
+    ssd_sizes: List[int] = [
+        (
+            ssd_specific_size
+            if compute_kernel
+            in {
+                EmbeddingComputeKernel.KEY_VALUE.value,
+            }
+            else 0
+        )
+        for ssd_specific_size in ssd_specific_sizes
+    ]
+
+    return [
+        Storage(
+            hbm=hbm_size,
+            ddr=ddr_size,
+            ssd=ssd_size,
+        )
+        for hbm_size, ddr_size, ssd_size in zip(hbm_sizes, ddr_sizes, ssd_sizes)
+    ]
+
+
+def calculate_shard_storages_v2(
+    sharder_data: SharderData,
+    sharding_type: str,
+    tensor: torch.Tensor,
+    compute_device: str,
+    compute_kernel: str,
+    shard_sizes: List[List[int]],
+    batch_sizes: List[int],
+    world_size: int,
+    local_world_size: int,
+    input_lengths: List[float],
+    num_poolings: List[float],
+    caching_ratio: float,
+    is_pooled: bool,
+    input_data_type_size: float,
+    output_data_type_size: float,
+    pipeline_type: PipelineType = PipelineType.NONE,
+    count_ephemeral_storage_cost: bool = False,
+    is_inference: bool = False,
+    multipass_prefetch_max_pass: Optional[int] = None,
+    key_value_params: Optional[KeyValueParams] = None,
+    kv_cache_load_factor: float = KV_CACHING_RATIO,
+    use_virtual_table: bool = False,
+) -> List[Storage]:
+    """
+    Calculates estimated storage sizes for each sharded tensor using SharderData.
+
+    Like calculate_shard_storages but takes a SharderData snapshot instead of a live
+    ModuleSharder, enabling picklability.
+    """
+    input_sizes, output_sizes = _calculate_shard_io_sizes(
+        sharding_type=sharding_type,
+        batch_sizes=batch_sizes,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        input_lengths=input_lengths,
+        emb_dim=tensor.shape[1],
+        shard_sizes=shard_sizes,
+        input_data_type_size=input_data_type_size,
+        output_data_type_size=output_data_type_size,
+        num_poolings=num_poolings,
+        is_pooled=is_pooled,
+    )
+
+    tensor_storage = compute_storage_usage(
+        tensor, compute_device, compute_kernel, sharder_data.storage_usage_type
+    )
+    hbm_storage: int = tensor_storage.get("hbm", 0)
+    ddr_storage: int = tensor_storage.get("ddr", 0)
+
+    table_cached = _is_table_cached(compute_kernel)
+    if table_cached:
+        hbm_storage = round(ddr_storage * caching_ratio)
+
+    optimizer_class = getattr(tensor, "_optimizer_classes", [None])[0]
+
+    hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
+        storage=hbm_storage,
+        shape=tensor.shape,
+        shard_sizes=shard_sizes,
+        sharding_type=sharding_type,
+        optimizer_class=optimizer_class,
+        is_inference=is_inference,
+        clf=caching_ratio if table_cached else None,
+    )
+    ddr_specific_sizes: List[int] = _calculate_storage_specific_sizes(
+        storage=ddr_storage,
+        shape=tensor.shape,
+        shard_sizes=shard_sizes,
+        sharding_type=sharding_type,
+        optimizer_class=optimizer_class,
+        is_inference=is_inference,
+    )
+    ssd_specific_sizes: List[int] = [
+        hbm_specific_size + ddr_specific_size
+        for hbm_specific_size, ddr_specific_size in zip(
+            _calculate_storage_specific_sizes(
+                storage=tensor_storage.get("hbm", 0),
+                shape=tensor.shape,
+                shard_sizes=shard_sizes,
+                sharding_type=sharding_type,
+                optimizer_class=optimizer_class,
+                is_inference=is_inference,
+                clf=caching_ratio if table_cached else None,
+            ),
+            _calculate_storage_specific_sizes(
+                storage=tensor_storage.get("ddr", 0),
+                shape=tensor.shape,
+                shard_sizes=shard_sizes,
+                sharding_type=sharding_type,
+                optimizer_class=optimizer_class,
+                is_inference=is_inference,
+            ),
+        )
+    ]
+
+    if (
+        compute_kernel
+        in {
+            EmbeddingComputeKernel.KEY_VALUE.value,
+            EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+            EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+        }
+        or use_virtual_table
+    ):
+        key_value_params = key_value_params or KeyValueParams(
+            max_l1_cache_size=0, l2_cache_size=0
+        )
+
+        hbm_specific_sizes = [
+            min(
+                (key_value_params.max_l1_cache_size or 0) * 1024 * 1024,
+                math.ceil(
+                    tensor.shape[0]
+                    * kv_cache_load_factor
+                    * tensor.element_size()
+                    * tensor.shape[1],
+                ),
+            )
+            for _ in hbm_specific_sizes
+        ]
+        ddr_specific_sizes = [0 for _ in ddr_specific_sizes]
 
     hbm_sizes: List[int] = [
         (

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -160,8 +160,15 @@ class EmbeddingStorageEstimator(ShardEstimator):
             assert not sharding_options, "sharder_map not provided for sharding_options"
             return
 
+        from torch._utils_internal import justknobs_check
+
         for sharding_option in sharding_options:
-            sharder_key = sharder_name(type(sharding_option.module[1]))
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder_key = sharding_option.module_type_key
+            else:
+                sharder_key = sharder_name(type(sharding_option.module[1]))
             sharder = sharder_map[sharder_key]
 
             caching_ratio = sharding_option.cache_load_factor

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -898,7 +898,14 @@ class EmbeddingStats(Stats):
             num_poolings = str(round(sum(num_poolings), 3))
             output = "pooled" if so.is_pooled else "sequence"
             weighted = "weighted" if so.is_weighted else "unweighted"
-            sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
+            from torch._utils_internal import justknobs_check
+
+            if justknobs_check(
+                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+            ):
+                sharder = sharder_map.get(so.module_type_key, None)
+            else:
+                sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
             sharder_name = type(sharder).__name__
             num_features = len(so.input_lengths)
             embedding_dim = _get_embedding_dim(so)

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -49,10 +49,13 @@ from torchrec.distributed.tests.test_sequence_model import TestSequenceSparseNN
 from torchrec.distributed.types import (
     CacheParams,
     CacheStatistics,
+    compute_storage_usage,
+    get_tensor_size_bytes,
     ModuleSharder,
     MultiPassPrefetchConfig,
     PipelineType,
     ShardingType,
+    StorageUsageType,
 )
 from torchrec.modules.embedding_configs import (
     DataType,
@@ -1711,3 +1714,82 @@ class TestEmbeddingOffloadStats(unittest.TestCase):
             ]
         )
         torch.testing.assert_close(miss_rates, torch.tensor([0.0, 0.0, 0.0]))
+
+
+class TestComputeStorageUsage(unittest.TestCase):
+    def test_base_quant_hbm(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cuda",
+            compute_kernel="fused",
+            storage_usage_type=StorageUsageType.BASE_QUANT,
+        )
+        expected = get_tensor_size_bytes(tensor) + tensor.shape[0] * 4
+        self.assertEqual(result, {"hbm": expected})
+
+    def test_base_quant_uvm(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cuda",
+            compute_kernel="quant_uvm",
+            storage_usage_type=StorageUsageType.BASE_QUANT,
+        )
+        expected = get_tensor_size_bytes(tensor) + tensor.shape[0] * 4
+        self.assertEqual(result, {"ddr": expected})
+
+    def test_base_fused_uvm(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cuda",
+            compute_kernel="fused_uvm",
+            storage_usage_type=StorageUsageType.BASE,
+        )
+        expected = get_tensor_size_bytes(tensor)
+        self.assertEqual(result, {"ddr": expected})
+
+    def test_base_cuda(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cuda",
+            compute_kernel="fused",
+            storage_usage_type=StorageUsageType.BASE,
+        )
+        expected = get_tensor_size_bytes(tensor)
+        self.assertEqual(result, {"hbm": expected})
+
+    def test_base_cpu(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cpu",
+            compute_kernel="fused",
+            storage_usage_type=StorageUsageType.BASE,
+        )
+        expected = get_tensor_size_bytes(tensor)
+        self.assertEqual(result, {"ddr": expected})
+
+    def test_default_cuda(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="cuda",
+            compute_kernel="fused",
+            storage_usage_type=StorageUsageType.DEFAULT,
+        )
+        expected = get_tensor_size_bytes(tensor)
+        self.assertEqual(result, {"hbm": expected})
+
+    def test_unknown_device_defaults_to_hbm(self) -> None:
+        tensor = torch.zeros(100, 64)
+        result = compute_storage_usage(
+            tensor,
+            compute_device_type="tpu",
+            compute_kernel="fused",
+            storage_usage_type=StorageUsageType.DEFAULT,
+        )
+        expected = get_tensor_size_bytes(tensor)
+        self.assertEqual(result, {"hbm": expected})

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1426,6 +1426,7 @@ class ShardEstimator(abc.ABC):
         self,
         sharding_options: List[ShardingOption],
         sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: Optional[SharderDataMap] = None,
     ) -> None:
         # update sharding_options with per shard estimate in-place
         ...

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -97,6 +97,19 @@ def is_prefetch_pipelined(
     return prefetch_pipeline
 
 
+def is_prefetch_pipelined_v2(
+    sharding_option: ShardingOption, sharder_data: SharderData
+) -> bool:
+    prefetch_pipeline = (
+        sharding_option.cache_params.prefetch_pipeline
+        if sharding_option.cache_params
+        else None
+    )
+    if not prefetch_pipeline:
+        prefetch_pipeline = sharder_data.fused_params.get("prefetch_pipeline", False)
+    return prefetch_pipeline
+
+
 def extract_comm_data_type_size(
     sharder: ModuleSharder[nn.Module], sharding_option: ShardingOption
 ) -> Tuple[float, float, float, float]:
@@ -146,6 +159,47 @@ def extract_comm_data_type_size(
             bwd_sr_comm_data_type_size = torch.tensor(
                 [], dtype=codecs.backward.quantized_dtype
             ).element_size()
+
+    return (
+        fwd_a2a_comm_data_type_size,
+        bwd_a2a_comm_data_type_size,
+        fwd_sr_comm_data_type_size,
+        bwd_sr_comm_data_type_size,
+    )
+
+
+def extract_comm_data_type_size_v2(
+    sharding_option: ShardingOption, sharder_data: SharderData
+) -> Tuple[float, float, float, float]:
+    table_data_type_size = sharding_option.tensor.element_size()
+
+    fwd_a2a_comm_data_type_size = table_data_type_size
+    bwd_a2a_comm_data_type_size = table_data_type_size
+    fwd_sr_comm_data_type_size = table_data_type_size
+    bwd_sr_comm_data_type_size = table_data_type_size
+
+    qcomm = sharder_data.qcomm_dtype_sizes
+
+    if sharding_option.is_pooled and CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name in qcomm:
+        fwd_a2a_comm_data_type_size, bwd_a2a_comm_data_type_size = qcomm[
+            CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name
+        ]
+
+    if (
+        not sharding_option.is_pooled
+        and CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name in qcomm
+    ):
+        fwd_a2a_comm_data_type_size, bwd_a2a_comm_data_type_size = qcomm[
+            CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name
+        ]
+
+    if (
+        sharding_option.is_pooled
+        and CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name in qcomm
+    ):
+        fwd_sr_comm_data_type_size, bwd_sr_comm_data_type_size = qcomm[
+            CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name
+        ]
 
     return (
         fwd_a2a_comm_data_type_size,


### PR DESCRIPTION
Summary:

The counterpart to D95299288 — all estimators stop using live ModuleSharder and use SharderData exclusively.

Reviewed By: mserturk

Differential Revision: D95315153
