### PR TITLE
Add 2D sparse parallel support for Triton TBE (FULLY_SHARDED) (#3859)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3910,6 +3910,172 @@ class TritonBatchedFusedEmbeddingBag(
         self._emb_module.reset_cache_states()
 
 
+class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
+    """
+    Collective Communications:
+        - Forward: async reduce_scatter (ReduceOp.AVG) on weights via replica_pg
+        - Backward (pre-hook): all_gather on weights via replica_pg
+    """
+
+    def __init__(
+        self,
+        config: GroupedEmbeddingConfig,
+        pg: Optional[dist.ProcessGroup] = None,
+        device: Optional[torch.device] = None,
+        sharding_type: Optional[ShardingType] = None,
+        env: Optional[ShardingEnv] = None,
+    ) -> None:
+        super().__init__(config, pg, device, sharding_type, env)
+        assert isinstance(
+            env, ShardingEnv2D
+        ), "env is required for ShardedTritonBatchedFusedEmbeddingBag"
+
+        self._env: ShardingEnv2D = env
+
+        self.weights_sharded = False
+        self._input_tensor = None
+        self._element_size = self._emb_module.weight.element_size()
+        # pyre-ignore[8]
+        self._original_shape: torch.Size = self._emb_module.weight.shape
+        # Triton TBE's weight is a plain tensor attribute (not nn.Parameter),
+        # same pattern as CUDA TBE's weights_dev.
+        # pyre-ignore[8]
+        self._unsharded_param: torch.Tensor = self._emb_module.weight
+        self._shard_buf_nbytes: int = 0
+        self._shard_buf: Optional[torch.Tensor] = None
+
+        self._async_stream: torch.cuda.Stream = torch.cuda.Stream(
+            device=self._emb_module.weight.device
+        )
+        self._async_work: Optional[dist.Work] = None
+        self._async_event: Optional[torch.cuda.Event] = None
+        self._rs_awaitable: Optional[ReduceScatterResizeAwaitable] = None
+
+        self.register_full_backward_pre_hook(
+            self._hybrid_sharded_backward_hook,  # pyre-ignore[6]
+        )
+
+    def _all_gather_table_weights(self) -> None:
+        if not self.weights_sharded:
+            return
+        self.ensure_reduce_scatter_complete()
+
+        shard_size = self._shard_buf.numel()
+        padded_total_size = shard_size * self._env.num_sharding_groups()
+
+        self._unsharded_param.untyped_storage().resize_(
+            padded_total_size * self._element_size
+        )
+        output_tensor = self._unsharded_param
+
+        if padded_total_size != self._unsharded_param.numel():
+            output_tensor = torch.empty(
+                0,
+                dtype=self._unsharded_param.dtype,
+                device=self._unsharded_param.device,
+            )
+            output_tensor.set_(
+                self._unsharded_param.untyped_storage(),
+                0,  # storage_offset
+                (padded_total_size,),  # size
+            )
+
+        with record_function("## 2d_allgather_fully_sharded ##"):
+            dist.all_gather_into_tensor(
+                output_tensor=output_tensor,
+                input_tensor=self._shard_buf,
+                group=self._env.replica_pg,
+                async_op=False,
+            )
+        # pyre-ignore[16]
+        self._emb_module.weight = self._unsharded_param[: self._original_shape.numel()]
+        # pyre-ignore[16]
+        self._shard_buf.untyped_storage().resize_(0)
+        self.weights_sharded = False
+
+    def _hybrid_sharded_backward_hook(
+        self, module: nn.Module, grad_input: List[torch.Tensor]
+    ) -> None:
+        self._all_gather_table_weights()
+
+    def get_rs_awaitable(self) -> Optional[ReduceScatterResizeAwaitable]:
+        return self._rs_awaitable
+
+    def ensure_reduce_scatter_complete(self) -> None:
+        if self._rs_awaitable is not None:
+            self._rs_awaitable.wait()
+            self._rs_awaitable = None
+
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+        vbe_output: Optional[torch.Tensor] = None,
+        vbe_output_offsets: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        embs = super().forward(features, vbe_output, vbe_output_offsets)
+        self._async_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._async_stream):
+            self._rs_awaitable = self._reduce_scatter_weights_async()
+        return embs
+
+    def _reduce_scatter_weights_async(self) -> ReduceScatterResizeAwaitable:
+        with torch.no_grad():
+            self.weights_sharded = True
+
+            total_size = self._emb_module.weight.numel()
+
+            num_groups = self._env.num_sharding_groups()
+            shard_size = (total_size + num_groups - 1) // num_groups  # ceil division
+            padded_total_size = shard_size * num_groups
+            padding_size = padded_total_size - total_size
+
+            self._input_tensor = self._emb_module.weight.contiguous()
+            if padding_size > 0:
+                self._input_tensor = torch.nn.functional.pad(
+                    self._emb_module.weight.contiguous(),
+                    (0, padding_size),
+                    value=0.0,
+                )
+
+            if self._shard_buf is None:
+                self._shard_buf = torch.empty(
+                    shard_size,
+                    dtype=self._emb_module.weight.dtype,
+                    device=self._emb_module.weight.device,
+                )
+                # pyre-ignore[16]
+                self._shard_buf_nbytes = self._shard_buf.untyped_storage().nbytes()
+            else:
+                self._shard_buf.untyped_storage().resize_(self._shard_buf_nbytes)
+
+            with record_function("## 2d_reduce_scatter_fully_sharded ##"):
+                self._async_work = dist.reduce_scatter_tensor(
+                    output=self._shard_buf,
+                    input=self._input_tensor,
+                    op=dist.ReduceOp.AVG,
+                    group=self._env.replica_pg,
+                    async_op=True,
+                )
+
+            self._async_event = torch.cuda.Event(enable_timing=False, blocking=False)
+            # pyre-ignore[16]
+            self._async_event.record(self._async_stream)
+
+            def resize_callback() -> None:
+                # pyre-ignore[29]
+                self._emb_module.weight.untyped_storage().resize_(0)
+                self._emb_module.weight = self._shard_buf  # pyre-ignore[16]
+                self._input_tensor.untyped_storage().resize_(0)  # pyre-ignore[29]
+                self._input_tensor = None
+
+            return ReduceScatterResizeAwaitable(
+                async_work=self._async_work,
+                async_event=self._async_event,
+                shard_buf=self._shard_buf,
+                resize_callback=resize_callback,
+            )
+
+
 class TritonEmbeddingFusedOptimizer(FusedOptimizer):
     """
     Fused optimizer for Triton TBE. The optimizer is built into the Triton TBE backward pass.

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -40,6 +40,7 @@ from torchrec.distributed.batched_embedding_kernel import (
     KeyValueEmbeddingBag,
     ShardedBatchedFusedEmbedding,
     ShardedBatchedFusedEmbeddingBag,
+    ShardedTritonBatchedFusedEmbeddingBag,
     SparseType,
     TritonBatchedFusedEmbeddingBag,
     ZeroCollisionEmbeddingCache,
@@ -624,11 +625,26 @@ class GroupedPooledEmbeddingsLookup(
                     env=env,
                 )
         elif config.compute_kernel == EmbeddingComputeKernel.FUSED_TRITON:
-            return TritonBatchedFusedEmbeddingBag(
-                config=config,
-                pg=pg,
-                device=device,
-            )
+            if (
+                env
+                and isinstance(env, ShardingEnv2D)
+                and env.sharding_strategy == ShardingStrategy.FULLY_SHARDED
+            ):
+                return ShardedTritonBatchedFusedEmbeddingBag(
+                    config=config,
+                    pg=pg,
+                    device=device,
+                    sharding_type=sharding_type,
+                    env=env,
+                )
+            else:
+                return TritonBatchedFusedEmbeddingBag(
+                    config=config,
+                    pg=pg,
+                    device=device,
+                    sharding_type=sharding_type,
+                    env=env,
+                )
         elif config.compute_kernel in {
             EmbeddingComputeKernel.KEY_VALUE,
         }:

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -19,6 +19,21 @@ import torch.distributed as dist
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+
+try:
+    from deeplearning.fbgemm.fbgemm_gpu.fb.triton.triton_table_batched_embeddings import (
+        TritonTableBatchedEmbeddingBags,
+    )
+
+    _SHARDED_TBE_TYPES: tuple[type, ...] = (
+        SplitTableBatchedEmbeddingBagsCodegen,
+        TritonTableBatchedEmbeddingBags,
+    )
+except ImportError:
+    _SHARDED_TBE_TYPES: tuple[type, ...] = (  # pyre-ignore[9]
+        SplitTableBatchedEmbeddingBagsCodegen,
+    )
+
 from torch import nn
 from torch.autograd.profiler import record_function
 from torch.distributed.algorithms.ddp_comm_hooks import (
@@ -1616,7 +1631,7 @@ class DMPCollection(DistributedModelParallel):
             module: nn.Module,
             prev_module: nn.Module,
         ) -> None:
-            if isinstance(module, SplitTableBatchedEmbeddingBagsCodegen):
+            if isinstance(module, _SHARDED_TBE_TYPES):
                 sharded_modules.append((module, prev_module))
             # pyrefly: ignore[invalid-argument]
             if not isinstance(module, tuple(modules_to_skip)) and hasattr(
@@ -1645,7 +1660,7 @@ class DMPCollection(DistributedModelParallel):
             module: nn.Module,
             prev_module: nn.Module,
         ) -> None:
-            if isinstance(module, SplitTableBatchedEmbeddingBagsCodegen):
+            if isinstance(module, _SHARDED_TBE_TYPES):
                 sharded_modules.append((module, prev_module))
             # pyrefly: ignore[invalid-argument]
             if isinstance(module, sharded_module):


### PR DESCRIPTION
Summary:

When 2D sparse parallelism is enabled with FULLY_SHARDED strategy, CUDA SplitTBE
correctly performs cross-replica weight synchronization (reduce-scatter in forward,
all-gather in backward), but Triton TBE does not. The Triton TBE kernel is created
without any awareness of the 2D environment, so replica groups train independently
and weights silently diverge.

This diff fixes the gap with three changes:

1. New `ShardedTritonBatchedFusedEmbeddingBag` class in `batched_embedding_kernel.py`
   that extends `TritonBatchedFusedEmbeddingBag` and adds cross-replica weight sync,
   mirroring `ShardedBatchedFusedEmbeddingBag` (CUDA path). Forward launches async
   reduce-scatter via replica_pg; backward pre-hook performs all-gather to restore
   full weights before gradient computation. FP8 Triton TBE is explicitly guarded
   against (not yet supported with FULLY_SHARDED).

2. Updated `_create_embedding_kernel` dispatch in `embedding_lookup.py` to route
   FUSED_TRITON + ShardingEnv2D + FULLY_SHARDED to the new sharded variant.

3. Updated `_find_sharded_modules` in `model_parallel.py` to recognize
   `TritonTableBatchedEmbeddingBags` alongside `SplitTableBatchedEmbeddingBagsCodegen`,
   enabling the DEFAULT strategy allreduce-based sync path for Triton TBE.

Reviewed By: axeisghost

Differential Revision: D96051158
