### PR TITLE
Use main stream for KJT assembly when clear_data_dist_inputs is enabled (#4018)

### DIFF
--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -9,6 +9,7 @@
 
 import itertools
 import logging
+from contextlib import nullcontext
 from typing import Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import torch
@@ -86,6 +87,8 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
     This pipeline is used in TrainPipelineSparseDist
     """
 
+    _use_main_stream_for_dist_init = False
+
     def __call__(self, *input, **kwargs) -> Awaitable:
         if self._name not in self._context.input_dist_tensors_requests:
             available_names = list(self._context.input_dist_tensors_requests.keys())
@@ -104,9 +107,14 @@ class PipelinedForward(BaseForward[TrainPipelineContext]):
         request = self._context.input_dist_tensors_requests.pop(self._name)
         assert isinstance(request, Awaitable)
         with record_function("## runtime_forward_assemble_KJT ##"):
+            stream_ctx = (
+                nullcontext()
+                if self._use_main_stream_for_dist_init
+                else torch.get_device_module(self._device).stream(self._stream)
+            )
             # Finish waiting on the dist_stream,
             # in case some delayed stream scheduling happens during the wait() call.
-            with torch.get_device_module(self._device).stream(self._stream):
+            with stream_ctx:
                 data = request.wait()
 
         # Make sure that both result of input_dist and context

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -605,6 +605,8 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._model_fwd: Callable[[Optional[In]], Tuple[torch.Tensor, Out]] = (
             custom_model_fwd if custom_model_fwd else model
         )
+        if self._clear_data_dist_inputs:
+            PipelinedForward._use_main_stream_for_dist_init = True
 
         super().__init__()
 


### PR DESCRIPTION
Summary:

## 1. Context
After the KJT input dist (AllToAll) completes, the received tensors from all ranks need to be assembled into a local KJT — this is `KJT.dist_init()`, which permutes and concatenates the data from multiple ranks into the correct feature order. This operation is triggered lazily via `request.wait()` inside `PipelinedForward.__call__` during the model forward pass.

Currently, `request.wait()` switches to the `data_dist_stream` before calling `dist_init()`. This was originally done so the KJT assembly could start immediately without waiting for work queued on the main stream. However, the permuted output tensor is allocated on the `data_dist_stream`, and this tensor is only needed until the embedding lookup completes — after that, the main stream cannot reuse the `data_dist_stream`-allocated memory without cross-stream synchronization, increasing peak HBM.

With `clear_data_dist_inputs=True` (D98744419), the AllToAll collectives are already waited on and the input tensors freed before the forward pass. At this point, `request.wait()` → `dist_init()` is no longer overlapping with anything on the data_dist_stream — it's just assembling already-available output tensors. Running it on the data_dist_stream is unnecessary and forces the output allocation onto a stream whose memory the main stream cannot efficiently reuse.

## 2. Approach
1. **Class-level flag on PipelinedForward**: Added `_use_main_stream_for_dist_init = False` as a class variable on `PipelinedForward`. When `True`, `request.wait()` (KJT assembly) runs on the main stream via `nullcontext()` instead of switching to `self._stream`.
2. **Set flag when clear_data_dist_inputs is enabled**: In `TrainPipelineSparseDist.__init__`, when `clear_data_dist_inputs=True`, the class-level flag is set to `True`, ensuring all `PipelinedForward` instances stay on the main stream for KJT assembly.

## 3. Results
* benchmark

|short name|GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|--|--|--|--|--|--|--|--|
|baseline|5789.23 ms|5412.62 ms|43.30 GB|66.88 GB|69.46 GB|0.0 / 0.0 / 0.0|31.36 GB|
|clear_inputs (D98744419)|5785.74 ms|5327.43 ms|43.30 GB|64.96 GB|67.54 GB|0.0 / 0.0 / 0.0|31.35 GB|
|clear_inputs (this diff)|5732.20 ms|5393.01 ms|43.30 GB|61.52 GB|63.56 GB|0.0 / 0.0 / 0.0|31.31 GB|

* repro commands
```
# OSS — baseline
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --name=baseline

# OSS — with clear_data_dist_inputs + main stream dist_init
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --name=clear_inputs \
  --clear_data_dist_inputs=True
```

* artifacts
- [manifold folder (D98744481)](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98744481)
- [manifold folder (D98744419)](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98744419)

|name|rank0 trace|rank0 memory|
|--|--|--|
|baseline|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98744481/trace-baseline-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98744481/trace-baseline-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98744481/memory-baseline-rank0.pickle)|
|clear_inputs (D98744419)|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98744419/trace-clear_inputs-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98744419/trace-clear_inputs-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98744419/memory-clear_inputs-rank0.pickle)|
|clear_inputs (this diff)|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D98744481/trace-clear_inputs-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D98744481/trace-clear_inputs-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D98744481/memory-clear_inputs-rank0.pickle)|

## 4. Analysis
1. **Peak allocated memory is unchanged**: GPU Peak Mem alloc is 43.30 GB in all three cases because the peak allocation happens at the beginning of backward, where none of these memory optimizations apply.
2. **Reserved memory reduction is due to multi-stream CCA behavior**: The CUDA caching allocator (CCA) cannot reuse memory across streams without explicit synchronization ([reference](https://fb.workplace.com/groups/429376538334034/permalink/1497469664858044/)). In the baseline, tensors allocated on `data_dist_stream` (input tensors from AllToAll, permuted output from `dist_init`) remain pinned to that stream's free pool and cannot be reused by the main stream's forward/backward. D98744419 frees the AllToAll input tensors on the main stream, reducing reserved from ~67 GB to ~65 GB. This diff additionally moves `dist_init()` to the main stream so its output allocation is also reusable, reducing reserved further to ~62 GB.
3. **Memory breakdown from snapshots**: Manually confirmed from the memory snapshots — the first ~2 GB reduction (D98744419) comes from freeing the KJT input tensors (`clear_inputs` via `storage().resize_(0)`), and the additional ~3 GB reduction (this diff) comes from moving the `dist_init()` permuted output allocation from `data_dist_stream` to the main stream.
4. **Stream correctness**: When `clear_data_dist_inputs` is enabled, `_wait_for_batch()` already synchronizes the data_dist_stream before the forward pass, and `clear_sparse_data_dist_inputs` frees tensors on the main stream. Keeping `request.wait()` on the main stream preserves correct ordering and avoids an unnecessary stream switch.
5. **Backward compatibility**: The default is `False`, so behavior is unchanged unless `clear_data_dist_inputs=True` is explicitly set.

## 5. Changes
1. **`runtime_forwards.py`**: Added `_use_main_stream_for_dist_init` class variable to `PipelinedForward`. Modified `__call__` to conditionally use `nullcontext()` (main stream) or `stream(self._stream)` based on the flag.
2. **`train_pipelines.py`**: In `TrainPipelineSparseDist.__init__`, set `PipelinedForward._use_main_stream_for_dist_init = True` when `clear_data_dist_inputs` is enabled.

Reviewed By: Fiery, aporialiao

Differential Revision: D98744481
