### PR TITLE
feat: add EMO prefetch benchmark yaml

### DIFF
--- a/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo.yml
@@ -1,0 +1,58 @@
+# EMO benchmark with prefetch pipeline and UVM caching
+# Runs on 2 ranks with prefetch pipelining to overlap cache prefetch with fwd/bwd
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "prefetch_sparse_dist_emo"
+  memory_snapshot: True
+  loglevel: "info"
+  num_float_features: 1000
+PipelineConfig:
+  pipeline: "prefetch"
+ModelInputConfig:
+  num_float_features: 1000
+  feature_pooling_avg: 60
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 1000
+    submodule_kwargs:
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 50
+  num_weighted_features: 50
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: large_table
+        embedding_dim: 256
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_0"]
+      - name: medium_table
+        embedding_dim: 128
+        num_embeddings: 500_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: small_table
+        embedding_dim: 64
+        num_embeddings: 100_000
+        feature_names: ["additional_2_0"]
+PlannerConfig:
+  pooling_factors: [60.0]
+  additional_constraints:
+    large_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True
+    medium_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True


### PR DESCRIPTION
Summary: Adds a benchmark config for EMO with prefetch pipeline and UVM caching. Uses PrefetchTrainPipelineSparseDist with two UVM_CACHING tables and cache_params.prefetch_pipeline=True.

Differential Revision: D97564110


