### PR TITLE
Replace bare assert torch.equal/allclose with torch.testing.assert_close for better diagnostics

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -476,7 +476,12 @@ class ModelParallelSingleRankBase(unittest.TestCase):
 
                             sorted_src_wid = torch.sort(src_wid.view(-1))[0]
                             sorted_dst_wid = torch.sort(dst_wid.view(-1))[0]
-                            assert torch.equal(sorted_src_wid, sorted_dst_wid)
+                            torch.testing.assert_close(
+                                sorted_src_wid,
+                                sorted_dst_wid,
+                                rtol=0,
+                                atol=0,
+                            )
                             # kvz zch emb table comparison, id is non-continuous
                             src_tensor = src.tensor.get_weights_by_ids(sorted_src_wid)
                             dst_tensor = dst.tensor.get_weights_by_ids(sorted_dst_wid)

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -144,7 +144,7 @@ def are_sharded_ebc_modules_identical(
         # Check parameter names
         assert param1[0] == param2[0]
         # Check parameter values
-        assert torch.allclose(param1[1], param2[1])
+        torch.testing.assert_close(param1[1], param2[1], rtol=1e-05, atol=1e-08)
 
     # Check if both modules have the same buffers
     buffers1 = list(module1.named_buffers())
@@ -154,7 +154,9 @@ def are_sharded_ebc_modules_identical(
 
     for buffer1, buffer2 in zip(buffers1, buffers2):
         assert buffer1[0] == buffer2[0]  # Check buffer names
-        assert torch.allclose(buffer1[1], buffer2[1])  # Check buffer values
+        torch.testing.assert_close(
+            buffer1[1], buffer2[1], rtol=1e-05, atol=1e-08
+        )  # Check buffer values
 
     # Hard-coded attributes for EmbeddingBagCollection
     attribute_list = [

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -210,9 +210,12 @@ def _test_sharding_and_remapping(  # noqa C901
             postfix = ".".join(key.split(".")[-2:])
             if postfix in initial_state_per_rank[ctx.rank]:
                 tensor = sharded_tensor.local_shards()[0].tensor.cpu()
-                assert torch.equal(
-                    tensor, initial_state_per_rank[ctx.rank][postfix]
-                ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {initial_state_per_rank[rank][postfix]}"
+                torch.testing.assert_close(
+                    tensor,
+                    initial_state_per_rank[ctx.rank][postfix],
+                    rtol=0,
+                    atol=0,
+                )
 
         sharded_sparse_arch.load_state_dict(initial_state_dict)
 
@@ -228,17 +231,22 @@ def _test_sharding_and_remapping(  # noqa C901
             postfix = ".".join(key.split(".")[-2:])
             if postfix in final_state_per_rank[ctx.rank]:
                 tensor = sharded_tensor.local_shards()[0].tensor.cpu()
-                assert torch.equal(
-                    tensor, final_state_per_rank[ctx.rank][postfix]
-                ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {final_state_per_rank[rank][postfix]}"
+                torch.testing.assert_close(
+                    tensor,
+                    final_state_per_rank[ctx.rank][postfix],
+                    rtol=0,
+                    atol=0,
+                )
 
         remapped_ids = [remapped_ids1, remapped_ids2]
         for key in output_keys:
             for i, kjt_out in enumerate(kjt_out_per_iter):
-                assert torch.equal(
+                torch.testing.assert_close(
                     remapped_ids[i][key].values(),
                     kjt_out[key].values(),
-                ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                    rtol=0,
+                    atol=0,
+                )
 
         # TODO: validate embedding rows, and eviction
 
@@ -306,9 +314,12 @@ def _test_in_place_embd_weight_update(  # noqa C901
             postfix = ".".join(key.split(".")[-2:])
             if postfix in initial_state_per_rank[ctx.rank]:
                 tensor = sharded_tensor.local_shards()[0].tensor.cpu()
-                assert torch.equal(
-                    tensor, initial_state_per_rank[ctx.rank][postfix]
-                ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {initial_state_per_rank[rank][postfix]}"
+                torch.testing.assert_close(
+                    tensor,
+                    initial_state_per_rank[ctx.rank][postfix],
+                    rtol=0,
+                    atol=0,
+                )
 
         sharded_sparse_arch.load_state_dict(initial_state_dict)
 
@@ -332,17 +343,22 @@ def _test_in_place_embd_weight_update(  # noqa C901
                 postfix = ".".join(key.split(".")[-2:])
                 if postfix in final_state_per_rank[ctx.rank]:
                     tensor = sharded_tensor.local_shards()[0].tensor.cpu()
-                    assert torch.equal(
-                        tensor, final_state_per_rank[ctx.rank][postfix]
-                    ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {final_state_per_rank[rank][postfix]}"
+                    torch.testing.assert_close(
+                        tensor,
+                        final_state_per_rank[ctx.rank][postfix],
+                        rtol=0,
+                        atol=0,
+                    )
 
             remapped_ids = [remapped_ids1, remapped_ids2]
             for key in output_keys:
                 for i, kjt_out in enumerate(kjt_out_per_iter):
-                    assert torch.equal(
+                    torch.testing.assert_close(
                         remapped_ids[i][key].values(),
                         kjt_out[key].values(),
-                    ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                        rtol=0,
+                        atol=0,
+                    )
 
 
 def _test_sharding_and_resharding(  # noqa C901
@@ -437,10 +453,12 @@ def _test_sharding_and_resharding(  # noqa C901
         remapped_ids = [remapped_ids1, remapped_ids2]
         for key in kjt_input.keys():
             for i, kjt_out in enumerate(kjt_out_per_iter[:2]):  # first two iterations
-                assert torch.equal(
+                torch.testing.assert_close(
                     remapped_ids[i][key].values(),
                     kjt_out[key].values(),
-                ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                    rtol=0,
+                    atol=0,
+                )
 
         state_dict = sharded_sparse_arch.state_dict()
         cpu_state_dict = {}
@@ -513,17 +531,22 @@ def _test_sharding_and_resharding(  # noqa C901
                 postfix = ".".join(key.split(".")[-2:])
                 if postfix in final_state_per_rank[ctx.rank]:
                     tensor = sharded_tensor.local_shards()[0].tensor.cpu()
-                    assert torch.equal(
-                        tensor, final_state_per_rank[ctx.rank][postfix]
-                    ), f"initial state {key} on {ctx.rank} does not match, got {tensor}, expect {final_state_per_rank[rank][postfix]}"
+                    torch.testing.assert_close(
+                        tensor,
+                        final_state_per_rank[ctx.rank][postfix],
+                        rtol=0,
+                        atol=0,
+                    )
 
             remapped_ids = [remapped_ids3]
             for key in kjt_input.keys():
                 for i, kjt_out in enumerate(kjt_out_per_iter[-1:]):  # last iteration
-                    assert torch.equal(
+                    torch.testing.assert_close(
                         remapped_ids[i][key].values(),
                         kjt_out[key].values(),
-                    ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                        rtol=0,
+                        atol=0,
+                    )
 
 
 def _test_sharding_dedup(  # noqa C901
@@ -633,7 +656,7 @@ def _test_sharding_dedup(  # noqa C901
         dedup_loss1, dedup_remapped_1 = dedup_sharded_sparse_arch(kjt_input)
         dedup_loss1.backward()
 
-        assert torch.allclose(loss1, dedup_loss1)
+        torch.testing.assert_close(loss1, dedup_loss1, rtol=1e-05, atol=1e-08)
         # deduping is not being used right now
         # assert torch.allclose(remapped_1.values(), dedup_remapped_1.values())
         # assert torch.allclose(remapped_1.lengths(), dedup_remapped_1.lengths())

--- a/torchrec/distributed/tests/test_mc_embeddingbag.py
+++ b/torchrec/distributed/tests/test_mc_embeddingbag.py
@@ -393,10 +393,12 @@ def _test_sharding_and_remapping(  # noqa C901
         remapped_ids = [remapped_ids1, remapped_ids2]
         for key in output_keys:
             for i, kjt_out in enumerate(kjt_out_per_iter):
-                assert torch.equal(
+                torch.testing.assert_close(
                     remapped_ids[i][key].values(),
                     kjt_out[key].values(),
-                ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                    rtol=0,
+                    atol=0,
+                )
 
         # TODO: validate embedding rows, and eviction
 
@@ -478,10 +480,12 @@ def _test_in_place_embd_weight_update(  # noqa C901
             remapped_ids = [remapped_ids1, remapped_ids2]
             for key in output_keys:
                 for i, kjt_out in enumerate(kjt_out_per_iter):
-                    assert torch.equal(
+                    torch.testing.assert_close(
                         remapped_ids[i][key].values(),
                         kjt_out[key].values(),
-                    ), f"feature {key} on {ctx.rank} iteration {i} does not match, got {remapped_ids[i][key].values()}, expect {kjt_out[key].values()}"
+                        rtol=0,
+                        atol=0,
+                    )
 
 
 def _merge_sharded_return_state_dict(

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -153,10 +153,12 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
                                 0
                             ].local_shards()
                         ][0]
-                        assert torch.equal(
+                        torch.testing.assert_close(
                             optim_weight_from_emb_tensor,
                             optim_weight_from_optim_tensor,
-                        ), "Expect optimizer weights from emb and optim to be equal."
+                            rtol=0,
+                            atol=0,
+                        )
 
     @staticmethod
     def _copy_ssd_emb_modules(

--- a/torchrec/metrics/test_utils/__init__.py
+++ b/torchrec/metrics/test_utils/__init__.py
@@ -423,25 +423,33 @@ def _assert_metric_results(
     """Helper function to assert metric results based on metric name."""
     # Serving Calibration uses Calibration naming inconsistently
     if metric_name == "serving_calibration":
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"{metric_name}-{task_names[0]}|window_calibration"],
+        torch.testing.assert_close(
+            test_metrics[1][task_names[0]].squeeze(),
+            res[f"{metric_name}-{task_names[0]}|window_calibration"].squeeze(),
+            rtol=1e-05,
+            atol=1e-08,
         )
     elif metric_name == "effective_sample_rate":
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"effective_rate-{task_names[0]}|window_{metric_name}"],
+        torch.testing.assert_close(
+            test_metrics[1][task_names[0]].squeeze(),
+            res[f"effective_rate-{task_names[0]}|window_{metric_name}"].squeeze(),
+            rtol=1e-05,
+            atol=1e-08,
         )
     elif metric_name in ("label_average", "prediction_average"):
         # Average metrics use "average" as namespace but different metric names
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"average-{task_names[0]}|window_{metric_name}"],
+        torch.testing.assert_close(
+            test_metrics[1][task_names[0]].squeeze(),
+            res[f"average-{task_names[0]}|window_{metric_name}"].squeeze(),
+            rtol=1e-05,
+            atol=1e-08,
         )
     else:
-        assert torch.allclose(
-            test_metrics[1][task_names[0]],
-            res[f"{metric_name}-{task_names[0]}|window_{metric_name}"],
+        torch.testing.assert_close(
+            test_metrics[1][task_names[0]].squeeze(),
+            res[f"{metric_name}-{task_names[0]}|window_{metric_name}"].squeeze(),
+            rtol=1e-05,
+            atol=1e-08,
         )
 
 
@@ -708,29 +716,37 @@ def metric_test_helper(
                 and target_clazz != AUPRCMetric
                 and target_clazz != RAUCMetric
             ):
-                assert torch.allclose(
+                torch.testing.assert_close(
                     target_metrics[
                         f"{str(target_clazz._namespace)}-{name}|lifetime_{metric_name}"
-                    ],
-                    test_metrics[0][name],
+                    ].squeeze(),
+                    test_metrics[0][name].squeeze(),
+                    rtol=1e-05,
+                    atol=1e-08,
                 )
-                assert torch.allclose(
+                torch.testing.assert_close(
                     target_metrics[
                         f"{str(target_clazz._namespace)}-{name}|local_lifetime_{metric_name}"
-                    ],
-                    test_metrics[2][name],
+                    ].squeeze(),
+                    test_metrics[2][name].squeeze(),
+                    rtol=1e-05,
+                    atol=1e-08,
                 )
-            assert torch.allclose(
+            torch.testing.assert_close(
                 target_metrics[
                     f"{str(target_clazz._namespace)}-{name}|window_{metric_name}"
-                ],
-                test_metrics[1][name],
+                ].squeeze(),
+                test_metrics[1][name].squeeze(),
+                rtol=1e-05,
+                atol=1e-08,
             )
 
-            assert torch.allclose(
+            torch.testing.assert_close(
                 target_metrics[
                     f"{str(target_clazz._namespace)}-{name}|local_window_{metric_name}"
-                ],
-                test_metrics[3][name],
+                ].squeeze(),
+                test_metrics[3][name].squeeze(),
+                rtol=1e-05,
+                atol=1e-08,
             )
     dist.destroy_process_group()

--- a/torchrec/metrics/tests/test_rauc.py
+++ b/torchrec/metrics/tests/test_rauc.py
@@ -175,7 +175,7 @@ class RAUCMetricValueTest(unittest.TestCase):
         expected_rauc = torch.tensor([1], dtype=torch.float)
         self.rauc.update(**self.batches)
         actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
-        assert torch.allclose(expected_rauc, actual_rauc)
+        torch.testing.assert_close(expected_rauc, actual_rauc, rtol=1e-05, atol=1e-08)
 
     def test_calc_rauc_zero(self) -> None:
         self.predictions["DefaultTask"] = torch.Tensor(
@@ -189,7 +189,7 @@ class RAUCMetricValueTest(unittest.TestCase):
         expected_rauc = torch.tensor([0], dtype=torch.float)
         self.rauc.update(**self.batches)
         actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
-        assert torch.allclose(expected_rauc, actual_rauc)
+        torch.testing.assert_close(expected_rauc, actual_rauc, rtol=1e-05, atol=1e-08)
 
     def test_calc_rauc_random(self) -> None:
         self.predictions["DefaultTask"] = torch.Tensor([[1, 2, 3, 4]])
@@ -199,7 +199,7 @@ class RAUCMetricValueTest(unittest.TestCase):
         expected_rauc = torch.tensor([2.0 / 3], dtype=torch.float)
         self.rauc.update(**self.batches)
         actual_rauc = self.rauc.compute()["rauc-DefaultTask|window_rauc"]
-        assert torch.allclose(expected_rauc, actual_rauc)
+        torch.testing.assert_close(expected_rauc, actual_rauc, rtol=1e-05, atol=1e-08)
 
     def test_window_size_rauc(self) -> None:
         # for determinisitc batches
@@ -230,9 +230,10 @@ class RAUCMetricValueTest(unittest.TestCase):
         # with bs 5, we expect 20 tensors per state, so 60 tensors
         self.assertEqual(len(rauc.get_memory_usage().values()), 60)
 
-        assert torch.allclose(
+        torch.testing.assert_close(
             rauc.compute()["rauc-DefaultTask|window_rauc"],
             torch.tensor([0.5152], dtype=torch.float),
+            rtol=1e-05,
             atol=1e-4,
         )
 
@@ -256,9 +257,10 @@ class RAUCMetricValueTest(unittest.TestCase):
         self.assertEqual(sum(rauc.get_memory_usage().values()), 1200)
         self.assertEqual(len(rauc.get_memory_usage().values()), 3)
 
-        assert torch.allclose(
+        torch.testing.assert_close(
             rauc.compute()["rauc-DefaultTask|window_rauc"],
             torch.tensor([0.5508], dtype=torch.float),
+            rtol=1e-05,
             atol=1e-4,
         )
 

--- a/torchrec/quant/tests/test_tensor_types.py
+++ b/torchrec/quant/tests/test_tensor_types.py
@@ -33,10 +33,10 @@ class QuantUtilsTest(unittest.TestCase):
         t_u4.detach()
 
         t_u4.to(torch.device("cuda"))
-        assert torch.equal(t_u4.view(torch.uint8), t_u8)
+        torch.testing.assert_close(t_u4.view(torch.uint8), t_u8, rtol=0, atol=0)
         t_u2 = UInt2Tensor(t_u8)
         t_u2.to(torch.device("cuda"))
-        assert torch.equal(t_u2.view(torch.uint8), t_u8)
+        torch.testing.assert_close(t_u2.view(torch.uint8), t_u8, rtol=0, atol=0)
 
         for t in [t_u4[:, :8], t_u4[:, 8:]]:
             self.assertEqual(t.size(1), 8)


### PR DESCRIPTION
Summary:
Bare `assert torch.equal(...)` and `assert torch.allclose(...)` statements produce minimal error messages on failure (just `AssertionError` with no tensor comparison details). This change replaces them with `torch.testing.assert_close(...)` which provides rich diagnostics including shape, dtype, device, max absolute/relative difference, and mismatched element counts.

- `assert torch.equal(a, b)` → `torch.testing.assert_close(a, b, rtol=0, atol=0)` (preserves exact-match semantics)
- `assert torch.allclose(a, b)` → `torch.testing.assert_close(a, b, rtol=1e-05, atol=1e-08)` (preserves default tolerances)
- Assertion messages (`, f"..."`) are dropped since `assert_close` provides better diagnostics automatically
- 47 replacements across 12 files

Stacked on D96070807.

Differential Revision: D96071384
