### PR TITLE
Refactor backward injection API with strategy pattern

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -15,22 +15,31 @@ pass of EC (EmbeddingCollection) and EBC (EmbeddingBagCollection) modules.
 Work functions are registered at specific injection sites and executed during
 the backward all-to-all communication phase.
 
+An ``InjectionSite`` pairs a module FQN with a ``GradTensorFinder`` strategy
+that determines which tensor to attach the backward hook to. Built-in finders:
+- ``FirstGradTensorFinder``: finds the first ``requires_grad`` tensor in output/input
+- ``OutputDistTensorFinder``: extracts ``dummy_tensor`` from EBC/EC output dist awaitables
+
 Example usage:
     from torchrec.distributed.train_pipeline.backward_injection import (
-        OutputDistSite,
+        InjectionSite,
+        OutputDistTensorFinder,
     )
     from torchrec.distributed.types import ShardingType
 
     # Register hooks on the pipeline
     pipeline.register_backward_hook(
-        OutputDistSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE),
+        InjectionSite(
+            fqn="sparse_arch.ebc",
+            tensor_finder=OutputDistTensorFinder(sharding_type=ShardingType.TABLE_WISE),
+        ),
         lambda p: p._optimizer.step(),
     )
 """
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Callable, Optional, Protocol, runtime_checkable, TYPE_CHECKING
 
 import torch
 from torch import nn
@@ -53,56 +62,66 @@ logger: logging.Logger = logging.getLogger(__name__)
 BackwardHookWork = Callable[["TrainPipeline"], None]
 
 
+@runtime_checkable
+class GradTensorFinder(Protocol):
+    """
+    Strategy for locating the tensor to attach a backward hook to.
+
+    Receives the module's forward input and output, and returns the tensor
+    on which to register the backward hook. Return ``None`` if no suitable
+    tensor is found.
+    """
+
+    def __call__(
+        self, module_input: Any, module_output: Any
+    ) -> Optional[torch.Tensor]: ...
+
+
 @dataclass(frozen=True)
-class InjectionSite:
+class FirstGradTensorFinder:
     """
-    Base class for backward hook injection sites.
+    Finds the first tensor with ``requires_grad=True`` from a module's
+    forward output (or input if ``use_input=True``).
 
-    Attributes:
-        fqn: Fully qualified name of the target module (e.g., "sparse_arch.ebc")
+    Handles single tensors, tuples/lists, dicts, and nested combinations.
     """
 
-    fqn: str
-    use_output_tensor: bool = True
+    use_input: bool = False
 
-    def find_target_module(self, model: nn.Module) -> Optional[nn.Module]:
-        """
-        Finds the module matching ``self.fqn`` in the model.
-
-        Returns:
-            The matching module, or ``None`` if not found.
-        """
-        try:
-            return model.get_submodule(self.fqn)
-        except AttributeError:
-            return None
-
-    def find_grad_tensor(self, output: Any) -> Optional[torch.Tensor]:
-        """
-        Finds the first tensor with ``requires_grad=True`` from a module output.
-
-        Handles single tensors, tuples/lists, dicts, and nested combinations.
-
-        Args:
-            output: The module's forward output.
-
-        Returns:
-            The first grad-requiring tensor, or ``None`` if none found.
-        """
-        if isinstance(output, torch.Tensor):
-            if output.requires_grad:
-                return output
-        elif isinstance(output, (tuple, list)):
-            for item in output:
-                t = self.find_grad_tensor(item)
+    def _search(self, data: Any) -> Optional[torch.Tensor]:
+        if isinstance(data, torch.Tensor):
+            if data.requires_grad:
+                return data
+        elif isinstance(data, (tuple, list)):
+            for item in data:
+                t = self._search(item)
                 if t is not None:
                     return t
-        elif isinstance(output, dict):
-            for v in output.values():
-                t = self.find_grad_tensor(v)
+        elif isinstance(data, dict):
+            for v in data.values():
+                t = self._search(v)
                 if t is not None:
                     return t
         return None
+
+    def __call__(self, module_input: Any, module_output: Any) -> Optional[torch.Tensor]:
+        data = module_input if self.use_input else module_output
+        return self._search(data)
+
+
+@dataclass(frozen=True)
+class InjectionSite:
+    """
+    Backward hook injection site = module FQN + tensor finding strategy.
+
+    Attributes:
+        fqn: Fully qualified name of the target module (e.g., "sparse_arch.ebc")
+        tensor_finder: Strategy for locating the tensor to attach the backward
+            hook to. Must conform to the ``GradTensorFinder`` protocol.
+    """
+
+    fqn: str
+    tensor_finder: GradTensorFinder
 
 
 def register_backward_hook(
@@ -130,8 +149,9 @@ def register_backward_hook(
         RuntimeError: If no grad-requiring tensor is found in the
             module's output during forward.
     """
-    target = site.find_target_module(model)
-    if target is None:
+    try:
+        target = model.get_submodule(site.fqn)
+    except AttributeError:
         raise ValueError(
             f"register_backward_hook: module '{site.fqn}' not found in model."
         )
@@ -141,10 +161,7 @@ def register_backward_hook(
         input: Any,
         output: Any,
     ) -> None:
-        if site.use_output_tensor:
-            tensor = site.find_grad_tensor(output)
-        else:
-            tensor = site.find_grad_tensor(input)
+        tensor = site.tensor_finder(input, output)
         if tensor is None:
             raise RuntimeError(
                 f"register_hook: no grad-requiring tensor in "
@@ -156,37 +173,23 @@ def register_backward_hook(
 
 
 @dataclass(frozen=True)
-class OutputDistSite(InjectionSite):
+class OutputDistTensorFinder:
     """
-    Injection site for hooking during backward all-to-all on output dist tensors.
+    Extracts the ``dummy_tensor`` from an EC/EBC output dist awaitable
+    matching the given sharding type.
 
-    Targets the ``dummy_tensor`` of the EC/EBC output dist awaitable matching
-    the given module FQN and sharding type.
+    For pipelined modules, the forward output is an EC/EBC awaitable.
+    This finder extracts the per-sharding awaitable matching
+    ``self.sharding_type`` and returns its ``dummy_tensor``.
 
     Attributes:
-        fqn: Fully qualified name of the EC/EBC module (e.g., "sparse_arch.ebc")
         sharding_type: The sharding type to target (e.g., ShardingType.TABLE_WISE)
     """
 
     sharding_type: ShardingType = ShardingType.TABLE_WISE
 
-    def find_grad_tensor(self, output: Any) -> Optional[torch.Tensor]:
-        """
-        Finds the dummy tensor from the output dist awaitable matching
-        this site's sharding type.
-
-        For pipelined modules, the forward output is an EC/EBC awaitable.
-        This method extracts the per-sharding awaitable matching
-        ``self.sharding_type`` and returns its ``dummy_tensor``.
-
-        Args:
-            output: The pipelined module's forward output (an EC/EBC awaitable,
-                possibly MC tuple-wrapped).
-
-        Returns:
-            The dummy tensor for the matching sharding type, or ``None`` if
-            not found.
-        """
+    def __call__(self, module_input: Any, module_output: Any) -> Optional[torch.Tensor]:
+        output = module_output
 
         # Handle MC EC/EBC tuple wrapping
         if isinstance(output, tuple):
@@ -218,7 +221,7 @@ class OutputDistSite(InjectionSite):
         ):
             if isinstance(w, NoWait):
                 continue
-            # pyrefly: ignore[unsupported-operation]
+
             if ShardingType(st) == self.sharding_type:
                 tensor_awaitable = getattr(w, "_tensor_awaitable", None)
                 if isinstance(tensor_awaitable, Request):
@@ -226,6 +229,5 @@ class OutputDistSite(InjectionSite):
                 return None
 
         raise RuntimeError(
-            f"Could not find awaitable for module {self.fqn} "
-            f"with sharding type: {self.sharding_type}"
+            f"Could not find awaitable for sharding type: {self.sharding_type}"
         )

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -28,8 +28,9 @@ from torch.autograd.profiler import record_function
 from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.train_pipeline.backward_injection import (
+    FirstGradTensorFinder,
     InjectionSite,
-    OutputDistSite,
+    OutputDistTensorFinder,
 )
 from torchrec.distributed.train_pipeline.pipeline_context import (
     CPUEmbeddingTrainPipelineContext,
@@ -776,7 +777,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
 class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
     """
     Extends TrainPipelineSparseDist by moving the optimizer step into the backward
-    pass via OutputDistSite backward hook injection. This overlaps the optimizer
+    pass via OutputDistTensorFinder backward hook injection. This overlaps the optimizer
     computation with backward all-to-all communication, improving training throughput.
 
     The explicit optimizer.step() in progress() is removed; instead, the optimizer
@@ -816,8 +817,9 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
         )
-        self._output_dist_site = OutputDistSite(
-            fqn=site_fqn, sharding_type=sharding_type
+        self._output_dist_site = InjectionSite(
+            fqn=site_fqn,
+            tensor_finder=OutputDistTensorFinder(sharding_type=sharding_type),
         )
 
     def _pipeline_model(
@@ -913,11 +915,11 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
     This frees HBM occupied by optimizer state (e.g. Shampoo's Kronecker
     factors) between optimizer steps, making it available for forward/backward
     computation. The restore is triggered during the backward pass at the
-    specified OutputDistSite, overlapping the CPU->GPU transfer with backward
+    specified OutputDistTensorFinder site, overlapping the CPU->GPU transfer with backward
     all-to-all communication.
 
     Timeline per iteration:
-        forward -> backward [ restore_optimizer_state at OutputDistSite ] ->
+        forward -> backward [ restore_optimizer_state at output dist site ] ->
         optimizer.step() -> stash_optimizer_state
     """
 
@@ -954,8 +956,9 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
         )
-        self._output_dist_site = OutputDistSite(
-            fqn=site_fqn, sharding_type=sharding_type
+        self._output_dist_site = InjectionSite(
+            fqn=site_fqn,
+            tensor_finder=OutputDistTensorFinder(sharding_type=sharding_type),
         )
         # Set up shared CUDA streams for memory stashing
         MemoryStashingManager.set_streams(
@@ -1106,7 +1109,9 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
             free_features_storage_early=free_features_storage_early,
         )
         if isinstance(site_fqn, str):
-            self._injection_site = InjectionSite(fqn=site_fqn)
+            self._injection_site = InjectionSite(
+                fqn=site_fqn, tensor_finder=FirstGradTensorFinder()
+            )
         else:
             self._injection_site = site_fqn
 

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -7,20 +7,32 @@
 
 # pyre-strict
 
+import copy
 import unittest
-from typing import Any, List
-from unittest.mock import MagicMock
+from typing import cast, List, Optional, Tuple
 
 import torch
+from hypothesis import given, settings, strategies as st
 from torch import nn
-from torchrec.distributed.comm_ops import Request
-from torchrec.distributed.embeddingbag import EmbeddingBagCollectionAwaitable
+from torchrec.distributed import DistributedModelParallel
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.emb_sharder import TestEBCSharder
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
 from torchrec.distributed.train_pipeline.backward_injection import (
+    FirstGradTensorFinder,
     InjectionSite,
-    OutputDistSite,
+    OutputDistTensorFinder,
     register_backward_hook,
 )
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+tc = unittest.TestCase()
+tc.maxDiff = None
 
 
 class SimpleModel(nn.Module):
@@ -39,31 +51,32 @@ class SimpleModel(nn.Module):
 
 
 class InjectionSiteTest(unittest.TestCase):
-    """Unit tests for InjectionSite (no GPU/distributed required)."""
+    """Unit tests for InjectionSite and FirstGradTensorFinder (no GPU/distributed required)."""
 
-    def test_find_target_module(self) -> None:
-        model = SimpleModel()
-        self.assertIs(
-            InjectionSite(fqn="layer_a").find_target_module(model), model.layer_a
-        )
-        self.assertIsNone(InjectionSite(fqn="nonexistent").find_target_module(model))
-
-    def test_find_grad_tensor_nested(self) -> None:
-        site = InjectionSite(fqn="")
+    def test_first_grad_tensor_finder_nested(self) -> None:
+        finder = FirstGradTensorFinder()
         grad = torch.tensor([1.0], requires_grad=True)
         nested = (torch.tensor([0.0]), {"k": [torch.tensor([0.0]), grad]})
-        self.assertIs(site.find_grad_tensor(nested), grad)
-        self.assertIsNone(site.find_grad_tensor(torch.tensor([1.0])))
+        self.assertIs(finder(None, nested), grad)
+        self.assertIsNone(finder(None, torch.tensor([1.0])))
+
+    def test_first_grad_tensor_finder_use_input(self) -> None:
+        finder = FirstGradTensorFinder(use_input=True)
+        grad = torch.tensor([1.0], requires_grad=True)
+        self.assertIs(finder(grad, torch.tensor([0.0])), grad)
+        self.assertIsNone(finder(torch.tensor([0.0]), grad))
 
     def test_register_hook_nonexistent_raises(self) -> None:
-        site = InjectionSite(fqn="nonexistent.module")
+        site = InjectionSite(
+            fqn="nonexistent.module", tensor_finder=FirstGradTensorFinder()
+        )
         with self.assertRaises(ValueError):
             register_backward_hook(site, SimpleModel(), lambda grad: None)
 
     def test_register_hook_persists_and_removable(self) -> None:
         """Hook fires every iteration; removing it stops firing."""
         model = SimpleModel()
-        site = InjectionSite(fqn="layer_a")
+        site = InjectionSite(fqn="layer_a", tensor_finder=FirstGradTensorFinder())
         call_count: List[int] = [0]
 
         handle = register_backward_hook(
@@ -83,83 +96,274 @@ class InjectionSiteTest(unittest.TestCase):
         self.assertEqual(call_count[0], 3)
 
 
-def _make_request_with_dummy_tensor() -> Request:
-    """Create a mock Request with a dummy_tensor that requires grad."""
-    req = MagicMock(spec=Request)
-    req.dummy_tensor = torch.tensor([1.0], requires_grad=True)
-    return req
+def _create_sharded_model(
+    ctx: MultiProcessContext,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    sharding_type: str,
+) -> DistributedModelParallel:
+    sharder = TestEBCSharder(
+        sharding_type=sharding_type,
+        kernel_type=EmbeddingComputeKernel.FUSED.value,
+    )
+    model = TestSparseNN(
+        tables=tables,
+        weighted_tables=weighted_tables,
+        dense_device=ctx.device,
+        sparse_device=torch.device("meta"),
+    )
+    assert ctx.pg is not None
+    return DistributedModelParallel(
+        module=copy.deepcopy(model),
+        env=ShardingEnv.from_process_group(ctx.pg),
+        init_data_parallel=False,
+        device=ctx.device,
+        sharders=[cast(ModuleSharder[nn.Module], sharder)],
+    )
 
 
-def _make_ebc_awaitable(
-    sharding_types: List[str],
-    awaitables: List[Any] | None = None,
-) -> EmbeddingBagCollectionAwaitable:
-    """Create a mock EBC awaitable with given sharding types."""
-    mock = MagicMock(spec=EmbeddingBagCollectionAwaitable)
-    mock._sharding_types = sharding_types
-    if awaitables is None:
-        awaitables = []
-        for _ in sharding_types:
-            w = MagicMock()
-            w._tensor_awaitable = _make_request_with_dummy_tensor()
-            awaitables.append(w)
-    mock._awaitables = awaitables
-    return mock
+def _run_output_dist_backward_hook_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[Tuple[ModelInput, List[ModelInput]]],
+    sharding_type: str,
+    backend: str = "nccl",
+    local_size: Optional[int] = None,
+) -> None:
+    """register_backward_hook with OutputDistTensorFinder fires during backward."""
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        dmp = _create_sharded_model(ctx, tables, weighted_tables, sharding_type)
 
-
-class OutputDistSiteTest(unittest.TestCase):
-    """Unit tests for OutputDistSite.find_grad_tensor."""
-
-    def test_ebc_awaitable(self) -> None:
-        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
-        result = site.find_grad_tensor(
-            _make_ebc_awaitable([ShardingType.TABLE_WISE.value])
+        call_count: List[int] = [0]
+        site = InjectionSite(
+            fqn="sparse.ebc",
+            tensor_finder=OutputDistTensorFinder(
+                sharding_type=ShardingType(sharding_type)
+            ),
         )
-        self.assertIsNotNone(result)
-        self.assertTrue(result.requires_grad)
-
-    def test_selects_correct_sharding_type(self) -> None:
-        """With multiple sharding types, returns tensor for the matching one."""
-        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.COLUMN_WISE)
-
-        tw_req = _make_request_with_dummy_tensor()
-        cw_req = _make_request_with_dummy_tensor()
-
-        tw_awaitable = MagicMock()
-        tw_awaitable._tensor_awaitable = tw_req
-        cw_awaitable = MagicMock()
-        cw_awaitable._tensor_awaitable = cw_req
-
-        ebc = _make_ebc_awaitable(
-            [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value],
-            [tw_awaitable, cw_awaitable],
+        register_backward_hook(
+            site,
+            dmp.module,
+            lambda grad: call_count.__setitem__(0, call_count[0] + 1),
         )
-        self.assertIs(site.find_grad_tensor(ebc), cw_req.dummy_tensor)
 
-    def test_sharding_type_mismatch_raises(self) -> None:
-        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.COLUMN_WISE)
-        with self.assertRaises(RuntimeError):
-            site.find_grad_tensor(_make_ebc_awaitable([ShardingType.TABLE_WISE.value]))
+        batch = data[0][1][ctx.rank].to(ctx.device)
+        loss, _pred = dmp(batch)
+        loss.backward()
 
-    def test_unsupported_type_raises(self) -> None:
-        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
-        with self.assertRaises(RuntimeError):
-            site.find_grad_tensor("not_an_awaitable")
+        tc.assertEqual(call_count[0], 1, "Backward hook must fire exactly once")
 
-    def test_hasattr_fallback(self) -> None:
-        """Objects with _awaitables/_sharding_types but not EBC/EC use hasattr fallback."""
-        site = OutputDistSite(fqn="ebc", sharding_type=ShardingType.TABLE_WISE)
 
-        class FakeAwaitable:
-            pass
+def _run_output_dist_backward_order_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[Tuple[ModelInput, List[ModelInput]]],
+    sharding_type: str,
+    backend: str = "nccl",
+    local_size: Optional[int] = None,
+) -> None:
+    """Dense backward hook fires before the EBC backward hook.
 
-        w = MagicMock()
-        w._tensor_awaitable = _make_request_with_dummy_tensor()
+    The model computes: dense -> sparse(ebc) -> over.  The dummy_tensor
+    lives deep inside the EBC's all-to-all op, so its backward hook fires
+    after the dense output hook.
+    """
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        dmp = _create_sharded_model(ctx, tables, weighted_tables, sharding_type)
 
-        fake = FakeAwaitable()
-        # pyrefly: ignore[missing-attribute]
-        fake._awaitables = [w]
-        # pyrefly: ignore[missing-attribute]
-        fake._sharding_types = [ShardingType.TABLE_WISE.value]
+        order: List[str] = []
 
-        self.assertIsNotNone(site.find_grad_tensor(fake))
+        ebc_site = InjectionSite(
+            fqn="sparse.ebc",
+            tensor_finder=OutputDistTensorFinder(
+                sharding_type=ShardingType(sharding_type)
+            ),
+        )
+        register_backward_hook(ebc_site, dmp.module, lambda grad: order.append("ebc"))
+
+        dense_site = InjectionSite(fqn="dense", tensor_finder=FirstGradTensorFinder())
+        register_backward_hook(
+            dense_site, dmp.module, lambda grad: order.append("dense")
+        )
+
+        batch = data[0][1][ctx.rank].to(ctx.device)
+        loss, _pred = dmp(batch)
+        loss.backward()
+
+        tc.assertEqual(order, ["dense", "ebc"])
+
+
+def _run_output_dist_multiple_hooks_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[Tuple[ModelInput, List[ModelInput]]],
+    sharding_type: str,
+    backend: str = "nccl",
+    local_size: Optional[int] = None,
+) -> None:
+    """Multiple hooks on the same site all fire in registration order."""
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        dmp = _create_sharded_model(ctx, tables, weighted_tables, sharding_type)
+
+        order: List[str] = []
+        site = InjectionSite(
+            fqn="sparse.ebc",
+            tensor_finder=OutputDistTensorFinder(
+                sharding_type=ShardingType(sharding_type)
+            ),
+        )
+        register_backward_hook(site, dmp.module, lambda grad: order.append("hook_0"))
+        register_backward_hook(site, dmp.module, lambda grad: order.append("hook_1"))
+        register_backward_hook(site, dmp.module, lambda grad: order.append("hook_2"))
+
+        batch = data[0][1][ctx.rank].to(ctx.device)
+        loss, _pred = dmp(batch)
+        loss.backward()
+
+        tc.assertEqual(order, ["hook_0", "hook_1", "hook_2"])
+
+
+def _run_output_dist_finder_mismatch_test(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    data: List[Tuple[ModelInput, List[ModelInput]]],
+    sharding_type: str,
+    mismatched_sharding_type: str,
+    backend: str = "nccl",
+    local_size: Optional[int] = None,
+) -> None:
+    """Mismatched sharding type raises RuntimeError during forward."""
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        dmp = _create_sharded_model(ctx, tables, weighted_tables, sharding_type)
+
+        site = InjectionSite(
+            fqn="sparse.ebc",
+            tensor_finder=OutputDistTensorFinder(
+                sharding_type=ShardingType(mismatched_sharding_type)
+            ),
+        )
+        register_backward_hook(site, dmp.module, lambda grad: None)
+
+        batch = data[0][1][ctx.rank].to(ctx.device)
+        with tc.assertRaises(RuntimeError):
+            dmp(batch)
+
+
+class OutputDistTensorFinderTest(MultiProcessTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        num_features = 4
+        num_weighted_features = 2
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(num_features)
+        ]
+        self.weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=(i + 1) * 100,
+                embedding_dim=(i + 1) * 4,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(num_weighted_features)
+        ]
+
+    def _generate_data(
+        self,
+        num_batches: int = 5,
+        batch_size: int = 1,
+    ) -> List[Tuple[ModelInput, List[ModelInput]]]:
+        return [
+            ModelInput.generate(
+                tables=self.tables,
+                weighted_tables=self.weighted_tables,
+                batch_size=batch_size,
+                world_size=2,
+                num_float_features=10,
+            )
+            for _ in range(num_batches)
+        ]
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Need at least 2 GPUs for distributed test",
+    )
+    @settings(max_examples=6, deadline=None)
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+            ]
+        ),
+    )
+    def test_output_dist_backward_hook(self, sharding_type: str) -> None:
+        data = self._generate_data()
+        self._run_multi_process_test(
+            callable=_run_output_dist_backward_hook_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=sharding_type,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Need at least 2 GPUs for distributed test",
+    )
+    def test_output_dist_backward_order(self) -> None:
+        data = self._generate_data()
+        self._run_multi_process_test(
+            callable=_run_output_dist_backward_order_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Need at least 2 GPUs for distributed test",
+    )
+    def test_output_dist_multiple_hooks(self) -> None:
+        data = self._generate_data()
+        self._run_multi_process_test(
+            callable=_run_output_dist_multiple_hooks_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Need at least 2 GPUs for distributed test",
+    )
+    def test_output_dist_finder_sharding_type_mismatch(self) -> None:
+        data = self._generate_data()
+        self._run_multi_process_test(
+            callable=_run_output_dist_finder_mismatch_test,
+            world_size=2,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            data=data,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            mismatched_sharding_type=ShardingType.COLUMN_WISE.value,
+        )

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -929,13 +929,16 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
 
         Args:
             site: Injection site specification.
-                  e.g., OutputDistSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE)
+                  e.g., InjectionSite(fqn="sparse_arch.ebc", tensor_finder=OutputDistTensorFinder(sharding_type=ShardingType.TABLE_WISE))
             work: Callable that receives the pipeline instance.
                   Executed sequentially with other work at same site.
 
         Example:
             pipeline.register_backward_hook(
-                site=OutputDistSite(fqn="sparse_arch.ebc", sharding_type=ShardingType.TABLE_WISE),
+                site=InjectionSite(
+                    fqn="sparse_arch.ebc",
+                    tensor_finder=OutputDistTensorFinder(sharding_type=ShardingType.TABLE_WISE),
+                ),
                 work=lambda p: p._optimizer.step(),
             )
         """


### PR DESCRIPTION
Summary:
Refactors the backward hook injection API in `backward_injection.py` to use a strategy pattern and replaces fragile mock-based tests with real distributed tests.

# Context
The original backward injection API had several design issues:

  1. **Inheritance over composition.** `OutputDistSite` subclassed `InjectionSite` and overrode `find_grad_tensor`, coupling the tensor-finding logic to the site identity. Adding a new tensor-finding strategy required creating another subclass, even though the only axis of variation is how to locate the target tensor.

  2. **Mixed responsibilities.** `InjectionSite` contained both the module lookup (`find_target_module`) and the tensor search (`find_grad_tensor`), making it harder to test or reuse either in isolation.

  3. **`use_output_tensor` boolean flag.** Switching between output-based and input-based tensor search was controlled by a boolean on `InjectionSite`, which doesn't scale — every new search mode would need another flag or enum value.

  4. **Mock-based tests hiding real breakage.** `OutputDistSiteTest` used `MagicMock` to simulate `EmbeddingBagCollectionAwaitable`. If the real awaitable structure changes (e.g. attribute renames, new wrapping layers), mocks stay green while production breaks.

# New Design

- **Strategy pattern via `GradTensorFinder` protocol.** Tensor-finding is a pluggable strategy passed to `InjectionSite`, not a method to override. `FirstGradTensorFinder` and `OutputDistTensorFinder` are independent, composable
  dataclasses.
- **Single-responsibility `InjectionSite`.** It is now just a pairing of FQN + finder strategy. Module lookup stays in `register_backward_hook`.
- **No boolean flags.** `FirstGradTensorFinder(use_input=True)` replaces `InjectionSite(use_output_tensor=False)` — the choice lives with the strategy, not the site.
- **Real distributed tests.** Tests create a sharded `TestSparseNN` via `DistributedModelParallel`, run `register_backward_hook` with `OutputDistTensorFinder` end-to-end, and verify the hook fires during `loss.backward()` in the correct order. Hypothesis parametrizes over TABLE_WISE, ROW_WISE, and COLUMN_WISE sharding types.
- **Decouple the API with train pipelines**. Train pipelines just need to call `register_backward_hook` properly and can set up its own hook signature, e.g. including the pipeline instance as parameter.

Differential Revision: D98830827


