### PR TITLE
Move the core backend of internal HashZCH to be OSS (#3873)

### DIFF
--- a/torchrec/modules/hash_mc_evictions.py
+++ b/torchrec/modules/hash_mc_evictions.py
@@ -64,8 +64,8 @@ class HashZchEvictionScorer:
 class HashZchSingleTtlScorer(HashZchEvictionScorer):
     def gen_score(self, feature: JaggedTensor, device: torch.device) -> torch.Tensor:
         assert (
-            self._config.single_ttl is not None and self._config.single_ttl > 0
-        ), "To use scorer HashZchSingleTtlScorer, a positive single_ttl is required."
+            self._config.single_ttl is not None
+        ), "To use scorer HashZchSingleTtlScorer, a single_ttl is required."
 
         return torch.full_like(
             feature.values(),

--- a/torchrec/modules/hash_mc_metrics.py
+++ b/torchrec/modules/hash_mc_metrics.py
@@ -7,12 +7,74 @@
 
 # pyre-strict
 
+import abc
 import logging
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from torchrec.modules.hash_mc_evictions import HashZchEvictionConfig
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ScalarLoggerBackend(abc.ABC):
+    """
+    Base class for ScalarLogger reporting backends.
+
+    Subclass this to implement custom metric reporting (e.g., TensorBoard, console, file).
+    The ``report`` method receives pre-formatted log messages and structured rate metrics.
+    """
+
+    @abc.abstractmethod
+    def report(
+        self,
+        log_message: str,
+        name: str,
+        run_type: str,
+        step: int,
+        rate_metrics: Dict[str, float],
+    ) -> None:
+        """
+        Report computed metrics.
+
+        Args:
+            log_message: Pre-formatted log message for console/file output.
+            name: The embedding table name.
+            run_type: "train" or "eval".
+            step: Current reporting step number.
+            rate_metrics: Dict of metric_name to value for structured reporting.
+                Keys: hit_rate, insert_rate, collision_rate, eviction_rate,
+                opt_in_rate, avg_eviction_age, table_usage_ratio.
+        """
+        ...
+
+
+class ConsoleScalarLoggerBackend(ScalarLoggerBackend):
+    """
+    Logs metrics to console or file using Python's logging module.
+
+    This is the default backend for ScalarLogger.
+
+    Args:
+        log_file_path: path to the log file. If empty, logs to console only.
+    """
+
+    def __init__(self, log_file_path: str = "") -> None:
+        self._logger: logging.Logger = logging.getLogger(__name__)
+        if log_file_path != "":
+            file_handler = logging.FileHandler(log_file_path, mode="w")
+            self._logger.addHandler(file_handler)
+
+    def report(
+        self,
+        log_message: str,
+        name: str,
+        run_type: str,
+        step: int,
+        rate_metrics: Dict[str, float],
+    ) -> None:
+        self._logger.info(log_message)
 
 
 class ScalarLogger(torch.nn.Module):
@@ -25,6 +87,8 @@ class ScalarLogger(torch.nn.Module):
         frequency: frequency of reporting metrics.
         start_bucket: start bucket of the rank.
         log_file_path: path to the log file. If not provided, logs will be printed to console.
+        backend: optional reporting backend. If not provided, defaults to
+            ConsoleScalarLoggerBackend with the given log_file_path.
 
     Example::
         logger = ScalarLogger(...)
@@ -46,6 +110,7 @@ class ScalarLogger(torch.nn.Module):
         device: torch.device,
         disable_fallback: bool,
         log_file_path: str = "",
+        backend: Optional[ScalarLoggerBackend] = None,
     ) -> None:
         super().__init__()
 
@@ -94,16 +159,12 @@ class ScalarLogger(torch.nn.Module):
         self._opt_in_cnt: int = 0
         self._sum_eviction_age: float = 0.0
 
-        self.logger: logging.Logger = logging.getLogger()
-        if (
-            log_file_path != ""
-        ):  # if a log file path is provided, create a file handler to output logs to the file
-            file_handler = logging.FileHandler(
-                log_file_path, mode="w"
-            )  # initialize file handler
-            self.logger.addHandler(file_handler)  # add file handler to logger
+        if backend is not None:
+            self._backend: ScalarLoggerBackend = backend
+        else:
+            self._backend = ConsoleScalarLoggerBackend(log_file_path=log_file_path)
 
-        self.logger.info(
+        logger.info(
             f"ScalarLogger: {self._name=}, {self._device=}, "
             f"{self._zch_size=}, {self._frequency=}, {self._start_bucket=}, "
             f"{self._num_buckets_per_rank=}, {self._num_reserved_slots_per_bucket=}, "
@@ -224,7 +285,7 @@ class ScalarLogger(torch.nn.Module):
             )
 
             # log the metrics to console (if no log file path is provided) or to the file (if a log file path is provided)
-            self.logger.info(
+            log_message = (
                 f"{self._name=}, {run_type=}, "
                 f"{self._total_cnt=}, {self._hit_cnt=}, {hit_rate=}, "
                 f"{self._insert_cnt=}, {insert_rate=}, "
@@ -232,6 +293,24 @@ class ScalarLogger(torch.nn.Module):
                 f"{self._eviction_cnt=}, {eviction_rate=}, {avg_eviction_age=}, "
                 f"{self._opt_in_cnt=}, {opt_in_rate=}, "
                 f"{total_unused_slots=}, {table_usage_ratio=}"
+            )
+
+            self._backend.report(
+                log_message=log_message,
+                name=self._name,
+                run_type=run_type,
+                # pyre-ignore[6]: Expected `int` for 4th positional argument
+                # pyrefly: ignore[not-callable]
+                step=int(self._scalar_logger_steps.item()),
+                rate_metrics={
+                    "hit_rate": hit_rate,
+                    "insert_rate": insert_rate,
+                    "collision_rate": collision_rate,
+                    "eviction_rate": eviction_rate,
+                    "opt_in_rate": opt_in_rate,
+                    "avg_eviction_age": avg_eviction_age,
+                    "table_usage_ratio": table_usage_ratio,
+                },
             )
 
             # reset the counter after reporting

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -220,13 +220,6 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
     BUCKET_BUFFER: str = "_hash_zch_bucket"
     RUNTIME_META_BUFFER: str = "_hash_zch_runtime_meta"
 
-    table_name_on_device_remapped_ids_dict: Dict[
-        str, torch.Tensor
-    ]  # used to store the on-device remapped ids
-    table_name_on_device_input_ids_dict: Dict[
-        str, torch.Tensor
-    ]  # used to store the on-device input ids
-
     def __init__(
         self,
         zch_size: int,
@@ -247,6 +240,8 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         percent_reserved_slots: float = 0,
         disable_fallback: bool = False,
         track_id_freq: bool = False,
+        read_only_suffix: str = "_readonly",
+        enable_per_feature_lookups: bool = False,
         no_bag: bool = False,
     ) -> None:
         if output_segments is None:
@@ -380,17 +375,8 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._eviction_policy_name_copy: Optional[HashZchEvictionPolicyName] = (
             self._eviction_policy_name
         )
-
-        # create two dictionaries to store the input values and remapped ids on the current rank
-        # these values are used for calculating zch metrics like hit rate and collision rate
-        ## on-device remapped ids
-        self.table_name_on_device_remapped_ids_dict: Dict[str, torch.Tensor] = (
-            {}
-        )  # {table_name: on_device_remapped_ids}
-        ## on-device input ids
-        self.table_name_on_device_input_ids_dict: Dict[str, torch.Tensor] = (
-            {}
-        )  # {table_name: input JT values that maps to the current rank}
+        self._read_only_suffix: str = read_only_suffix
+        self._enable_per_feature_lookups: bool = enable_per_feature_lookups
         self._no_bag = no_bag
 
         logger.info(
@@ -401,7 +387,9 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{self._buckets=}, {self._start_bucket=}, {self._end_bucket=}, "
             f"{self._output_global_offset_tensor=}, {self._output_segments=}, "
             f"{inference_dispatch_div_train_world_size=}, "
-            f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, {self._track_id_freq=}, {self._no_bag=}"
+            f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, "
+            f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
+            f"{self._no_bag=}"
         )
 
     @property
@@ -444,28 +432,28 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._eviction_policy_name = None
         self._eviction_module = None
 
+    @staticmethod
+    def _reset_inference_mode_load_state_dict_pre_hook(
+        module: "HashZchManagedCollisionModule",
+        state_dict: Dict[str, Any],
+        prefix: str,
+        *args: Any,
+    ) -> None:
+        logger.info("HashZchManagedCollisionModule loading state dict")
+        # We store the full identity in checkpoint and predictor, cut it at inference loading
+        if not module._is_inference:
+            return
+        if "_hash_zch_metadata" in state_dict:
+            del state_dict["_hash_zch_metadata"]
+
     def reset_inference_mode(
         self,
     ) -> None:
         logger.info("HashZchManagedCollisionModule resetting inference mode")
         self._set_eval_mode_impl()
         self._hash_zch_metadata = None
-
-        def _load_state_dict_pre_hook(
-            module: "HashZchManagedCollisionModule",
-            state_dict: Dict[str, Any],
-            prefix: str,
-            *args: Any,
-        ) -> None:
-            logger.info("HashZchManagedCollisionModule loading state dict")
-            # We store the full identity in checkpoint and predictor, cut it at inference loading
-            if not self._is_inference:
-                return
-            if "_hash_zch_metadata" in state_dict:
-                del state_dict["_hash_zch_metadata"]
-
         self._register_load_state_dict_pre_hook(
-            _load_state_dict_pre_hook, with_module=True
+            self._reset_inference_mode_load_state_dict_pre_hook, with_module=True
         )
 
     def reset_intrainer_bulk_eval_mode(self) -> None:
@@ -550,11 +538,22 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             remapped_features: Dict[str, JaggedTensor] = {}
             identities_0 = (
                 self._hash_zch_identities.data.clone()
-                # if self._tb_logging_frequency > 0
-                # else None
+                if self._tb_logging_frequency > 0
+                else None
             )
-
+            metadata_0 = (
+                self._hash_zch_metadata.data.clone()
+                if self._tb_logging_frequency > 0
+                and self._hash_zch_metadata is not None
+                else None
+            )
             for name, feature in features.items():
+                if name.lower().endswith(self._read_only_suffix):
+                    overwrite_readonly = True
+                    overwrite_metadata = None
+                else:
+                    overwrite_readonly = readonly
+                    overwrite_metadata = metadata
                 values = feature.values()
                 input_metadata, eviction_threshold = (
                     self._eviction_module(feature)
@@ -578,9 +577,6 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     output_offset=self._output_global_offset_tensor,
                 )
 
-                # record the input values
-                self.table_name_on_device_input_ids_dict[name] = values.clone()
-
                 num_reserved_slots = self.get_reserved_slots_per_bucket()
                 remapped_ids, evictions = torch.ops.fbgemm.zero_collision_hash(
                     input=values,
@@ -588,10 +584,10 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     max_probe=self._max_probe,
                     circular_probe=True,
                     exp_hours=-1,  # deprecated, always -1
-                    readonly=readonly,
+                    readonly=overwrite_readonly,
                     local_sizes=local_sizes,
                     offsets=offsets,
-                    metadata=metadata,
+                    metadata=overwrite_metadata,
                     # Use self._is_inference to turn on writing to pinned
                     # CPU memory directly. But may not have perf benefit.
                     output_on_uvm=False,  # self._is_inference,
@@ -605,9 +601,6 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     opt_in_rands=opt_in_rands,
                     runtime_meta=self._hash_zch_runtime_meta,
                 )
-
-                # record the on-device remapped ids
-                self.table_name_on_device_remapped_ids_dict[name] = remapped_ids.clone()
                 lengths: torch.Tensor = feature.lengths()
                 offsets: Optional[torch.Tensor] = feature.offsets()
                 hit_indices: torch.Tensor = remapped_ids != -1
@@ -640,7 +633,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                         remapped_ids=remapped_ids,
                         hit_indices=hit_indices,
                         evicted_emb_indices=evictions,
-                        metadata=metadata,
+                        metadata=metadata_0,
                         eviction_config=self._eviction_config,
                     )
 
@@ -722,6 +715,9 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             percent_reserved_slots=self._percent_reserved_slots,
             disable_fallback=self._disable_fallback,
             track_id_freq=self._track_id_freq,
+            read_only_suffix=self._read_only_suffix,
+            enable_per_feature_lookups=self._enable_per_feature_lookups,
+            no_bag=self._no_bag,
         )
 
     def lookup_runtime_meta(

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -309,22 +309,13 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
 
         if self._tb_logging_frequency > 0 and self._device.type != "meta":
             assert self._name is not None
-            self._scalar_logger = ScalarLogger(
-                name=self._name,
-                zch_size=self._zch_size,
-                frequency=self._tb_logging_frequency,
-                start_bucket=self._start_bucket,
-                num_buckets_per_rank=self._end_bucket - self._start_bucket,
-                num_reserved_slots_per_bucket=self.get_reserved_slots_per_bucket(),
-                device=self._device,
-                disable_fallback=self._disable_fallback,
-            )
+            self._scalar_logger = self._create_scalar_logger()
         else:
             logger.info(
                 f"ScalarLogger is disabled because {self._tb_logging_frequency=} and {self._device.type=}"
             )
 
-        identities, metadata = torch.ops.fbgemm.create_zch_buffer(
+        identities, metadata = self._create_zch_buffer(
             size=self._zch_size,
             support_evict=self._eviction_module is not None,
             device=self._device,
@@ -390,6 +381,77 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, "
             f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
             f"{self._no_bag=}"
+        )
+
+    def _create_zch_buffer(
+        self,
+        size: int,
+        support_evict: bool,
+        device: torch.device,
+        long_type: bool,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.fbgemm.create_zch_buffer(
+            size=size,
+            support_evict=support_evict,
+            device=device,
+            long_type=long_type,
+        )
+
+    def _zero_collision_hash(
+        self,
+        input: torch.Tensor,
+        identities: torch.Tensor,
+        max_probe: int,
+        circular_probe: bool,
+        exp_hours: int,
+        readonly: bool,
+        local_sizes: Optional[torch.Tensor],
+        offsets: Optional[torch.Tensor],
+        metadata: Optional[torch.Tensor],
+        output_on_uvm: bool,
+        disable_fallback: bool,
+        _modulo_identity_DPRECATED: bool,
+        input_metadata: Optional[torch.Tensor],
+        eviction_threshold: int,
+        eviction_policy: int,
+        opt_in_prob: int,
+        num_reserved_slots: int,
+        opt_in_rands: Optional[torch.Tensor],
+        runtime_meta: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        return torch.ops.fbgemm.zero_collision_hash(
+            input=input,
+            identities=identities,
+            max_probe=max_probe,
+            circular_probe=circular_probe,
+            exp_hours=exp_hours,
+            readonly=readonly,
+            local_sizes=local_sizes,
+            offsets=offsets,
+            metadata=metadata,
+            output_on_uvm=output_on_uvm,
+            disable_fallback=disable_fallback,
+            _modulo_identity_DPRECATED=_modulo_identity_DPRECATED,
+            input_metadata=input_metadata,
+            eviction_threshold=eviction_threshold,
+            eviction_policy=eviction_policy,
+            opt_in_prob=opt_in_prob,
+            num_reserved_slots=num_reserved_slots,
+            opt_in_rands=opt_in_rands,
+            runtime_meta=runtime_meta,
+        )
+
+    def _create_scalar_logger(self) -> ScalarLogger:
+        assert self._name is not None
+        return ScalarLogger(
+            name=self._name,
+            zch_size=self._zch_size,
+            frequency=self._tb_logging_frequency,
+            start_bucket=self._start_bucket,
+            num_buckets_per_rank=self._end_bucket - self._start_bucket,
+            num_reserved_slots_per_bucket=self.get_reserved_slots_per_bucket(),
+            device=self._device,
+            disable_fallback=self._disable_fallback,
         )
 
     @property
@@ -578,7 +640,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                 )
 
                 num_reserved_slots = self.get_reserved_slots_per_bucket()
-                remapped_ids, evictions = torch.ops.fbgemm.zero_collision_hash(
+                remapped_ids, evictions = self._zero_collision_hash(
                     input=values,
                     identities=self._hash_zch_identities,
                     max_probe=self._max_probe,

--- a/torchrec/modules/tests/test_hash_mc_metrics.py
+++ b/torchrec/modules/tests/test_hash_mc_metrics.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, Dict
+from unittest.mock import MagicMock, patch
+
+import torch
+from torchrec.modules.hash_mc_evictions import HashZchEvictionConfig
+from torchrec.modules.hash_mc_metrics import (
+    ConsoleScalarLoggerBackend,
+    ScalarLogger,
+    ScalarLoggerBackend,
+)
+
+
+class ConcreteBackend(ScalarLoggerBackend):
+    """A minimal concrete backend for testing."""
+
+    def __init__(self) -> None:
+        self.reported: list[Dict[str, object]] = []
+
+    def report(
+        self,
+        log_message: str,
+        name: str,
+        run_type: str,
+        step: int,
+        rate_metrics: Dict[str, float],
+    ) -> None:
+        self.reported.append(
+            {
+                "log_message": log_message,
+                "name": name,
+                "run_type": run_type,
+                "step": step,
+                "rate_metrics": dict(rate_metrics),
+            }
+        )
+
+
+def _make_logger(
+    backend: ScalarLoggerBackend,
+    frequency: int = 1,
+    start_bucket: int = 0,
+    zch_size: int = 10,
+    num_buckets_per_rank: int = 1,
+    disable_fallback: bool = False,
+) -> ScalarLogger:
+    return ScalarLogger(
+        name="test_table",
+        zch_size=zch_size,
+        frequency=frequency,
+        start_bucket=start_bucket,
+        num_buckets_per_rank=num_buckets_per_rank,
+        num_reserved_slots_per_bucket=0,
+        device=torch.device("cpu"),
+        disable_fallback=disable_fallback,
+        backend=backend,
+    )
+
+
+class ConsoleScalarLoggerBackendTest(unittest.TestCase):
+    def test_report_logs_message(self) -> None:
+        backend = ConsoleScalarLoggerBackend()
+        with patch.object(backend, "_logger") as mock_logger:
+            backend.report(
+                log_message="test message",
+                name="table",
+                run_type="train",
+                step=1,
+                rate_metrics={"hit_rate": 0.5},
+            )
+            mock_logger.info.assert_called_once_with("test message")
+
+    def test_file_logging_adds_handler(self) -> None:
+        with patch("torchrec.modules.hash_mc_metrics.logging") as mock_logging:
+            mock_logger = MagicMock()
+            mock_logging.getLogger.return_value = mock_logger
+            mock_handler = MagicMock()
+            mock_logging.FileHandler.return_value = mock_handler
+
+            ConsoleScalarLoggerBackend(log_file_path="/tmp/test.log")
+
+            mock_logging.FileHandler.assert_called_once_with("/tmp/test.log", mode="w")
+            mock_logger.addHandler.assert_called_once_with(mock_handler)
+
+    def test_no_file_handler_when_empty_path(self) -> None:
+        with patch("torchrec.modules.hash_mc_metrics.logging") as mock_logging:
+            mock_logger = MagicMock()
+            mock_logging.getLogger.return_value = mock_logger
+
+            ConsoleScalarLoggerBackend(log_file_path="")
+
+            mock_logging.FileHandler.assert_not_called()
+            mock_logger.addHandler.assert_not_called()
+
+
+class ScalarLoggerTest(unittest.TestCase):
+
+    def test_update_accumulates_counters(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, disable_fallback=False)
+
+        # 5 values, identities show 3 were already present (hits),
+        # 2 slots were empty before (inserts), 0 collisions
+        values = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+        # identities_0: before remap — slots 0,1,2 have IDs matching values (hits),
+        # slots 3,4 are empty (-1) → 2 inserts
+        identities_0 = torch.tensor([[0], [1], [2], [-1], [-1]], dtype=torch.int64)
+        # identities_1: after remap — all slots filled
+        identities_1 = torch.tensor([[0], [1], [2], [3], [4]], dtype=torch.int64)
+        remapped_ids = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+        hit_indices = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+
+        sl.update(
+            identities_0=identities_0,
+            identities_1=identities_1,
+            values=values,
+            remapped_ids=remapped_ids,
+            hit_indices=hit_indices,
+            evicted_emb_indices=None,
+            metadata=None,
+        )
+
+        self.assertEqual(sl._total_cnt, 5)
+        self.assertEqual(sl._hit_cnt, 3)
+        self.assertEqual(sl._insert_cnt, 2)
+        self.assertEqual(sl._collision_cnt, 0)
+
+    def test_update_accumulates_across_calls(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, disable_fallback=False)
+
+        values = torch.tensor([0, 1], dtype=torch.int64)
+        identities_0 = torch.tensor([[0], [-1]], dtype=torch.int64)
+        identities_1 = torch.tensor([[0], [1]], dtype=torch.int64)
+        remapped_ids = torch.tensor([0, 1], dtype=torch.int64)
+        hit_indices = torch.tensor([0, 1], dtype=torch.int64)
+
+        sl.update(
+            identities_0, identities_1, values, remapped_ids, hit_indices, None, None
+        )
+        sl.update(
+            identities_0, identities_1, values, remapped_ids, hit_indices, None, None
+        )
+
+        self.assertEqual(sl._total_cnt, 4)
+        self.assertEqual(sl._hit_cnt, 2)
+        self.assertEqual(sl._insert_cnt, 2)
+
+    def test_update_counts_evictions(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, disable_fallback=False)
+
+        values = torch.tensor([0], dtype=torch.int64)
+        identities_0 = torch.tensor([[0]], dtype=torch.int64)
+        identities_1 = torch.tensor([[0]], dtype=torch.int64)
+        remapped_ids = torch.tensor([0], dtype=torch.int64)
+        hit_indices = torch.tensor([0], dtype=torch.int64)
+        evicted = torch.tensor([5, 6, 5], dtype=torch.int64)  # 5 is duplicate
+        metadata = torch.zeros(10, 1, dtype=torch.float32)
+
+        sl.update(
+            identities_0,
+            identities_1,
+            values,
+            remapped_ids,
+            hit_indices,
+            evicted,
+            metadata,
+            eviction_config=HashZchEvictionConfig(features=[], single_ttl=10),
+        )
+
+        # 2 unique evictions (5 and 6)
+        self.assertEqual(sl._eviction_cnt, 2)
+
+    def test_should_report_respects_frequency(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, frequency=3)
+
+        # Needs data to report
+        sl._total_cnt = 10
+
+        # Steps buffer starts at 1
+        # Step 1: 1 % 3 != 0 → False
+        self.assertFalse(sl.should_report())
+
+        cast(torch.Tensor, sl._scalar_logger_steps).fill_(3)
+        self.assertTrue(sl.should_report())
+
+        cast(torch.Tensor, sl._scalar_logger_steps).fill_(4)
+        self.assertFalse(sl.should_report())
+
+        cast(torch.Tensor, sl._scalar_logger_steps).fill_(6)
+        self.assertTrue(sl.should_report())
+
+    def test_should_report_only_on_rank0(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, start_bucket=1)
+        sl._total_cnt = 10
+        self.assertFalse(sl.should_report())
+
+    def test_should_report_requires_data(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend)
+        # _total_cnt is 0 by default
+        self.assertFalse(sl.should_report())
+
+    def test_forward_calls_backend_report(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, zch_size=10)
+
+        # Set up counters directly for controlled rate computation
+        sl._total_cnt = 100
+        sl._hit_cnt = 70
+        sl._insert_cnt = 20
+        sl._collision_cnt = 10
+        sl._eviction_cnt = 5
+        sl._opt_in_cnt = 50
+        sl._sum_eviction_age = 25.0
+
+        identities = torch.zeros(10, 1, dtype=torch.int64)
+        # Fill 8 of 10 slots to get table_usage_ratio
+        identities[0, 0] = -1
+        identities[1, 0] = -1
+
+        sl.forward("train", identities)
+
+        self.assertEqual(len(backend.reported), 1)
+        report = backend.reported[0]
+        self.assertEqual(report["name"], "test_table")
+        self.assertEqual(report["run_type"], "train")
+        self.assertEqual(report["step"], 1)
+
+        metrics = cast(Dict[str, float], report["rate_metrics"])
+        self.assertAlmostEqual(metrics["hit_rate"], 0.7)
+        self.assertAlmostEqual(metrics["insert_rate"], 0.2)
+        self.assertAlmostEqual(metrics["collision_rate"], 0.1)
+        self.assertAlmostEqual(metrics["eviction_rate"], 0.05)
+        self.assertAlmostEqual(metrics["opt_in_rate"], 0.5)
+        self.assertAlmostEqual(metrics["avg_eviction_age"], 5.0)
+        self.assertAlmostEqual(metrics["table_usage_ratio"], 0.8)
+
+    def test_forward_resets_counters_after_report(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend)
+
+        sl._total_cnt = 100
+        sl._hit_cnt = 70
+        sl._insert_cnt = 20
+        sl._collision_cnt = 10
+        sl._eviction_cnt = 5
+        sl._opt_in_cnt = 50
+        sl._sum_eviction_age = 25.0
+
+        identities = torch.zeros(10, 1, dtype=torch.int64)
+        sl.forward("train", identities)
+
+        self.assertEqual(sl._total_cnt, 0)
+        self.assertEqual(sl._hit_cnt, 0)
+        self.assertEqual(sl._insert_cnt, 0)
+        self.assertEqual(sl._collision_cnt, 0)
+        self.assertEqual(sl._eviction_cnt, 0)
+        self.assertEqual(sl._opt_in_cnt, 0)
+        self.assertAlmostEqual(sl._sum_eviction_age, 0.0)
+
+    def test_forward_does_not_report_when_not_due(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, frequency=3)
+
+        sl._total_cnt = 100
+        identities = torch.zeros(10, 1, dtype=torch.int64)
+
+        # Step 1: 1 % 3 != 0 → should not report
+        sl.forward("train", identities)
+
+        self.assertEqual(len(backend.reported), 0)
+        # Counters should NOT be reset
+        self.assertEqual(sl._total_cnt, 100)
+
+    def test_forward_increments_steps(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, frequency=100)  # high frequency to avoid reporting
+
+        identities = torch.zeros(10, 1, dtype=torch.int64)
+
+        self.assertEqual(cast(torch.Tensor, sl._scalar_logger_steps).item(), 1)
+        sl.forward("train", identities)
+        self.assertEqual(cast(torch.Tensor, sl._scalar_logger_steps).item(), 2)
+        sl.forward("train", identities)
+        self.assertEqual(cast(torch.Tensor, sl._scalar_logger_steps).item(), 3)
+
+    def test_eviction_age_computation(self) -> None:
+        backend = ConcreteBackend()
+        sl = _make_logger(backend, zch_size=10)
+
+        values = torch.tensor([0], dtype=torch.int64)
+        identities_0 = torch.tensor([[0]], dtype=torch.int64)
+        identities_1 = torch.tensor([[0]], dtype=torch.int64)
+        remapped_ids = torch.tensor([0], dtype=torch.int64)
+        hit_indices = torch.tensor([0], dtype=torch.int64)
+        evicted = torch.tensor([0, 1], dtype=torch.int64)
+
+        # metadata stores the insertion hour for each slot
+        metadata = torch.zeros(10, 1, dtype=torch.float32)
+        metadata[0, 0] = 100.0  # slot 0 was inserted at hour 100
+        metadata[1, 0] = 200.0  # slot 1 was inserted at hour 200
+
+        eviction_config = HashZchEvictionConfig(features=[], single_ttl=10)
+
+        with patch("torchrec.modules.hash_mc_metrics.time") as mock_time:
+            mock_time.time.return_value = 360000  # hour 100
+            sl.update(
+                identities_0,
+                identities_1,
+                values,
+                remapped_ids,
+                hit_indices,
+                evicted,
+                metadata,
+                eviction_config=eviction_config,
+            )
+
+        self.assertEqual(sl._eviction_cnt, 2)
+        # sum_eviction_age = (cur_hour + ttl - metadata[0]) + (cur_hour + ttl - metadata[1])
+        # cur_hour = 360000 / 3600 % (2^31 - 1) = 100
+        # = (100 + 10 - 100) + (100 + 10 - 200) = 10 + (-90) = -80
+        # The computation is sum, tested via the raw value
+        self.assertAlmostEqual(sl._sum_eviction_age, -80.0, places=0)

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import unittest
-from typing import cast, Dict
+from typing import cast, Dict, Optional
 from unittest.mock import patch
 
 import torch
@@ -539,6 +539,171 @@ class TestMCH(unittest.TestCase):
                 inf_output["f"].values(),
                 torch.index_select(
                     o1_2["f"].values(),
+                    dim=0,
+                    index=cast(torch.Tensor, permute),
+                ),
+            )
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    @given(hash_size=st.sampled_from([0, 80]))
+    @settings(max_examples=5, deadline=None)
+    def test_zch_hash_train_rescales_four(self, hash_size: int) -> None:
+        keep_original_indices = True
+        kjt = KeyedJaggedTensor(
+            keys=["f"],
+            values=torch.cat(
+                [
+                    torch.randint(
+                        0,
+                        hash_size if hash_size > 0 else 1000,
+                        (20,),
+                        dtype=torch.int64,
+                        device="cuda",
+                    ),
+                ]
+            ),
+            lengths=torch.cat(
+                [
+                    torch.tensor([4, 6], dtype=torch.int64, device="cuda"),
+                    torch.tensor([4, 6], dtype=torch.int64, device="cuda"),
+                ]
+            ),
+        )
+
+        # initialize mch with 8 buckets
+        m0 = HashZchManagedCollisionModule(
+            zch_size=40,
+            device=torch.device("cuda"),
+            input_hash_size=hash_size,
+            total_num_buckets=4,
+            eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+            eviction_config=HashZchEvictionConfig(
+                features=[],
+                single_ttl=10,
+            ),
+        )
+
+        # start with world_size = 4
+        world_size = 4
+        block_sizes = torch.tensor(
+            [(size + world_size - 1) // world_size for size in [hash_size]],
+            dtype=torch.int64,
+            device="cuda",
+        )
+
+        m1_1 = m0.rebuild_with_output_id_range((0, 10))
+        m2_1 = m0.rebuild_with_output_id_range((10, 20))
+        m3_1 = m0.rebuild_with_output_id_range((20, 30))
+        m4_1 = m0.rebuild_with_output_id_range((30, 40))
+
+        # shard, now world size 2!
+        # start with world_size = 4
+        if hash_size > 0:
+            world_size = 2
+            block_sizes = torch.tensor(
+                [(size + world_size - 1) // world_size for size in [hash_size]],
+                dtype=torch.int64,
+                device="cuda",
+            )
+            # simulate kjt call
+            bucketized_kjt, permute = bucketize_kjt_before_all2all(
+                kjt,
+                num_buckets=world_size,
+                block_sizes=block_sizes,
+                keep_original_indices=keep_original_indices,
+                output_permute=True,
+            )
+            in1_2, in2_2 = bucketized_kjt.split([len(kjt.keys())] * world_size)
+        else:
+            bucketized_kjt, permute = bucketize_kjt_before_all2all(
+                kjt,
+                num_buckets=world_size,
+                block_sizes=block_sizes,
+                keep_original_indices=keep_original_indices,
+                output_permute=True,
+            )
+            kjts = bucketized_kjt.split([len(kjt.keys())] * world_size)
+            # rebuild kjt
+            in1_2 = KeyedJaggedTensor(
+                keys=kjts[0].keys(),
+                values=torch.cat([kjts[0].values(), kjts[1].values()], dim=0),
+                lengths=torch.cat([kjts[0].lengths(), kjts[1].lengths()], dim=0),
+            )
+            in2_2 = KeyedJaggedTensor(
+                keys=kjts[2].keys(),
+                values=torch.cat([kjts[2].values(), kjts[3].values()], dim=0),
+                lengths=torch.cat([kjts[2].lengths(), kjts[3].lengths()], dim=0),
+            )
+
+        m1_2 = m0.rebuild_with_output_id_range((0, 20))
+        m2_2 = m0.rebuild_with_output_id_range((20, 40))
+        m1_zch_identities = torch.cat(
+            [
+                m1_1.state_dict()["_hash_zch_identities"],
+                m2_1.state_dict()["_hash_zch_identities"],
+            ]
+        )
+        m1_zch_metadata = torch.cat(
+            [
+                m1_1.state_dict()["_hash_zch_metadata"],
+                m2_1.state_dict()["_hash_zch_metadata"],
+            ]
+        )
+        state_dict = m1_2.state_dict()
+        state_dict["_hash_zch_identities"] = m1_zch_identities
+        state_dict["_hash_zch_metadata"] = m1_zch_metadata
+        m1_2.load_state_dict(state_dict)
+
+        m2_zch_identities = torch.cat(
+            [
+                m3_1.state_dict()["_hash_zch_identities"],
+                m4_1.state_dict()["_hash_zch_identities"],
+            ]
+        )
+        m2_zch_metadata = torch.cat(
+            [
+                m3_1.state_dict()["_hash_zch_metadata"],
+                m4_1.state_dict()["_hash_zch_metadata"],
+            ]
+        )
+        state_dict = m2_2.state_dict()
+        state_dict["_hash_zch_identities"] = m2_zch_identities
+        state_dict["_hash_zch_metadata"] = m2_zch_metadata
+        m2_2.load_state_dict(state_dict)
+
+        _ = m1_2(in1_2.to_dict())
+        _ = m2_2(in2_2.to_dict())
+
+        m0.reset_inference_mode()  # just clears out training state
+        full_zch_identities = torch.cat(
+            [
+                m1_2.state_dict()["_hash_zch_identities"],
+                m2_2.state_dict()["_hash_zch_identities"],
+            ]
+        )
+        state_dict = m0.state_dict()
+        state_dict["_hash_zch_identities"] = full_zch_identities
+        m0.load_state_dict(state_dict)
+
+        # now set all models to eval, and run kjt
+        m1_2.eval()
+        m2_2.eval()
+        assert m0.training is False
+
+        inf_input = kjt.to_dict()
+        inf_output = m0(inf_input)
+
+        o1_2 = m1_2(in1_2.to_dict())
+        o2_2 = m2_2(in2_2.to_dict())
+        self.assertTrue(
+            torch.allclose(
+                inf_output["f"].values(),
+                torch.index_select(
+                    torch.cat([x["f"].values() for x in [o1_2, o2_2]]),
                     dim=0,
                     index=cast(torch.Tensor, permute),
                 ),
@@ -1129,6 +1294,190 @@ class TestMCH(unittest.TestCase):
             atol=0,
         )
 
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_zch_hash_disable_fallback_no_bag(self) -> None:
+        """
+        Test that when no_bag=True and disable_fallback=True,
+        missed IDs are replaced with 0 instead of being filtered out.
+        This is useful for EC (EmbeddingCollection) where we don't pool embeddings.
+        """
+        m = HashZchManagedCollisionModule(
+            zch_size=10,
+            device=torch.device("cuda"),
+            total_num_buckets=2,
+            eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+            eviction_config=HashZchEvictionConfig(
+                features=[],
+                single_ttl=10,
+            ),
+            max_probe=4,
+            start_bucket=0,
+            output_segments=None,
+            disable_fallback=True,
+            no_bag=True,
+        )
+        jt = JaggedTensor(
+            values=torch.arange(0, 4, dtype=torch.int64, device="cuda"),
+            lengths=torch.tensor([1, 1, 1, 1], dtype=torch.int64, device="cuda"),
+        )
+        # Run once to insert ids
+        output0 = m.remap({"test": jt})
+        # All values should be inserted
+        self.assertTrue(
+            torch.equal(
+                output0["test"].values(),
+                torch.tensor([3, 5, 4, 6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                output0["test"].lengths(),
+                torch.tensor([1, 1, 1, 1], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+
+        m.reset_inference_mode()
+        jt = JaggedTensor(
+            values=torch.tensor([9, 0, 1, 4, 6, 8], dtype=torch.int64, device="cuda"),
+            lengths=torch.tensor([1, 1, 1, 1, 1, 1], dtype=torch.int64, device="cuda"),
+        )
+        # Run again in inference mode: only values 0 and 1 exist in the table.
+        # With no_bag=True:
+        # - Missed IDs should be replaced with 0 instead of being removed
+        # - Lengths should still be mutated to 0 for missed IDs (since mutate_miss_lengths defaults to True)
+        output1 = m.remap({"test": jt})
+        # For missed IDs (9, 4, 6, 8), remapped_ids should be 0 instead of being removed
+        self.assertTrue(
+            torch.equal(
+                output1["test"].values(),
+                torch.tensor([0, 3, 5, 0, 0, 0], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        # Lengths should be mutated to 0 for misses (default mutate_miss_lengths=True behavior)
+        self.assertTrue(
+            torch.equal(
+                output1["test"].lengths(),
+                torch.tensor([0, 1, 1, 0, 0, 0], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                output1["test"].offsets(),
+                torch.tensor([0, 0, 1, 2, 2, 2, 2], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+
+        # Run again in inference mode: only values 0 and 1 exist in the table.
+        # With mutate_miss_lengths=False and no_bag=True:
+        # - Missed IDs should be replaced with 0 instead of being removed
+        # - Lengths should NOT be mutated to 0 for missed IDs
+        jt1 = JaggedTensor(
+            values=torch.tensor([9, 0, 1, 4, 6, 8], dtype=torch.int64, device="cuda"),
+            lengths=torch.tensor([6], dtype=torch.int64, device="cuda"),
+        )
+        output1 = m.remap({"test": jt1}, mutate_miss_lengths=False)
+        # For missed IDs (9, 4, 6, 8), remapped_ids should be 0 instead of being removed
+        self.assertTrue(
+            torch.equal(
+                output1["test"].values(),
+                torch.tensor([0, 3, 5, 0, 0, 0], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        # Lengths should remain unchanged (all 1s, not mutated to 0 for misses)
+        self.assertTrue(
+            torch.equal(
+                output1["test"].lengths(),
+                torch.tensor([6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                output1["test"].offsets(),
+                torch.tensor([0, 6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_zch_hash_disable_fallback_mutate_miss_lengths_false(self) -> None:
+        """
+        Test that when mutate_miss_lengths=False and disable_fallback=True,
+        lengths are NOT mutated even though missed IDs are handled.
+        This is useful for non-NRO features in EC where we want to keep original lengths.
+        """
+        m = HashZchManagedCollisionModule(
+            zch_size=10,
+            device=torch.device("cuda"),
+            total_num_buckets=2,
+            eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+            eviction_config=HashZchEvictionConfig(
+                features=[],
+                single_ttl=10,
+            ),
+            max_probe=4,
+            start_bucket=0,
+            output_segments=None,
+            disable_fallback=True,
+            no_bag=False,  # for ebc
+        )
+        jt0 = JaggedTensor(
+            values=torch.arange(0, 4, dtype=torch.int64, device="cuda"),
+            lengths=torch.tensor([1, 1, 1, 1], dtype=torch.int64, device="cuda"),
+        )
+        # Run once to insert ids
+        output0 = m.remap({"test": jt0}, mutate_miss_lengths=False)
+        # All values should be inserted, and lengths should remain unchanged
+        self.assertTrue(
+            torch.equal(
+                output0["test"].values(),
+                torch.tensor([3, 5, 4, 6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                output0["test"].lengths(),
+                torch.tensor([1, 1, 1, 1], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+
+        m.reset_inference_mode()
+        jt1 = JaggedTensor(
+            values=torch.tensor([9, 0, 1, 4, 6, 8], dtype=torch.int64, device="cuda"),
+            lengths=torch.tensor([6], dtype=torch.int64, device="cuda"),
+        )
+        # Run again in inference mode: only values 0 and 1 exist in the table.
+        # With mutate_miss_lengths=False and no_bag=True:
+        # - Missed IDs should be replaced with 0 instead of being removed
+        # - Lengths should NOT be mutated to 0 for missed IDs
+        output1 = m.remap({"test": jt1}, mutate_miss_lengths=False)
+        # For missed IDs (9, 4, 6, 8), remapped_ids should be 0 instead of being removed
+        self.assertTrue(
+            torch.equal(
+                output1["test"].values(),
+                torch.tensor([3, 5], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        # Lengths should remain unchanged (all 1s, not mutated to 0 for misses)
+        self.assertTrue(
+            torch.equal(
+                output1["test"].lengths(),
+                torch.tensor([6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                output1["test"].offsets(),
+                torch.tensor([0, 6], dtype=torch.int64, device="cuda:0"),
+            )
+        )
+
     def test_is_sharded_property(self) -> None:
         # Non-sharded: full module with all buckets
         m = HashZchManagedCollisionModule(
@@ -1237,6 +1586,239 @@ class TestMCH(unittest.TestCase):
             rtol=0,
             atol=0,
         )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_mc_module_forward(self) -> None:
+        embedding_configs = [
+            EmbeddingConfig(
+                name="t1",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f1", "f2"],
+            ),
+            EmbeddingConfig(
+                name="t2",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f3", "f4"],
+            ),
+        ]
+
+        mc_modules = {
+            "t1": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+            ),
+            "t2": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+            ),
+        }
+        for mc_module in mc_modules.values():
+            mc_module.reset_inference_mode()
+        mc_ebc = ManagedCollisionCollection(
+            # pyrefly: ignore[bad-argument-type]
+            managed_collision_modules=mc_modules,
+            embedding_configs=embedding_configs,
+        )
+        kjt = KeyedJaggedTensor(
+            keys=["f1", "f2", "f3", "f4"],
+            values=torch.cat(
+                [
+                    torch.arange(0, 20, 2, dtype=torch.int64, device="cpu"),
+                    torch.arange(30, 60, 3, dtype=torch.int64, device="cpu"),
+                    torch.arange(20, 30, 2, dtype=torch.int64, device="cpu"),
+                    torch.arange(0, 20, 2, dtype=torch.int64, device="cpu"),
+                ]
+            ),
+            lengths=torch.cat(
+                [
+                    torch.tensor([4, 6], dtype=torch.int64, device="cpu"),
+                    torch.tensor([5, 5], dtype=torch.int64, device="cpu"),
+                    torch.tensor([1, 4], dtype=torch.int64, device="cpu"),
+                    torch.tensor([7, 3], dtype=torch.int64, device="cpu"),
+                ]
+            ),
+        )
+        res = mc_ebc.forward(kjt)
+        self.assertTrue(torch.equal(res.lengths(), kjt.lengths()))
+        self.assertTrue(
+            torch.equal(
+                res.lengths(), torch.tensor([4, 6, 5, 5, 1, 4, 7, 3], dtype=torch.int64)
+            )
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_mc_module_lookup_remapped_lengths_mask(self) -> None:
+        embedding_configs = [
+            EmbeddingBagConfig(
+                name="t1",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f1"],
+            ),
+            EmbeddingBagConfig(
+                name="t2",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f2"],
+            ),
+        ]
+
+        mc_modules = {
+            "t1": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+                disable_fallback=False,
+            ),
+            "t2": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+                disable_fallback=False,
+            ),
+        }
+        for mc_module in mc_modules.values():
+            mc_module.reset_inference_mode()
+        kjt = KeyedJaggedTensor(
+            keys=["f1", "f2"],
+            values=torch.cat(
+                [
+                    torch.arange(0, 20, 2, dtype=torch.int64, device="cpu"),
+                    torch.arange(30, 60, 3, dtype=torch.int64, device="cpu"),
+                ]
+            ),
+            lengths=torch.cat(
+                [
+                    torch.ones([10], dtype=torch.int64, device="cpu"),
+                    torch.ones([10], dtype=torch.int64, device="cpu"),
+                ]
+            ),
+        )
+        mc_ebc = None
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            EmbeddingBagCollection(
+                device=torch.device("cuda"),
+                tables=embedding_configs,
+                is_weighted=False,
+            ),
+            ManagedCollisionCollection(
+                # pyrefly: ignore[bad-argument-type]
+                managed_collision_modules=mc_modules,
+                embedding_configs=embedding_configs,
+            ),
+            return_remapped_features=True,
+        )
+        mask = mc_ebc.lookup_remapped_lengths_mask(kjt)
+        self.assertTrue(torch.equal(mask, torch.ones(20, dtype=torch.bool)))
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_mc_module_lookup_remapped_lengths_mask_no_fallback(self) -> None:
+        embedding_configs = [
+            EmbeddingBagConfig(
+                name="t1",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f1"],
+            ),
+            EmbeddingBagConfig(
+                name="t2",
+                num_embeddings=100,
+                embedding_dim=8,
+                feature_names=["f2"],
+            ),
+        ]
+
+        mc_modules = {
+            "t1": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+                disable_fallback=True,
+            ),
+            "t2": HashZchManagedCollisionModule(
+                zch_size=100,
+                device=torch.device("cpu"),
+                total_num_buckets=1,
+                eviction_policy_name=HashZchEvictionPolicyName.SINGLE_TTL_EVICTION,
+                eviction_config=HashZchEvictionConfig(
+                    features=[],
+                    single_ttl=10,
+                ),
+                disable_fallback=True,
+            ),
+        }
+        for mc_module in mc_modules.values():
+            mc_module.reset_inference_mode()
+        kjt = KeyedJaggedTensor(
+            keys=["f1", "f2"],
+            values=torch.cat(
+                [
+                    torch.arange(0, 20, 2, dtype=torch.int64, device="cpu"),
+                    torch.arange(30, 60, 3, dtype=torch.int64, device="cpu"),
+                ]
+            ),
+            lengths=torch.cat(
+                [
+                    torch.ones([10], dtype=torch.int64, device="cpu"),
+                    torch.ones([10], dtype=torch.int64, device="cpu"),
+                ]
+            ),
+        )
+        mc_ebc: Optional[ManagedCollisionEmbeddingBagCollection] = None
+        mc_ebc = ManagedCollisionEmbeddingBagCollection(
+            EmbeddingBagCollection(
+                device=torch.device("cuda"),
+                tables=embedding_configs,
+                is_weighted=False,
+            ),
+            ManagedCollisionCollection(
+                # pyrefly: ignore[bad-argument-type]
+                managed_collision_modules=mc_modules,
+                embedding_configs=embedding_configs,
+            ),
+            return_remapped_features=True,
+        )
+        mask = mc_ebc.lookup_remapped_lengths_mask(kjt)
+        # It should be all cache miss as we initialize identity tensor as -1.
+        self.assertTrue(torch.equal(mask, torch.zeros(20, dtype=torch.bool)))
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Summary:

Context
---------

This diff stack is meant to unify different MP-ZCH implementations into OSS.

The goal of this diff is to move the backend of internal `hash_mc_modules` to be OSS, and make all differences to be imported.

Implementation
-----------------

- Internal needs the following for now:
    - OSS uses FBGEMM, whereas internal uses torch/retrieval.
    - TensorBoard

So it makes the internal class be a super-class of OSS, and the key changes are added to be imported from internal.

Reviewed By: kausv

Differential Revision: D96242593
