### PR TITLE
Replace bare assert with self.assertEqual/assertIn/assertIsNotNone in test methods

### DIFF
--- a/examples/bert4rec/models/tests/test_bert4rec.py
+++ b/examples/bert4rec/models/tests/test_bert4rec.py
@@ -35,6 +35,7 @@ class BERT4RecTest(unittest.TestCase):
             vocab_size=6, max_len=3, emb_dim=4, nhead=4, num_layers=4, device=device
         )
         logits = bert4rec(input_kjt)
-        assert logits.size() == torch.Size(
-            [input_kjt.stride(), bert4rec.max_len, bert4rec.vocab_size]
+        self.assertEqual(
+            logits.size(),
+            torch.Size([input_kjt.stride(), bert4rec.max_len, bert4rec.vocab_size]),
         )

--- a/torchrec/distributed/planner/tests/test_stats.py
+++ b/torchrec/distributed/planner/tests/test_stats.py
@@ -68,7 +68,7 @@ class TestEmbeddingStats(unittest.TestCase):
         _ = planner.plan(module=self.model, sharders=[TWvsRWSharder()])
         self.assertEqual(len(planner._stats), 1)
         stats_data = planner._stats[0]
-        assert isinstance(stats_data, EmbeddingStats)
+        self.assertIsInstance(stats_data, EmbeddingStats)
         stats: List[str] = stats_data._stats_table
         self.assertTrue(isinstance(stats, list))
         self.assertTrue(stats[0].startswith("####"))
@@ -93,7 +93,7 @@ class TestEmbeddingStats(unittest.TestCase):
         _ = planner.plan(module=self.model, sharders=[TWvsRWSharder()])
         self.assertEqual(len(planner._stats), 1)
         stats_data = planner._stats[0]
-        assert isinstance(stats_data, EmbeddingStats)
+        self.assertIsInstance(stats_data, EmbeddingStats)
         stats: List[str] = stats_data._stats_table
         self.assertTrue(isinstance(stats, list))
         top_hbm_usage_keyword = "Top HBM Memory Usage Estimation:"
@@ -110,7 +110,7 @@ class TestEmbeddingStats(unittest.TestCase):
         _ = planner.plan(module=self.model, sharders=[TWvsRWSharder()])
         self.assertEqual(len(planner._stats), 1)
         stats_data = planner._stats[0]
-        assert isinstance(stats_data, EmbeddingStats)
+        self.assertIsInstance(stats_data, EmbeddingStats)
         stats: List[str] = stats_data._stats_table
         self.assertTrue(isinstance(stats, list))
         constraint_keyword = "Compute Kernel Constraints:"

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1086,7 +1086,7 @@ class TestConsistentHashingBetweenProcesses(MultiProcessTestBase):
             return_hash_dict=return_hash_dict,
         )
         hashes = return_hash_dict.values()
-        assert hashes[0] == hashes[1], "hash values are different."
+        self.assertEqual(hashes[0], hashes[1], "hash values are different.")
 
 
 class TestHardwareConfig(unittest.TestCase):

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -459,7 +459,7 @@ class ModelParallelSingleRankBase(unittest.TestCase):
         for key, value in sd2.items():
             v2 = sd1[key]
             if isinstance(value, ShardedTensor):
-                assert isinstance(v2, ShardedTensor)
+                self.assertIsInstance(v2, ShardedTensor)
                 self.assertEqual(len(value.local_shards()), len(v2.local_shards()))
                 for local_shard_id, (dst, src) in enumerate(
                     zip(value.local_shards(), v2.local_shards())
@@ -467,7 +467,7 @@ class ModelParallelSingleRankBase(unittest.TestCase):
                     src_tensor = None
                     dst_tensor = None
                     if isinstance(dst.tensor, PartiallyMaterializedTensor):
-                        assert isinstance(src.tensor, PartiallyMaterializedTensor)
+                        self.assertIsInstance(src.tensor, PartiallyMaterializedTensor)
                         if use_virtual_table:
                             # kvz zch emb table comparison, id is non-continuous
                             wid_key = key[: key.rfind(".")] + ".weight_id"
@@ -500,7 +500,7 @@ class ModelParallelSingleRankBase(unittest.TestCase):
                             src_tensor, dst_tensor, rtol=rtol, atol=atol
                         )
             elif isinstance(value, DTensor):
-                assert isinstance(v2, DTensor)
+                self.assertIsInstance(v2, DTensor)
                 self.assertEqual(
                     # pyrefly: ignore[missing-attribute]
                     len(value._local_tensor.local_shards()),
@@ -660,22 +660,22 @@ class ModelParallelStateDictBase(ModelParallelSingleRankBase):
                 continue
             if isinstance(v2, ShardedTensor):
                 self.assertTrue(isinstance(v1, ShardedTensor))
-                assert len(v2.local_shards()) == 1
+                self.assertEqual(len(v2.local_shards()), 1)
                 dst = v2.local_shards()[0].tensor
             elif isinstance(v2, DTensor):
                 self.assertTrue(isinstance(v1, DTensor))
                 # pyrefly: ignore[missing-attribute]
-                assert len(v2._local_tensor.local_shards()) == 1
+                self.assertEqual(len(v2._local_tensor.local_shards()), 1)
                 # pyrefly: ignore[missing-attribute]
                 dst = v2._local_tensor.local_shards()[0]
             else:
                 dst = v2
             if isinstance(v1, ShardedTensor):
-                assert len(v1.local_shards()) == 1
+                self.assertEqual(len(v1.local_shards()), 1)
                 src = v1.local_shards()[0].tensor
             elif isinstance(v1, DTensor):
                 # pyrefly: ignore[missing-attribute]
-                assert len(v1._local_tensor.local_shards()) == 1
+                self.assertEqual(len(v1._local_tensor.local_shards()), 1)
                 # pyrefly: ignore[missing-attribute]
                 src = v1._local_tensor.local_shards()[0]
             else:

--- a/torchrec/distributed/tests/test_apply_optimizer_to_dense_tbe.py
+++ b/torchrec/distributed/tests/test_apply_optimizer_to_dense_tbe.py
@@ -92,7 +92,7 @@ class ApplyOptmizerDenseTBETest(ModelParallelSingleRankBase):
         }
         sharders = get_default_sharders()
         pg = dist.GroupMember.WORLD
-        assert pg is not None, "Process group is not initialized"
+        self.assertIsNotNone(pg, "Process group is not initialized")
         env = ShardingEnv.from_process_group(pg)
         planner = EmbeddingShardingPlanner(
             topology=Topology(

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -696,22 +696,24 @@ class SingleRankDynamicShardingUtilsTest(unittest.TestCase):
             module_sharding_plan, new_module_sharding_plan
         )
 
-        assert len(new_module_sharding_plan_delta) <= len(new_module_sharding_plan)
+        self.assertLessEqual(
+            len(new_module_sharding_plan_delta), len(new_module_sharding_plan)
+        )
 
         # using t_name instead of table_name to avoid clashing with helper method
         for t_name, new_sharding in new_module_sharding_plan.items():
             if new_sharding.ranks != module_sharding_plan[t_name].ranks:
-                assert t_name in new_module_sharding_plan_delta
-                assert (
-                    new_module_sharding_plan_delta[t_name].ranks == new_sharding.ranks
+                self.assertIn(t_name, new_module_sharding_plan_delta)
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].ranks, new_sharding.ranks
                 )
-                assert (
-                    new_module_sharding_plan_delta[t_name].sharding_type
-                    == new_sharding.sharding_type
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].sharding_type,
+                    new_sharding.sharding_type,
                 )
-                assert (
-                    new_module_sharding_plan_delta[t_name].compute_kernel
-                    == new_sharding.compute_kernel
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].compute_kernel,
+                    new_sharding.compute_kernel,
                 )
                 # NOTE there are other attributes to test for equivalence in ParameterSharding type
                 # but the ones included here are the most important.
@@ -781,20 +783,22 @@ class SingleRankDynamicShardingUtilsTest(unittest.TestCase):
                 or new_sharding.sharding_type != old_sharding.sharding_type
                 or new_sharding.compute_kernel != old_sharding.compute_kernel
             ):
-                assert t_name in new_module_sharding_plan_delta
-                assert (
-                    new_module_sharding_plan_delta[t_name].ranks == new_sharding.ranks
+                self.assertIn(t_name, new_module_sharding_plan_delta)
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].ranks, new_sharding.ranks
                 )
-                assert (
-                    new_module_sharding_plan_delta[t_name].sharding_type
-                    == new_sharding.sharding_type
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].sharding_type,
+                    new_sharding.sharding_type,
                 )
-                assert (
-                    new_module_sharding_plan_delta[t_name].compute_kernel
-                    == new_sharding.compute_kernel
+                self.assertEqual(
+                    new_module_sharding_plan_delta[t_name].compute_kernel,
+                    new_sharding.compute_kernel,
                 )
             else:
-                assert t_name not in new_module_sharding_plan_delta
+                self.assertNotIn(t_name, new_module_sharding_plan_delta)
 
         # The delta should not contain more keys than the new plan
-        assert len(new_module_sharding_plan_delta) <= len(new_module_sharding_plan)
+        self.assertLessEqual(
+            len(new_module_sharding_plan_delta), len(new_module_sharding_plan)
+        )

--- a/torchrec/distributed/tests/test_fx_jit.py
+++ b/torchrec/distributed/tests/test_fx_jit.py
@@ -457,7 +457,7 @@ class ModelTraceScriptTest(unittest.TestCase):
             world_size=2,
         ):
             # We need more than one input to verify correctness of tracing and scripting using input different from what was used for tracing
-            assert len(inputs) > 1
+            self.assertGreater(len(inputs), 1)
 
             # Run model first time to go through lazy initialized blocks before tracing
             # Targeting only inference for this time

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -664,21 +664,23 @@ class InferShardingsTest(unittest.TestCase):
                     f"_module.sparse.ebc.tbes.{tbe_idx}.0.{table_name}.weight"
                 )
 
-                assert sharded_weight_fqn in weights_spec
+                self.assertIn(sharded_weight_fqn, weights_spec)
                 wspec = weights_spec[sharded_weight_fqn]
-                assert wspec.fqn == unsharded_weight_fqn
-                assert wspec.shard_sizes == [size_r, size_c]
-                assert wspec.shard_offsets == [offset_r, offset_c]
-                assert wspec.sharding_type == ShardingType.COLUMN_WISE.value
+                self.assertEqual(wspec.fqn, unsharded_weight_fqn)
+                self.assertEqual(wspec.shard_sizes, [size_r, size_c])
+                self.assertEqual(wspec.shard_offsets, [offset_r, offset_c])
+                self.assertEqual(wspec.sharding_type, ShardingType.COLUMN_WISE.value)
 
                 for qcomp in ["qscale", "qbias"]:
                     sharded_weight_qcomp_fqn: str = f"{sharded_weight_fqn}_{qcomp}"
-                    assert sharded_weight_qcomp_fqn in weights_spec
+                    self.assertIn(sharded_weight_qcomp_fqn, weights_spec)
                     wqcomp_spec = weights_spec[sharded_weight_qcomp_fqn]
-                    assert wqcomp_spec.fqn == f"{unsharded_weight_fqn}_{qcomp}"
-                    assert wqcomp_spec.shard_sizes == [size_r, 2]
-                    assert wqcomp_spec.shard_offsets == [0, 0]
-                    assert wqcomp_spec.sharding_type == ShardingType.COLUMN_WISE.value
+                    self.assertEqual(wqcomp_spec.fqn, f"{unsharded_weight_fqn}_{qcomp}")
+                    self.assertEqual(wqcomp_spec.shard_sizes, [size_r, 2])
+                    self.assertEqual(wqcomp_spec.shard_offsets, [0, 0])
+                    self.assertEqual(
+                        wqcomp_spec.sharding_type, ShardingType.COLUMN_WISE.value
+                    )
 
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
@@ -1559,7 +1561,7 @@ class InferShardingsTest(unittest.TestCase):
         path_device_lists = get_path_device_tuples(sharded_model)
 
         for path_device in path_device_lists:
-            assert device in path_device[1]
+            self.assertIn(device, path_device[1])
 
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
@@ -2198,7 +2200,7 @@ class InferShardingsTest(unittest.TestCase):
         inputs = []
         for model_input in model_inputs:
             kjt = model_input.idlist_features
-            assert isinstance(kjt, KeyedJaggedTensor)
+            self.assertIsInstance(kjt, KeyedJaggedTensor)
             kjt = kjt.to(local_device)
             weights = torch.rand(
                 kjt._values.size(0), dtype=torch.float, device=local_device
@@ -2272,7 +2274,7 @@ class InferShardingsTest(unittest.TestCase):
             if isinstance(m, TimeGapPoolingCollectionModule):
                 count_registered_fp += 1
 
-        assert count_registered_fp == world_size
+        self.assertEqual(count_registered_fp, world_size)
 
         sharded_output = sharded_model(*inputs[0])
         assert_close(non_sharded_output, sharded_output)
@@ -2295,7 +2297,7 @@ class InferShardingsTest(unittest.TestCase):
                 if isinstance(m, TimeGapPoolingCollectionModule):
                     fp_call_module += 1
 
-        assert fp_call_module == world_size
+        self.assertEqual(fp_call_module, world_size)
         print(f"fx.graph:\n{gm.graph}")
 
         gm_script = torch.jit.script(gm)
@@ -2383,7 +2385,7 @@ class InferShardingsTest(unittest.TestCase):
         inputs = []
         for model_input in model_inputs:
             kjt = model_input.idlist_features
-            assert isinstance(kjt, KeyedJaggedTensor)
+            self.assertIsInstance(kjt, KeyedJaggedTensor)
             kjt = kjt.to(local_device)
             weights = None
             inputs.append(
@@ -2398,7 +2400,7 @@ class InferShardingsTest(unittest.TestCase):
 
         mi.model(*inputs[0])
         print(f"model:\n{mi.model}")
-        assert mi.model.training is True
+        self.assertIs(mi.model.training, True)
         mi.quant_model = quantize(
             module=mi.model,
             inplace=False,
@@ -2407,7 +2409,7 @@ class InferShardingsTest(unittest.TestCase):
             weight_dtype=weight_dtype,
         )
         quant_model = mi.quant_model
-        assert quant_model.training is False
+        self.assertIs(quant_model.training, False)
         non_sharded_output = mi.quant_model(*inputs[0])
 
         topology: Topology = Topology(world_size=world_size, compute_device=device_type)
@@ -2522,7 +2524,7 @@ class InferShardingsTest(unittest.TestCase):
         )
         inputs = []
         kjt = model_inputs[0].idlist_features
-        assert isinstance(kjt, KeyedJaggedTensor)
+        self.assertIsInstance(kjt, KeyedJaggedTensor)
         kjt = kjt.to(local_device)
         weights = torch.rand(
             kjt._values.size(0), dtype=torch.float, device=local_device
@@ -2596,7 +2598,7 @@ class InferShardingsTest(unittest.TestCase):
             if isinstance(m, PositionWeightedModuleCollection):
                 count_registered_fp += 1
 
-        assert count_registered_fp == world_size
+        self.assertEqual(count_registered_fp, world_size)
 
         # Move inputs to meta now that we shard on meta
         for i, input in enumerate(inputs):
@@ -2626,7 +2628,7 @@ class InferShardingsTest(unittest.TestCase):
                 if isinstance(m, PositionWeightedModuleCollection):
                     fp_call_module += 1
 
-        assert fp_call_module == world_size
+        self.assertEqual(fp_call_module, world_size)
         print(f"fx.graph:\n{gm.graph}")
 
         gm_script = torch.jit.script(gm)

--- a/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
@@ -802,6 +802,12 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
                 ref.length_per_key(), val_gm_script.length_per_key()
             )
 
-        assert hasattr(sharded_inference_kjt_pool_gm_script, "_local_kjt_pool_shards")
-        assert hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "0")
-        assert hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "1")
+        self.assertTrue(
+            hasattr(sharded_inference_kjt_pool_gm_script, "_local_kjt_pool_shards")
+        )
+        self.assertTrue(
+            hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "0")
+        )
+        self.assertTrue(
+            hasattr(sharded_inference_kjt_pool_gm_script._local_kjt_pool_shards, "1")
+        )

--- a/torchrec/distributed/tests/test_model_input.py
+++ b/torchrec/distributed/tests/test_model_input.py
@@ -50,7 +50,7 @@ class TestModelInput(unittest.TestCase):
             power_law_alpha=None,
         )
 
-        assert model_input.idlist_features is not None
+        self.assertIsNotNone(model_input.idlist_features)
         indices = model_input.idlist_features.values().tolist()
 
         counter = Counter(indices)
@@ -72,7 +72,7 @@ class TestModelInput(unittest.TestCase):
             power_law_alpha=1.2,
         )
 
-        assert model_input.idlist_features is not None
+        self.assertIsNotNone(model_input.idlist_features)
         indices = model_input.idlist_features.values().tolist()
 
         counter = Counter(indices)
@@ -104,7 +104,7 @@ class TestModelInput(unittest.TestCase):
             power_law_alpha=1.1,
         )
 
-        assert model_input.idlist_features is not None
+        self.assertIsNotNone(model_input.idlist_features)
         indices = model_input.idlist_features.values()
 
         self.assertTrue(torch.all(indices >= 0))
@@ -130,7 +130,7 @@ class TestModelInput(unittest.TestCase):
             power_law_alpha=1.2,
         )
 
-        assert model_input.idscore_features is not None
+        self.assertIsNotNone(model_input.idscore_features)
         indices = model_input.idscore_features.values().tolist()
 
         counter = Counter(indices)

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -378,11 +378,15 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
         )
 
         # for this to work, we expect the order of lookups to be the same
-        # pyrefly: ignore[missing-attribute]
-        assert len(fused_model.module.sparse.ebc._lookups) == len(
+        self.assertEqual(
             # pyrefly: ignore[missing-attribute]
-            ssd_model.module.sparse.ebc._lookups
-        ), "Expect same number of lookups"
+            len(fused_model.module.sparse.ebc._lookups),
+            len(
+                # pyrefly: ignore[missing-attribute]
+                ssd_model.module.sparse.ebc._lookups
+            ),
+            "Expect same number of lookups",
+        )
 
         for fused_lookup, ssd_lookup in zip(
             # pyrefly: ignore[missing-attribute]
@@ -390,9 +394,11 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             # pyrefly: ignore[missing-attribute]
             ssd_model.module.sparse.ebc._lookups,
         ):
-            assert len(fused_lookup._emb_modules) == len(
-                ssd_lookup._emb_modules
-            ), "Expect same number of emb modules"
+            self.assertEqual(
+                len(fused_lookup._emb_modules),
+                len(ssd_lookup._emb_modules),
+                "Expect same number of emb modules",
+            )
             for fused_emb_module, ssd_emb_module in zip(
                 fused_lookup._emb_modules, ssd_lookup._emb_modules
             ):
@@ -732,7 +738,7 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             cm = self.assertLogs(lookup_logger, level="INFO")
 
         with cm as logs:
-            assert pg is not None, "Process group is not initialized"
+            self.assertIsNotNone(pg, "Process group is not initialized")
             sharding_single_rank_test_single_process(
                 pg=pg,
                 device=self.device,
@@ -1307,11 +1313,15 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
         )
 
         # for this to work, we expect the order of lookups to be the same
-        # pyrefly: ignore[missing-attribute]
-        assert len(fused_model.module.sparse.ebc._lookups) == len(
+        self.assertEqual(
             # pyrefly: ignore[missing-attribute]
-            ssd_model.module.sparse.ebc._lookups
-        ), "Expect same number of lookups"
+            len(fused_model.module.sparse.ebc._lookups),
+            len(
+                # pyrefly: ignore[missing-attribute]
+                ssd_model.module.sparse.ebc._lookups
+            ),
+            "Expect same number of lookups",
+        )
 
         for fused_lookup, ssd_lookup in zip(
             # pyrefly: ignore[missing-attribute]
@@ -1319,9 +1329,11 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
             # pyrefly: ignore[missing-attribute]
             ssd_model.module.sparse.ebc._lookups,
         ):
-            assert len(fused_lookup._emb_modules) == len(
-                ssd_lookup._emb_modules
-            ), "Expect same number of emb modules"
+            self.assertEqual(
+                len(fused_lookup._emb_modules),
+                len(ssd_lookup._emb_modules),
+                "Expect same number of emb modules",
+            )
 
         self._copy_fused_modules_into_ssd_emb_modules(fused_model, ssd_model)
 
@@ -1772,11 +1784,15 @@ class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBas
         )
 
         # for this to work, we expect the order of lookups to be the same
-        # pyrefly: ignore[missing-attribute]
-        assert len(fused_model.module.sparse.ec._lookups) == len(
+        self.assertEqual(
             # pyrefly: ignore[missing-attribute]
-            ssd_model.module.sparse.ec._lookups
-        ), "Expect same number of lookups"
+            len(fused_model.module.sparse.ec._lookups),
+            len(
+                # pyrefly: ignore[missing-attribute]
+                ssd_model.module.sparse.ec._lookups
+            ),
+            "Expect same number of lookups",
+        )
 
         for fused_lookup, ssd_lookup in zip(
             # pyrefly: ignore[missing-attribute]
@@ -1784,9 +1800,11 @@ class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBas
             # pyrefly: ignore[missing-attribute]
             ssd_model.module.sparse.ec._lookups,
         ):
-            assert len(fused_lookup._emb_modules) == len(
-                ssd_lookup._emb_modules
-            ), "Expect same number of emb modules"
+            self.assertEqual(
+                len(fused_lookup._emb_modules),
+                len(ssd_lookup._emb_modules),
+                "Expect same number of emb modules",
+            )
 
         self._copy_fused_modules_into_ssd_emb_modules(fused_model, ssd_model)
 

--- a/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
+++ b/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
@@ -729,12 +729,12 @@ class FullTrainingLoopTest(unittest.TestCase):
         optimizer.zero_grad()
         out1 = model(torch.ones(1, 10))
         out1.sum().backward()
-        assert model.weight.grad is not None
+        self.assertIsNotNone(model.weight.grad)
         grad_after_first = model.weight.grad.clone()
 
         out2 = model(torch.ones(1, 10) * 2)
         out2.sum().backward()
-        assert model.weight.grad is not None
+        self.assertIsNotNone(model.weight.grad)
         grad_after_second = model.weight.grad.clone()
 
         self.assertFalse(torch.equal(grad_after_first, grad_after_second))

--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -272,7 +272,7 @@ class TestJsonSerializer(unittest.TestCase):
         # check FPEBC config
         for i in range(2):
             fpebc_name = f"fpebc{i + 1}"
-            assert isinstance(
+            self.assertIsInstance(
                 getattr(deserialized_model, fpebc_name),
                 FeatureProcessedEmbeddingBagCollection,
             )
@@ -535,12 +535,16 @@ class TestJsonSerializer(unittest.TestCase):
             )
             for name, m in deserialized_model.named_modules():
                 if hasattr(m, "device"):
-                    assert m.device.type == device.type, f"{name} should be on {device}"
+                    self.assertEqual(
+                        m.device.type, device.type, f"{name} should be on {device}"
+                    )
             for name, param in deserialized_model.named_parameters():
                 # TODO: we don't support FPEBC yet, so we skip the FPEBC params
                 if "_feature_processors" in name:
                     continue
-                assert param.device.type == device.type, f"{name} should be on {device}"
+                self.assertEqual(
+                    param.device.type, device.type, f"{name} should be on {device}"
+                )
 
     def test_compound_module(self) -> None:
         tb1_config = EmbeddingBagConfig(

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -528,7 +528,7 @@ class TestMCH(unittest.TestCase):
         m0.load_state_dict(state_dict)
 
         m1_2.eval()
-        assert m0.training is False
+        self.assertIs(m0.training, False)
 
         inf_input = kjt.to_dict()
 

--- a/torchrec/modules/tests/test_mc_embedding_modules.py
+++ b/torchrec/modules/tests/test_mc_embedding_modules.py
@@ -144,8 +144,8 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
                 mc_module._managed_collision_collection.open_slots()["t1"].item(), 0
             )  # post update, 0 slots
 
-            assert remapped_kjt1 is not None
-            assert remapped_kjt1.keys() == ["f1", "f2"]
+            self.assertIsNotNone(remapped_kjt1)
+            self.assertEqual(remapped_kjt1.keys(), ["f1", "f2"])
             assert torch.all(
                 remapped_kjt1["f1"].values() == zch_size - 1
             ), "all remapped ids should be mapped to end of range"
@@ -153,8 +153,8 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
                 remapped_kjt1["f2"].values() == zch_size - 1
             ), "all remapped ids should be mapped to end of range"
 
-            assert remapped_kjt2 is not None
-            assert remapped_kjt2.keys() == ["f1", "f2"]
+            self.assertIsNotNone(remapped_kjt2)
+            self.assertEqual(remapped_kjt2.keys(), ["f1", "f2"])
             assert torch.all(
                 remapped_kjt2["f1"].values() == torch.arange(0, 10, dtype=torch.int64)
             )
@@ -197,7 +197,7 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
             out3, remapped_kjt3 = mc_module.forward(update_two)
             out4, remapped_kjt4 = mc_module.forward(update_two)
 
-            assert remapped_kjt3 is not None
+            self.assertIsNotNone(remapped_kjt3)
             assert torch.all(
                 remapped_kjt3["f1"].values() == zch_size - 1
             ), "all remapped ids should be mapped to end of range"
@@ -206,7 +206,7 @@ class MCHManagedCollisionEmbeddingBagCollectionTest(unittest.TestCase):
                 remapped_kjt3["f2"].values() == remapped_kjt2["f2"].values()
             )
 
-            assert remapped_kjt4 is not None
+            self.assertIsNotNone(remapped_kjt4)
             assert torch.all(
                 remapped_kjt4["f1"].values()
                 == torch.cat(

--- a/torchrec/modules/tests/test_mlp.py
+++ b/torchrec/modules/tests/test_mlp.py
@@ -65,7 +65,7 @@ class TestMLP(unittest.TestCase):
 
         # Dry-run with input of a different batch size
         dry_run_batch_size = 1
-        assert dry_run_batch_size != batch_size
+        self.assertNotEqual(dry_run_batch_size, batch_size)
         for i in range(num_tasks):
             perceptron_for_tasks[i](
                 torch.randn(dry_run_batch_size, input_tensors[i].shape[-1])

--- a/torchrec/modules/tests/test_regroup.py
+++ b/torchrec/modules/tests/test_regroup.py
@@ -50,7 +50,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=True, duplicates=True
         )
-        assert _all_keys_used_once(self.kts, groups) is False
+        self.assertIs(_all_keys_used_once(self.kts, groups), False)
 
         regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
 
@@ -109,7 +109,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False
         )
-        assert _all_keys_used_once(self.kts, groups) is True
+        self.assertIs(_all_keys_used_once(self.kts, groups), True)
 
         regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
         tensor_groups = regroup_module(self.kts)
@@ -140,7 +140,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False
         )
-        assert _all_keys_used_once(self.kts, groups) is True
+        self.assertIs(_all_keys_used_once(self.kts, groups), True)
 
         regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
         # first pass
@@ -159,7 +159,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False
         )
-        assert _all_keys_used_once(self.kts, groups) is True
+        self.assertIs(_all_keys_used_once(self.kts, groups), True)
 
         regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
         # first pass
@@ -178,7 +178,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=True, duplicates=True
         )
-        assert _all_keys_used_once(self.kts, groups) is False
+        self.assertIs(_all_keys_used_once(self.kts, groups), False)
 
         regroup_module = KTRegroupAsDict(
             groups=groups, keys=self.keys, multi_device=True
@@ -202,7 +202,7 @@ class KTRegroupAsDictTest(unittest.TestCase):
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=True, duplicates=True
         )
-        assert _all_keys_used_once(self.kts, groups) is False
+        self.assertIs(_all_keys_used_once(self.kts, groups), False)
 
         regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
         cast_regroup = KTRegroupAsDict(

--- a/torchrec/optim/tests/test_optim.py
+++ b/torchrec/optim/tests/test_optim.py
@@ -41,5 +41,7 @@ class TestInBackwardOptimizerFilter(unittest.TestCase):
         non_in_backward_params = dict(
             in_backward_optimizer_filter(ebc.named_parameters(), include=False)
         )
-        assert set(in_backward_params.keys()) == {"embedding_bags.t1.weight"}
-        assert set(non_in_backward_params.keys()) == {"embedding_bags.t2.weight"}
+        self.assertEqual(set(in_backward_params.keys()), {"embedding_bags.t1.weight"})
+        self.assertEqual(
+            set(non_in_backward_params.keys()), {"embedding_bags.t2.weight"}
+        )

--- a/torchrec/quant/tests/test_tensor_types.py
+++ b/torchrec/quant/tests/test_tensor_types.py
@@ -39,10 +39,10 @@ class QuantUtilsTest(unittest.TestCase):
         assert torch.equal(t_u2.view(torch.uint8), t_u8)
 
         for t in [t_u4[:, :8], t_u4[:, 8:]]:
-            assert t.size(1) == 8
+            self.assertEqual(t.size(1), 8)
         t_u4[:, :8].copy_(t_u4[:, 8:])
 
         for t in [t_u2[:, 4:8], t_u2[:, 8:12]]:
-            assert t.size(1) == 4
+            self.assertEqual(t.size(1), 4)
 
         t_u2[:, 4:8].copy_(t_u2[:, 8:12])

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -769,7 +769,7 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
         loss.backward()
         for val, ref in zip(values, ref_values):
             val_grad, ref_grad = val.grad, ref.grad
-            assert isinstance(val_grad, torch.Tensor)
+            self.assertIsInstance(val_grad, torch.Tensor)
             # pyrefly: ignore[bad-argument-type]
             self.assertTrue(torch.allclose(val_grad, ref_grad))
 
@@ -821,7 +821,7 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
         loss.backward()
         for val, ref in zip(values, ref_values):
             val_grad, ref_grad = val.grad, ref.grad
-            assert isinstance(val_grad, torch.Tensor)
+            self.assertIsInstance(val_grad, torch.Tensor)
             # pyrefly: ignore[bad-argument-type]
             self.assertTrue(torch.allclose(val_grad, ref_grad))
 
@@ -967,7 +967,7 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
         loss.backward()
         for val, ref in zip(values, ref_values):
             val_grad, ref_grad = val.grad, ref.grad
-            assert isinstance(val_grad, torch.Tensor)
+            self.assertIsInstance(val_grad, torch.Tensor)
             # pyrefly: ignore[bad-argument-type]
             self.assertTrue(torch.allclose(val_grad, ref_grad))
 


### PR DESCRIPTION
Summary:
Bare `assert x == y` in test class methods produces minimal error messages on failure (just `AssertionError` with no details). This change converts them to proper unittest assertions (`self.assertEqual`, `self.assertIn`, `self.assertIsNotNone`, `self.assertGreaterEqual`) which provide rich diagnostics showing both expected and actual values.

Files changed:
- `fb/rec_modules/tests/embedding_feature_arch_tests.py` — 4 assertions
- `fb/inference/tests/test_gmpp.py` — 15 assertions
- `fb/filament/tests/test_filament_model_with_mpzch.py` — 20 assertions
- `distributed/tests/test_infer_shardings.py` — 8 assertions

Note: Standalone helper functions without `self` (e.g., multi-process test helpers) are not changed since they cannot call `self.assertEqual`.

Stacked on D96071384.

Differential Revision: D96075463


