### PR TITLE
feat: add storage_reservation event to training optimization logger

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -95,11 +95,13 @@ except Exception:
 
 try:
     from torchrec.fb.distributed.training_optimization_logger import (
+        log_offloading_summary,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
     )
 except ImportError:
+    log_offloading_summary = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -744,6 +746,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
             except Exception:
                 logger.debug("Failed to log planning_result", exc_info=True)
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import (
@@ -90,6 +91,18 @@ except Exception:
             return func
 
         return decorator
+
+
+try:
+    from torchrec.fb.distributed.training_optimization_logger import (
+        OptimizationTechnique,
+        StackLayer,
+        TrainingOptimizationLogger,
+    )
+except ImportError:
+    OptimizationTechnique = None  # pyre-ignore[9]
+    StackLayer = None  # pyre-ignore[9]
+    TrainingOptimizationLogger = None  # pyre-ignore[9]
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -715,6 +728,23 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            try:
+                TrainingOptimizationLogger.log(
+                    layer=StackLayer.TORCHREC,
+                    event_name="planning_result",
+                    event_type=EventType.SUCCESS,
+                    technique=OptimizationTechnique.EMO,
+                    metadata={
+                        "planner_type": self.__class__.__name__,
+                        "num_proposals": str(self._num_proposals),
+                        "num_plans": str(self._num_plans),
+                        "duration_s": str(round(end_time - start_time, 3)),
+                    },
+                )
+            except Exception:
+                logger.debug("Failed to log planning_result", exc_info=True)
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -773,6 +803,23 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            try:
+                TrainingOptimizationLogger.log(
+                    layer=StackLayer.TORCHREC,
+                    event_name="planning_result",
+                    event_type=EventType.FAILURE,
+                    technique=OptimizationTechnique.EMO,
+                    metadata={
+                        "planner_type": self.__class__.__name__,
+                        "num_proposals": str(self._num_proposals),
+                        "num_plans": str(self._num_plans),
+                        "duration_s": str(round(end_time - start_time, 3)),
+                    },
+                    error_message=str(last_planner_error),
+                )
+            except Exception:
+                logger.debug("Failed to log planning_result", exc_info=True)
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,12 +96,14 @@ except Exception:
 try:
     from torchrec.fb.distributed.training_optimization_logger import (
         log_offloading_summary,
+        log_storage_reservation,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
     )
 except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
+    log_storage_reservation = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -586,6 +588,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             storage_policy=storage_policy,
             storage_percentage=storage_percentage,
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
+        )
+
+        dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
+        kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
+        log_storage_reservation(
+            reservation_type=storage_policy,
+            percentage=storage_percentage,
+            dense_hbm_bytes=dense_storage.hbm if dense_storage else None,
+            kjt_hbm_bytes=kjt_storage.hbm if kjt_storage else None,
+            original_hbm_per_rank=self._topology.devices[0].storage.hbm,
+            available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
+            planner_type=self.__class__.__name__,
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -36,8 +36,10 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingEnv,
     ShardingPlan,
+    ShardingPlanner,
     ShardingType,
 )
+from torchrec.fb.distributed.planner.lp_planner import LinearProgrammingPlanner
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -200,7 +202,7 @@ class PlannerConfig:
     def generate_planner(
         self,
         tables: List[EmbeddingBagConfig],
-    ) -> Union[EmbeddingShardingPlanner, HeteroEmbeddingShardingPlanner]:
+    ) -> ShardingPlanner:
         """
         Generate an embedding sharding planner based on the specified configuration.
 
@@ -235,6 +237,13 @@ class PlannerConfig:
 
         if self.planner_type == "embedding":
             return EmbeddingShardingPlanner(
+                topology=topology,
+                batch_size=self.batch_size,
+                constraints=constraints if constraints else None,
+                storage_reservation=storage_reservation,
+            )
+        elif self.planner_type == "lp":
+            return LinearProgrammingPlanner(
                 topology=topology,
                 batch_size=self.batch_size,
                 constraints=constraints if constraints else None,
@@ -357,12 +366,7 @@ class ShardingConfig:
         self,
         model: nn.Module,
         pg: dist.ProcessGroup,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[List[ModuleSharder[nn.Module]], Optional[ShardingPlan]]:
         """
         Convert fused params, create sharders, and run the planner.
@@ -376,7 +380,7 @@ class ShardingConfig:
         plan = None
         if planner is not None:
             if pg is not None:
-                plan = planner.collective_plan(model, sharders, pg)
+                plan = planner.collective_plan(model, sharders, pg)  # pyre-ignore[28]
             else:
                 # pyrefly: ignore[bad-argument-type, missing-argument]
                 plan = planner.plan(model, sharders)
@@ -388,12 +392,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> DistributedModelParallel:
         """
         Generate a standard DistributedModelParallel model.
@@ -416,12 +415,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> HybridEvalDMP:
         """
         Generate a HybridEvalDMP model for split-device placement.
@@ -486,12 +480,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[nn.Module, Optimizer]:
         """
         Generate a sharded model and optimizer for distributed training.


### PR DESCRIPTION
Summary: Log storage reservation breakdown (percentage, dense/KJT bytes, original/available HBM per rank) after reserve() in both OSS and LP planners via shared `log_storage_reservation()` helper.

Differential Revision: D97807909


