### PR TITLE
Reland: prototype embedding stashing for EBC

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -1,0 +1,65 @@
+# Embedding weight stashing benchmark config
+# Based on sparse_data_dist_base.yml with stash_weights on selected tables.
+# large_table has stash_weights: true, FP16_table does not — verifies
+# that only marked tables have weights moved from HBM to CPU after forward.
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_emb_stash"
+  memory_snapshot: True
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse-emb-stash"
+  kwargs:
+    site_fqn: "over.overarch.0"  # dense
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  stash_weights: true
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+      - name: large_table_no_stash
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_2"]
+        stash_weights: false
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]
+    large_table_no_stash:
+      sharding_types: [column_wise]

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -54,6 +54,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sequence_sharding import (
     CwSequenceEmbeddingSharding,
 )
@@ -1623,6 +1624,11 @@ class ShardedEmbeddingCollection(
                 EmbeddingEvent.LOOKUP, self._module_fqn, sharding_type
             ):
                 embs = lookup(features)
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore[not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -255,6 +255,7 @@ def create_sharding_infos_by_sharding_device_group(
                         total_num_buckets=config.total_num_buckets,
                         use_virtual_table=config.use_virtual_table,
                         virtual_table_eviction_policy=config.virtual_table_eviction_policy,
+                        stash_weights=getattr(config, "stash_weights", False),
                     ),
                     param_sharding=parameter_sharding,
                     param=param,

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -567,6 +567,7 @@ def group_tables(
                 _prefetch_and_cached(table),
                 table.use_virtual_table if is_inference else None,
                 table.enable_embedding_update,
+                table.stash_weights,
             )
             # micromanage the order of we traverse the groups to ensure backwards compatibility
             if grouping_key not in groups:
@@ -584,6 +585,7 @@ def group_tables(
                 _,
                 use_virtual_table,
                 enable_embedding_update,
+                _,
             ) = grouping_key
             grouped_tables = groups[grouping_key]
             # remove non-native fused params

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -316,6 +316,7 @@ def create_sharding_infos_by_sharding_device_group(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
+                    stash_weights=getattr(config, "stash_weights", False),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -55,6 +55,7 @@ from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_SSD_TABLE,
     FUSED_PARAM_SSD_TABLE_LIST,
 )
+from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.sharding.cw_sharding import CwPooledEmbeddingSharding
 from torchrec.distributed.sharding.dp_sharding import DpPooledEmbeddingSharding
 from torchrec.distributed.sharding.dynamic_sharding import (
@@ -1868,6 +1869,11 @@ class ShardedEmbeddingBagCollection(
                 if hasattr(lookup, "wait_for_forward"):
                     # pyre-ignore[29]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
+                if MemoryStashingManager.is_enabled():
+                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    if stash_result is not None:
+                        await_restore, _ = stash_result
+                        embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]
                     resize_awaitables.extend(lookup.get_resize_awaitables())

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.logger import capped_logger, one_time_rank0_logger
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -68,6 +69,11 @@ class MemoryStashingManager:
         return cls._device_to_host_stream
 
     @classmethod
+    def is_enabled(cls) -> bool:
+        """Return whether memory stashing streams have been initialized."""
+        return cls._device_to_host_stream is not None
+
+    @classmethod
     def set_streams(
         cls,
         host_to_device_stream: Optional[torch.cuda.Stream] = None,
@@ -79,11 +85,13 @@ class MemoryStashingManager:
             cls._device_to_host_stream = host_to_device_stream
         else:
             cls._device_to_host_stream = device_to_host_stream
+        logger.info("MemoryStashingManager: streams initialized")
         one_time_rank0_logger.info("MemoryStashingManager: streams initialized")
 
     @classmethod
     def reset(cls) -> None:
         """Release all resources."""
+        logger.info("MemoryStashingManager: resetting all resources")
         cls._host_to_device_stream = None
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
@@ -270,9 +278,11 @@ class MemoryStashingManager:
     def stash_embedding_weights(
         cls,
         lookup: nn.Module,
-    ) -> Tuple[
-        Callable[[Optional[torch.Tensor]], None],
-        Callable[[Optional[torch.Tensor]], None],
+    ) -> Optional[
+        Tuple[
+            Callable[[Optional[torch.Tensor]], None],
+            Callable[[Optional[torch.Tensor]], None],
+        ]
     ]:
         """
         Stash embedding weights from HBM to CPU asynchronously.
@@ -288,7 +298,7 @@ class MemoryStashingManager:
                 embedding modules with weights to stash.
 
         Returns:
-            A tuple of two callback functions:
+            A tuple of two callback functions, or None if no tensors were stashed:
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
 
@@ -314,13 +324,24 @@ class MemoryStashingManager:
             capped_logger.info(
                 "stash_embedding_weights: no _emb_modules found, skipping"
             )
-            return lambda _grad: None, lambda _grad: None
+            return None
 
-        # Collect CUDA embedding weight tensors
+        # Collect CUDA embedding weight tensors from TBE groups marked for stashing
         tensors: List[torch.Tensor] = []
         for emb_module in module._emb_modules:
             if not hasattr(emb_module, "_emb_module"):
                 continue
+            # Check if this TBE group is marked for stashing via per-table config.
+            # If _config is a GroupedEmbeddingConfig, only stash TBEs where at
+            # least one table has stash_weights=True. Otherwise (e.g., in tests
+            # with mock objects), stash all TBEs.
+            config = getattr(emb_module, "_config", None)
+            if isinstance(config, GroupedEmbeddingConfig):
+                should_stash = any(
+                    getattr(t, "stash_weights", False) for t in config.embedding_tables
+                )
+                if not should_stash:
+                    continue
             inner = emb_module._emb_module
             if not hasattr(inner, "weights_dev"):
                 continue
@@ -334,6 +355,9 @@ class MemoryStashingManager:
             f"module={type(module).__name__}, "
             f"collected {len(tensors)} weight tensors"
         )
+
+        if not tensors:
+            return None
 
         await_restore, restore = cls._stash_tensors(tensors, label="embedding")
         cls._embedding_weight_restore_callbacks.append(restore)

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -230,6 +230,7 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         num_embeddings_post_pruning=info.embedding_config.num_embeddings_post_pruning,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -93,6 +93,7 @@ class BaseDpEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
         return tables_per_rank

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -277,6 +277,7 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_max=info.embedding_config.weight_init_max,
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -231,6 +231,7 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         use_virtual_table=info.embedding_config.use_virtual_table,
                         virtual_table_eviction_policy=info.embedding_config.virtual_table_eviction_policy,
                         enable_embedding_update=info.embedding_config.enable_embedding_update,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
         return tables_per_rank

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -185,6 +185,7 @@ class BaseTwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                     fused_params=info.fused_params,
                     num_embeddings_post_pruning=info.embedding_config.num_embeddings_post_pruning,
                     use_virtual_table=info.embedding_config.use_virtual_table,
+                    stash_weights=info.embedding_config.stash_weights,
                 )
             )
         return tables_per_rank

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -202,6 +202,7 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         weight_init_min=info.embedding_config.weight_init_min,
                         fused_params=info.fused_params,
                         use_virtual_table=info.embedding_config.use_virtual_table,
+                        stash_weights=info.embedding_config.stash_weights,
                     )
                 )
 

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -143,6 +143,10 @@ class EmbeddingTablesConfig:
     table_data_type: DataType = DataType.FP32
     total_num_buckets: Optional[int] = None
     additional_tables: List[List[Dict[str, Any]]] = field(default_factory=list)
+
+    # Default for all tables; per-table overrides in additional_tables
+    stash_weights: bool = False
+
     # ManagedCollision configs for all tables
     mc_config: Optional[ManagedCollisionConfig] = None  # Default for all tables
     mc_configs_per_table: Dict[str, ManagedCollisionConfig] = field(
@@ -180,6 +184,10 @@ class EmbeddingTablesConfig:
 
         # Remove all keys that are not part of EmbeddingBagConfig
         kwargs.pop("location", None)
+
+        # Apply global stash_weights default if not set per-table
+        if "stash_weights" not in kwargs:
+            kwargs["stash_weights"] = self.stash_weights
 
         # Support EmbeddingConfig via config_class field
         if "config_class" in kwargs:
@@ -221,6 +229,7 @@ class EmbeddingTablesConfig:
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_unweighted_features)
         ]
@@ -231,6 +240,7 @@ class EmbeddingTablesConfig:
                 name="weighted_table_" + str(i),
                 feature_names=["weighted_feature_" + str(i)],
                 data_type=self.table_data_type,
+                stash_weights=self.stash_weights,
             )
             for i in range(self.num_weighted_features)
         ]

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -14,7 +14,13 @@ from unittest.mock import Mock
 
 import torch
 from torch import nn
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
 from torchrec.distributed.memory_stashing import MemoryStashingManager
+from torchrec.modules.embedding_configs import DataType, PoolingType
 
 
 class TestStashTensors(unittest.TestCase):
@@ -111,14 +117,49 @@ class TestStashEmbeddingWeights(unittest.TestCase):
     def tearDown(self) -> None:
         MemoryStashingManager.reset()
 
-    def _create_mock_lookup(self, weights_list: List[torch.Tensor]) -> Mock:
-        """Helper to create a mock lookup with multiple embedding modules."""
+    def _create_mock_lookup(
+        self,
+        weights_list: List[torch.Tensor],
+        stash_weights_list: Optional[List[bool]] = None,
+    ) -> Mock:
+        """Helper to create a mock lookup with multiple embedding modules.
+
+        Args:
+            weights_list: List of weight tensors, one per TBE group.
+            stash_weights_list: If provided, sets _config to a
+                GroupedEmbeddingConfig with a single ShardedEmbeddingTable
+                per group whose stash_weights matches this list. If None,
+                no _config is set (backward-compatible: stash everything).
+        """
         emb_modules = []
-        for weights in weights_list:
+        for i, weights in enumerate(weights_list):
             inner = Mock()
             inner.weights_dev = weights
             emb_module = Mock()
             emb_module._emb_module = inner
+            if stash_weights_list is not None:
+                emb_module._config = GroupedEmbeddingConfig(
+                    data_type=DataType.FP32,
+                    pooling=PoolingType.SUM,
+                    is_weighted=False,
+                    has_feature_processor=False,
+                    compute_kernel=EmbeddingComputeKernel.FUSED,
+                    embedding_tables=[
+                        ShardedEmbeddingTable(
+                            num_embeddings=weights.shape[0],
+                            embedding_dim=weights.shape[1],
+                            name=f"table_{i}",
+                            feature_names=[f"feature_{i}"],
+                            pooling=PoolingType.SUM,
+                            is_weighted=False,
+                            has_feature_processor=False,
+                            compute_kernel=EmbeddingComputeKernel.FUSED,
+                            local_rows=weights.shape[0],
+                            local_cols=weights.shape[1],
+                            stash_weights=stash_weights_list[i],
+                        ),
+                    ],
+                )
             emb_modules.append(emb_module)
 
         lookup = Mock(spec=["_emb_modules"])
@@ -343,6 +384,100 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         torch.testing.assert_close(weights, original_values, rtol=1e-05, atol=1e-08)
+
+    def test_stash_weights_config_filters_tbe_groups(self) -> None:
+        """Test that only TBE groups with stash_weights=True are stashed."""
+        stash_weights = torch.ones((50, 32), device=self.device)
+        no_stash_weights = torch.ones((80, 64), device=self.device) * 2
+
+        stash_original = stash_weights.clone()
+        no_stash_original = no_stash_weights.clone()
+
+        lookup = self._create_mock_lookup(
+            [stash_weights, no_stash_weights],
+            stash_weights_list=[True, False],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
+
+        # Only the stash_weights=True group should be stashed
+        self.assertEqual(stash_weights.untyped_storage().size(), 0)
+        # The stash_weights=False group should NOT be stashed
+        self.assertGreater(no_stash_weights.untyped_storage().size(), 0)
+        self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
+
+        # Restore
+        MemoryStashingManager.restore_embedding_weights()
+        await_restore(None)
+
+        # Stashed weights should be restored correctly
+        self.assertTrue(torch.allclose(stash_weights, stash_original))
+        # Non-stashed weights should remain unchanged
+        self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
+
+    def test_stash_weights_all_false_returns_none(self) -> None:
+        """Test that stash_embedding_weights returns None when all tables have stash_weights=False."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device)
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=[False, False],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNone(result)
+
+        # No weights should be stashed
+        self.assertGreater(weights_1.untyped_storage().size(), 0)
+        self.assertGreater(weights_2.untyped_storage().size(), 0)
+
+    def test_stash_weights_all_true_stashes_all(self) -> None:
+        """Test that all TBE groups are stashed when all have stash_weights=True."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device) * 2
+
+        original_1 = weights_1.clone()
+        original_2 = weights_2.clone()
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=[True, True],
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
+
+        # Both should be stashed
+        self.assertEqual(weights_1.untyped_storage().size(), 0)
+        self.assertEqual(weights_2.untyped_storage().size(), 0)
+
+        # Restore
+        MemoryStashingManager.restore_embedding_weights()
+        await_restore(None)
+
+        self.assertTrue(torch.allclose(weights_1, original_1))
+        self.assertTrue(torch.allclose(weights_2, original_2))
+
+    def test_stash_weights_no_config_stashes_all(self) -> None:
+        """Test backward compat: without _config, all TBE groups are stashed."""
+        weights_1 = torch.ones((50, 32), device=self.device)
+        weights_2 = torch.ones((80, 64), device=self.device)
+
+        lookup = self._create_mock_lookup(
+            [weights_1, weights_2],
+            stash_weights_list=None,  # No config set
+        )
+
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+
+        # Both should be stashed (no config = stash everything)
+        self.assertEqual(weights_1.untyped_storage().size(), 0)
+        self.assertEqual(weights_2.untyped_storage().size(), 0)
 
     def test_is_enabled(self) -> None:
         """Test is_enabled reflects stream initialization state."""

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -9,7 +9,7 @@
 
 import unittest
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
 import torch
@@ -132,7 +132,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify HBM is freed
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -159,7 +161,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([weights_1, weights_2, weights_3])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify all are stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)
@@ -188,7 +192,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         lookup = self._create_mock_lookup([original_weights])
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Verify stash worked
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -214,7 +220,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         output = torch.matmul(x, weights.t())
 
         # Stash and restore
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
@@ -254,7 +262,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Only CUDA weights should be stashed
         self.assertEqual(cuda_weights.untyped_storage().size(), 0)
@@ -290,7 +300,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         lookup = Mock(spec=["_emb_modules"])
         lookup._emb_modules = emb_modules
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Valid weights should be stashed
         self.assertEqual(valid_weights.untyped_storage().size(), 0)
@@ -314,7 +326,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         x = torch.randn(3, 5, device=self.device, requires_grad=True)
         output = torch.matmul(x, weights.t())
 
-        await_restore, _restore = MemoryStashingManager.stash_embedding_weights(lookup)
+        result = MemoryStashingManager.stash_embedding_weights(lookup)
+        self.assertIsNotNone(result)
+        await_restore, _restore = result
 
         # Register restore via class method and await_restore as backward hook
         output.register_hook(
@@ -329,6 +343,12 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Weights should be restored after backward
         self.assertGreater(weights.untyped_storage().size(), 0)
         torch.testing.assert_close(weights, original_values, rtol=1e-05, atol=1e-08)
+
+    def test_is_enabled(self) -> None:
+        """Test is_enabled reflects stream initialization state."""
+        self.assertTrue(MemoryStashingManager.is_enabled())
+        MemoryStashingManager.reset()
+        self.assertFalse(MemoryStashingManager.is_enabled())
 
 
 class TestStashOptimizerState(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -63,6 +63,7 @@ class InjectionSite:
     """
 
     fqn: str
+    use_output_tensor: bool = True
 
     def find_target_module(self, model: nn.Module) -> Optional[nn.Module]:
         """
@@ -140,7 +141,10 @@ def register_backward_hook(
         input: Any,
         output: Any,
     ) -> None:
-        tensor = site.find_grad_tensor(output)
+        if site.use_output_tensor:
+            tensor = site.find_grad_tensor(output)
+        else:
+            tensor = site.find_grad_tensor(input)
         if tensor is None:
             raise RuntimeError(
                 f"register_hook: no grad-requiring tensor in "

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -367,6 +367,8 @@ class BaseEmbeddingConfig:
             for number embedding memory for virtual table is dynamic and only materialized when
             id is trained this needs to be paired with SSD/DRAM Virtual talbe in EmbeddingComputeKernel
         virtual_table_eviction_policy (Optional[VirtualTableEvictionPolicy]): eviction policy for virtual table.
+        enable_embedding_update (bool): whether to enable embedding update.
+        stash_weights (bool): whether to stash weights.
     """
 
     num_embeddings: int
@@ -389,6 +391,7 @@ class BaseEmbeddingConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
 
     def get_weight_init_max(self) -> float:
         if self.weight_init_max is None:

--- a/torchrec/schema/api_tests/test_embedding_config_schema.py
+++ b/torchrec/schema/api_tests/test_embedding_config_schema.py
@@ -43,6 +43,7 @@ class StableEmbeddingBagConfig:
     use_virtual_table: bool = False
     virtual_table_eviction_policy: Optional[VirtualTableEvictionPolicy] = None
     enable_embedding_update: bool = False
+    stash_weights: bool = False
     pooling: PoolingType = PoolingType.SUM
 
 


### PR DESCRIPTION
Summary:
Reland of D92586272 which was reverted by D96335089 (as part of the
D94770461 revert stack).

This diff propagates the `stash_weights` field from `BaseEmbeddingConfig`
through the sharding infrastructure so that `ShardedEmbeddingTable` instances
carry the per-table stash flag. Changes:

- `embedding.py`, `embeddingbag.py`: Pass `stash_weights` when constructing
  `ShardedEmbeddingTable` during sharding setup.
- `embedding_sharding.py`: Include `stash_weights` in the TBE grouping key
  so tables with different stash settings are placed in separate TBE groups.
- All sharding strategies (`tw`, `rw`, `cw`, `dp`, `twrw`, `grid`): Propagate
  `stash_weights` to `ShardedEmbeddingTable`.
- `test_memory_stashing.py`: Add config-aware `_create_mock_lookup` helper and
  4 new tests for per-table stash filtering.

Differential Revision: D96359284


