### PR TITLE
Fix torchrec enrichment func name

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -2498,7 +2498,7 @@ class ZeroCollisionEmbeddingEnrichmentCache(ZeroCollisionKeyValueEmbedding):
         """
         Update the embedding table with the new embeddings.
         """
-        self.emb_module.direct_write_embedding(
+        self.emb_module.enrichment_query_id(
             embeddings.values(), embeddings.offsets(), embeddings.weights()
         )
 


### PR DESCRIPTION
Summary:
CONTEXT: The enrichment API function name was renamed from `direct_write_embedding` to `enrichment_query_id` in the underlying emb_module, but the caller in `batched_embedding_kernel.py` was not updated accordingly.

WHAT: Update the function call in `BatchedFusedEmbeddingBag.update_embedding` to use the new `enrichment_query_id` method name, aligning with the upstream API change.

Differential Revision: D98329035


