### PR TITLE
Re-classify missing label names in model out as input errors

### DIFF
--- a/torchrec/metrics/model_utils.py
+++ b/torchrec/metrics/model_utils.py
@@ -56,6 +56,8 @@ def parse_model_outputs(
     weight_name: str,
     model_out: Dict[str, torch.Tensor],
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+    if label_name not in model_out:
+        raise ValueError(f"Label name {label_name} not found in model output")
     labels = model_out[label_name].squeeze()
     if not prediction_name:
         assert not weight_name, "weight name must be empty if prediction name is empty"


### PR DESCRIPTION
Summary:
As title. If the label name is missing in the model output, we'll get a key error, but this is an issue with how the model was authored, not a platform error

Since the error comes from torchrec, we cannot rethrow as input error directly. Instead, we throw the key errors explicitly with a recognizable error string, which PyPer then re-categorizes as input error

Differential Revision: D96930246


