### PR TITLE
add a json option

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -234,6 +234,21 @@ class BenchmarkResult:
 
         return "\n".join(lines)
 
+    def to_dict(self) -> dict[str, float | str]:
+        """Return a dict of key P90 metrics for structured (JSON) output."""
+        d: dict[str, float | str] = {
+            "short_name": self.short_name,
+            "gpu_runtime_p90_ms": float(self.runtime_percentile(90, device="gpu")),
+            "cpu_runtime_p90_ms": float(self.runtime_percentile(90, device="cpu")),
+            "cpu_peak_rss_p90_mb": float(self.cpu_mem_percentile(90)),
+        }
+        if len(self.gpu_mem_stats) > 0:
+            d["gpu_peak_alloc_p90_mb"] = float(self.max_mem_alloc_percentile(90))
+            d["gpu_peak_reserved_p90_mb"] = float(self.max_mem_reserved_percentile(90))
+            d["gpu_mem_used_p90_mb"] = float(self.device_mem_used(90))
+            d["gpu_malloc_retries_p90"] = float(self.mem_retries(90))
+        return d
+
     @classmethod
     def print_table(cls, res: List["BenchmarkResult"]) -> str:
         """Print a human-readable formatted table for console output."""

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -21,6 +21,7 @@ To support a new model in pipeline benchmark:
 """
 
 import itertools
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -130,6 +131,7 @@ class RunOptions(BenchFuncConfig):
     local_world_size: Optional[int] = None
     ga_num_steps: int = 1
     num_iters: Optional[int] = None
+    output_json: bool = False
 
 
 # single-rank runner
@@ -301,8 +303,11 @@ def runner(
 
         if rank == 0:
             logger.setLevel(logging.INFO)
-            logger.info(result.prettify())
-            logger.info("\nMarkdown format:\n%s", result)
+            if run_option.output_json:
+                print(json.dumps(result.to_dict(), indent=2))
+            else:
+                logger.info(result.prettify())
+                logger.info("\nMarkdown format:\n%s", result)
 
         return result
 


### PR DESCRIPTION
Summary:
Benchmark results are currently only output as human-readable text (prettified block + markdown table), which makes it difficult for automated tooling to programmatically consume and log benchmark metrics to Scuba or other datastores. Adding a structured JSON output mode enables downstream consumers to parse benchmark results reliably.

I'm working on to have automatic benchmark running daily and log benchmark result to scuba

In order to populate the metrics to scuba, I add an option in benchmark to optionally print output in json format

Reviewed By: TroyGarden

Differential Revision: D96521319


