### PR TITLE
[benchmark][pipeline] Add UVM benchmark config for sparse data dist eval (#3946)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/fused_sdd_uvm_eval.yml
+++ b/torchrec/distributed/benchmark/yaml/fused_sdd_uvm_eval.yml
@@ -12,9 +12,9 @@ RunOptions:
   profile_dir: "."
   loglevel: "INFO"
   memory_snapshot: True
-  name: "sparse_data_dist_eval"
+  name: "fused_sdd_uvm_eval"
 PipelineConfig:
-  pipeline: "eval-sdd"
+  pipeline: "eval-fused"
 ModelInputConfig:
   num_float_features: 1000
   feature_pooling_avg: 30
@@ -40,7 +40,7 @@ EmbeddingTablesConfig:
         data_type: FP16
 PlannerConfig:
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
-  # compute_kernel: fused_uvm_caching
+  compute_kernel: fused_uvm
   additional_constraints:
     FP16_table:
       sharding_types: [row_wise]


### PR DESCRIPTION
Summary:
## 1. Context
The existing `sparse_data_dist_eval.yml` benchmark config uses the default fused compute kernel. To profile sparse data distribution evaluation under UVM (Unified Virtual Memory), we need a dedicated config that places all embedding tables on UVM.

## 2. Approach
1. **New UVM config**: Add `fused_sdd_uvm_eval.yml` with `compute_kernel: fused_uvm` in PlannerConfig, applying UVM to all 101 tables (50 unweighted + 50 weighted + 1 FP16 additional table)
2. **Improve existing config**: Add `loglevel: "INFO"` and `memory_snapshot: True` to `sparse_data_dist_eval.yml` for better debugging and memory profiling
3. **UVM caching hint**: Add commented-out `compute_kernel: fused_uvm_caching` option in the existing config as a quick-switch reference

## 3. Results

* benchmark

|config                       |GPU Runtime (P90)|CPU Runtime (P90)|CPU Utilization (P90)|Normalized CPU Util (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|QPS (P90)|
|--|--|--|--|--|--|--|--|--|--|--|
|baseline (fused)              |11010.92 ms      |10596.07 ms      |96.24%               |0.25%                    |70.50 GB                |77.32 GB                   |79.30 GB          |0.0 / 0.0 / 0.0              |18.61 GB          |59522    |
|UVM (fused_uvm)               |47068.23 ms      |44943.51 ms      |95.49%               |0.25%                    |32.18 GB                |43.89 GB                   |45.88 GB          |0.0 / 0.0 / 0.0              |18.60 GB          |13923    |
|UVM no_sync (fused_uvm)       |46888.99 ms      |40259.46 ms      |96.31%               |0.25%                    |32.18 GB                |59.00 GB                   |60.98 GB          |0.0 / 0.0 / 0.0              |18.64 GB          |15677    |

* baseline
<img width="4656" height="1264" alt="image" src="https://github.com/user-attachments/assets/16781985-6670-40c4-9012-59b5a3fcccee" />

* uvm
<img width="4642" height="1256" alt="image" src="https://github.com/user-attachments/assets/a3890930-c8f6-4ca0-a4a4-8148458673af" />

* no-sync
<img width="4668" height="1230" alt="image" src="https://github.com/user-attachments/assets/53a8858b-33ed-4930-8a83-8dfcf49bd493" />

* repro commands
```bash
# baseline (fused)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_eval.yml

# UVM (fused_uvm)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/fused_sdd_uvm_eval.yml

# UVM no_sync (fused_uvm, sync_fwd=False)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/fused_sdd_uvm_eval.yml \
  --name=fused_sdd_uvm_eval_no_sync --sync_fwd=False
```

* trace
- [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98577232)

|name|rank0 trace|rank0 memory|
|--|--|--|
|baseline (fused)|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98577232/trace-sparse_data_dist_eval-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98577232/trace-sparse_data_dist_eval-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98577232/memory-sparse_data_dist_eval-rank0.pickle)|
|UVM (fused_uvm)|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98577232/trace-fused_sdd_uvm_eval-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98577232/trace-fused_sdd_uvm_eval-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98577232/memory-fused_sdd_uvm_eval-rank0.pickle)|
|UVM no_sync|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98577232/trace-fused_sdd_uvm_eval_no_sync-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98577232/trace-fused_sdd_uvm_eval_no_sync-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98577232/memory-fused_sdd_uvm_eval_no_sync-rank0.pickle)|

## 4. Changes
1. **`fused_sdd_uvm_eval.yml`** (new): Benchmark config with `compute_kernel: fused_uvm` for all tables, using the eval-fused pipeline with 2 ranks and table-wise sharding
2. **`sparse_data_dist_eval.yml`**: Added `loglevel` and `memory_snapshot` to RunOptions; replaced MP-ZCH comment with commented-out UVM caching compute kernel option


Differential Revision: D98577232


