### PR TITLE
Filter empty grads before clip_grad_norm_ with infinity norm

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -120,11 +120,20 @@ class GradientClippingOptimizer(OptimizerWrapper):
                     p._local_tensor if isinstance(p, DTensor) else p
                     for p in self._replicate_params
                 ]
-                torch.nn.utils.clip_grad_norm_(
-                    parameters=replicate_params,
-                    max_norm=self._max_gradient,
-                    norm_type=self._norm_type,
-                )
+                # Filter out parameters with empty gradients to avoid
+                # torch._foreach_norm failing on empty tensors with infinity
+                # norm. This matches the filtering in _get_grads().
+                replicate_params = [
+                    p
+                    for p in replicate_params
+                    if p.grad is not None and p.grad.numel() > 0
+                ]
+                if replicate_params:
+                    torch.nn.utils.clip_grad_norm_(
+                        parameters=replicate_params,
+                        max_norm=self._max_gradient,
+                        norm_type=self._norm_type,
+                    )
             else:
                 self.clip_grad_norm_()
 

--- a/torchrec/optim/tests/test_clipping.py
+++ b/torchrec/optim/tests/test_clipping.py
@@ -242,6 +242,60 @@ class TestGradientClippingOptimizer(unittest.TestCase):
 
         mock_clip_grad_norm.assert_not_called()
 
+    def test_clip_inf_norm_with_empty_grad_no_sharded_params(self) -> None:
+        """Test that infinity norm gradient clipping handles empty gradients
+        when there are no sharded parameters (uses torch.nn.utils.clip_grad_norm_ path).
+
+        This is a regression test for T256567466 / T260346508 where
+        torch._foreach_norm raises an error on empty tensors with infinity norm
+        during optimizer init_state().
+        """
+        param_1 = Variable(torch.tensor([3.0, 4.0]), requires_grad=True)
+        param_2 = Variable(torch.tensor([]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1, "param_2": param_2},
+            {},
+            [{"params": [param_1, param_2]}],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.NORM,
+            norm_type=float("inf"),
+        )
+
+        # Simulate empty gradient (as happens during init_state)
+        param_1.grad = torch.tensor([1.0, 2.0])
+        param_2.grad = torch.tensor([])
+
+        # This should not raise RuntimeError about empty tensor infinity norm
+        gradient_clipping_optimizer.step()
+
+    def test_clip_inf_norm_all_empty_grads_no_sharded_params(self) -> None:
+        """Test that infinity norm gradient clipping handles the case where
+        all parameters have empty gradients and there are no sharded params."""
+        param_1 = Variable(torch.tensor([]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1},
+            {},
+            [{"params": [param_1]}],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.NORM,
+            norm_type=float("inf"),
+        )
+
+        param_1.grad = torch.tensor([])
+
+        # This should not raise - should gracefully handle empty params
+        gradient_clipping_optimizer.step()
+
 
 class TestGetGrads(unittest.TestCase):
     def test_get_grads_returns_gradients(self) -> None:


### PR DESCRIPTION
Summary:
Fix the second code path for the _foreach_norm infinity norm crash on empty
tensors (T260346508, T256567466). D94430621 fixed the TorchRec custom
`_batch_cal_norm` path, but when `len(self._sharded_params) == 0`,
`GradientClippingOptimizer.step()` delegates to PyTorch core's
`torch.nn.utils.clip_grad_norm_()` which does not filter empty gradient
tensors. When `norm_type=inf`, `_get_total_norm` passes empty tensors to
`torch._foreach_norm` which raises RuntimeError because max() over an empty
set has no identity element.

This diff filters out parameters with no gradients or empty gradients (numel==0)
before calling `clip_grad_norm_`, matching the same filtering done in `_get_grads()`.
Also adds regression tests for this specific code path.

Root cause: Interaction of D79128843 (TorchRec clipping refactor) and D91979475
(PyTorch _foreach_norm validation). The refactor removed the empty-list guard
and the PyTorch change made empty lists with inf norm an error.

Reviewed By: wz337

Differential Revision: D97129718


