### PR TITLE
Add observability and correctness counters to CPUOffloadedRecMetricModule (#3999)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -11,12 +11,14 @@ import logging
 import queue
 import threading
 import time
+import traceback
 from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import torch
 from torch import distributed as dist
 from torch.profiler import record_function
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+from torchrec.distributed.logging_utils import EventType
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.deferrable_metrics import DeferrableMetrics
 from torchrec.metrics.metric_job_types import (
@@ -124,11 +126,45 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             "all_gather_time_ms", log_interval=10
         )
 
+        # Correctness counters
+        self._total_updates_enqueued: int = 0
+        self._total_updates_processed: int = 0
+        self._total_computes_enqueued: int = 0
+        self._total_computes_processed: int = 0
+        self._update_errors: int = 0
+        self._compute_errors: int = 0
+
         self.update_thread.start()
         self.compute_thread.start()
 
         logger.info(
             f"CPUOffloadedRecMetricModule initialization complete with {model_out_device.type=}, {update_queue_size=}, {compute_queue_size=}."
+        )
+        self._log_event(
+            "init",
+            EventType.INFO,
+            {
+                "model_out_device": str(model_out_device),
+                "update_queue_size": str(update_queue_size),
+                "compute_queue_size": str(compute_queue_size),
+            },
+        )
+
+    def _log_event(
+        self,
+        event_name: str,
+        event_type: EventType,
+        metadata: Optional[Dict[str, str]] = None,
+        error_message: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None:
+        EventLoggingHandler.log_event(
+            component=TorchrecComponent.REC_METRICS.value,
+            event_name=f"CPUOffloadedRecMetricModule.{event_name}",
+            event_type=event_type,
+            metadata=metadata,
+            error_message=error_message,
+            stack_trace=stack_trace,
         )
 
     @override
@@ -163,8 +199,18 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                     kwargs=kwargs,
                 )
             )
+            self._total_updates_enqueued += 1
             self.update_queue_size_logger.add(self.update_queue.qsize())
         except queue.Full:
+            self._log_event(
+                "enqueue_update",
+                EventType.FAILURE,
+                {
+                    "update_queue_size": str(self.update_queue.qsize()),
+                    "total_updates_enqueued": str(self._total_updates_enqueued),
+                },
+                error_message="update metric queue is full",
+            )
             raise RecMetricException("update metric queue is full.")
 
     def _transfer_to_cpu(
@@ -242,7 +288,9 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             if self.throughput_metric:
                 self.throughput_metric.update()
 
-            self.update_job_time_logger.add((time.time() - start_time) * 1000)
+            elapsed_ms = (time.time() - start_time) * 1000
+            self.update_job_time_logger.add(elapsed_ms)
+            self._total_updates_processed += 1
 
     @override
     def shutdown(self) -> None:
@@ -265,15 +313,58 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         self.compute_metrics_time_logger.log_percentiles()
         self.all_gather_time_logger.log_percentiles()
 
+        correctness_metadata = {
+            "total_updates_enqueued": str(self._total_updates_enqueued),
+            "total_updates_processed": str(self._total_updates_processed),
+            "total_computes_enqueued": str(self._total_computes_enqueued),
+            "total_computes_processed": str(self._total_computes_processed),
+            "update_errors": str(self._update_errors),
+            "compute_errors": str(self._compute_errors),
+            "update_queue_remaining": str(self.update_queue.qsize()),
+            "compute_queue_remaining": str(self.compute_queue.qsize()),
+            "update_thread_alive": str(self.update_thread.is_alive()),
+            "compute_thread_alive": str(self.compute_thread.is_alive()),
+        }
+
+        updates_match = self._total_updates_enqueued == self._total_updates_processed
+        computes_match = self._total_computes_enqueued == self._total_computes_processed
+        has_errors = self._update_errors > 0 or self._compute_errors > 0
+
+        if not updates_match or not computes_match or has_errors:
+            logger.warning(
+                f"Correctness issue: updates_match={updates_match}, "
+                f"computes_match={computes_match}, "
+                f"update_errors={self._update_errors}, "
+                f"compute_errors={self._compute_errors}"
+            )
+
         if self.update_thread.is_alive():
+            self._log_event(
+                "shutdown",
+                EventType.FAILURE,
+                correctness_metadata,
+                error_message="update thread did not shut down gracefully",
+            )
             raise RecMetricException(
                 f"update thread did not shut down gracefully. remaining queue size: {self.update_queue.qsize()}"
             )
         if self.compute_thread.is_alive():
+            self._log_event(
+                "shutdown",
+                EventType.FAILURE,
+                correctness_metadata,
+                error_message="compute thread did not shut down gracefully",
+            )
             raise RecMetricException(
                 f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
             )
-        logger.info("CPUOffloadedRecMetricModule has been successfully shutdown.")
+
+        self._log_event("shutdown", EventType.SUCCESS, correctness_metadata)
+        logger.info(
+            f"CPUOffloadedRecMetricModule shutdown complete. "
+            f"updates={self._total_updates_processed}/{self._total_updates_enqueued}, "
+            f"computes={self._total_computes_processed}/{self._total_computes_enqueued}"
+        )
 
     @override
     def compute(self) -> DeferrableMetrics:
@@ -302,8 +393,23 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             assert self._captured_exception is not None
             raise self._captured_exception
 
-        self.update_queue.put_nowait(SynchronizationMarker(metrics_future))
-        self.update_queue_size_logger.add(self.update_queue.qsize())
+        try:
+            self.update_queue.put_nowait(SynchronizationMarker(metrics_future))
+            self._total_computes_enqueued += 1
+            self.update_queue_size_logger.add(self.update_queue.qsize())
+        except queue.Full:
+            self._log_event(
+                "enqueue_compute",
+                EventType.FAILURE,
+                {
+                    "update_queue_size": str(self.update_queue.qsize()),
+                    "total_computes_enqueued": str(self._total_computes_enqueued),
+                },
+                error_message="update queue is full when enqueueing compute marker",
+            )
+            raise RecMetricException(
+                "update queue is full when enqueueing compute marker."
+            )
         return DeferrableMetrics(metrics_future)
 
     def _process_synchronization_marker(
@@ -375,6 +481,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                     (time.time() - compute_start_ms) * 1000
                 )
                 self.compute_count += 1
+                self._total_computes_processed += 1
                 self._adjust_compute_interval()
                 return computed_metrics
 
@@ -390,7 +497,18 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             try:
                 self._do_work(self.update_queue)
             except Exception as e:
+                self._update_errors += 1
                 logger.exception(f"Exception in update loop: {e}")
+                self._log_event(
+                    "update_loop",
+                    EventType.FAILURE,
+                    {
+                        "update_queue_size": str(self.update_queue.qsize()),
+                        "total_updates_processed": str(self._total_updates_processed),
+                    },
+                    error_message=str(e),
+                    stack_trace=traceback.format_exc(),
+                )
                 self._captured_exception = e
                 self._captured_exception_event.set()
                 raise e
@@ -409,7 +527,18 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             try:
                 self._do_work(self.compute_queue)
             except Exception as e:
+                self._compute_errors += 1
                 logger.exception(f"Exception in compute loop: {e}")
+                self._log_event(
+                    "compute_loop",
+                    EventType.FAILURE,
+                    {
+                        "compute_queue_size": str(self.compute_queue.qsize()),
+                        "total_computes_processed": str(self._total_computes_processed),
+                    },
+                    error_message=str(e),
+                    stack_trace=traceback.format_exc(),
+                )
                 self._captured_exception = e
                 self._captured_exception_event.set()
                 raise e

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.metrics.cpu_offloaded_metric_module import (
     CPUOffloadedRecMetricModule,
@@ -655,6 +656,174 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         self.assertEqual(module.compute_queue.maxsize, 75)
 
         module.shutdown()
+
+    def test_correctness_counters_after_update_and_compute(self) -> None:
+        """Verify correctness counters are incremented through update+compute cycle."""
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        num_updates = 3
+        for _ in range(num_updates):
+            self.cpu_module.update(model_out)
+
+        self.assertEqual(self.cpu_module._total_updates_enqueued, num_updates)
+
+        future = self.cpu_module.async_compute()
+        self.assertEqual(self.cpu_module._total_computes_enqueued, 1)
+
+        future.resolve()
+
+        wait_until_true(lambda: self.cpu_module._total_updates_processed == num_updates)
+        self.assertEqual(self.cpu_module._total_updates_processed, num_updates)
+        self.assertEqual(self.cpu_module._total_computes_processed, 1)
+        self.assertEqual(self.cpu_module._update_errors, 0)
+        self.assertEqual(self.cpu_module._compute_errors, 0)
+
+    def test_log_event_called_on_init(self) -> None:
+        """Verify _log_event is called with INFO during __init__."""
+        with patch.object(CPUOffloadedRecMetricModule, "_log_event") as mock_log_event:
+            module = CPUOffloadedRecMetricModule(
+                model_out_device=torch.device("cpu"),
+                batch_size=self.batch_size,
+                world_size=self.world_size,
+                rec_tasks=self.tasks,
+                rec_metrics=self.rec_metrics,
+            )
+
+            mock_log_event.assert_called_once_with(
+                "init",
+                EventType.INFO,
+                {
+                    "model_out_device": "cpu",
+                    "update_queue_size": "100",
+                    "compute_queue_size": "100",
+                },
+            )
+            module.shutdown()
+
+    def test_shutdown_logs_success_event(self) -> None:
+        """Verify shutdown logs SUCCESS event with correctness metadata."""
+        with patch.object(self.cpu_module, "_log_event") as mock_log_event:
+            self.cpu_module.shutdown()
+
+            mock_log_event.assert_called_once()
+            args = mock_log_event.call_args
+            self.assertEqual(args[0][0], "shutdown")
+            self.assertEqual(args[0][1], EventType.SUCCESS)
+            metadata = args[0][2]
+            self.assertIn("total_updates_enqueued", metadata)
+            self.assertIn("total_updates_processed", metadata)
+            self.assertIn("update_thread_alive", metadata)
+
+    def test_update_error_counter_incremented_on_thread_exception(self) -> None:
+        """Verify _update_errors is incremented when update thread hits an exception."""
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_update_job",
+            side_effect=RuntimeError("test error"),
+        ):
+            self.cpu_module.update(
+                {
+                    "task1-prediction": torch.tensor([0.5]),
+                    "task1-label": torch.tensor([0.7]),
+                    "task1-weight": torch.tensor([1.0]),
+                }
+            )
+
+            self.cpu_module._captured_exception_event.wait(timeout=5.0)
+            self.assertEqual(self.cpu_module._update_errors, 1)
+
+    def test_compute_error_counter_incremented_on_thread_exception(self) -> None:
+        """Verify _compute_errors is incremented when compute thread hits an exception."""
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_compute_job",
+            side_effect=RuntimeError("test error"),
+        ):
+            self.cpu_module.async_compute()
+
+            self.cpu_module._captured_exception_event.wait(timeout=5.0)
+            self.assertEqual(self.cpu_module._compute_errors, 1)
+
+    def test_enqueue_update_logs_failure_on_queue_full(self) -> None:
+        """Verify FAILURE event is logged when update queue is full."""
+        cpu_module = CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"),
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+            update_queue_size=1,
+        )
+
+        block_event = threading.Event()
+
+        def controlled_process_job(_: MetricUpdateJob) -> None:
+            block_event.wait()
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.5]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        with patch.object(
+            cpu_module, "_process_metric_update_job", side_effect=controlled_process_job
+        ), patch.object(cpu_module, "_log_event") as mock_log_event:
+            cpu_module._update_rec_metrics(model_out)
+            cpu_module._update_rec_metrics(model_out)
+
+            with self.assertRaises(RecMetricException):
+                cpu_module._update_rec_metrics(model_out)
+
+            mock_log_event.assert_called_once()
+            args = mock_log_event.call_args
+            self.assertEqual(args[0][0], "enqueue_update")
+            self.assertEqual(args[0][1], EventType.FAILURE)
+
+            block_event.set()
+
+    def test_enqueue_compute_logs_failure_on_queue_full(self) -> None:
+        """Verify FAILURE event is logged when update queue is full during async_compute."""
+        cpu_module = CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"),
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+            update_queue_size=1,
+        )
+
+        block_event = threading.Event()
+
+        def controlled_process_job(_: MetricUpdateJob) -> None:
+            block_event.wait()
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.5]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        with patch.object(
+            cpu_module, "_process_metric_update_job", side_effect=controlled_process_job
+        ), patch.object(cpu_module, "_log_event") as mock_log_event:
+            # Fill the queue: 1 item being processed + 1 in queue = full
+            cpu_module._update_rec_metrics(model_out)
+            cpu_module._update_rec_metrics(model_out)
+
+            with self.assertRaises(RecMetricException):
+                cpu_module.async_compute()
+
+            mock_log_event.assert_called_once()
+            args = mock_log_event.call_args
+            self.assertEqual(args[0][0], "enqueue_compute")
+            self.assertEqual(args[0][1], EventType.FAILURE)
+
+            block_event.set()
 
 
 @skip_if_asan_class


### PR DESCRIPTION
Summary:

Add EventLoggingHandler instrumentation and correctness counters to
CPUOffloadedRecMetricModule for production observability.

Instrumentation points:
- init (INFO): device, queue capacities
- enqueue failure (FAILURE): queue full events (update and compute paths)
- update/compute thread crash (FAILURE): exception details + stack trace
- shutdown (SUCCESS/FAILURE): correctness summary

Correctness counters:
- total_updates_enqueued/processed: detect dropped updates
- total_computes_enqueued/processed: detect dropped computes
- update_errors/compute_errors: error counts

All instrumentation is on background threads or error paths only -- no
overhead on the GPU critical path.

Differential Revision: D99160439


