### PR TITLE
S638573 : Add additional logging for ZeroDivisionErrors in sharding (#3922)

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -211,30 +211,42 @@ class EmbeddingStorageEstimator(ShardEstimator):
             # TODO: remove after deprecating fused_params in sharder
             if mpp_conf is None:
                 mpp_conf = sharder_data.fused_params.get("multipass_prefetch_config")
-            shard_storages = calculate_shard_storages(
-                sharder_data=sharder_data,
-                sharding_type=sharding_option.sharding_type,
-                tensor=sharding_option.tensor,
-                compute_device=self._topology.compute_device,
-                compute_kernel=sharding_option.compute_kernel,
-                shard_sizes=[shard.size for shard in sharding_option.shards],
-                batch_sizes=batch_sizes,
-                world_size=self._topology.world_size,
-                local_world_size=self._topology.intra_group_size,
-                input_lengths=sharding_option.input_lengths,
-                num_poolings=num_poolings,
-                caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
-                is_pooled=sharding_option.is_pooled,
-                input_data_type_size=input_data_type_size,
-                output_data_type_size=output_data_type_size,
-                pipeline_type=self._pipeline_type,
-                count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
-                is_inference=self._is_inference,
-                multipass_prefetch_max_pass=mpp_conf.num_passes if mpp_conf else None,
-                key_value_params=key_value_params,
-                kv_cache_load_factor=kv_cache_load_factor,
-                use_virtual_table=use_virtual_table,
-            )
+            try:
+                shard_storages = calculate_shard_storages(
+                    sharder_data=sharder_data,
+                    sharding_type=sharding_option.sharding_type,
+                    tensor=sharding_option.tensor,
+                    compute_device=self._topology.compute_device,
+                    compute_kernel=sharding_option.compute_kernel,
+                    shard_sizes=[shard.size for shard in sharding_option.shards],
+                    batch_sizes=batch_sizes,
+                    world_size=self._topology.world_size,
+                    local_world_size=self._topology.intra_group_size,
+                    input_lengths=sharding_option.input_lengths,
+                    num_poolings=num_poolings,
+                    caching_ratio=caching_ratio if caching_ratio else UVM_CACHING_RATIO,
+                    is_pooled=sharding_option.is_pooled,
+                    input_data_type_size=input_data_type_size,
+                    output_data_type_size=output_data_type_size,
+                    pipeline_type=self._pipeline_type,
+                    count_ephemeral_storage_cost=self._run_embedding_at_peak_memory,
+                    is_inference=self._is_inference,
+                    multipass_prefetch_max_pass=(
+                        mpp_conf.num_passes if mpp_conf else None
+                    ),
+                    key_value_params=key_value_params,
+                    kv_cache_load_factor=kv_cache_load_factor,
+                    use_virtual_table=use_virtual_table,
+                )
+            except ZeroDivisionError as e:
+                raise ValueError(
+                    f"Failed to calculate sharding plan: {str(e)} "
+                    f"Context: table_name='{sharding_option.name}', "
+                    f"module_path='{sharding_option.path}', "
+                    f"tensor.shape={sharding_option.tensor.shape}, "
+                    f"sharding_type='{sharding_option.sharding_type}', "
+                    f"compute_kernel='{sharding_option.compute_kernel}'"
+                ) from e
             for shard, storage in zip(sharding_option.shards, shard_storages):
                 shard.storage = storage
 

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -39,6 +39,9 @@ from torchrec.distributed.planner.types import (
     BasicCommsBandwidths,
     ParameterConstraints,
     Perf,
+    Shard,
+    SharderData,
+    ShardingOption,
     Topology,
 )
 from torchrec.distributed.quant_embeddingbag import QuantEmbeddingBagCollectionSharder
@@ -1632,6 +1635,55 @@ class TestEmbeddingStorageEstimator(unittest.TestCase):
             hbms.append(sharding_options[0].shards[0].storage.hbm)
 
         self.assertEqual(hbms[0], hbms[1])
+
+    def test_zero_dimension_tensor_raises_value_error(self) -> None:
+        topology = Topology(world_size=2, compute_device="cuda")
+        estimator = EmbeddingStorageEstimator(topology=topology)
+
+        # Construct a ShardingOption directly with a zero-dimension tensor
+        # to simulate the crash path: prod(shape)==0 in _calculate_tensor_sizes
+        zero_dim_tensor = torch.zeros(100, 0, device="meta")
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=10,
+                name="table_dummy",
+                feature_names=["feature_0"],
+            )
+        ]
+        model = TestSparseNN(tables=tables, weighted_tables=[])
+        # Get a valid module reference from the model
+        ebc_module = model.sparse.ebc
+        assert isinstance(ebc_module, torch.nn.Module)
+
+        sharding_option = ShardingOption(
+            name="table_zero_dim",
+            tensor=zero_dim_tensor,
+            module=("sparse.ebc", ebc_module),
+            input_lengths=[1.0],
+            batch_size=BATCH_SIZE,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            partition_by="host",
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[Shard(size=[100, 0], offset=[0, 0])],
+        )
+
+        sharder_data_map = {
+            sharding_option.module_type_key: SharderData(
+                fused_params={},
+                qcomm_dtype_sizes={},
+                storage_usage_type=StorageUsageType.DEFAULT,
+            ),
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            estimator.estimate([sharding_option], sharder_data_map=sharder_data_map)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("table_zero_dim", error_msg)
+        self.assertIn("tensor.shape=", error_msg)
+        self.assertIn("sharding_type=", error_msg)
+        self.assertIn("compute_kernel=", error_msg)
 
 
 class TestEmbeddingOffloadStats(unittest.TestCase):


### PR DESCRIPTION
Summary:

MAST job aps-f1054585034-1054612727 was failing with an unhelpful ZeroDivisionError in the storage estimation code path (EmbeddingStorageEstimator.estimate -> calculate_shard_storages -> _calculate_tensor_sizes).

Following the pattern from D79766535 which added similar logging in enumerators.py, this diff wraps the calculate_shard_storages/v2 calls in EmbeddingStorageEstimator.estimate() with a try/except ZeroDivisionError that re-raises as ValueError with rich context (table_name, module_path, tensor.shape, sharding_type, compute_kernel).

Also adds a test (test_zero_dimension_tensor_raises_value_error) that verifies the ValueError is raised with proper context when a zero-dimension tensor is encountered.

All 22 tests pass.

Reviewed By: TroyGarden

Differential Revision: D97994554
