### PR TITLE
Clean up packaging workaround for Python 3.14 in CI workflows

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -152,10 +152,6 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/${{ matrix.cuda-tag }}
         fi
         echo "index_url: $index_url"
-        if [[ "${{ matrix.python.version }}" = "3.14" ]]; then
-          # temporary workaround for torch package issue in python 3.14
-          conda run -n build_binary pip install packaging
-        fi
         conda run -n build_binary \
           pip install torch --index-url $index_url
         conda run -n build_binary \

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -102,10 +102,6 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/cpu
         fi
         echo "index_url: $index_url"
-        if [[ "${{ matrix.python.version }}" = "3.14" ]]; then
-          # temporary workaround for torch package issue in python 3.14
-          conda run -n build_binary pip install packaging
-        fi
         conda run -n build_binary \
           pip install torch --index-url $index_url
         conda run -n build_binary \


### PR DESCRIPTION
Summary:
The conditional `pip install packaging` workaround added in D98744375 is no longer needed — the upstream torch packaging issue for Python 3.14 has been resolved.

Remove the workaround from both `unittest_ci.yml` and `unittest_ci_cpu.yml`.

Reference: https://fb.workplace.com/groups/4571909969591489/posts/26555342144154956/?comment_id=26573432535679250
https://github.com/pytorch/vision/issues/9467
https://github.com/pytorch/pytorch/pull/179456

Reviewed By: xywang9334

Differential Revision: D99678816


