### PR TITLE
Reduce sparse_data_dist_eval benchmark size for H100/A100

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml
@@ -4,9 +4,10 @@
 #      and MP-ZCH only works with row-wise sharding.
 RunOptions:
   world_size: 2
-  num_batches: 20
-  num_benchmarks: 5
+  num_batches: 10
+  num_benchmarks: 1
   num_profiles: 1
+  num_iters: 20
   sharding_type: table_wise
   profile_dir: "."
   name: "sparse_data_dist_eval"
@@ -26,8 +27,8 @@ ModelSelectionConfig:
       over_arch_hidden_layers: 10
       dense_arch_hidden_sizes: [128, 128, 128]
 EmbeddingTablesConfig:
-  num_unweighted_features: 70
-  num_weighted_features: 70
+  num_unweighted_features: 50
+  num_weighted_features: 50
   embedding_feature_dim: 256
   additional_tables:
     - - name: FP16_table


### PR DESCRIPTION
Summary:
The `sparse_data_dist_eval` benchmark config was too heavy to run on H100 or A100 GPUs. Reduced batch count, benchmark repeats, and feature count so the benchmark fits in GPU memory.

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_eval              |11103.93 ms      |10073.66 ms      |72.78 GB                |82.30 GB                   |84.28 GB          |0.0 / 0.0 / 0.0              |18.45 GB          |

* repro commands
```bash
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml \
    --memory_snapshot=True \
    --loglevel=INFO
```

* sharding stats
```
#######################################################################################################################################################################################################################################################################################################################################
#                                                                                                                                                     --- Planner Statistics ---                                                                                                                                                      #
#                                                                                                                              --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.05s ---                                                                                                                               #
# ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
#      Rank       HBM (GB)     DDR (GB)                 Perf (ms)     Input (MB)     Output (MB)         Shards                                                                                                                                                                                                                       #
#    ------     ----------   ----------               -----------   ------------   -------------       --------                                                                                                                                                                                                                       #
#         0   29.704 (37%)     0.0 (0%)   400.272 (110,5,280,5,0)          757.5          3232.0   RW: 1 TW: 50                                                                                                                                                                                                                       #
#         1   29.704 (37%)     0.0 (0%)   400.272 (110,5,280,5,0)          757.5          3232.0   RW: 1 TW: 50                                                                                                                                                                                                                       #
#                                                                                                                                                                                                                                                                                                                                     #
# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                                               #
# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                                                 #
# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                                                      #
#                                                                                                                                                                                                                                                                                                                                     #
# Parameter Info:                                                                                                                                                                                                                                                                                                                     #
#                                      FQN     Sharding     Compute Kernel               Perf (ms)      Storage (HBM, DDR, SSD)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size     Ranks   #
#                                    -----   ----------   ----------------             -----------    -------------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------   -------   #
#     sparse.weighted_ebc.weighted_table_0           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#     sparse.weighted_ebc.weighted_table_1           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#     sparse.weighted_ebc.weighted_table_2           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#     sparse.weighted_ebc.weighted_table_3           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#     sparse.weighted_ebc.weighted_table_4           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#     sparse.weighted_ebc.weighted_table_5           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#     sparse.weighted_ebc.weighted_table_6           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#     sparse.weighted_ebc.weighted_table_7           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#     sparse.weighted_ebc.weighted_table_8           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#     sparse.weighted_ebc.weighted_table_9           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_10           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_11           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_12           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_13           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_14           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_15           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_16           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_17           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_18           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_19           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_20           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_21           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_22           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_23           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_24           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_25           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_26           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_27           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_28           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_29           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_30           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_31           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_32           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_33           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_34           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_35           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_36           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_37           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_38           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_39           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_40           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_41           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_42           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_43           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_44           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_45           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_46           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_47           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#    sparse.weighted_ebc.weighted_table_48           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#    sparse.weighted_ebc.weighted_table_49           TW              fused   9.198 (2,0.1,7,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                       sparse.ebc.table_0           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                       sparse.ebc.table_1           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                       sparse.ebc.table_2           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                       sparse.ebc.table_3           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                       sparse.ebc.table_4           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                       sparse.ebc.table_5           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                       sparse.ebc.table_6           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                       sparse.ebc.table_7           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                       sparse.ebc.table_8           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                       sparse.ebc.table_9           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_10           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_11           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_12           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_13           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_14           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_15           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_16           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_17           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_18           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_19           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_20           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_21           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_22           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_23           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_24           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_25           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_26           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_27           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_28           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_29           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_30           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_31           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_32           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_33           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_34           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_35           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_36           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_37           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_38           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_39           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_40           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_41           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_42           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_43           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_44           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_45           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_46           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_47           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                      sparse.ebc.table_48           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
#                      sparse.ebc.table_49           TW              fused   6.737 (2,0.1,4,0.1,0)   (0.173 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
#                    sparse.ebc.FP16_table           RW              fused   3.773 (1,0.1,2,0.3,0)   (0.125 GB, 0.0 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000       0-1   #
#                                                                                                                                                                                                                                                                                                                                     #
# Batch Size: 32768                                                                                                                                                                                                                                                                                                                   #
#                                                                                                                                                                                                                                                                                                                                     #
# Compute Kernels Count:                                                                                                                                                                                                                                                                                                              #
#    fused: 101                                                                                                                                                                                                                                                                                                                       #
#                                                                                                                                                                                                                                                                                                                                     #
# Compute Kernels Storage:                                                                                                                                                                                                                                                                                                            #
#    fused: HBM: 17.376 GB, DDR: 0.0 GB, SSD: 0.0 GB                                                                                                                                                                                                                                                                                  #
#                                                                                                                                                                                                                                                                                                                                     #
# Compute Kernel Constraints:                                                                                                                                                                                                                                                                                                         #
#    Hardcoded: 101, Auto-selected: 0                                                                                                                                                                                                                                                                                                 #
#    Hardcoded fused: 101                                                                                                                                                                                                                                                                                                             #
#                                                                                                                                                                                                                                                                                                                                     #
# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                                                     #
# Total Variation: 0.000                                                                                                                                                                                                                                                                                                              #
# Total Distance: 0.000                                                                                                                                                                                                                                                                                                               #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                               #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                #
#                                                                                                                                                                                                                                                                                                                                     #
# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                                            #
# Total Variation: 0.000                                                                                                                                                                                                                                                                                                              #
# Total Distance: 0.000                                                                                                                                                                                                                                                                                                               #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                               #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                #
#                                                                                                                                                                                                                                                                                                                                     #
# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                                             #
#                                                                                                                                                                                                                                                                                                                                     #
# Maximum of Total Perf: 400.272 ms on ranks 0-1                                                                                                                                                                                                                                                                                      #
# Mean Total Perf: 400.272 ms                                                                                                                                                                                                                                                                                                         #
# Max Total Perf is 0% greater than the mean                                                                                                                                                                                                                                                                                          #
# Maximum of Forward Compute: 109.789 ms on ranks 0-1                                                                                                                                                                                                                                                                                 #
# Maximum of Forward Comms: 5.26 ms on ranks 0-1                                                                                                                                                                                                                                                                                      #
# Maximum of Backward Compute: 279.876 ms on ranks 0-1                                                                                                                                                                                                                                                                                #
# Maximum of Backward Comms: 5.346 ms on ranks 0-1                                                                                                                                                                                                                                                                                    #
# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                                                    #
# Sum of Maxima: 400.272 ms                                                                                                                                                                                                                                                                                                           #
#                                                                                                                                                                                                                                                                                                                                     #
# Estimated Sharding Distribution                                                                                                                                                                                                                                                                                                      #
# Sparse only Max HBM: 8.688 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                       #
# Sparse only Min HBM: 8.688 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                       #
# Max HBM: 29.704 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                                  #
# Min HBM: 29.704 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                                  #
# Mean HBM: 29.704 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                                 #
# Low Median HBM: 29.704 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                           #
# High Median HBM: 29.704 GB on ranks [0, 1]                                                                                                                                                                                                                                                                                          #
# Critical Path (comms): 10.606                                                                                                                                                                                                                                                                                                       #
# Critical Path (compute): 389.665                                                                                                                                                                                                                                                                                                    #
# Critical Path (comms + compute): 400.272                                                                                                                                                                                                                                                                                            #
# Max HBM is 0% greater than the mean                                                                                                                                                                                                                                                                                                 #
#                                                                                                                                                                                                                                                                                                                                     #
#                                                                                                                                                                                                                                                                                                                                     #
# Top HBM Memory Usage Estimation: 29.704 GB                                                                                                                                                                                                                                                                                          #
# Top Tier #1 Estimated Peak HBM Pressure: 29.704 GB on ranks 0-1                                                                                                                                                                                                                                                                     #
#                                                                                                                                                                                                                                                                                                                                     #
# Reserved Memory:                                                                                                                                                                                                                                                                                                                    #
#    HBM: 14.251 GB                                                                                                                                                                                                                                                                                                                   #
#    Percent of Total HBM: 15%                                                                                                                                                                                                                                                                                                        #
# Planning Memory:                                                                                                                                                                                                                                                                                                                    #
#    HBM: 80.754 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                                                    #
#    Percent of Total HBM: 85%                                                                                                                                                                                                                                                                                                        #
#                                                                                                                                                                                                                                                                                                                                     #
# Dense Storage (per rank):                                                                                                                                                                                                                                                                                                           #
#    HBM: 6.221 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                       #
#                                                                                                                                                                                                                                                                                                                                     #
# KJT Storage (per rank):                                                                                                                                                                                                                                                                                                             #
#    HBM: 14.795 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                      #
#                                                                                                                                                                                                                                                                                                                                     #
# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                                                      #
# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                                                       #
#######################################################################################################################################################################################################################################################################################################################################
```

Differential Revision: D97574641


