### PR TITLE
Migrate pyre-ignore/pyre-fixme comments to pyrefly: ignore format (#3887)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3939,11 +3939,11 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
         self.weights_sharded = False
         self._input_tensor = None
         self._element_size = self._emb_module.weight.element_size()
-        # pyre-ignore[8]
+        # pyrefly: ignore[bad-assignment]
         self._original_shape: torch.Size = self._emb_module.weight.shape
         # Triton TBE's weight is a plain tensor attribute (not nn.Parameter),
         # same pattern as CUDA TBE's weights_dev.
-        # pyre-ignore[8]
+        # pyrefly: ignore[bad-assignment]
         self._unsharded_param: torch.Tensor = self._emb_module.weight
         self._shard_buf_nbytes: int = 0
         self._shard_buf: Optional[torch.Tensor] = None
@@ -3956,7 +3956,7 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
         self._rs_awaitable: Optional[ReduceScatterResizeAwaitable] = None
 
         self.register_full_backward_pre_hook(
-            self._hybrid_sharded_backward_hook,  # pyre-ignore[6]
+            self._hybrid_sharded_backward_hook,  # pyrefly: ignore[bad-argument-type]
         )
 
     def _all_gather_table_weights(self) -> None:
@@ -3964,7 +3964,7 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
             return
         self.ensure_reduce_scatter_complete()
 
-        shard_size = self._shard_buf.numel()
+        shard_size = self._shard_buf.numel()  # pyrefly: ignore[missing-attribute]
         padded_total_size = shard_size * self._env.num_sharding_groups()
 
         self._unsharded_param.untyped_storage().resize_(
@@ -3978,7 +3978,7 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
                 dtype=self._unsharded_param.dtype,
                 device=self._unsharded_param.device,
             )
-            output_tensor.set_(
+            output_tensor.set_(  # pyrefly: ignore[no-matching-overload]
                 self._unsharded_param.untyped_storage(),
                 0,  # storage_offset
                 (padded_total_size,),  # size
@@ -3991,9 +3991,9 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
                 group=self._env.replica_pg,
                 async_op=False,
             )
-        # pyre-ignore[16]
+        # pyrefly: ignore[missing-attribute]
         self._emb_module.weight = self._unsharded_param[: self._original_shape.numel()]
-        # pyre-ignore[16]
+        # pyrefly: ignore[missing-attribute]
         self._shard_buf.untyped_storage().resize_(0)
         self.weights_sharded = False
 
@@ -4047,7 +4047,7 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
                     dtype=self._emb_module.weight.dtype,
                     device=self._emb_module.weight.device,
                 )
-                # pyre-ignore[16]
+                # pyrefly: ignore[missing-attribute]
                 self._shard_buf_nbytes = self._shard_buf.untyped_storage().nbytes()
             else:
                 self._shard_buf.untyped_storage().resize_(self._shard_buf_nbytes)
@@ -4062,14 +4062,16 @@ class ShardedTritonBatchedFusedEmbeddingBag(TritonBatchedFusedEmbeddingBag):
                 )
 
             self._async_event = torch.cuda.Event(enable_timing=False, blocking=False)
-            # pyre-ignore[16]
+            # pyrefly: ignore[missing-attribute]
             self._async_event.record(self._async_stream)
 
             def resize_callback() -> None:
-                # pyre-ignore[29]
+                # pyrefly: ignore[not-callable]
                 self._emb_module.weight.untyped_storage().resize_(0)
-                self._emb_module.weight = self._shard_buf  # pyre-ignore[16]
-                self._input_tensor.untyped_storage().resize_(0)  # pyre-ignore[29]
+                # pyrefly: ignore[bad-assignment]
+                self._emb_module.weight = self._shard_buf
+                # pyrefly: ignore[missing-attribute]
+                self._input_tensor.untyped_storage().resize_(0)
                 self._input_tensor = None
 
             return ReduceScatterResizeAwaitable(

--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -487,7 +487,7 @@ class cmd_conf:
 
     Example 1: direct decorating (see the overloaded __new__ method below)
     ```
-    @cmd_conf  # you might need "pyre-ignore [56]"
+    @cmd_conf  # you might need "pyrefly: ignore"
     def main(
         run_option: RunOptions,
         table_config: EmbeddingTablesConfig,

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -1014,7 +1014,7 @@ class GroupedPooledEmbeddingsLookup(
         """
         for emb_module in self._emb_modules:
             if hasattr(emb_module, "wait_for_forward"):
-                # pyre-ignore[16]: `wait_for_forward` is dynamically checked above
+                # pyrefly: ignore[not-callable]: `wait_for_forward` is dynamically checked above
                 emb_module.wait_for_forward()
 
     def get_resize_awaitables(self) -> List[LazyAwaitable[torch.Tensor]]:

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1877,7 +1877,7 @@ class ShardedEmbeddingBagCollection(
                 # use a separate stream. The wait_for_forward() method synchronizes via
                 # CUDA events recorded after the Triton kernel completes.
                 if hasattr(lookup, "wait_for_forward"):
-                    # pyre-ignore[29]: `wait_for_forward` is dynamically checked
+                    # pyrefly: ignore[not-callable]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
                 if MemoryStashingManager.is_enabled():
                     stash_result = MemoryStashingManager.stash_embedding_weights(lookup)

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -30,7 +30,7 @@ try:
         TritonTableBatchedEmbeddingBags,
     )
 except ImportError:
-    _SHARDED_TBE_TYPES: tuple[type, ...] = (  # pyre-ignore[9]
+    _SHARDED_TBE_TYPES: tuple[type, ...] = (  # pyrefly: ignore[bad-assignment]
         SplitTableBatchedEmbeddingBagsCodegen,
     )
 
@@ -958,7 +958,7 @@ class HybridEvalDMP(DistributedModelParallel):
     ) -> None:
         super().__init__(module, init_data_parallel=init_data_parallel, **kwargs)
 
-    # pyre-ignore[14]: inconsistent override
+    # pyrefly: ignore[bad-override]: inconsistent override
     def to(self, *args: Any, **kwargs: Any) -> "HybridEvalDMP":
         def _selective_to(mod: nn.Module) -> None:
             for key, param in mod._parameters.items():

--- a/torchrec/distributed/planner/estimator/annotations.py
+++ b/torchrec/distributed/planner/estimator/annotations.py
@@ -254,7 +254,7 @@ def hbm_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.hbm_mem_bw = value  # pyre-ignore[16]
+        cls.hbm_mem_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -276,7 +276,7 @@ def ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.ddr_mem_bw = value  # pyre-ignore[16]
+        cls.ddr_mem_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -298,7 +298,7 @@ def ssd_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.ssd_mem_bw = value  # pyre-ignore[16]
+        cls.ssd_mem_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -321,7 +321,7 @@ def hbm_to_ddr_mem_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.hbm_to_ddr_mem_bw = value  # pyre-ignore[16]
+        cls.hbm_to_ddr_mem_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -363,7 +363,7 @@ def device_bw(
                 not hasattr(cls, "kernel_device_bandwidths")
                 or cls.kernel_device_bandwidths is None
             ):
-                cls.kernel_device_bandwidths = {}  # pyre-ignore[16]
+                cls.kernel_device_bandwidths = {}  # pyrefly: ignore[missing-attribute]
             else:
                 # Check if we're using an inherited dictionary by comparing with parent's
                 # If so, create a new copy for this class
@@ -375,7 +375,7 @@ def device_bw(
                     ):
                         cls.kernel_device_bandwidths = dict(
                             cls.kernel_device_bandwidths
-                        )  # pyre-ignore[16]
+                        )  # pyrefly: ignore[missing-attribute]
                         break
 
             # Normalize compute_kernel to a list for uniform processing
@@ -388,10 +388,11 @@ def device_bw(
             # Store with lowercase keys for case-insensitive lookup
             for kernel in kernels:
                 key = (device_str.lower(), kernel.lower())
-                cls.kernel_device_bandwidths[key] = bandwidth  # pyre-ignore[16]
+                # pyrefly: ignore[missing-attribute]
+                cls.kernel_device_bandwidths[key] = bandwidth
         else:
             # General device bandwidth (existing behavior)
-            cls.device_bw = bandwidth  # pyre-ignore[16]
+            cls.device_bw = bandwidth  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -419,7 +420,7 @@ def intra_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.intra_host_bw = value  # pyre-ignore[16]
+        cls.intra_host_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -442,7 +443,7 @@ def inter_host_bw(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls.inter_host_bw = value  # pyre-ignore[16]
+        cls.inter_host_bw = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -514,8 +515,10 @@ def forward_compute(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_forward_compute = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_forward_compute = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @forward_compute (no parentheses)
@@ -589,8 +592,10 @@ def backward_compute(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_backward_compute = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_backward_compute = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @backward_compute (no parentheses)
@@ -638,7 +643,7 @@ def prefetch_compute(
                 # Custom prefetch logic
                 return expected_cache_fetches * ctx.shard_embedding_dim / self.custom_prefetch_bw
     """
-    method._is_custom_prefetch_compute = True  # pyre-ignore[16]
+    method._is_custom_prefetch_compute = True  # pyrefly: ignore[missing-attribute]
     return method
 
 
@@ -699,8 +704,10 @@ def input_dist_comms(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_input_dist_comms = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_input_dist_comms = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @input_dist_comms (no parentheses)
@@ -789,8 +796,10 @@ def fwd_comms(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_fwd_comms = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_fwd_comms = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @fwd_comms (no parentheses)
@@ -879,8 +888,10 @@ def bwd_comms(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_bwd_comms = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_bwd_comms = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @bwd_comms (no parentheses)
@@ -974,8 +985,10 @@ def output_write_size(
         method: Callable[..., float],
         target_sharding_type: Optional[Union[str, List[str]]],
     ) -> Callable[..., float]:
-        method._is_custom_output_write_size = True  # pyre-ignore[16]
-        method._custom_sharding_type = target_sharding_type  # pyre-ignore[16]
+        method._is_custom_output_write_size = True  # pyrefly: ignore[missing-attribute]
+        method._custom_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            target_sharding_type
+        )
         return method
 
     # Case 1: @output_write_size (no parentheses)
@@ -1029,7 +1042,7 @@ def use_min_dim_for_lookup(value: bool = True) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls._use_min_dim_for_lookup = value  # pyre-ignore[16]
+        cls._use_min_dim_for_lookup = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -1058,7 +1071,7 @@ def use_block_usage_penalty(value: bool = True) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls._use_block_usage_penalty = value  # pyre-ignore[16]
+        cls._use_block_usage_penalty = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -1085,7 +1098,7 @@ def use_bytes_for_input_read_size(value: bool = True) -> Callable[[Type[T]], Typ
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls._use_bytes_for_input_read_size = value  # pyre-ignore[16]
+        cls._use_bytes_for_input_read_size = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -1108,7 +1121,7 @@ def input_data_type_size(value: float) -> Callable[[Type[T]], Type[T]]:
     """
 
     def decorator(cls: Type[T]) -> Type[T]:
-        cls._input_data_type_size = value  # pyre-ignore[16]
+        cls._input_data_type_size = value  # pyrefly: ignore[missing-attribute]
         return cls
 
     return decorator
@@ -1138,7 +1151,7 @@ def supported_sharding_types(*sharding_types: str) -> Callable[[Type[T]], Type[T
 
     def decorator(cls: Type[T]) -> Type[T]:
         # Store as a frozenset for O(1) lookup, lowercase for case-insensitive matching
-        cls._supported_sharding_types = frozenset(  # pyre-ignore[16]
+        cls._supported_sharding_types = frozenset(  # pyrefly: ignore[missing-attribute]
             st.lower() for st in sharding_types
         )
         return cls
@@ -1200,8 +1213,10 @@ def fwd_coefficient(
     """
 
     def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
-        method._is_fwd_coefficient = True  # pyre-ignore[16]
-        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        method._is_fwd_coefficient = True  # pyrefly: ignore[missing-attribute]
+        method._coefficient_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            sharding_type
+        )
         return method
 
     return decorator
@@ -1233,8 +1248,10 @@ def bwd_coefficient(
     """
 
     def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
-        method._is_bwd_coefficient = True  # pyre-ignore[16]
-        method._coefficient_sharding_type = sharding_type  # pyre-ignore[16]
+        method._is_bwd_coefficient = True  # pyrefly: ignore[missing-attribute]
+        method._coefficient_sharding_type = (  # pyrefly: ignore[missing-attribute]
+            sharding_type
+        )
         return method
 
     return decorator
@@ -1258,7 +1275,7 @@ def prefetch_coefficient() -> Callable[[Callable[..., Any]], Callable[..., Any]]
     """
 
     def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
-        method._is_prefetch_coefficient = True  # pyre-ignore[16]
+        method._is_prefetch_coefficient = True  # pyrefly: ignore[missing-attribute]
         return method
 
     return decorator

--- a/torchrec/distributed/planner/estimator/tests/test_annotations.py
+++ b/torchrec/distributed/planner/estimator/tests/test_annotations.py
@@ -47,10 +47,13 @@ class FwdCoefficientDecoratorTest(unittest.TestCase):
         method = config.get_table_wise_fwd
 
         self.assertTrue(hasattr(method, "_is_fwd_coefficient"))
-        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(
+            method._is_fwd_coefficient
+        )  # pyrefly: ignore[missing-attribute]
         self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
         self.assertEqual(
-            method._coefficient_sharding_type, "table_wise"  # pyre-ignore[16]
+            method._coefficient_sharding_type,
+            "table_wise",  # pyrefly: ignore[missing-attribute]
         )
 
     def test_fwd_coefficient_decorator_with_multiple_sharding_types(self) -> None:
@@ -64,9 +67,12 @@ class FwdCoefficientDecoratorTest(unittest.TestCase):
         config = TestConfig()
         method = config.get_fwd
 
-        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(
+            # pyrefly: ignore[missing-attribute]
+            method._is_fwd_coefficient
+        )
         self.assertEqual(
-            method._coefficient_sharding_type,  # pyre-ignore[16]
+            method._coefficient_sharding_type,  # pyrefly: ignore[missing-attribute]
             ["table_wise", "row_wise"],
         )
 
@@ -81,8 +87,14 @@ class FwdCoefficientDecoratorTest(unittest.TestCase):
         config = TestConfig()
         method = config.get_fwd_all
 
-        self.assertTrue(method._is_fwd_coefficient)  # pyre-ignore[16]
-        self.assertIsNone(method._coefficient_sharding_type)  # pyre-ignore[16]
+        self.assertTrue(
+            # pyrefly: ignore[missing-attribute]
+            method._is_fwd_coefficient
+        )
+        self.assertIsNone(
+            # pyrefly: ignore[missing-attribute]
+            method._coefficient_sharding_type
+        )
 
     def test_get_fwd_coefficient_returns_coefficient_for_matching_sharding_type(
         self,
@@ -98,7 +110,9 @@ class FwdCoefficientDecoratorTest(unittest.TestCase):
         result = get_fwd_coefficient(config, "table_wise")
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["emb_lookup"], 1.5)  # pyre-ignore[16]
+        self.assertEqual(
+            result["emb_lookup"], 1.5
+        )  # pyrefly: ignore[missing-attribute]
 
     def test_get_fwd_coefficient_returns_none_for_non_matching_sharding_type(
         self,
@@ -162,10 +176,13 @@ class BwdCoefficientDecoratorTest(unittest.TestCase):
         method = config.get_row_wise_bwd
 
         self.assertTrue(hasattr(method, "_is_bwd_coefficient"))
-        self.assertTrue(method._is_bwd_coefficient)  # pyre-ignore[16]
+        self.assertTrue(
+            method._is_bwd_coefficient
+        )  # pyrefly: ignore[missing-attribute]
         self.assertTrue(hasattr(method, "_coefficient_sharding_type"))
         self.assertEqual(
-            method._coefficient_sharding_type, "row_wise"  # pyre-ignore[16]
+            method._coefficient_sharding_type,
+            "row_wise",  # pyrefly: ignore[missing-attribute]
         )
 
     def test_get_bwd_coefficient_returns_coefficient_for_matching_sharding_type(
@@ -182,7 +199,9 @@ class BwdCoefficientDecoratorTest(unittest.TestCase):
         result = get_bwd_coefficient(config, "row_wise")
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["emb_lookup"], 3.0)  # pyre-ignore[16]
+        self.assertEqual(
+            result["emb_lookup"], 3.0
+        )  # pyrefly: ignore[missing-attribute]
 
     def test_get_bwd_coefficient_returns_none_for_non_matching_sharding_type(
         self,
@@ -218,7 +237,9 @@ class PrefetchCoefficientDecoratorTest(unittest.TestCase):
         method = config.get_prefetch
 
         self.assertTrue(hasattr(method, "_is_prefetch_coefficient"))
-        self.assertTrue(method._is_prefetch_coefficient)  # pyre-ignore[16]
+        self.assertTrue(
+            method._is_prefetch_coefficient
+        )  # pyrefly: ignore[missing-attribute]
 
     def test_get_prefetch_coefficient_returns_coefficients(self) -> None:
         """Test get_prefetch_coefficient returns prefetch coefficients."""
@@ -236,7 +257,8 @@ class PrefetchCoefficientDecoratorTest(unittest.TestCase):
 
         self.assertIsNotNone(result)
         self.assertEqual(
-            result["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+            result["expected_num_lookups_coefficient"],
+            0.5,  # pyrefly: ignore[missing-attribute]
         )
 
     def test_get_prefetch_coefficient_returns_none_when_no_decorator(self) -> None:
@@ -265,7 +287,7 @@ class DeviceBwDecoratorTest(unittest.TestCase):
         config = TestConfig()
 
         self.assertTrue(hasattr(config, "device_bw"))
-        self.assertEqual(config.device_bw, 100.0)  # pyre-ignore[16]
+        self.assertEqual(config.device_bw, 100.0)  # pyrefly: ignore[missing-attribute]
 
     def test_device_bw_decorator_with_specific_device_and_kernel(self) -> None:
         """Test @device_bw decorator with specific device and compute kernel."""
@@ -278,10 +300,13 @@ class DeviceBwDecoratorTest(unittest.TestCase):
 
         self.assertTrue(hasattr(config, "kernel_device_bandwidths"))
         self.assertIn(
-            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+            ("cuda", "fused"),
+            config.kernel_device_bandwidths,  # pyrefly: ignore[missing-attribute]
         )
         self.assertEqual(
-            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            config.kernel_device_bandwidths[
+                ("cuda", "fused")
+            ],  # pyrefly: ignore[missing-attribute]
             200.0,
         )
 
@@ -296,17 +321,21 @@ class DeviceBwDecoratorTest(unittest.TestCase):
         config = TestConfig()
 
         self.assertIn(
-            ("cuda", "fused"), config.kernel_device_bandwidths  # pyre-ignore[16]
+            ("cuda", "fused"),
+            config.kernel_device_bandwidths,  # pyrefly: ignore[missing-attribute]
         )
         self.assertIn(
-            ("cuda", "dense"), config.kernel_device_bandwidths  # pyre-ignore[16]
+            ("cuda", "dense"),
+            config.kernel_device_bandwidths,  # pyrefly: ignore[missing-attribute]
         )
         self.assertEqual(
-            config.kernel_device_bandwidths[("cuda", "fused")],  # pyre-ignore[16]
+            # pyrefly: ignore[missing-attribute]
+            config.kernel_device_bandwidths[("cuda", "fused")],
             200.0,
         )
         self.assertEqual(
-            config.kernel_device_bandwidths[("cuda", "dense")],  # pyre-ignore[16]
+            # pyrefly: ignore[missing-attribute]
+            config.kernel_device_bandwidths[("cuda", "dense")],
             150.0,
         )
 
@@ -326,7 +355,9 @@ class OutputWriteSizeDecoratorTest(unittest.TestCase):
         method = config.custom_output_write
 
         self.assertTrue(hasattr(method, "_is_custom_output_write_size"))
-        self.assertTrue(method._is_custom_output_write_size)  # pyre-ignore[16]
+        self.assertTrue(
+            method._is_custom_output_write_size
+        )  # pyrefly: ignore[missing-attribute]
 
     def test_get_output_write_size_returns_method_for_matching_sharding_type(
         self,
@@ -370,10 +401,15 @@ class SupportedShardingTypesDecoratorTest(unittest.TestCase):
         config = TestConfig()
 
         self.assertTrue(hasattr(config, "_supported_sharding_types"))
-        self.assertIn("table_wise", config._supported_sharding_types)  # pyre-ignore[16]
-        self.assertIn("row_wise", config._supported_sharding_types)  # pyre-ignore[16]
+        self.assertIn(
+            "table_wise", config._supported_sharding_types
+        )  # pyrefly: ignore[missing-attribute]
+        self.assertIn(
+            "row_wise", config._supported_sharding_types
+        )  # pyrefly: ignore[missing-attribute]
         self.assertNotIn(
-            "column_wise", config._supported_sharding_types  # pyre-ignore[16]
+            "column_wise",
+            config._supported_sharding_types,  # pyrefly: ignore[missing-attribute]
         )
 
 
@@ -405,13 +441,19 @@ class MultipleCoefficientDecoratorTest(unittest.TestCase):
         bwd_rw = get_bwd_coefficient(config, "row_wise")
 
         self.assertIsNotNone(fwd_tw)
-        self.assertEqual(fwd_tw["emb_lookup"], 1.0)  # pyre-ignore[16]
+        self.assertEqual(
+            fwd_tw["emb_lookup"], 1.0
+        )  # pyrefly: ignore[missing-attribute]
 
         self.assertIsNotNone(fwd_rw)
-        self.assertEqual(fwd_rw["emb_lookup"], 1.5)  # pyre-ignore[16]
+        self.assertEqual(
+            fwd_rw["emb_lookup"], 1.5
+        )  # pyrefly: ignore[missing-attribute]
 
         self.assertIsNotNone(bwd_tw)
-        self.assertEqual(bwd_tw["emb_lookup"], 2.0)  # pyre-ignore[16]
+        self.assertEqual(
+            bwd_tw["emb_lookup"], 2.0
+        )  # pyrefly: ignore[missing-attribute]
 
         # No bwd for row_wise
         self.assertIsNone(bwd_rw)
@@ -435,7 +477,8 @@ class MultipleCoefficientDecoratorTest(unittest.TestCase):
 
         self.assertIsNotNone(fwd)
         self.assertIsNotNone(prefetch)
-        self.assertEqual(fwd["emb_lookup"], 1.0)  # pyre-ignore[16]
+        self.assertEqual(fwd["emb_lookup"], 1.0)  # pyrefly: ignore[missing-attribute]
         self.assertEqual(
-            prefetch["expected_num_lookups_coefficient"], 0.5  # pyre-ignore[16]
+            prefetch["expected_num_lookups_coefficient"],
+            0.5,  # pyrefly: ignore[missing-attribute]
         )

--- a/torchrec/distributed/planner/estimator/tests/test_estimator.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator.py
@@ -79,9 +79,9 @@ def create_test_context(
     compute_kernel: str = EmbeddingComputeKernel.FUSED.value,
     hash_size: int = 10000,
     emb_dim: int = 128,
-    batch_sizes: Optional[list] = None,  # pyre-ignore[24]
-    num_poolings: Optional[list] = None,  # pyre-ignore[24]
-    input_lengths: Optional[list] = None,  # pyre-ignore[24]
+    batch_sizes: Optional[list] = None,  # pyrefly: ignore
+    num_poolings: Optional[list] = None,  # pyrefly: ignore
+    input_lengths: Optional[list] = None,  # pyrefly: ignore
     world_size: int = 8,
     local_world_size: int = 4,
     device_bw: float = HBM_MEM_BW,

--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -65,7 +65,7 @@ class PerfCoefficientTest(unittest.TestCase):
         """Test that PerfCoefficient is frozen (immutable)."""
         coeff = PerfCoefficient()
         with self.assertRaises(AttributeError):
-            coeff.input_read_size_multiplier = 2.0  # pyre-ignore[41]
+            coeff.input_read_size_multiplier = 2.0  # pyrefly: ignore[read-only]
 
 
 class EstimatorPerfCoefficientsTest(unittest.TestCase):
@@ -297,7 +297,7 @@ class HardwarePerfConfigTest(unittest.TestCase):
         perf_config = config.coefficients
         self.assertIsNotNone(perf_config.row_wise)
         self.assertEqual(
-            perf_config.row_wise.fwd.lookup_size_multiplier,  # pyre-ignore[16]
+            perf_config.row_wise.fwd.lookup_size_multiplier,  # pyrefly: ignore[missing-attribute]
             3.0,
         )
         self.assertIsNotNone(perf_config.prefetch)

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -613,7 +613,9 @@ class ShardPerfContext:
         caching_ratio = sharding_option.cache_load_factor
         if caching_ratio is None:
             caching_ratio = (
-                sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
+                sharder.fused_params.get(
+                    "cache_load_factor"
+                )  # pyrefly: ignore[missing-attribute]
                 if hasattr(sharder, "fused_params") and sharder.fused_params
                 else None
             )
@@ -771,15 +773,15 @@ class ShardPerfContext:
                 hasattr(module, "_feature_processor")
                 and hasattr(module._feature_processor, "feature_processor_modules")
                 and isinstance(
-                    module._feature_processor.feature_processor_modules,  # pyre-ignore[16]
+                    module._feature_processor.feature_processor_modules,  # pyrefly: ignore[missing-attribute]
                     nn.ModuleDict,
                 )
                 and sharding_option.name
-                in module._feature_processor.feature_processor_modules.keys()  # pyre-ignore[16]
+                in module._feature_processor.feature_processor_modules.keys()  # pyrefly: ignore[missing-attribute]
             ):
                 has_feature_processor = True
             if isinstance(module, EmbeddingBagCollectionInterface):
-                is_weighted = module.is_weighted()  # pyre-ignore[29]
+                is_weighted = module.is_weighted()  # pyrefly: ignore[not-callable]
             elif (
                 constraints
                 and constraints.get(sharding_option.name)

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -796,7 +796,7 @@ def get_num_poolings(
 
     # Second priority: use constraint-based num_poolings
     if constraints and constraints.get(so.name) and constraints[so.name].num_poolings:
-        # pyre-ignore[6]
+        # pyrefly: ignore[bad-argument-type]
         return cast(List[float], constraints[so.name].num_poolings)
 
     # Fallback: use default NUM_POOLINGS constant

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1134,7 +1134,7 @@ class ShardingOption:
                 "feature_processor_modules",
             )
             and isinstance(
-                # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+                # pyrefly: ignore[missing-attribute]: `Module` has no attribute `_feature_processor`
                 child_module._feature_processor.feature_processor_modules,
                 nn.ModuleDict,
             )
@@ -1142,12 +1142,12 @@ class ShardingOption:
         self._has_feature_processor: bool = (
             _module_has_fp
             and name
-            # pyre-ignore[16]: `Module` has no attribute `_feature_processor`
+            # pyrefly: ignore[missing-attribute]: `Module` has no attribute `_feature_processor`
             in child_module._feature_processor.feature_processor_modules.keys()
         )
         if hasattr(child_module, "is_weighted") and callable(child_module.is_weighted):
             if isinstance(child_module, EmbeddingBagCollectionInterface):
-                # pyre-ignore[29]: `Module` has no attribute `is_weighted`
+                # pyrefly: ignore[not-callable]: `Module` has no attribute `is_weighted`
                 self.is_weighted = child_module.is_weighted()
 
     @property

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -90,7 +90,9 @@ def is_prefetch_pipelined(
     # TODO: remove after deprecating fused_params in sharder
     if not prefetch_pipeline:
         prefetch_pipeline = (
-            sharder.fused_params.get("prefetch_pipeline", False)  # pyre-ignore[16]
+            sharder.fused_params.get(
+                "prefetch_pipeline", False
+            )  # pyrefly: ignore[missing-attribute]
             if hasattr(sharder, "fused_params") and sharder.fused_params
             else False
         )

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -336,7 +336,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
         )
         self._sparse_future: Optional[Future[In]] = None
 
-    # pyre-ignore[14]
+    # pyrefly: ignore[bad-override]
     def _pipeline_model(
         self,
         batch: In,
@@ -540,7 +540,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
         else:
             return self._copy_to_gpu(batch, context)
 
-    # pyre-ignore[14]
+    # pyrefly: ignore[bad-override]
     def enqueue_batch(self, dataloader_iter: Iterator[In]) -> bool:
         """
         Load a batch from the dataloader, create context, and append to
@@ -728,8 +728,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
                 def _copy_work() -> In:
                     # pyrefly: ignore [bad-argument-type]
                     with self._stream_context(self._memcpy_stream):
-                        # pyrefly: ignore [redundant-cast]
-                        return _to_device(cast(In, batch), self._device, True)
+                        return _to_device(batch, self._device, True)
 
                 future_batch = self._copy_executor.submit(_copy_work)
                 return cast(In, future_batch), context

--- a/torchrec/distributed/train_pipeline/gradient_accumulation.py
+++ b/torchrec/distributed/train_pipeline/gradient_accumulation.py
@@ -147,7 +147,7 @@ class GradientAccumulationWrapper(Generic[In, Out]):
         # Only replace optimizer in pipeline when GA is enabled
         # This avoids unintended side effects when GA is disabled
         if config.is_enabled and hasattr(pipeline, "_optimizer"):
-            # pyre-ignore[16]: pipeline may not have _optimizer
+            # pyrefly: ignore[missing-attribute]: pipeline may not have _optimizer
             pipeline._optimizer = self._optimizer_wrapper
 
     def _should_sync_grad(self, is_last_batch: bool = False) -> bool:
@@ -185,7 +185,7 @@ class GradientAccumulationWrapper(Generic[In, Out]):
 
         # Check for DMP-wrapped DDP
         if hasattr(model, "_dmp_wrapped_module"):
-            # pyre-ignore[16]: model may not have _dmp_wrapped_module
+            # pyrefly: ignore[missing-attribute]: model may not have _dmp_wrapped_module
             dmp = model._dmp_wrapped_module
             if hasattr(dmp, "no_sync"):
                 # pyrefly: ignore[not-callable]
@@ -193,7 +193,7 @@ class GradientAccumulationWrapper(Generic[In, Out]):
 
         # Check for direct DDP
         if hasattr(model, "no_sync"):
-            # pyre-ignore[29]: model is typed as nn.Module; no_sync exists on DDP subclasses
+            # pyrefly: ignore[not-callable]: model is typed as nn.Module; no_sync exists on DDP subclasses
             return model.no_sync()
 
         return contextlib.nullcontext()

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -236,7 +236,7 @@ class CPUEmbeddingPipelinedForward(EmbeddingPipelinedForward):
     which are populated by Stage 2 (``_copy_to_gpu``) of ``EvalPipelineCPUSparse``.
     """
 
-    # pyre-ignore [2, 24]
+    # pyrefly: ignore
     def __call__(self, *input, **kwargs) -> Union[
         Awaitable[EmbeddingModuleRetType],
         Tuple[

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -157,7 +157,9 @@ class OutputDistSiteTest(unittest.TestCase):
         w._tensor_awaitable = _make_request_with_dummy_tensor()
 
         fake = FakeAwaitable()
-        fake._awaitables = [w]  # pyre-ignore[16]
-        fake._sharding_types = [ShardingType.TABLE_WISE.value]  # pyre-ignore[16]
+        # pyrefly: ignore[missing-attribute]
+        fake._awaitables = [w]
+        # pyrefly: ignore[missing-attribute]
+        fake._sharding_types = [ShardingType.TABLE_WISE.value]
 
         self.assertIsNotNone(site.find_grad_tensor(fake))

--- a/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
+++ b/torchrec/distributed/train_pipeline/tests/test_gradient_accumulation.py
@@ -26,7 +26,7 @@ class _MockPipeline(TrainPipeline[Any, float]):
     """Mock pipeline that tracks progress() calls and can raise StopIteration."""
 
     def __init__(self, num_batches: int) -> None:
-        super().__init__()  # pyre-ignore[20]
+        super().__init__()  # pyrefly: ignore[missing-argument]
         self._optimizer = MagicMock()
         self._num_batches = num_batches
         self._calls: int = 0
@@ -52,7 +52,7 @@ class _RealForwardPipeline(TrainPipeline[Any, torch.Tensor]):
         model: nn.Module,
         optimizer: optim.Optimizer,
     ) -> None:
-        super().__init__()  # pyre-ignore[20]
+        super().__init__()  # pyrefly: ignore[missing-argument]
         self._model = model
         self._optimizer = optimizer
         self._progress_count = 0
@@ -518,7 +518,9 @@ class StopIterationHandlingTest(unittest.TestCase):
             flush_call_count[0] += 1
             return original_flush(steps)
 
-        ga._flush_accumulated_gradients = counting_flush  # pyre-ignore[8]
+        ga._flush_accumulated_gradients = (
+            counting_flush  # pyrefly: ignore[bad-assignment]
+        )
 
         with self.assertRaises(StopIteration):
             ga.progress(dummy_iter, is_last_batch=True)
@@ -626,7 +628,9 @@ class IsLastBatchTest(unittest.TestCase):
             step_call_count[0] += 1
             return original_step(*args, **kwargs)
 
-        wrapper.optimizer_wrapper._optimizer.step = counting_step  # pyre-ignore[8]
+        wrapper.optimizer_wrapper._optimizer.step = (
+            counting_step  # pyrefly: ignore[bad-assignment]
+        )
 
         # 4th batch is at accumulation boundary AND is_last_batch=True
         wrapper.progress(iter([torch.randn(2, 10)]), is_last_batch=True)

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -607,12 +607,12 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             )
 
         self.assertTrue(offloaded_metric.predictions_update_calls is not None)
-        # pyre-ignore[6]: predictions_update_calls contains Dict[str, Tensor]
+        # pyrefly: ignore[bad-argument-type]
         torch.testing.assert_close(
             offloaded_metric.predictions_update_calls[0],
             {"task1": torch.tensor([0.5, 0.7])},
         )
-        # pyre-ignore[6]: labels_update_calls contains Dict[str, Tensor]
+        # pyrefly: ignore[bad-argument-type]
         torch.testing.assert_close(
             offloaded_metric.labels_update_calls[0],
             {"task1": torch.tensor([0.0, 1.0])},
@@ -620,7 +620,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
         offloaded_module.shutdown()
 
-    # pyre-ignore[56]
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -469,7 +469,7 @@ class ManagedCollisionCollection(nn.Module):
         for i, (table, mc_module) in enumerate(self._managed_collision_modules.items()):
             kjt: KeyedJaggedTensor = feature_splits[i]
             remapped_ids_kjt: KeyedJaggedTensor = remapped_ids_splits[i]
-            # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
+            # pyre-ignore[29]: `Union[Module, Tensor]` is not a function.
             per_table_runtime_meta = mc_module.lookup_runtime_meta(
                 kjt.values(), remapped_ids_kjt.values()
             )

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -693,7 +693,7 @@ class TestMCH(unittest.TestCase):
         self.assertTrue(m._eviction_policy_name is None)
         self.assertTrue(m._eviction_module is None)
 
-    # pyre-ignore[56]
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",

--- a/torchrec/modules/tests/test_itep_embedding_modules.py
+++ b/torchrec/modules/tests/test_itep_embedding_modules.py
@@ -917,7 +917,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
 
         return input_kjt_cuda
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -941,7 +941,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             )
             _ = itep_ec(input_kjt)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -965,7 +965,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             )
             _ = itep_ec(input_kjt)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -996,7 +996,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
 
         self.assertEqual(mock_reset_weight_momentum.call_count, 5)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1028,7 +1028,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
 
         self.assertEqual(mock_reset_weight_momentum.call_count, 0)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1056,7 +1056,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             _ = itep_ec(input_kjt)
             self.assertEqual(itep_ec._iter.item(), expected_iter)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1078,7 +1078,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
         original_forward = itep_module.forward
         captured_iter_args = []
 
-        # pyre-ignore[53]: Captured variable `captured_iter_args` is not annotated.
+        # pyrefly: ignore
         def mock_forward(
             features: KeyedJaggedTensor, iter_val: int
         ) -> KeyedJaggedTensor:
@@ -1098,7 +1098,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             self.assertEqual(arg_type, int)
             self.assertEqual(arg_value, 42)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1130,7 +1130,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             if jt.values().numel() > 0:
                 self.assertEqual(jt.values().shape[1], 4)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1158,7 +1158,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
         config_names = {c.name for c in configs}
         self.assertEqual(config_names, {"table1", "table2"})
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -1193,7 +1193,7 @@ class TestITEPEmbeddingCollection(unittest.TestCase):
             self.assertIsInstance(jt, JaggedTensor)
             self.assertEqual(jt.values().shape[1], 4)
 
-    # pyre-ignore[56]: Pyre was not able to infer the type of argument
+    # pyrefly: ignore
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",


### PR DESCRIPTION
Summary:

Migrate all `pyre-ignore` and `pyre-fixme` type suppression comments in the torchrec codebase (excluding torchrecipes) to pyrefly-compatible `pyrefly: ignore` format, in preparation for Meta's Pyre → Pyrefly migration.

Changes:
* Convert 9 `pyre-fixme` occurrences across 4 files to `pyre-ignore`, then to `pyrefly: ignore`
* Convert ~100+ `pyre-ignore` occurrences across 27 source and test files to `pyrefly: ignore`
* Map Pyre numeric error codes to Pyrefly named error codes (e.g. `[16]` → `[missing-attribute]`, `[29]` → `[not-callable]`, `[14]` → `[bad-override]`, etc.)
* Add missing suppress comments for 2 new errors found by pyrefly in `batched_embedding_kernel.py`
* Fix mismatched error codes caught by pyrefly check (e.g. `[read-only]` vs `[bad-assignment]`)

Reviewed By: spmex

Differential Revision: D96625573


