### PR TITLE
Replace weak assertTrue assertions with specific unittest methods (#3875)

### DIFF
--- a/contrib/dynamic_embedding/tests/test_id_transformer.py
+++ b/contrib/dynamic_embedding/tests/test_id_transformer.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import torch
@@ -55,7 +62,7 @@ class TestIDTransformer(unittest.TestCase):
             self.assertTrue(success)
 
             python_cache_ids = python_transformer.transform(global_ids)
-            self.assertTrue(torch.all(cache_ids == python_cache_ids))
+            self.assertTrue(torch.all(cache_ids == python_cache_ids).item())
 
             if ids_to_fetch is not None:
                 ids_map = {

--- a/contrib/dynamic_embedding/tests/test_id_transformer_collection.py
+++ b/contrib/dynamic_embedding/tests/test_id_transformer_collection.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import torch
@@ -21,9 +28,9 @@ class TestIDTransformerCollection(unittest.TestCase):
         for handle in fetch_handles:
             handle.wait()
         self.assertEqual(cache_kjt.keys(), global_kjt.keys())
-        self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()))
+        self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()).item())
         self.assertTrue(
-            torch.all(cache_kjt.values() == torch.tensor([0, 1, 2, 1, 0, 1, 2]))
+            torch.all(cache_kjt.values() == torch.tensor([0, 1, 2, 1, 0, 1, 2])).item()
         )
 
     def testFeatureNames(self):
@@ -43,9 +50,9 @@ class TestIDTransformerCollection(unittest.TestCase):
         for handle in fetch_handles:
             handle.wait()
         self.assertEqual(cache_kjt.keys(), global_kjt.keys())
-        self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()))
+        self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()).item())
         self.assertTrue(
             torch.all(
                 cache_kjt.values() == torch.tensor([0, 1, 2, 1, 0, 1, 2, 1, 2, 0])
-            )
+            ).item()
         )

--- a/contrib/dynamic_embedding/tests/test_ps_collection.py
+++ b/contrib/dynamic_embedding/tests/test_ps_collection.py
@@ -99,7 +99,8 @@ class TestPSCollection(unittest.TestCase):
         weight = (
             model.module.state_dict()["embeddings.AB.weight"].local_shards()[0].tensor
         )
-        self.assertTrue(weight.shape[0] == 4 and weight.shape[1] == embedding_dim)
+        self.assertEqual(weight.shape[0], 4)
+        self.assertEqual(weight.shape[1], embedding_dim)
 
         # init to zero
         weight[:] = torch.zeros_like(weight)
@@ -114,7 +115,7 @@ class TestPSCollection(unittest.TestCase):
             handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
-            torch.all(cache_kjt.values() == torch.tensor([0, 1, 2, 3, 0, 1]))
+            torch.all(cache_kjt.values() == torch.tensor([0, 1, 2, 3, 0, 1])).item()
         )
         self.assertTrue(
             torch.allclose(
@@ -139,7 +140,7 @@ class TestPSCollection(unittest.TestCase):
             handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
-            torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 2, 3]))
+            torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 2, 3])).item()
         )
         self.assertTrue(
             torch.allclose(
@@ -164,7 +165,7 @@ class TestPSCollection(unittest.TestCase):
             handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
-            torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 3, 2]))
+            torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 3, 2])).item()
         )
         self.assertTrue(
             torch.allclose(

--- a/examples/cloud_deployment/quickstart/tests/test_train_torchrec_quickstart.py
+++ b/examples/cloud_deployment/quickstart/tests/test_train_torchrec_quickstart.py
@@ -215,8 +215,8 @@ class DLRMTest(unittest.TestCase):
         output = model(dense_features, sparse_features)
 
         # All outputs should be between 0 and 1
-        self.assertTrue(torch.all(output >= 0).item())
-        self.assertTrue(torch.all(output <= 1).item())
+        self.assertGreaterEqual(output.min().item(), 0)
+        self.assertLessEqual(output.max().item(), 1)
 
     def test_dlrm_backward_pass(self) -> None:
         """Test that DLRM can perform backward pass."""
@@ -360,8 +360,8 @@ class SyntheticDatasetTest(unittest.TestCase):
 
         for _, sparse, _ in dataset:
             values = sparse.values()
-            self.assertTrue(torch.all(values >= 0))
-            self.assertTrue(torch.all(values < self.num_embeddings))
+            self.assertGreaterEqual(values.min().item(), 0)
+            self.assertLess(values.max().item(), self.num_embeddings)
 
     def test_dataset_dense_features_range(self) -> None:
         """Test that dense features are in [0, 1] range (from torch.rand)."""
@@ -375,8 +375,8 @@ class SyntheticDatasetTest(unittest.TestCase):
         )
 
         for dense, _, _ in dataset:
-            self.assertTrue(torch.all(dense >= 0))
-            self.assertTrue(torch.all(dense <= 1))
+            self.assertGreaterEqual(dense.min().item(), 0)
+            self.assertLessEqual(dense.max().item(), 1)
 
 
 class SetupDistributedTest(unittest.TestCase):
@@ -523,15 +523,15 @@ class MLPEdgeCaseTest(unittest.TestCase):
         x = torch.randn(100, 10)
         output = mlp(x)
         # After ReLU, output should be non-negative
-        self.assertTrue(torch.all(output >= 0))
+        self.assertGreaterEqual(output.min().item(), 0)
 
     def test_mlp_sigmoid_output_range(self) -> None:
         """Test that MLP with sigmoid produces outputs in (0, 1)."""
         mlp = MLP(in_size=10, layer_sizes=[32], activation="sigmoid")
         x = torch.randn(100, 10)
         output = mlp(x)
-        self.assertTrue(torch.all(output >= 0).item())
-        self.assertTrue(torch.all(output <= 1).item())
+        self.assertGreaterEqual(output.min().item(), 0)
+        self.assertLessEqual(output.max().item(), 1)
 
 
 class DLRMEdgeCaseTest(unittest.TestCase):
@@ -618,8 +618,8 @@ class DLRMEdgeCaseTest(unittest.TestCase):
         with torch.no_grad():
             output = model(dense, sparse)
         self.assertEqual(output.shape, (4,))
-        self.assertTrue(torch.all(output >= 0).item())
-        self.assertTrue(torch.all(output <= 1).item())
+        self.assertGreaterEqual(output.min().item(), 0)
+        self.assertLessEqual(output.max().item(), 1)
 
     def test_dlrm_deterministic_in_eval(self) -> None:
         """Test that DLRM produces same output for same input in eval mode."""
@@ -728,8 +728,8 @@ class DLRMEdgeCaseTest(unittest.TestCase):
         sparse = self._make_sparse_features(3, 4, 50)
         output = model(dense, sparse)
         self.assertEqual(output.shape, (4,))
-        self.assertTrue(torch.all(output >= 0).item())
-        self.assertTrue(torch.all(output <= 1).item())
+        self.assertGreaterEqual(output.min().item(), 0)
+        self.assertLessEqual(output.max().item(), 1)
 
     def test_dlrm_rejects_mismatched_dense_arch_and_embedding_dim(self) -> None:
         """dense_arch_layer_sizes[-1] must equal embedding_dim."""
@@ -840,8 +840,8 @@ class SyntheticDatasetEdgeCaseTest(unittest.TestCase):
         )
         for _, sparse, _ in dataset:
             lengths = sparse.lengths()
-            self.assertTrue(torch.all(lengths >= 1))
-            self.assertTrue(torch.all(lengths <= 3))
+            self.assertGreaterEqual(lengths.min().item(), 1)
+            self.assertLessEqual(lengths.max().item(), 3)
 
     def test_dataset_reiterable(self) -> None:
         """Test that dataset can be iterated over multiple times."""

--- a/examples/prediction/test_predict_using_torchrec.py
+++ b/examples/prediction/test_predict_using_torchrec.py
@@ -313,7 +313,7 @@ class TestCreateKJTFromBatch(unittest.TestCase):
 
         # Check lengths
         self.assertEqual(kjt.lengths().shape[0], self.batch_size * 4)
-        self.assertTrue((kjt.lengths() == 1).all())
+        self.assertTrue((kjt.lengths() == 1).all().item())
 
 
 if __name__ == "__main__":

--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -824,7 +824,7 @@ class TestMemoryBalancedPartitioner(unittest.TestCase):
                     #  got `Optional[int]`.
                     memory_balanced_hbm_uses[shard.rank] += shard.storage.hbm
 
-        self.assertTrue(max(memory_balanced_hbm_uses) < max(greedy_perf_hbm_uses))
+        self.assertLess(max(memory_balanced_hbm_uses), max(greedy_perf_hbm_uses))
 
 
 class TestBalanceModules(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -1094,7 +1094,7 @@ class TestPlanLoaderIntegration(unittest.TestCase):
 
         # Verify a plan was generated
         self.assertIsNotNone(loaded_plan)
-        self.assertTrue(len(loaded_plan.plan) > 0)
+        self.assertGreater(len(loaded_plan.plan), 0)
 
 
 class TestExtractPlan(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_utils.py
+++ b/torchrec/distributed/planner/tests/test_utils.py
@@ -73,7 +73,7 @@ class TestFindImbalanceTables(unittest.TestCase):
             sharding_option.name
             for sharding_option in _find_imbalance_tables(self.best_plan)
         ]
-        self.assertTrue(expected_max_perf_table_names, max_perf_table_names)
+        self.assertEqual(expected_max_perf_table_names, max_perf_table_names)
 
     def test_find_hbm_imbalance_tables(self) -> None:
         reset_shard_rank(self.best_plan)
@@ -92,7 +92,7 @@ class TestFindImbalanceTables(unittest.TestCase):
                 self.best_plan, target_imbalance="hbm"
             )
         ]
-        self.assertTrue(expected_max_hbm_table_names, max_hbm_table_names)
+        self.assertEqual(expected_max_hbm_table_names, max_hbm_table_names)
 
 
 class TestBinarySearchPredicate(unittest.TestCase):

--- a/torchrec/distributed/tests/test_emb_dim_bucketer.py
+++ b/torchrec/distributed/tests/test_emb_dim_bucketer.py
@@ -72,14 +72,14 @@ class TestEmbDimBucketer(unittest.TestCase):
         emb_dim_bucketer = EmbDimBucketer(
             embedding_tables, EmbDimBucketerPolicy.CACHELINE_BUCKETS
         )
-        self.assertTrue(emb_dim_bucketer.bucket_count() == 1)
+        self.assertEqual(emb_dim_bucketer.bucket_count(), 1)
 
     def test_single_bucket_policy(self) -> None:
         embedding_tables, _ = self.gen_tables()
         emb_dim_bucketer = EmbDimBucketer(
             embedding_tables, EmbDimBucketerPolicy.SINGLE_BUCKET
         )
-        self.assertTrue(emb_dim_bucketer.bucket_count() == 1)
+        self.assertEqual(emb_dim_bucketer.bucket_count(), 1)
 
     def test_cacheline_bucket_policy(self) -> None:
         embedding_tables, _ = self.gen_tables()
@@ -95,7 +95,7 @@ class TestEmbDimBucketer(unittest.TestCase):
             embedding_tables, EmbDimBucketerPolicy.ALL_BUCKETS
         )
 
-        self.assertTrue(emb_dim_bucketer.bucket_count() == num_buckets)
+        self.assertEqual(emb_dim_bucketer.bucket_count(), num_buckets)
 
         for i in range(emb_dim_bucketer.bucket_count()):
             self.assertTrue(i in emb_dim_bucketer.emb_dim_buckets.values())

--- a/torchrec/distributed/tests/test_infer_hetero_shardings.py
+++ b/torchrec/distributed/tests/test_infer_hetero_shardings.py
@@ -121,7 +121,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
         # pyrefly: ignore[bad-index]
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_lookups"))
         # pyrefly: ignore[bad-index]
-        self.assertTrue(len(sharded_model._module_kjt_input[0]._lookups) == 2)
+        self.assertEqual(len(sharded_model._module_kjt_input[0]._lookups), 2)
         # pyrefly: ignore[bad-index]
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_input_dists"))
 
@@ -133,14 +133,14 @@ class InferHeteroShardingsTest(unittest.TestCase):
                     "_embedding_lookups_per_rank",
                 )
             )
-            self.assertTrue(
+            self.assertEqual(
                 len(
                     # pyrefly: ignore[bad-index]
                     sharded_model._module_kjt_input[0]
                     ._lookups[i]
                     ._embedding_lookups_per_rank
-                )
-                == env.world_size
+                ),
+                env.world_size,
             )
 
     @unittest.skipIf(
@@ -218,7 +218,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
         # pyrefly: ignore[bad-index]
         self.assertTrue(hasattr(sharded_model._module_kjt_input[0], "_lookups"))
         # pyrefly: ignore[bad-index]
-        self.assertTrue(len(sharded_model._module_kjt_input[0]._lookups) == 2)
+        self.assertEqual(len(sharded_model._module_kjt_input[0]._lookups), 2)
         for i, env in enumerate(env_dict.values()):
             self.assertTrue(
                 hasattr(
@@ -227,14 +227,14 @@ class InferHeteroShardingsTest(unittest.TestCase):
                     "_embedding_lookups_per_rank",
                 )
             )
-            self.assertTrue(
+            self.assertEqual(
                 len(
                     # pyrefly: ignore[bad-index]
                     sharded_model._module_kjt_input[0]
                     ._lookups[i]
                     ._embedding_lookups_per_rank
-                )
-                == env.world_size
+                ),
+                env.world_size,
             )
 
     def test_cpu_gpu_sharding_autoplanner(self) -> None:
@@ -285,7 +285,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
         )
         print(module_plan)
 
-        self.assertTrue(
+        self.assertEqual(
             # pyrefly: ignore[bad-index]
             module_plan.plan["_module_kjt_input.0"]["table_0"]
             .sharding_spec.shards[0]
@@ -293,7 +293,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
             .type,
             "cpu",
         )
-        self.assertTrue(
+        self.assertEqual(
             # pyrefly: ignore[bad-index]
             module_plan.plan["_module_kjt_input.0"]["table_1"]
             .sharding_spec.shards[0]
@@ -301,7 +301,7 @@ class InferHeteroShardingsTest(unittest.TestCase):
             .type,
             "cuda",
         )
-        self.assertTrue(
+        self.assertEqual(
             # pyrefly: ignore[bad-index]
             module_plan.plan["_module_kjt_input.0"]["table_2"]
             .sharding_spec.shards[0]

--- a/torchrec/distributed/tests/test_model_input.py
+++ b/torchrec/distributed/tests/test_model_input.py
@@ -107,8 +107,8 @@ class TestModelInput(unittest.TestCase):
         self.assertIsNotNone(model_input.idlist_features)
         indices = model_input.idlist_features.values()
 
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
 
     def test_generate_power_law_with_weighted_tables(self) -> None:
         """Power-law distribution should work with weighted tables."""
@@ -170,10 +170,10 @@ class TestModelInput(unittest.TestCase):
             all_zeros=True,
         )
 
-        self.assertTrue(torch.all(model_input.float_features == 0))
-        self.assertTrue(torch.all(model_input.label == 0))
+        self.assertTrue(torch.all(model_input.float_features == 0).item())
+        self.assertTrue(torch.all(model_input.label == 0).item())
         self.assertIsNotNone(model_input.idlist_features)
-        self.assertTrue(torch.all(model_input.idlist_features.values() == 0))
+        self.assertTrue(torch.all(model_input.idlist_features.values() == 0).item())
 
     def test_generate_with_use_offsets(self) -> None:
         """When use_offsets=True, KJT should use offsets instead of lengths."""
@@ -264,7 +264,7 @@ class TestModelInput(unittest.TestCase):
         self.assertIsNotNone(model_input.idlist_features)
         kjt = model_input.idlist_features
         lengths = kjt.lengths()
-        self.assertTrue(torch.all(lengths <= max_length))
+        self.assertLessEqual(lengths.max().item(), max_length)
 
     def test_generate_without_tables(self) -> None:
         """ModelInput.generate should work when tables are empty or None."""
@@ -534,8 +534,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
 
         # Check distribution is roughly uniform
         counter = Counter(indices.tolist())
@@ -556,8 +556,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
         # Verify index 0 is actually generated (validates off-by-one fix)
         self.assertIn(0, indices.tolist())
 
@@ -575,8 +575,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
         # Verify index 0 is actually generated (validates off-by-one fix)
         self.assertIn(0, indices.tolist())
 
@@ -600,8 +600,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
         # Verify index 0 is actually generated (validates off-by-one fix)
         self.assertIn(0, indices.tolist())
 
@@ -622,7 +622,7 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 100)
-        self.assertTrue(torch.all(indices == 0))
+        self.assertTrue(torch.all(indices == 0).item())
 
     def test_generate_power_law_indices_alpha_near_one_from_below(self) -> None:
         """Test alpha very close to 1 from below uses log-uniform branch."""
@@ -638,8 +638,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
         # Should not have numerical overflow issues
         self.assertFalse(torch.any(torch.isnan(indices.float())))
         self.assertFalse(torch.any(torch.isinf(indices.float())))
@@ -658,8 +658,8 @@ class TestModelInput(unittest.TestCase):
         )
 
         self.assertEqual(indices.numel(), 10000)
-        self.assertTrue(torch.all(indices >= 0))
-        self.assertTrue(torch.all(indices < num_embeddings))
+        self.assertGreaterEqual(indices.min().item(), 0)
+        self.assertLess(indices.max().item(), num_embeddings)
         # Should not have numerical overflow issues
         self.assertFalse(torch.any(torch.isnan(indices.float())))
         self.assertFalse(torch.any(torch.isinf(indices.float())))

--- a/torchrec/inference/tests/test_inference.py
+++ b/torchrec/inference/tests/test_inference.py
@@ -281,9 +281,9 @@ class InferenceTest(unittest.TestCase):
 
         # When world_size = 1, we should have 1 TBE per sharded, quantized ebc
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(sharded_quant_model.sparse.ebc.tbes) == 1)
+        self.assertEqual(len(sharded_quant_model.sparse.ebc.tbes), 1)
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(sharded_quant_model.sparse.weighted_ebc.tbes) == 1)
+        self.assertEqual(len(sharded_quant_model.sparse.weighted_ebc.tbes), 1)
 
         # Check the weights are close
         torch.testing.assert_close(output, quantized_output, rtol=1e-05, atol=1e-3)
@@ -367,9 +367,9 @@ class InferenceTest(unittest.TestCase):
 
         # When world_size = 1, we should have 1 TBE per sharded, quantized ebc
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(sharded_quant_model.sparse.ebc.tbes) == 1)
+        self.assertEqual(len(sharded_quant_model.sparse.ebc.tbes), 1)
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(sharded_quant_model.sparse.weighted_ebc.tbes) == 1)
+        self.assertEqual(len(sharded_quant_model.sparse.weighted_ebc.tbes), 1)
 
         # Check the weights are close
         torch.testing.assert_close(output, quantized_output, rtol=1e-05, atol=1e-3)
@@ -403,9 +403,9 @@ class InferenceTest(unittest.TestCase):
         quantized_model = quantize_inference_model(model)
         # We should have 2 TBEs for unweighted ebc as the 2 tables here have different pooling types
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(quantized_model.sparse.ebc.tbes) == 2)
+        self.assertEqual(len(quantized_model.sparse.ebc.tbes), 2)
         # pyrefly: ignore[missing-attribute]
-        self.assertTrue(len(quantized_model.sparse.weighted_ebc.tbes) == 1)
+        self.assertEqual(len(quantized_model.sparse.weighted_ebc.tbes), 1)
         # Changing this back
         self.tables[0].pooling = PoolingType.SUM
 

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -210,8 +210,8 @@ class NEMetricTest(unittest.TestCase):
             eta=eta,
             allow_missing_label_with_zero_weight=True,
         )
-        self.assertTrue(torch.all(~ne.isinf()))
-        self.assertTrue(torch.all(~ne.isnan()))
+        self.assertFalse(ne.isinf().any().item())
+        self.assertFalse(ne.isnan().any().item())
         torch.testing.assert_close(
             ne.eq(eta), torch.tensor([False, True, False]), rtol=0, atol=0
         )

--- a/torchrec/metrics/tests/test_precision_session.py
+++ b/torchrec/metrics/tests/test_precision_session.py
@@ -304,23 +304,23 @@ class PrecisionSessionValueTest(unittest.TestCase):
         self.assertSetEqual(
             precision_metric.get_required_inputs(), {"session1", "session2"}
         )
-        self.assertTrue(len(precision_metric._tasks) == 2)
-        self.assertTrue(precision_metric._tasks[0] == task_info1)
-        self.assertTrue(precision_metric._tasks[1] == task_info2)
+        self.assertEqual(len(precision_metric._tasks), 2)
+        self.assertEqual(precision_metric._tasks[0], task_info1)
+        self.assertEqual(precision_metric._tasks[1], task_info2)
 
         # metrics_computations checks
-        self.assertTrue(precision_metric._metrics_computations[0]._my_rank == 5)
-        self.assertTrue(precision_metric._metrics_computations[1]._my_rank == 5)
-        self.assertTrue(precision_metric._metrics_computations[0]._batch_size == 100)
-        self.assertTrue(precision_metric._metrics_computations[1]._batch_size == 100)
+        self.assertEqual(precision_metric._metrics_computations[0]._my_rank, 5)
+        self.assertEqual(precision_metric._metrics_computations[1]._my_rank, 5)
+        self.assertEqual(precision_metric._metrics_computations[0]._batch_size, 100)
+        self.assertEqual(precision_metric._metrics_computations[1]._batch_size, 100)
 
-        self.assertTrue(precision_metric._metrics_computations[0].top_threshold == 1)
-        self.assertTrue(precision_metric._metrics_computations[1].top_threshold == 2)
-        self.assertTrue(
-            precision_metric._metrics_computations[0].session_var_name == "session1"
+        self.assertEqual(precision_metric._metrics_computations[0].top_threshold, 1)
+        self.assertEqual(precision_metric._metrics_computations[1].top_threshold, 2)
+        self.assertEqual(
+            precision_metric._metrics_computations[0].session_var_name, "session1"
         )
-        self.assertTrue(
-            precision_metric._metrics_computations[1].session_var_name == "session2"
+        self.assertEqual(
+            precision_metric._metrics_computations[1].session_var_name, "session2"
         )
         self.assertTrue(precision_metric._metrics_computations[0].run_ranking_of_labels)
         self.assertTrue(

--- a/torchrec/metrics/tests/test_recall_session.py
+++ b/torchrec/metrics/tests/test_recall_session.py
@@ -313,23 +313,23 @@ class RecallSessionValueTest(unittest.TestCase):
         self.assertSetEqual(
             recall_metric.get_required_inputs(), {"session1", "session2"}
         )
-        self.assertTrue(len(recall_metric._tasks) == 2)
-        self.assertTrue(recall_metric._tasks[0] == task_info1)
-        self.assertTrue(recall_metric._tasks[1] == task_info2)
+        self.assertEqual(len(recall_metric._tasks), 2)
+        self.assertEqual(recall_metric._tasks[0], task_info1)
+        self.assertEqual(recall_metric._tasks[1], task_info2)
 
         # metrics_computations checks
-        self.assertTrue(recall_metric._metrics_computations[0]._my_rank == 5)
-        self.assertTrue(recall_metric._metrics_computations[1]._my_rank == 5)
-        self.assertTrue(recall_metric._metrics_computations[0]._batch_size == 100)
-        self.assertTrue(recall_metric._metrics_computations[1]._batch_size == 100)
+        self.assertEqual(recall_metric._metrics_computations[0]._my_rank, 5)
+        self.assertEqual(recall_metric._metrics_computations[1]._my_rank, 5)
+        self.assertEqual(recall_metric._metrics_computations[0]._batch_size, 100)
+        self.assertEqual(recall_metric._metrics_computations[1]._batch_size, 100)
 
-        self.assertTrue(recall_metric._metrics_computations[0].top_threshold == 1)
-        self.assertTrue(recall_metric._metrics_computations[1].top_threshold == 2)
-        self.assertTrue(
-            recall_metric._metrics_computations[0].session_var_name == "session1"
+        self.assertEqual(recall_metric._metrics_computations[0].top_threshold, 1)
+        self.assertEqual(recall_metric._metrics_computations[1].top_threshold, 2)
+        self.assertEqual(
+            recall_metric._metrics_computations[0].session_var_name, "session1"
         )
-        self.assertTrue(
-            recall_metric._metrics_computations[1].session_var_name == "session2"
+        self.assertEqual(
+            recall_metric._metrics_computations[1].session_var_name, "session2"
         )
         self.assertTrue(recall_metric._metrics_computations[0].run_ranking_of_labels)
         self.assertTrue(

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -65,10 +65,10 @@ class RecMetricTest(unittest.TestCase):
         )
         ne1 = ne1._metrics_computations[0]
         ne2 = ne2._metrics_computations[0]
-        self.assertTrue(ne1.cross_entropy_sum == ne2.cross_entropy_sum)
-        self.assertTrue(ne1.weighted_num_samples == ne2.weighted_num_samples)
-        self.assertTrue(ne1.pos_labels == ne2.pos_labels)
-        self.assertTrue(ne1.neg_labels == ne2.neg_labels)
+        self.assertEqual(ne1.cross_entropy_sum, ne2.cross_entropy_sum)
+        self.assertEqual(ne1.weighted_num_samples, ne2.weighted_num_samples)
+        self.assertEqual(ne1.pos_labels, ne2.pos_labels)
+        self.assertEqual(ne1.neg_labels, ne2.neg_labels)
 
     def test_zero_weights(self) -> None:
         # Test if weights = 0 for an update

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -605,7 +605,7 @@ class TestMCH(unittest.TestCase):
         )
         bucket4 = gpu_zch.rebuild_with_output_id_range((15, 20))
         self.assertIsNotNone(bucket4._output_global_offset_tensor)
-        self.assertTrue(bucket4._output_global_offset_tensor.device.type == "cuda")
+        self.assertEqual(bucket4._output_global_offset_tensor.device.type, "cuda")
         self.assertEqual(
             bucket4._output_global_offset_tensor, torch.tensor([15], device="cuda")
         )
@@ -619,7 +619,7 @@ class TestMCH(unittest.TestCase):
         self.assertIsNone(meta_zch._output_global_offset_tensor)
         bucket5 = meta_zch.rebuild_with_output_id_range((15, 20))
         self.assertIsNotNone(bucket5._output_global_offset_tensor)
-        self.assertTrue(bucket5._output_global_offset_tensor.device.type == "cpu")
+        self.assertEqual(bucket5._output_global_offset_tensor.device.type, "cpu")
         self.assertEqual(bucket5._output_global_offset_tensor, torch.tensor([15]))
 
     @unittest.skipIf(
@@ -670,7 +670,7 @@ class TestMCH(unittest.TestCase):
 
         # check self._hash_zch_metadata is frozen
         # pyrefly: ignore[no-matching-overload]
-        self.assertTrue(torch.all(m._hash_zch_metadata == 110))
+        self.assertTrue(torch.all(m._hash_zch_metadata == 110).item())
 
         m.reset_training_mode()
         self.assertTrue(m.training)
@@ -685,7 +685,7 @@ class TestMCH(unittest.TestCase):
             m.remap({"test": jt})
             # check self._hash_zch_metadata is updated
             # pyrefly: ignore[no-matching-overload]
-            self.assertTrue(torch.all(m._hash_zch_metadata == 160))
+            self.assertTrue(torch.all(m._hash_zch_metadata == 160).item())
 
         m.reset_inference_mode()
         self.assertFalse(m.training)

--- a/torchrec/modules/tests/test_mc_modules.py
+++ b/torchrec/modules/tests/test_mc_modules.py
@@ -527,7 +527,7 @@ class TestManagedCollisionCollection(unittest.TestCase):
             torch.arange(10, 10 + zch_size, device=device).reshape(zch_size, -1),
             requires_grad=False,
         )
-        self.assertTrue(hash_zch_mc1._hash_zch_runtime_meta.size(0), zch_size)
+        self.assertEqual(hash_zch_mc1._hash_zch_runtime_meta.size(0), zch_size)
         hash_zch_mc1._hash_zch_identities = torch.nn.Parameter(
             torch.tensor([50, 100, 999, 300, 400, 500, 600, -1], device=device),
             requires_grad=False,

--- a/torchrec/schema/api_tests/test_inference_schema.py
+++ b/torchrec/schema/api_tests/test_inference_schema.py
@@ -128,7 +128,7 @@ class TestInferenceSchema(unittest.TestCase):
             module_type,
         ) in STABLE_DEFAULT_QUANT_MAPPING.items():
             self.assertTrue(name in DEFAULT_QUANT_MAPPING)
-            self.assertTrue(DEFAULT_QUANT_MAPPING[name] == module_type)
+            self.assertEqual(DEFAULT_QUANT_MAPPING[name], module_type)
 
         # check that the fused params are a superset of the stable ones
         for (
@@ -136,10 +136,10 @@ class TestInferenceSchema(unittest.TestCase):
             val,
         ) in STABLE_DEFAULT_FUSED_PARAMS.items():
             self.assertTrue(name in DEFAULT_FUSED_PARAMS)
-            self.assertTrue(DEFAULT_FUSED_PARAMS[name] == val)
+            self.assertEqual(DEFAULT_FUSED_PARAMS[name], val)
 
         # Check default quant type
-        self.assertTrue(DEFAULT_QUANTIZATION_DTYPE == STABLE_DEFAULT_QUANTIZATION_DTYPE)
+        self.assertEqual(DEFAULT_QUANTIZATION_DTYPE, STABLE_DEFAULT_QUANTIZATION_DTYPE)
 
         # Check default sharders are a superset of the stable ones
         # and check fused_params are also a superset
@@ -151,11 +151,11 @@ class TestInferenceSchema(unittest.TestCase):
                     for key in sharder.fused_params.keys():
                         # pyrefly: ignore[missing-attribute]
                         self.assertTrue(key in default_sharder.fused_params)
-                        self.assertTrue(
+                        self.assertEqual(
                             # pyrefly: ignore[missing-attribute]
-                            default_sharder.fused_params[key]
+                            default_sharder.fused_params[key],
                             # pyrefly: ignore[missing-attribute]
-                            == sharder.fused_params[key]
+                            sharder.fused_params[key],
                         )
                     found = True
 

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -212,8 +212,8 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         torch.testing.assert_close(kjt_0.weights(), kjt_1.weights(), rtol=0, atol=0)
         torch.testing.assert_close(kjt_0.offsets(), kjt_1.offsets(), rtol=0, atol=0)
         self.assertEqual(kjt_0.keys(), kjt_1.keys())
-        self.assertTrue(len(kjt_0.stride_per_key_per_rank()) == 0)
-        self.assertTrue(len(kjt_1.stride_per_key_per_rank()) == 0)
+        self.assertEqual(len(kjt_0.stride_per_key_per_rank()), 0)
+        self.assertEqual(len(kjt_1.stride_per_key_per_rank()), 0)
         self.assertIsNone(kjt_0.inverse_indices_or_none())
         self.assertIsNone(kjt_1.inverse_indices_or_none())
 


### PR DESCRIPTION
Summary:

## 1. Context
Many TorchRec test files use `self.assertTrue(a == b)` instead of `self.assertEqual(a, b)`, and `self.assertTrue(torch.all(x >= val))` instead of more specific assertions like `self.assertGreaterEqual(x.min().item(), val)`. When these assertions fail, `assertTrue` only reports `False is not true` with no context about the actual vs expected values, making test failures difficult to debug. Additionally, several tests had latent bugs where `self.assertTrue(a, b)` was used intending to compare `a` and `b`, but `assertTrue`'s second argument is actually the failure message — so these tests silently always passed.

## 2. Approach
1. **`assertTrue(a == b)` → `assertEqual(a, b)`**: Provides actual and expected values on failure
2. **`assertTrue(torch.all(x >= val))` → `assertGreaterEqual(x.min().item(), val)`**: Shows the violating min/max value instead of just `False`
3. **`assertTrue(torch.all(~x.isnan()))` → `assertFalse(x.isnan().any().item())`**: Clearer semantics
4. **`assertTrue((x == y).all())` → `assertTrue((x == y).all().item())`**: Ensures Python bool instead of tensor
5. **`assertTrue("x" in y)` → `assertIn("x", y)`** and **`assertTrue(isinstance(...))` → `assertIsInstance(...)`**: More specific assertions with better failure messages
6. **Bug fixes**: `assertTrue(a, b)` where `b` was incorrectly used as a comparison value → `assertEqual(a, b)`. These were silently passing tests (9 bugs total across 4 files).

## 3. Results
N/A — test-only changes with no benchmark impact.

## 4. Analysis
1. **Risk**: Low. All changes are test-only and do not modify any production code. The assertion semantics are preserved (or strengthened in the case of bug fixes).
2. **Bug fixes found**: 9 instances across 4 files where `assertTrue(a, b)` was silently always passing: `test_utils.py` (planner, 2 bugs), `test_mc_modules.py` (1 bug), `test_ads_general_pooled_embedding_arch.py` (3 bugs), `test_infer_hetero_shardings.py` (3 bugs).
3. **Backward compatibility**: No BC concerns — only test files are modified.

## 5. Changes
1. **`distributed/planner/tests/test_utils.py`**: BUG FIX — `assertTrue(expected, actual)` → `assertEqual` (2 fixes)
2. **`distributed/planner/tests/test_partitioners.py`**: `assertTrue(a < b)` → `assertLess`
3. **`distributed/planner/tests/test_planners.py`**: `assertTrue(len(...) > 0)` → `assertGreater`
4. **`distributed/tests/test_emb_dim_bucketer.py`**: `assertTrue(a == b)` → `assertEqual` (3 fixes)
5. **`distributed/tests/test_infer_hetero_shardings.py`**: `assertTrue(a == b)` → `assertEqual` + BUG FIX `assertTrue(expr, "cpu")` → `assertEqual` (7 fixes)
6. **`distributed/tests/test_model_input.py`**: `assertTrue(torch.all(...))` → specific assertions (19 fixes)
7. **`modules/tests/test_mc_modules.py`**: BUG FIX — `assertTrue(size, expected)` → `assertEqual`
8. **`modules/tests/test_hash_mc_modules.py`**: `assertTrue(a == b)` → `assertEqual` + `.item()` additions (4 fixes)
9. **`metrics/tests/test_recmetric.py`**: `assertTrue(a == b)` → `assertEqual` (4 fixes)
10. **`metrics/tests/test_precision_session.py`**: `assertTrue(a == b)` → `assertEqual` (11 fixes)
11. **`metrics/tests/test_recall_session.py`**: `assertTrue(a == b)` → `assertEqual` (11 fixes)
12. **`metrics/tests/test_ne.py`**: `assertTrue(torch.all(~x.isinf/isnan()))` → `assertFalse` (2 fixes)
13. **`inference/tests/test_inference.py`**: `assertTrue(len(...) == val)` → `assertEqual` (6 fixes)
14. **`schema/api_tests/test_inference_schema.py`**: `assertTrue(a == b)` → `assertEqual` (4 fixes)
15. **`sparse/tests/test_keyed_jagged_tensor.py`**: `assertTrue(len(...) == 0)` → `assertEqual` (2 fixes)
16. **`fb/ads/modules/tests/test_ads_general_pooled_embedding_arch.py`**: BUG FIX — `assertTrue(list, list)` → `assertEqual` (3 fixes)
17. **`fb/ads/modules/tests/test_ebf_to_embedding.py`**: `.all().item()` + `assertGreaterEqual/assertLessEqual` (4 fixes)
18. **`fb/ads/modules/tests/test_variable_length_embedding_arch.py`**: `assertTrue(a == b)` → `assertEqual`
19. **`fb/ads/modules/tests/test_variable_length_embedding_arch_pruning.py`**: `assertTrue(a == b)` → `assertEqual`
20. **`fb/distributed/planner/tests/test_lp_planner_utils.py`**: `assertTrue(x in y)` → `assertIn` (2 fixes)
21. **`fb/distributed/planner/tests/test_manifold_planner.py`**: `assertTrue(x in y)` → `assertIn`
22. **`fb/distributed/planner/tests/test_partitioners.py`**: `assertTrue(isinstance(...))` → `assertIsInstance` (2 fixes)
23. **`fb/distributed/planner/tests/test_plan_loaders.py`**: `assertTrue("x" in y)` → `assertIn` (8 fixes)
24. **`fb/distributed/planner/thrift/adaptors/tests/test_types_adaptors.py`**: compound `assertTrue(a == b and c == d)` → separate `assertEqual` calls
25. **`fb/distributed/tests/test_infer_hetero_shardings.py`**: `assertTrue(len(...) == val)` → `assertEqual` (32 fixes)
26. **`fb/distributed/tests/test_quant_mc_embedding.py`**: `assertTrue(len/in)` → `assertEqual/assertIn` (3 fixes)
27. **`fb/distributed/tests/test_quant_mc_embedding_bag.py`**: `assertTrue(len(...) == 1)` → `assertEqual`
28. **`fb/distributed/tests/test_zero_allocation.py`**: `assertTrue(x in y)` → `assertIn` (4 fixes)
29. **`fb/feed/modules/peft/tests/lora_test.py`**: `.all()` → `.all().item()` (8 fixes)
30. **`fb/feed/modules/peft/tests/mov_test.py`**: `.all()` → `.all().item()` (7 fixes)
31. **`fb/feed/modules/roo/tests/test_roo_model_utils.py`**: `assertTrue(a == b)` → `assertEqual` (3 fixes)
32. **`fb/modules/tests/test_cel_utils.py`**: `.all()` → `.all().item()`
33. **`fb/modules/tests/test_gradient_balancing.py`**: `assertTrue(torch.all(~torch.isnan/isinf(...)))` → `assertFalse` (6 fixes)
34. **`fb/modules/tests/test_hash_mc_modules.py`**: `assertTrue(a == b)` → `assertEqual` + `.item()` additions (5 fixes)
35. **`fb/modules/tests/test_normalization.py`**: `assertTrue(a == b)` → `assertEqual` (3 fixes)
36. **`fb/rec_modules/loss/tests/grad_clip_test.py`**: `assertTrue(torch.all(x >= val))` → `assertGreaterEqual/assertLessEqual` (3 fixes)
37. **`fb/rec_modules/tests/dense_arch_tests.py`**: `assertTrue((x <= val).all())` → `assertLessEqual/assertGreaterEqual` (6 fixes)
38. **`github/contrib/dynamic_embedding/tests/test_id_transformer.py`**: `.all()` → `.all().item()`
39. **`github/contrib/dynamic_embedding/tests/test_id_transformer_collection.py`**: `.all()` → `.all().item()` (4 fixes)
40. **`github/contrib/dynamic_embedding/tests/test_ps_collection.py`**: `assertTrue(a == b and ...)` → separate `assertEqual` + `.item()` additions (4 fixes)
41. **`github/examples/.../test_train_torchrec_quickstart.py`**: `assertTrue(torch.all(...))` → specific assertions (14 fixes)
42. **`github/examples/prediction/test_predict_using_torchrec.py`**: `.all()` → `.all().item()`

Differential Revision: D96260259


