### PR TITLE
Enable Event Logger In Train Pipeline

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -6,9 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import contextlib
+import functools
 import logging
 from collections import defaultdict
-from typing import Dict, Generator, Optional
+from enum import Enum
+from typing import Any, Callable, Dict, Generator, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import EventLoggingHandlerBase, EventType
 
@@ -23,12 +25,91 @@ Cap1Logger = "Cap1Logger"
 Cap01Logger = "Cap01Logger"
 MethodLogger = "MethodLogger"
 
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class TorchrecComponent(Enum):
+    """Enum representing different TorchRec components for event logging."""
+
+    PLANNER = "planner"
+    SHARDER = "sharder"
+    TRAIN_PIPELINE = "train_pipeline"
+    INPUT_DIST = "input_dist"
+    OUTPUT_DIST = "output_dist"
+    LOOKUP = "lookup"
+    REC_METRICS = "rec_metrics"
+
 
 class EventLoggingHandler(EventLoggingHandlerBase):
     """No-op event logging handler for open-source builds.
 
     This class can be used to add event logging implementation to Torchrec Components
     """
+
+    @classmethod
+    def event_logger(
+        cls,
+        component: TorchrecComponent,
+        prefix: str = "",
+        n: Optional[int] = None,
+        add_wait_counter: bool = False,
+    ) -> Callable[[F], F]:
+        """
+        Decorator that wraps a method with EventLoggingHandler.log_event_context
+        or n_batch_log_event_context.
+
+        The event name is constructed as "{prefix}{func.__qualname__}".
+
+        Args:
+            component: TorchrecComponent enum value for logging
+            prefix: Optional prefix to prepend to the qualname (default: "")
+            n: If provided, use n_batch_log_event_context to log only every
+                n batches. If None (default), use log_event_context.
+            add_wait_counter: If True, a _WaitCounter is managed for the
+                duration of the decorated function. Defaults to False.
+
+        Example::
+
+            class MyPlanner:
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
+                def plan(self, module, sharders):
+                    # This will log event_name="MyPlanner.plan"
+                    ...
+
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER, prefix="v2_")
+                def collective_plan(self, module, sharders):
+                    # This will log event_name="v2_MyPlanner.collective_plan"
+                    ...
+
+                @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER, n=1000)
+                def frequent_op(self, data):
+                    # This will log only every 1000 batches
+                    ...
+        """
+
+        def decorator(func: F) -> F:
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                event_name = f"{prefix}{func.__qualname__}"
+                if n is None:
+                    ctx = cls.log_event_context(
+                        component=component.value,
+                        event_name=event_name,
+                        add_wait_counter=add_wait_counter,
+                    )
+                else:
+                    ctx = cls.n_batch_log_event_context(
+                        component=component.value,
+                        event_name=event_name,
+                        n=n,
+                        add_wait_counter=add_wait_counter,
+                    )
+                with ctx:
+                    return func(*args, **kwargs)
+
+            return wrapper  # pyre-ignore[7]
+
+        return decorator
 
     @classmethod
     def log_event(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -18,6 +18,7 @@ import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import (
@@ -330,6 +331,7 @@ class EmbeddingPlannerBase(ShardingPlanner):
             assert timeout_seconds > 0, "Timeout must be positive"
         self._timeout_seconds = timeout_seconds
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -484,6 +486,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         self._num_plans: int = 0
         self._best_plan: Optional[List[ShardingOption]] = None
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -520,8 +523,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             sharders,
         )
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     @_torchrec_method_logger()
-    # pyrefly: ignore[bad-param-name-override]
     def plan(
         self,
         module: nn.Module,
@@ -540,6 +543,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         """
         self._num_proposals = 0
         self._num_plans = 0
+
         start_time = perf_counter()
         best_plan = None
         lowest_storage = Storage(MAX_SIZE, MAX_SIZE, MAX_SIZE)
@@ -919,6 +923,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             Callable[[List[ShardingOption]], List[ShardingOption]]
         ] = ([] if callbacks is None else callbacks)
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(
         self,
         module: nn.Module,
@@ -948,6 +953,7 @@ class HeteroEmbeddingShardingPlanner(ShardingPlanner):
             sharders,
         )
 
+    @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def plan(
         self,
         module: nn.Module,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -38,6 +38,7 @@ from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionAwaitable,  # noqa: F401
 )
 from torchrec.distributed.logger import one_time_rank0_logger
+from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.backward_injection import (
     BackwardHookWork,
@@ -309,6 +310,9 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
                         cur_batch, self._device, non_blocking=True
                     )
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         if not self._connected:
             self._connect(dataloader_iter)
@@ -401,6 +405,9 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
         self._iter = 0
         self._cur_batch: Optional[In] = None
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         self._state = PipelineState.IDLE
         if self._iter == 0:
@@ -762,6 +769,9 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         with record_function(f"## backward {batch_id} ##"):
             torch.sum(losses, dim=0).backward()
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         """
         For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
@@ -1246,6 +1256,9 @@ class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
         with record_function(f"## wait_for_batch {batch_id} ##"):
             _wait_for_batch(cast(In, self.batches[0]), self._memcpy_stream)
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         self._state = PipelineState.IDLE
 
@@ -1425,6 +1438,9 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
                         stream_context=self._stream_context,
                     )
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         """
         For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
@@ -1636,6 +1652,9 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             return
         self._optimizer.step()
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         # attach the model just in case the user forgets to call it, especially when the user
         # pauses the pipeline.progress and detach the model for other purpose.
@@ -2029,6 +2048,9 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         self._batch_ip1 = self._copy_batch_to_gpu(dataloader_iter)
         self._start_sparse_data_dist(self._batch_ip1)
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         """
         Executes one training iteration with prefetch pipelining.
@@ -2203,6 +2225,9 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             self._batch_loader.stop()
         self._batch_loader = None
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         if not self._batch_loader:
             self._batch_loader = DataLoadingThread(
@@ -2262,6 +2287,9 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
 
 class EvalPipelineFusedSparseDist(TrainPipelineFusedSparseDist[In, Out]):
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         """
         For TrainPipelineSparseDist, we assume the max pipelined batches == 3 (capacity):
@@ -2572,6 +2600,9 @@ class StagedTrainPipeline(TrainPipeline[In, Optional[StageOut]]):
         if self.on_flush_end is not None:
             self.on_flush_end()
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(
         self,
         dataloader_iter: Iterator[In],
@@ -2710,6 +2741,9 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
             torch.compile(**self.compiled_autograd_options)
         )
 
+    @EventLoggingHandler.event_logger(
+        TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
+    )
     def progress(self, dataloader_iter: Iterator[In]) -> Out:
         # attach the model just in case the user forgets to call it, especially when the user
         # pauses the pipeline.progress and detach the model for other purpose.


### PR DESCRIPTION
Summary:
## This Diff

**TorchRec Observability 2/n: Enable Event Logger In Train Pipeline**

### Summary
Enables **event logging in the train pipeline** by wiring in `EventLoggingHandler` (from `torchrec.fb.distributed.logging_handlers`).

### Key Changes
- Update `train_pipelines.py` to import `EventLoggingHandler` and `TorchrecComponent`.
- Add code to **emit train-pipeline lifecycle events** via the event logger.

Differential Revision: D96829947


