### PR TITLE
Add INPUT_VALIDATION to PlannerErrorType enum (#4048)

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1434,6 +1434,7 @@ class PlannerErrorType(Enum):
     PLANNER_INPUT_CONTEXT_MISMATCH = "planner_input_context_mismatch"
     PLAN_LOADING_FAILED = "plan_loading_failed"
     INVALID_RANK_ASSIGNMENT = "invalid_rank_assignment"
+    INPUT_VALIDATION = "input_validation"
 
 
 class PlannerError(Exception):


### PR DESCRIPTION
Summary:

Add a new `INPUT_VALIDATION` variant to the `PlannerErrorType` enum.

Reviewed By: ShatianWang

Differential Revision: D98979383
