### PR TITLE
VBE support (#3941)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3969,10 +3969,16 @@ class TritonBatchedFusedEmbeddingBag(
         weights = features.weights_or_none()
         if weights is not None and not torch.is_floating_point(weights):
             weights = None
+        forward_kwargs: Dict[str, Any] = {}
+        if features.variable_stride_per_key():
+            forward_kwargs["batch_size_per_feature_per_rank"] = (
+                features.stride_per_key_per_rank()
+            )
         return self._emb_module(
             indices=features.values().long(),
             offsets=features.offsets().long(),
             per_sample_weights=weights,
+            **forward_kwargs,
         )
 
     def named_buffers(


### PR DESCRIPTION
Summary:

## Summary

Add Variable Batch-size Embedding (VBE) support to Triton TBE, covering forward, backward, bounds checking, CPU-side performance, and the TorchRec dispatch integration. This brings feature parity with CUDA TBE's VBE support and enables Triton TBE to be used with `ShardedVariableLengthEmbeddingArch` in production.

### 1. Forward VBE support (`triton_table_batched_embeddings.py`)

**Weighted kernel** (`table_batched_embedding_bag_forward_weighted_kernel`):
- Added `row_output_offsets_ptr`, `b_t_map_ptr`, `vbe`, `info_B_num_bits`, `info_B_mask` parameters
- VBE path: decodes `(t, b)` from `b_t_map` instead of `b_t // B` / `b_t % B`
- VBE output addressing: uses `row_output_offsets[b_t]` instead of `b * total_embedding_dim + embedding_offset`

**Unweighted kernel** (`table_batched_embedding_bag_forward_unweighted_kernel`):
- Added `row_output_offsets_ptr`, `B_offsets_ptr`, `vbe` parameters
- Adapted to D96989938's t-loop structure (`b = program_id`, inner `for t in range(T)`)
- VBE path: computes `b_t = B_offsets[t] + b`, skips out-of-bounds batches (`b >= B_t`), uses `row_output_offsets[b_t]` for output addressing

### 2. Backward VBE support (`triton_table_batched_embeddings.py`)

**4 backward kernels** that read `dout` (short_run_unweighted, short_run_weighted, long_run_grad_accum_unweighted, long_run_grad_accum_weighted):
- Added `row_output_offsets_ptr`, `B_offsets_ptr`, `vbe` parameters
- VBE dout addressing: `dout_ptr + row_output_offsets[B_offsets[t] + b]` instead of `dout_ptr + b * total_embedding_dim + embedding_offsets[t]`

**long_run_apply_unweighted**: No changes needed (doesn't access `dout`)

**Backward infrastructure**:
- Pass `vbe_b_t_map` to `transpose_embedding_input` so it correctly maps VBE offsets to `(t, b)` pairs (also passes `info_B_mask`)
- Save `row_output_offsets`, `B_offsets`, `b_t_map` in autograd context for backward

### 3. Bounds check support (`triton_table_batched_embeddings.py`)

- Added `_generate_vbe_metadata_for_bounds_check()` method to `TritonTableBatchedEmbeddingBags`
- VBE metadata (B_offsets, b_t_map, info_B_num_bits, info_B_mask, max_B) is computed once and used for both `bounds_check_indices` and the forward/backward kernels
- `bounds_check_indices` is now called with VBE parameters on the VBE path (previously skipped entirely)

### 4. CPU-side performance fixes (`triton_table_batched_embeddings.py`)

**Triton kernel recompilation prevention**:
- Changed `B`, `info_B_num_bits`, `info_B_mask` from `tl.constexpr` to regular parameters in all 7 training kernels (2 forward + 5 backward)
- In VBE mode, `B = max_B` changes every batch, which caused Triton to recompile the kernel for every unique value (same issue as the learning rate recompilation fixed in D95892380)

**Cached VBE constants** (avoid GPU→CPU transfers on every call):
- Pre-compute `_feature_dims_cpu`, `_D_offsets`, `_max_D` in `__init__()` — these are constant for a model's lifetime but were being recomputed via `embedding_dims.cpu()`, `torch.cumsum()`, and `embedding_dims.max().item()` on every forward call

### 5. TorchRec dispatch integration (`batched_embedding_kernel.py`)

- Updated `TritonBatchedFusedEmbeddingBag.forward()` to check `features.variable_stride_per_key()` and pass `batch_size_per_feature_per_rank=features.stride_per_key_per_rank()` to the Triton TBE module
- Previously, this method overrode `BaseBatchedEmbeddingBag.forward()` and dropped all VBE handling, so Triton TBE could never receive VBE metadata from `ShardedVariableLengthEmbeddingArch`

### 6. Benchmark VBE support (`triton_table_batched_embeddings_bench.py`)

- Added `--vbe`, `--sigma-B`, `--vbe-num-ranks` CLI options to the `device` command
- VBE path uses `generate_requests(sigma_B=..., vbe_num_ranks=...)` and `benchmark_requests_with_spec` (4-arg lambda passing `batch_size_per_feature_per_rank`)
- Forward correctness check only on first iteration for VBE (weights diverge after backward with independent random grads)
- Weight comparison skipped in VBE mode for the same reason

Reviewed By: stashuk-olek

Differential Revision: D98361027


