### PR TITLE
Add EmainplaceRowWiseAdagrad optimizer and preserve explicit optimizer type during DMP sharding

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -267,7 +267,9 @@ def create_sharding_infos_by_sharding_device_group(
 
         optimizer_class = optimizer_classes[0]
         optimizer_params = optimizer_params[0]
-        if optimizer_class:
+        # Only derive optimizer type from class if not already explicitly set
+        # (e.g., EmainplaceRowwiseAdagradConfig sets it explicitly in fused_params)
+        if optimizer_class and "optimizer" not in optimizer_params:
             optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
                 optimizer_class
             )
@@ -854,7 +856,9 @@ class ShardedEmbeddingBagCollection(
 
             optimizer_class = optimizer_classes[0]
             optimizer_params = optimizer_params[0]
-            if optimizer_class:
+            # Only derive optimizer type from class if not already explicitly set
+            # (e.g., EmainplaceRowwiseAdagradConfig sets it explicitly in fused_params)
+            if optimizer_class and "optimizer" not in optimizer_params:
                 optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(
                     optimizer_class
                 )


### PR DESCRIPTION
Summary:
Preserve explicit optimizer type in fused_params during DMP sharding.

**Why this change is necessary:**
Without this fix, the TorchRec sharding layer always overwrites the optimizer type based on the optimizer class. When APF's EmainplaceRowwiseAdagradConfig sets fused_params["optimizer"] = EMAINPLACE_ROWWISE_ADAGRAD explicitly, TorchRec would overwrite it to EXACT_ROWWISE_ADAGRAD (derived from the RowWiseAdagrad class), causing EMAINPLACE sparse sync to silently fail.

**The fix:**
Only derive optimizer type from the optimizer class if not already explicitly set in optimizer_params:
```python
# Before (always overwrites):
if optimizer_class:
    optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(optimizer_class)

# After (preserves explicit setting):
if optimizer_class and "optimizer" not in optimizer_params:
    optimizer_params["optimizer"] = optimizer_type_to_emb_opt_type(optimizer_class)
```

This allows EMAINPLACE_ROWWISE_ADAGRAD to flow through correctly during sharding.

Differential Revision: D96198738


