### PR TITLE
Fix EADDRINUSE TOCTOU race in run_multi_process_func

### DIFF
--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -242,7 +242,8 @@ def run_multi_process_func(
 ) -> List[Any]:
     """ """
     os.environ["MASTER_ADDR"] = str("localhost")
-    os.environ["MASTER_PORT"] = str(get_free_port())
+    if "MASTER_PORT" not in os.environ:
+        os.environ["MASTER_PORT"] = str(get_free_port())
     os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
     os.environ["NCCL_SOCKET_IFNAME"] = "lo"
 


### PR DESCRIPTION
Summary:
`run_multi_process_func` unconditionally overwrites `MASTER_PORT` with
`get_free_port()`, which has a TOCTOU race: the socket is closed after
recording the port, allowing another process (e.g. MetricsServer
ThriftServers) to grab it before `TCPStore` can bind.

Respect a pre-set `MASTER_PORT` env var so callers can reserve a port
themselves and avoid the race window.

Differential Revision: D98794727


