### PR TITLE
Fix double log entries from static logger (#3951)

### DIFF
--- a/torchrec/distributed/logger.py
+++ b/torchrec/distributed/logger.py
@@ -115,7 +115,8 @@ def _get_or_create_logger(destination: str) -> logging.Logger:
     )
     logging_handler.setFormatter(formatter)
     logger.propagate = False
-    logger.addHandler(logging_handler)
+    if not logger.handlers:
+        logger.addHandler(logging_handler)
     return logger
 
 

--- a/torchrec/distributed/tests/test_logger.py
+++ b/torchrec/distributed/tests/test_logger.py
@@ -272,6 +272,7 @@ class TestLoggerUtils(unittest.TestCase):
     def test_get_or_create_logger(self, mock_get_logger: mock.MagicMock) -> None:
         """Test _get_or_create_logger function."""
         mock_logger = mock.MagicMock(spec=logging.Logger)
+        mock_logger.handlers = []
         mock_get_logger.return_value = mock_logger
 
         # Test with SingleRankStaticLogger destination


### PR DESCRIPTION
Summary:

Depending on how the code is used if _get_or_create_logger is called with separate instances of _log_handlers due to different import paths from different packages, we can end up with two handlers in the same logger. This can result in double the logging actions being performed for the same log call.

Differential Revision: D98647171


