### PR TITLE
Support Postproc in Benchmark (#3923)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_postproc.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_postproc.yml
@@ -1,0 +1,27 @@
+# Benchmark config for postproc pipelining with TestModelWithPreproc
+# Exercises PipelinedPostproc to measure postproc pipelining performance
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_postproc"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+  pipeline_postproc: true
+ModelInputConfig:
+  num_float_features: 10
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "test_model_with_preproc"
+  model_config:
+    num_float_features: 10
+EmbeddingTablesConfig:
+  num_unweighted_features: 3
+  num_weighted_features: 1
+  embedding_feature_dim: 128
+PlannerConfig:
+  pooling_factors: [30.0] # Must match ModelInputConfig.feature_pooling_avg

--- a/torchrec/distributed/test_utils/model_config.py
+++ b/torchrec/distributed/test_utils/model_config.py
@@ -27,6 +27,7 @@ from torchrec.distributed.test_utils.test_model import (
     TestMixedEmbeddingSparseArch,
     TestMixedSequenceOverArch,
     TestMixedSequenceOverArchLargeActivation,
+    TestModelWithPreproc,
     TestOverArch,
     TestOverArchLarge,
     TestOverArchRegroupModule,
@@ -273,6 +274,30 @@ class MixedEmbeddingConfig(BaseModelConfig):
         )
 
 
+@dataclass
+class TestModelWithPreprocConfig(BaseModelConfig):
+    """Configuration for TestModelWithPreproc model (model with postproc modules)."""
+
+    postproc_module: Optional[nn.Module] = None
+    run_postproc_inline: bool = False
+
+    def generate_model(
+        self,
+        tables: List[EmbeddingBagConfig],
+        weighted_tables: List[EmbeddingBagConfig],
+        dense_device: torch.device,
+        **kwargs: Any,
+    ) -> nn.Module:
+        return TestModelWithPreproc(
+            tables=tables,
+            weighted_tables=weighted_tables,
+            device=dense_device,
+            postproc_module=self.postproc_module,
+            num_float_features=self.num_float_features,
+            run_postproc_inline=self.run_postproc_inline,
+        )
+
+
 def create_model_config(model_name: str, **kwargs: Any) -> BaseModelConfig:
     """
     deprecated function, please use ModelSelectionConfig.create_model_config instead
@@ -284,6 +309,7 @@ def create_model_config(model_name: str, **kwargs: Any) -> BaseModelConfig:
         "deepfm": DeepFMConfig,
         "dlrm": DLRMConfig,
         "mixed_embedding": MixedEmbeddingConfig,
+        "test_model_with_preproc": TestModelWithPreprocConfig,
     }
 
     if model_name not in model_configs:
@@ -318,6 +344,8 @@ class ModelSelectionConfig:
                 return DLRMConfig
             case "mixed_embedding":
                 return MixedEmbeddingConfig
+            case "test_model_with_preproc":
+                return TestModelWithPreprocConfig
             case _:
                 raise ValueError(f"Unknown model name: {self.model_name}")
 

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -60,10 +60,13 @@ class PipelineConfig:
     pipeline: str = "base"
     enable_inplace_copy_batch: bool = False
     free_features_storage_early: bool = False
+    pipeline_postproc: bool = False
     kwargs: Dict[str, Any] = field(default_factory=dict)
 
     def get_kwargs(self, **default_kwargs) -> Dict[str, Any]:
         kwargs = default_kwargs | self.kwargs
+        if self.pipeline_postproc:
+            kwargs["pipeline_postproc"] = True
         if "sharding_type" in kwargs:
             kwargs["sharding_type"] = ShardingType(kwargs["sharding_type"])
         if self.pipeline in ("base", "sparse", "sparse_lite", "prefetch"):
@@ -72,6 +75,8 @@ class PipelineConfig:
                     kwargs.pop(key)
         if self.pipeline in ("sparse-emb-stash",):
             kwargs.pop("sharding_type", None)
+        if self.pipeline in ("base", "eval-sdd"):
+            kwargs.pop("pipeline_postproc", None)
         return kwargs
 
     def generate_pipeline(


### PR DESCRIPTION
Summary:

Adds benchmark support for postproc pipelining by:

1. Adding `TestModelWithPreprocConfig` in `model_config.py` that wraps the existing `TestModelWithPreproc` test model (which has built-in `TestPreprocNonWeighted` and `TestPreprocWeighted` postproc modules). Registered in both `create_model_config()` and `ModelSelectionConfig.get_model_config_class()`.

2. Wiring `pipeline_postproc` through `PipelineConfig` in `pipeline_config.py` as a first-class field (`pipeline_postproc: bool = False`). When enabled, it gets passed through `get_kwargs()` to pipeline constructors that support it (e.g., `TrainPipelineSparseDist`, `TrainPipelineFusedSparseDist`). Filtered out for pipeline types that don't accept it (`base`, `eval-sdd`).

3. Adding `sparse_data_dist_postproc.yml` benchmark YAML config that uses the new `test_model_with_preproc` model with `pipeline_postproc: true` on the sparse pipeline. This exercises the `PipelinedPostproc` code path during benchmark runs.

Reviewed By: spmex

Differential Revision: D97540925
