### PR TITLE
Add light weight logging to indicate EMS is enabled (#4062)

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -327,6 +327,13 @@ def create_sharding_infos_by_sharding_device_group(
                 fused_params=per_table_fused_params,
             )
         )
+    if any(
+        info.embedding_config.stash_weights
+        for infos in sharding_type_device_group_to_sharding_infos.values()
+        for info in infos
+    ):
+        logger.info("EmbeddingMemoryStashing: stash_weights is enabled")
+
     return sharding_type_device_group_to_sharding_infos
 
 


### PR DESCRIPTION
Summary:

light weight logging for stash_weights enablement. Help speed up tuning process.

Reviewed By: TroyGarden

Differential Revision: D99918931
