### PR TITLE
Add auto version mapping and stricter validation to validate_binaries.sh (#3878)

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -5,6 +5,62 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Auto version mapping: torchrec 1.X -> torch 2.(X+5)
+# e.g. torchrec 1.4 -> torch 2.9, 1.5 -> 2.10, 1.6 -> 2.11
+get_expected_torch_version() {
+    local torchrec_ver="$1"
+    local minor
+    minor=$(echo "$torchrec_ver" | cut -d'.' -f2)
+    if [[ -z "$minor" || ! "$minor" =~ ^[0-9]+$ ]]; then
+        echo "Cannot parse torchrec version: $torchrec_ver" >&2
+        return 1
+    fi
+    echo "2.$((minor + 5))"
+}
+
+# Validate installed package versions against expected versions
+validate_versions() {
+    local expected_torchrec_ver="$1"
+    local expected_torch_ver="$2"
+
+    local torchrec_ver
+    torchrec_ver=$(conda run -n "${CONDA_ENV}" pip show torchrec | grep Version | cut -d' ' -f2)
+    local fbgemm_ver
+    fbgemm_ver=$(conda run -n "${CONDA_ENV}" pip show fbgemm_gpu | grep Version | cut -d' ' -f2)
+    local torch_ver
+    torch_ver=$(conda run -n "${CONDA_ENV}" pip show torch | grep Version | cut -d' ' -f2)
+
+    echo "Installed versions: torchrec=$torchrec_ver, fbgemm_gpu=$fbgemm_ver, torch=$torch_ver"
+    echo "Expected versions: torchrec=${expected_torchrec_ver}, fbgemm_gpu=${expected_torchrec_ver}, torch=${expected_torch_ver}.*"
+
+    local failed=0
+    if [[ "$torchrec_ver" != "$expected_torchrec_ver"* ]]; then
+        echo "Error: torchrec version mismatch: got $torchrec_ver, expected ${expected_torchrec_ver}*"
+        failed=1
+    fi
+    if [[ "$fbgemm_ver" != "$expected_torchrec_ver"* ]]; then
+        echo "Error: fbgemm_gpu version mismatch: got $fbgemm_ver, expected ${expected_torchrec_ver}*"
+        failed=1
+    fi
+    if [[ "$torch_ver" != "$expected_torch_ver"* ]]; then
+        echo "Error: torch version mismatch: got $torch_ver, expected ${expected_torch_ver}*"
+        failed=1
+    fi
+    if [[ "$failed" -eq 1 ]]; then
+        exit 1
+    fi
+    echo "All package versions validated successfully."
+}
+
+# Read expected version from version.txt
+EXPECTED_TORCHREC_VERSION=$(tr -d '[:space:]' < version.txt)
+EXPECTED_TORCH_VERSION=$(get_expected_torch_version "$EXPECTED_TORCHREC_VERSION")
+if [[ $? -ne 0 ]]; then
+    echo "Failed to determine expected torch version for torchrec=$EXPECTED_TORCHREC_VERSION"
+    exit 1
+fi
+echo "Expected torchrec/fbgemm version: $EXPECTED_TORCHREC_VERSION"
+echo "Expected torch version: $EXPECTED_TORCH_VERSION.*"
 
 export PYTORCH_CUDA_PKG=""
 export CONDA_ENV="build_binary"
@@ -113,19 +169,16 @@ else
 fi
 
 
+# Validate all package versions (skip nightly — versions use dev/date formats)
+if [[ ${MATRIX_CHANNEL} != 'nightly' ]]; then
+    validate_versions "$EXPECTED_TORCHREC_VERSION" "$EXPECTED_TORCH_VERSION"
+fi
+
+
 # redo for pypi release
 
 if [[ ${MATRIX_CHANNEL} != 'release' ]]; then
     exit 0
-else
-    # Check version matches only for release binaries
-    torchrec_version=$(conda run -n "${CONDA_ENV}" pip show torchrec | grep Version | cut -d' ' -f2)
-    fbgemm_version=$(conda run -n "${CONDA_ENV}" pip show fbgemm_gpu | grep Version | cut -d' ' -f2)
-
-    if [ "$torchrec_version" != "$fbgemm_version" ]; then
-        echo "Error: TorchRec package version does not match FBGEMM package version"
-        exit 1
-    fi
 fi
 
 if [[ ${MATRIX_PYTHON_VERSION} = '3.14' ]]; then
@@ -152,14 +205,8 @@ conda run -n "${CONDA_ENV}" pip install torch
 conda run -n "${CONDA_ENV}" pip install fbgemm-gpu
 conda run -n "${CONDA_ENV}" pip install torchrec
 
-# Check version matching again for PyPI
-torchrec_version=$(conda run -n "${CONDA_ENV}" pip show torchrec | grep Version | cut -d' ' -f2)
-fbgemm_version=$(conda run -n "${CONDA_ENV}" pip show fbgemm_gpu | grep Version | cut -d' ' -f2)
-
-if [ "$torchrec_version" != "$fbgemm_version" ]; then
-    echo "Error: TorchRec package version does not match FBGEMM package version"
-    exit 1
-fi
+# Validate all package versions for PyPI release
+validate_versions "$EXPECTED_TORCHREC_VERSION" "$EXPECTED_TORCH_VERSION"
 
 # check directory
 ls -R


### PR DESCRIPTION
Summary:


Refactored version validation in `validate_binaries.sh`:
- Added `get_expected_torch_version()` that auto-maps torchrec version to expected torch version (torchrec 1.X -> torch 2.(X+5)), eliminating manual version tracking
- Added `validate_versions()` that checks torchrec, fbgemm_gpu, and torch versions against expected values (previously only checked torchrec == fbgemm_gpu)
- Reads expected version from `version.txt` once at the top and reuses it for both release and PyPI validation passes
- Deduplicated version check logic that was copy-pasted in two places

```
2026-03-15T16:19:23.5305248Z +++ EXPECTED_TORCHREC_VERSION=1.6.0
2026-03-15T16:19:23.5309157Z ++++ get_expected_torch_version 1.6.0
2026-03-15T16:19:23.5309526Z ++++ local torchrec_ver=1.6.0
2026-03-15T16:19:23.5309806Z ++++ local minor
2026-03-15T16:19:23.5314711Z +++++ echo 1.6.0
2026-03-15T16:19:23.5315258Z +++++ cut -d. -f2
2026-03-15T16:19:23.5341630Z ++++ minor=6
2026-03-15T16:19:23.5341907Z ++++ [[ -z 6 ]]
2026-03-15T16:19:23.5342167Z ++++ [[ ! 6 =~ ^[0-9]+$ ]]
2026-03-15T16:19:23.5342421Z ++++ echo 2.11
2026-03-15T16:19:23.5345394Z +++ EXPECTED_TORCH_VERSION=2.11
2026-03-15T16:19:23.5345754Z +++ [[ 0 -ne 0 ]]
2026-03-15T16:19:23.5346154Z +++ echo 'Expected torchrec/fbgemm version: 1.6.0'
2026-03-15T16:19:23.5346705Z Expected torchrec/fbgemm version: 1.6.0
2026-03-15T16:19:23.5347262Z +++ echo 'Expected torch version: 2.11.*'
2026-03-15T16:19:23.5347738Z Expected torch version: 2.11.*
```

```
2026-03-15T16:20:49.5716080Z +++ validate_versions 1.6.0 2.11
2026-03-15T16:20:49.5716755Z +++ local expected_torchrec_ver=1.6.0
2026-03-15T16:20:49.5717125Z +++ local expected_torch_ver=2.11
2026-03-15T16:20:49.5717406Z +++ local torchrec_ver
2026-03-15T16:20:49.5722950Z ++++ conda run -n build_binary pip show torchrec
2026-03-15T16:20:49.5723457Z ++++ local cmd=run
2026-03-15T16:20:49.5723796Z ++++ case "$cmd" in
2026-03-15T16:20:49.5724088Z ++++ __conda_exe run -n build_binary pip show torchrec
2026-03-15T16:20:49.5724584Z ++++ grep Version
2026-03-15T16:20:49.5724868Z ++++ cut '-d ' -f2
2026-03-15T16:20:49.5725921Z ++++ /opt/conda/bin/conda run -n build_binary pip show torchrec
2026-03-15T16:20:49.8028172Z Could not load conda plugin `menuinst`:
2026-03-15T16:20:49.8028461Z 
2026-03-15T16:20:49.8028581Z Plugin requires `conda` to be installed.
2026-03-15T16:20:50.9029806Z WARNING: overwriting environment variables set in the machine
2026-03-15T16:20:50.9030385Z overwriting variable {'LD_LIBRARY_PATH'}
2026-03-15T16:20:50.9030867Z 
2026-03-15T16:20:50.9489827Z +++ torchrec_ver=1.6.0+cpu
2026-03-15T16:20:50.9490158Z +++ local fbgemm_ver
2026-03-15T16:20:50.9495833Z ++++ conda run -n build_binary pip show fbgemm_gpu
2026-03-15T16:20:50.9496413Z ++++ local cmd=run
2026-03-15T16:20:50.9496723Z ++++ case "$cmd" in
2026-03-15T16:20:50.9497069Z ++++ __conda_exe run -n build_binary pip show fbgemm_gpu
2026-03-15T16:20:50.9497478Z ++++ grep Version
2026-03-15T16:20:50.9497844Z ++++ cut '-d ' -f2
2026-03-15T16:20:50.9500165Z ++++ /opt/conda/bin/conda run -n build_binary pip show fbgemm_gpu
2026-03-15T16:20:51.1761109Z Could not load conda plugin `menuinst`:
2026-03-15T16:20:51.1761424Z 
2026-03-15T16:20:51.1761557Z Plugin requires `conda` to be installed.
2026-03-15T16:20:52.2748438Z WARNING: overwriting environment variables set in the machine
2026-03-15T16:20:52.2748947Z overwriting variable {'LD_LIBRARY_PATH'}
2026-03-15T16:20:52.2749241Z 
2026-03-15T16:20:52.3213973Z +++ fbgemm_ver=1.6.0+cpu
2026-03-15T16:20:52.3214294Z +++ local torch_ver
2026-03-15T16:20:52.3220017Z ++++ conda run -n build_binary pip show torch
2026-03-15T16:20:52.3220551Z ++++ local cmd=run
2026-03-15T16:20:52.3220875Z ++++ case "$cmd" in
2026-03-15T16:20:52.3221199Z ++++ __conda_exe run -n build_binary pip show torch
2026-03-15T16:20:52.3221703Z ++++ grep Version
2026-03-15T16:20:52.3221984Z ++++ cut '-d ' -f2
2026-03-15T16:20:52.3224289Z ++++ /opt/conda/bin/conda run -n build_binary pip show torch
2026-03-15T16:20:52.5562646Z Could not load conda plugin `menuinst`:
2026-03-15T16:20:52.5563143Z 
2026-03-15T16:20:52.5563287Z Plugin requires `conda` to be installed.
2026-03-15T16:20:53.7212702Z WARNING: overwriting environment variables set in the machine
2026-03-15T16:20:53.7213190Z overwriting variable {'LD_LIBRARY_PATH'}
2026-03-15T16:20:53.7213483Z 
2026-03-15T16:20:53.7689480Z +++ torch_ver=2.11.0+cpu
2026-03-15T16:20:53.7690095Z +++ echo 'Installed versions: torchrec=1.6.0+cpu, fbgemm_gpu=1.6.0+cpu, torch=2.11.0+cpu'
2026-03-15T16:20:53.7690780Z Installed versions: torchrec=1.6.0+cpu, fbgemm_gpu=1.6.0+cpu, torch=2.11.0+cpu
2026-03-15T16:20:53.7691408Z +++ echo 'Expected versions: torchrec=1.6.0, fbgemm_gpu=1.6.0, torch=2.11.*'
2026-03-15T16:20:53.7692093Z Expected versions: torchrec=1.6.0, fbgemm_gpu=1.6.0, torch=2.11.*
2026-03-15T16:20:53.7692571Z +++ local failed=0
2026-03-15T16:20:53.7692801Z +++ [[ 1.6.0+cpu != \1\.\6\.\0* ]]
2026-03-15T16:20:53.7693101Z +++ [[ 1.6.0+cpu != \1\.\6\.\0* ]]
2026-03-15T16:20:53.7693418Z +++ [[ 2.11.0+cpu != \2\.\1\1* ]]
2026-03-15T16:20:53.7693711Z +++ [[ 0 -eq 1 ]]
2026-03-15T16:20:53.7694017Z +++ echo 'All package versions validated successfully.'
2026-03-15T16:20:53.7694438Z All package versions validated successfully.
```

Differential Revision: D96650472


