### PR TITLE
Update import for EmbeddingLocation from fbgemm_gpu

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -28,7 +28,7 @@ from typing import (
 )
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import EmbeddingLocation
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from torch import fx, nn
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed._tensor.placement_types import Placement


### PR DESCRIPTION
EmbeddingLocation is defined in split_table_batched_embeddings_ops_common but was imported from split_table_batched_embeddings_ops_training in embedding_types.py. This causes embedding_types (and all its dependents) to unnecessarily pull in the heavy training GPU ops.