### PR TITLE
feat: add per-proposer proposer_result event and winning_proposer to planning_result

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -619,9 +619,18 @@ def group_tables(
     assert all(table_weightedness) or not any(table_weightedness)
 
     grouped_embedding_configs_by_rank: List[List[GroupedEmbeddingConfig]] = []
-    for tables in tables_per_rank:
+    for rank, tables in enumerate(tables_per_rank):
         grouped_embedding_configs = _group_tables_per_rank(tables)
         grouped_embedding_configs_by_rank.append(grouped_embedding_configs)
+        if rank == 0 and grouped_embedding_configs:
+            try:
+                from torchrec.fb.distributed.training_optimization_logger import (
+                    log_tbe_composition,
+                )
+
+                log_tbe_composition(grouped_embedding_configs, rank)
+            except ImportError:
+                pass
 
     return grouped_embedding_configs_by_rank
 

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -97,6 +97,7 @@ try:
     from torchrec.fb.distributed.training_optimization_logger import (
         log_offloading_summary,
         log_planner_config,
+        log_proposer_result,
         log_search_space_summary,
         log_storage_reservation,
         log_table_assignment,
@@ -108,6 +109,7 @@ try:
 except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
     log_planner_config = None  # pyre-ignore[9]
+    log_proposer_result = None  # pyre-ignore[9]
     log_search_space_summary = None  # pyre-ignore[9]
     log_storage_reservation = None  # pyre-ignore[9]
     log_table_assignment = None  # pyre-ignore[9]
@@ -654,6 +656,9 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     loaded_sharding_options=loaded_sharding_options,
                 )
 
+        winning_proposer_name: str = ""
+        winning_proposer_idx: int = -1
+
         # Loaded plan is validated successfully and can be used for generate the sharding plan, skipping new plan generation.
         if loaded_best_plan:
             logger.info(
@@ -671,7 +676,10 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 proposer.load(search_space=search_space, enumerator=self._enumerator)
 
             start = time.time()
-            for proposer in self._proposers:
+            for proposer_idx, proposer in enumerate(self._proposers):
+                proposer_proposals = 0
+                proposer_plans = 0
+                proposer_best_rating: Optional[float] = None
                 proposal = proposer.propose()
 
                 while proposal:
@@ -696,6 +704,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                         continue
 
                     self._num_proposals += 1
+                    proposer_proposals += 1
                     try:
                         # plan is just proposal where shard.rank is populated
                         plan = self._partitioner.partition(
@@ -703,10 +712,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                             storage_constraint=storage_constraint,
                         )
                         self._num_plans += 1
+                        proposer_plans += 1
                         perf_rating = self._perf_model.rate(plan=plan)
+                        if (
+                            proposer_best_rating is None
+                            or perf_rating < proposer_best_rating
+                        ):
+                            proposer_best_rating = perf_rating
                         if perf_rating < best_perf_rating:
                             best_perf_rating = perf_rating
                             best_plan = copy.deepcopy(plan)
+                            winning_proposer_name = proposer.__class__.__name__
+                            winning_proposer_idx = proposer_idx
                         proposal_cache[proposal_key] = (True, plan, perf_rating)
                         proposer.feedback(
                             partitionable=True,
@@ -741,6 +758,16 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     # clear shard.rank for each sharding_option
                     reset_shard_rank(proposal)
                     proposal = proposer.propose()
+
+                log_proposer_result(
+                    planner_type=self.__class__.__name__,
+                    proposer_name=proposer.__class__.__name__,
+                    proposer_index=proposer_idx,
+                    num_proposals=proposer_proposals,
+                    num_plans=proposer_plans,
+                    best_perf_rating=proposer_best_rating,
+                    is_winning_proposer=(winning_proposer_idx == proposer_idx),
+                )
 
         if best_plan:
             for callback in self._callbacks:
@@ -783,6 +810,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                         "num_proposals": str(self._num_proposals),
                         "num_plans": str(self._num_plans),
                         "duration_s": str(round(end_time - start_time, 3)),
+                        "winning_proposer": winning_proposer_name,
                     },
                 )
             except Exception:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -97,6 +97,7 @@ try:
     from torchrec.fb.distributed.training_optimization_logger import (
         log_offloading_summary,
         log_planner_config,
+        log_search_space_summary,
         log_storage_reservation,
         log_table_assignment,
         log_table_constraints,
@@ -107,6 +108,7 @@ try:
 except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
     log_planner_config = None  # pyre-ignore[9]
+    log_search_space_summary = None  # pyre-ignore[9]
     log_storage_reservation = None  # pyre-ignore[9]
     log_table_assignment = None  # pyre-ignore[9]
     log_table_constraints = None  # pyre-ignore[9]
@@ -632,6 +634,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         if not search_space:
             # No shardable parameters
             return ShardingPlan({})
+
+        log_search_space_summary(search_space, self.__class__.__name__)
 
         loaded_sharding_options = None
         loaded_best_plan: List[ShardingOption] = []

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -95,11 +95,13 @@ except Exception:
 
 try:
     from torchrec.fb.distributed.training_optimization_logger import (
+        log_offloading_summary,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
     )
 except ImportError:
+    log_offloading_summary = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -744,6 +746,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
             except Exception:
                 logger.debug("Failed to log planning_result", exc_info=True)
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -98,6 +98,7 @@ try:
         log_offloading_summary,
         log_planner_config,
         log_storage_reservation,
+        log_table_assignment,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
@@ -106,6 +107,7 @@ except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
     log_planner_config = None  # pyre-ignore[9]
     log_storage_reservation = None  # pyre-ignore[9]
+    log_table_assignment = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -779,6 +781,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 logger.debug("Failed to log planning_result", exc_info=True)
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.partitioners import (
@@ -90,6 +91,18 @@ except Exception:
             return func
 
         return decorator
+
+
+try:
+    from torchrec.fb.distributed.training_optimization_logger import (
+        OptimizationTechnique,
+        StackLayer,
+        TrainingOptimizationLogger,
+    )
+except ImportError:
+    OptimizationTechnique = None  # pyre-ignore[9]
+    StackLayer = None  # pyre-ignore[9]
+    TrainingOptimizationLogger = None  # pyre-ignore[9]
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -715,6 +728,23 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            try:
+                TrainingOptimizationLogger.log(
+                    layer=StackLayer.TORCHREC,
+                    event_name="planning_result",
+                    event_type=EventType.SUCCESS,
+                    technique=OptimizationTechnique.EMO,
+                    metadata={
+                        "planner_type": self.__class__.__name__,
+                        "num_proposals": str(self._num_proposals),
+                        "num_plans": str(self._num_plans),
+                        "duration_s": str(round(end_time - start_time, 3)),
+                    },
+                )
+            except Exception:
+                logger.debug("Failed to log planning_result", exc_info=True)
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -773,6 +803,23 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            try:
+                TrainingOptimizationLogger.log(
+                    layer=StackLayer.TORCHREC,
+                    event_name="planning_result",
+                    event_type=EventType.FAILURE,
+                    technique=OptimizationTechnique.EMO,
+                    metadata={
+                        "planner_type": self.__class__.__name__,
+                        "num_proposals": str(self._num_proposals),
+                        "num_plans": str(self._num_plans),
+                        "duration_s": str(round(end_time - start_time, 3)),
+                    },
+                    error_message=str(last_planner_error),
+                )
+            except Exception:
+                logger.debug("Failed to log planning_result", exc_info=True)
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,12 +96,14 @@ except Exception:
 try:
     from torchrec.fb.distributed.training_optimization_logger import (
         log_offloading_summary,
+        log_storage_reservation,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
     )
 except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
+    log_storage_reservation = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -586,6 +588,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             storage_policy=storage_policy,
             storage_percentage=storage_percentage,
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
+        )
+
+        dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
+        kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
+        log_storage_reservation(
+            reservation_type=storage_policy,
+            percentage=storage_percentage,
+            dense_hbm_bytes=dense_storage.hbm if dense_storage else None,
+            kjt_hbm_bytes=kjt_storage.hbm if kjt_storage else None,
+            original_hbm_per_rank=self._topology.devices[0].storage.hbm,
+            available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
+            planner_type=self.__class__.__name__,
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -99,6 +99,7 @@ try:
         log_planner_config,
         log_storage_reservation,
         log_table_assignment,
+        log_table_constraints,
         OptimizationTechnique,
         StackLayer,
         TrainingOptimizationLogger,
@@ -108,6 +109,7 @@ except ImportError:
     log_planner_config = None  # pyre-ignore[9]
     log_storage_reservation = None  # pyre-ignore[9]
     log_table_assignment = None  # pyre-ignore[9]
+    log_table_constraints = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
     TrainingOptimizationLogger = None  # pyre-ignore[9]
@@ -620,6 +622,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 ),
             }
         )
+        if self._constraints:
+            log_table_constraints(self._constraints, self.__class__.__name__)
 
         search_space = self._enumerator.enumerate(
             module=module,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,6 +96,7 @@ except Exception:
 try:
     from torchrec.fb.distributed.training_optimization_logger import (
         log_offloading_summary,
+        log_planner_config,
         log_storage_reservation,
         OptimizationTechnique,
         StackLayer,
@@ -103,6 +104,7 @@ try:
     )
 except ImportError:
     log_offloading_summary = None  # pyre-ignore[9]
+    log_planner_config = None  # pyre-ignore[9]
     log_storage_reservation = None  # pyre-ignore[9]
     OptimizationTechnique = None  # pyre-ignore[9]
     StackLayer = None  # pyre-ignore[9]
@@ -600,6 +602,21 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             original_hbm_per_rank=self._topology.devices[0].storage.hbm,
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
+        )
+
+        log_planner_config(
+            {
+                "planner_type": self.__class__.__name__,
+                "proposers": ",".join(p.__class__.__name__ for p in self._proposers),
+                "partitioner": self._partitioner.__class__.__name__,
+                "perf_model": self._perf_model.__class__.__name__,
+                "timeout_s": (
+                    str(self._timeout_seconds) if self._timeout_seconds else "none"
+                ),
+                "num_table_constraints": (
+                    str(len(self._constraints)) if self._constraints else "0"
+                ),
+            }
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -36,8 +36,10 @@ from torchrec.distributed.types import (
     ModuleSharder,
     ShardingEnv,
     ShardingPlan,
+    ShardingPlanner,
     ShardingType,
 )
+from torchrec.fb.distributed.planner.lp_planner import LinearProgrammingPlanner
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -200,7 +202,7 @@ class PlannerConfig:
     def generate_planner(
         self,
         tables: List[EmbeddingBagConfig],
-    ) -> Union[EmbeddingShardingPlanner, HeteroEmbeddingShardingPlanner]:
+    ) -> ShardingPlanner:
         """
         Generate an embedding sharding planner based on the specified configuration.
 
@@ -235,6 +237,13 @@ class PlannerConfig:
 
         if self.planner_type == "embedding":
             return EmbeddingShardingPlanner(
+                topology=topology,
+                batch_size=self.batch_size,
+                constraints=constraints if constraints else None,
+                storage_reservation=storage_reservation,
+            )
+        elif self.planner_type == "lp":
+            return LinearProgrammingPlanner(
                 topology=topology,
                 batch_size=self.batch_size,
                 constraints=constraints if constraints else None,
@@ -357,12 +366,7 @@ class ShardingConfig:
         self,
         model: nn.Module,
         pg: dist.ProcessGroup,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[List[ModuleSharder[nn.Module]], Optional[ShardingPlan]]:
         """
         Convert fused params, create sharders, and run the planner.
@@ -376,7 +380,7 @@ class ShardingConfig:
         plan = None
         if planner is not None:
             if pg is not None:
-                plan = planner.collective_plan(model, sharders, pg)
+                plan = planner.collective_plan(model, sharders, pg)  # pyre-ignore[28]
             else:
                 # pyrefly: ignore[bad-argument-type, missing-argument]
                 plan = planner.plan(model, sharders)
@@ -388,12 +392,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> DistributedModelParallel:
         """
         Generate a standard DistributedModelParallel model.
@@ -416,12 +415,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> HybridEvalDMP:
         """
         Generate a HybridEvalDMP model for split-device placement.
@@ -486,12 +480,7 @@ class ShardingConfig:
         model: nn.Module,
         pg: dist.ProcessGroup,
         device: torch.device,
-        planner: Optional[
-            Union[
-                EmbeddingShardingPlanner,
-                HeteroEmbeddingShardingPlanner,
-            ]
-        ] = None,
+        planner: Optional[ShardingPlanner] = None,
     ) -> Tuple[nn.Module, Optimizer]:
         """
         Generate a sharded model and optimizer for distributed training.


### PR DESCRIPTION
Summary: Log per-proposer stats (proposals, plans, best perf rating, is_winning) after each proposer exhausts in the OSS planner loop. Also adds winning_proposer to the planning_result event.

Differential Revision: D98067922


