### PR TITLE
Use sym_int in JaggedTensor.to_padded_dense and to_padded_dense_weights (#3939)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -985,7 +985,11 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             # ]
         """
         if desired_length is None:
-            N = int(torch.max(self.lengths()).item())
+            _max = torch.max(self.lengths()).item()
+            if not torch.jit.is_scripting() and is_non_strict_exporting():
+                N = torch.sym_int(_max)
+            else:
+                N = int(_max)
         else:
             N = desired_length
         return torch.ops.fbgemm.jagged_to_padded_dense(
@@ -1039,7 +1043,11 @@ class JaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         if self.weights_or_none() is None:
             return None
         if desired_length is None:
-            N = int(torch.max(self.lengths()).item())
+            _max = torch.max(self.lengths()).item()
+            if not torch.jit.is_scripting() and is_non_strict_exporting():
+                N = torch.sym_int(_max)
+            else:
+                N = int(_max)
         else:
             N = desired_length
         return torch.ops.fbgemm.jagged_to_padded_dense(


### PR DESCRIPTION
Summary:

Replace bare int() calls with conditional torch.sym_int() during
non-strict torch.export to preserve symbolic integer shapes. This
follows the same pattern already used in _maybe_compute_stride_kjt()
and _use_segment_sum_csr() in the same file.

Without this fix, torch.export non-strict mode concretizes symbolic
integer values from torch.max(lengths).item(), which causes export
failures for models using to_padded_dense or to_padded_dense_weights.

Reviewed By: malaybag

Differential Revision: D96342361


