### PR TITLE
Fix plan hash, placement, and Topology fallbacks for pod_size > 1 (#3998)

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -30,7 +30,7 @@ from torch.distributed.tensor import DeviceMesh
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.collective_utils import create_on_rank_and_share_result
-from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.mc_embedding_modules import (
     BaseShardedManagedCollisionEmbeddingCollection,
@@ -325,6 +325,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
                     local_world_size=get_local_size(self._env.world_size),
                     world_size=self._env.world_size,
                     compute_device=self.device.type,
+                    pod_size=get_topology_domain_multiple(),
                 )
             )
             pg = self._env.process_group

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -1314,27 +1314,26 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     Evaluator for TABLE_ROW_WISE sharding.
 
     Differences from base (TABLE_WISE):
-    - batch_inputs divided by local_world_size
+    - batch_inputs divided by intra_group_size (TWRW group size)
     - Uses SR comm data type (always, unlike ROW_WISE which checks is_pooled)
     - No block_usage_penalty
-    - Forward: Reduce-scatter (intra) + All-to-all (inter)
+    - Forward: Reduce-scatter (intra, within TWRW group) + All-to-all (inter, across groups)
     - Backward: All-to-all (inter) + All-gather (intra) + batched_copy
-    - Prefetch divided by local_world_size
+    - Prefetch divided by intra_group_size
+
+    Note: intra_group_size = pod_size * local_world_size. For pod_size=1,
+    this equals local_world_size. For pod_size>1 (e.g. GB200_HP), the TWRW
+    group spans multiple physical nodes within the NVSwitch domain.
     """
 
     def get_batch_inputs_divisor(self, ctx: ShardPerfContext) -> int:
-        return ctx.local_world_size
+        return ctx.intra_group_size
 
     def _get_input_read_size(
         self, ctx: ShardPerfContext, config: Optional[HardwarePerfConfig] = None
     ) -> float:
         """
-        TABLE_ROW_WISE: input_read_size = (raw / local_world_size) * world_size * input_data_type_size.
-
-        This is different from ROW_WISE where world_size cancels out.
-
-        Note: TABLE_ROW_WISE always uses bytes (input_data_type_size), ignoring the
-        use_bytes_for_input_read_size config flag since legacy behavior was consistent.
+        TABLE_ROW_WISE: input_read_size = (raw / intra_group_size) * world_size * input_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1350,7 +1349,7 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         self, ctx: ShardPerfContext, use_min_dim: bool = False
     ) -> float:
         """
-        TABLE_ROW_WISE: embedding_lookup_size = (raw / local_world_size) * world_size * emb_dim * table_data_type_size.
+        TABLE_ROW_WISE: embedding_lookup_size = (raw / intra_group_size) * world_size * emb_dim * table_data_type_size.
         """
         effective_batch_inputs = ctx.batch_inputs / self.get_batch_inputs_divisor(
             ctx=ctx
@@ -1368,13 +1367,10 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
     ) -> float:
         """
         TABLE_ROW_WISE: output_write_size uses batch_outputs * world_size * emb_dim.
-
-        This matches the OLD estimator formula exactly.
         """
         if ctx.is_pooled:
             size = ctx.batch_outputs * ctx.world_size * ctx.emb_dim * data_type_size
         else:
-            # For non-pooled (sequence), world_size factor cancels out in OLD estimator
             size = (
                 ctx.batch_outputs
                 / self.get_batch_inputs_divisor(ctx=ctx)
@@ -1395,31 +1391,13 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         self, ctx: ShardPerfContext, config: HardwarePerfConfig
     ) -> float:
         """
-        TABLE_ROW_WISE: expected_lookups for prefetch (input_read_size in OLD estimator).
+        TABLE_ROW_WISE: expected_lookups for prefetch.
 
-        OLD estimator behavior:
-        - batch_inputs is pre-divided by local_world_size
-        - input_read_size = (batch_inputs/local_world_size) * world_size * input_data_type_size (bytes)
-        - if is_weighted: input_read_size *= 2
-
-        Note: We return the PRE-DIVISOR value since _default_prefetch_comp
-        will divide by prefetch_divisor (local_world_size) afterwards.
+        Uses intra_group_size as the divisor (matching the TWRW group size).
+        Returns PRE-DIVISOR value since _default_prefetch_comp divides by
+        prefetch_divisor (intra_group_size) afterwards.
         """
-        # TABLE_ROW_WISE uses bytes (includes input_data_type_size)
-        # Compute the full value (before division by local_world_size)
-        # Formula: (batch_inputs / local_world_size) * world_size * input_data_type_size
-        # But we return before local_world_size division, so:
-        # (batch_inputs * world_size * input_data_type_size) / local_world_size
-        # which equals ctx.batch_inputs * (world_size / local_world_size) * input_data_type_size
-        # Simplified: ctx.batch_inputs * num_hosts * input_data_type_size
-        #
-        # Actually, the OLD estimator passes input_read_size directly to
-        # _get_expected_cache_prefetch_time, then divides by local_world_size inside.
-        # So we need to compute: input_read_size = (batch_inputs/local_world_size) * world_size * input_data_type_size
-        # WITHOUT the division (since _default_prefetch_comp will divide)
-        #
-        # Let's compute: batch_inputs * (world_size / local_world_size) * input_data_type_size
-        effective_batch_inputs = ctx.batch_inputs / ctx.local_world_size
+        effective_batch_inputs = ctx.batch_inputs / ctx.intra_group_size
         expected_lookups = float(
             math.ceil(
                 effective_batch_inputs * ctx.world_size * ctx.input_data_type_size
@@ -1441,30 +1419,34 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             ctx, self._get_comm_data_type_size(ctx, is_fwd=True)
         )
 
-        # Intra-host: reduce-scatter within the host
+        # Intra-group: reduce-scatter within the TWRW group (NVSwitch domain)
+        # local_world_size for bandwidth lookup: min(igs, lws) because if the
+        # group fits within one host, all GPUs are local; if it spans hosts,
+        # physical local_world_size determines the bandwidth tier.
+        intra_local_world_size = min(ctx.intra_group_size, ctx.local_world_size)
         intra_comms = self._compute_collective_comms(
             ctx=ctx,
             output_size=fwd_output_write_size,
             collective_type=CollectiveType.REDUCE_SCATTER,
-            world_size=ctx.local_world_size,
-            local_world_size=ctx.local_world_size,
+            world_size=ctx.intra_group_size,
+            local_world_size=intra_local_world_size,
         )
 
-        # Inter-host: all-to-all across hosts (only if num_hosts > 1)
+        # Inter-group: all-to-all across TWRW groups
+        num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
-        if ctx.num_hosts > 1:
-            # Inter-host uses A2A data type and different output size
-            inter_host_fwd_output_write_size = (
+        if num_groups > 1:
+            inter_group_fwd_output_write_size = (
                 ctx.batch_outputs
-                * ctx.num_hosts
+                * num_groups
                 * ctx.emb_dim
                 * ctx.fwd_a2a_comm_data_type_size
             )
             inter_comms = self._compute_collective_comms(
                 ctx=ctx,
-                output_size=inter_host_fwd_output_write_size,
+                output_size=inter_group_fwd_output_write_size,
                 collective_type=CollectiveType.ALL_TO_ALL,
-                world_size=ctx.num_hosts,
+                world_size=num_groups,
                 local_world_size=1,
             )
 
@@ -1478,32 +1460,32 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
             ctx, self._get_comm_data_type_size(ctx, is_fwd=False)
         )
 
-        # Inter-host: all-to-all across hosts (only if num_hosts > 1)
+        # Inter-group: all-to-all across TWRW groups
+        num_groups = ctx.num_twrw_groups
         inter_comms = 0.0
-        if ctx.num_hosts > 1:
-
-            # Inter-host uses A2A data type and different output size
-            inter_host_bwd_output_write_size = (
+        if num_groups > 1:
+            inter_group_bwd_output_write_size = (
                 ctx.batch_outputs
-                * ctx.num_hosts
+                * num_groups
                 * ctx.emb_dim
                 * ctx.bwd_a2a_comm_data_type_size
             )
             inter_comms = self._compute_collective_comms(
                 ctx=ctx,
-                output_size=inter_host_bwd_output_write_size,
+                output_size=inter_group_bwd_output_write_size,
                 collective_type=CollectiveType.ALL_TO_ALL,
-                world_size=ctx.num_hosts,
+                world_size=num_groups,
                 local_world_size=1,
             )
 
-        # Intra-host: all-gather within the host
+        # Intra-group: all-gather within the TWRW group
+        intra_local_world_size = min(ctx.intra_group_size, ctx.local_world_size)
         intra_comms = self._compute_collective_comms(
             ctx=ctx,
             output_size=bwd_output_write_size,
             collective_type=CollectiveType.ALL_GATHER,
-            world_size=ctx.local_world_size,
-            local_world_size=ctx.local_world_size,
+            world_size=ctx.intra_group_size,
+            local_world_size=intra_local_world_size,
         )
 
         # Batched copy (same formula as ROW_WISE)
@@ -1516,8 +1498,8 @@ class TableRowWiseEvaluator(EmbeddingShardingPerfEvaluator):
         return inter_comms + intra_comms + bwd_batched_copy
 
     def get_prefetch_divisor(self, ctx: ShardPerfContext) -> int:
-        """TABLE_ROW_WISE divides prefetch by local_world_size (per OSS)."""
-        return ctx.local_world_size
+        """TABLE_ROW_WISE divides prefetch by intra_group_size."""
+        return ctx.intra_group_size
 
 
 class DataParallelEvaluator(EmbeddingShardingPerfEvaluator):

--- a/torchrec/distributed/planner/estimator/estimator.py
+++ b/torchrec/distributed/planner/estimator/estimator.py
@@ -166,7 +166,14 @@ class EmbeddingShardingPerfEvaluator(ABC):
         """
         Compute communication time for a two-level hierarchical collective.
 
-        This is used by TABLE_ROW_WISE which has:
+        NOTE: This base class method is NOT used by TableRowWiseEvaluator, which
+        overrides _default_fwd_comms and _default_bwd_comms directly. It uses
+        ctx.local_world_size for intra-host sizing, which is the physical
+        local_world_size — correct for RW but NOT for TWRW (which needs
+        intra_group_size). Any future subclass using this for TWRW must use
+        ctx.intra_group_size instead.
+
+        Used by:
         - Intra-host collective (within a node)
         - Inter-host collective (across nodes)
 

--- a/torchrec/distributed/planner/estimator/tests/test_estimator.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator.py
@@ -82,12 +82,15 @@ def create_test_context(
     input_lengths: Optional[list] = None,  # pyrefly: ignore
     world_size: int = 8,
     local_world_size: int = 4,
+    intra_group_size: Optional[int] = None,
     device_bw: float = HBM_MEM_BW,
     is_pooled: bool = True,
     is_weighted: bool = False,
     comms_bw: float = 1000.0,
 ) -> ShardPerfContext:
     """Helper to create a ShardPerfContext for testing."""
+    if intra_group_size is None:
+        intra_group_size = local_world_size
     return ShardPerfContext(
         sharding_type=sharding_type,
         compute_kernel=compute_kernel,
@@ -98,6 +101,7 @@ def create_test_context(
         input_lengths=input_lengths or [10.0],
         world_size=world_size,
         local_world_size=local_world_size,
+        intra_group_size=intra_group_size,
         device_bw=device_bw,
         hbm_to_ddr_mem_bw=device_bw,
         is_pooled=is_pooled,
@@ -259,23 +263,49 @@ class TableRowWiseEvaluatorTest(unittest.TestCase):
         self.evaluator = TableRowWiseEvaluator()
         self.config = HardwarePerfConfig()
 
-    def test_batch_inputs_divisor_is_local_world_size(self) -> None:
-        """Test that TABLE_ROW_WISE divides batch inputs by local_world_size."""
-        ctx = create_test_context(world_size=8, local_world_size=4)
-        divisor = self.evaluator.get_batch_inputs_divisor(ctx)
-        self.assertEqual(divisor, 4)
+    def test_batch_inputs_divisor_is_intra_group_size(self) -> None:
+        """Test that TABLE_ROW_WISE divides batch inputs by intra_group_size."""
+        with self.subTest("pod_size_1"):
+            ctx = create_test_context(world_size=8, local_world_size=4)
+            self.assertEqual(self.evaluator.get_batch_inputs_divisor(ctx), 4)
+        with self.subTest("pod_size_gt_1"):
+            # GB200-like: lws=2, igs=4 (pod_size=2)
+            ctx = create_test_context(
+                world_size=64, local_world_size=2, intra_group_size=4
+            )
+            # Must use intra_group_size (4), not local_world_size (2)
+            self.assertEqual(self.evaluator.get_batch_inputs_divisor(ctx), 4)
 
-    def test_prefetch_divisor_is_local_world_size(self) -> None:
-        """Test that TABLE_ROW_WISE prefetch divisor is local_world_size."""
-        ctx = create_test_context(world_size=8, local_world_size=4)
-        divisor = self.evaluator.get_prefetch_divisor(ctx)
-        self.assertEqual(divisor, 4)
+    def test_prefetch_divisor_is_intra_group_size(self) -> None:
+        """Test that TABLE_ROW_WISE prefetch divisor is intra_group_size."""
+        with self.subTest("pod_size_1"):
+            ctx = create_test_context(world_size=8, local_world_size=4)
+            self.assertEqual(self.evaluator.get_prefetch_divisor(ctx), 4)
+        with self.subTest("pod_size_gt_1"):
+            ctx = create_test_context(
+                world_size=64, local_world_size=2, intra_group_size=4
+            )
+            self.assertEqual(self.evaluator.get_prefetch_divisor(ctx), 4)
 
     def test_compute_perf_returns_perf_object(self) -> None:
         """Test that compute_perf returns a Perf object."""
-        ctx = create_test_context(sharding_type=ShardingType.TABLE_ROW_WISE.value)
-        perf = self.evaluator.compute_perf(ctx, self.config)
-        self.assertIsNotNone(perf)
+        with self.subTest("pod_size_1"):
+            ctx = create_test_context(sharding_type=ShardingType.TABLE_ROW_WISE.value)
+            perf = self.evaluator.compute_perf(ctx, self.config)
+            self.assertIsNotNone(perf)
+        with self.subTest("pod_size_gt_1"):
+            # Verify no crash with pod_size > 1 topology
+            ctx = create_test_context(
+                sharding_type=ShardingType.TABLE_ROW_WISE.value,
+                world_size=64,
+                local_world_size=2,
+                intra_group_size=4,
+            )
+            perf = self.evaluator.compute_perf(ctx, self.config)
+            self.assertIsNotNone(perf)
+            # Verify num_twrw_groups is used (16 groups of 4, not 32 groups of 2)
+            self.assertEqual(ctx.num_twrw_groups, 16)
+            self.assertEqual(ctx.num_hosts, 32)
 
 
 class ColumnWiseEvaluatorTest(unittest.TestCase):

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -514,6 +514,7 @@ class ShardPerfContext:
     # Topology info
     world_size: int = 1
     local_world_size: int = 1
+    intra_group_size: int = 1  # pod_size * local_world_size; TWRW group size
 
     # Data type sizes
     input_data_type_size: float = BIGINT_DTYPE
@@ -759,6 +760,7 @@ class ShardPerfContext:
                 input_lengths=sharding_option.input_lengths,
                 world_size=topology.world_size,
                 local_world_size=topology.local_world_size,
+                intra_group_size=topology.intra_group_size,
                 input_data_type_size=input_data_type_size,
                 table_data_type_size=table_data_type_size,
                 output_data_type_size=output_data_type_size,
@@ -794,8 +796,13 @@ class ShardPerfContext:
 
     @property
     def num_hosts(self) -> int:
-        """Number of hosts in the topology."""
+        """Number of physical hosts in the topology."""
         return max(1, self.world_size // self.local_world_size)
+
+    @property
+    def num_twrw_groups(self) -> int:
+        """Number of TWRW groups (virtual hosts) in the topology."""
+        return max(1, self.world_size // self.intra_group_size)
 
     @property
     def batch_inputs(self) -> float:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -18,7 +18,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
-from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
@@ -102,7 +102,7 @@ def to_sharding_plan(
 ) -> ShardingPlan:
 
     compute_device = topology.compute_device
-    local_size = topology.intra_group_size
+    local_size = topology.local_world_size
 
     plan = {}
     for sharding_option in sharding_options:
@@ -301,6 +301,7 @@ class EmbeddingPlannerBase(ShardingPlanner):
                 local_world_size=get_local_size(),
                 world_size=dist.get_world_size(),
                 compute_device=compute_device,
+                pod_size=get_topology_domain_multiple(),
             )
         self._topology: Topology = topology
         self._batch_size: int = batch_size if batch_size else BATCH_SIZE

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1724,6 +1724,7 @@ def hash_planner_context_inputs(
         topology.compute_device,
         rounded_devices,
         topology.local_world_size,
+        topology.intra_group_size,
         topology.hbm_mem_bw,
         topology.ddr_mem_bw,
         topology.ssd_mem_bw,

--- a/torchrec/distributed/shard.py
+++ b/torchrec/distributed/shard.py
@@ -13,7 +13,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed._composable.contract import contract
-from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
 from torchrec.distributed.global_settings import get_propogate_device
 from torchrec.distributed.model_parallel import get_default_sharders
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
@@ -264,6 +264,7 @@ def _shard_modules(  # noqa: C901
                     local_world_size=get_local_size(env.world_size),
                     world_size=env.world_size,
                     compute_device=device.type,
+                    pod_size=get_topology_domain_multiple(),
                 )
             )
         pg = env.process_group


### PR DESCRIPTION
Summary:

Follow-up to D98566473. Fixes additional planner-scope sites where
`local_world_size` and `intra_group_size` are conflated. On GB200_HP,
`local_world_size=2` but `intra_group_size=4`.

1. Plan hash (`types.py`): `hash_planner_context_inputs()` did not include
   `intra_group_size`. Topologies differing only by `pod_size` produced
   identical hashes, risking silent cached plan reuse across different group
   sizes. Affects LP planner, ManifoldPlanner, and FB stats.

2. Placement device index (`planners.py`, `manifold_planner.py`):
   `to_sharding_plan()` used `topology.intra_group_size` for CUDA device
   indexing (`rank % local_size`). On GB200_HP this produces `cuda:2`/`cuda:3`
   which don't exist on hosts with 2 GPUs. Changed to
   `topology.local_world_size`. Affects all planners.

3. Topology fallbacks (`planners.py`, `model_parallel.py`, `shard.py`,
   `sparsenn_configs.py`): Four entry points created `Topology()` without
   `pod_size`, causing `intra_group_size` to default to `local_world_size`.
   Now pass `pod_size=get_topology_domain_multiple()` from the environment.
   `EmbeddingPlannerBase.__init__` is the root fallback for all planners.

4. Documentation (`estimator.py`, `proposers.py`): Clarified
   `_compute_two_level_comms` is unused by `TableRowWiseEvaluator` and would
   need `intra_group_size` for TWRW. Commented proposer defaults.

Reviewed By: kausv

Differential Revision: D98986451
