### PR TITLE
Fix missing embedding_names_per_rank in quant sequence sharding and misc test fixes (#3949)

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -9,7 +9,6 @@
 
 import unittest
 from typing import Any, cast, Dict, List, Optional, Tuple, Type
-from unittest.mock import Mock, patch
 
 import torch
 import torch.nn as nn
@@ -832,17 +831,12 @@ class ModelParallelBase(ModelParallelTestShared):
         is_jk_enabled=st.just(True),
     )
     @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
-    @patch("torch._utils_internal.justknobs_check")
     def test_sharding_multiple_kernels(
         self,
-        mock_jk: Mock,
         sharding_type: str,
         data_type: DataType,
         is_jk_enabled: bool,
     ) -> None:
-        if self.backend == "gloo":
-            self.skipTest("ProcessGroupGloo does not support reduce_scatter")
-
         # prefetch_pipeline is neeeded to enable multiple kernels
         fused_params = {"prefetch_pipeline": True}
         constraints = {
@@ -857,7 +851,6 @@ class ModelParallelBase(ModelParallelTestShared):
             )
             for i, table_name in enumerate(self.table_names)
         }
-        mock_jk.return_value = is_jk_enabled
 
         self._test_sharding(
             # pyrefly: ignore[bad-argument-type]

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -11,7 +11,6 @@ import os
 import unittest
 from collections import defaultdict
 from typing import Any, Callable, cast, Dict, List, Optional, OrderedDict, Tuple
-from unittest.mock import Mock, patch
 
 import numpy as np
 import torch

--- a/torchrec/modules/tests/test_kjt_pool_lookup.py
+++ b/torchrec/modules/tests/test_kjt_pool_lookup.py
@@ -15,13 +15,13 @@ from torchrec.sparse.jagged_tensor import JaggedTensor
 
 class KeyedJaggedTensorPoolLookupTest(unittest.TestCase):
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
     )
     def test_uvm_caching_int64_lookup(
         self,
     ) -> None:
-        device = torch.device("cuda:0")
+        device = torch.device("cuda")
 
         pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
         lookup = UVMCachingInt64Lookup(


### PR DESCRIPTION
Summary:

`ShardedQuantSequenceEmbeddingArch.compute()` creates `InferSequenceShardingContext` without `embedding_names_per_rank`, causing `TypeError` in `InferTwSequenceEmbeddingDist.forward()`. This only affects the internal `ShardedQuantSequenceEmbeddingArch` path — the mainstream `ShardedQuantEmbeddingCollection` already passes this field correctly.

Fix: pass `self._embedding_names_per_sharding` to the context constructor, matching the pattern in `quant_embedding.py`.

Other fixes:
1. Remove unused `justknobs_check` mock and imports in `test_sharding_multiple_kernels`
2. Fix `test_uvm_caching_int64_lookup` GPU requirement (2→1)
3. Adjust remote execution configs (resource_units, MIG) for test targets

Differential Revision: D98604138
