### PR TITLE
feat: add per-table table_assignment event

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -222,4 +222,18 @@ def log_offloading_summary(best_plan: List, planner_type: str, technique: Optimi
     pass
 
 
+def log_storage_reservation(
+    reservation_type: str,
+    percentage: Optional[float] = None,
+    dense_hbm_bytes: Optional[int] = None,
+    kjt_hbm_bytes: Optional[int] = None,
+    original_hbm_per_rank: int = 0,
+    available_hbm_per_rank: int = 0,
+    planner_type: str = "",
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -292,4 +292,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -217,4 +217,9 @@ def log_planning_result(
     pass
 
 
+def log_offloading_summary(best_plan: List, planner_type: str, technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -207,4 +207,14 @@ def detect_technique(items: List) -> OptimizationTechnique:  # type: ignore[type
     return OptimizationTechnique.NONE
 
 
+def log_planning_result(
+    planner_type: str,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+    error_message: Optional[str] = None,
+    **extra_metadata: str,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -279,4 +279,17 @@ def log_cacheability_resolved(
     pass
 
 
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -236,4 +236,12 @@ def log_storage_reservation(
     pass
 
 
+def log_planner_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -244,4 +244,28 @@ def log_planner_config(
     pass
 
 
+def log_stats_match(
+    table_name: str = "",
+    table_height: int = 0,
+    match_level: str = "",
+    min_working_set: int = 0,
+    recommended_cache_rows: int = 0,
+    global_batch_size: int = 0,
+    matched_height: Optional[int] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_clf_computed(
+    table_name: str = "",
+    table_height: int = 0,
+    clf: float = 0.0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -268,4 +268,15 @@ def log_clf_computed(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,6 +93,9 @@ except Exception:
         return decorator
 
 
+from torchrec.distributed.logging_handlers import log_planning_result
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -720,6 +723,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
 
             validate_rank_assignment(sharding_plan, self._topology)
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
+
             return sharding_plan
         else:
             global_storage_capacity = reduce(
@@ -778,6 +788,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     enumerator=self._enumerator,
                     debug=self._debug,
                 )
+
+            log_planning_result(
+                planner_type=self.__class__.__name__,
+                error_message=str(last_planner_error),
+                num_proposals=str(self._num_proposals),
+                num_plans=str(self._num_plans),
+            )
 
             if not lowest_storage.fits_in(global_storage_constraints):
                 raise PlannerError(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -98,6 +98,7 @@ from torchrec.distributed.logging_handlers import (
     log_planner_config,
     log_planning_result,
     log_storage_reservation,
+    log_table_assignment,
 )
 
 
@@ -763,6 +764,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -93,7 +93,10 @@ except Exception:
         return decorator
 
 
-from torchrec.distributed.logging_handlers import log_planning_result
+from torchrec.distributed.logging_handlers import (
+    log_offloading_summary,
+    log_planning_result,
+)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -729,6 +732,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),
             )
+
+            log_offloading_summary(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -96,6 +96,7 @@ except Exception:
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
     log_planning_result,
+    log_storage_reservation,
 )
 
 
@@ -582,6 +583,18 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             storage_policy=storage_policy,
             storage_percentage=storage_percentage,
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
+        )
+
+        dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
+        kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
+        log_storage_reservation(
+            reservation_type=storage_policy,
+            percentage=storage_percentage,
+            dense_hbm_bytes=dense_storage.hbm if dense_storage else None,
+            kjt_hbm_bytes=kjt_storage.hbm if kjt_storage else None,
+            original_hbm_per_rank=self._topology.devices[0].storage.hbm,
+            available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
+            planner_type=self.__class__.__name__,
         )
 
         search_space = self._enumerator.enumerate(

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -95,6 +95,7 @@ except Exception:
 
 from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
+    log_planner_config,
     log_planning_result,
     log_storage_reservation,
 )
@@ -595,6 +596,21 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             original_hbm_per_rank=self._topology.devices[0].storage.hbm,
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
+        )
+
+        log_planner_config(
+            {
+                "planner_type": self.__class__.__name__,
+                "proposers": ",".join(p.__class__.__name__ for p in self._proposers),
+                "partitioner": self._partitioner.__class__.__name__,
+                "perf_model": self._perf_model.__class__.__name__,
+                "timeout_s": (
+                    str(self._timeout_seconds) if self._timeout_seconds else "none"
+                ),
+                "num_table_constraints": (
+                    str(len(self._constraints)) if self._constraints else "0"
+                ),
+            }
         )
 
         search_space = self._enumerator.enumerate(


### PR DESCRIPTION
Summary: Log the planner's final per-table assignment (compute_kernel, sharding_type, CLF, HBM/DDR) after planning completes. One Scuba event per table in best_plan, called from both OSS and LP planners next to log_offloading_summary.

Differential Revision: D97985051


