### PR TITLE
Add RecMetrics support to train pipeline benchmark (#3874)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -20,6 +20,7 @@ To support a new model in pipeline benchmark:
     See benchmark_pipeline_utils.py for step-by-step instructions.
 """
 
+import itertools
 import logging
 import os
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 import torch
 from torch import nn
+from torch.autograd.profiler import record_function
 from torchrec.distributed.benchmark.base import (
     BenchFuncConfig,
     benchmark_func,
@@ -38,6 +40,7 @@ from torchrec.distributed.benchmark.base import (
     GPUMemoryStats,
 )
 from torchrec.distributed.test_utils.input_config import ModelInputConfig
+from torchrec.distributed.test_utils.metric_config import RecMetricConfig
 from torchrec.distributed.test_utils.model_config import (
     BaseModelConfig,
     ModelSelectionConfig,
@@ -61,6 +64,7 @@ from torchrec.distributed.train_pipeline import (
     GradientAccumulationWrapper,
     TrainPipeline,
 )
+from torchrec.metrics.metric_module import RecMetricModule
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
@@ -105,6 +109,12 @@ class RunOptions(BenchFuncConfig):
             (default), the pipeline runs without gradient accumulation. When > 1,
             the pipeline is wrapped with GradientAccumulationWrapper to accumulate
             gradients over multiple micro-batches before synchronizing.
+        num_iters (Optional[int]): Total number of training iterations per
+            benchmark run. When set, the dataloader cycles over the pre-generated
+            batches (num_batches) repeatedly until num_iters iterations are
+            reached. This allows simulating long training runs without the CPU
+            memory cost of generating unique batches. When None (default),
+            num_batches iterations are run (no cycling).
     """
 
     world_size: int = 2
@@ -119,6 +129,7 @@ class RunOptions(BenchFuncConfig):
     topology_domain_max_group_count: Optional[int] = None
     local_world_size: Optional[int] = None
     ga_num_steps: int = 1
+    num_iters: Optional[int] = None
 
 
 # single-rank runner
@@ -133,6 +144,7 @@ def runner(
     input_config: ModelInputConfig,
     planner_config: PlannerConfig,
     sharding_config: ShardingConfig,
+    metric_config: RecMetricConfig,
     table_related_configs: Optional[TableExtendedConfigs] = None,
     debug_mode: bool = False,
 ) -> BenchmarkResult:
@@ -210,16 +222,48 @@ def runner(
             planner=planner,
         )
 
+        metric_module: Optional[RecMetricModule] = metric_config.generate_metric_module(
+            batch_size=run_option.batch_size,
+            world_size=world_size,
+            rank=rank,
+            device=ctx.device,
+            process_group=ctx.pg,
+        )
+
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],
             model: nn.Module,
             pipeline: TrainPipeline,
         ) -> None:
             pipeline.reset()
-            dataloader = iter(bench_inputs)
+            if metric_module is not None:
+                metric_module.reset()
+                metric_module.trained_batches = 0
+            if run_option.num_iters is not None:
+                dataloader = itertools.islice(
+                    itertools.cycle(bench_inputs), run_option.num_iters
+                )
+            else:
+                dataloader = iter(bench_inputs)
             while True:
                 try:
-                    pipeline.progress(dataloader)
+                    output = pipeline.progress(dataloader)
+                    if metric_module is not None and output is not None:
+                        # Reduce to 1D [batch_size] for binary classification
+                        # metrics (NE, AUC). The model produces [batch_size,
+                        # over_arch_out_size] which would cause OOM in metric
+                        # sync (dist.all_gather accumulates all predictions).
+                        pred = output.detach().mean(dim=-1)
+                        model_out = {
+                            "prediction": pred,
+                            "label": torch.rand_like(pred),
+                            "weight": torch.ones_like(pred),
+                        }
+                        with record_function("## metric_update ##"):
+                            metric_module.update(model_out)
+                        if metric_module.should_compute():
+                            with record_function("## metric_compute ##"):
+                                metric_module.compute()
                 except StopIteration:
                     break
 
@@ -272,6 +316,7 @@ def run_pipeline(
     input_config: ModelInputConfig,
     planner_config: PlannerConfig,
     sharding_config: ShardingConfig,
+    metric_config: RecMetricConfig,
 ) -> BenchmarkResult:
     tables, weighted_tables, *_ = table_config.generate_tables()
 
@@ -286,6 +331,7 @@ def run_pipeline(
         input_config=input_config,
         planner_config=planner_config,
         sharding_config=sharding_config,
+        metric_config=metric_config,
     )
 
     # Combine results from all ranks into a single BenchmarkResult
@@ -323,6 +369,7 @@ def main(
     input_config: ModelInputConfig,
     planner_config: PlannerConfig,
     sharding_config: ShardingConfig,
+    metric_config: RecMetricConfig,
 ) -> None:
     if run_option.debug_mode:
         # pyrefly: ignore[missing-module-attribute]
@@ -348,6 +395,7 @@ def main(
         input_config=input_config,
         planner_config=planner_config,
         sharding_config=sharding_config,
+        metric_config=metric_config,
         table_related_configs=table_extended_config,
         debug_mode=run_option.debug_mode,
     )

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_metrics.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_metrics.yml
@@ -1,0 +1,41 @@
+# Sparse data dist benchmark with RecMetrics enabled
+# Measures pipeline overhead including metric update/compute
+#
+# Usage:
+#   buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
+#     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_metrics.yml
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  profile_dir: "."
+  memory_snapshot: True
+  name: "sparse_data_dist_metrics"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+PlannerConfig:
+  pooling_factors: [30.0]
+RecMetricConfig:
+  enable_metrics: true
+  metrics: [ne, auc]
+  compute_interval: 5
+  window_size: 10_000_000

--- a/torchrec/distributed/test_utils/metric_config.py
+++ b/torchrec/distributed/test_utils/metric_config.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import torch
+import torch.distributed as dist
+from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
+from torchrec.metrics.metrics_config import (
+    MetricsConfig,
+    RecMetricDef,
+    RecMetricEnum,
+    RecTaskInfo,
+)
+
+
+# Mapping from string names to RecMetricEnum values for CLI usage
+_METRIC_NAME_MAP = {e.value: e for e in RecMetricEnum}
+
+
+@dataclass
+class RecMetricConfig:
+    """
+    Configuration for including RecMetrics in the benchmark loop.
+
+    When enabled, a RecMetricModule is created and its update()/compute()
+    calls are included in the benchmark timing, reflecting the overhead
+    that metrics add to a real training pipeline.
+
+    Args:
+        enable_metrics (bool): Whether to include RecMetricModule
+            update/compute in the benchmark loop. Default is False.
+        metrics (List[str]): List of metric names to compute.
+            Valid values: "ne", "auc", "calibration", "mse", "mae", etc.
+            (see RecMetricEnum for all options). Default is ["ne"].
+        compute_interval (int): How often to call compute() in batches.
+            Default is 10 (once per benchmark iteration with default
+            num_batches=10).
+        window_size (int): Window size for windowed metric computation.
+            Default is 10_000_000.
+        task_name (str): Name of the metric task. Default is "DefaultTask".
+    """
+
+    enable_metrics: bool = False
+    metrics: List[str] = field(default_factory=lambda: ["ne"])
+    compute_interval: int = 10
+    window_size: int = 10_000_000
+    task_name: str = "DefaultTask"
+
+    def generate_metric_module(
+        self,
+        batch_size: int,
+        world_size: int,
+        rank: int,
+        device: torch.device,
+        process_group: Optional[dist.ProcessGroup] = None,
+    ) -> Optional[RecMetricModule]:
+        """
+        Generate a RecMetricModule based on this configuration.
+
+        Returns None if enable_metrics is False.
+
+        Args:
+            batch_size: Batch size for the benchmark.
+            world_size: Number of distributed ranks.
+            rank: Current rank.
+            device: Device to place metric tensors on.
+            process_group: Distributed process group for metric sync.
+
+        Returns:
+            A RecMetricModule if metrics are enabled, None otherwise.
+        """
+        if not self.enable_metrics:
+            return None
+
+        task = RecTaskInfo(
+            name=self.task_name,
+            label_name="label",
+            prediction_name="prediction",
+            weight_name="weight",
+        )
+
+        rec_metrics: Dict[RecMetricEnum, RecMetricDef] = {}
+        for metric_name in self.metrics:
+            if metric_name not in _METRIC_NAME_MAP:
+                raise ValueError(
+                    f"Unknown metric '{metric_name}'. "
+                    f"Valid options: {sorted(_METRIC_NAME_MAP.keys())}"
+                )
+            rec_metrics[_METRIC_NAME_MAP[metric_name]] = RecMetricDef(
+                rec_tasks=[task],
+                window_size=self.window_size,
+            )
+
+        metrics_config = MetricsConfig(
+            rec_tasks=[task],
+            rec_metrics=rec_metrics,
+            compute_interval_steps=self.compute_interval,
+        )
+
+        module = generate_metric_module(
+            metric_class=RecMetricModule,
+            metrics_config=metrics_config,
+            batch_size=batch_size,
+            world_size=world_size,
+            my_rank=rank,
+            state_metrics_mapping={},
+            device=device,
+            process_group=process_group,
+        )
+
+        return module


### PR DESCRIPTION
Summary:

## 1. Context

The train pipeline benchmark (`benchmark_train_pipeline.py`) currently measures only execution time and memory. In production, `RecMetricModule.update()` and `RecMetricModule.compute()` consume significant GPU time, but this overhead is invisible in the benchmark. Adding optional metrics computation makes the benchmark more representative of real training workloads.

## 2. Approach

1. **`RecMetricConfig` dataclass** (`metric_config.py`): New reusable config following the existing pattern (`PipelineConfig`, `ShardingConfig`, etc.). Supports configurable metric list (NE, AUC, etc.), compute interval, and window size. The `generate_metric_module()` factory creates a `RecMetricModule` ready for use in the benchmark loop.
2. **Benchmark integration** (`benchmark_train_pipeline.py`): After each `pipeline.progress()`, the output is detached, reduced to 1D, and fed to `metric_module.update()`. `compute()` is called at the configured interval. Both calls are wrapped in `record_function` annotations (`## metric_update ##`, `## metric_compute ##`) for profiler visibility.
3. **YAML config** (`sparse_data_dist_metrics.yml`): Pre-configured SDD benchmark with NE + AUC metrics enabled, compute every 5 batches, 20 benchmark iterations.

## 3. Results

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_metrics           |5541.44 ms       |5611.77 ms       |43.22 GB                |62.65 GB                   |65.28 GB          |0.0 / 0.0 / 0.0              |57.14 GB          |

* repro commands
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_metrics.yml
```

* trace
metric_update runs every batch, metric_compute runs every 5 batches (as config)
{F1986665748} 

## 4. Analysis

1. **No BC risk**: `RecMetricConfig` is a new dataclass with `enable_metrics=False` by default. Existing callers (e.g., `automatic_train_pipeline.py`) pass `RecMetricConfig()` which keeps metrics disabled.
2. **Output shape reduction**: The model output `[batch_size, over_arch_out_size]` is reduced to `[batch_size]` via `.mean(dim=-1)` before feeding to metrics. Without this, AUC would accumulate 1024x more data per batch, causing OOM during `dist.all_gather`.
3. **Detach from computation graph**: `output.detach()` prevents the metric module from holding references to the pipeline's computation graph, which would prevent memory from being freed between batches.

## 5. Changes

1. **`metric_config.py`** (new): `RecMetricConfig` dataclass with `generate_metric_module()` factory.
2. **`benchmark_train_pipeline.py`**: Adds `metric_config: RecMetricConfig` parameter to `runner()`, `run_pipeline()`, and `main()`. Integrates `metric_module.update()` and `compute()` into the benchmark loop with `record_function` annotations.
3. **`sparse_data_dist_metrics.yml`** (new): YAML config for SDD benchmark with NE + AUC metrics, `compute_interval: 5`, `window_size: 10_000_000`.
4. **`automatic_train_pipeline.py`**: Updated to pass `metric_config=RecMetricConfig()` (metrics disabled) to `run_pipeline()`.
5. **BUCK files**: Added `metric_config` library target and deps.

Reviewed By: xywang9334

Differential Revision: D96398832


