### PR TITLE
Clear killswitch_enable_preallocated_vbe_merge

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -765,31 +765,6 @@ class GroupedPooledEmbeddingsLookup(
                         ),
                     )
 
-    def _merge_variable_batch_embeddings(
-        self, embeddings: List[torch.Tensor], splits: List[List[int]]
-    ) -> torch.Tensor:
-        assert len(embeddings) > 1 and len(splits) > 1
-
-        logger.info(
-            "[Deprecated] Merge VBE embeddings from the following TBEs "
-            f"(world size: {self._world_size}):\n"
-            + "\n".join(
-                [
-                    f"\t{module.__class__.__name__}:{len(split)} splits"
-                    for module, split in zip(self._emb_modules, splits)
-                ]
-            )
-        )
-
-        split_embs = [e.split(s) for e, s in zip(embeddings, splits)]
-        combined_embs = [
-            emb
-            for rank in range(self._world_size)
-            for n, embs in zip(self._feature_splits, split_embs)
-            for emb in embs[n * rank : n * rank + n]
-        ]
-        return torch.cat(combined_embs)
-
     def _vbe_splits(
         self, features_by_group: List[KeyedJaggedTensor]
     ) -> List[List[int]]:
@@ -965,21 +940,10 @@ class GroupedPooledEmbeddingsLookup(
         """Merges the TBE output when VBE is enabled and multiple TBEs are
         involved.
 
-        If opt-in for the preallocated merge approach, an 1D empty tensor will be
-        preallocated for TBEs to handle the merging logic. Otherwise, the output
-        will be split and then merged via `torch.cat`.
+        An 1D empty tensor will be preallocated for TBEs to handle the merging
+        logic.
         """
         vbe_splits = self._vbe_splits(features_by_group)
-
-        # If we do not opt-in to pre-allocate the VBE output, we need to run
-        # forward for each TBE individually and merge the results via
-        # `torch.cat`.
-        if not torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:killswitch_enable_preallocated_vbe_merge"
-        ):
-            return self._merge_variable_batch_embeddings(
-                self._forward(features_by_group), vbe_splits
-            )
 
         vbe_output, vbe_offsets = self._create_vbe_output_and_offsets(
             vbe_splits, device

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -10,7 +10,6 @@
 import copy
 import unittest
 from typing import cast, List, OrderedDict, Union
-from unittest.mock import Mock, patch
 
 import torch
 import torch.distributed as dist
@@ -24,7 +23,6 @@ from torchrec.distributed.batched_embedding_kernel import (
     ZeroCollisionKeyValueEmbedding,
     ZeroCollisionKeyValueEmbeddingBag,
 )
-from torchrec.distributed.embedding_lookup import logger as lookup_logger
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     ShardedEmbeddingTable,
@@ -703,16 +701,12 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             ]
         ),
         dtype=st.sampled_from([DataType.FP32, DataType.FP16]),
-        is_jk_enabled=st.booleans(),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None, database=None)
-    @patch("torch._utils_internal.justknobs_check")
     def test_ssd_mixed_kernels_with_vbe(
         self,
-        mock_jk: Mock,
         sharding_type: str,
         dtype: DataType,
-        is_jk_enabled: bool,
     ) -> None:
         self._set_table_weights_precision(dtype)
         optimizer_configs = {
@@ -733,47 +727,28 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
             for i, table in enumerate(self.tables)
         }
         pg = dist.GroupMember.WORLD
-        mock_jk.return_value = is_jk_enabled
-        if is_jk_enabled:
-            cm = self.assertNoLogs(lookup_logger, level="INFO")
-        else:
-            cm = self.assertLogs(lookup_logger, level="INFO")
-
-        with cm as logs:
-            self.assertIsNotNone(pg, "Process group is not initialized")
-            sharding_single_rank_test_single_process(
-                pg=pg,
-                device=self.device,
-                rank=0,
-                world_size=1,
-                # pyrefly: ignore[bad-argument-type]
-                model_class=TestSparseNN,
-                embedding_groups={},
-                tables=self.tables,
-                # pyrefly: ignore[bad-argument-type]
-                sharders=[EmbeddingBagCollectionSharder()],
-                optim=EmbOptimType.EXACT_SGD,
-                # The optimizer config here will overwrite the SGD optimizer above
-                apply_optimizer_in_backward_config={
-                    "embedding_bags": optimizer_configs[dtype],
-                    "embeddings": optimizer_configs[dtype],
-                },
-                constraints=constraints,
-                variable_batch_per_feature=True,
-                random_seed=100,
-            )
-
-        mock_jk.assert_any_call(
-            "pytorch/torchrec:killswitch_enable_preallocated_vbe_merge"
+        self.assertIsNotNone(pg, "Process group is not initialized")
+        sharding_single_rank_test_single_process(
+            pg=pg,
+            device=self.device,
+            rank=0,
+            world_size=1,
+            # pyrefly: ignore[bad-argument-type]
+            model_class=TestSparseNN,
+            embedding_groups={},
+            tables=self.tables,
+            # pyrefly: ignore[bad-argument-type]
+            sharders=[EmbeddingBagCollectionSharder()],
+            optim=EmbOptimType.EXACT_SGD,
+            # The optimizer config here will overwrite the SGD optimizer above
+            apply_optimizer_in_backward_config={
+                "embedding_bags": optimizer_configs[dtype],
+                "embeddings": optimizer_configs[dtype],
+            },
+            constraints=constraints,
+            variable_batch_per_feature=True,
+            random_seed=100,
         )
-        # Should only print logs when JK is disabled. Only used for JK testing
-        # and should be cleaned up later.
-        self.assertEqual(is_jk_enabled, logs is None)
-        if logs is not None:
-            matched_logs = list(
-                filter(lambda s: "[Deprecated] Merge VBE" in s, logs.output)
-            )
-            self.assertGreater(len(matched_logs), 0)
 
     @unittest.skipIf(
         not torch.cuda.is_available(),


### PR DESCRIPTION
Summary:
## 1. Context
test is failing due to logging:
{F1987340591} 

The `killswitch_enable_preallocated_vbe_merge` JustKnob was introduced to gate the preallocated VBE merge approach behind a killswitch while it was being rolled out. The preallocated approach pre-allocates a 1D output tensor and lets each TBE write to it at the correct offsets, avoiding the need to run each TBE individually and merge via `torch.cat`. The killswitch has been fully enabled and is ready to be cleared.

## 2. Approach
1. **Remove deprecated code path**: Delete the `_merge_variable_batch_embeddings` method which implemented the old `torch.cat`-based merging logic, along with its `[Deprecated]` log message.
2. **Remove killswitch check**: Remove the `justknobs_check` call in `_forward_with_vbe_merging` so the preallocated merge is the only code path.
3. **Clean up tests**: Remove the `is_jk_enabled` hypothesis parameter, `patch` decorator, mock assertions, and log assertions from `test_ssd_mixed_kernels_with_vbe`. The test now exercises the preallocated path directly.
4. **Clean up imports and deps**: Remove unused `Mock`, `patch`, and `lookup_logger` imports; remove the `//torchrec/distributed:embedding_lookup` BUCK dependency from the test targets.

## 3. Analysis
1. **No behavioral change**: The preallocated VBE merge was already the enabled path in production. This only removes the dead fallback code.
2. **Backward compatibility**: No public API changes. The removed method was private (`_merge_variable_batch_embeddings`).
3. **Test coverage**: The `test_ssd_mixed_kernels_with_vbe` test still exercises the VBE merging path with mixed kernels (FUSED + KEY_VALUE) across multiple sharding types and dtypes. The `is_jk_enabled` parameter is removed, which halves the hypothesis search space since there is now only one code path to test.

## 4. Changes
1. **`embedding_lookup.py`**: Removed `_merge_variable_batch_embeddings` method (25 lines) and killswitch check block (8 lines) in `_forward_with_vbe_merging`. Updated docstring.
2. **`test_model_parallel_nccl_ssd_single_gpu.py`**: Removed `is_jk_enabled` parameter, `patch` decorator, `mock_jk` setup, log context manager, and all killswitch-related assertions. Removed unused imports (`Mock`, `patch`, `lookup_logger`).
3. **`tests/BUCK`**: Removed `//torchrec/distributed:embedding_lookup` dep from `test_model_parallel_nccl_ssd_single_gpu` and its debug binary target.

Differential Revision: D98523811


