### PR TITLE
Suppress pyrefly type errors in query_deltoid, experimental_pipelines, and halo targets

### DIFF
--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -724,6 +724,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
                 def _copy_work() -> In:
                     # pyrefly: ignore [bad-argument-type]
                     with self._stream_context(self._memcpy_stream):
+                        # pyrefly: ignore [redundant-cast]
                         return _to_device(cast(In, batch), self._device, True)
 
                 future_batch = self._copy_executor.submit(_copy_work)


### PR DESCRIPTION
Summary:
D95956047 (pyrefly dotslash update) introduced new type-checking errors in three targets that were not covered by D96148401.

This diff adds `pyrefly: ignore` comments to suppress the following errors:

1. `fbcode/instagram/feed/scripts/query_deltoid.py:389` - `not-iterable`: The variable `all_arms` could be non-iterable types from the row dict. Added `# pyrefly: ignore [not-iterable]`.

2. `fbcode/torchrec/distributed/train_pipeline/experimental_pipelines.py:727` - `redundant-cast`: Cast of `In` to `In` flagged as redundant. Added `# pyrefly: ignore [redundant-cast]`.

3. `fbcode/mapillary/vision/recognition/halo/rasterizer/production.py:398` - `redundant-cast`: Cast of `list` flagged as redundant. Added `# pyrefly: ignore [redundant-cast]`.

This follows the same pattern used in D96148401 which fixed the other 5 affected targets.

Reviewed By: jeffkbkim, rchen152

Differential Revision: D96768027


