### PR TITLE
Add multi-task scaling and timing instrumentation (#3881)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -24,6 +24,7 @@ import itertools
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -232,6 +233,14 @@ def runner(
             process_group=ctx.pg,
         )
 
+        # Pre-allocate synthetic model_out to avoid CUDA allocator noise
+        # in the timing loop. Values don't matter for benchmarking overhead.
+        metric_model_out = (
+            metric_config.generate_model_output(run_option.batch_size, ctx.device)
+            if metric_module is not None
+            else None
+        )
+
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],
             model: nn.Module,
@@ -241,6 +250,11 @@ def runner(
             if metric_module is not None:
                 metric_module.reset()
                 metric_module.trained_batches = 0
+
+            progress_times_ms: List[float] = []
+            update_times_ms: List[float] = []
+            compute_times_ms: List[float] = []
+
             if run_option.num_iters is not None:
                 dataloader = itertools.islice(
                     itertools.cycle(bench_inputs), run_option.num_iters
@@ -249,25 +263,57 @@ def runner(
                 dataloader = iter(bench_inputs)
             while True:
                 try:
+                    torch.cuda.synchronize()
+                    t0 = time.perf_counter()
                     output = pipeline.progress(dataloader)
+                    torch.cuda.synchronize()
+                    progress_times_ms.append((time.perf_counter() - t0) * 1000.0)
+
                     if metric_module is not None and output is not None:
-                        # Reduce to 1D [batch_size] for binary classification
-                        # metrics (NE, AUC). The model produces [batch_size,
-                        # over_arch_out_size] which would cause OOM in metric
-                        # sync (dist.all_gather accumulates all predictions).
-                        pred = output.detach().mean(dim=-1)
-                        model_out = {
-                            "prediction": pred,
-                            "label": torch.rand_like(pred),
-                            "weight": torch.ones_like(pred),
-                        }
+                        t1 = time.perf_counter()
+                        assert metric_model_out is not None
                         with record_function("## metric_update ##"):
-                            metric_module.update(model_out)
+                            metric_module.update(metric_model_out)
+                        torch.cuda.synchronize()
+                        update_times_ms.append((time.perf_counter() - t1) * 1000.0)
                         if metric_module.should_compute():
+                            t2 = time.perf_counter()
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
+                            torch.cuda.synchronize()
+                            compute_times_ms.append((time.perf_counter() - t2) * 1000.0)
                 except StopIteration:
                     break
+
+            if rank == 0 and progress_times_ms:
+                avg_progress = sum(progress_times_ms) / len(progress_times_ms)
+                avg_update = (
+                    sum(update_times_ms) / len(update_times_ms)
+                    if update_times_ms
+                    else 0.0
+                )
+                avg_compute = (
+                    sum(compute_times_ms) / len(compute_times_ms)
+                    if compute_times_ms
+                    else 0.0
+                )
+                update_pct = (
+                    avg_update / avg_progress * 100.0 if avg_progress > 0 else 0.0
+                )
+                compute_pct = (
+                    avg_compute / avg_progress * 100.0 if avg_progress > 0 else 0.0
+                )
+                print(
+                    f"[Metric Timing] iters={len(progress_times_ms)} "
+                    f"avg_progress={avg_progress:.2f}ms "
+                    f"avg_update={avg_update:.2f}ms ({update_pct:.1f}%) "
+                    f"avg_compute={avg_compute:.2f}ms ({compute_pct:.1f}%) "
+                    f"compute_calls={len(compute_times_ms)} "
+                    f"n_tasks={metric_config.num_tasks} "
+                    f"n_metrics={len(metric_config.metrics)} "
+                    f"mode={metric_config.rec_compute_mode}",
+                    flush=True,
+                )
 
         pipeline = pipeline_config.generate_pipeline(
             model=sharded_model,

--- a/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
+++ b/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
@@ -1,0 +1,44 @@
+# Production-like metric scaling benchmark
+# Tests ZORM overhead with 20 tasks x 5 metrics (~25% update overhead)
+# Uses lighter embeddings so metric update is a meaningful fraction of iter time
+#
+# Usage:
+#   buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
+#     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 3
+  num_profiles: 1
+  num_iters: 100
+  profile_dir: "."
+  name: "metric_scaling_prod"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 10
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 128
+      over_arch_out_size: 1024
+      over_arch_hidden_layers: 5
+      dense_arch_hidden_sizes: [128, 128, 128]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 10
+  num_weighted_features: 5
+  embedding_feature_dim: 32
+PlannerConfig:
+  pooling_factors: [10.0]
+RecMetricConfig:
+  enable_metrics: true
+  metrics: [ne, calibration, ctr, mse, auc]
+  num_tasks: 20
+  rec_compute_mode: "unfused"
+  compute_interval: 25
+  window_size: 10000000

--- a/torchrec/distributed/test_utils/metric_config.py
+++ b/torchrec/distributed/test_utils/metric_config.py
@@ -15,6 +15,7 @@ import torch.distributed as dist
 from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
 from torchrec.metrics.metrics_config import (
     MetricsConfig,
+    RecComputeMode,
     RecMetricDef,
     RecMetricEnum,
     RecTaskInfo,
@@ -23,6 +24,12 @@ from torchrec.metrics.metrics_config import (
 
 # Mapping from string names to RecMetricEnum values for CLI usage
 _METRIC_NAME_MAP = {e.value: e for e in RecMetricEnum}
+
+_REC_COMPUTE_MODE_MAP: Dict[str, RecComputeMode] = {
+    "unfused": RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    "fused": RecComputeMode.FUSED_TASKS_COMPUTATION,
+    "fused_states": RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION,
+}
 
 
 @dataclass
@@ -45,14 +52,51 @@ class RecMetricConfig:
             num_batches=10).
         window_size (int): Window size for windowed metric computation.
             Default is 10_000_000.
-        task_name (str): Name of the metric task. Default is "DefaultTask".
+        num_tasks (int): Number of metric tasks. Each task gets unique
+            prediction/label/weight keys in model_out. Default is 1.
+        rec_compute_mode (str): Computation mode for RecMetrics.
+            "unfused" (default), "fused", or "fused_states".
     """
 
     enable_metrics: bool = False
     metrics: List[str] = field(default_factory=lambda: ["ne"])
     compute_interval: int = 10
     window_size: int = 10_000_000
-    task_name: str = "DefaultTask"
+    num_tasks: int = 1
+    rec_compute_mode: str = "unfused"
+
+    def _generate_tasks(self) -> List[RecTaskInfo]:
+        if self.num_tasks == 1:
+            return [
+                RecTaskInfo(
+                    name="DefaultTask",
+                    label_name="label",
+                    prediction_name="prediction",
+                    weight_name="weight",
+                )
+            ]
+        return [
+            RecTaskInfo(
+                name=f"task_{i}",
+                label_name=f"label_{i}",
+                prediction_name=f"prediction_{i}",
+                weight_name=f"weight_{i}",
+            )
+            for i in range(self.num_tasks)
+        ]
+
+    def generate_model_output(
+        self,
+        batch_size: int,
+        device: torch.device,
+    ) -> Dict[str, torch.Tensor]:
+        """Generate synthetic per-task model output tensors for metric update."""
+        model_out: Dict[str, torch.Tensor] = {}
+        for task in self._generate_tasks():
+            model_out[task.prediction_name] = torch.rand(batch_size, device=device)
+            model_out[task.label_name] = torch.rand(batch_size, device=device)
+            model_out[task.weight_name] = torch.ones(batch_size, device=device)
+        return model_out
 
     def generate_metric_module(
         self,
@@ -66,26 +110,18 @@ class RecMetricConfig:
         Generate a RecMetricModule based on this configuration.
 
         Returns None if enable_metrics is False.
-
-        Args:
-            batch_size: Batch size for the benchmark.
-            world_size: Number of distributed ranks.
-            rank: Current rank.
-            device: Device to place metric tensors on.
-            process_group: Distributed process group for metric sync.
-
-        Returns:
-            A RecMetricModule if metrics are enabled, None otherwise.
         """
         if not self.enable_metrics:
             return None
 
-        task = RecTaskInfo(
-            name=self.task_name,
-            label_name="label",
-            prediction_name="prediction",
-            weight_name="weight",
-        )
+        if self.rec_compute_mode not in _REC_COMPUTE_MODE_MAP:
+            raise ValueError(
+                f"Unknown rec_compute_mode '{self.rec_compute_mode}'. "
+                f"Valid options: {sorted(_REC_COMPUTE_MODE_MAP.keys())}"
+            )
+        compute_mode = _REC_COMPUTE_MODE_MAP[self.rec_compute_mode]
+
+        tasks = self._generate_tasks()
 
         rec_metrics: Dict[RecMetricEnum, RecMetricDef] = {}
         for metric_name in self.metrics:
@@ -96,13 +132,14 @@ class RecMetricConfig:
                     f"Valid options: {sorted(_METRIC_NAME_MAP.keys())}"
                 )
             rec_metrics[_METRIC_NAME_MAP[metric_name]] = RecMetricDef(
-                rec_tasks=[task],
+                rec_tasks=tasks,
                 window_size=self.window_size,
             )
 
         metrics_config = MetricsConfig(
-            rec_tasks=[task],
+            rec_tasks=tasks,
             rec_metrics=rec_metrics,
+            rec_compute_mode=compute_mode,
             compute_interval_steps=self.compute_interval,
         )
 


### PR DESCRIPTION
Summary:

Extends the RecMetrics benchmark with multi-task support, per-step timing
instrumentation, and a production-like YAML config for metric module computation overhead analysis.

## Changes

**`metric_config.py`**
- Replace `task_name: str` with `num_tasks: int` (default 1, backward compatible)
- Add `rec_compute_mode: str` ("unfused"/"fused"/"fused_states")
- Add `generate_model_output()` for synthetic per-task prediction/label/weight tensors
- Add `_generate_tasks()` helper creating N RecTaskInfo with unique keys

**`benchmark_train_pipeline.py`**
- Add `cuda.synchronize()` + `time.perf_counter()` timing around progress, update, compute
- Pre-allocate model_out tensors outside the loop to avoid CUDA allocator noise
- Print `[Metric Timing]` summary: avg times, overhead %, compute calls, task/metric count

**`metric_scaling_prod.yml`** (new)
- 20 tasks x 5 metrics (ne, calibration, ctr, mse, auc), unfused mode
- Lighter embeddings (10+5 features, dim=32) to isolate metric overhead
- 100 iters, compute every 25

## How to run

```bash
# Build
buck2 build fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline

# Run production-like metric scaling benchmark (2x GPU)
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml \
  --num_benchmarks=1 --num_profiles=0

# Compare with fused mode
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml \
  --num_benchmarks=1 --num_profiles=0 --rec_compute_mode=fused

# Sweep task counts
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml \
  --num_benchmarks=1 --num_profiles=0 --num_tasks=10
```

## Results (2x H100, batch_size=32768)

```
[Metric Timing] iters=100 avg_progress=45.31ms avg_update=9.57ms (21.1%)
  avg_compute=270.64ms (597.2%) compute_calls=4
  n_tasks=20 n_metrics=5 mode=unfused
```

- 20 tasks x 5 metrics: **21.1% update overhead**, ~9.6ms per update call
- Compute (GLOO all-gather) adds 270ms per call, fires every 25 iters
- Update cost scales linearly with task count (~0.5ms per task)

Differential Revision: D96519825


