### PR TITLE
Import EmbeddingLocation from ops_common instead of ops_training (#3932)

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -28,7 +28,7 @@ from typing import (
 )
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import EmbeddingLocation
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from torch import fx, nn
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed._tensor.placement_types import Placement


### PR DESCRIPTION
Summary:

EmbeddingLocation is defined in split_table_batched_embeddings_ops_common but
was imported from split_table_batched_embeddings_ops_training in embedding_types.py.
This caused embedding_types (and all its dependents) to unnecessarily pull in the
heavy training GPU ops. Change the import and BUCK dep to use the common module,
which is already a transitive dep via the :types target.

This removes embedding_ops_training_gpu from several build graphs that only need
the EmbeddingLocation enum.

Reviewed By: yf225

Differential Revision: D98075898


