### PR TITLE
Reduce metric_scaling_prod num_tasks from 20 to 10

### DIFF
--- a/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
+++ b/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
@@ -1,5 +1,5 @@
 # Production-like metric scaling benchmark
-# Tests ZORM overhead with 20 tasks x 5 metrics (~25% update overhead)
+# Tests ZORM overhead with 10 tasks x 5 metrics (~20% update overhead)
 # Uses lighter embeddings so metric update is a meaningful fraction of iter time
 #
 # Usage:
@@ -38,7 +38,7 @@ PlannerConfig:
 RecMetricConfig:
   enable_metrics: true
   metrics: [ne, calibration, ctr, mse, auc]
-  num_tasks: 20
+  num_tasks: 10
   rec_compute_mode: "unfused"
   compute_interval: 25
   window_size: 10000000


### PR DESCRIPTION
Summary:

Reduce `num_tasks` from 20 to 10 so metric update overhead is ~20% of
training iteration time, matching production-like proportions. 20 tasks
produced ~50% overhead which overstated the cost ZORM offloads.

Validated via profiler trace: 10 tasks × 5 metrics gives ~10ms/call
metric_update, ~20% of the ~50ms profiled iteration.

Differential Revision: D99713723


