### PR TITLE
Suppress pyrefly type errors in feed and torchrec targets

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_zch/models/models/dlrmv3.py
+++ b/torchrec/distributed/benchmark/benchmark_zch/models/models/dlrmv3.py
@@ -100,6 +100,7 @@ class DLRMv3(nn.Module):
         # convert the predictions to [batch_size, ]
         mt_target_preds = mt_target_preds.squeeze()
         # return the loss and the predictions
+        # pyrefly: ignore [bad-return]
         return sum(aux_losses.values()), (
             aux_losses,
             mt_target_preds.detach(),

--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -574,6 +574,7 @@ class ModelInput(Pipelineable):
             # Resample any out-of-bounds values
             mask = indices >= num_embeddings
             while mask.any():
+                # pyrefly: ignore [no-matching-overload]
                 u_new = torch.rand(mask.sum(), device=device).clamp(1e-10, 1 - 1e-10)
                 indices[mask] = ((1 - u_new) ** exponent - 1).long()
                 mask = indices >= num_embeddings

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -550,6 +550,7 @@ class ModelInput(Pipelineable):
             # Resample any out-of-bounds values
             mask = indices >= num_embeddings
             while mask.any():
+                # pyrefly: ignore [no-matching-overload]
                 u_new = torch.rand(mask.sum(), device=device).clamp(1e-10, 1 - 1e-10)
                 indices[mask] = ((1 - u_new) ** exponent - 1).long()
                 mask = indices >= num_embeddings


### PR DESCRIPTION
Summary: Add pyrefly ignore comments to suppress type errors across instagram/feed, torchrec/distributed, and torchrec/fb/feed/modules/peft targets.

Reviewed By: grievejia

Differential Revision: D96148401


