### PR TITLE
Disable flaky test_zch_hash_disable_fallback_sharded_module for OSS

### DIFF
--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -1052,7 +1052,9 @@ class TestMCH(unittest.TestCase):
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
     )
-    def test_zch_hash_disable_fallback_sharded_module(self) -> None:
+    def test_zch_hash_disable_fallback_sharded_module_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
         # Lengths should not be modified when disabling fallback in traning eval.
         m = HashZchManagedCollisionModule(
             zch_size=30,


### PR DESCRIPTION
Summary: Disable `test_zch_hash_disable_fallback_sharded_module` for OSS by appending `_disabled_in_oss_compatibility` suffix. This test is flaky on OSS CI, following the existing convention used by other tests in this file to disable flaky tests from OSS runs.

Differential Revision: D96068258


