### PR TITLE
Replace remaining assertTrue(torch.equal(...)) with torch.testing.assert_close (#3869)

### DIFF
--- a/torchrec/modules/tests/test_embedding_modules.py
+++ b/torchrec/modules/tests/test_embedding_modules.py
@@ -291,14 +291,23 @@ class EmbeddingCollectionTest(unittest.TestCase):
         sequence_embeddings = ec(
             features=id_list_features,
         )
-        self.assertTrue(
-            torch.equal(sequence_embeddings["f1"].weights(), torch.tensor([0, 1, 2]))
+        torch.testing.assert_close(
+            sequence_embeddings["f1"].weights(),
+            torch.tensor([0, 1, 2]),
+            rtol=0,
+            atol=0,
         )
-        self.assertTrue(
-            torch.equal(sequence_embeddings["f2@t1"].weights(), torch.tensor([3]))
+        torch.testing.assert_close(
+            sequence_embeddings["f2@t1"].weights(),
+            torch.tensor([3]),
+            rtol=0,
+            atol=0,
         )
-        self.assertTrue(
-            torch.equal(sequence_embeddings["f2@t2"].weights(), torch.tensor([3]))
+        torch.testing.assert_close(
+            sequence_embeddings["f2@t2"].weights(),
+            torch.tensor([3]),
+            rtol=0,
+            atol=0,
         )
 
     def test_fx(self) -> None:

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -1334,19 +1334,28 @@ class TestVBEWithManagedCollision(unittest.TestCase):
                     i
                 ] : kjt_with_weights.offset_per_key()[i + 1]
             ]
-            self.assertTrue(
-                torch.equal(original_inds, mapping[remapped_inds]),
-                f"ID remapping incorrect for {table}",
+            torch.testing.assert_close(
+                original_inds,
+                mapping[remapped_inds],
+                rtol=0,
+                atol=0,
+                msg=f"ID remapping incorrect for {table}",
             )
 
         # Verify all other attributes (relevant to VBE) are preserved
-        self.assertTrue(
-            torch.equal(kjt_with_weights.lengths(), output.lengths()),
-            "Lengths should be preserved",
+        torch.testing.assert_close(
+            kjt_with_weights.lengths(),
+            output.lengths(),
+            rtol=0,
+            atol=0,
+            msg="Lengths should be preserved",
         )
-        self.assertTrue(
-            torch.equal(kjt_with_weights.weights(), output.weights()),
-            "Weights should be preserved",
+        torch.testing.assert_close(
+            kjt_with_weights.weights(),
+            output.weights(),
+            rtol=0,
+            atol=0,
+            msg="Weights should be preserved",
         )
         self.assertEqual(
             kjt_with_weights.stride(), output.stride(), "Stride should be preserved"
@@ -1371,9 +1380,12 @@ class TestVBEWithManagedCollision(unittest.TestCase):
             output_inverse_indices[0],
             "inverse_indices keys should be preserved",
         )
-        self.assertTrue(
-            torch.equal(input_inverse_indices[1], output_inverse_indices[1]),
-            "inverse_indices tensor should be preserved",
+        torch.testing.assert_close(
+            input_inverse_indices[1],
+            output_inverse_indices[1],
+            rtol=0,
+            atol=0,
+            msg="inverse_indices tensor should be preserved",
         )
 
     def test_mcebc_with_vbe(self) -> None:

--- a/torchrec/optim/tests/test_semi_sync.py
+++ b/torchrec/optim/tests/test_semi_sync.py
@@ -172,11 +172,11 @@ class TestSemisyncOptimizer(unittest.TestCase):
         self.assertEqual(set(param_state.keys()), expected_keys)
 
         # Verify exact tensor values
-        self.assertTrue(
-            torch.equal(param_state["semi_sync_local_momentum"], local_momentum)
+        torch.testing.assert_close(
+            param_state["semi_sync_local_momentum"], local_momentum, rtol=0, atol=0
         )
-        self.assertTrue(
-            torch.equal(param_state["semi_sync_global_momentum"], global_momentum)
+        torch.testing.assert_close(
+            param_state["semi_sync_global_momentum"], global_momentum, rtol=0, atol=0
         )
 
         # Verify step counters
@@ -319,8 +319,11 @@ class TestSemisyncOptimizer(unittest.TestCase):
                     for key in case["expected_keys"]:
                         # pyrefly: ignore [unsupported-operation]
                         original_key = case["prefix"] + key
-                        self.assertTrue(
-                            torch.equal(result[key], param_state[original_key])
+                        torch.testing.assert_close(
+                            result[key],
+                            param_state[original_key],
+                            rtol=0,
+                            atol=0,
                         )
 
 


### PR DESCRIPTION
Summary:

Convert remaining assertTrue(torch.equal(...)), assertEqual(torch.equal(...), True),
and equal=torch.equal(...);assertTrue(equal) patterns to torch.testing.assert_close
for better error diagnostics on test failures. Also fixes torch.torch.equal typos.

Differential Revision: D96260260
