### PR TITLE
Add back the missing stash_weights from EBC

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -56,8 +56,6 @@ EmbeddingTablesConfig:
         feature_names: ["additional_2_1"]
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  hardware:  # A100
-    hbm_cap: 85899345920  # 80GB
   additional_constraints:
     large_table:
       sharding_types: [column_wise]

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -902,6 +902,7 @@ class ShardedEmbeddingBagCollection(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
+                    stash_weights=getattr(config, "stash_weights", False),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,


### PR DESCRIPTION
Summary:
This diff adds support for `stash_weights` in the `EmbeddingBagCollection` sharding flow and removes hardcoded A100 HBM capacity from the `sparse_data_dist_emb_stash` benchmark config.

**Changes:**
1. **`embeddingbag.py`** — Passes the `stash_weights` attribute from the embedding bag config to `ShardedEmbeddingBagConfig`, enabling embedding stash weight support in the distributed path.
2. **`sparse_data_dist_emb_stash.yml`** — Removes the hardcoded A100 `hbm_cap` (80GB) from the planner hardware config, allowing the planner to auto-detect hardware capabilities (e.g., for GB200).

**Benchmark results** (GB200, opt mode, `sparse_data_dist_emb_stash` config):

| Benchmark | GPU Runtime (P90) | CPU Runtime (P90) | GPU Peak Mem alloc (P90) | GPU Peak Mem reserved (P90) |
|---|---|---|---|---|
| sparse_data_dist_emb_stash | 3421.86 ms | 3049.33 ms | 54.40 GB | 72.72 GB |

Traces: [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D97253575/trace-sparse_data_dist_emb_stash-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Memory Visualizer](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D97253575/memory-sparse_data_dist_emb_stash-rank0.pickle)

Differential Revision: D97253575


