### PR TITLE
Reland: Embedding Memory Stashing — Onboarding Guide (#3871)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -1,0 +1,65 @@
+# Embedding weight stashing benchmark config
+# Based on sparse_data_dist_base.yml with stash_weights on selected tables.
+# large_table has stash_weights: true, FP16_table does not — verifies
+# that only marked tables have weights moved from HBM to CPU after forward.
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_emb_stash"
+  memory_snapshot: True
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse-emb-stash"
+  kwargs:
+    site_fqn: "over.overarch.0"  # dense
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  stash_weights: true
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+      - name: large_table_no_stash
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_2"]
+        stash_weights: false
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]
+    large_table_no_stash:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -54,6 +54,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sequence_sharding import (
     CwSequenceEmbeddingSharding,
 )
@@ -1623,6 +1624,11 @@ class ShardedEmbeddingCollection(
                 EmbeddingEvent.LOOKUP, self._module_fqn, sharding_type
             ):
                 embs = lookup(features)
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore[not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -55,6 +55,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sharding import CwPooledEmbeddingSharding
 from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
 from torchrec.distributed.sharding.dynamic_sharding import (
@@ -1868,6 +1869,11 @@ class ShardedEmbeddingBagCollection(
                 if hasattr(lookup, "wait_for_forward"):
                     # pyre-ignore[29]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.logger import capped_logger, one_time_rank0_logger
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ class MemoryStashingManager:
         return cls._device_to_host_stream
 
     @classmethod
+    def is_enabled(cls) -> bool:
+        """Return whether memory stashing streams have been initialized."""
+        return cls._device_to_host_stream is not None
+
+    @classmethod
     def set_streams(
         cls,
         host_to_device_stream: Optional[torch.cuda.Stream] = None,
@@ -79,11 +85,13 @@ class MemoryStashingManager:
             cls._device_to_host_stream = host_to_device_stream
         else:
             cls._device_to_host_stream = device_to_host_stream
+        logger.info("MemoryStashingManager: streams initialized")
         one_time_rank0_logger.info("MemoryStashingManager: streams initialized")
 
     @classmethod
     def reset(cls) -> None:
         """Release all resources."""
+        logger.info("MemoryStashingManager: resetting all resources")
         cls._host_to_device_stream = None
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
@@ -270,9 +278,11 @@ class MemoryStashingManager:
     def stash_embedding_weights(
         cls,
         lookup: nn.Module,
-    ) -> Tuple[
-        Callable[[Optional[torch.Tensor]], None],
-        Callable[[Optional[torch.Tensor]], None],
+    ) -> Optional[
+        Tuple[
+            Callable[[Optional[torch.Tensor]], None],
+            Callable[[Optional[torch.Tensor]], None],
+        ]
     ]:
         """
         Stash embedding weights from HBM to CPU asynchronously.
@@ -288,7 +298,7 @@ class MemoryStashingManager:
                 embedding modules with weights to stash.
 
         Returns:
-            A tuple of two callback functions:
+            A tuple of two callback functions, or None if no tensors were stashed:
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
 
@@ -314,13 +324,24 @@ class MemoryStashingManager:
             capped_logger.info(
                 "stash_embedding_weights: no _emb_modules found, skipping"
             )
-            return lambda _grad: None, lambda _grad: None
+            return None
 
-        # Collect CUDA embedding weight tensors
+        # Collect CUDA embedding weight tensors from TBE groups marked for stashing
         tensors: List[torch.Tensor] = []
         for emb_module in module._emb_modules:
             if not hasattr(emb_module, "_emb_module"):
                 continue
+            # Check if this TBE group is marked for stashing via per-table config.
+            # If _config is a GroupedEmbeddingConfig, only stash TBEs where at
+            # least one table has stash_weights=True. Otherwise (e.g., in tests
+            # with mock objects), stash all TBEs.
+            config = getattr(emb_module, "_config", None)
+            if isinstance(config, GroupedEmbeddingConfig):
+                should_stash = any(
+                    getattr(t, "stash_weights", False) for t in config.embedding_tables
+                )
+                if not should_stash:
+                    continue
             inner = emb_module._emb_module
             if not hasattr(inner, "weights_dev"):
                 continue
@@ -334,6 +355,9 @@ class MemoryStashingManager:
             f"module={type(module).__name__}, "
             f"collected {len(tensors)} weight tensors"
         )
+
+        if not tensors:
+            return None
 
         await_restore, restore = cls._stash_tensors(tensors, label="embedding")
         cls._embedding_weight_restore_callbacks.append(restore)

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -143,6 +143,10 @@ class EmbeddingTablesConfig:
     table_data_type: DataType = DataType.FP32
     total_num_buckets: Optional[int] = None
     additional_tables: List[List[Dict[str, Any]]] = field(default_factory=list)
+
+    # Default for all tables; per-table overrides in additional_tables
+    stash_weights: bool = False
+
     # ManagedCollision configs for all tables
     mc_config: Optional[ManagedCollisionConfig] = None  # Default for all tables
     mc_configs_per_table: Dict[str, ManagedCollisionConfig] = field(
@@ -180,6 +184,10 @@ class EmbeddingTablesConfig:
 
         # Remove all keys that are not part of EmbeddingBagConfig
         kwargs.pop("location", None)
+
+        # Apply global stash_weights default if not set per-table
+        if "stash_weights" not in kwargs:
+            kwargs["stash_weights"] = self.stash_weights
 
         # Support EmbeddingConfig via config_class field
         if "config_class" in kwargs:
@@ -221,6 +229,7 @@ class EmbeddingTablesConfig:
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_unweighted_features)
         ]
@@ -231,6 +240,7 @@ class EmbeddingTablesConfig:
                 name="weighted_table_" + str(i),
                 feature_names=["weighted_feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_weighted_features)
         ]

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -9,7 +9,7 @@
 
 import unittest
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
 import torch
@@ -132,7 +132,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify HBM is freed
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -159,7 +161,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([weights_1, weights_2, weights_3])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify all are stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)
@@ -188,7 +192,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify stash worked
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -214,7 +220,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         output = torch.matmul(x, weights.t())
 
         # Stash and restore
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
@@ -254,7 +262,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Only CUDA weights should be stashed
         self.assertEqual(cuda_weights.untyped_storage().size(), 0)
@@ -290,7 +300,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Valid weights should be stashed
         self.assertEqual(valid_weights.untyped_storage().size(), 0)
@@ -314,7 +326,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         x = torch.randn(3, 5, device=self.device, requires_grad=True)
         output = torch.matmul(x, weights.t())
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Register restore via class method and await_restore as backward hook
         output.register_hook(
@@ -329,6 +343,12 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         torch.testing.assert_close(weights, original_values, rtol=1e-05, atol=1e-08)
+
+    def test_is_enabled(self) -> None:
+        """Test is_enabled reflects stream initialization state."""
+        self.assertTrue(MemoryStashingManager.is_enabled())
+        MemoryStashingManager.reset()
+        self.assertFalse(MemoryStashingManager.is_enabled())
 
 
 class TestStashOptimizerState(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -63,6 +63,7 @@ class InjectionSite:
     """
 
     fqn: str
+    use_output_tensor: bool = True
 
     def find_target_module(self, model: nn.Module) -> Optional[nn.Module]:
         """
@@ -140,7 +141,10 @@ def register_backward_hook(
         input: Any,
         output: Any,
     ) -> None:
-        tensor = site.find_grad_tensor(output)
+        if site.use_output_tensor:
+            tensor = site.find_grad_tensor(output)
+        else:
+            tensor = site.find_grad_tensor(input)
         if tensor is None:
             raise RuntimeError(
                 f"register_hook: no grad-requiring tensor in "

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -367,6 +367,8 @@ class BaseEmbeddingConfig:
             for number embedding memory for virtual table is dynamic and only materialized when
             id is trained this needs to be paired with SSD/DRAM Virtual talbe in EmbeddingComputeKernel
         virtual_table_eviction_policy (Optional[VirtualTableEvictionPolicy]): eviction policy for virtual table.
+        enable_embedding_update (bool): whether to enable embedding update.
+        stash_weights (bool): whether to stash weights.
     """
 
     num_embeddings: int
@@ -389,6 +391,7 @@ class BaseEmbeddingConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
 
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:

--- a/torchrec/schema/api_tests/test_embedding_config_schema.py
+++ b/torchrec/schema/api_tests/test_embedding_config_schema.py
@@ -43,6 +43,7 @@ class StableEmbeddingBagConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
     pooling: PoolingType = PoolingType.SUM
 
 


### PR DESCRIPTION
Summary:

Reland of D94770461 which was reverted by D96335092.

The revert was caused by 4 module stability tests in `aps_models/` that explicitly enumerate every field of `EmbeddingTableConfig` (which inherits `BaseEmbeddingConfig`). The original diff added `stash_weights: bool = False` to `BaseEmbeddingConfig`, which propagates to `EmbeddingTableConfig`. The stability tests construct `EmbeddingTableStabilityConfig` by listing every dataclass field — the missing `stash_weights` field caused them to fail.

This reland includes the fix: added `stash_weights=SimpleStrategy(
use_field_default_as_first_value=True)` to all 4 affected stability tests:
- split_pooled_embedding_arch_stability_tests/group_based_split_pooled_embedding_arch_test.py
- split_pooled_embedding_arch_stability_tests/request_only_split_pooled_embedding_stability_test.py
- split_pooled_embedding_arch_stability_tests/split_pooled_embedding_stability_test.py
- split_pooled_embedding_non_kjt_stability_tests/group_based_split_pooled_embedding_stability_test.py

Differential Revision: D96357043


