### PR TITLE
Unify hash_mc_evictions.py (#3866)

### DIFF
--- a/torchrec/modules/hash_mc_evictions.py
+++ b/torchrec/modules/hash_mc_evictions.py
@@ -64,8 +64,8 @@ class HashZchEvictionScorer:
 class HashZchSingleTtlScorer(HashZchEvictionScorer):
     def gen_score(self, feature: JaggedTensor, device: torch.device) -> torch.Tensor:
         assert (
-            self._config.single_ttl is not None and self._config.single_ttl > 0
-        ), "To use scorer HashZchSingleTtlScorer, a positive single_ttl is required."
+            self._config.single_ttl is not None
+        ), "To use scorer HashZchSingleTtlScorer, a single_ttl is required."
 
         return torch.full_like(
             feature.values(),


### PR DESCRIPTION
Summary:

Context
---------

This diff stack is meant to unify different MP-ZCH implementations into OSS.

The goal is to remove hash_mc_evictions to unify internal with OSS.

Implementation
------------------

- The only difference between internal and OSS, is one assertion statement.
    - Internal has the newer assertion: `self._config.single_ttl is not None` 
    - OSS has the older assertion: ` self._config.single_ttl is not None and self._config.single_ttl > 0`
- Inside Internal:
    - Added a simple depreciated warning, and imported from OSS, in this case.
    - Removed the internal tests: `fb/modules/tests/test_hash_mc_evictions.py`
- Changed all internal imports for fb/ within TREC to be OSS.
    - External imports will be removed in a seperate diff

NOTE: Internal is imported in over 100 different places inside fbcode, these aren't touched.

Reviewed By: kausv

Differential Revision: D96242594


