### PR TITLE
Integrate new Topology  with JK switch

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1362,7 +1362,10 @@ class TestTopologyFactory(unittest.TestCase):
                 intra_host_bw=150.0,
                 inter_host_bw=75.0,
             )
-            kernel_config = KernelConfig(compute_device="cuda")
+            kernel_config = KernelConfig(
+                compute_device="cuda",
+                use_hardware_based_bandwidth=True,
+            )
 
             topology = TopologyFactory.create_topology(
                 trainer_config=trainer_config,
@@ -1381,10 +1384,15 @@ class TestTopologyFactory(unittest.TestCase):
                 hbm_to_ddr_mem_bw=50.0,
                 ssd_mem_bw=10.0,
             )
+            kernel_config = KernelConfig(
+                compute_device="cuda",
+                use_hardware_based_bandwidth=True,
+            )
 
             topology = TopologyFactory.create_topology(
                 trainer_config=trainer_config,
                 hardware_config=hardware_config,
+                kernel_config=kernel_config,
             )
 
             self.assertEqual(topology.hbm_mem_bw, 1000.0)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -654,9 +654,10 @@ class TopologyFactory:
 
         # Add optional parameters from configs
         TopologyFactory._add_trainer_params(topology_kwargs, trainer_config, hardware)
-        TopologyFactory._add_hardware_params(topology_kwargs, hardware)
+        TopologyFactory._add_hardware_params(topology_kwargs, hardware, kernel)
         TopologyFactory._add_comms_params(topology_kwargs, hardware, kernel)
 
+        # TODO: add eventlogger in future
         return Topology(**topology_kwargs)
 
     @staticmethod
@@ -696,16 +697,39 @@ class TopologyFactory:
             kwargs["custom_topology_data"] = custom_topology_data
 
     @staticmethod
-    def _add_hardware_params(kwargs: Dict[str, Any], hardware: HardwareConfig) -> None:
-        """Add hardware config parameters (memory bandwidths)."""
-        if hardware.hbm_mem_bw is not None:
-            kwargs["hbm_mem_bw"] = hardware.hbm_mem_bw
-        if hardware.ddr_mem_bw is not None:
-            kwargs["ddr_mem_bw"] = hardware.ddr_mem_bw
-        if hardware.hbm_to_ddr_mem_bw is not None:
-            kwargs["hbm_to_ddr_mem_bw"] = hardware.hbm_to_ddr_mem_bw
-        if hardware.ssd_mem_bw is not None:
-            kwargs["ssd_mem_bw"] = hardware.ssd_mem_bw
+    def _add_hardware_params(
+        kwargs: Dict[str, Any], hardware: HardwareConfig, kernel: KernelConfig
+    ) -> None:
+        """Add hardware config parameters (memory bandwidths).
+
+        When use_hardware_based_bandwidth=True: use hardware-detected values
+        (falls back to TorchRec defaults if hardware values are None)
+
+        When use_hardware_based_bandwidth=False: use TorchRec defaults
+        (matches old legacy path which doesn't set these, so Topology uses defaults)
+        """
+        if kernel.use_hardware_based_bandwidth:
+            # Hardware-based path: use hardware values, fall back to TorchRec defaults
+            kwargs["hbm_mem_bw"] = (
+                hardware.hbm_mem_bw if hardware.hbm_mem_bw is not None else HBM_MEM_BW
+            )
+            kwargs["ddr_mem_bw"] = (
+                hardware.ddr_mem_bw if hardware.ddr_mem_bw is not None else DDR_MEM_BW
+            )
+            kwargs["ssd_mem_bw"] = (
+                hardware.ssd_mem_bw if hardware.ssd_mem_bw is not None else SSD_MEM_BW
+            )
+            kwargs["hbm_to_ddr_mem_bw"] = (
+                hardware.hbm_to_ddr_mem_bw
+                if hardware.hbm_to_ddr_mem_bw is not None
+                else HBM_TO_DDR_MEM_BW
+            )
+        else:
+            # Default path: match Topology defaults (old legacy path doesn't set these)
+            kwargs["hbm_mem_bw"] = HBM_MEM_BW
+            kwargs["ddr_mem_bw"] = DDR_MEM_BW
+            kwargs["ssd_mem_bw"] = SSD_MEM_BW
+            kwargs["hbm_to_ddr_mem_bw"] = HBM_TO_DDR_MEM_BW
 
     @staticmethod
     def _add_comms_params(
@@ -713,15 +737,37 @@ class TopologyFactory:
         hardware: HardwareConfig,
         kernel: KernelConfig,
     ) -> None:
-        """Add communication bandwidth parameters."""
-        # generalized_comms_bandwidths takes precedence over individual bandwidths
+        """Add communication bandwidth parameters.
+
+        When generalized_comms_bandwidths is provided (from get_bw_info_for_curr_capability()
+        when use_hardware_based_bandwidth=True): use it directly.
+
+        When use_hardware_based_bandwidth=True but no generalized_comms_bandwidths:
+        use hardware-detected intra/inter bandwidth values.
+
+        When use_hardware_based_bandwidth=False: use TorchRec defaults
+        (matches old legacy path which creates BasicCommsBandwidths() with defaults)
+        """
         if kernel.generalized_comms_bandwidths is not None:
+            # Hardware-based path with generalized bandwidths from
+            # get_bw_info_for_curr_capability()
             kwargs["generalized_comms_bandwidths"] = kernel.generalized_comms_bandwidths
+        elif kernel.use_hardware_based_bandwidth:
+            # Hardware-based path: use hardware values, fall back to TorchRec defaults
+            kwargs["intra_host_bw"] = (
+                hardware.intra_host_bw
+                if hardware.intra_host_bw is not None
+                else INTRA_NODE_BANDWIDTH
+            )
+            kwargs["inter_host_bw"] = (
+                hardware.inter_host_bw
+                if hardware.inter_host_bw is not None
+                else CROSS_NODE_BANDWIDTH
+            )
         else:
-            if hardware.intra_host_bw is not None:
-                kwargs["intra_host_bw"] = hardware.intra_host_bw
-            if hardware.inter_host_bw is not None:
-                kwargs["inter_host_bw"] = hardware.inter_host_bw
+            # Default path: match Topology defaults (old legacy path)
+            kwargs["intra_host_bw"] = INTRA_NODE_BANDWIDTH
+            kwargs["inter_host_bw"] = CROSS_NODE_BANDWIDTH
 
 
 class Topology:


### PR DESCRIPTION
Summary:
### Overview
- This diff is  a part of Topology Unification Work, where we try to consolidate the different trainer's hardware capabilities detection logics into one module (Hardware Utility Module) and later  use MAST for proper detection of  attributes such as ram capacity, number of gpus allocated etc. https://docs.google.com/document/d/12K8eWMORt5OPsxCKWoVf9Zt31uLfDnXf0ZbGxdifZUg/edit?usp=sharing

- This diff integrates the new unified TopologyFactory into APF's sharding planner topology creation,
gated behind a JustKnobs feature flag (pytorch/torchrec:enable_topology_unification). The legacy
topology creation path is preserved as a fallback.



Changes by File

1. fbcode/apf/rec/distributed/parallel.py

 - New unified topology path: Added a new code path gated by
pytorch/torchrec:enable_topology_unification JustKnobs flag that uses TopologyFactory.create_topology() instead of manually constructing a Topology object.
- Imports: Added TopologyFactory, create_topology_configs.
- BHA config passthrough: Extracts bha_config_map from MastMultiProcessLauncherConfig and passes it to create_topology_configs() for pod_size fallback.
- Legacy path preserved: The existing topology creation logic (hardware-based bandwidth detection, manual Topology() construction) is moved into an else branch, preserving backward compatibility.

2. fbcode/apf/rec/distributed/BUCK (+1)
- Added dependency on //torchrec/fb/distributed/hardware_utilities:hardware_utilities.

3. fbcode/torchrec/distributed/planner/types.py (+1)
- Added a # TODO: add event logger comment in TopologyFactory.create_topology().
4. fbcode/torchrec/fb/distributed/hardware_utilities/config_utils.py (+155/-16)
 - _get_pod_size_from_bha_config() (new): Parses BHA config map (JSON string or file path) to extract domain.multiple as pod_size. Duplicated from APF's parallel.py for compatibility.
- _detect_distributed_topology(): Extended to support APF framework — now detects pod_size for APF
 (not just MVAI) and falls back to BHA config when get_topology_domain_multiple() returns None.
- create_topology_configs(): Added new parameters: bha_config_map, hbm_cap_bytes_override, and
  ddr_cap_bytes_override.
  - Framework-specific DDR adjustments: Added post-detection DDR capacity division logic:
    - APF: Divides total DDR by local_world_size (per-rank)
    - Pyper CPU: Divides total DDR by local_world_size (per-rank)
    - Pyper CUDA: Uses total DDR (no division)
    - MVAI: No adjustment (uses hardcoded value)
  - bwd_compute_multiplier fix: Changed getattr fallback logic to handle None attribute values properly
   (using or instead of relying on getattr default).

  5. fbcode/torchrec/fb/distributed/hardware_utilities/detection.py (+9/-9)

  - detect_ddr_cap_bytes(): Updated to return total host memory without per-rank division.
  Framework-specific division is now the caller's responsibility (moved to config_utils.py). Updated
  docstring to reflect this change.
  - detect_hardware_config(): Added clarifying comments about DDR division responsibility.

  Key Design Decisions

  - Feature-flagged rollout: The unified path is behind a JustKnobs flag for safe rollout.
  - Separation of concerns: DDR detection returns raw total memory; per-rank division is handled in
  config_utils.py based on the training framework.
  - Backward compatibility: Legacy topology creation is fully preserved when the flag is off.

  ---

Differential Revision: D95249926


