### PR TITLE
Revert caching eviction_flag

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -288,7 +288,6 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._eviction_policy_name: Optional[HashZchEvictionPolicyName] = (
             eviction_policy_name
         )
-        self._eviction_flag: int = get_kernel_from_policy(self._eviction_policy_name)
         self._eviction_config: Optional[HashZchEvictionConfig] = eviction_config
         self._eviction_module: Optional[HashZchEvictionModule] = (
             HashZchEvictionModule(
@@ -475,7 +474,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
 
     @property
     def eviction_flag(self) -> int:
-        return self._eviction_flag
+        return get_kernel_from_policy(self._eviction_policy_name)
 
     def buckets(self) -> int:
         return self._buckets
@@ -676,7 +675,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     _modulo_identity_DPRECATED=False,  # deprecated, always False
                     input_metadata=input_metadata,
                     eviction_threshold=eviction_threshold,
-                    eviction_policy=self._eviction_flag,
+                    eviction_policy=self.eviction_flag,
                     opt_in_prob=self._opt_in_prob,
                     num_reserved_slots=num_reserved_slots,
                     opt_in_rands=opt_in_rands,


### PR DESCRIPTION
Summary:
This diff is to fix the following task T262893869 that broke 10+ tests for unified_feature_cache.

Before eviction policy was cached, however since that test changes it dynamically, this reverts it back to eviction policy being set on each call to process_item_zch.

Differential Revision: D99448717


