### PR TITLE
Add logging to DataLoadingThread

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -524,6 +524,12 @@ class DataLoadingThread(Thread, Generic[In]):
         self._to_device_non_blocking = to_device_non_blocking
         self._buffered: Optional[In] = None
         self._buffer_empty_event.set()
+        one_time_rank0_logger.info(
+            f"{self.__class__.__name__} created with device={device}, "
+            f"to_device_non_blocking={to_device_non_blocking}, "
+            f"memcpy_stream_priority={memcpy_stream_priority}, "
+            f"memcpy_stream={'provided' if memcpy_stream is not None else 'auto-created' if self._memcpy_stream is not None else 'None'}"
+        )
 
     def run(self) -> None:
         if self._device.type == "cuda" and torch.cuda.is_available():
@@ -558,12 +564,12 @@ class DataLoadingThread(Thread, Generic[In]):
                 self._buffer_filled_event.set()
 
     def stop(self) -> None:
-        logger.info("Stopping data loading thread...")
+        logger.info(f"{self.__class__.__name__}: Stopping data loading thread...")
         self._stop = True
         # Unblock any thread that are waiting for these events.
         self._buffer_filled_event.set()
         self._buffer_empty_event.set()
-        logger.info("Data loading thread stopped.")
+        logger.info(f"{self.__class__.__name__}: Data loading thread stopped.")
 
     def get_next_batch(self, none_throws: bool = False) -> Optional[In]:
         """


### PR DESCRIPTION
Summary:
## 1. Context
When debugging data loading issues in pipelined training, there is limited visibility into `DataLoadingThread` lifecycle events. The existing logging in `stop()` uses hardcoded class names, which is unhelpful when subclasses are involved.

## 2. Approach
1. **One-time creation log**: Added a `one_time_rank0_logger.info()` call in `__init__` that logs device, `to_device_non_blocking`, `memcpy_stream_priority`, and whether the memcpy stream was provided, auto-created, or None. This uses the `Cap01Logger` (one-time per location on rank 0 only) to avoid log spam in multi-step training.
2. **Dynamic class name**: All log messages use `self.__class__.__name__` instead of hardcoded strings, so subclasses of `DataLoadingThread` will correctly identify themselves in logs.

## 3. Results
No benchmark impact — logging-only change.

## 4. Analysis
1. **Risk**: Low. Only adds logging statements with no behavioral changes.
2. **Backward compatibility**: No API changes. The `one_time_rank0_logger` is already imported and used elsewhere in the file (e.g., `FutureDeque`).

## 5. Changes
1. **`utils.py` (`DataLoadingThread.__init__`)**: Added `one_time_rank0_logger.info()` with creation config details using `self.__class__.__name__`.
2. **`utils.py` (`DataLoadingThread.stop`)**: Updated two existing `logger.info()` calls to prefix messages with `self.__class__.__name__`.

Differential Revision: D98575560


