### PR TITLE
Remove redundant manual metric timing from pipeline benchmark

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -24,7 +24,6 @@ import itertools
 import json
 import logging
 import os
-import time
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -251,10 +250,6 @@ def runner(
                 metric_module.reset()
                 metric_module.trained_batches = 0
 
-            progress_times_ms: List[float] = []
-            update_times_ms: List[float] = []
-            compute_times_ms: List[float] = []
-
             if run_option.num_iters is not None:
                 dataloader = itertools.islice(
                     itertools.cycle(bench_inputs), run_option.num_iters
@@ -263,57 +258,17 @@ def runner(
                 dataloader = iter(bench_inputs)
             while True:
                 try:
-                    torch.cuda.synchronize()
-                    t0 = time.perf_counter()
                     output = pipeline.progress(dataloader)
-                    torch.cuda.synchronize()
-                    progress_times_ms.append((time.perf_counter() - t0) * 1000.0)
 
                     if metric_module is not None and output is not None:
-                        t1 = time.perf_counter()
                         assert metric_model_out is not None
                         with record_function("## metric_update ##"):
                             metric_module.update(metric_model_out)
-                        torch.cuda.synchronize()
-                        update_times_ms.append((time.perf_counter() - t1) * 1000.0)
                         if metric_module.should_compute():
-                            t2 = time.perf_counter()
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
-                            torch.cuda.synchronize()
-                            compute_times_ms.append((time.perf_counter() - t2) * 1000.0)
                 except StopIteration:
                     break
-
-            if rank == 0 and progress_times_ms:
-                avg_progress = sum(progress_times_ms) / len(progress_times_ms)
-                avg_update = (
-                    sum(update_times_ms) / len(update_times_ms)
-                    if update_times_ms
-                    else 0.0
-                )
-                avg_compute = (
-                    sum(compute_times_ms) / len(compute_times_ms)
-                    if compute_times_ms
-                    else 0.0
-                )
-                update_pct = (
-                    avg_update / avg_progress * 100.0 if avg_progress > 0 else 0.0
-                )
-                compute_pct = (
-                    avg_compute / avg_progress * 100.0 if avg_progress > 0 else 0.0
-                )
-                print(
-                    f"[Metric Timing] iters={len(progress_times_ms)} "
-                    f"avg_progress={avg_progress:.2f}ms "
-                    f"avg_update={avg_update:.2f}ms ({update_pct:.1f}%) "
-                    f"avg_compute={avg_compute:.2f}ms ({compute_pct:.1f}%) "
-                    f"compute_calls={len(compute_times_ms)} "
-                    f"n_tasks={metric_config.num_tasks} "
-                    f"n_metrics={len(metric_config.metrics)} "
-                    f"mode={metric_config.rec_compute_mode}",
-                    flush=True,
-                )
 
         pipeline = pipeline_config.generate_pipeline(
             model=sharded_model,


### PR DESCRIPTION
Summary:
## 1. Context
The `_func_to_benchmark` inner function in `benchmark_train_pipeline.py` contained manual `torch.cuda.synchronize()` + `time.perf_counter()` timing instrumentation around `pipeline.progress()`, `metric_module.update()`, and `metric_module.compute()`. This timing was redundant because the outer `benchmark_func` framework already provides standardized timing and profiling. The manual instrumentation also added unnecessary `cuda.synchronize()` calls inside the hot loop, which can degrade benchmark accuracy by preventing overlap of CPU and GPU work.

## 2. Approach
1. **Remove manual timing lists**: Deleted `progress_times_ms`, `update_times_ms`, and `compute_times_ms` tracking lists
2. **Remove sync barriers**: Removed `torch.cuda.synchronize()` calls from the training loop, allowing the pipeline to run without artificial serialization points
3. **Remove rank-0 print block**: Removed the per-iteration timing summary that printed average progress/update/compute times
4. **Preserve `record_function` annotations**: Kept the `## metric_update ##` and `## metric_compute ##` annotations for PyTorch profiler tracing

## 3. Results
N/A — cleanup-only change, no new benchmarks.

## 4. Analysis
1. **Performance impact**: Removing `torch.cuda.synchronize()` from the hot loop eliminates forced CPU-GPU synchronization points, which should improve benchmark accuracy by not artificially serializing the pipeline
2. **Observability**: The `record_function` annotations are preserved, so metric operations remain visible in PyTorch traces and profiler output
3. **Risk**: Low — benchmark-only change with no impact on production training code

## 5. Changes
1. **`distributed/benchmark/benchmark_train_pipeline.py`**: Removed ~50 lines of manual timing instrumentation from `_func_to_benchmark`, including timing lists, `cuda.synchronize()` calls, `time.perf_counter()` measurements, and the rank-0 summary print block

Differential Revision: D98744414


