### PR TITLE
Fix type error in EmbeddingEnumerator.enumerate cache path (#3914)

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -155,7 +155,9 @@ class EmbeddingEnumerator(Enumerator):
             self._last_stored_module == module
             and self._last_stored_sharders == sharders
         ):
-            # pyrefly: ignore[bad-argument-type]
+            assert (
+                self._last_stored_search_space is not None
+            ), "Cache invariant: _last_stored_search_space must be set atomically with module/sharders"
             return copy.deepcopy(self._last_stored_search_space)
 
         self._sharder_map = {


### PR DESCRIPTION
Summary:

Replace broken pyrefly suppress comment (wrong error code `bad-argument-type`)
with an assertion that narrows the type of `_last_stored_search_space` from
`Optional[List[ShardingOption]]` to `List[ShardingOption]`.

The assertion is always true: `_last_stored_search_space` is set atomically
with `_last_stored_module` and `_last_stored_sharders`, so if the cache-hit
condition fires the search space is guaranteed non-None.

Fixes https://www.internalfb.com/intern/test/281475269893308

Differential Revision: D97833769


