### PR TITLE
fix _free_features_storage_early crash with multiple pipelined modules (#3927)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -41,6 +41,7 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
+    EarlyReleasableInputs,
     EmbeddingComputeKernel,
     KJTList,
     ShardedEmbeddingModule,
@@ -319,6 +320,7 @@ class EmbeddingCollectionContext(Multistreamable):
         self.reverse_indices: List[torch.Tensor] = reverse_indices or []
         self.seq_vbe_ctx: List[SequenceVBEContext] = seq_vbe_ctx or []
         self.table_name_to_unpruned_hash_sizes: Dict[str, int] = {}
+        self.early_releasable_inputs: Optional[EarlyReleasableInputs] = None
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -1523,12 +1525,13 @@ class ShardedEmbeddingCollection(
                     # pyrefly: ignore[bad-argument-type]
                     self._features_order_tensor,
                 )
-                # For non-VBE: free original KJT tensor storage now since
-                # permute() created independent tensors.
+                # For non-VBE: defer clearing original KJT tensor storage
+                # until after all pipelined modules' input_dist calls
+                # complete, to avoid freeing shared features.
                 # For VBE: deferred until after _compute_sequence_vbe_context
                 # which still needs the original (unpadded) features.
                 if self._free_features_storage_early and unpadded_features is None:
-                    original_features.clear_storage()
+                    ctx.early_releasable_inputs = (original_features, None)
             features_by_shards = features.split(self._feature_splits)
             features_by_shards = may_collect_feature_scores(
                 features_by_shards,
@@ -1559,15 +1562,15 @@ class ShardedEmbeddingCollection(
                 )
             if unpadded_features is not None:
                 self._compute_sequence_vbe_context(ctx, unpadded_features)
-                # Free original KJT tensor storage now that VBE context
-                # computation is done. permute() created independent tensors
-                # for the main input_dist path.
+                # Defer clearing original KJT tensor storage now that VBE
+                # context computation is done. permute() created independent
+                # tensors for the main input_dist path.
                 if (
                     self._free_features_storage_early
                     and need_permute
                     and self._features_order
                 ):
-                    original_features.clear_storage()
+                    ctx.early_releasable_inputs = (original_features, None)
 
         return KJTListSplitsAwaitable(
             awaitables,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -369,6 +369,8 @@ CompIn = TypeVar("CompIn", KJTList, ListOfKJTList, KeyedJaggedTensor)
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 
+EarlyReleasableInputs = Tuple[Optional[KeyedJaggedTensor], Optional[KeyedJaggedTensor]]
+
 
 class ShardedEmbeddingModule(
     ShardedModule[CompIn, DistOut, Out, ShrdCtx],

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -47,6 +47,7 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
+    EarlyReleasableInputs,
     EmbeddingComputeKernel,
     KJTList,
     ShardedEmbeddingModule,
@@ -464,6 +465,7 @@ class EmbeddingBagCollectionContext(Multistreamable):
     inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None
     variable_batch_per_feature: bool = False
     divisor: Optional[torch.Tensor] = None
+    early_releasable_inputs: Optional[EarlyReleasableInputs] = None
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -1756,12 +1758,10 @@ class ShardedEmbeddingBagCollection(
                     self._features_order_tensor,
                 )
                 if self._free_features_storage_early:
-                    # Free original KJT tensor storage to reclaim HBM early.
-                    # permute() created independent tensors, so the original
-                    # batch KJT's data is no longer needed. The batch Python
-                    # object still exists but PipelinedForward ignores the
-                    # sparse features during model forward.
-                    original_features.clear_storage()
+                    # Defer clearing original KJT tensor storage until after
+                    # all pipelined modules' input_dist calls complete, to
+                    # avoid freeing shared features that other modules need.
+                    ctx.early_releasable_inputs = (original_features, None)
             if self._has_mean_pooling_callback:
                 ctx.divisor = _create_mean_pooling_divisor(
                     lengths=features.lengths(),

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
@@ -138,7 +139,8 @@ class ShardedManagedCollisionEmbeddingBagCollection(
                     self._managed_collision_collection._features_order_tensor,
                 )
                 if self._free_features_storage_early:
-                    original_features.clear_storage()
+                    # pyrefly: ignore[missing-attribute]
+                    ctx.early_releasable_inputs = (original_features, None)
 
             # TODO: Consider turning this into a hook inside mc_modules and remove skip_permute
             #   from mc_modules, and fix all the private methods to be public.

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -38,6 +38,7 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
+    EarlyReleasableInputs,
     GroupedEmbeddingConfig,
     KJTList,
     ListOfKJTList,
@@ -83,6 +84,7 @@ class EmbeddingCollectionContext(Multistreamable):
     # VBE-Attributes for EBC
     inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None
     variable_batch_per_feature: bool = False
+    early_releasable_inputs: Optional[EarlyReleasableInputs] = None
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -646,7 +648,7 @@ class ShardedManagedCollisionCollection(
                     self._features_order_tensor,
                 )
                 if self._free_features_storage_early:
-                    original_features.clear_storage()
+                    ctx.early_releasable_inputs = (original_features, None)
 
             feature_splits: List[KeyedJaggedTensor] = []
             if self.need_preprocess:

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -25,6 +25,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TYPE_CHECKING,
 )
 
 import torch
@@ -36,6 +37,9 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
+
+if TYPE_CHECKING:
+    from torchrec.distributed.embedding_types import EarlyReleasableInputs
 from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
@@ -152,6 +156,36 @@ def _wait_for_events(
         batch.record_stream(stream)
 
 
+def _clear_releasable_inputs(context: TrainPipelineContext) -> None:
+    """Clear deferred KJT feature storage from a context's module contexts.
+
+    Called after all pipelined modules' input_dist calls are complete, so it's
+    safe to free the original batch KJT tensor storage. Each module has already
+    permuted and extracted its features into independent tensors.
+    """
+    # module contexts for the current batch are in module_contexts_next_batch or module_contexts.
+    contexts_dict = (
+        context.module_contexts_next_batch
+        if context.version == 0
+        else context.module_contexts
+    )
+    for module_ctx in contexts_dict.values():
+        early_released: EarlyReleasableInputs | None = getattr(
+            module_ctx, "early_releasable_inputs", None
+        )
+        if early_released is not None:
+            assert (
+                len(early_released) == 2
+            ), "expecting early_releasable_inputs types with 2 KJT elements"
+            id_list, id_score_list = early_released
+            if id_list is not None:
+                id_list.clear_storage()
+            if id_score_list is not None:
+                id_score_list.clear_storage()
+            # pyre-ignore[16]: `Optional` has no attribute `early_releasable_inputs`.
+            module_ctx.early_releasable_inputs = None
+
+
 def _start_data_dist(
     pipelined_modules: List[ShardedModule],
     batch: Pipelineable,
@@ -195,6 +229,12 @@ def _start_data_dist(
         context.input_dist_splits_requests[forward.name] = module.input_dist(
             module_ctx, *args, **kwargs
         )
+
+    # All pipelined modules' input_dist calls are complete. Safe to clear deferred
+    # KJT feature storage now — each sharded module has already permuted and extracted
+    # its features, so the original input batch KJT storage can be cleared to free up HBM.
+    _clear_releasable_inputs(context)
+
     _fuse_input_dist_splits(context)
 
 


### PR DESCRIPTION
Summary:

Fix crash when `_free_features_storage_early` is used with multiple pipelined modules. Previously, each module's `input_dist` immediately called `clear_storage()` on the shared batch KJT, freeing memory that other modules still needed. This defers the clearing: modules now store a reference to the original features on their context, and a new `_clear_deferred_features()` function frees all of them after every module's `input_dist` has completed. 


Benchmarks confirm similar peak memory reduction with no runtime regression. Hypothesis for additional savings (-3.22 GB vs -1.61 GB) coming from storage release timing difference: by deferring all frees to the same point, CCA likely sees a larger contiguous free block before the forward pass, thus reducing peak allocation.

Reviewed By: Guanchuwu

Differential Revision: D97997763


