### PR TITLE
Remove enable_precomputed_sharding_option_fields killswitch

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -36,9 +36,7 @@ from torch.nn.modules.module import _addindent
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.types import (
     compute_storage_usage,
-    get_tensor_size_bytes,
     ModuleSharder,
-    ParameterStorage,
     QuantizedCommCodecs,
     ShardedModule,
     ShardedTensorMetadata,
@@ -589,29 +587,9 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
-        from torch._utils_internal import justknobs_check
-
-        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
-            return compute_storage_usage(
-                tensor, compute_device_type, compute_kernel, StorageUsageType.BASE
-            )
-        tensor_bytes = get_tensor_size_bytes(tensor)
-        if compute_kernel in {
-            EmbeddingComputeKernel.FUSED_UVM.value,
-            EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
-        }:
-            assert compute_device_type in {"cuda"}
-            return {ParameterStorage.DDR.value: tensor_bytes}
-        else:
-            assert compute_device_type in {"cuda", "cpu", "mtia"}
-            storage_map = {
-                "cuda": ParameterStorage.HBM,
-                "cpu": ParameterStorage.DDR,
-                "mtia": ParameterStorage.HBM,
-            }
-            return {
-                storage_map[compute_device_type].value: get_tensor_size_bytes(tensor)
-            }
+        return compute_storage_usage(
+            tensor, compute_device_type, compute_kernel, StorageUsageType.BASE
+        )
 
 
 class BaseGroupedFeatureProcessor(nn.Module):
@@ -698,25 +676,6 @@ class BaseQuantEmbeddingSharder(ModuleSharder[M]):
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
-        from torch._utils_internal import justknobs_check
-
-        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
-            return compute_storage_usage(
-                tensor, compute_device_type, compute_kernel, StorageUsageType.BASE_QUANT
-            )
-        tensor_bytes = get_tensor_size_bytes(tensor) + tensor.shape[0] * 4
-        if compute_kernel in {
-            EmbeddingComputeKernel.QUANT_UVM.value,
-            EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
-        }:
-            assert compute_device_type in {"cuda"}
-            return {ParameterStorage.DDR.value: tensor_bytes}
-        else:
-            assert compute_device_type in {"cuda", "cpu", "mtia"}
-            storage_map = {
-                "cuda": ParameterStorage.HBM,
-                "cpu": ParameterStorage.DDR,
-                # TODO: Update it later. Setting for MTIA is same as CPU's for now.
-                "mtia": ParameterStorage.DDR,
-            }
-            return {storage_map[compute_device_type].value: tensor_bytes}
+        return compute_storage_usage(
+            tensor, compute_device_type, compute_kernel, StorageUsageType.BASE_QUANT
+        )

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -161,10 +161,7 @@ class EmbeddingEnumerator(Enumerator):
         self._sharder_map = {
             sharder_name(sharder.module_type): sharder for sharder in sharders
         }
-        from torch._utils_internal import justknobs_check
-
-        if justknobs_check("pytorch/torchrec:enable_sharder_data"):
-            self._sharder_data_map = build_sharder_data_map(self._sharder_map)
+        self._sharder_data_map = build_sharder_data_map(self._sharder_map)
         sharding_options: List[ShardingOption] = []
 
         named_modules_queue = [("", module)]
@@ -335,19 +332,11 @@ class EmbeddingEnumerator(Enumerator):
         return self._last_stored_search_space
 
     def populate_estimates(self, sharding_options: List[ShardingOption]) -> None:
-        from torch._utils_internal import justknobs_check
-
         for estimator in self._estimators:
-            if justknobs_check("pytorch/torchrec:enable_sharder_data"):
-                estimator.estimate(
-                    sharding_options,
-                    sharder_data_map=self._sharder_data_map,
-                )
-            else:
-                estimator.estimate(
-                    sharding_options,
-                    sharder_map=self._sharder_map,
-                )
+            estimator.estimate(
+                sharding_options,
+                sharder_data_map=self._sharder_data_map,
+            )
 
     def _filter_sharding_types(
         self, name: str, allowed_sharding_types: List[str], sharder_key: str = ""

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -21,7 +21,6 @@ import math
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Type
 
-from torch._utils_internal import justknobs_check
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     BATCHED_COPY_PERF_FACTOR,
@@ -52,7 +51,6 @@ from torchrec.distributed.planner.types import (
     ShardingOption,
     Topology,
 )
-from torchrec.distributed.planner.utils import sharder_name
 from torchrec.distributed.types import ShardingType
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -1727,12 +1725,7 @@ class EmbeddingPerfEstimator(ShardEstimator):
             # (raises ValueError if not supported)
             self._config.validate_sharding_type(sharding_option.sharding_type)
 
-            if justknobs_check(
-                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
-            ):
-                sharder_key = sharding_option.module_type_key
-            else:
-                sharder_key = sharder_name(type(sharding_option.module[1]))
+            sharder_key = sharding_option.module_type_key
 
             shard_sizes = [shard.size for shard in sharding_option.shards]
 

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -21,7 +21,7 @@ import math
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Type
 
-from torch import nn
+from torch._utils_internal import justknobs_check
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     BATCHED_COPY_PERF_FACTOR,
@@ -53,7 +53,7 @@ from torchrec.distributed.planner.types import (
     Topology,
 )
 from torchrec.distributed.planner.utils import sharder_name
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import ShardingType
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -1711,30 +1711,15 @@ class EmbeddingPerfEstimator(ShardEstimator):
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
-        sharder_data_map: Optional[SharderDataMap] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         """
         Estimates the wall time of given sharding options
         Args:
             sharding_options: List of sharding options to estimate
-            sharder_map: Optional map of sharder names to ModuleSharder instances
-            sharder_data_map: Optional map of sharder names to SharderData instances
-                (used when enable_sharder_data killswitch is on)
+            sharder_data_map: Map of sharder names to SharderData instances
         """
         assert self._topology is not None, "Topology must be set to use estimate method"
-
-        from torch._utils_internal import justknobs_check
-
-        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
-        if use_sharder_data:
-            assert (
-                sharder_data_map is not None
-            ), "sharder_data_map required when enable_sharder_data is on"
-        else:
-            assert (
-                sharder_map is not None
-            ), "sharder_map required when enable_sharder_data is off"
 
         num_feature_processors = 0
         for sharding_option in sharding_options:
@@ -1751,34 +1736,18 @@ class EmbeddingPerfEstimator(ShardEstimator):
 
             shard_sizes = [shard.size for shard in sharding_option.shards]
 
-            # Build contexts using the appropriate version based on killswitch
-            contexts: List[ShardPerfContext] = []
-            if sharder_data_map is not None:
-                sharder_data = sharder_data_map[sharder_key]
-                contexts = ShardPerfContext.build_shard_perf_contexts_v2(
-                    config=self._config,
-                    shard_sizes=shard_sizes,
-                    sharding_option=sharding_option,
-                    topology=self._topology,
-                    constraints=self._constraints,
-                    sharder_data=sharder_data,
-                    is_inference=self._is_inference,
-                    use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
-                    use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
-                )
-            elif sharder_map is not None:
-                sharder = sharder_map[sharder_key]
-                contexts = ShardPerfContext.build_shard_perf_contexts(
-                    config=self._config,
-                    shard_sizes=shard_sizes,
-                    sharding_option=sharding_option,
-                    topology=self._topology,
-                    constraints=self._constraints,
-                    sharder=sharder,
-                    is_inference=self._is_inference,
-                    use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
-                    use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
-                )
+            sharder_data = sharder_data_map[sharder_key]
+            contexts = ShardPerfContext.build_shard_perf_contexts(
+                config=self._config,
+                shard_sizes=shard_sizes,
+                sharding_option=sharding_option,
+                topology=self._topology,
+                constraints=self._constraints,
+                sharder_data=sharder_data,
+                is_inference=self._is_inference,
+                use_batch_inputs_for_expected_cache_fetches=self._use_batch_inputs_for_expected_cache_fetches,
+                use_linear_regression_prefetch_estimate=self._use_linear_regression_prefetch_estimate,
+            )
 
             # Update is_weighted from first context (common across all shards)
             if contexts:

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -22,7 +22,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
-from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     BIGINT_DTYPE,
@@ -55,7 +54,6 @@ from torchrec.distributed.planner.utils import (
 )
 from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
-from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -674,46 +672,17 @@ class ShardPerfContext:
         ), "Provided `pooling_factors`, `num_poolings`, and `batch_sizes` constraints must match."
 
         # Check for feature processor and determine is_weighted
-        from torch._utils_internal import justknobs_check
-
-        if justknobs_check(
-            "pytorch/torchrec:enable_precomputed_sharding_option_fields"
+        has_feature_processor = sharding_option.has_feature_processor
+        if sharding_option.is_weighted is not None:
+            is_weighted = sharding_option.is_weighted
+        elif (
+            constraints
+            and constraints.get(sharding_option.name)
+            and constraints[sharding_option.name].is_weighted
         ):
-            has_feature_processor = sharding_option.has_feature_processor
-            if sharding_option.is_weighted is not None:
-                is_weighted = sharding_option.is_weighted
-            elif (
-                constraints
-                and constraints.get(sharding_option.name)
-                and constraints[sharding_option.name].is_weighted
-            ):
-                is_weighted = constraints[sharding_option.name].is_weighted
-            else:
-                is_weighted = False
+            is_weighted = constraints[sharding_option.name].is_weighted
         else:
-            module = sharding_option.module[1]
-            has_feature_processor = False
-            if (
-                hasattr(module, "_feature_processor")
-                and hasattr(module._feature_processor, "feature_processor_modules")
-                and isinstance(
-                    module._feature_processor.feature_processor_modules,  # pyrefly: ignore[missing-attribute]
-                    nn.ModuleDict,
-                )
-                and sharding_option.name
-                in module._feature_processor.feature_processor_modules.keys()  # pyrefly: ignore[missing-attribute]
-            ):
-                has_feature_processor = True
-            if isinstance(module, EmbeddingBagCollectionInterface):
-                is_weighted = module.is_weighted()  # pyrefly: ignore[not-callable]
-            elif (
-                constraints
-                and constraints.get(sharding_option.name)
-                and constraints[sharding_option.name].is_weighted
-            ):
-                is_weighted = constraints[sharding_option.name].is_weighted
-            else:
-                is_weighted = False
+            is_weighted = False
 
         is_weighted = is_weighted or has_feature_processor
 

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -50,12 +50,10 @@ from torchrec.distributed.planner.types import (
 )
 from torchrec.distributed.planner.utils import (
     extract_comm_data_type_size,
-    extract_comm_data_type_size_v2,
     get_num_poolings,
     is_prefetch_pipelined,
-    is_prefetch_pipelined_v2,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
 from torchrec.modules.embedding_modules import EmbeddingBagCollectionInterface
 
@@ -582,88 +580,14 @@ class ShardPerfContext:
         sharding_option: ShardingOption,
         topology: Topology,
         constraints: Optional[Dict[str, ParameterConstraints]],
-        sharder: ModuleSharder[nn.Module],
-        is_inference: bool = False,
-        use_batch_inputs_for_expected_cache_fetches: bool = False,
-        use_linear_regression_prefetch_estimate: bool = False,
-    ) -> List["ShardPerfContext"]:
-        """
-        Build list of ShardPerfContexts from ShardingOption and Topology using a live
-        ModuleSharder.
-
-        Args:
-            config: Hardware performance configuration
-            shard_sizes: List of [hash_size, emb_dim] for each shard
-            sharding_option: The sharding option being evaluated
-            topology: Device topology with bandwidth and world size info
-            constraints: Optional parameter constraints
-            sharder: Module sharder for this option
-            is_inference: Whether this is for inference
-            use_batch_inputs_for_expected_cache_fetches: If True, expected_cache_fetches
-                is computed as expected_miss_rate * batch_inputs (total lookups per batch).
-                If False (default), uses expected_miss_rate * expected_unique_lookups.
-            use_linear_regression_prefetch_estimate: If True, clamps num_unique_lookups
-                to min(num_unique_lookups, batch_inputs, hash_size) before computing
-                prefetch time.
-
-        Returns:
-            List of ShardPerfContext instances, one per shard.
-        """
-        # Get caching ratio
-        caching_ratio = sharding_option.cache_load_factor
-        if caching_ratio is None:
-            caching_ratio = (
-                sharder.fused_params.get(
-                    "cache_load_factor"
-                )  # pyrefly: ignore[missing-attribute]
-                if hasattr(sharder, "fused_params") and sharder.fused_params
-                else None
-            )
-
-        # Get data type sizes
-        (
-            fwd_a2a_comm_data_type_size,
-            bwd_a2a_comm_data_type_size,
-            fwd_sr_comm_data_type_size,
-            bwd_sr_comm_data_type_size,
-        ) = extract_comm_data_type_size(sharder, sharding_option)
-
-        # Check prefetch pipeline
-        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder)
-
-        return cls._build_contexts(
-            config=config,
-            shard_sizes=shard_sizes,
-            sharding_option=sharding_option,
-            topology=topology,
-            constraints=constraints,
-            caching_ratio=caching_ratio,
-            fwd_a2a_comm_data_type_size=fwd_a2a_comm_data_type_size,
-            bwd_a2a_comm_data_type_size=bwd_a2a_comm_data_type_size,
-            fwd_sr_comm_data_type_size=fwd_sr_comm_data_type_size,
-            bwd_sr_comm_data_type_size=bwd_sr_comm_data_type_size,
-            prefetch_pipeline=prefetch_pipeline,
-            is_inference=is_inference,
-            use_batch_inputs_for_expected_cache_fetches=use_batch_inputs_for_expected_cache_fetches,
-            use_linear_regression_prefetch_estimate=use_linear_regression_prefetch_estimate,
-        )
-
-    @classmethod
-    def build_shard_perf_contexts_v2(
-        cls,
-        config: HardwarePerfConfig,
-        shard_sizes: List[List[int]],
-        sharding_option: ShardingOption,
-        topology: Topology,
-        constraints: Optional[Dict[str, ParameterConstraints]],
         sharder_data: SharderData,
         is_inference: bool = False,
         use_batch_inputs_for_expected_cache_fetches: bool = False,
         use_linear_regression_prefetch_estimate: bool = False,
     ) -> List["ShardPerfContext"]:
         """
-        Build list of ShardPerfContexts from ShardingOption and Topology using a
-        SharderData snapshot.
+        Build list of ShardPerfContexts from ShardingOption and Topology using
+        SharderData.
 
         Args:
             config: Hardware performance configuration
@@ -694,10 +618,10 @@ class ShardPerfContext:
             bwd_a2a_comm_data_type_size,
             fwd_sr_comm_data_type_size,
             bwd_sr_comm_data_type_size,
-        ) = extract_comm_data_type_size_v2(sharding_option, sharder_data)
+        ) = extract_comm_data_type_size(sharding_option, sharder_data)
 
         # Check prefetch pipeline
-        prefetch_pipeline = is_prefetch_pipelined_v2(sharding_option, sharder_data)
+        prefetch_pipeline = is_prefetch_pipelined(sharding_option, sharder_data)
 
         return cls._build_contexts(
             config=config,
@@ -734,7 +658,7 @@ class ShardPerfContext:
         use_batch_inputs_for_expected_cache_fetches: bool = False,
         use_linear_regression_prefetch_estimate: bool = False,
     ) -> List["ShardPerfContext"]:
-        """Shared context-building logic for both build_shard_perf_contexts variants."""
+        """Shared context-building logic for build_shard_perf_contexts."""
         # Get num_poolings and batch_sizes
         num_poolings = get_num_poolings(constraints, sharding_option)
         batch_sizes = (

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -13,7 +13,6 @@ from typing import cast, Dict, List, Optional, Tuple, Type
 
 import torch
 import torchrec.optim as trec_optim
-from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     BIGINT_DTYPE,
@@ -39,7 +38,6 @@ from torchrec.distributed.types import (
     CacheStatistics,
     compute_storage_usage,
     KeyValueParams,
-    ModuleSharder,
     PipelineType,
     ShardingType,
 )
@@ -96,37 +94,19 @@ class EmbeddingPerfEstimator(ShardEstimator):
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
-        sharder_data_map: Optional[SharderDataMap] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         """
         Estimates the wall time of a given sharding option.
 
         Args:
             sharding_options (List[ShardingOption]): list of sharding options.
-            sharder_map (Optional[Dict[str, ModuleSharder[nn.Module]]]): sharder map.
-            sharder_data_map (Optional[SharderDataMap]): sharder data map
-                (used when enable_sharder_data killswitch is on).
+            sharder_data_map (SharderDataMap): sharder data map.
         """
-        from torch._utils_internal import justknobs_check
-
-        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
-        if use_sharder_data:
-            assert (
-                sharder_data_map is not None
-            ), "sharder_data_map required when enable_sharder_data is on"
-            return self._estimator.estimate(
-                sharding_options,
-                sharder_data_map=sharder_data_map,
-            )
-        else:
-            assert (
-                sharder_map is not None
-            ), "sharder_map required when enable_sharder_data is off"
-            return self._estimator.estimate(
-                sharding_options,
-                sharder_map=sharder_map,
-            )
+        self._estimator.estimate(
+            sharding_options,
+            sharder_data_map=sharder_data_map,
+        )
 
 
 class EmbeddingStorageEstimator(ShardEstimator):
@@ -170,31 +150,18 @@ class EmbeddingStorageEstimator(ShardEstimator):
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
-        sharder_data_map: Optional[SharderDataMap] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         """
         Estimate the storage cost of each sharding option.
 
         Args:
             sharding_options (List[ShardingOption]): list of sharding options.
-            sharder_map (Optional[Dict[str, ModuleSharder[nn.Module]]]): sharder map.
-            sharder_data_map (Optional[SharderDataMap]): sharder data map
-                (used when enable_sharder_data killswitch is on).
+            sharder_data_map (SharderDataMap): sharder data map.
         """
-        from torch._utils_internal import justknobs_check
-
-        use_sharder_data = justknobs_check("pytorch/torchrec:enable_sharder_data")
-        if use_sharder_data:
-            assert (
-                sharder_data_map is not None
-            ), "sharder_data_map required when enable_sharder_data is on"
-        else:
-            assert (
-                sharder_map is not None
-            ), "sharder_map required when enable_sharder_data is off"
-
         for sharding_option in sharding_options:
+            from torch._utils_internal import justknobs_check
+
             if justknobs_check(
                 "pytorch/torchrec:enable_precomputed_sharding_option_fields"
             ):
@@ -202,24 +169,12 @@ class EmbeddingStorageEstimator(ShardEstimator):
             else:
                 sharder_key = sharder_name(type(sharding_option.module[1]))
 
-            sharder_data: Optional[SharderData] = None
-            sharder: Optional[ModuleSharder[nn.Module]] = None
-            if sharder_data_map is not None:
-                sharder_data = sharder_data_map[sharder_key]
-            elif sharder_map is not None:
-                sharder = sharder_map[sharder_key]
+            sharder_data = sharder_data_map[sharder_key]
 
             caching_ratio = sharding_option.cache_load_factor
             # TODO: remove after deprecating fused_params in sharder
             if caching_ratio is None:
-                if sharder_data is not None:
-                    caching_ratio = sharder_data.fused_params.get("cache_load_factor")
-                elif sharder is not None:
-                    caching_ratio = (
-                        sharder.fused_params.get("cache_load_factor")  # pyre-ignore[16]
-                        if hasattr(sharder, "fused_params") and sharder.fused_params
-                        else None
-                    )
+                caching_ratio = sharder_data.fused_params.get("cache_load_factor")
             constraints: Optional[ParameterConstraints] = (
                 self._constraints.get(sharding_option.name, None)
                 if self._constraints
@@ -238,20 +193,9 @@ class EmbeddingStorageEstimator(ShardEstimator):
                 if constraints and constraints.key_value_params
                 else None
             )
-            if sharder_data is not None:
-                kv_cache_load_factor: float = sharder_data.fused_params.get(
-                    "cache_load_factor", KV_CACHING_RATIO
-                )
-            elif sharder is not None:
-                kv_cache_load_factor: float = (
-                    # pyrefly: ignore[missing-attribute]
-                    sharder.fused_params.get("cache_load_factor", KV_CACHING_RATIO)
-                    # pyrefly: ignore[missing-attribute]
-                    if sharder.fused_params
-                    else KV_CACHING_RATIO
-                )
-            else:
-                kv_cache_load_factor = KV_CACHING_RATIO
+            kv_cache_load_factor: float = sharder_data.fused_params.get(
+                "cache_load_factor", KV_CACHING_RATIO
+            )
             use_virtual_table: bool = (
                 constraints.use_virtual_table if constraints else False
             )
@@ -273,71 +217,31 @@ class EmbeddingStorageEstimator(ShardEstimator):
             )
             # TODO: remove after deprecating fused_params in sharder
             if mpp_conf is None:
-                if sharder_data is not None:
-                    mpp_conf = sharder_data.fused_params.get(
-                        "multipass_prefetch_config"
-                    )
-                elif sharder is not None:
-                    mpp_conf = (
-                        sharder.fused_params.get("multipass_prefetch_config", None)
-                        if hasattr(sharder, "fused_params") and sharder.fused_params
-                        else None
-                    )
-            if sharder_data is not None:
-                shard_storages = calculate_shard_storages_v2(
-                    sharder_data=sharder_data,
-                    sharding_type=sharding_option.sharding_type,
-                    tensor=sharding_option.tensor,
-                    compute_device=self._topology.compute_device,
-                    compute_kernel=sharding_option.compute_kernel,
-                    shard_sizes=[shard.size for shard in sharding_option.shards],
-                    batch_sizes=batch_sizes,
-                    world_size=self._topology.world_size,
-                    local_world_size=self._topology.intra_group_size,
-                    input_lengths=sharding_option.input_lengths,
-                    num_poolings=num_poolings,
-                    caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
-                    is_pooled=sharding_option.is_pooled,
-                    input_data_type_size=input_data_type_size,
-                    output_data_type_size=output_data_type_size,
-                    pipeline_type=self._pipeline_type,
-                    count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
-                    is_inference=self._is_inference,
-                    multipass_prefetch_max_pass=(
-                        mpp_conf.num_passes if mpp_conf else None
-                    ),
-                    key_value_params=key_value_params,
-                    kv_cache_load_factor=kv_cache_load_factor,
-                    use_virtual_table=use_virtual_table,
-                )
-            else:
-                assert sharder is not None
-                shard_storages = calculate_shard_storages(
-                    sharder=sharder,
-                    sharding_type=sharding_option.sharding_type,
-                    tensor=sharding_option.tensor,
-                    compute_device=self._topology.compute_device,
-                    compute_kernel=sharding_option.compute_kernel,
-                    shard_sizes=[shard.size for shard in sharding_option.shards],
-                    batch_sizes=batch_sizes,
-                    world_size=self._topology.world_size,
-                    local_world_size=self._topology.intra_group_size,
-                    input_lengths=sharding_option.input_lengths,
-                    num_poolings=num_poolings,
-                    caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
-                    is_pooled=sharding_option.is_pooled,
-                    input_data_type_size=input_data_type_size,
-                    output_data_type_size=output_data_type_size,
-                    pipeline_type=self._pipeline_type,
-                    count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
-                    is_inference=self._is_inference,
-                    multipass_prefetch_max_pass=(
-                        mpp_conf.num_passes if mpp_conf else None
-                    ),
-                    key_value_params=key_value_params,
-                    kv_cache_load_factor=kv_cache_load_factor,
-                    use_virtual_table=use_virtual_table,
-                )
+                mpp_conf = sharder_data.fused_params.get("multipass_prefetch_config")
+            shard_storages = calculate_shard_storages(
+                sharder_data=sharder_data,
+                sharding_type=sharding_option.sharding_type,
+                tensor=sharding_option.tensor,
+                compute_device=self._topology.compute_device,
+                compute_kernel=sharding_option.compute_kernel,
+                shard_sizes=[shard.size for shard in sharding_option.shards],
+                batch_sizes=batch_sizes,
+                world_size=self._topology.world_size,
+                local_world_size=self._topology.intra_group_size,
+                input_lengths=sharding_option.input_lengths,
+                num_poolings=num_poolings,
+                caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
+                is_pooled=sharding_option.is_pooled,
+                input_data_type_size=input_data_type_size,
+                output_data_type_size=output_data_type_size,
+                pipeline_type=self._pipeline_type,
+                count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
+                is_inference=self._is_inference,
+                multipass_prefetch_max_pass=mpp_conf.num_passes if mpp_conf else None,
+                key_value_params=key_value_params,
+                kv_cache_load_factor=kv_cache_load_factor,
+                use_virtual_table=use_virtual_table,
+            )
             for shard, storage in zip(sharding_option.shards, shard_storages):
                 shard.storage = storage
 
@@ -386,212 +290,6 @@ def calculate_pipeline_io_cost(
 
 
 def calculate_shard_storages(
-    sharder: ModuleSharder[nn.Module],
-    sharding_type: str,
-    tensor: torch.Tensor,
-    compute_device: str,
-    compute_kernel: str,
-    shard_sizes: List[List[int]],
-    batch_sizes: List[int],
-    world_size: int,
-    local_world_size: int,
-    input_lengths: List[float],
-    num_poolings: List[float],
-    caching_ratio: float,
-    is_pooled: bool,
-    input_data_type_size: float,
-    output_data_type_size: float,
-    pipeline_type: PipelineType = PipelineType.NONE,
-    count_ephemeral_storage_cost: bool = False,
-    is_inference: bool = False,
-    multipass_prefetch_max_pass: Optional[int] = None,
-    key_value_params: Optional[KeyValueParams] = None,
-    kv_cache_load_factor: float = KV_CACHING_RATIO,
-    use_virtual_table: bool = False,
-) -> List[Storage]:
-    """
-    Calculates estimated storage sizes for each sharded tensor, comprised of input,
-    output, tensor, gradient, and optimizer sizes.
-
-    Args:
-        sharder (ModuleSharder[nn.Module]): sharder for module that supports sharding.
-        sharding_type (str): provided ShardingType value.
-        tensor (torch.Tensor): tensor to be sharded.
-        compute_device (str): compute device to be used.
-        compute_kernel (str): compute kernel to be used.
-        shard_sizes (List[List[int]]): list of dimensions of each sharded tensor.
-        batch_sizes (List[int]): batch size for each input feature.
-        world_size (int): total number of devices in topology.
-        local_world_size (int): total number of devices in host group topology.
-        input_lengths (List[float]): average input lengths synonymous with pooling
-            factors.
-        num_poolings (List[float]): average number of poolings per sample
-            (typically 1.0).
-        caching_ratio (float): ratio of HBM to DDR memory for UVM caching.
-        is_pooled (bool): True if embedding output is pooled (ie. `EmbeddingBag`), False
-            if unpooled/sequential (ie. `Embedding`).
-        input_data_type_size (int): number of bytes of input data type.
-        output_data_type_size (int): number of bytes of output data type.
-        pipeline_type: PipelineType: pipeline type if for training.
-        is_inference: bool, whether the model is for inference.
-        key_value_params (Optional[KeyValueParams]): fused params for SSD/DRAM KV cache.
-
-    Returns:
-        List[Storage]: storage object for each device in topology.
-    """
-    input_sizes, output_sizes = _calculate_shard_io_sizes(
-        sharding_type=sharding_type,
-        batch_sizes=batch_sizes,
-        world_size=world_size,
-        local_world_size=local_world_size,
-        input_lengths=input_lengths,
-        emb_dim=tensor.shape[1],
-        shard_sizes=shard_sizes,
-        input_data_type_size=input_data_type_size,
-        output_data_type_size=output_data_type_size,
-        num_poolings=num_poolings,
-        is_pooled=is_pooled,
-    )
-
-    tensor_storage = sharder.storage_usage(tensor, compute_device, compute_kernel)
-    hbm_storage: int = tensor_storage.get("hbm", 0)
-    ddr_storage: int = tensor_storage.get("ddr", 0)
-
-    table_cached = _is_table_cached(compute_kernel)
-    if table_cached:
-        hbm_storage = round(ddr_storage * caching_ratio)
-
-    optimizer_class = getattr(tensor, "_optimizer_classes", [None])[0]
-
-    hbm_specific_sizes: List[int] = _calculate_storage_specific_sizes(
-        storage=hbm_storage,
-        shape=tensor.shape,
-        shard_sizes=shard_sizes,
-        sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
-        is_inference=is_inference,
-        clf=caching_ratio if table_cached else None,
-    )
-    ddr_specific_sizes: List[int] = _calculate_storage_specific_sizes(
-        storage=ddr_storage,
-        shape=tensor.shape,
-        shard_sizes=shard_sizes,
-        sharding_type=sharding_type,
-        optimizer_class=optimizer_class,
-        is_inference=is_inference,
-    )
-    ssd_specific_sizes: List[int] = [
-        hbm_specific_size + ddr_specific_size
-        for hbm_specific_size, ddr_specific_size in zip(
-            _calculate_storage_specific_sizes(
-                storage=tensor_storage.get("hbm", 0),
-                shape=tensor.shape,
-                shard_sizes=shard_sizes,
-                sharding_type=sharding_type,
-                optimizer_class=optimizer_class,
-                is_inference=is_inference,
-                clf=caching_ratio if table_cached else None,
-            ),
-            _calculate_storage_specific_sizes(
-                storage=tensor_storage.get("ddr", 0),
-                shape=tensor.shape,
-                shard_sizes=shard_sizes,
-                sharding_type=sharding_type,
-                optimizer_class=optimizer_class,
-                is_inference=is_inference,
-            ),
-        )
-    ]
-
-    if (
-        compute_kernel
-        in {
-            EmbeddingComputeKernel.KEY_VALUE.value,
-            EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
-            EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
-        }
-        or use_virtual_table
-    ):
-        # KVZCH does not have dedicated inference compute kernel, so we use use_virtual_table
-        # to settup ddr_specific_sizes
-        key_value_params = key_value_params or KeyValueParams(
-            max_l1_cache_size=0, l2_cache_size=0
-        )
-
-        hbm_specific_sizes = [
-            min(
-                (key_value_params.max_l1_cache_size or 0) * 1024 * 1024,
-                math.ceil(
-                    tensor.shape[0]  # num_embeddings
-                    * kv_cache_load_factor
-                    * tensor.element_size()  # size of one column
-                    * tensor.shape[1],  # number of columns in embedding
-                ),
-            )
-            for _ in hbm_specific_sizes
-        ]
-        ddr_specific_sizes = [
-            # TODO: revisit the logic for SSD virtual table
-            0
-            for _ in ddr_specific_sizes
-        ]
-
-    hbm_sizes: List[int] = [
-        (
-            hbm_specific_size
-            + calculate_pipeline_io_cost(
-                input_size=input_size,
-                output_size=output_size,
-                prefetch_size=input_size if table_cached else 0,
-                pipeline_type=pipeline_type,
-                multipass_prefetch_max_pass=multipass_prefetch_max_pass,
-                count_ephemeral_storage_cost=count_ephemeral_storage_cost,
-                is_inference=is_inference,
-            )
-            if compute_device in {"cuda", "mtia"}
-            else 0
-        )
-        for input_size, output_size, hbm_specific_size in zip(
-            input_sizes,
-            output_sizes,
-            hbm_specific_sizes,
-        )
-    ]
-    ddr_sizes: List[int] = [
-        (
-            input_size + output_size + ddr_specific_size
-            if compute_device == "cpu" and not is_inference
-            else ddr_specific_size
-        )
-        for input_size, output_size, ddr_specific_size in zip(
-            input_sizes,
-            output_sizes,
-            ddr_specific_sizes,
-        )
-    ]
-    ssd_sizes: List[int] = [
-        (
-            ssd_specific_size
-            if compute_kernel
-            in {
-                EmbeddingComputeKernel.KEY_VALUE.value,
-            }
-            else 0
-        )
-        for ssd_specific_size in ssd_specific_sizes
-    ]
-
-    return [
-        Storage(
-            hbm=hbm_size,
-            ddr=ddr_size,
-            ssd=ssd_size,
-        )
-        for hbm_size, ddr_size, ssd_size in zip(hbm_sizes, ddr_sizes, ssd_sizes)
-    ]
-
-
-def calculate_shard_storages_v2(
     sharder_data: SharderData,
     sharding_type: str,
     tensor: torch.Tensor,

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -33,7 +33,7 @@ from torchrec.distributed.planner.types import (
     Storage,
     Topology,
 )
-from torchrec.distributed.planner.utils import prod, sharder_name
+from torchrec.distributed.planner.utils import prod
 from torchrec.distributed.types import (
     CacheStatistics,
     compute_storage_usage,
@@ -160,14 +160,7 @@ class EmbeddingStorageEstimator(ShardEstimator):
             sharder_data_map (SharderDataMap): sharder data map.
         """
         for sharding_option in sharding_options:
-            from torch._utils_internal import justknobs_check
-
-            if justknobs_check(
-                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
-            ):
-                sharder_key = sharding_option.module_type_key
-            else:
-                sharder_key = sharder_name(type(sharding_option.module[1]))
+            sharder_key = sharding_option.module_type_key
 
             sharder_data = sharder_data_map[sharder_key]
 

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -898,14 +898,7 @@ class EmbeddingStats(Stats):
             num_poolings = str(round(sum(num_poolings), 3))
             output = "pooled" if so.is_pooled else "sequence"
             weighted = "weighted" if so.is_weighted else "unweighted"
-            from torch._utils_internal import justknobs_check
-
-            if justknobs_check(
-                "pytorch/torchrec:enable_precomputed_sharding_option_fields"
-            ):
-                sharder = sharder_map.get(so.module_type_key, None)
-            else:
-                sharder = sharder_map.get(get_sharder_name(type(so.module[1])), None)
+            sharder = sharder_map.get(so.module_type_key, None)
             sharder_name = type(sharder).__name__
             num_features = len(so.input_lengths)
             embedding_dim = _get_embedding_dim(so)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1471,8 +1471,7 @@ class ShardEstimator(abc.ABC):
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
-        sharder_data_map: Optional[SharderDataMap] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         # update sharding_options with per shard estimate in-place
         ...

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -80,27 +80,8 @@ def sharder_name(t: Type[Any]) -> str:
 
 
 def is_prefetch_pipelined(
-    sharding_option: ShardingOption, sharder: ModuleSharder[nn.Module]
-) -> bool:
-    prefetch_pipeline = (
-        sharding_option.cache_params.prefetch_pipeline
-        if sharding_option.cache_params
-        else None
-    )
-    # TODO: remove after deprecating fused_params in sharder
-    if not prefetch_pipeline:
-        prefetch_pipeline = (
-            sharder.fused_params.get(
-                "prefetch_pipeline", False
-            )  # pyrefly: ignore[missing-attribute]
-            if hasattr(sharder, "fused_params") and sharder.fused_params
-            else False
-        )
-    return prefetch_pipeline
-
-
-def is_prefetch_pipelined_v2(
-    sharding_option: ShardingOption, sharder_data: SharderData
+    sharding_option: ShardingOption,
+    sharder_data: SharderData,
 ) -> bool:
     prefetch_pipeline = (
         sharding_option.cache_params.prefetch_pipeline
@@ -113,65 +94,8 @@ def is_prefetch_pipelined_v2(
 
 
 def extract_comm_data_type_size(
-    sharder: ModuleSharder[nn.Module], sharding_option: ShardingOption
-) -> Tuple[float, float, float, float]:
-    table_data_type_size = sharding_option.tensor.element_size()
-
-    fwd_a2a_comm_data_type_size = table_data_type_size
-    bwd_a2a_comm_data_type_size = table_data_type_size
-    fwd_sr_comm_data_type_size = table_data_type_size
-    bwd_sr_comm_data_type_size = table_data_type_size
-
-    if sharder.qcomm_codecs_registry is not None:
-        qcomm_codecs_registry = sharder.qcomm_codecs_registry
-        if (
-            sharding_option.is_pooled
-            and CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name in qcomm_codecs_registry
-        ):
-            codecs = sharder.qcomm_codecs_registry[
-                CommOp.POOLED_EMBEDDINGS_ALL_TO_ALL.name
-            ]
-            fwd_a2a_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.forward.quantized_dtype
-            ).element_size()
-            bwd_a2a_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.backward.quantized_dtype
-            ).element_size()
-
-        if (
-            not sharding_option.is_pooled
-            and CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name in qcomm_codecs_registry
-        ):
-            codecs = qcomm_codecs_registry[CommOp.SEQUENCE_EMBEDDINGS_ALL_TO_ALL.name]
-            fwd_a2a_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.forward.quantized_dtype
-            ).element_size()
-            bwd_a2a_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.backward.quantized_dtype
-            ).element_size()
-
-        if (
-            sharding_option.is_pooled
-            and CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name in qcomm_codecs_registry
-        ):
-            codecs = qcomm_codecs_registry[CommOp.POOLED_EMBEDDINGS_REDUCE_SCATTER.name]
-            fwd_sr_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.forward.quantized_dtype
-            ).element_size()
-            bwd_sr_comm_data_type_size = torch.tensor(
-                [], dtype=codecs.backward.quantized_dtype
-            ).element_size()
-
-    return (
-        fwd_a2a_comm_data_type_size,
-        bwd_a2a_comm_data_type_size,
-        fwd_sr_comm_data_type_size,
-        bwd_sr_comm_data_type_size,
-    )
-
-
-def extract_comm_data_type_size_v2(
-    sharding_option: ShardingOption, sharder_data: SharderData
+    sharding_option: ShardingOption,
+    sharder_data: SharderData,
 ) -> Tuple[float, float, float, float]:
     table_data_type_size = sharding_option.tensor.element_size()
 

--- a/torchrec/schema/api_tests/test_planner_schema.py
+++ b/torchrec/schema/api_tests/test_planner_schema.py
@@ -30,6 +30,7 @@ from torchrec.distributed.planner.types import (
     Partitioner,
     PerfModel,
     Proposer,
+    SharderDataMap,
     ShardEstimator,
     ShardingOption,
     ShardingPlan,
@@ -165,7 +166,7 @@ class StableEmbeddingPerfEstimator:
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         pass
 
@@ -184,7 +185,7 @@ class StableEmbeddingStorageEstimator:
     def estimate(
         self,
         sharding_options: List[ShardingOption],
-        sharder_map: Optional[Dict[str, ModuleSharder[nn.Module]]] = None,
+        sharder_data_map: SharderDataMap,
     ) -> None:
         pass
 


### PR DESCRIPTION
Summary:
Removes the `pytorch/torchrec:enable_precomputed_sharding_option_fields`
JustKnob killswitch introduced in D95081573, now that the new code path
has been validated in production.

All callsites now unconditionally use the pre-computed ShardingOption
fields (`module_type_key`, `has_feature_processor`, `is_weighted`)
instead of accessing `sharding_option.module[1]` at runtime.

Removes dead code paths and cleans up unused imports (`sharder_name`
in shard_estimators.py and estimator.py, `EmbeddingBagCollectionInterface`
in estimator/types.py, `justknobs_check` where no other JK remains).

Reviewed By: mserturk

Differential Revision: D96158322


