### PR TITLE
[detailed][memory] Add clear_data_dist_inputs to free KJT input tensors after AllToAll (#4017)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -496,6 +496,7 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
 
         self._output_tensors: List[torch.Tensor] = []
         self._awaitables: List[dist.Work] = []
+        self._input_tensors = input_tensors
         self._world_size: int = self._pg.size()
         rank = dist.get_rank(self._pg)
 
@@ -558,6 +559,22 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
                 self._output_tensors.append(output_tensor)
                 self._awaitables.append(awaitable)
 
+    def clear_inputs(self) -> None:
+        """
+        Clears input KJT tensors after wait.
+        """
+        if self._workers == 1 or is_torchdynamo_compiling():
+            return
+
+        # Wait for all-to-all collectives to complete before freeing input storage.
+        for awaitable in self._awaitables:
+            awaitable.wait()
+
+        for tensor in self._input_tensors:
+            tensor.storage().resize_(0)
+
+        self._input_tensors.clear()
+
     def _wait_impl(self) -> KeyedJaggedTensor:
         """
         Overwrites wait function as we don't handle callbacks here.
@@ -571,6 +588,8 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
             return self._input
 
         if not is_torchdynamo_compiling():
+            # dist.Work.wait() is idempotent, so this is safe even if
+            # clear_inputs() already waited on these awaitables.
             for awaitable in self._awaitables:
                 awaitable.wait()
 

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -61,6 +61,7 @@ class PipelineConfig:
     pipeline: str = "base"
     enable_inplace_copy_batch: bool = False
     free_features_storage_early: bool = False
+    clear_data_dist_inputs: bool = False
     pipeline_postproc: bool = False
     kwargs: Dict[str, Any] = field(default_factory=dict)
 
@@ -151,6 +152,7 @@ class PipelineConfig:
                     optimizer=opt,
                     device=device,
                     free_features_storage_early=self.free_features_storage_early,
+                    clear_data_dist_inputs=self.clear_data_dist_inputs,
                     **self.get_kwargs(start_batch=0),
                 )
             case "fused":
@@ -160,6 +162,7 @@ class PipelineConfig:
                     device=device,
                     enable_inplace_copy_batch=self.enable_inplace_copy_batch,
                     free_features_storage_early=self.free_features_storage_early,
+                    clear_data_dist_inputs=self.clear_data_dist_inputs,
                     **self.get_kwargs(emb_lookup_stream="data_dist"),
                 )
             case _:
@@ -171,5 +174,6 @@ class PipelineConfig:
                     device=device,
                     enable_inplace_copy_batch=self.enable_inplace_copy_batch,
                     free_features_storage_early=self.free_features_storage_early,
+                    clear_data_dist_inputs=self.clear_data_dist_inputs,
                     **self.get_kwargs(),
                 )

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -210,6 +210,9 @@ class TrainEvalHybridPipelineBase(TrainPipelineSparseDist[In, Out]):
         # the input_dist of batches[0] has been invoked in previous iter. TODO: fact check
         self._wait_for_batch()
 
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
+
         # Start sparse data distribution for the next batch (overlapped with current forward)
         if len(self.batches) >= 2:
             # Invoke splits all_to_all comms (first part of input_dist)
@@ -310,6 +313,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
         multi_thread: bool = False,
         pipeline_depth: int = 2,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -321,6 +325,7 @@ class EvalPipelineCPUSparse(TrainPipelineSparseDist[In, Out]):
             pipeline_postproc=pipeline_postproc,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         assert pipeline_depth in (1, 2), "pipeline_depth must be 1 or 2"
         self._pipeline_depth = pipeline_depth
@@ -703,6 +708,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -717,6 +723,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
             enqueue_batch_after_forward=False,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._copy_executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=1)
         self.batches: Deque[Optional[In]] = cast(Deque[Optional[In]], FutureDeque())
@@ -814,6 +821,7 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -828,6 +836,7 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._output_dist_site = InjectionSite(
             fqn=site_fqn,
@@ -880,6 +889,9 @@ class TrainPipelineSparseDistBwdOpt(TrainPipelineSparseDist[In, Out]):
         # wait for batches[0] being available on device, this should always be completed since
         # the input_dist of batches[0] has be invoked in previous iter. TODO: fact check
         self._wait_for_batch()
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 2:
             # invoke splits all_to_all comms (first part of input_dist)
@@ -954,6 +966,7 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -968,6 +981,7 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._output_dist_site = InjectionSite(
             fqn=site_fqn,
@@ -1017,6 +1031,9 @@ class TrainPipelineSparseDistOptStash(TrainPipelineSparseDist[In, Out]):
                 self._optimizer.zero_grad()
 
         self._wait_for_batch()
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 2:
             self.start_sparse_data_dist(self.batches[1], self.contexts[1])
@@ -1108,6 +1125,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         free_features_storage_early: bool = False,
         delay_stash: bool = False,
         stash_site_fqn: Optional[str] = None,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1122,6 +1140,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         if isinstance(site_fqn, str):
             self._injection_site = InjectionSite(

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -68,6 +68,7 @@ from torchrec.distributed.train_pipeline.tracing import PipelinedPostproc
 from torchrec.distributed.train_pipeline.types import PipelineState
 from torchrec.distributed.train_pipeline.utils import (
     _batch_tensor_size,
+    _clear_input_dist_tensors,
     _override_input_dist_forwards,
     _pipeline_detach_model,
     _rewrite_model,
@@ -537,6 +538,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -548,6 +550,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._free_features_storage_early = free_features_storage_early
         self._batch_count = 0
         self._inplace_copy_batch_size_logged = False
+        self._clear_data_dist_inputs = clear_data_dist_inputs
 
         logger.info(
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "
@@ -820,6 +823,9 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         # wait for batches[0] being available on device, this should always be completed since
         # the input_dist of batches[0] has be invoked in previous iter. TODO: fact check
         self._wait_for_batch()
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 2:
             # invoke splits all_to_all comms (first part of input_dist)
@@ -1109,6 +1115,19 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         context.input_dist_splits_requests.clear()
         context.fused_splits_awaitables.clear()
 
+    def clear_sparse_data_dist_inputs(self, context: TrainPipelineContext) -> None:
+        """
+        Clears the input dist tensors requests from the context.
+        """
+        # Free input tensor storage early, now that AllToAll collectives are in flight.
+        one_time_rank0_logger.info(
+            f"{self.__class__.__name__} clear_input_dist_tensors"
+        )
+        logger.info(f"{self.__class__.__name__} clear_input_dist_tensors")
+        # pyrefly: ignore [bad-argument-type]
+        with self._stream_context(self._data_dist_stream):
+            _clear_input_dist_tensors(context)
+
     def _copy_batch_to_gpu(self, dataloader_iter: Iterator[In]) -> Optional[In]:
         """
         DEPRECATED: exists for backward compatibility on TrainPipelineContext.version 0
@@ -1254,6 +1273,7 @@ class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
         ] = None,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1268,6 +1288,7 @@ class TrainPipelineSparseDistLite(TrainPipelineSparseDist[In, Out]):
             enqueue_batch_after_forward=False,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
 
         # SDD Lite only uses memcpy stream for H2D copy.
@@ -1416,6 +1437,7 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
         enable_inplace_copy_batch: bool = False,
         enqueue_batch_after_forward: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1429,6 +1451,7 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             enqueue_batch_after_forward=enqueue_batch_after_forward,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._embedding_lookup_after_data_dist = embedding_lookup_after_data_dist
 
@@ -1522,6 +1545,9 @@ class TrainPipelineFusedSparseDist(TrainPipelineSparseDist[In, Out]):
         # the input_dist of batches[0] has be invoked in previous iter. TODO: fact check
         self._wait_for_batch()
 
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
+
         if len(self.batches) >= 2:
             # invoke splits all_to_all comms (first part of input_dist)
             self.start_sparse_data_dist(self.batches[1], self.contexts[1])
@@ -1610,6 +1636,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
         dmp_collection_sync_interval_batches: Optional[int] = 1,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1623,6 +1650,7 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._start_batch = start_batch
         self._stash_gradients = stash_gradients
@@ -1709,6 +1737,9 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
                 f"training stopped at {self._batch_count} batches"
             )
             raise StopIteration
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 3:
             self.start_sparse_data_dist(
@@ -1992,6 +2023,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         ] = None,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -2004,6 +2036,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             custom_model_fwd=custom_model_fwd,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._prefetch_stream: Optional[torch.Stream] = (
             (torch.get_device_module(device).Stream())
@@ -2214,6 +2247,7 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         pipeline_postproc: bool = False,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -2224,6 +2258,7 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             pipeline_postproc=pipeline_postproc,
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
         self._batch_loader: Optional[DataLoadingThread[In]] = None
 
@@ -2281,6 +2316,9 @@ class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         with record_function("## wait_for_batch ##"):
             _wait_for_batch(cast(In, self.batches[0]), self._data_dist_stream)
 
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
+
         if len(self.batches) >= 2:
             self.start_sparse_data_dist(self.batches[1], self.contexts[1])
 
@@ -2337,6 +2375,9 @@ class EvalPipelineFusedSparseDist(TrainPipelineFusedSparseDist[In, Out]):
         # wait for batches[0] being available on device, this should always be completed since
         # the input_dist of batches[0] has be invoked in previous iter. TODO: fact check
         self._wait_for_batch()
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 2:
             # invoke splits all_to_all comms (first part of input_dist)
@@ -2693,6 +2734,7 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
             Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
         ] = None,
         free_features_storage_early: bool = False,
+        clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
             model,
@@ -2704,6 +2746,7 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
             pipeline_postproc,
             custom_model_fwd,
             free_features_storage_early=free_features_storage_early,
+            clear_data_dist_inputs=clear_data_dist_inputs,
         )
 
         torch._logging.set_logs(compiled_autograd_verbose=True)
@@ -2778,6 +2821,9 @@ class TrainPipelineSparseDistCompAutograd(TrainPipelineSparseDist[In, Out]):
 
         with record_function("## wait_for_batch ##"):
             _wait_for_batch(cast(In, self.batches[0]), self._data_dist_stream)
+
+        if self._clear_data_dist_inputs:
+            self.clear_sparse_data_dist_inputs(self.contexts[0])
 
         if len(self.batches) >= 2:
             self.start_sparse_data_dist(self.batches[1], self.contexts[1])

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -33,6 +33,7 @@ from torch.utils._pytree import tree_flatten
 from torchrec.distributed.dist_data import KJTAllToAll, KJTAllToAllTensorsAwaitable
 from torchrec.distributed.embedding_sharding import (
     FusedKJTListSplitsAwaitable,
+    KJTListAwaitable,
     KJTListSplitsAwaitable,
     KJTSplitsAllToAllMeta,
 )
@@ -197,6 +198,21 @@ def _clear_releasable_inputs(context: TrainPipelineContext) -> None:
             return msg
 
         one_time_logger.info(LazyStr(get_kjt_size))
+
+
+def _clear_input_dist_tensors(context: TrainPipelineContext) -> None:
+    """Free input tensor storage for all in-flight KJT AllToAll operations.
+
+    Iterates over input_dist_tensors_requests and calls clear_inputs() on each
+    KJTAllToAllTensorsAwaitable. This waits for the AllToAll collectives to
+    complete and frees the input tensor storage early, before _wait_impl() is
+    called during the model forward pass.
+    """
+    for request in context.input_dist_tensors_requests.values():
+        if isinstance(request, KJTListAwaitable):
+            for awaitable in request.awaitables:
+                if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
+                    awaitable.clear_inputs()
 
 
 def _start_data_dist(


### PR DESCRIPTION
HBM Tax Audit: A Thorough Examination of Memory Efficiency in TorchRec's Train Pipeline (https://github.com/meta-pytorch/torchrec/pull/4067)
Summary:
Pull Request resolved: https://github.com/meta-pytorch/torchrec/pull/4067

# HBM Tax Audit: A Thorough Examination of Memory Efficiency in TorchRec's Train Pipeline

## TL;DR

- **We thoroughly analyzed HBM usage in TorchRec's SDD (Sparse Data Distribution) pipeline**, tracing the lifetimes of major tensors involved in distributed embedding lookup (sparse data dist) across the multi-stream pipeline stages.
- **We identified several sources of inefficient HBM usage** and reduced the memory overhead (the "tax" of pipelining over a non-pipelined baseline) from ~10x input KJT size down to the theoretical minimum of ~2–3x input KJT size (could be on-par with base pipeline).
- **This post is technically in-depth** — it covers CUDA stream semantics, caching allocator behavior, and tensor lifetime analysis. It is intended to serve as a reference for future memory optimization work and pipeline design considerations.
- Below is the full list of HBM optimizations identified and implemented:

| Technique | Description | HBM Saving | Status |
|-----------|-------------|------------|--------|
| [In-place batch copy](https://fb.workplace.com/groups/429376538334034/permalink/1497469664858044/) | Pre-allocate batch buffers on main stream to reduce CCA cross-stream overhead [D86068070/https://github.com/meta-pytorch/torchrec/pull/3510] | ~2–3x input KJT size | In Prod |
| Early free sparse features | Free original batch KJT storage right after input_dist permute completes [D95906581/https://github.com/meta-pytorch/torchrec/pull/3853] | ~2–3x input KJT size | Testing |
| Clear input tensors after AllToAll | Free AllToAll input tensors right after collective completes [D98744419/https://github.com/meta-pytorch/torchrec/pull/4017] | ~1x permuted KJT size<sup>*</sup> | Prototype |
| KJT dist_init in main stream | Run KJT.dist_init (post-A2A permute) on main stream to avoid CCA cross-stream overhead [D98744481/https://github.com/meta-pytorch/torchrec/pull/4018] | ~1x permuted KJT size<sup>*</sup> | Prototype |
| Clear batch references in time | Holding stale references to batch tensors delays HBM reclamation by GC [D85483966/https://github.com/meta-pytorch/torchrec/pull/3530, D98744415/https://github.com/meta-pytorch/torchrec/pull/4008] | ~1x input KJT size | In Prod |

<sup>*</sup> Permuted KJT size depends on the sharding type: it is the same as input KJT size for table-wise and row-wise shardings, but scales by the number of shards for column-wise sharding.

## Background & Motivation

Numerous workstreams have encountered challenges related to inaccurate CUDA memory estimation and surprisingly high CUDA memory consumption, leading to performance bottlenecks and OOM issues:

- **[CMSL training efficiency](https://docs.google.com/document/d/1g7QoetlN5ZTIgEq4TMqH0hpqSVPHWX7wtwrUSS02J3o/edit?tab=t.0)**: The IFR model cannot run with the SDD pipeline due to unexpected memory regression. The base pipeline showed ~85% peak HBM usage ([zoomer](https://www.internalfb.com/ai_infra/zoomer/profiling-run/overview?tab=OVERVIEW&profilingRunID=2019190532209896) / [job_inspector](https://www.internalfb.com/ai_infra/job_inspector/guided/gpu_memory?jobName=fire-tjia-ifr_test_new_baseline&jobVersion=1&jobAttempt=1&env=PRODUCTION)) while SDD showed ~99% ([zoomer](https://www.internalfb.com/ai_infra/zoomer/profiling-run/overview?tab=OVERVIEW&profilingRunID=2544583642583881) / [job_inspector](https://www.internalfb.com/ai_infra/job_inspector/guided/gpu_memory?jobName=fire-tjia-ifr_test_new_baseline_sdd&jobVersion=1&jobAttempt=0&env=PRODUCTION)), blocking an ~8% QPS gain. Memory snapshots ([baseline](https://www.internalfb.com/pytorch_memory_visualizer/mvai_gpu_traces/tree/gpu_snapshot/fire-tjia-ifr_test_new_baseline/1/rank-11_itrn-3.Oct_15_12_00_27.2469.snapshot.pickle), [SDD](https://www.internalfb.com/pytorch_memory_visualizer/mvai_gpu_traces/tree/gpu_snapshot/fire-tjia-ifr_test_new_baseline_sdd/0/rank-32_itrn-3.Oct_15_10_46_50.2266.snapshot.pickle)) indicated ~3 GB regression, but actual regression observed via job_inspector was ~7 GB.
- **[APEX hardware heterogeneity](https://docs.google.com/document/d/12uw2dAqZoQA75kT643915cuWIqZ9yFm8UBhLEPl23n0/edit?tab=t.0) & [sharding plan optimization](https://docs.google.com/document/d/1l9yyB_tI8ByYB_YlUHOWEoiP5H09fyVXP8tsSqUiUTA/edit?tab=t.0#heading=h.8ek1yjvmsi8v)**: The planner cannot make accurate estimates of sparse HBM usage in the SDD pipeline, resorting to guesswork. HBM is tight in these scenarios, making inaccurate estimates especially costly.
- **Semi-Sync pipeline**: The efficiency-vs-HBM tradeoff is not favorable enough — the additional memory overhead has blocked production adoption.
- **Other HBM-tight use cases**: Many models (e.g., eval jobs, MRS models) are already at the edge of HBM limits, where any pipeline memory overhead can push them into OOM.

The gap between expected and observed memory usage — and the discrepancy between snapshot-reported and actual regression — made it clear that we needed a thorough, first-principles understanding of where HBM is used in the SDD pipeline.

## Fundamentals

This section covers the prerequisite concepts needed to understand the memory optimizations discussed in this post.

### [CUDA Caching Allocator (CCA)](https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html)

PyTorch does not call `cudaMalloc`/`cudaFree` for every tensor allocation. Instead, the CUDA Caching Allocator maintains a pool of previously allocated blocks and reuses them for future allocations. This is critical for performance — `cudaMalloc` is expensive and synchronizing.

Key behaviors:
- **Block reuse**: When a tensor is freed, its underlying memory block returns to the CCA's free pool rather than being released back to the GPU. Future allocations of similar size reuse these blocks.
- **`reserved` vs `allocated`**: `reserved` is the total memory the CCA holds (free + in-use). `allocated` is the memory currently in use by tensors. The gap (`reserved - allocated`) is the CCA's free pool.
- **Fragmentation**: Over time, the free pool can become fragmented — plenty of total free memory, but no single contiguous block large enough for a new allocation. This can trigger `cudaMalloc` retries or OOM.
- **Note**: The actual GPU memory consumed is `reserved`, not `allocated`. `reserved` is usually much larger than `allocated` due to the free pool, fragmentation, and cross-stream overhead. This is why memory snapshots (which report `allocated`) can underestimate the true HBM usage.

**Multi-stream considerations**:
- The CCA manages separate pools for different CUDA streams. When a block is freed on stream A, it returns to stream A's free pool and is only immediately reusable by allocations on that same stream.
- If stream B needs memory and its own pool is exhausted, the CCA can attempt to reclaim blocks from other streams' pools — but this requires a cross-stream (and host) synchronization to ensure the owning stream has completed all work using that block. This synchronization is expensive and is also known as **[CCA jitter](https://fb.workplace.com/notes/1619355872222997)**.
- In the worst case, when no single stream's pool can satisfy an allocation, the CCA triggers a `cudaMalloc` retry: it synchronizes across *all* streams, reclaims all reclaimable blocks, and retries the allocation. This is a heavy-weight operation that stalls the entire GPU pipeline.
- The implication for multi-stream pipelines is clear: allocating and freeing tensors on different streams inflates `reserved` memory and increases the risk of costly retries.

### Tensor Lifecycle in PyTorch

A tensor's HBM lifetime is governed by:

1. **Allocation**: CCA assigns a block (from free pool or via `cudaMalloc`).
2. **Usage**: Tensor is read/written by CUDA kernels on one or more streams.
3. **Python reference drop**: When the last Python reference is deleted (`del tensor`, goes out of scope, or overwritten), Python's GC notifies the CCA.
4. **CCA free**: The block returns to the free pool — *unless* `record_stream` was called, in which case the free is deferred.

The critical insight: **a tensor's HBM is not freed until *both* all Python references are dropped *and* all recorded streams have completed their use.** Holding an unnecessary Python reference (e.g., in a dict or list) delays step 3, even if no code will ever read the tensor again.

```python
# Example 1:
A = torch.rand(1024, device="cuda")      # Allocation: CCA assigns block 0x1000 for A
A = A * 2                                # Allocation: CCA assigns block
                                         # 0x2000 for new A. new A can't
                                         # re-use 0x1000 because it's needed
                                         # for the multiplication. 0x1000
                                         # freed implicitly (old A ref dropped)
                                         # after this line.
B = A * 2                                # Allocation: CCA assigns block 0x1000 for B
del A                                    # 0x2000 freed explicitly (B ref dropped)
# ... only A is used from here on ...
# without `del A`, 0x2000 would remain allocated until A goes out of scope
```

<img width="1429" height="413" alt="Image" src="https://github.com/user-attachments/assets/4a5fad46-9880-4f96-b184-58033549fec2" />

In practice, intermediate tensors are not freed until the last Python reference is dropped. During training, autograd retains them for the backward pass. If some intermediates are no longer needed (e.g., input tensors after a collective completes), they should be freed explicitly to reclaim HBM early. If intermediates are needed for backward but you still want to reduce memory, consider [Activation Stashing](https://fb.workplace.com/groups/811751593969209/permalink/1382593183551711/).

```python
# Example 2: in a typical forward pass
def forward(self, model_input):
    pooled_embs = self.sparse_arch(model_input.sparse_features)
    dense_embs = self.dense_arch(model_input.float_features)
    act1 = self.interaction_arch(pooled_embs, dense_embs)
    act2 = self.over_arch(act1)
    pred = self.task_arch(act2)
    return pred
```

### [`record_stream`](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html) and Cross-Stream Memory Safety

When a tensor is used on multiple CUDA streams, PyTorch must ensure the memory is not freed while another stream is still using it. One approach is to use `stream.wait_stream()` to synchronize before freeing:

```python
# Example 3: without record_stream — using wait_stream for safety
main_stream = torch.cuda.current_stream()
side_stream = torch.cuda.Stream()

A = torch.rand(1024, device="cuda")      # Allocation: 0x1000 for A
side_stream.wait_stream(main_stream)     # side_stream waits for A to be ready
with side_stream:
    some_execution(A)                    # side_stream reads 0x1000
A = A * 2                                # Allocation: 0x2000 for new A
                                         # but 0x1000 is NOT safe to re-use yet —
                                         # side_stream may still be reading it!
main_stream.wait_stream(side_stream)     # main_stream blocks until side_stream
                                         # finishes. Now 0x1000 is safe to re-use.

B = A * 2                                # Allocation: 0x1000 reused for B
```
<img width="1428" height="531" alt="Image" src="https://github.com/user-attachments/assets/58be1cb9-8b42-48d7-9af6-a52b04996087" />

This is correct but requires the main stream to block until the side stream finishes. This is preferred approach if we know when the side_stream will finish before certain point in the main stream. Note here, the order is between two CUDA streams, no CPU timing involved.
An alternative approach is to use `record_stream` to defer the free until the recorded stream has finished:

```python
# Example 4: with record_stream — no blocking
A = torch.rand(1024, device="cuda")      # Allocation: 0x1000 for A
side_stream.wait_stream(main_stream)     # side_stream waits for A to be ready
with side_stream:
    some_execution_1(A)                  # side_stream reads 0x1000
A.record_stream(side_stream)             # tell CCA: side_stream uses 0x1000

with side_stream:
    some_execution_2()                   # side_stream continues with other work
A = A * 2                                # Allocation: 0x2000 for new A
                                         # 0x1000 has no Python ref, but NOT
                                         # freed yet — deferred by record_stream
with side_stream:
    some_execution_3()
# main_stream and side_stream continue without blocking!
# 0x1000 is freed by CCA when side_stream finishes some_execution_2()
```

<img width="1820" height="632" alt="Image" src="https://github.com/user-attachments/assets/8d1520f1-7e89-48e7-a38a-64ad00f5bdaf" />

**The cost**: A block with `record_stream` is **not** immediately reusable after Python-side deallocation. The CCA (on host) defers freeing until the recorded stream has progressed past the deallocation point on GPU. Since GPU typically runs behind CPU, the recorded stream often has not caught up by the time the block is deallocated — so the CCA cannot reclaim the memory right away, inflating `reserved` memory.

## TorchRec Distributed Embedding Lookup

Before diving into the optimizations, it helps to understand the key memory-producing operations in a single training iteration for distributed embedding lookup. From a memory perspective, the critical steps are:

1. **Input KJT copy (CPU → GPU)**: The input `KeyedJaggedTensor` is copied from host to device, usually via a dedicated `memcpy_stream`.
2. **Input KJT permute**: The KJT is permuted to match the sharding layout for input distribution. The permuted tensor size is the same as the input KJT for table-wise and row-wise sharding, but can be larger for column-wise sharding — CW-sharded features are duplicated across shards, multiplying their size by the number of shards.
3. **Input dist (AllToAll)**: The permuted KJT is split and exchanged across ranks via AllToAll collectives. This involves both an `input_tensor` (sent) and an `output_tensor` (received). The `output_tensor` size is determined by the sharding plan; assuming a well-balanced plan, the `output_tensor` is roughly the same size as the `input_tensor`.
4. **Output KJT assembly (`KJT.dist_init`)**: The AllToAll output tensors are permuted and reassembled into feature-grouped KJTs. For example, if each rank sends `[f1, f2, f3]`, the output from all ranks is `[f1, f2, f3, f1, f2, f3, ...]` and after permute becomes `[f1, f1, ..., f2, f2, ..., f3, f3, ...]`.
5. **TBE lookup and output dist**: Embedding table lookups (via FBGEMM TBE kernels) followed by output AllToAll to redistribute embeddings back to the original ranks.
6. **Forward, backward, optimizer**: The rest of the training iteration — dense forward pass, loss computation, backward pass, and optimizer step. The memory peak usually occurs at the beginning of the backward pass, when all forward activations are still alive and gradients start to accumulate.

Each of these steps allocates tensors that occupy HBM. The following table summarizes each tensor's lifecycle:

| Tensor | Created | Used by | Earliest Free Point |
|--------|---------|---------|---------------------|
| Input KJT (GPU copy) | Step 1: CPU → GPU copy | Step 2: permute | After permute completes |
| Permuted KJT (AllToAll input) | Step 2: permute | Step 3: AllToAll send | After AllToAll completes |
| AllToAll output tensor | Step 3: AllToAll init | Step 4: `dist_init` permute | After `dist_init` completes |
| Assembled KJT | Step 4: `dist_init` | Step 5: TBE lookup | After TBE lookup completes |
| TBE embeddings | Step 5: TBE lookup | Step 5: output AllToAll send | After output dist completes |
| Output dist result | Step 5: output AllToAll | Step 6: forward / backward | After backward completes |

The optimizations in this post target the gap between a tensor's "earliest free point" and when it is actually freed in the current pipeline. Ideally, all distributed embedding tensors should be freed by the time output dist completes, leaving only the output dist result alive for the rest of the forward/backward pass.

## Step-by-Step Memory Analysis

### Step 1: Copy Batch to GPU

The input batch is copied from CPU to GPU via `memcpy_stream` to overlap the H2D transfer with computation on the main stream. The diagram below shows the current base pipeline's memory profile, highlighting the copy batch operation on `memcpy_stream`:

<img width="1559" height="831" alt="Image" src="https://github.com/user-attachments/assets/0e7fb113-2202-49b4-a32d-0bcda6764881" />

There are two issues with the current approach:

1. **The input KJT is last used by permute (early input dist)** — after permute, the original KJT is no longer needed, but its memory is not freed until much later. The batch reference is dropped on the CPU side after the forward pass, but because `record_stream` is used for cross-stream safety, the CCA defers the actual free until the forward pass completes on the GPU — which typically means the next copy batch has already started on CPU.
2. **The memory is allocated on `memcpy_stream` and cannot be reused by `main_stream`** — since the tensors are allocated on a different stream, they sit on top of the peak memory and cannot be reclaimed by `main_stream` without cross-stream synchronization (CCA jitter).

The theoretically minimum HBM overhead for copy batch should be **zero** — the input KJT's last use (permute) completes well before the memory peak (beginning of backward), so if freed promptly it would not contribute to peak memory at all.

**Fix 1 ([in-place batch copy](https://fb.workplace.com/groups/429376538334034/permalink/1497469664858044/))**: Pre-allocate batch buffers on `main_stream` and reuse them across iterations. The `memcpy_stream` copies data in-place into these pre-allocated buffers rather than allocating new tensors. Since the buffers belong to `main_stream`, no cross-stream overhead is incurred.

**Fix 2 (early free sparse features)**: Free the original input KJT storage right after permute completes, since it is no longer needed. This drops the batch memory well before the forward pass, eliminating its contribution to peak memory.

Together, the optimized copy batch can bring ~2x input KJT size HBM saving in the base pipeline. The saving is even larger (~3x) in the standard SDD pipeline, where multiple batches are in flight simultaneously:

<img width="1533" height="664" alt="Image" src="https://github.com/user-attachments/assets/5fc8c953-52c7-49d6-aa1e-02a43bf4f5bf" />

<img width="1563" height="945" alt="Image" src="https://github.com/user-attachments/assets/c953be29-493f-4e9a-93a6-33a98ae90619" />

### Step 2: Input KJT Permute

During `start_sparse_data_dist`, the input KJT is permuted to reorder features according to the sharding layout, so that each rank's portion is contiguous for the AllToAll collective. The permuted tensor becomes the `input_tensor` for the AllToAll communication in Step 3.

Once the permute completes, the original input KJT is no longer needed — `permute()` creates independent tensors (via `fbgemm.permute_2D_sparse_data`), not views. This is where **Fix 2 (early free sparse features)** from Step 1 takes effect.

However, we cannot simply `del` the KJT — the batch object is still alive in the pipeline queue (it won't be dequeued until the next iteration), so Python references to the KJT and its underlying tensors remain. Instead, we call `tensor.untyped_storage().resize_(0)` on each of the KJT's storage tensors (`_values`, `_lengths`, `_offsets`, `_weights`). This immediately releases the GPU memory while keeping the Python tensor objects intact. As long as the KJT is only used for embedding lookup, the freed storage will not be read again since `permute()` already produced independent copies.

### Step 3: Input Dist (AllToAll)

In `wait_sparse_data_dist` (also on the `data_dist_stream`), the AllToAll collective is started. The `input_tensor` (to be sent) is the permuted KJT from Step 2, and the `output_tensor` (to receive into) is allocated at AllToAll init. The `output_tensor` is consumed by `dist_init` (Step 4) and freed after assembly completes. The `input_tensor` is only needed until the AllToAll collective completes (`work.wait()`), but in the current pipeline, `wait()` doesn't happen until `PipelinedForward.__call__` — long after the collective has actually finished. This means the `input_tensor` stays alive until the start of the forward pass, overlapping with the next batch's `input_tensor` and increasing the memory footprint of the `data_dist_stream`.

<img width="1549" height="953" alt="Image" src="https://github.com/user-attachments/assets/2f6c65d9-fe86-4c72-b7be-5c74ec5fffac" />

**Fix (clear input tensors after AllToAll, [D98744419/https://github.com/meta-pytorch/torchrec/pull/4017])**: Add a `clear_inputs()` method to `KJTAllToAllTensorsAwaitable` that calls `work.wait()` and then frees input tensor storage via `tensor.storage().resize_(0)`. The pipeline calls this right before `start_sparse_data_dist` — the earliest safe point where the AllToAll is guaranteed to have completed.

This saves ~1x permuted KJT size by freeing the `input_tensor` right after the collective completes, rather than holding it until the forward pass.

<img width="1572" height="859" alt="Image" src="https://github.com/user-attachments/assets/dcad50f9-3858-4a74-a431-8566fd180281" />

### Step 4: Output KJT Assembly (`dist_init`)

After the AllToAll completes, the raw output tensors contain features interleaved by source rank — they need to be permuted back into feature-grouped KJTs before TBE lookup can consume them. This is done by `KJT.dist_init`, which permutes the output tensors and produces the assembled KJTs.

Currently, `dist_init` runs on the `data_dist_stream` inside `PipelinedForward.__call__`, because it is part of the awaitable resolution chain (`request.wait()`). However, by this point the AllToAll has already completed — `dist_init` is purely local computation (a permute), not a collective. Running it on `data_dist_stream` has two consequences:

1. **Pro**: Since `start_sparse_data_dist` is already done at this point, `dist_init` can start immediately on `data_dist_stream` without waiting.
2. **Con — cross-stream memory overhead**: The permuted output tensors are allocated on `data_dist_stream` but consumed on `main_stream` (for TBE lookup and forward), requiring `record_stream` and preventing immediate memory reuse.

**Fix (KJT `dist_init` in main stream, [D98744481/https://github.com/meta-pytorch/torchrec/pull/4018])**: When `clear_data_dist_inputs` is enabled, run `request.wait()` (which triggers `dist_init`) on the main stream instead of switching to `data_dist_stream`. Note that `dist_init` includes a few device-to-host data transfers (e.g., `length_per_key`), which typically add ~5ms runtime on the main stream. However, this tradeoff saves significantly more memory by avoiding cross-stream CCA overhead. Additionally, `KJT.dist_init` output won't contribute to peak memory — it is consumed by TBE lookup immediately and freed well before the backward pass.

Together, Step 3 and Step 4 fixes save ~2x permuted KJT size — ~1x from freeing the `input_tensor` early, and ~1x from avoiding cross-stream CCA overhead on the `dist_init` output.

<img width="1568" height="845" alt="Image" src="https://github.com/user-attachments/assets/b5e1b6f3-2695-4f7c-90c0-f1b8fb4f2380" />

## Summary: Optimized Pipeline vs Base Pipeline

With all optimizations applied, the HBM overhead of the SDD pipeline over a non-pipelined baseline is significantly reduced:

| Source | SDD Pipeline (Before) | SDD Pipeline (Optimized) | Base Pipeline (Before) | Base Pipeline (Optimized) |
|--------|-----------------------|--------------------------|------------------------|---------------------------|
| Copy batch | ~3x input KJT | ~0x | ~2x input KJT | ~0x |
| Input dist | ~3x permuted KJT | ~2x permuted KJT | 0x | 0x |
| `dist_init` | ~1x permuted KJT | ~0x | 0x | 0x |
| **Total** | ~3x input KJT + ~4x permuted KJT | ~2x permuted KJT | ~2x input KJT | ~0x |

With all optimizations applied, the **base pipeline** achieves theoretically **zero** distributed sparse HBM overhead — all sparse tensors (input KJT, permuted KJT, AllToAll input/output, `dist_init` output) complete their last use well before the memory peak, so if freed promptly they do not contribute to peak memory at all.

The **optimized SDD pipeline** still has ~2x permuted KJT overhead — which is almost on par with the unoptimized base pipeline's ~2x input KJT overhead.

This remaining ~2x is inherent to pipelining: the SDD pipeline overlaps input dist with compute (forward), so the next batch's AllToAll `input_tensor` and `output_tensor` must remain allocated while the current batch's forward pass is running. The constraint is that the AllToAll time window is not short enough to complete before the memory peak (beginning of backward) — the in-flight collective spans across the peak, so its tensors cannot be freed in time.

A more aggressive approach would reduce another ~1x permuted KJT by calling `wait_sparse_data_dist` in the middle of the backward pass and pre-allocating the `output_tensor` on the main stream, as shown below:

<img width="1582" height="769" alt="Image" src="https://github.com/user-attachments/assets/d37d29f3-2d39-47c6-b99e-26b0618942b6" />

However, this comes with significant risks: the timing is hard to control — pre-allocating the `output_tensor` reduces the time window available for the AllToAll to complete, and the same physical network channel is shared with backward AllToAll (output dist), DDP AllReduce, and FSDP AllGather, all competing for bandwidth.

## Benchmark Results

We benchmarked each optimization incrementally using the TorchRec pipeline benchmark (`benchmark_train_pipeline`) with the following setup: 2 GPUs, 90 unweighted + 80 weighted features, embedding_dim=256, batch_size=32768, table-wise sharding. The total input batch size is ~1.58 GB.

|short name|GPU Peak Alloc|GPU Peak Reserved|GPU Mem Used|Comparison|
|--|--|--|--|--|
|base_pipeline|48.08 GB|58.77 GB|60.81 GB|baseline (same peak alloc as base_optimized — copy batch memory does not contribute to peak)|
|base_optimized|48.08 GB|56.85 GB|58.89 GB|-1.92 GB (~2x KJT size) reserved vs base_pipeline — pre-allocation avoids multi-stream CCA overhead|
|sdd_pipeline|53.04 GB|70.38 GB|72.42 GB|baseline|
|sdd_copy_batch_optimized|49.83 GB|64.43 GB|66.47 GB|~3x KJT reduction in reserved, ~2x KJT reduction in alloc vs sdd_pipeline|
|sdd_clear_inputs|49.83 GB|61.73 GB|63.77 GB|same peak alloc as above, ~1x permuted KJT (~2 GB) saving in reserved|
|sdd_minimum_overhead|49.83 GB|59.74 GB|61.78 GB|same peak alloc as above, another ~1x permuted KJT (~2 GB) saving in reserved|

- **base_pipeline**: Base pipeline, no optimizations.
- **base_optimized**: Base pipeline + in-place batch copy + early free sparse features (Step 1 fixes).
- **sdd_pipeline**: SDD pipeline, no optimizations.
- **sdd_copy_batch_optimized**: SDD + in-place batch copy + early free sparse features (Step 1 fixes).
- **sdd_clear_inputs**: SDD + Step 1 fixes + clear input tensors after AllToAll (Step 3 fix).
- **sdd_minimum_overhead**: SDD + all optimizations (Step 1 + Step 3 + Step 4 fixes).

**sdd_minimum_overhead vs base_pipeline**:
- ~2 GB (1x permuted KJT) higher in peak alloc — as expected, the SDD pipeline has one extra in-flight batch's permuted KJT at peak.
- ~1 GB (2x permuted KJT - 2x KJT) higher in reserved — as expected, the remaining overhead is minimal.

**sdd_minimum_overhead vs sdd_pipeline**:
- ~3 GB (2x KJT) lower in peak alloc.
- ~10.5 GB (3x KJT + 3x permuted KJT) lower in reserved.

Repro commands (OSS):
```bash
# 1. Base pipeline (no optimizations)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --pipeline=base \
  --name=base_pipeline

# 2. Base pipeline + in-place batch copy + early free sparse features
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --pipeline=base \
  --enable_inplace_copy_batch=True \
  --free_features_storage_early=True \
  --name=base_optimized

# 3. SDD pipeline (no optimizations)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --name=sdd_pipeline

# 4. SDD + in-place batch copy + early free sparse features
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --enable_inplace_copy_batch=True \
  --free_features_storage_early=True \
  --name=sdd_copy_batch_optimized

# 5. SDD + copy batch optimized + clear data dist inputs
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --enable_inplace_copy_batch=True \
  --free_features_storage_early=True \
  --clear_data_dist_inputs=True \
  --name=sdd_clear_inputs

# 6. SDD + all optimizations (+ main stream dist_init)
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
  --enable_inplace_copy_batch=True \
  --free_features_storage_early=True \
  --clear_data_dist_inputs=True \
  --name=sdd_minimum_overhead

Reviewed By: Fiery, aporialiao

Differential Revision: D98744419


