### PR TITLE
Refactor create_topology_configs to accept explicit parameters

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1362,7 +1362,10 @@ class TestTopologyFactory(unittest.TestCase):
                 intra_host_bw=150.0,
                 inter_host_bw=75.0,
             )
-            kernel_config = KernelConfig(compute_device="cuda")
+            kernel_config = KernelConfig(
+                compute_device="cuda",
+                use_hardware_based_bandwidth=True,
+            )
 
             topology = TopologyFactory.create_topology(
                 trainer_config=trainer_config,
@@ -1381,10 +1384,15 @@ class TestTopologyFactory(unittest.TestCase):
                 hbm_to_ddr_mem_bw=50.0,
                 ssd_mem_bw=10.0,
             )
+            kernel_config = KernelConfig(
+                compute_device="cuda",
+                use_hardware_based_bandwidth=True,
+            )
 
             topology = TopologyFactory.create_topology(
                 trainer_config=trainer_config,
                 hardware_config=hardware_config,
+                kernel_config=kernel_config,
             )
 
             self.assertEqual(topology.hbm_mem_bw, 1000.0)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -654,9 +654,10 @@ class TopologyFactory:
 
         # Add optional parameters from configs
         TopologyFactory._add_trainer_params(topology_kwargs, trainer_config, hardware)
-        TopologyFactory._add_hardware_params(topology_kwargs, hardware)
+        TopologyFactory._add_hardware_params(topology_kwargs, hardware, kernel)
         TopologyFactory._add_comms_params(topology_kwargs, hardware, kernel)
 
+        # TODO: add eventlogger in future
         return Topology(**topology_kwargs)
 
     @staticmethod
@@ -696,16 +697,39 @@ class TopologyFactory:
             kwargs["custom_topology_data"] = custom_topology_data
 
     @staticmethod
-    def _add_hardware_params(kwargs: Dict[str, Any], hardware: HardwareConfig) -> None:
-        """Add hardware config parameters (memory bandwidths)."""
-        if hardware.hbm_mem_bw is not None:
-            kwargs["hbm_mem_bw"] = hardware.hbm_mem_bw
-        if hardware.ddr_mem_bw is not None:
-            kwargs["ddr_mem_bw"] = hardware.ddr_mem_bw
-        if hardware.hbm_to_ddr_mem_bw is not None:
-            kwargs["hbm_to_ddr_mem_bw"] = hardware.hbm_to_ddr_mem_bw
-        if hardware.ssd_mem_bw is not None:
-            kwargs["ssd_mem_bw"] = hardware.ssd_mem_bw
+    def _add_hardware_params(
+        kwargs: Dict[str, Any], hardware: HardwareConfig, kernel: KernelConfig
+    ) -> None:
+        """Add hardware config parameters (memory bandwidths).
+
+        When use_hardware_based_bandwidth=True: use hardware-detected values
+        (falls back to TorchRec defaults if hardware values are None)
+
+        When use_hardware_based_bandwidth=False: use TorchRec defaults
+        (matches old legacy path which doesn't set these, so Topology uses defaults)
+        """
+        if kernel.use_hardware_based_bandwidth:
+            # Hardware-based path: use hardware values, fall back to TorchRec defaults
+            kwargs["hbm_mem_bw"] = (
+                hardware.hbm_mem_bw if hardware.hbm_mem_bw is not None else HBM_MEM_BW
+            )
+            kwargs["ddr_mem_bw"] = (
+                hardware.ddr_mem_bw if hardware.ddr_mem_bw is not None else DDR_MEM_BW
+            )
+            kwargs["ssd_mem_bw"] = (
+                hardware.ssd_mem_bw if hardware.ssd_mem_bw is not None else SSD_MEM_BW
+            )
+            kwargs["hbm_to_ddr_mem_bw"] = (
+                hardware.hbm_to_ddr_mem_bw
+                if hardware.hbm_to_ddr_mem_bw is not None
+                else HBM_TO_DDR_MEM_BW
+            )
+        else:
+            # Default path: match Topology defaults (old legacy path doesn't set these)
+            kwargs["hbm_mem_bw"] = HBM_MEM_BW
+            kwargs["ddr_mem_bw"] = DDR_MEM_BW
+            kwargs["ssd_mem_bw"] = SSD_MEM_BW
+            kwargs["hbm_to_ddr_mem_bw"] = HBM_TO_DDR_MEM_BW
 
     @staticmethod
     def _add_comms_params(
@@ -713,15 +737,37 @@ class TopologyFactory:
         hardware: HardwareConfig,
         kernel: KernelConfig,
     ) -> None:
-        """Add communication bandwidth parameters."""
-        # generalized_comms_bandwidths takes precedence over individual bandwidths
+        """Add communication bandwidth parameters.
+
+        When generalized_comms_bandwidths is provided (from get_bw_info_for_curr_capability()
+        when use_hardware_based_bandwidth=True): use it directly.
+
+        When use_hardware_based_bandwidth=True but no generalized_comms_bandwidths:
+        use hardware-detected intra/inter bandwidth values.
+
+        When use_hardware_based_bandwidth=False: use TorchRec defaults
+        (matches old legacy path which creates BasicCommsBandwidths() with defaults)
+        """
         if kernel.generalized_comms_bandwidths is not None:
+            # Hardware-based path with generalized bandwidths from
+            # get_bw_info_for_curr_capability()
             kwargs["generalized_comms_bandwidths"] = kernel.generalized_comms_bandwidths
+        elif kernel.use_hardware_based_bandwidth:
+            # Hardware-based path: use hardware values, fall back to TorchRec defaults
+            kwargs["intra_host_bw"] = (
+                hardware.intra_host_bw
+                if hardware.intra_host_bw is not None
+                else INTRA_NODE_BANDWIDTH
+            )
+            kwargs["inter_host_bw"] = (
+                hardware.inter_host_bw
+                if hardware.inter_host_bw is not None
+                else CROSS_NODE_BANDWIDTH
+            )
         else:
-            if hardware.intra_host_bw is not None:
-                kwargs["intra_host_bw"] = hardware.intra_host_bw
-            if hardware.inter_host_bw is not None:
-                kwargs["inter_host_bw"] = hardware.inter_host_bw
+            # Default path: match Topology defaults (old legacy path)
+            kwargs["intra_host_bw"] = INTRA_NODE_BANDWIDTH
+            kwargs["inter_host_bw"] = CROSS_NODE_BANDWIDTH
 
 
 class Topology:


### PR DESCRIPTION
Summary:
Refactor create_topology_configs() to accept explicit typed parameters instead of
planner_config: Any and dry_run_config: Optional[Any]. Each trainer framework is
now responsible for extracting values from their native configs before calling
create_topology_configs().

New API:
- create_topology_configs() now accepts explicit parameters: compute_device,
  hbm_cap_bytes, ddr_cap_bytes, ssd_cap_bytes, is_dry_run, dry_run_hbm_bytes,
  dry_run_ddr_bytes, bwd_compute_multiplier, weighted_feature_bwd_compute_multiplier,
  use_hardware_based_bandwidth, world_size, local_world_size, pod_size, launcher_hardware

Differential Revision: D96804760


