### PR TITLE
[detailed][memory] add option to free input storage early in the train pipeline

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -501,6 +501,7 @@ class ShardedEmbeddingCollection(
         self._writable_embedding_names: set[str] = set()
 
         self._has_uninitialized_input_dist: bool = True
+        self._free_features_storage_early: bool = False
         logger.info(f"EC index dedup enabled: {self._use_index_dedup}.")
 
         self._enable_feature_score_weight_accumulation: bool = False
@@ -1508,6 +1509,7 @@ class ShardedEmbeddingCollection(
             self._has_uninitialized_input_dist = False
         with torch.no_grad():
             unpadded_features = None
+            original_features = features
             if features.variable_stride_per_key():
                 unpadded_features = features
                 features = pad_vbe_kjt_lengths(unpadded_features)
@@ -1519,6 +1521,12 @@ class ShardedEmbeddingCollection(
                     # pyrefly: ignore[bad-argument-type]
                     self._features_order_tensor,
                 )
+                # For non-VBE: free original KJT tensor storage now since
+                # permute() created independent tensors.
+                # For VBE: deferred until after _compute_sequence_vbe_context
+                # which still needs the original (unpadded) features.
+                if self._free_features_storage_early and unpadded_features is None:
+                    original_features.clear_storage()
             features_by_shards = features.split(self._feature_splits)
             features_by_shards = may_collect_feature_scores(
                 features_by_shards,
@@ -1549,6 +1557,15 @@ class ShardedEmbeddingCollection(
                 )
             if unpadded_features is not None:
                 self._compute_sequence_vbe_context(ctx, unpadded_features)
+                # Free original KJT tensor storage now that VBE context
+                # computation is done. permute() created independent tensors
+                # for the main input_dist path.
+                if (
+                    self._free_features_storage_early
+                    and need_permute
+                    and self._features_order
+                ):
+                    original_features.clear_storage()
 
         return KJTListSplitsAwaitable(
             awaitables,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -738,6 +738,7 @@ class ShardedEmbeddingBagCollection(
         # forward pass flow control
         self._has_uninitialized_input_dist: bool = True
         self._has_features_permute: bool = True
+        self._free_features_storage_early: bool = False
         # Get all fused optimizers and combine them.
         optims = []
         for lookup in self._lookups:
@@ -1719,12 +1720,20 @@ class ShardedEmbeddingBagCollection(
 
         with torch.no_grad():
             if self._has_features_permute:
+                original_features = features
                 features = features.permute(
                     self._features_order,
                     #  but got `Union[Module, Tensor]`.
                     # pyrefly: ignore [bad-argument-type]
                     self._features_order_tensor,
                 )
+                if self._free_features_storage_early:
+                    # Free original KJT tensor storage to reclaim HBM early.
+                    # permute() created independent tensors, so the original
+                    # batch KJT's data is no longer needed. The batch Python
+                    # object still exists but PipelinedForward ignores the
+                    # sparse features during model forward.
+                    original_features.clear_storage()
             if self._has_mean_pooling_callback:
                 ctx.divisor = _create_mean_pooling_divisor(
                     lengths=features.lengths(),

--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -129,6 +129,7 @@ class BaseShardedManagedCollisionEmbeddingCollection(
                 ),
             )
         )
+        self._free_features_storage_early: bool = False
         self._return_remapped_features: bool = module._return_remapped_features
         self._allow_in_place_embed_weight_update: bool = (
             module._allow_in_place_embed_weight_update

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -131,11 +131,14 @@ class ShardedManagedCollisionEmbeddingBagCollection(
             skip_permute = False
             if self._managed_collision_collection._features_order:
                 skip_permute = True
+                original_features = features
                 features = features.permute(
                     self._managed_collision_collection._features_order,
                     # pyrefly: ignore[bad-argument-type]
                     self._managed_collision_collection._features_order_tensor,
                 )
+                if self._free_features_storage_early:
+                    original_features.clear_storage()
 
             # TODO: Consider turning this into a hook inside mc_modules and remove skip_permute
             #   from mc_modules, and fix all the private methods to be public.

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -239,6 +239,7 @@ class ShardedManagedCollisionCollection(
             module._table_name_to_config
         )
         self._has_uninitialized_input_dists: bool = True
+        self._free_features_storage_early: bool = False
         self._input_dists: List[nn.Module] = []
         self._managed_collision_modules = nn.ModuleDict()
         self._create_managed_collision_modules(module)
@@ -635,6 +636,7 @@ class ShardedManagedCollisionCollection(
         with torch.no_grad():
             # skip_permute added since these were used earlier in `mc_embeddingbag`
             if not skip_permute and self._features_order:
+                original_features = features
                 features = features.permute(
                     #  `Union[Module, Tensor]`.
                     self._features_order,
@@ -642,6 +644,8 @@ class ShardedManagedCollisionCollection(
                     # pyrefly: ignore[bad-argument-type]
                     self._features_order_tensor,
                 )
+                if self._free_features_storage_early:
+                    original_features.clear_storage()
 
             feature_splits: List[KeyedJaggedTensor] = []
             if self.need_preprocess:

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -59,6 +59,7 @@ class PipelineConfig:
 
     pipeline: str = "base"
     enable_inplace_copy_batch: bool = False
+    free_features_storage_early: bool = False
     kwargs: Dict[str, Any] = field(default_factory=dict)
 
     def get_kwargs(self, **default_kwargs) -> Dict[str, Any]:
@@ -134,6 +135,7 @@ class PipelineConfig:
                     model=model,
                     optimizer=opt,
                     device=device,
+                    free_features_storage_early=self.free_features_storage_early,
                     **self.get_kwargs(start_batch=0),
                 )
             case "fused":
@@ -142,6 +144,7 @@ class PipelineConfig:
                     optimizer=opt,
                     device=device,
                     enable_inplace_copy_batch=self.enable_inplace_copy_batch,
+                    free_features_storage_early=self.free_features_storage_early,
                     **self.get_kwargs(emb_lookup_stream="data_dist"),
                 )
             case _:
@@ -152,5 +155,6 @@ class PipelineConfig:
                     optimizer=opt,
                     device=device,
                     enable_inplace_copy_batch=self.enable_inplace_copy_batch,
+                    free_features_storage_early=self.free_features_storage_early,
                     **self.get_kwargs(),
                 )

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -305,6 +305,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
         enable_inplace_copy_batch: bool = False,
         multi_thread: bool = False,
         pipeline_depth: int = 2,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -315,6 +316,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
             context_type=CPUEmbeddingTrainPipelineContext,
             pipeline_postproc=pipeline_postproc,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         assert pipeline_depth in (1, 2), "pipeline_depth must be 1 or 2"
         self._pipeline_depth = pipeline_depth
@@ -696,6 +698,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
         ] = None,
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -709,6 +712,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enqueue_batch_after_forward=False,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._copy_executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=1)
         self.batches: Deque[Optional[In]] = cast(Deque[Optional[In]], FutureDeque())
@@ -796,6 +800,7 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -809,6 +814,7 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._output_dist_site = OutputDistSite(
             fqn=site_fqn, sharding_type=sharding_type
@@ -932,6 +938,7 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -945,6 +952,7 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._output_dist_site = OutputDistSite(
             fqn=site_fqn, sharding_type=sharding_type
@@ -1081,6 +1089,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1094,6 +1103,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         if isinstance(site_fqn, str):
             self._injection_site = InjectionSite(fqn=site_fqn)

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -486,6 +486,9 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             (applicable to 2D sharding only)
             if set and DMP collection is enabled for 2D sharding,
             sync DMPs every N batches (default to 1, i.e. every batch, None to disable)
+        free_features_storage_early (bool): if True, free the original batch KJT
+            tensor storage right after permute in input_dist.  Safe because
+            PipelinedForward ignores the KJT args during model forward.
     """
 
     # The PipelinedForward class that is used in _rewrite_model
@@ -508,6 +511,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -516,6 +520,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._apply_jit = apply_jit
         self._enqueue_batch_after_forward = enqueue_batch_after_forward
         self._enable_inplace_copy_batch = enable_inplace_copy_batch
+        self._free_features_storage_early = free_features_storage_early
         self._batch_count = 0
 
         logger.info(
@@ -837,6 +842,11 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             pipelined_forward=pipelined_forward,
             pipeline_postproc=self._pipeline_postproc,
         )
+        if self._free_features_storage_early:
+            for module in self._pipelined_modules:
+                if hasattr(module, "_free_features_storage_early"):
+                    # pyrefly: ignore [bad-argument-type]
+                    module._free_features_storage_early = True
         # initializes input dist, so we can override input dist forwards
         self.start_sparse_data_dist(batch, context)
         self._original_kjt_dist_forwards = _override_input_dist_forwards(
@@ -1156,6 +1166,7 @@ class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1169,6 +1180,7 @@ class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=None,
             enqueue_batch_after_forward=False,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
 
         # SDD Lite only uses memcpy stream for H2D copy.
@@ -1313,6 +1325,7 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
         embedding_lookup_after_data_dist: bool = False,
         enable_inplace_copy_batch: bool = False,
         enqueue_batch_after_forward: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1325,6 +1338,7 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
             custom_model_fwd=custom_model_fwd,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             enqueue_batch_after_forward=enqueue_batch_after_forward,
+            free_features_storage_early=free_features_storage_early,
         )
         self._embedding_lookup_after_data_dist = embedding_lookup_after_data_dist
 
@@ -1502,6 +1516,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
         strict: bool = False,
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1514,6 +1529,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             custom_model_fwd=custom_model_fwd,
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._start_batch = start_batch
         self._stash_gradients = stash_gradients
@@ -1879,6 +1895,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1890,6 +1907,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             pipeline_postproc=pipeline_postproc,
             custom_model_fwd=custom_model_fwd,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._context = PrefetchTrainPipelineContext(version=0)
         self._prefetch_stream: Optional[torch.Stream] = (
@@ -2089,6 +2107,7 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         device: torch.device,
         apply_jit: bool = False,
         enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -2097,6 +2116,7 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             execute_all_batches=True,
             apply_jit=apply_jit,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
         )
         self._batch_loader: Optional[DataLoadingThread[In]] = None
 
@@ -2556,6 +2576,7 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
         custom_model_fwd: Optional[
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
+        free_features_storage_early: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -2566,6 +2587,7 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
             context_type,
             pipeline_postproc,
             custom_model_fwd,
+            free_features_storage_early=free_features_storage_early,
         )
 
         torch._logging.set_logs(compiled_autograd_verbose=True)

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -3121,6 +3121,23 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             splits.append(length_per_split)
         return splits
 
+    @torch.jit.unused
+    def clear_storage(self) -> None:
+        """
+        Frees the underlying storage of all internal tensors (_values, _lengths,
+        _offsets, _weights) by resizing their untyped storage to zero.
+
+        The Python KJT object remains alive but its tensor data is released,
+        allowing GPU HBM to be reclaimed early.
+        """
+        self._values.untyped_storage().resize_(0)
+        if self._lengths is not None:
+            self._lengths.untyped_storage().resize_(0)
+        if self._offsets is not None:
+            self._offsets.untyped_storage().resize_(0)
+        if self._weights is not None:
+            self._weights.untyped_storage().resize_(0)
+
     def dist_tensors(self) -> List[torch.Tensor]:
         tensors = [self.lengths(), self.values()]
         if self.variable_stride_per_key():

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1386,6 +1386,21 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertTrue(result_kjt.values().is_cuda)
         self.assertTrue(result_kjt.lengths().is_cuda)
 
+    def test_clear_storage(self) -> None:
+        kjt = KeyedJaggedTensor(
+            values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            keys=["index_0", "index_1"],
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+            weights=torch.Tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        )
+        self.assertGreater(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertGreater(kjt._lengths.untyped_storage().nbytes(), 0)
+        self.assertGreater(kjt._weights.untyped_storage().nbytes(), 0)
+        kjt.clear_storage()
+        self.assertEqual(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertEqual(kjt._lengths.untyped_storage().nbytes(), 0)
+        self.assertEqual(kjt._weights.untyped_storage().nbytes(), 0)
+
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):
     def test_scriptable_forward(self) -> None:


### PR DESCRIPTION
## 1. Context
In the standard `TrainPipelineSparseDist`, the batch's KJT features are extracted during `start_sparse_data_dist` via `input_dist`, but the batch object stays alive in the pipeline queue until `dequeue_batch()` — one full iteration later. Since `PipelinedForward` ignores the KJT args (using pre-computed input_dist results instead), the original KJT's HBM is wasted for an entire pipeline iteration.

This is significant for large models with many embedding features, where the batch KJT can consume multiple GB of HBM unnecessarily.

## 2. Approach
1. **`KJT.clear_storage()` method**: Added a `clear_storage()` method to `KeyedJaggedTensor` in `jagged_tensor.py` that calls `untyped_storage().resize_(0)` on all internal tensors (`_values`, `_lengths`, `_offsets`, `_weights`). This frees GPU memory while keeping the Python object alive.
2. **Early storage freeing in ShardedEBC/EC**: Added `_free_features_storage_early` flag (default `False`) to both `ShardedEmbeddingBagCollection` and `ShardedEmbeddingCollection`. When enabled, `input_dist` calls `original_features.clear_storage()` right after `permute()` creates independent copies.
3. **SDD pipeline init argument**: Added `free_features_storage_early` as an `__init__` parameter to `TrainPipelineSparseDist` and all its subclasses. When enabled, `_pipeline_model` sets the flag on all pipelined modules after model surgery. This keeps the optimization opt-in and available across all SDD-based pipelines.
4. **Benchmark integration**: Added `free_features_storage_early` as a top-level field on `PipelineConfig` so it can be selected via YAML config or CLI `--free_features_storage_early=True`.

### 2.1 VBE handling in EC
For `ShardedEmbeddingCollection` with variable-batch-size (VBE) features, the storage resize is deferred until after `_compute_sequence_vbe_context`, which still needs the original (unpadded) features. Non-VBE EC and all EBC paths free immediately after permute.

## 3. Results

### Without inplace copy batch

| Metric | Baseline (`sparse`) | Free-Input (`sparse-free-input`) | Delta |
|---|---|---|---|
| **Peak Allocated (P90)** | 49.06 GB | 47.45 GB | **-1.61 GB (-3.3%)** |
| **Peak Reserved (P90)** | 67.27 GB | 62.85 GB | **-4.42 GB (-6.6%)** |
| GPU Mem Used (P90) | 68.32 GB | 63.90 GB | **-4.42 GB (-6.5%)** |
| GPU Runtime (P90) | 12350.61 ms | 12596.27 ms | +245 ms |
| CPU Runtime (P90) | 9660.21 ms | 10954.42 ms | +1294 ms |

### With enable_inplace_copy_batch=True

| Metric | Baseline (`sparse`) | Free-Input (`sparse-free-input`) | Delta |
|---|---|---|---|
| **Peak Allocated (P90)** | 49.06 GB | 47.45 GB | **-1.61 GB (-3.3%)** |
| **Peak Reserved (P90)** | 65.07 GB | 63.06 GB | **-2.01 GB (-3.1%)** |
| GPU Mem Used (P90) | 66.12 GB | 64.11 GB | **-2.01 GB (-3.0%)** |
| GPU Runtime (P90) | 13521.37 ms | 14954.97 ms | +1433 ms |
| CPU Runtime (P90) | 10975.14 ms | 10765.90 ms | -209 ms |

* repro commands
```bash
# Baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_baseline

# Free-Input
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_free_input \
    --free_features_storage_early=True

# Baseline + inplace copy
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_inplace \
    --enable_inplace_copy_batch=True

# Free-Input + inplace copy
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_free_input_inplace \
    --free_features_storage_early=True \
    --enable_inplace_copy_batch=True
```

* baseline the copy-batch lives 3 full batches
<img width="5112" height="2606" alt="image" src="https://github.com/user-attachments/assets/bab8b935-8b5c-4631-900e-97c0a6d629c7" />

* early-free the copy-batch lives 1 batch
<img width="5086" height="2520" alt="image" src="https://github.com/user-attachments/assets/49ba90a2-6c5e-4291-955f-60abe2e2a6c3" />

## 4. Analysis
1. **Safety**: The optimization is safe because `PipelinedForward` ignores the KJT args passed to it and uses pre-computed `input_dist` results from context. The original batch KJT is never read after `input_dist` extracts features.
2. **permute() independence**: `KJT.permute()` creates entirely new tensors via `torch.ops.fbgemm.permute_2D_sparse_data` — not views. So freeing the original storage does not affect the permuted KJT used downstream.
3. **EC features_before_input_dist**: `SequenceShardingContext.features_before_input_dist` stores split-view KJTs from the permuted KJT (not the original batch KJT), so freeing the original is safe for EC's `output_dist` path.
4. **Backward compatibility**: Fully backward compatible. The `free_features_storage_early` flag defaults to `False` on both `TrainPipelineSparseDist` and all its subclasses. Existing pipelines are unaffected.
5. **Runtime**: The runtime differences are within noise for a single-benchmark run (num_benchmarks=1). The `resize_(0)` call itself is negligible.

## 5. Changes
1. **`jagged_tensor.py`**: Added `clear_storage()` method to `KeyedJaggedTensor` that calls `untyped_storage().resize_(0)` on `_values`, `_lengths`, `_offsets`, and `_weights`.
2. **`embedding.py`**: Added `_free_features_storage_early` flag to `ShardedEmbeddingCollection`. In `input_dist`, calls `original_features.clear_storage()` after permute when flag is set. VBE case defers until after `_compute_sequence_vbe_context`.
3. **`embeddingbag.py`**: Added `_free_features_storage_early` flag to `ShardedEmbeddingBagCollection`. In `input_dist`, calls `original_features.clear_storage()` after permute when flag is set.
4. **`train_pipelines.py`**: Added `free_features_storage_early` init parameter to `TrainPipelineSparseDist` and all subclasses (`TrainPipelineSparseDistLite`, `TrainPipelineFusedSparseDist`, `TrainPipelineSemiSync`, `PrefetchTrainPipelineSparseDist`, `EvalPipelineSparseDist`, `TrainPipelineSparseDistCompAutograd`). When enabled, `_pipeline_model` sets the flag on all pipelined modules after model surgery.
5. **`experimental_pipelines.py`**: Added `free_features_storage_early` init parameter to all subclasses (`TrainPipelineSparseDistT`, `TrainPipelineSparseDistBwdOpt`, `TrainPipelineSparseDistOptStash`, `TrainPipelineSparseDistEmbStash`, `EvalPipelineCPUSparse`).
6. **`pipeline_config.py`**: Added `free_features_storage_early` as a top-level `PipelineConfig` field, passed to all pipeline constructors.
7. **`test_keyed_jagged_tensor.py`**: Added `test_clear_storage` test verifying `size_in_bytes()` drops to 0 after `clear_storage()`.


Differential Revision: D95906581


