### PR TITLE
Add config flag for CPUOffloadedRecMetricModule (#3884)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -127,7 +127,9 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         self.update_thread.start()
         self.compute_thread.start()
 
-        logger.info("CPUOffloadedRecMetricModule initialization complete.")
+        logger.info(
+            f"CPUOffloadedRecMetricModule initialization complete with {model_out_device.type=}, {update_queue_size=}, {compute_queue_size=}."
+        )
 
     @override
     def update(self, model_out: Dict[str, torch.Tensor], **kwargs: Any) -> None:

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -684,6 +684,7 @@ def generate_metric_module(
     device: torch.device,
     process_group: Optional[dist.ProcessGroup] = None,
     batch_size_stages: Optional[List[BatchSizeStage]] = None,
+    module_kwargs: Optional[Dict[str, Any]] = None,
 ) -> RecMetricModule:
     rec_metrics = _generate_rec_metrics(
         metrics_config,
@@ -716,6 +717,7 @@ def generate_metric_module(
         compute_interval_steps=metrics_config.compute_interval_steps,
         min_compute_interval=metrics_config.min_compute_interval,
         max_compute_interval=metrics_config.max_compute_interval,
+        **(module_kwargs if module_kwargs else {}),
     )
     metrics.to(device)
     return metrics

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -195,6 +195,7 @@ class MetricsConfig:
     should_validate_update: bool = False
     enable_pt2_compile: bool = False
     should_clone_update_inputs: bool = False
+    use_cpu_offloaded_rec_metric_module: Optional[bool] = None
 
     def __post_init__(self) -> None:
         for metric_enum, metric_def in self.rec_metrics.items():

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -22,7 +22,8 @@ from torchrec.metrics.cpu_offloaded_metric_module import (
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
 )
-from torchrec.metrics.metric_module import RecMetricModule
+from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
+from torchrec.metrics.metrics_config import DefaultMetricsConfig
 from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
 from torchrec.metrics.test_utils import gen_test_tasks
 from torchrec.metrics.test_utils.mock_metrics import (
@@ -630,6 +631,30 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
     def test_no_dtoh_transfer_for_cpu_device(self) -> None:
         self._run_dtoh_transfer_test(use_cuda=False)
+
+    def test_generate_metric_module_creates_cpu_offloaded_module(self) -> None:
+        module_kwargs = {
+            "model_out_device": torch.device("cpu"),
+            "update_queue_size": 50,
+            "compute_queue_size": 75,
+        }
+
+        module = generate_metric_module(
+            metric_class=CPUOffloadedRecMetricModule,
+            metrics_config=DefaultMetricsConfig,
+            batch_size=128,
+            world_size=1,
+            my_rank=0,
+            state_metrics_mapping={},
+            device=torch.device("cpu"),
+            module_kwargs=module_kwargs,
+        )
+
+        self.assertIsInstance(module, CPUOffloadedRecMetricModule)
+        self.assertEqual(module.update_queue.maxsize, 50)
+        self.assertEqual(module.compute_queue.maxsize, 75)
+
+        module.shutdown()
 
 
 @skip_if_asan_class


### PR DESCRIPTION
Summary:

Add tri-state config and `module_kwargs` plumbing for CPUOffloadedRecMetricModule.

- Add `use_cpu_offloaded_rec_metric_module: Optional[bool]` to OSSMetricsConfig
- Add `module_kwargs` parameter to `generate_metric_module()` for passing extra kwargs to the metric module constructor

Reviewed By: sahshah-meta

Differential Revision: D94260585
