### PR TITLE
Upgrade API of Prefetch SDD (#4021)

### DIFF
--- a/torchrec/distributed/train_pipeline/pipeline_context.py
+++ b/torchrec/distributed/train_pipeline/pipeline_context.py
@@ -66,7 +66,9 @@ class TrainPipelineContext:
 
 @dataclass
 class PrefetchTrainPipelineContext(TrainPipelineContext):
-    module_input_post_prefetch: Dict[str, Multistreamable] = field(default_factory=dict)
+    module_input_post_prefetch: Dict[str, Multistreamable | torch.Tensor] = field(
+        default_factory=dict
+    )
     module_contexts_post_prefetch: Dict[str, Multistreamable] = field(
         default_factory=dict
     )

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipeline_prefetch_sparse_dist.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipeline_prefetch_sparse_dist.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for PrefetchTrainPipelineSparseDist.
+
+This module tests the prefetch pipeline API changes including:
+- The new prefetch_embeddings utility function
+- The fill_pipeline method with batch queue management
+- The progress method with proper prefetch flow
+- Stream synchronization and context management
+"""
+
+import unittest
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+import torch
+from hypothesis import given, settings, strategies as st
+from torch import nn
+from torch.optim import Optimizer
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.test_model import ModelInput
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.train_pipeline.pipeline_context import (
+    PrefetchTrainPipelineContext,
+)
+from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import (
+    TrainPipelineSparseDistTestBase,
+)
+from torchrec.distributed.train_pipeline.train_pipelines import (
+    PrefetchTrainPipelineSparseDist,
+)
+from torchrec.distributed.train_pipeline.utils import prefetch_embeddings
+from torchrec.distributed.types import ShardingType
+from torchrec.modules.embedding_configs import DataType
+
+
+class PrefetchEmbeddingsUtilTest(unittest.TestCase):
+    """Tests for the prefetch_embeddings utility function."""
+
+    def test_prefetch_embeddings_returns_early_when_data_dist_stream_is_none(
+        self,
+    ) -> None:
+        """Test that prefetch_embeddings returns early when data_dist_stream is None."""
+        context = PrefetchTrainPipelineContext()
+        pipelined_modules: List[MagicMock] = []
+        stream_context = MagicMock()
+
+        prefetch_embeddings(
+            context=context,
+            pipelined_modules=pipelined_modules,
+            device=torch.device("cpu"),
+            stream_context=stream_context,
+            data_dist_stream=None,
+            forward_stream=None,
+        )
+
+        stream_context.assert_not_called()
+
+
+class PrefetchTrainPipelineTestBase(TrainPipelineSparseDistTestBase):
+    """
+    Base class for PrefetchTrainPipelineSparseDist tests.
+
+    Provides common setup and helper methods to reduce code duplication.
+    """
+
+    # Default fused params for prefetch pipeline tests
+    DEFAULT_FUSED_PARAMS: Dict[str, Any] = {
+        "cache_load_factor": 0.5,
+        "cache_precision": DataType.FP32,
+        "stochastic_rounding": False,
+        "prefetch_pipeline": True,
+    }
+
+    def _create_pipeline(
+        self,
+        num_batches: int = 5,
+        batch_size: int = 32,
+        execute_all_batches: bool = True,
+        fused_params: Optional[Dict[str, Any]] = None,
+        sharding_type: str = ShardingType.TABLE_WISE.value,
+        kernel_type: str = EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+    ) -> Tuple[
+        PrefetchTrainPipelineSparseDist,
+        Iterator[ModelInput],
+        nn.Module,
+        Optimizer,
+    ]:
+        """
+        Creates a prefetch pipeline with all necessary components.
+
+        Returns:
+            Tuple of (pipeline, dataloader, sharded_model, optimizer)
+        """
+        self._set_table_weights_precision(DataType.FP32)
+        data = self._generate_data(num_batches=num_batches, batch_size=batch_size)
+        dataloader = iter(data)
+
+        params = fused_params if fused_params is not None else self.DEFAULT_FUSED_PARAMS
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, params
+        )
+
+        pipeline = PrefetchTrainPipelineSparseDist(
+            model=sharded_model,
+            optimizer=optim,
+            device=self.device,
+            execute_all_batches=execute_all_batches,
+        )
+
+        return pipeline, dataloader, sharded_model, optim
+
+
+class PrefetchTrainPipelineTest(PrefetchTrainPipelineTestBase):
+    """Tests for PrefetchTrainPipelineSparseDist API and behavior."""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_fill_pipeline_initializes_batches_and_contexts(self) -> None:
+        """Test that fill_pipeline properly initializes the batch and context queues."""
+        pipeline, dataloader, _, _ = self._create_pipeline()
+
+        pipeline.fill_pipeline(dataloader)
+
+        self.assertEqual(len(pipeline.batches), 2)
+        self.assertEqual(len(pipeline.contexts), 2)
+        self.assertIsInstance(pipeline.contexts[0], PrefetchTrainPipelineContext)
+        self.assertIsInstance(pipeline.contexts[1], PrefetchTrainPipelineContext)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_fill_pipeline_is_idempotent(self) -> None:
+        """Test that calling fill_pipeline multiple times doesn't add extra batches."""
+        pipeline, dataloader, _, _ = self._create_pipeline(num_batches=10)
+
+        pipeline.fill_pipeline(dataloader)
+        initial_batch_count = len(pipeline.batches)
+        pipeline.fill_pipeline(dataloader)
+
+        self.assertEqual(len(pipeline.batches), initial_batch_count)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_progress_dequeues_batch_after_processing(self) -> None:
+        """Test that progress properly dequeues batches after processing."""
+        pipeline, dataloader, _, _ = self._create_pipeline()
+
+        _ = pipeline.progress(dataloader)
+
+        self.assertLessEqual(len(pipeline.batches), 3)
+        self.assertEqual(len(pipeline.batches), len(pipeline.contexts))
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_progress_raises_stop_iteration_when_empty(self) -> None:
+        """Test that progress raises StopIteration when no batches are available."""
+        pipeline, _, _, _ = self._create_pipeline(num_batches=0)
+        empty_dataloader: Iterator[ModelInput] = iter([])
+
+        with self.assertRaises(StopIteration):
+            pipeline.progress(empty_dataloader)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_prefetch_stream_initialization(self) -> None:
+        """Test that prefetch and default streams are properly initialized."""
+        pipeline, _, _, _ = self._create_pipeline()
+
+        self.assertIsNotNone(pipeline._prefetch_stream)
+        self.assertIsNotNone(pipeline._default_stream)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_context_indices_are_sequential(self) -> None:
+        """Test that context indices are properly assigned sequentially."""
+        pipeline, dataloader, _, _ = self._create_pipeline(num_batches=8)
+
+        observed_indices = []
+        for _ in range(5):
+            _ = pipeline.progress(dataloader)
+            if pipeline.contexts:
+                observed_indices.append(pipeline.contexts[0].index)
+
+        self.assertGreater(len(observed_indices), 0)
+        for idx in observed_indices:
+            self.assertIsNotNone(idx)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_batch_queue_maintains_sync_with_context_queue(self) -> None:
+        """Test that batch queue and context queue remain synchronized."""
+        pipeline, dataloader, _, _ = self._create_pipeline(num_batches=10)
+
+        for _ in range(7):
+            _ = pipeline.progress(dataloader)
+            self.assertEqual(
+                len(pipeline.batches),
+                len(pipeline.contexts),
+                "Batch and context queues must have the same length",
+            )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_single_batch_execution(self) -> None:
+        """Test pipeline behavior with only a single batch in the dataloader."""
+        pipeline, dataloader, _, _ = self._create_pipeline(num_batches=1)
+
+        output = pipeline.progress(dataloader)
+
+        self.assertIsNotNone(output)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_two_batch_execution(self) -> None:
+        """Test pipeline behavior with exactly two batches in the dataloader."""
+        pipeline, dataloader, _, _ = self._create_pipeline(num_batches=2)
+
+        output1 = pipeline.progress(dataloader)
+        output2 = pipeline.progress(dataloader)
+
+        self.assertIsNotNone(output1)
+        self.assertIsNotNone(output2)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_execute_all_batches_false(self) -> None:
+        """Test pipeline behavior with execute_all_batches=False."""
+        pipeline, dataloader, _, _ = self._create_pipeline(execute_all_batches=False)
+
+        outputs = []
+        try:
+            for _ in range(10):
+                outputs.append(pipeline.progress(dataloader))
+        except StopIteration:
+            pass
+
+        self.assertGreater(len(outputs), 0)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    @settings(max_examples=4, deadline=None)
+    # pyre-ignore[56]
+    @given(
+        weight_precision=st.sampled_from([DataType.FP16, DataType.FP32]),
+        cache_precision=st.sampled_from([DataType.FP16, DataType.FP32]),
+        load_factor=st.sampled_from([0.2, 0.4, 0.6]),
+        sharding_type=st.sampled_from(
+            [ShardingType.TABLE_WISE.value, ShardingType.ROW_WISE.value]
+        ),
+    )
+    def test_prefetch_pipeline_correctness(
+        self,
+        weight_precision: DataType,
+        cache_precision: DataType,
+        load_factor: float,
+        sharding_type: str,
+    ) -> None:
+        """
+        Verifies that pipelined execution with prefetch produces the same results
+        as non-pipelined execution when using FUSED_UVM_CACHING kernel.
+        """
+        mixed_precision: bool = weight_precision != cache_precision
+        self._set_table_weights_precision(weight_precision)
+        data = self._generate_data(num_batches=12, batch_size=32)
+        dataloader = iter(data)
+
+        fused_params = {
+            "cache_load_factor": load_factor,
+            "cache_precision": cache_precision,
+            "stochastic_rounding": False,
+        }
+        fused_params_pipelined = {**fused_params, "prefetch_pipeline": True}
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model,
+            sharding_type,
+            EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            fused_params,
+        )
+        sharded_model_pipelined, optim_pipelined = (
+            self._generate_sharded_model_and_optimizer(
+                model,
+                sharding_type,
+                EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+                fused_params_pipelined,
+            )
+        )
+        copy_state_dict(
+            sharded_model.state_dict(), sharded_model_pipelined.state_dict()
+        )
+
+        pipeline = PrefetchTrainPipelineSparseDist(
+            model=sharded_model_pipelined,
+            optimizer=optim_pipelined,
+            device=self.device,
+            execute_all_batches=True,
+        )
+
+        for batch in data:
+            batch = batch.to(self.device)
+            optim.zero_grad(set_to_none=True)
+            loss, pred = sharded_model(batch)
+            loss.backward()
+            optim.step()
+
+            pred_pipeline = pipeline.progress(dataloader)
+
+            if not mixed_precision:
+                self.assertTrue(torch.equal(pred, pred_pipeline))
+            else:
+                torch.testing.assert_close(pred, pred_pipeline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -69,7 +69,6 @@ from torchrec.distributed.train_pipeline.types import PipelineState
 from torchrec.distributed.train_pipeline.utils import (
     _override_input_dist_forwards,
     _pipeline_detach_model,
-    _prefetch_embeddings,
     _rewrite_model,
     _start_data_dist,
     _start_embedding_lookup,
@@ -77,6 +76,7 @@ from torchrec.distributed.train_pipeline.utils import (
     _wait_for_batch,
     _wait_for_events,
     DataLoadingThread,
+    prefetch_embeddings,
     use_context_for_postprocs,
 )
 from torchrec.distributed.types import Awaitable, NoWait, ShardingType  # noqa: F401
@@ -1977,7 +1977,6 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
         )
-        self._context = PrefetchTrainPipelineContext(version=0)
         self._prefetch_stream: Optional[torch.Stream] = (
             (torch.get_device_module(device).Stream())
             if self._device.type in ["cuda", "mtia"]
@@ -1988,79 +1987,43 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             if self._device.type in ["cuda", "mtia"]
             else None
         )
-        self._batch_ip3: Optional[In] = None
-        self._staged_postproc_fwd_results: Dict[str, Any] = {}
 
-    def _start_sparse_data_dist(self, batch: Optional[In]) -> None:
+    def fill_pipeline(self, dataloader_iter: Iterator[In]) -> None:
         """
-        Override to use a staging context for postprocs, preventing
-        postproc_fwd_results cache contamination in the shared v0 context.
-        """
-        if batch is None:
-            return
-        self._set_module_context(self._context)
-        staging_context = PrefetchTrainPipelineContext(version=0)
-        with record_function("## start_sparse_data_dist ##"):
-            # pyrefly: ignore [bad-argument-type]
-            with self._stream_context(self._data_dist_stream):
-                _wait_for_batch(batch, self._memcpy_stream)
-                with use_context_for_postprocs(
-                    self._pipelined_postprocs, staging_context
-                ):
-                    _start_data_dist(self._pipelined_modules, batch, self._context)
-        self._staged_postproc_fwd_results = staging_context.postproc_fwd_results
-
-    def _commit_postproc_results(self) -> None:
-        """
-        Swap staged postproc results into the live context so forward reads
-        the correct batch's postproc results.
-        """
-        self._context.postproc_fwd_results = self._staged_postproc_fwd_results
-        self._staged_postproc_fwd_results = {}
-
-    def _fill_pipeline(self, dataloader_iter: Iterator[In]) -> None:
-        """
-        DEPRECATED: exists for backward compatibility
-        Initializes the prefetch pipeline with batches.
 
         This method fills the pipeline with initial batches to enable overlapping of
         device transfer, input dist, and cache prefetching operations.
 
         Args:
             dataloader_iter: Iterator that produces training batches.
-
-        Raises:
-            StopIteration: if the dataloader iterator is exhausted on the first batch.
         """
-        one_time_rank0_logger.warning(
-            f"{self.__class__.__name__} is using deprecated _fill_pipeline"
-        )
         # pipeline is already filled
-        if self._batch_i and self._batch_ip1 and self._batch_ip2:
-            return
-        # executes last batch in pipeline
-        if self._execute_all_batches and (self._batch_i or self._batch_ip1):
+        if len(self.batches) >= 3:
             return
 
-        # batch 1
-        self._batch_i = self._copy_batch_to_gpu(dataloader_iter)
-        if self._batch_i is None:
-            raise StopIteration
+        # executes last batch in pipeline
+        if self.batches and self._execute_all_batches:
+            return
+
+        # Fetch data for the first iteration of the whole pipeline
+        if not self.enqueue_batch(dataloader_iter):
+            return
 
         self._init_pipelined_modules(
-            self._batch_i,
-            self._context,
+            cast(In, self.batches[0]),
+            self.contexts[0],
             # pyrefly: ignore [bad-argument-type]
             self._pipelined_forward_type,
         )
-        self._start_sparse_data_dist(self._batch_i)
-        self._wait_sparse_data_dist()
-        self._commit_postproc_results()
-        self._prefetch(self._batch_i)
 
-        # batch 2
-        self._batch_ip1 = self._copy_batch_to_gpu(dataloader_iter)
-        self._start_sparse_data_dist(self._batch_ip1)
+        self.wait_sparse_data_dist(self.contexts[0])
+        self._prefetch(cast(PrefetchTrainPipelineContext, self.contexts[0]))
+
+        # Fetch data for the second iteration of the whole pipeline
+        if not self.enqueue_batch(dataloader_iter):
+            return
+
+        self.start_sparse_data_dist(self.batches[1], self.contexts[1])
 
     @EventLoggingHandler.event_logger(
         TorchrecComponent.TRAIN_PIPELINE, n=1000, add_wait_counter=True
@@ -2087,25 +2050,50 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         Raises:
             StopIteration: if the dataloader iterator is exhausted.
         """
-        self._fill_pipeline(dataloader_iter)
+
+        self.fill_pipeline(dataloader_iter)
+
+        if not self.batches:
+            raise StopIteration
+
+        self._set_module_context(self.contexts[0])
 
         if self._model.training:
             with record_function("## zero_grad ##"):
                 self._optimizer.zero_grad()
 
         with record_function("## wait_for_batch ##"):
-            _wait_for_batch(cast(In, self._batch_i), self._prefetch_stream)
+            _wait_for_batch(cast(In, self.batches[0]), self._prefetch_stream)
 
-        self._batch_ip2 = self._copy_batch_to_gpu(dataloader_iter)
+        # batch i+2: load data and copy to gpu
+        self.enqueue_batch(dataloader_iter)
 
-        self._wait_sparse_data_dist()
+        # Wait for sparse data dist for batch i+1 (kicked off in previous
+        # iteration or fill_pipeline). This completes the splits all2all and
+        # populates input_dist_tensors_requests, which kicks off the tensor
+        # data all2all asynchronously. By doing this BEFORE forward, the
+        # tensor data transfer overlaps with forward compute.
+        if len(self.batches) >= 2:
+            self.wait_sparse_data_dist(self.contexts[1])
+
         # forward
         with record_function("## forward ##"):
-            losses, output = self._model_fwd(self._batch_i)
+            losses, output = self._model_fwd(self.batches[0])
 
-        self._commit_postproc_results()
+        # Free prefetch data from batch i (just used by forward) so the
+        # CUDA caching allocator can reuse those blocks for batch i+1's prefetch.
+        cast(
+            PrefetchTrainPipelineContext, self.contexts[0]
+        ).module_input_post_prefetch.clear()
+        cast(
+            PrefetchTrainPipelineContext, self.contexts[0]
+        ).module_contexts_post_prefetch.clear()
 
-        self._prefetch(self._batch_ip1)
+        # Prefetch for batch i+1 after forward. The tensor data all2all has
+        # had the entire forward pass to complete, so prefetch_embeddings'
+        # request.wait() should resolve quickly.
+        if len(self.batches) >= 2:
+            self._prefetch(cast(PrefetchTrainPipelineContext, self.contexts[1]))
 
         if self._model.training:
             # backward
@@ -2116,14 +2104,16 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             with record_function("## optimizer ##"):
                 self._optimizer.step()
 
-        self._start_sparse_data_dist(self._batch_ip2)
+        # Start sparse data dist for batch i+2 at the end, so it overlaps
+        # with the next iteration's early phases.
+        if len(self.batches) >= 3:
+            self.start_sparse_data_dist(self.batches[2], self.contexts[2])
 
-        self._batch_i = self._batch_ip1
-        self._batch_ip1 = self._batch_ip2
+        self.dequeue_batch()
 
         return output
 
-    def _prefetch(self, batch: Optional[In]) -> None:
+    def _prefetch(self, context: PrefetchTrainPipelineContext) -> None:
         """
         Prefetches embedding data from cache to GPU memory.
 
@@ -2133,30 +2123,21 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         pipeline context for use in the next forward pass.
 
         Args:
-            batch: The batch to prefetch embeddings for. If None, this method
-                returns early without prefetching.
+            context: The prefetch pipeline context containing input distribution
+                requests and module contexts for the batch to prefetch.
 
         Note:
             This operation runs on self._prefetch_stream to enable overlap with
             forward/backward computation on the default stream.
         """
-        if batch is None:
-            return
-        # pyrefly: ignore [missing-attribute]
-        self._context.module_input_post_prefetch.clear()
-        # pyrefly: ignore [missing-attribute]
-        self._context.module_contexts_post_prefetch.clear()
+        context.module_input_post_prefetch.clear()
+        context.module_contexts_post_prefetch.clear()
 
-        with record_function("## sharded_module_prefetch ##"):
+        with record_function(f"## sharded_module_prefetch {context.index} ##"):
             # pyrefly: ignore [bad-argument-type]
             with self._stream_context(self._prefetch_stream):
-                batch.record_stream(
-                    torch.get_device_module(self._device).current_stream()
-                )
-                data_per_pipelined_module = _prefetch_embeddings(
-                    batch,
-                    # pyrefly: ignore [bad-argument-type]
-                    self._context,
+                prefetch_embeddings(
+                    context,
                     self._pipelined_modules,
                     self._device,
                     # pyrefly: ignore [bad-argument-type]
@@ -2164,17 +2145,6 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
                     self._data_dist_stream,
                     self._default_stream,
                 )
-                for sharded_module in self._pipelined_modules:
-                    forward = sharded_module.forward
-                    # pyrefly: ignore [missing-attribute]
-                    data = data_per_pipelined_module[forward._name]
-                    # pyrefly: ignore [missing-attribute]
-                    self._context.module_input_post_prefetch[forward._name] = data
-                    # pyrefly: ignore [missing-attribute]
-                    self._context.module_contexts_post_prefetch[forward._name] = (
-                        # pyrefly: ignore [missing-attribute]
-                        self._context.module_contexts.pop(forward._name)
-                    )
 
 
 class EvalPipelineSparseDist(TrainPipelineSparseDist[In, Out]):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -637,6 +637,78 @@ class DataLoadingThread(Thread, Generic[In]):
         return batch
 
 
+def prefetch_embeddings(
+    context: PrefetchTrainPipelineContext,
+    pipelined_modules: List[ShardedModule],
+    device: torch.device,
+    stream_context: Callable[[Optional[torch.Stream]], torch.cuda.StreamContext],
+    data_dist_stream: Optional[torch.Stream],
+    forward_stream: Optional[torch.Stream],
+) -> None:
+    """
+    Prefetches embeddings for the given batch.
+
+    This function processes each sharded module by:
+    1. Retrieving and waiting for the input distribution request for the module
+    2. Ensuring proper stream synchronization for the resulting data
+    3. Initiating the prefetch operation for the module
+
+    Args:
+        context: The prefetch pipeline context containing state information
+        pipelined_modules: List of sharded modules to process
+        device: The device to use for computation
+        stream_context: Context manager for stream operations
+        data_dist_stream: Stream used for data distribution operations
+        forward_stream: Default stream for operations
+    """
+
+    if data_dist_stream is None:
+        return
+
+    cur_stream = torch.get_device_module(device).current_stream()
+
+    for sharded_module in pipelined_modules:
+        forward = sharded_module.forward
+        assert isinstance(forward, PrefetchPipelinedForward)
+
+        assert forward._name in context.input_dist_tensors_requests
+        request = context.input_dist_tensors_requests.pop(forward._name)
+        assert isinstance(request, Awaitable)
+
+        with record_function(f"## _prefetch_embeddings {context.index} ##"):
+            # Finish waiting on the dist_stream,
+            # in case some delayed stream scheduling happens during the wait() call.
+            with stream_context(data_dist_stream):
+                dist_input = request.wait()
+                assert isinstance(
+                    dist_input, (torch.Tensor, Multistreamable)
+                ), f"{type(dist_input)} must implement Multistreamable interface"
+
+        # Ensure prefetch stream waits for data_dist stream's GPU work
+        # before launching prefetch kernels that read the dist output.
+        cur_stream.wait_stream(data_dist_stream)
+
+        # Make sure that both result of input_dist and context
+        # are properly transferred to the current stream.
+        module_context = context.module_contexts[forward._name]
+
+        dist_input.record_stream(cur_stream)
+        module_context.record_stream(cur_stream)
+        if forward_stream is not None:
+            dist_input.record_stream(forward_stream)
+            module_context.record_stream(forward_stream)
+
+        sharded_module.prefetch(
+            ctx=module_context,
+            dist_input=dist_input,
+            forward_stream=forward_stream,
+        )
+        context.module_input_post_prefetch[forward._name] = dist_input
+        context.module_contexts_post_prefetch[forward._name] = (
+            context.module_contexts.pop(forward._name)
+        )
+
+
 def _prefetch_embeddings(
     batch: In,
     context: PrefetchTrainPipelineContext,


### PR DESCRIPTION
Summary:

This diff upgrades context from v0 to v1 in prefetch pipeline. As a result, we can enable postproc on prefetch pipeline. Note a careful review is needed

Changes
* replacing the legacy _batch_i/_batch_ip1/_batch_ip2 pattern with self.batches[]/self.contexts[] and enqueue_batch()/dequeue_batch().
* Remove single shared context: Replace self._context (one shared PrefetchTrainPipelineContext) with per-batch contexts from the base class queue, eliminating the staging context workaround (_staged_postproc_fwd_results, _commit_postproc_results, _start_sparse_data_dist override).

Reviewed By: TroyGarden, spmex

Differential Revision: D92926400


