### PR TITLE
Remove EarlyReleasableInputs type alias, simplify to list[KJT]

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -42,7 +42,6 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
-    EarlyReleasableInputs,
     EmbeddingComputeKernel,
     KJTList,
     ShardedEmbeddingModule,
@@ -310,6 +309,7 @@ class EmbeddingCollectionContext(Multistreamable):
     reverse_indices: List[torch.Tensor] = field(default_factory=list)
     seq_vbe_ctx: List[SequenceVBEContext] = field(default_factory=list)
     table_name_to_unpruned_hash_sizes: Dict[str, int] = field(default_factory=dict)
+    early_releasable_inputs: list[KeyedJaggedTensor] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if torch._utils_internal.justknobs_check(
@@ -327,7 +327,6 @@ class EmbeddingCollectionContext(Multistreamable):
         if self.table_name_to_unpruned_hash_sizes is None:
             # pyrefly: ignore[bad-assignment]
             self.table_name_to_unpruned_hash_sizes = {}
-        self.early_releasable_inputs: Optional[EarlyReleasableInputs] = None
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -1538,7 +1537,7 @@ class ShardedEmbeddingCollection(
                 # For VBE: deferred until after _compute_sequence_vbe_context
                 # which still needs the original (unpadded) features.
                 if self._free_features_storage_early and unpadded_features is None:
-                    ctx.early_releasable_inputs = (original_features, None)
+                    ctx.early_releasable_inputs.append(original_features)
             features_by_shards = features.split(self._feature_splits)
             features_by_shards = may_collect_feature_scores(
                 features_by_shards,
@@ -1577,7 +1576,7 @@ class ShardedEmbeddingCollection(
                     and need_permute
                     and self._features_order
                 ):
-                    ctx.early_releasable_inputs = (original_features, None)
+                    ctx.early_releasable_inputs.append(original_features)
 
         return KJTListSplitsAwaitable(
             awaitables,

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -369,8 +369,6 @@ CompIn = TypeVar("CompIn", KJTList, ListOfKJTList, KeyedJaggedTensor)
 DistOut = TypeVar("DistOut")
 ShrdCtx = TypeVar("ShrdCtx", bound=Multistreamable)
 
-EarlyReleasableInputs = Tuple[Optional[KeyedJaggedTensor], Optional[KeyedJaggedTensor]]
-
 
 class ShardedEmbeddingModule(
     ShardedModule[CompIn, DistOut, Out, ShrdCtx],

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -47,7 +47,6 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
-    EarlyReleasableInputs,
     EmbeddingComputeKernel,
     KJTList,
     ShardedEmbeddingModule,
@@ -465,7 +464,7 @@ class EmbeddingBagCollectionContext(Multistreamable):
     inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None
     variable_batch_per_feature: bool = False
     divisor: Optional[torch.Tensor] = None
-    early_releasable_inputs: Optional[EarlyReleasableInputs] = None
+    early_releasable_inputs: list[KeyedJaggedTensor] = field(default_factory=list)
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -1761,7 +1760,7 @@ class ShardedEmbeddingBagCollection(
                     # Defer clearing original KJT tensor storage until after
                     # all pipelined modules' input_dist calls complete, to
                     # avoid freeing shared features that other modules need.
-                    ctx.early_releasable_inputs = (original_features, None)
+                    ctx.early_releasable_inputs.append(original_features)
             if self._has_mean_pooling_callback:
                 ctx.divisor = _create_mean_pooling_divisor(
                     lengths=features.lengths(),

--- a/torchrec/distributed/mc_embeddingbag.py
+++ b/torchrec/distributed/mc_embeddingbag.py
@@ -140,7 +140,7 @@ class ShardedManagedCollisionEmbeddingBagCollection(
                 )
                 if self._free_features_storage_early:
                     # pyrefly: ignore[missing-attribute]
-                    ctx.early_releasable_inputs = (original_features, None)
+                    ctx.early_releasable_inputs.append(original_features)
 
             # TODO: Consider turning this into a hook inside mc_modules and remove skip_permute
             #   from mc_modules, and fix all the private methods to be public.

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -38,7 +38,6 @@ from torchrec.distributed.embedding_sharding import (
 )
 from torchrec.distributed.embedding_types import (
     BaseEmbeddingSharder,
-    EarlyReleasableInputs,
     GroupedEmbeddingConfig,
     KJTList,
     ListOfKJTList,
@@ -85,7 +84,7 @@ class EmbeddingCollectionContext(Multistreamable):
     # VBE-Attributes for EBC
     inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None
     variable_batch_per_feature: bool = False
-    early_releasable_inputs: Optional[EarlyReleasableInputs] = None
+    early_releasable_inputs: list[KeyedJaggedTensor] = field(default_factory=list)
 
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
@@ -663,7 +662,7 @@ class ShardedManagedCollisionCollection(
                     self._features_order_tensor,
                 )
                 if self._free_features_storage_early:
-                    ctx.early_releasable_inputs = (original_features, None)
+                    ctx.early_releasable_inputs.append(original_features)
 
             feature_splits: List[KeyedJaggedTensor] = []
             if self.need_preprocess:

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -25,7 +25,6 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TYPE_CHECKING,
 )
 
 import torch
@@ -37,9 +36,6 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
-
-if TYPE_CHECKING:
-    from torchrec.distributed.embedding_types import EarlyReleasableInputs
 from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
@@ -170,20 +166,12 @@ def _clear_releasable_inputs(context: TrainPipelineContext) -> None:
         else context.module_contexts
     )
     for module_ctx in contexts_dict.values():
-        early_released: EarlyReleasableInputs | None = getattr(
-            module_ctx, "early_releasable_inputs", None
+        early_released: list[KeyedJaggedTensor] = getattr(
+            module_ctx, "early_releasable_inputs", []
         )
-        if early_released is not None:
-            assert (
-                len(early_released) == 2
-            ), "expecting early_releasable_inputs types with 2 KJT elements"
-            id_list, id_score_list = early_released
-            if id_list is not None:
-                id_list.clear_storage()
-            if id_score_list is not None:
-                id_score_list.clear_storage()
-            # pyre-ignore[16]: `Optional` has no attribute `early_releasable_inputs`.
-            module_ctx.early_releasable_inputs = None
+        for kjt in early_released:
+            kjt.clear_storage()
+        early_released.clear()
 
 
 def _start_data_dist(


### PR DESCRIPTION
Summary:
`EarlyReleasableInputs = Tuple[Optional[KJT], Optional[KJT]]` was over-designed — the second tuple element was almost always `None`, and the consumer had an unnecessary `assert len(...) == 2` with positional unpacking. This replaces it with a plain `list[KeyedJaggedTensor]` using `field(default_factory=list)`.

## 1. Context
The `EarlyReleasableInputs` type alias added indirection for what is conceptually just "a list of KJTs whose storage can be freed after input distribution." The fixed 2-tuple structure forced producers to pass `None` placeholders and the consumer to unpack positionally, making the code harder to read and extend.

## 2. Approach
1. **Remove type alias**: Delete `EarlyReleasableInputs` from `embedding_types.py` and all imports.
2. **Use `list[KJT]` with `field(default_factory=list)`**: Replace `Optional[EarlyReleasableInputs] = None` in all context dataclasses.
3. **Append inline**: Producers call `ctx.early_releasable_inputs.append(kjt)` directly where each releasable input is determined, eliminating temporary variables.
4. **Simplify consumer**: `_clear_releasable_inputs` now iterates the list and calls `.clear()`.

## 3. Results
```
# baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse \
  --name=sparse_data_dist_baseline

# free_input
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse \
  --name=sparse_data_dist_free_input \
  --free_features_storage_early=True

# inplace
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse \
  --name=sparse_data_dist_inplace \
  --enable_inplace_copy_batch=True

# free_input + inplace
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --pipeline=sparse \
  --name=sparse_data_dist_free_input_inplace \
  --free_features_storage_early=True \
  --enable_inplace_copy_batch=True
```
|name|GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|
|---|---|---|---|---|---|
|sparse_data_dist_baseline|5734.37 ms|5687.07 ms|49.06 GB|64.29 GB|66.33 GB|
|sparse_data_dist_free_input|5825.47 ms|5279.07 ms|45.84 GB|62.11 GB|64.15 GB|
|sparse_data_dist_inplace|5914.09 ms|5394.21 ms|49.06 GB|67.47 GB|69.51 GB|
|sparse_data_dist_free_input_inplace|5786.93 ms|5533.58 ms|45.84 GB|61.25 GB|63.29 GB|

No regression from the refactor. Peak Allocated memory values (49.06 GB baseline, 45.84 GB with free_input) match D97997763 exactly, confirming behavioral equivalence.

## 4. Changes
1. **`embedding_types.py`**: Remove `EarlyReleasableInputs` type alias.
2. **`embedding.py`**: Update `EmbeddingCollectionContext` field and two producer sites.
3. **`embeddingbag.py`**: Update `EmbeddingBagCollectionContext` field and one producer site.
4. **`mc_modules.py`**: Update `ManagedCollisionEmbeddingBagCollectionContext` field and one producer site.
5. **`mc_embeddingbag.py`**: Update one producer site.
6. **`train_pipeline/utils.py`**: Simplify `_clear_releasable_inputs` consumer; remove `TYPE_CHECKING` import.
7. **`fb/distributed/sequence_embedding_arch.py`**: Update `SequenceArchContext` field and one producer site.
8. **`fb/distributed/pooled_embedding_arch.py`**: Inline appends, remove temporary variables.
9. **`fb/ads/distributed/variable_length_embedding_arch.py`**: Inline appends, remove temporary variables.

Differential Revision: D95708457


