### PR TITLE
feat: add planner_config event to training optimization logger (#4012)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -230,4 +230,18 @@ def log_offloading_summary(best_plan: List, planner_type: str, technique: Optimi
     pass
 
 
+def log_storage_reservation(
+    reservation_type: str,
+    percentage: Optional[float] = None,
+    dense_hbm_bytes: Optional[int] = None,
+    kjt_hbm_bytes: Optional[int] = None,
+    original_hbm_per_rank: int = 0,
+    available_hbm_per_rank: int = 0,
+    planner_type: str = "",
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -10,7 +10,7 @@ import functools
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, Optional, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import (
     EventLoggingHandlerBase,
@@ -200,6 +200,19 @@ class TrainingOptimizationLogger(EventLoggingHandler):
         add_wait_counter: bool = False,
     ) -> Generator[None, None, None]:
         yield
+
+
+_UVM_KERNELS = frozenset(
+    {"fused_uvm_caching", "quant_uvm_caching", "fused_uvm", "quant_uvm"}
+)
+
+
+def detect_technique(
+    constraints: Optional[Dict] = None,  # type: ignore[type-arg]
+    best_plan: Optional[List] = None,  # type: ignore[type-arg]
+) -> OptimizationTechnique:
+    """Detect if EMO is active from constraints or plan. No-op OSS stub."""
+    return OptimizationTechnique.NONE
 
 
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -215,4 +215,14 @@ def detect_technique(
     return OptimizationTechnique.NONE
 
 
+def log_planning_result(
+    planner_type: str,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+    error_message: Optional[str] = None,
+    **extra_metadata: str,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -244,4 +244,12 @@ def log_storage_reservation(
     pass
 
 
+def log_planner_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -225,4 +225,9 @@ def log_planning_result(
     pass
 
 
+def log_offloading_summary(best_plan: List, planner_type: str, technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -37,6 +37,7 @@ class StackLayer(Enum):
 class OptimizationTechnique(Enum):
     """Training optimization techniques."""
 
+    NONE = "none"
     EMO = "emo"
     ITEP = "itep"
     ALBT = "albt"

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -95,6 +95,7 @@ except Exception:
 
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
+    log_planner_config,
     log_planning_result,
     log_storage_reservation,
 )
@@ -594,6 +595,21 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             original_hbm_per_rank=self._topology.devices[0].storage.hbm,
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
+        )
+
+        log_planner_config(
+            {
+                "planner_type": self.__class__.__name__,
+                "proposers": ",".join(p.__class__.__name__ for p in self._proposers),
+                "partitioner": self._partitioner.__class__.__name__,
+                "perf_model": self._perf_model.__class__.__name__,
+                "timeout_s": (
+                    str(self._timeout_seconds) if self._timeout_seconds else "none"
+                ),
+                "num_table_constraints": (
+                    str(len(self._constraints)) if self._constraints else "0"
+                ),
+            }
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,6 +96,7 @@ except Exception:
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
     log_planning_result,
+    log_storage_reservation,
 )
 
 
@@ -581,6 +582,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             storage_policy=storage_policy,
             storage_percentage=storage_percentage,
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
+        )
+
+        dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
+        kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
+        log_storage_reservation(
+            reservation_type=storage_policy,
+            percentage=storage_percentage,
+            dense_hbm_bytes=dense_storage.hbm if dense_storage else None,
+            kjt_hbm_bytes=kjt_storage.hbm if kjt_storage else None,
+            original_hbm_per_rank=self._topology.devices[0].storage.hbm,
+            available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
+            planner_type=self.__class__.__name__,
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,7 +93,10 @@ except Exception:
         return decorator
 
 
-from torchrec.distributed.logging_handlers import log_planning_result
+from torchrec.distributed.logging_handlers import (
+    log_offloading_summary,
+    log_planning_result,
+)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -728,6 +731,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),
             )
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,6 +93,9 @@ except Exception:
         return decorator
 
 
+from torchrec.distributed.logging_handlers import log_planning_result
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -719,6 +722,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -777,6 +787,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                error_message=str(last_planner_error),
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(


### PR DESCRIPTION
Summary:


Log planner configuration (objective, solver_type, proposers, constraints count, etc.) at the start of plan() for both OSS and LP planners.

Differential Revision: D97832975
