### PR TITLE
Fine-grained PT2 compilation for rec metric get_*_states (#4032)

### DIFF
--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -65,6 +65,7 @@ class CalibrationMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=True,
         )
+        self._get_calibration_states = self._maybe_compile(get_calibration_states)
 
     def update(
         self,
@@ -79,7 +80,7 @@ class CalibrationMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CalibrationMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-        for state_name, state_value in get_calibration_states(
+        for state_name, state_value in self._get_calibration_states(
             labels, predictions, weights
         ).items():
             state = getattr(self, state_name)

--- a/torchrec/metrics/ctr.py
+++ b/torchrec/metrics/ctr.py
@@ -61,6 +61,7 @@ class CTRMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=True,
         )
+        self._get_ctr_states = self._maybe_compile(get_ctr_states)
 
     def update(
         self,
@@ -75,7 +76,7 @@ class CTRMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for CTRMetricComputation update"
             )
         num_samples = predictions.shape[-1]
-        for state_name, state_value in get_ctr_states(
+        for state_name, state_value in self._get_ctr_states(
             labels, predictions, weights
         ).items():
             state = getattr(self, state_name)

--- a/torchrec/metrics/mae.py
+++ b/torchrec/metrics/mae.py
@@ -71,6 +71,7 @@ class MAEMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=True,
         )
+        self._get_mae_states = self._maybe_compile(get_mae_states)
 
     def update(
         self,
@@ -84,7 +85,7 @@ class MAEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for MAEMetricComputation update"
             )
-        states = get_mae_states(labels, predictions, weights)
+        states = self._get_mae_states(labels, predictions, weights)
         num_samples = predictions.shape[-1]
         for state_name, state_value in states.items():
             state = getattr(self, state_name)

--- a/torchrec/metrics/mse.py
+++ b/torchrec/metrics/mse.py
@@ -118,6 +118,7 @@ class MSEMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=include_r_squared,
         )
+        self._get_mse_states = self._maybe_compile(get_mse_states)
 
     def update(
         self,
@@ -131,7 +132,7 @@ class MSEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for MSEMetricComputation update"
             )
-        states = get_mse_states(labels, predictions, weights)
+        states = self._get_mse_states(labels, predictions, weights)
         num_samples = predictions.shape[-1]
         for state_name, state_value in states.items():
             state = getattr(self, state_name)

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -145,6 +145,7 @@ class NEMetricComputation(RecMetricComputation):
             persistent=True,
         )
         self.eta = 1e-12
+        self._get_ne_states = self._maybe_compile(get_ne_states)
 
     def update(
         self,
@@ -158,7 +159,7 @@ class NEMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for NEMetricComputation update"
             )
-        states = get_ne_states(labels, predictions, weights, self.eta)
+        states = self._get_ne_states(labels, predictions, weights, self.eta)
         num_samples = predictions.shape[-1]
 
         for state_name, state_value in states.items():

--- a/torchrec/metrics/ne_positive.py
+++ b/torchrec/metrics/ne_positive.py
@@ -129,6 +129,7 @@ class NEPositiveMetricComputation(RecMetricComputation):
             persistent=True,
         )
         self.eta = 1e-12
+        self._get_ne_positive_states = self._maybe_compile(get_ne_positive_states)
 
     def update(
         self,
@@ -142,7 +143,7 @@ class NEPositiveMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for NEMetricComputation update"
             )
-        states = get_ne_positive_states(labels, predictions, weights, self.eta)
+        states = self._get_ne_positive_states(labels, predictions, weights, self.eta)
         num_samples = predictions.shape[-1]
 
         for state_name, state_value in states.items():

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -144,6 +144,7 @@ class RecMetricComputation(Metric, abc.ABC):
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        self._enable_pt2_compile: bool = kwargs.pop("enable_pt2_compile", False)
         metric_init_signature = inspect.signature(Metric.__init__)
         if "fuse_state_tensors" in metric_init_signature.parameters:
             kwargs["fuse_state_tensors"] = (
@@ -240,6 +241,12 @@ class RecMetricComputation(Metric, abc.ABC):
         self._batch_window_buffers[window_state_name].aggregate_state(
             getattr(self, window_state_name), curr_state=state, size=num_samples
         )
+
+    def _maybe_compile(self, fn: Callable) -> Callable:
+        """Wrap ``fn`` with ``torch.compile`` when PT2 compilation is enabled."""
+        if self._enable_pt2_compile:
+            return torch.compile(fn)
+        return fn
 
     @abc.abstractmethod
     # pyrefly: ignore[bad-override]
@@ -447,7 +454,11 @@ class RecMetric(nn.Module, abc.ABC):
                 compute_mode=compute_mode,
                 process_group=process_group,
                 # pyrefly: ignore[bad-argument-type]
-                **{**kwargs, **self._get_task_kwargs(task_config)},
+                **{
+                    **kwargs,
+                    **self._get_task_kwargs(task_config),
+                    "enable_pt2_compile": self.enable_pt2_compile,
+                },
             )
             required_inputs = self._get_task_required_inputs(task_config)
 

--- a/torchrec/metrics/xauc.py
+++ b/torchrec/metrics/xauc.py
@@ -100,6 +100,7 @@ class XAUCMetricComputation(RecMetricComputation):
             dist_reduce_fx="sum",
             persistent=True,
         )
+        self._get_xauc_states = self._maybe_compile(get_xauc_states)
 
     def update(
         self,
@@ -113,7 +114,7 @@ class XAUCMetricComputation(RecMetricComputation):
             raise RecMetricException(
                 "Inputs 'predictions' and 'weights' should not be None for XAUCMetricComputation update"
             )
-        states = get_xauc_states(labels, predictions, weights)
+        states = self._get_xauc_states(labels, predictions, weights)
         num_samples = predictions.shape[-1]
         for state_name, state_value in states.items():
             state = getattr(self, state_name)


### PR DESCRIPTION
Summary:

Add `_maybe_compile()` to `RecMetricComputation` base class, gated by the existing `MetricsConfig.enable_pt2_compile` flag (default `False`).

Compiles only the pure-tensor `get_*_states` functions - producing zero graph breaks. `torch.compile` is lazy, so unused metrics incur zero compilation cost.

This diff covers the first 7 metrics:
- `ne.py`: `get_ne_states`
- `ctr.py`: `get_ctr_states`
- `calibration.py`: `get_calibration_states`
- `ne_positive.py`: `get_ne_positive_states`
- `mse.py`: `get_mse_states`
- `mae.py`: `get_mae_states`
- `xauc.py`: `get_xauc_states`

## Internal
Instead of compiling the upper-level `_update_metrics` / `_update_segment_metrics` functions (which causes ~42 graph breaks per call due to `torch.compiler.disable` on `_aggregate_window_state`), this compiles only the pure-tensor `get_*_states` functions - producing zero graph breaks.

RFC: https://docs.google.com/document/d/19qFLAG9qicn34Md6XmjwvKulRKNTEDGx9qkzPGuKYdo/edit

Reviewed By: jeffkbkim

Differential Revision: D98940494


