### PR TITLE
Fix score_weights not passed to TBE in non-VBE path for EBC auto collection (#3942)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3665,7 +3665,6 @@ class ZeroCollisionKeyValueEmbeddingBag(
                 forward_args.update(
                     {
                         "batch_size_per_feature_per_rank": features.stride_per_key_per_rank(),
-                        "weights": score_weights,
                     }
                 )
             if isinstance(
@@ -3677,7 +3676,6 @@ class ZeroCollisionKeyValueEmbeddingBag(
                         "batch_size_per_feature_per_rank": features.stride_per_key_per_rank(),
                         "vbe_output": vbe_output,
                         "vbe_output_offsets": vbe_output_offsets,
-                        "weights": score_weights,
                     }
                 )
 
@@ -3685,12 +3683,14 @@ class ZeroCollisionKeyValueEmbeddingBag(
             return self.emb_module(
                 indices=features.values().to(self._embedding_table_index_type),
                 offsets=features.offsets().to(self._embedding_table_index_type),
+                weights=score_weights,
                 per_sample_weights=per_sample_weights,
             )
         else:
             return self.emb_module(
                 indices=features.values().to(self._embedding_table_index_type),
                 offsets=features.offsets().to(self._embedding_table_index_type),
+                weights=score_weights,
                 per_sample_weights=per_sample_weights,
                 **forward_args,
             )


### PR DESCRIPTION
Summary:

CONTEXT: D95503524 redo'd feature score auto collection for EBC but introduced a regression where `score_weights` was only passed to `emb_module` inside the VBE-specific `variable_stride_per_key()` branch. For non-VBE cases (most EBC usage), `score_weights` was computed but never sent to the TBE, causing auto collection to silently fail.

WHAT: Move `weights=score_weights` out of VBE-specific `forward_args.update()` and into the final `self.emb_module()` calls directly, ensuring all code paths pass score_weights to the TBE — matching the original D85017179 behavior.

Reviewed By: xywang9334, emlin

Differential Revision: D98433607
