### PR TITLE
Complete sharder_data_map migration and pass enumerator to all stats.log calls (#3928)

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -1086,6 +1086,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
                         best_plan=best_plan,
                         constraints=self._constraints,
                         sharders=sharders,
+                        enumerator=self._enumerators[group],
                         debug=self._debug,
                     )
             else:
@@ -1149,6 +1150,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
                         best_plan=last_proposal,
                         constraints=self._constraints,
                         sharders=sharders,
+                        enumerator=self._enumerators[group],
                         debug=self._debug,
                     )
 

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -53,8 +53,10 @@ from torchrec.distributed.planner.types import (
 )
 from torchrec.distributed.planner.utils import (
     _find_imbalance_tables,
+    build_sharder_data_map,
     bytes_to_gb,
     bytes_to_mb,
+    sharder_name as _sharder_name,
 )
 from torchrec.distributed.types import (
     ModuleSharder,
@@ -258,6 +260,10 @@ class EmbeddingStats(Stats):
             sharder_data_map: Optional[SharderDataMap] = None
             if enumerator is not None:
                 sharder_data_map = getattr(enumerator, "_sharder_data_map", None)
+            if sharder_data_map is None and sharders:
+                sharder_data_map = build_sharder_data_map(
+                    {_sharder_name(s.module_type): s for s in sharders}
+                )
             formatted_param_table = self._log_sharding_plan(
                 best_plan=best_plan,
                 sharding_plan=sharding_plan,
@@ -393,6 +399,15 @@ class EmbeddingStats(Stats):
             output_data_type_size=output_data_type_size,
             num_poolings=num_poolings,
             is_pooled=sharding_option.is_pooled,
+        )
+
+        assert len(ranks) == len(input_sizes), (
+            f"ranks/io_sizes length mismatch for {sharding_option.fqn}: "
+            f"ParameterSharding has {len(ranks)} ranks but "
+            f"ShardingOption has {len(sharding_option.shards)} shards "
+            f"(produced {len(input_sizes)} io entries). "
+            f"This usually means the plan was constructed with mismatched "
+            f"ParameterSharding.ranks and ShardingOption.shards."
         )
 
         input_sizes = [bytes_to_mb(input_size) for input_size in input_sizes]


### PR DESCRIPTION
Summary:

Completes the sharder-to-sharder_data migration and fixes missing enumerator in other stats.log calls.

**1. Complete sharder_data_map migration**:

- **OSS EmbeddingStats.log()**: Added sharders fallback -- when
  `enumerator._sharder_data_map` is unavailable, builds `SharderData` from live
  sharders so debug table doesn't lose sharder names and cache load factors.

**2. Defensive assertion**:

- `_get_shard_stats`: asserts `len(ranks) == len(input_sizes)` to fail fast on
  ParameterSharding/ShardingOption length mismatches.

Reviewed By: micrain

Differential Revision: D98066813
