### PR TITLE
Remove output_dist_embeddings_requests from TrainPipelineContext (#4008)

### DIFF
--- a/torchrec/distributed/train_pipeline/pipeline_context.py
+++ b/torchrec/distributed/train_pipeline/pipeline_context.py
@@ -35,9 +35,6 @@ class TrainPipelineContext:
         input_dist_tensors_requests (Dict[str, Awaitable[Any]]): Stores input dist
             requests in the tensors awaitable stage, which occurs after calling `wait()`
             on the splits awaitable.
-        output_dist_embeddings_requests (Dict[str, Awaitable[Any]]): Stores output dist
-            awaitables for pipelined modules, keyed by module FQN. Used for registering
-            backward hooks on the output dist tensors during the backward pass.
         module_contexts (Dict[str, Multistreamable]): Stores module contexts from the
             input dist for the current batch.
         module_contexts_next_batch (Dict[str, Multistreamable]): Stores module contexts
@@ -52,9 +49,6 @@ class TrainPipelineContext:
 
     input_dist_splits_requests: Dict[str, Awaitable[Any]] = field(default_factory=dict)
     input_dist_tensors_requests: Dict[str, Awaitable[Any]] = field(default_factory=dict)
-    output_dist_embeddings_requests: Dict[str, Awaitable[Any]] = field(
-        default_factory=dict
-    )
     module_contexts: Dict[str, Multistreamable] = field(default_factory=dict)
     module_contexts_next_batch: Dict[str, Multistreamable] = field(
         default_factory=dict

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -73,9 +73,6 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
     def __call__(self, *input, **kwargs) -> Awaitable:
         if self._name not in self._context.input_dist_tensors_requests:
             available_names = list(self._context.input_dist_tensors_requests.keys())
-            output_dist_names = list(
-                self._context.output_dist_embeddings_requests.keys()
-            )
             raise AssertionError(
                 f"Invalid PipelinedForward usage, input_dist of {self._name} "
                 f"is not available, probably consumed by others. "
@@ -84,14 +81,13 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
                 f"or the pipeline context was not properly populated for this "
                 f"iteration. Each embedding module (EBC, EC, etc.) can only be "
                 f"invoked once per forward pass when using pipelined training. "
-                f"Available input_dist names: {available_names}. "
-                f"Already completed output_dist names: {output_dist_names}."
+                f"Available input_dist names: {available_names}."
             )
         # we made a basic assumption that an embedding module (EBC, EC, etc.) should only be evoked only
         # once in the model's forward pass. For more details: https://github.com/meta-pytorch/torchrec/pull/3294
         request = self._context.input_dist_tensors_requests.pop(self._name)
         assert isinstance(request, Awaitable)
-        with record_function("## wait_sparse_data_dist ##"):
+        with record_function("## runtime_forward_assemble_KJT ##"):
             # Finish waiting on the dist_stream,
             # in case some delayed stream scheduling happens during the wait() call.
             with torch.get_device_module(self._device).stream(self._stream):
@@ -113,9 +109,7 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
             data.record_stream(cur_stream)
             ctx.record_stream(cur_stream)
 
-        awaitable = self._module.compute_and_output_dist(ctx, data)
-        self._context.output_dist_embeddings_requests[self._name] = awaitable
-        return awaitable
+        return self._module.compute_and_output_dist(ctx, data)
 
 
 class EmbeddingPipelinedForward(BaseForward[EmbeddingTrainPipelineContext]):


### PR DESCRIPTION
Summary:

## 1. Context
`output_dist_embeddings_requests` was introduced in D83789518 to store output dist (all-to-all) awaitables in `TrainPipelineContext`, keyed by module FQN. However, no downstream code ever consumes these awaitables from the context — they are already returned directly from `PipelinedForward.__call__`. Holding references to the embedding awaitables in the context prevents the tensors from being freed when the model no longer needs them, unnecessarily increasing peak memory usage.

## 2. Approach
1. **Remove the field**: Delete `output_dist_embeddings_requests` from the `TrainPipelineContext` dataclass, including its docstring.
2. **Remove the write**: Stop storing the awaitable in the context dict after `compute_and_output_dist` — it's already returned to the caller.
3. **Simplify error message**: Remove the diagnostic `output_dist_names` from the `AssertionError` in `PipelinedForward.__call__`, since the field no longer exists.

## 3. Results
* benchmark

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|sparse_data_dist_base_before       |6046.93 ms       |5533.60 ms       |**49.06 GB**                |67.47 GB                   |70.05 GB          |0.0 / 0.0 / 0.0              |31.40 GB          |
|sparse_data_dist_base_after        |5794.76 ms       |5371.52 ms       |**43.30 GB**                |67.68 GB                   |70.26 GB          |0.0 / 0.0 / 0.0              |31.39 GB          |

* repro commands
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=sparse_data_dist_base_[before|after]
```

* before 2.5+3.1 GB pooled embeddings are not freed util optimizer.step
 {F1987713292} 

* after 2.5+3.1 GB pooled embeddings are freed in early forward
 {F1987713392} 

## 4. Analysis
1. **Memory improvement**: GPU Peak Mem allocated dropped from 49.06 GB to 43.30 GB (~12% reduction). The context was holding strong references to output dist awaitables (which contain embedding tensors from all-to-all collectives). These references prevented GC from freeing the tensors even after the model consumed them, increasing peak memory.
2. **No functional impact**: The dict was write-only — no code path ever retrieved values from it. The only read was `.keys()` for a diagnostic error message.
3. **Backward compatibility**: `output_dist_embeddings_requests` is an internal field on `TrainPipelineContext`. It's not part of any public API contract.

## 5. Changes
1. **`pipeline_context.py`**: Removed `output_dist_embeddings_requests` field definition and its docstring from `TrainPipelineContext`.
2. **`runtime_forwards.py`**: Removed the write to `output_dist_embeddings_requests` after `compute_and_output_dist`, removed the diagnostic `.keys()` read from the error message, and renamed the `record_function` label from `wait_sparse_data_dist` to `runtime_forward_assemble_KJT`.

Differential Revision: D98744415


