### PR TITLE
Fix spelling and grammar typos in comments and docstrings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,7 @@ To begin learning about TorchRec, check out:
 - Quantization support for reduced precision training and inference, along with optimizing a TorchRec model for C++ inference.
 - Common modules for RecSys.
 - RecSys datasets (criteo click logs and movielens)
-- Examples of end-to-end training such the dlrm event prediction model trained on criteo click logs dataset.
+- Examples of end-to-end training such as the DLRM event prediction model trained on criteo click logs dataset.
 
 
 ## Installation

--- a/torchrec/datasets/__init__.py
+++ b/torchrec/datasets/__init__.py
@@ -9,7 +9,7 @@
 
 """Torchrec Datasets
 
-Torchrec contains two popular recys datasets, the `Kaggle/Criteo Display Advertising <https://www.kaggle.com/c/criteo-display-ad-challenge/>`_ Dataset
+Torchrec contains two popular RecSys datasets, the `Kaggle/Criteo Display Advertising <https://www.kaggle.com/c/criteo-display-ad-challenge/>`_ Dataset
 and the `MovieLens 20M <https://grouplens.org/datasets/movielens/20m/>`_ Dataset.
 
 Additionally, it contains a RandomDataset, which is useful to generate random data in the same format as the above.

--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -155,7 +155,7 @@ class BaseShardedManagedCollisionEmbeddingCollection(
         ctx: ShrdCtx,
         features: KeyedJaggedTensor,
     ) -> Awaitable[Awaitable[KJTList]]:
-        # TODO: resolve incompatiblity with different contexts
+        # TODO: resolve incompatibility with different contexts
         return self._managed_collision_collection.input_dist(
             # pyrefly: ignore[bad-argument-type]
             ctx,

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -1376,7 +1376,7 @@ class ShardedQuantManagedCollisionEmbeddingCollection(ShardedQuantEmbeddingColle
         ctx: EmbeddingCollectionContext,
         features: KeyedJaggedTensor,
     ) -> ListOfKJTList:
-        # TODO: resolve incompatiblity with different contexts
+        # TODO: resolve incompatibility with different contexts
         if self._has_uninitialized_output_dist:
             self._create_output_dist(features.device())
             self._has_uninitialized_output_dist = False

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -854,7 +854,7 @@ class ShardedQuantManagedCollisionEmbeddingBagCollection(
         ctx: NullShardedModuleContext,
         features: KeyedJaggedTensor,
     ) -> ListOfKJTList:
-        # TODO: resolve incompatiblity with different contexts
+        # TODO: resolve incompatibility with different contexts
         if self._has_uninitialized_output_dist:
             self._create_output_dist(features.device())
             self._has_uninitialized_output_dist = False

--- a/torchrec/fx/tracer.py
+++ b/torchrec/fx/tracer.py
@@ -117,7 +117,7 @@ class Tracer(torch.fx.Tracer):
                 type_expr=NoWait,
             )
 
-        # Not equivalent to when LazyAwaitable.wait() is called in eager. Here can be called earlier, as attr was not requested and this is not guranteed to be torch function
+        # Not equivalent to when LazyAwaitable.wait() is called in eager. Here can be called earlier, as attr was not requested and this is not guaranteed to be torch function
         # TODO(ivankobzarev): support equivalent timing of LazyAwaitable
         if isinstance(a, LazyAwaitable):
             if a._result is None:

--- a/torchrec/metrics/auc.py
+++ b/torchrec/metrics/auc.py
@@ -65,7 +65,7 @@ def _compute_auc_helper(
     sorted_indices = torch.argsort(predictions, descending=True, dim=-1)
     sorted_labels = torch.index_select(labels, dim=0, index=sorted_indices)
     if apply_bin:
-        # TODO - [add flag to set bining dyamically] for use with soft labels, >=0.039 --> 1, <0.039 --> 0
+        # TODO - [add flag to set binning dynamically] for use with soft labels, >=0.039 --> 1, <0.039 --> 0
         sorted_labels = torch.ge(sorted_labels, 0.039).to(dtype=sorted_labels.dtype)
     sorted_weights = torch.index_select(weights, dim=0, index=sorted_indices)
     if sorted_weights.numel() > 0:

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -916,7 +916,7 @@ class RecMetricList(nn.Module):
 
     def __init__(self, rec_metrics: List[RecMetric]) -> None:
         # TODO(stellaya): consider to inherit from TorchMetrics.MetricCollection.
-        # The prequsite to use MetricCollection is that RecMetric inherits from
+        # The prerequisite to use MetricCollection is that RecMetric inherits from
         # TorchMetrics.Metric or TorchMetrics.MetricCollection
 
         super().__init__()

--- a/torchrec/modules/crossnet.py
+++ b/torchrec/modules/crossnet.py
@@ -23,7 +23,7 @@ class CrossNet(torch.nn.Module):
     `Cross Network <https://arxiv.org/abs/1708.05123>`_:
 
     Cross Net is a stack of "crossing" operations on a tensor of shape :math:`(*, N)`
-    to the same shape, effectively creating :math:`N` learnable polynomical functions
+    to the same shape, effectively creating :math:`N` learnable polynomial functions
     over the input tensor.
 
     In this module, the crossing operations are defined based on a full rank matrix

--- a/torchrec/modules/deepfm.py
+++ b/torchrec/modules/deepfm.py
@@ -13,7 +13,7 @@ Deep Factorization-Machine Modules
 The following modules are based off the `Deep Factorization-Machine (DeepFM) paper
 <https://arxiv.org/pdf/1703.04247.pdf>`_
 
-* Class DeepFM implents the DeepFM Framework
+* Class DeepFM implements the DeepFM Framework
 * Class FactorizationMachine implements FM as noted in the above paper.
 
 """

--- a/torchrec/modules/embedding_tower.py
+++ b/torchrec/modules/embedding_tower.py
@@ -21,7 +21,7 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 def tower_input_params(module: nn.Module) -> Tuple[bool, bool]:
     """
-    Utilty to compute the mapping of tower KJT args to pass to the embedding modules.
+    Utility to compute the mapping of tower KJT args to pass to the embedding modules.
 
     Args:
         module (nn.Module):

--- a/torchrec/modules/keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/keyed_jagged_tensor_pool.py
@@ -34,7 +34,7 @@ def _fx_wrap_lookup(
     is_weighted: bool,
     values_dtype: torch.dtype,
     device: torch.device,
-    lookup: TensorJaggedIndexSelectLookup,  # This type enforement is a hack to make it work with torch.jit.script
+    lookup: TensorJaggedIndexSelectLookup,  # This type enforcement is a hack to make it work with torch.jit.script
     weigth_dtype: Optional[torch.dtype] = None,
 ) -> KeyedJaggedTensor:
     jt_lookup: JaggedTensor = lookup.lookup(ids)

--- a/torchrec/sparse/__init__.py
+++ b/torchrec/sparse/__init__.py
@@ -20,7 +20,7 @@ information.
 
 KeyedJaggedTensor
 
-KeyedJaggedTensor has additional "Key" information. Keyed on first dimesion,
+KeyedJaggedTensor has additional "Key" information. Keyed on first dimension,
 and jagged on last dimension. Please refer to KeyedJaggedTensor docstring for full example and
 further information.
 


### PR DESCRIPTION
Summary:
Fix various spelling and grammar mistakes across TorchRec:
- polynomical -> polynomial (crossnet.py)
- implents -> implements (deepfm.py)
- Utilty -> Utility (embedding_tower.py)
- dimesion -> dimension (sparse/__init__.py)
- recys -> RecSys (datasets/__init__.py)
- prequsite -> prerequisite (rec_metric.py)
- guranteed -> guaranteed (tracer.py)
- incompatiblity -> incompatibility (mc_embedding_modules.py, quant_embeddingbag.py, quant_embedding.py)
- bining dyamically -> binning dynamically (auc.py)
- enforement -> enforcement (keyed_jagged_tensor_pool.py)
- such the dlrm -> such as the DLRM (README.MD)

Differential Revision: D98011672


