### PR TITLE
fix: re-add packaging workaround for Python 3.14 in CI workflows

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -152,6 +152,10 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/${{ matrix.cuda-tag }}
         fi
         echo "index_url: $index_url"
+        if [[ "${{ matrix.python.version }}" = "3.14" ]]; then
+          # temporary workaround for torch package issue in python 3.14
+          conda run -n build_binary pip install packaging
+        fi
         conda run -n build_binary \
           pip install torch --index-url $index_url
         conda run -n build_binary \

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -102,6 +102,10 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/cpu
         fi
         echo "index_url: $index_url"
+        if [[ "${{ matrix.python.version }}" = "3.14" ]]; then
+          # temporary workaround for torch package issue in python 3.14
+          conda run -n build_binary pip install packaging
+        fi
         conda run -n build_binary \
           pip install torch --index-url $index_url
         conda run -n build_binary \


### PR DESCRIPTION
Summary:
Re-add conditional `pip install packaging` before torch install for Python 3.14 CI jobs. The upstream torch nightly still doesn't include packaging as a dependency, causing `import torch` to fail with `ModuleNotFoundError: No module named 'packaging'` in `cutedsl_utils.py`.

Reverts the cleanup in D99678816 until the upstream fix ships in a nightly.

Differential Revision: D99837723


