### PR TITLE
feat: add per-table stats_match event to training optimization logger (#3985)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -202,4 +202,13 @@ class TrainingOptimizationLogger(EventLoggingHandler):
         yield
 
 
+def log_planning_result(
+    planner_type: str,
+    error_message: Optional[str] = None,
+    **extra_metadata: str,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -12,7 +12,13 @@ from collections import defaultdict
 from enum import Enum
 from typing import Any, Callable, Dict, Generator, Optional, TypeVar
 
-from torchrec.distributed.logging_utils import EventLoggingHandlerBase, EventType
+from torchrec.distributed.logging_utils import (
+    EventLoggingHandlerBase,
+    EventScope,
+    EventType,
+    OptimizationTechnique,
+    StackLayer,
+)
 
 
 __all__: list[str] = []
@@ -156,6 +162,40 @@ class EventLoggingHandler(EventLoggingHandlerBase):
         component: str,
         event_name: str,
         n: int = 1,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+    ) -> Generator[None, None, None]:
+        yield
+
+
+class TrainingOptimizationLogger(EventLoggingHandler):
+    """No-op training optimization logger for open-source builds."""
+
+    @classmethod
+    def log(
+        cls,
+        layer: StackLayer,
+        event_name: str,
+        event_type: EventType,
+        technique: OptimizationTechnique,
+        component: TorchrecComponent,
+        event_scope: EventScope,
+        metadata: Optional[Dict[str, str]] = None,
+        add_wait_counter: bool = False,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None:
+        pass
+
+    @classmethod
+    @contextlib.contextmanager
+    def log_context(
+        cls,
+        layer: StackLayer,
+        event_name: str,
+        technique: OptimizationTechnique,
+        component: TorchrecComponent,
+        event_scope: EventScope,
         metadata: Optional[Dict[str, str]] = None,
         add_wait_counter: bool = False,
     ) -> Generator[None, None, None]:

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -10,7 +10,7 @@ import functools
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, Optional, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import (
     EventLoggingHandlerBase,
@@ -207,6 +207,11 @@ def log_planning_result(
     error_message: Optional[str] = None,
     **extra_metadata: str,
 ) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_offloading_summary(best_plan: List, planner_type: str) -> None:  # type: ignore[type-arg]
     """No-op OSS stub."""
     pass
 

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -229,4 +229,9 @@ def log_storage_reservation(
     pass
 
 
+def log_planner_config(metadata: Optional[Dict[str, str]] = None) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -234,4 +234,26 @@ def log_planner_config(metadata: Optional[Dict[str, str]] = None) -> None:
     pass
 
 
+def log_stats_match(
+    table_name: str = "",
+    table_height: int = 0,
+    match_level: str = "",
+    min_working_set: int = 0,
+    recommended_cache_rows: int = 0,
+    global_batch_size: int = 0,
+    matched_height: Optional[int] = None,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_clf_computed(
+    table_name: str = "",
+    table_height: int = 0,
+    clf: float = 0.0,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -216,4 +216,17 @@ def log_offloading_summary(best_plan: List, planner_type: str) -> None:  # type:
     pass
 
 
+def log_storage_reservation(
+    reservation_type: str,
+    percentage: Optional[float] = None,
+    dense_hbm_bytes: Optional[int] = None,
+    kjt_hbm_bytes: Optional[int] = None,
+    original_hbm_per_rank: int = 0,
+    available_hbm_per_rank: int = 0,
+    planner_type: str = "",
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -23,6 +23,35 @@ class EventType(Enum):
     INFO = "INFO"
 
 
+@unique
+class StackLayer(Enum):
+    """Layer in the training stack where the event originates."""
+
+    TORCHREC = "torchrec"
+    FBGEMM = "fbgemm"
+    FRAMEWORK = "framework"
+    DPP = "dpp"
+
+
+@unique
+class OptimizationTechnique(Enum):
+    """Training optimization techniques."""
+
+    EMO = "emo"
+    ITEP = "itep"
+    ALBT = "albt"
+    SSD_OFFLOADING = "ssd_offloading"
+
+
+@unique
+class EventScope(Enum):
+    """Scope of the logged event."""
+
+    JOB = "job"
+    TABLE = "table"
+    TBE = "tbe"
+
+
 class EventLoggingHandlerBase(abc.ABC):
     """Abstract base class for event logging handlers.
 

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -95,6 +95,7 @@ except Exception:
 
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
+    log_planner_config,
     log_planning_result,
     log_storage_reservation,
 )
@@ -594,6 +595,21 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             original_hbm_per_rank=self._topology.devices[0].storage.hbm,
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
+        )
+
+        log_planner_config(
+            {
+                "planner_type": self.__class__.__name__,
+                "proposers": ",".join(p.__class__.__name__ for p in self._proposers),
+                "partitioner": self._partitioner.__class__.__name__,
+                "perf_model": self._perf_model.__class__.__name__,
+                "timeout_s": (
+                    str(self._timeout_seconds) if self._timeout_seconds else "none"
+                ),
+                "num_table_constraints": (
+                    str(len(self._constraints)) if self._constraints else "0"
+                ),
+            }
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,6 +96,7 @@ except Exception:
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
     log_planning_result,
+    log_storage_reservation,
 )
 
 
@@ -581,6 +582,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             storage_policy=storage_policy,
             storage_percentage=storage_percentage,
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
+        )
+
+        dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
+        kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
+        log_storage_reservation(
+            reservation_type=storage_policy,
+            percentage=storage_percentage,
+            dense_hbm_bytes=dense_storage.hbm if dense_storage else None,
+            kjt_hbm_bytes=kjt_storage.hbm if kjt_storage else None,
+            original_hbm_per_rank=self._topology.devices[0].storage.hbm,
+            available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
+            planner_type=self.__class__.__name__,
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,7 +93,10 @@ except Exception:
         return decorator
 
 
-from torchrec.distributed.logging_handlers import log_planning_result
+from torchrec.distributed.logging_handlers import (
+    log_offloading_summary,
+    log_planning_result,
+)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -728,6 +731,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),
             )
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,6 +93,9 @@ except Exception:
         return decorator
 
 
+from torchrec.distributed.logging_handlers import log_planning_result
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -719,6 +722,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -777,6 +787,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                error_message=str(last_planner_error),
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(


### PR DESCRIPTION
Summary:

Log per-table stats match results (match_status, min_working_set, recommended_cache_rows, table_height) from EmbeddingStatsUniqueAccessor in sparsenn_configs.py. First table-scoped event using event_scope=TABLE.

Differential Revision: D97949790
