### PR TITLE
Remove //torchrec:torchrec umbrella dep from test_model to fix KVTensorWrapper CPU stub conflict

### DIFF
--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -15,7 +15,6 @@ from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type, Union
 import torch
 import torch.nn as nn
 from tensordict import TensorDict
-from torchrec import EmbeddingCollection
 from torchrec.distributed.embedding_types import EmbeddingTableConfig
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.utils import CopyableMixin
@@ -25,7 +24,10 @@ from torchrec.modules.embedding_configs import (
     EmbeddingBagConfig,
     EmbeddingConfig,
 )
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+)
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
 from torchrec.modules.feature_processor import PositionWeightedProcessor
 from torchrec.modules.feature_processor_ import PositionWeightedModuleCollection


### PR DESCRIPTION
Summary:
The `test_kv_zch_load_state_dict` test (and all other SSD tests) in
`test_model_parallel_nccl_ssd_single_gpu` started consistently failing with
`RuntimeError: Not implemented` from `kv_tensor_wrapper_cpu.cpp`.

Root cause: The `test_model` library depended on `//torchrec:torchrec` (the
umbrella package), which transitively pulled in `kv_tensor_wrapper_cpu` via:
```
test_model → //torchrec:torchrec → torchrec_models → dlrm → datasets:utils
  → iopath → ... → checkpoint_tensor → kv_tensor_selective_deps
  → kv_tensor_wrapper_cpu
```

The `kv_tensor_selective_deps` alias defaults to the CPU stub of
`KVTensorWrapper`, which always throws "Not implemented". When both the CPU
stub and the GPU implementation are linked into the test binary, the CPU
stub's constructor wins via C++ symbol interposition (main binary symbols
take precedence over dlopen'd shared library symbols).

Fix: Import `EmbeddingCollection` from its actual module
(`torchrec.modules.embedding_modules`) instead of the umbrella `torchrec`
package, and remove the `//torchrec:torchrec` dependency. All other imports
in `test_model.py` already use specific submodule paths.

Verified with `buck2 cquery` that `kv_tensor_wrapper_cpu` is no longer in
the resolved dependency tree.

Differential Revision: D98088246


