### PR TITLE
feat: add OptimizationTechnique.NONE for non-technique-specific events

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -10,7 +10,7 @@ import functools
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, Optional, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import (
     EventLoggingHandlerBase,
@@ -200,6 +200,19 @@ class TrainingOptimizationLogger(EventLoggingHandler):
         add_wait_counter: bool = False,
     ) -> Generator[None, None, None]:
         yield
+
+
+_UVM_KERNELS = frozenset(
+    {"fused_uvm_caching", "quant_uvm_caching", "fused_uvm", "quant_uvm"}
+)
+
+
+def detect_technique(
+    constraints: Optional[Dict] = None,  # type: ignore[type-arg]
+    best_plan: Optional[List] = None,  # type: ignore[type-arg]
+) -> OptimizationTechnique:
+    """Detect if EMO is active from constraints or plan. No-op OSS stub."""
+    return OptimizationTechnique.NONE
 
 
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -37,6 +37,7 @@ class StackLayer(Enum):
 class OptimizationTechnique(Enum):
     """Training optimization techniques."""
 
+    NONE = "none"
     EMO = "emo"
     ITEP = "itep"
     ALBT = "albt"


### PR DESCRIPTION
Summary: Add NONE value to OptimizationTechnique enum so general planner events can indicate no specific technique is active.

Differential Revision: D99529682


