### PR TITLE
Fix possibly-unbound sync_bwd_out in _test_async_sync_compile

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -155,7 +155,9 @@ class EmbeddingEnumerator(Enumerator):
             self._last_stored_module == module
             and self._last_stored_sharders == sharders
         ):
-            # pyrefly: ignore[bad-argument-type]
+            assert (
+                self._last_stored_search_space is not None
+            )  # set atomically with module/sharders
             return copy.deepcopy(self._last_stored_search_space)
 
         self._sharder_map = {

--- a/torchrec/distributed/tests/test_comm.py
+++ b/torchrec/distributed/tests/test_comm.py
@@ -114,6 +114,7 @@ def _test_async_sync_compile(
     sync_fwd_out = out.clone()
     _assert_close(sync_fwd_out, async_fwd_out)
 
+    sync_bwd_out: Optional[torch.Tensor] = None
     if not compile_config.skip_sync_backward:
         out.retain_grad()
         out.backward(out)
@@ -151,6 +152,7 @@ def _test_async_sync_compile(
                 out.backward(out)
                 compile_bwd_out = _grad_detach_clone(input_tensor_compile)
 
+                assert sync_bwd_out is not None
                 _assert_close(compile_bwd_out, sync_bwd_out)
 
 


### PR DESCRIPTION
Summary:
sync_bwd_out was only assigned inside an
block, but Pyrefly flagged it as possibly-unbound at its usage site further down
the function (inside the compile-backward block, which also guards on the same
condition). The type checker cannot prove cross-block flow equivalence.

Fix by:
1. Initializing sync_bwd_out to None before the conditional block.
2. Adding an assert before the usage to narrow the type from
   Optional[torch.Tensor] to torch.Tensor.

Fixes https://www.internalfb.com/intern/test/281475269893307

Differential Revision: D97845012


