### PR TITLE
Fix TrainPipelineBase.__init__() unexpected keyword argument 'free_features_storage_early'

### DIFF
--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -130,6 +130,14 @@ class PipelineConfig:
         }
 
         match self.pipeline:
+            case "base":
+                return TrainPipelineBase(
+                    model=model,
+                    optimizer=opt,
+                    device=device,
+                    enable_inplace_copy_batch=self.enable_inplace_copy_batch,
+                    **self.get_kwargs(),
+                )
             case "semi":
                 return TrainPipelineSemiSync(
                     model=model,


### PR DESCRIPTION
Summary:
The fallback `case _:` in `PipelineConfig.generate_pipeline()` was passing
`free_features_storage_early` to all pipeline classes, including `TrainPipelineBase`
which doesn't accept that parameter. Added an explicit `case "base":` branch that
constructs `TrainPipelineBase` with only the parameters it supports.

Repro:
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml

python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=base --name=base_pipeline
```

Differential Revision: D97612086


