### PR TITLE
feat: add LP planner support to benchmark framework

### DIFF
--- a/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo.yml
@@ -1,0 +1,58 @@
+# EMO benchmark with prefetch pipeline and UVM caching
+# Runs on 2 ranks with prefetch pipelining to overlap cache prefetch with fwd/bwd
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "prefetch_sparse_dist_emo"
+  memory_snapshot: True
+  loglevel: "info"
+  num_float_features: 1000
+PipelineConfig:
+  pipeline: "prefetch"
+ModelInputConfig:
+  num_float_features: 1000
+  feature_pooling_avg: 60
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 1000
+    submodule_kwargs:
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 50
+  num_weighted_features: 50
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: large_table
+        embedding_dim: 256
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_0"]
+      - name: medium_table
+        embedding_dim: 128
+        num_embeddings: 500_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: small_table
+        embedding_dim: 64
+        num_embeddings: 100_000
+        feature_names: ["additional_2_0"]
+PlannerConfig:
+  pooling_factors: [60.0]
+  additional_constraints:
+    large_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True
+    medium_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True

--- a/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo_lp.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_sparse_dist_emo_lp.yml
@@ -1,0 +1,59 @@
+# EMO benchmark with LP planner, prefetch pipeline and UVM caching
+# Identical to prefetch_sparse_dist_emo.yml but uses the LinearProgrammingPlanner
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "prefetch_sparse_dist_emo_lp"
+  memory_snapshot: True
+  loglevel: "info"
+  num_float_features: 1000
+PipelineConfig:
+  pipeline: "prefetch"
+ModelInputConfig:
+  num_float_features: 1000
+  feature_pooling_avg: 60
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 1000
+    submodule_kwargs:
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 50
+  num_weighted_features: 50
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: large_table
+        embedding_dim: 256
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_0"]
+      - name: medium_table
+        embedding_dim: 128
+        num_embeddings: 500_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: small_table
+        embedding_dim: 64
+        num_embeddings: 100_000
+        feature_names: ["additional_2_0"]
+PlannerConfig:
+  planner_type: "lp"
+  pooling_factors: [60.0]
+  additional_constraints:
+    large_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True
+    medium_table:
+      compute_kernels: [fused_uvm_caching]
+      sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -36,8 +36,10 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingEnv,
     ShardingPlan,
+    ShardingPlanner,
     ShardingType,
 )
+from torchrec.fb.distributed.planner.lp_planner import LinearProgrammingPlanner
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -200,7 +202,7 @@ class PlannerConfig:
     def generate_planner(
         self,
         tables: List[EmbeddingBagConfig],
-    ) -> Union[EmbeddingShardingPlanner, HeteroEmbeddingShardingPlanner]:
+    ) -> ShardingPlanner:
         """
         Generate an embedding sharding planner based on the specified configuration.
 
@@ -235,6 +237,13 @@ class PlannerConfig:
 
         if self.planner_type == "embedding":
             return EmbeddingShardingPlanner(
+                topology=topology,
+                batch_size=self.batch_size,
+                constraints=constraints if constraints else None,
+                storage_reservation=storage_reservation,
+            )
+        elif self.planner_type == "lp":
+            return LinearProgrammingPlanner(
                 topology=topology,
                 batch_size=self.batch_size,
                 constraints=constraints if constraints else None,
@@ -357,12 +366,7 @@ class ShardingConfig:
         self,
         model: nn.Module,
         pg: dist.ProcessGroup,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[List[ModuleSharder[nn.Module]], Optional[ShardingPlan]]:
         """
         Convert fused params, create sharders, and run the planner.
@@ -376,7 +380,7 @@ class ShardingConfig:
         plan = None
         if planner is not None:
             if pg is not None:
-                plan = planner.collective_plan(model, sharders, pg)
+                plan = planner.collective_plan(model, sharders, pg)  # pyre-ignore[28]
             else:
                 # pyrefly: ignore[bad-argument-type, missing-argument]
                 plan = planner.plan(model, sharders)
@@ -388,12 +392,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> DistributedModelParallel:
         """
         Generate a standard DistributedModelParallel model.
@@ -416,12 +415,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> HybridEvalDMP:
         """
         Generate a HybridEvalDMP model for split-device placement.
@@ -486,12 +480,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[nn.Module, Optimizer]:
         """
         Generate a sharded model and optimizer for distributed training.


### PR DESCRIPTION
Summary: Add `planner_type: "lp"` support to `PlannerConfig.generate_planner()` so we can E2E verify LP planner logging in `training_optimization_events` Scuba table.

Differential Revision: D97776591


