### PR TITLE
Fix cap==0 in TrainerConfig cannot overwrite HardwareConfig

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1296,6 +1296,37 @@ class TestTopologyFactory(unittest.TestCase):
 
             self.assertEqual(topology.devices[0].storage.ssd, 500 * 1024**3)
 
+        with self.subTest("trainer_ssd_cap_zero_overrides_hardware"):
+            trainer_config = TrainerConfig(
+                world_size=8,
+                local_world_size=8,
+                ssd_cap_bytes=0,
+            )
+            hardware_config = HardwareConfig(ssd_cap_bytes=4 * 1024**4)
+
+            topology = TopologyFactory.create_topology(
+                trainer_config=trainer_config,
+                hardware_config=hardware_config,
+            )
+
+            self.assertEqual(topology.devices[0].storage.ssd, 0)
+
+        with self.subTest("custom_topology_data_ssd_cap"):
+            custom_data = CustomTopologyData(
+                data={"ssd_cap": [500 * 1024**3, 1000 * 1024**3]},
+                world_size=2,
+            )
+            trainer_config = TrainerConfig(
+                world_size=2,
+                local_world_size=2,
+                additional_params={"custom_topology_data": custom_data},
+            )
+
+            topology = TopologyFactory.create_topology(trainer_config=trainer_config)
+
+            self.assertEqual(topology.devices[0].storage.ssd, 500 * 1024**3)
+            self.assertEqual(topology.devices[1].storage.ssd, 1000 * 1024**3)
+
         with self.subTest("custom_topology_data_from_additional_params"):
             custom_data = CustomTopologyData(
                 data={"hbm_cap": [40 * 1024**3, 80 * 1024**3]},

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -175,7 +175,7 @@ class CustomTopologyData:
     Custom device data for individual device in a topology.
     """
 
-    supported_fields = ["ddr_cap", "hbm_cap"]
+    supported_fields = ["ddr_cap", "hbm_cap", "ssd_cap"]
 
     def __init__(
         self,
@@ -680,9 +680,21 @@ class TopologyFactory:
             kwargs["pod_size"] = trainer.pod_size
 
         # Memory capacities: trainer > hardware > defaults
-        hbm_cap = trainer.hbm_cap_bytes or hardware.hbm_cap_bytes
-        ddr_cap = trainer.ddr_cap_bytes or hardware.ddr_cap_bytes
-        ssd_cap = trainer.ssd_cap_bytes or hardware.ssd_cap_bytes
+        hbm_cap = (
+            trainer.hbm_cap_bytes
+            if trainer.hbm_cap_bytes is not None
+            else hardware.hbm_cap_bytes
+        )
+        ddr_cap = (
+            trainer.ddr_cap_bytes
+            if trainer.ddr_cap_bytes is not None
+            else hardware.ddr_cap_bytes
+        )
+        ssd_cap = (
+            trainer.ssd_cap_bytes
+            if trainer.ssd_cap_bytes is not None
+            else hardware.ssd_cap_bytes
+        )
 
         # Handle dry-run mode overrides
         if trainer.is_dry_run:
@@ -826,9 +838,9 @@ class Topology:
 
         hbm_per_device = [0] * world_size
         if self._compute_device == "cuda" or self._compute_device == "mtia":
-            hbm_per_device = [hbm_cap if hbm_cap else HBM_CAP] * world_size
-        ddr_cap_per_rank = [ddr_cap if ddr_cap else DDR_CAP] * world_size
-        ssd_cap_per_rank = [ssd_cap if ssd_cap else SSD_CAP] * world_size
+            hbm_per_device = [hbm_cap if hbm_cap is not None else HBM_CAP] * world_size
+        ddr_cap_per_rank = [ddr_cap if ddr_cap is not None else DDR_CAP] * world_size
+        ssd_cap_per_rank = [ssd_cap if ssd_cap is not None else SSD_CAP] * world_size
 
         if custom_topology_data:
             if custom_topology_data.has_data("hbm_cap"):


### PR DESCRIPTION
Summary:
Fix truthiness bug in `TopologyFactory._add_trainer_params()` where memory capacity precedence resolution used Python `or` operator instead of `is not None` checks.

This fails when a TrainerConfig explicitly sets any capacity to 0 to disable that storage tier, because Python treats 0 as falsy. So, 0 or hardware.xxx_cap_bytes silently falls through to the hardware value instead of honoring the explicit override.

Fixed by using `if x is not None else` for all three capacity fields so that 0 is respected as an intentional override while None still defers to HardwareConfig.

Reviewed By: isururanawaka

Differential Revision: D98948851


