### PR TITLE
Add log_api_usage_once tracking to try/catch import guards

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -30,6 +30,9 @@ try:
         TritonTableBatchedEmbeddingBags,
     )
 except ImportError:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.model_parallel.import_failure.TritonTableBatchedEmbeddingBags"
+    )
     _SHARDED_TBE_TYPES: tuple[type, ...] = (  # pyrefly: ignore[bad-assignment]
         SplitTableBatchedEmbeddingBagsCodegen,
     )

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -14,6 +14,7 @@ from functools import reduce
 from time import perf_counter
 from typing import Callable, cast, Dict, List, Optional, Tuple, Union
 
+import torch
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
@@ -78,6 +79,9 @@ try:
     # dependencies
     from torchrec.distributed.logger import _torchrec_method_logger
 except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.planner.planners.import_failure._torchrec_method_logger"
+    )
 
     def _torchrec_method_logger(*args, **kwargs):
         """A no-op decorator that accepts any arguments."""

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -50,6 +50,9 @@ try:
     # dependencies
     from torchrec.distributed.logger import _torchrec_method_logger
 except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.planner.shard_estimators.import_failure._torchrec_method_logger"
+    )
 
     def _torchrec_method_logger(*args, **kwargs):
         """A no-op decorator that accepts any arguments."""

--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -47,6 +47,8 @@ try:
 
 except Exception:
     # BC for torch versions without compiler and torch deploy path
+    torch._C._log_api_usage_once("torchrec.pt2.checks.import_failure.torch_compiler")
+
     def is_torchdynamo_compiling() -> bool:
         return False
 


### PR DESCRIPTION
Summary:
Add `torch._C._log_api_usage_once` tracking to defensive try/catch import blocks across torchrec that currently lack usage tracking. This allows us to verify via the `Caffe2PytorchUsageLogger` Scuba table whether these fallback paths are ever hit in production, enabling safe cleanup later.

Files instrumented:
- `planner/planners.py` — `_torchrec_method_logger` import fallback
- `planner/shard_estimators.py` — `_torchrec_method_logger` import fallback
- `model_parallel.py` — `TritonTableBatchedEmbeddingBags` import fallback
- `pt2/checks.py` — `torch.compiler` import fallback (BC for older torch / torch deploy)
- `fb/distributed/sparsenn_configs.py` — eviction policy classes import fallback

Differential Revision: D98581331


