### PR TITLE
Enable Event Logger In Planner

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -6,9 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
+import functools
 import logging
 from collections import defaultdict
-from typing import Dict, Generator, Optional
+from enum import Enum
+from typing import Any, Callable, Dict, Generator, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import EventLoggingHandlerBase, EventType
 
@@ -23,12 +25,91 @@ Cap1Logger = "Cap1Logger"
 Cap01Logger = "Cap01Logger"
 MethodLogger = "MethodLogger"
 
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class TorchrecComponent(Enum):
+    """Enum representing different TorchRec components for event logging."""
+
+    PLANNER = "planner"
+    SHARDER = "sharder"
+    TRAIN_PIPELINE = "train_pipeline"
+    INPUT_DIST = "input_dist"
+    OUTPUT_DIST = "output_dist"
+    LOOKUP = "lookup"
+    REC_METRICS = "rec_metrics"
+
 
 class EventLoggingHandler(EventLoggingHandlerBase):
     """No-op event logging handler for open-source builds.
 
     This class can be used to add event logging implementation to Torchrec Components
     """
+
+    @classmethod
+    def event_logger(
+        cls,
+        component: TorchrecComponent,
+        prefix: str = "",
+        n: Optional[int] = None,
+        add_wait_counter: bool = False,
+    ) -> Callable[[F], F]:
+        """
+        Decorator that wraps a method with EventLoggingHandler.log_event_context
+        or n_batch_log_event_context.
+
+        The event name is constructed as "{prefix}{func.__qualname__}".
+
+        Args:
+            component: TorchrecComponent enum value for logging
+            prefix: Optional prefix to prepend to the qualname (default: "")
+            n: If provided, use n_batch_log_event_context to log only every
+                n batches. If None (default), use log_event_context.
+            add_wait_counter: If True, a _WaitCounter is managed for the
+                duration of the decorated function. Defaults to False.
+
+        Example::
+
+            class MyPlanner:
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
+                def plan(self, module, sharders):
+                    # This will log event_name="MyPlanner.plan"
+                    ...
+
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER, prefix="v2_")
+                def collective_plan(self, module, sharders):
+                    # This will log event_name="v2_MyPlanner.collective_plan"
+                    ...
+
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER, n=1000)
+                def frequent_op(self, data):
+                    # This will log only every 1000 batches
+                    ...
+        """
+
+        def decorator(func: F) -> F:
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                event_name = f"{prefix}{func.__qualname__}"
+                if n is None:
+                    ctx = cls.log_event_context(
+                        component=component.value,
+                        event_name=event_name,
+                        add_wait_counter=add_wait_counter,
+                    )
+                else:
+                    ctx = cls.n_batch_log_event_context(
+                        component=component.value,
+                        event_name=event_name,
+                        n=n,
+                        add_wait_counter=add_wait_counter,
+                    )
+                with ctx:
+                    return func(*args, **kwargs)
+
+            return wrapper  # pyre-ignore[7]
+
+        return decorator
 
     @classmethod
     def log_event(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -18,6 +18,7 @@ import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import (
@@ -330,6 +331,7 @@ class EmbeddingPlannerBase(ShardingPlanner):
             assert timeout_seconds > 0, "Timeout must be positive"
         self._timeout_seconds = timeout_seconds
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -484,6 +486,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         self._num_plans: int = 0
         self._best_plan: Optional[List[ShardingOption]] = None
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -520,8 +523,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             sharders,
         )
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     @_torchrec_method_logger()
-    # pyrefly: ignore[bad-param-name-override]
     def plan(
         self,
         module: nn.Module,
@@ -540,6 +543,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         """
         self._num_proposals = 0
         self._num_plans = 0
+
         start_time = perf_counter()
         best_plan = None
         lowest_storage = Storage(MAX_SIZE, MAX_SIZE, MAX_SIZE)
@@ -919,6 +923,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             Callable[[List[ShardingOption]], List[ShardingOption]]
         ] = ([] if callbacks is None else callbacks)
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -948,6 +953,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             sharders,
         )
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def plan(
         self,
         module: nn.Module,


### PR DESCRIPTION
Summary:
### Summary of Changes

This diff is the first step in adding observability to TorchRec. It enables event logging in the planner module, which is responsible for planning the sharding of embeddings in a distributed setting.

### Key Changes

* Added `EventLoggingHandler` and `TorchrecComponent` imports to `planners.py` and `embedding_planner.py` files.
* Decorated the `plan` and `collective_plan` method in `planners.py` with `EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)`.
* Updated `BUCK` files to include `//torchrec/fb/distributed:logging_handlers` dependency.

### Impact

This change enables event logging for the planner module, which will help in monitoring and debugging the planning process. The logged events can be used to analyze the performance and efficiency of the planner, and make data-driven decisions to improve it.

Differential Revision: D97364564


