### PR TITLE
Prefetch pipeline work with feature preprocessing SEV S582283 (#3870)

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1903,6 +1903,34 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             else None
         )
         self._batch_ip3: Optional[In] = None
+        self._staged_postproc_fwd_results: Dict[str, Any] = {}
+
+    def _start_sparse_data_dist(self, batch: Optional[In]) -> None:
+        """
+        Override to use a staging context for postprocs, preventing
+        postproc_fwd_results cache contamination in the shared v0 context.
+        """
+        if batch is None:
+            return
+        self._set_module_context(self._context)
+        staging_context = PrefetchTrainPipelineContext(version=0)
+        with record_function("## start_sparse_data_dist ##"):
+            # pyrefly: ignore [bad-argument-type]
+            with self._stream_context(self._data_dist_stream):
+                _wait_for_batch(batch, self._memcpy_stream)
+                with use_context_for_postprocs(
+                    self._pipelined_postprocs, staging_context
+                ):
+                    _start_data_dist(self._pipelined_modules, batch, self._context)
+        self._staged_postproc_fwd_results = staging_context.postproc_fwd_results
+
+    def _commit_postproc_results(self) -> None:
+        """
+        Swap staged postproc results into the live context so forward reads
+        the correct batch's postproc results.
+        """
+        self._context.postproc_fwd_results = self._staged_postproc_fwd_results
+        self._staged_postproc_fwd_results = {}
 
     def _fill_pipeline(self, dataloader_iter: Iterator[In]) -> None:
         """
@@ -1938,6 +1966,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         )
         self._start_sparse_data_dist(self._batch_i)
         self._wait_sparse_data_dist()
+        self._commit_postproc_results()
         self._prefetch(self._batch_i)
 
         # batch 2
@@ -1981,6 +2010,8 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         # forward
         with record_function("## forward ##"):
             losses, output = self._model_fwd(self._batch_i)
+
+        self._commit_postproc_results()
 
         self._prefetch(self._batch_ip1)
 


### PR DESCRIPTION
Summary:

Context
--------

We have recently resolved the difficult NE regression issue regarding SEV S582283 regarding Ads OBA model. This has recently affected other MRS models, and brought the issue into more attention.

The issue of NE regression was found to be due to two reasons: pre-emption (related to S588656), and feature preprocessing. One has to be careful to control for pre-emption when analyzing difficult NE regressions. Once controlled, it took around 10+jobs to pinpoint exactly the issue, testing across GPU type, compute kernels (e.g. UVM, UVM_CACHING), and pipeline. It was ultimately found to be due to prefetch pipeline inability to store the cache for feature pre-processing.

Sparse-dist and Ads customized-order-sparse-dist pipeline do not have these issues, since they use the newer v1 context management. However, going through diff history, it was found that Prefetch pipeline was later reverted to v0 D57143337, due to memory regressions.

This diff is meant to quickly unblock, but further investigation is needed to determine which is the better pipeline to use. We found conflicting result of which is better to use, and decided to stick with the original v0 solution with the minimal amounts of code and blast radius to quickly unblock model owners.

See the doc for the full analysis and investigation into this SEV.

Implementation
------------------

This solution stores the postproc into a seperate context then stages them into the actual context before forward/backward.  The start_sparse_dist is effectively ported over inside Prefetch Pipeline

Reviewed By: spmex, ahmed-shuaibi

Differential Revision: D95972107


