### PR TITLE
Use intra_group_size instead of local_world_size for placement and stats

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -97,7 +97,7 @@ def to_sharding_plan(
 ) -> ShardingPlan:
 
     compute_device = topology.compute_device
-    local_size = topology.local_world_size
+    local_size = topology.intra_group_size
 
     plan = {}
     for sharding_option in sharding_options:

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -224,7 +224,7 @@ class EmbeddingStats(Stats):
                 shard=shard,
                 sharding_option=sharding_option,
                 world_size=topology.world_size,
-                local_world_size=topology.local_world_size,
+                local_world_size=topology.intra_group_size,
                 constraints=constraints,
             )
             sharding_type_abbr = _get_sharding_type_abbr(shard.sharding_type)


### PR DESCRIPTION
Summary:
The enumerator and shard estimators use `topology.intra_group_size`
( = `pod_size * local_world_size`) to determine TWRW shard counts and I/O
size calculations. However, three downstream consumers use
`topology.local_world_size` directly, which ignores `pod_size`.

This causes incorrect behavior when `pod_size` is set (e.g., GB200 32x2
with `--topology-domain-multiple 4`):
- `local_world_size = 2` (GPUs per host)
- `intra_group_size = 4 * 2 = 8` (GPUs in pod)
- Plan generation uses 8 (correct), but plan consumption uses 2 (wrong)

This produces wrong `placement()` strings (`rank % 2` instead of
`rank % 8`) and wrong I/O size calculations in stats logging.

Fix: Replace `topology.local_world_size` with `topology.intra_group_size`
in all three consumers, matching the enumerator and estimator behavior.

Reviewed By: aporialiao

Differential Revision: D98207414


