### PR TITLE
feat: add offloading_summary event to training optimization logger (#3982)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -217,4 +217,9 @@ def log_planning_result(
     pass
 
 
+def log_offloading_summary(best_plan: List, planner_type: str, technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -207,4 +207,14 @@ def detect_technique(items: List) -> OptimizationTechnique:  # type: ignore[type
     return OptimizationTechnique.NONE
 
 
+def log_planning_result(
+    planner_type: str,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+    error_message: Optional[str] = None,
+    **extra_metadata: str,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -10,7 +10,7 @@ import functools
 import logging
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Callable, Dict, Generator, Optional, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, TypeVar
 
 from torchrec.distributed.logging_utils import (
     EventLoggingHandlerBase,
@@ -200,6 +200,11 @@ class TrainingOptimizationLogger(EventLoggingHandler):
         add_wait_counter: bool = False,
     ) -> Generator[None, None, None]:
         yield
+
+
+def detect_technique(items: List) -> OptimizationTechnique:  # type: ignore[type-arg]
+    """Detect if EMO is active. No-op OSS stub."""
+    return OptimizationTechnique.NONE
 
 
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -37,6 +37,7 @@ class StackLayer(Enum):
 class OptimizationTechnique(Enum):
     """Training optimization techniques."""
 
+    NONE = "none"
     EMO = "emo"
     ITEP = "itep"
     ALBT = "albt"

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,6 +93,9 @@ except Exception:
         return decorator
 
 
+from torchrec.distributed.logging_handlers import log_planning_result
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -720,6 +723,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -778,6 +788,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                error_message=str(last_planner_error),
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,7 +93,10 @@ except Exception:
         return decorator
 
 
-from torchrec.distributed.logging_handlers import log_planning_result
+from torchrec.distributed.logging_handlers import (
+    log_offloading_summary,
+    log_planning_result,
+)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -729,6 +732,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),
             )
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:


### PR DESCRIPTION
Summary:


Log num_offloaded, num_cached, HBM/DDR sparse bytes after successful planning in both OSS and LP planners via shared `log_offloading_summary()` helper.

Differential Revision: D97783060


