### PR TITLE
Fix planner context hash instability across machines

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -31,6 +31,7 @@ from torchrec.distributed.planner.types import (
     ParameterConstraints,
     Shard,
     ShardingOption,
+    Storage,
     Topology,
     TopologyFactory,
     TrainerConfig,
@@ -561,10 +562,20 @@ class TestHashPlannerContextInputsRounding(unittest.TestCase):
         ]
         return enumerator
 
-    def _create_mock_storage_reservation(self) -> MagicMock:
-        """Create a mock storage reservation."""
+    def _create_mock_storage_reservation(
+        self,
+        topology: Optional[Topology] = None,
+    ) -> MagicMock:
+        """Create a mock storage reservation with a real Topology."""
         storage_reservation = MagicMock()
-        storage_reservation._last_reserved_topology = "mock_topology"
+        if topology is None:
+            topology = Topology(
+                world_size=2,
+                compute_device="cuda",
+                hbm_cap=1024 * 1024 * 1024,
+                local_world_size=2,
+            )
+        storage_reservation.last_reserved_topology = topology
         return storage_reservation
 
     def test_rounding_produces_same_hash_for_small_memory_differences(self) -> None:
@@ -732,9 +743,14 @@ class TestHashPlannerContextInputsWithConstraints(unittest.TestCase):
         return enumerator
 
     def _create_mock_storage_reservation(self) -> MagicMock:
-        """Create a mock storage reservation."""
+        """Create a mock storage reservation with a real Topology."""
         storage_reservation = MagicMock()
-        storage_reservation._last_reserved_topology = "mock_topology"
+        storage_reservation.last_reserved_topology = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 1024,
+            local_world_size=2,
+        )
         return storage_reservation
 
     def _create_topology(self) -> Topology:
@@ -1087,6 +1103,193 @@ class TestConsistentHashingBetweenProcesses(MultiProcessTestBase):
         )
         hashes = return_hash_dict.values()
         self.assertEqual(hashes[0], hashes[1], "hash values are different.")
+
+
+class TestHashStabilityAcrossMachines(unittest.TestCase):
+    """Tests that hash_planner_context_inputs produces stable hashes when
+    the same job runs on different machines with slightly different DDR.
+
+    Regression test for the cache-miss bug where MAST job restarts on
+    different machines produced different context hashes because
+    last_reserved_topology included unrounded DDR values.
+    """
+
+    def _create_mock_enumerator(
+        self,
+        with_real_shards: bool = False,
+    ) -> MagicMock:
+        enumerator = MagicMock()
+        if with_real_shards:
+            enumerator.last_stored_search_space = [
+                MagicMock(
+                    fqn="table_0",
+                    sharding_type=ShardingType.TABLE_WISE.value,
+                    compute_kernel=EmbeddingComputeKernel.FUSED.value,
+                    shards=[
+                        Shard(
+                            size=[1000, 64],
+                            offset=[0, 0],
+                            storage=Storage(hbm=256000, ddr=0, ssd=0),
+                            rank=0,
+                        ),
+                    ],
+                    cache_params=None,
+                ),
+            ]
+        else:
+            enumerator.last_stored_search_space = [
+                MagicMock(
+                    fqn="table_0",
+                    sharding_type=ShardingType.TABLE_WISE.value,
+                    compute_kernel=EmbeddingComputeKernel.FUSED.value,
+                    shards=(),
+                    cache_params=None,
+                ),
+            ]
+        return enumerator
+
+    def test_ddr_variation_in_reserved_topology_does_not_change_hash(
+        self,
+    ) -> None:
+        """Simulates the production bug: two machines report slightly
+        different DDR capacity (~283.34 GB vs ~283.35 GB).  The hash
+        must be identical because both round to the same 300 GB bucket.
+        """
+        DDR_MACHINE_A = 304_243_365_376  # ~283.35 GB
+        DDR_MACHINE_B = 304_233_892_864  # ~283.34 GB — different machine
+
+        topology_a = Topology(
+            world_size=8,
+            compute_device="cuda",
+            hbm_cap=191_503_138_816,
+            ddr_cap=DDR_MACHINE_A,
+            local_world_size=2,
+        )
+        topology_b = Topology(
+            world_size=8,
+            compute_device="cuda",
+            hbm_cap=191_503_138_816,
+            ddr_cap=DDR_MACHINE_B,
+            local_world_size=2,
+        )
+
+        enumerator = self._create_mock_enumerator()
+
+        # Simulate FixedPercentageStorageReservation: deepcopy + reduce HBM
+        reserved_a = deepcopy(topology_a)
+        reserved_b = deepcopy(topology_b)
+        for t in [reserved_a, reserved_b]:
+            for d in t.devices:
+                d.storage.hbm = int(0.7 * d.storage.hbm)
+
+        sr_a = MagicMock()
+        sr_a.__class__.__name__ = "FixedPercentageStorageReservation"
+        sr_a.last_reserved_topology = reserved_a
+
+        sr_b = MagicMock()
+        sr_b.__class__.__name__ = "FixedPercentageStorageReservation"
+        sr_b.last_reserved_topology = reserved_b
+
+        hash_a = hash_planner_context_inputs(
+            topology=topology_a,
+            batch_size=3072,
+            enumerator=enumerator,
+            storage_reservation=sr_a,
+            constraints=None,
+        )
+        hash_b = hash_planner_context_inputs(
+            topology=topology_b,
+            batch_size=3072,
+            enumerator=enumerator,
+            storage_reservation=sr_b,
+            constraints=None,
+        )
+
+        self.assertEqual(
+            hash_a,
+            hash_b,
+            f"Hash should be stable across machines with small DDR differences "
+            f"(DDR_A={DDR_MACHINE_A}, DDR_B={DDR_MACHINE_B})",
+        )
+
+    def test_large_ddr_difference_changes_hash(self) -> None:
+        """A genuinely different DDR capacity (e.g. 256 GB vs 512 GB)
+        should produce a different hash.
+        """
+        topology_small = Topology(
+            world_size=2,
+            compute_device="cuda",
+            ddr_cap=256 * 1024**3,
+            local_world_size=2,
+        )
+        topology_large = Topology(
+            world_size=2,
+            compute_device="cuda",
+            ddr_cap=512 * 1024**3,
+            local_world_size=2,
+        )
+
+        enumerator = self._create_mock_enumerator()
+
+        sr_small = MagicMock()
+        sr_small.last_reserved_topology = deepcopy(topology_small)
+        sr_large = MagicMock()
+        sr_large.last_reserved_topology = deepcopy(topology_large)
+
+        hash_small = hash_planner_context_inputs(
+            topology=topology_small,
+            batch_size=128,
+            enumerator=enumerator,
+            storage_reservation=sr_small,
+            constraints=None,
+        )
+        hash_large = hash_planner_context_inputs(
+            topology=topology_large,
+            batch_size=128,
+            enumerator=enumerator,
+            storage_reservation=sr_large,
+            constraints=None,
+        )
+
+        self.assertNotEqual(
+            hash_small,
+            hash_large,
+            "Hash should differ for genuinely different DDR capacities",
+        )
+
+    def test_hash_stable_with_real_shard_objects(self) -> None:
+        """Verify that real Shard objects (with Storage) produce stable
+        hashes regardless of topology DDR variation.
+        """
+        DDR_A = 304_243_365_376
+        DDR_B = 304_243_365_888  # differs by 512 bytes
+
+        results = []
+        for ddr in [DDR_A, DDR_B]:
+            topo = Topology(
+                world_size=2,
+                compute_device="cuda",
+                hbm_cap=191_503_138_816,
+                ddr_cap=ddr,
+                local_world_size=2,
+            )
+            enumerator = self._create_mock_enumerator(with_real_shards=True)
+            sr = MagicMock()
+            sr.last_reserved_topology = deepcopy(topo)
+            h = hash_planner_context_inputs(
+                topology=topo,
+                batch_size=128,
+                enumerator=enumerator,
+                storage_reservation=sr,
+                constraints=None,
+            )
+            results.append(h)
+
+        self.assertEqual(
+            results[0],
+            results[1],
+            "Hash should be stable with real Shard objects across DDR variation",
+        )
 
 
 class TestHardwareConfig(unittest.TestCase):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1700,38 +1700,32 @@ def hash_sha256_str(hashable_list: List[Any]) -> str:
     return hash_digest
 
 
-def hash_planner_context_inputs(
+def _topology_hash_components(
     topology: Topology,
-    batch_size: int,
-    enumerator: Enumerator,
-    storage_reservation: StorageReservation,
-    constraints: Optional[Dict[str, ParameterConstraints]],
-    hash_function: Callable[[List[Any]], int] = hash_sha256_to_int,
-) -> int:
-    assert hasattr(
-        enumerator, "last_stored_search_space"
-    ), "This enumerator is not compatible with hashing"
-    assert (
-        enumerator.last_stored_search_space is not None
-    ), "Unable to hash planner context without an enumerator that has a precomputed search space"
-    search_space = enumerator.last_stored_search_space
-    storage_reservation_policy = type(storage_reservation).__name__
+    round_unit: int = HUNDRED_GB,
+) -> List[Any]:
+    """Extract hash-stable components from a Topology with storage rounding.
 
-    assert (
-        # pyrefly: ignore[missing-attribute]
-        storage_reservation._last_reserved_topology
-        is not None
-    ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
+    Device memory (HBM/DDR/SSD) is rounded to the nearest ``round_unit``
+    (default 100 GB) so that minor driver/OS differences across machines
+    do not change the hash.  Every other field is included verbatim.
 
-    # Round device memory to 1% to avoid hash mismatches due to minor driver version differences which does not impact the behavior of planner
+    This helper is the *single* place where topology normalisation happens.
+    Both ``hash_planner_context_inputs`` and ``hash_planner_context_inputs_str``
+    must use it for every Topology they include in the hash (raw topology,
+    ``_last_reserved_topology``, etc.).
+    """
     rounded_devices = []
     for device in topology.devices:
-        rounded_hbm = round_to_nearest(device.storage.hbm, HUNDRED_GB)
-        rounded_ddr = round_to_nearest(device.storage.ddr, HUNDRED_GB)
-        rounded_ssd = round_to_nearest(device.storage.ssd, HUNDRED_GB)
-        rounded_devices.append((device.rank, rounded_hbm, rounded_ddr, rounded_ssd))
-
-    topology_hash_components = [
+        rounded_devices.append(
+            (
+                device.rank,
+                round_to_nearest(device.storage.hbm, round_unit),
+                round_to_nearest(device.storage.ddr, round_unit),
+                round_to_nearest(device.storage.ssd, round_unit),
+            )
+        )
+    return [
         topology.world_size,
         topology.compute_device,
         rounded_devices,
@@ -1747,9 +1741,65 @@ def hash_planner_context_inputs(
         topology.weighted_feature_bwd_compute_multiplier,
         topology.uneven_sharding_perf_multiplier,
     ]
-    hashed_topology = hash_function(topology_hash_components)
 
-    hashable_list = [
+
+def _shard_hash_components(shard: "Shard") -> tuple:
+    """Extract hash-stable components from a Shard.
+
+    Uses explicit field extraction rather than ``__repr__()`` so the hash
+    is not affected by new fields added to ``Shard`` or by
+    machine-specific values leaking through ``Storage``/``Perf`` reprs.
+    """
+    return (
+        tuple(shard.size),
+        tuple(shard.offset),
+        shard.rank,
+        (
+            (shard.storage.hbm, shard.storage.ddr, shard.storage.ssd)
+            if shard.storage
+            else None
+        ),
+    )
+
+
+def _build_hashable_list(
+    topology: Topology,
+    batch_size: int,
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+    constraints: Optional[Dict[str, ParameterConstraints]],
+) -> List[Any]:
+    """Build the canonical hashable list for planner context inputs.
+
+    Shared by both ``hash_planner_context_inputs`` (int hash) and
+    ``hash_planner_context_inputs_str`` (str hash) so the two can never
+    drift apart.
+    """
+    assert hasattr(
+        enumerator, "last_stored_search_space"
+    ), "This enumerator is not compatible with hashing"
+    assert (
+        enumerator.last_stored_search_space is not None
+    ), "Unable to hash planner context without an enumerator that has a precomputed search space"
+
+    reserved_topology = storage_reservation.last_reserved_topology
+    assert (
+        reserved_topology is not None
+    ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
+
+    search_space = enumerator.last_stored_search_space
+    storage_reservation_policy = type(storage_reservation).__name__
+
+    # Hash topology components with storage rounding applied uniformly.
+    # Previously _last_reserved_topology was included as a raw Topology
+    # object, whose __repr__ embedded unrounded device DDR values that
+    # vary across machines — causing cache misses on MAST job restarts.
+    hashed_topology = hash_sha256_to_int(_topology_hash_components(topology))
+    hashed_reserved_topology = hash_sha256_to_int(
+        _topology_hash_components(reserved_topology)
+    )
+
+    return [
         hashed_topology,
         batch_size,
         [
@@ -1757,19 +1807,32 @@ def hash_planner_context_inputs(
                 shard_option.fqn,
                 shard_option.sharding_type,
                 shard_option.compute_kernel,
-                tuple(shard_option.shards),
+                tuple(_shard_hash_components(shard) for shard in shard_option.shards),
                 shard_option.cache_params,
             ]
             for shard_option in search_space
         ],
         storage_reservation_policy,
-        storage_reservation._last_reserved_topology,
+        hashed_reserved_topology,
         (
             tuple((k, v.__hash__()) for k, v in sorted(constraints.items()))
             if constraints
             else None
         ),
     ]
+
+
+def hash_planner_context_inputs(
+    topology: Topology,
+    batch_size: int,
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+    constraints: Optional[Dict[str, ParameterConstraints]],
+    hash_function: Callable[[List[Any]], int] = hash_sha256_to_int,
+) -> int:
+    hashable_list = _build_hashable_list(
+        topology, batch_size, enumerator, storage_reservation, constraints
+    )
     return hash_function(hashable_list)
 
 
@@ -1781,42 +1844,9 @@ def hash_planner_context_inputs_str(
     constraints: Optional[Dict[str, ParameterConstraints]],
     hash_function: Callable[[List[Any]], str] = hash_sha256_str,
 ) -> str:
-    assert hasattr(
-        enumerator, "last_stored_search_space"
-    ), "This enumerator is not compatible with hashing"
-    assert (
-        enumerator.last_stored_search_space is not None
-    ), "Unable to hash planner context without an enumerator that has a precomputed search space"
-    search_space = enumerator.last_stored_search_space
-    storage_reservation_policy = type(storage_reservation).__name__
-
-    assert (
-        # pyrefly: ignore[missing-attribute]
-        storage_reservation._last_reserved_topology
-        is not None
-    ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
-
-    hashable_list = [
-        topology,
-        batch_size,
-        [
-            [
-                shard_option.fqn,
-                shard_option.sharding_type,
-                shard_option.compute_kernel,
-                tuple(shard_option.shards),
-                shard_option.cache_params,
-            ]
-            for shard_option in search_space
-        ],
-        storage_reservation_policy,
-        storage_reservation._last_reserved_topology,
-        (
-            tuple((k, v.__hash__()) for k, v in sorted(constraints.items()))
-            if constraints
-            else None
-        ),
-    ]
+    hashable_list = _build_hashable_list(
+        topology, batch_size, enumerator, storage_reservation, constraints
+    )
     return hash_function(hashable_list)
 
 


### PR DESCRIPTION
Summary:
The `hash_planner_context_inputs()` function included
`storage_reservation._last_reserved_topology` as a raw `Topology`
object in the hashable list. When `str()` was called, `Topology.__repr__()`
printed every device with raw `Storage(hbm=..., ddr=..., ssd=...)` values.

`FixedPercentageStorageReservation.reserve()` creates the reserved topology
via `copy.deepcopy(topology)` and only reduces HBM — DDR values are carried
over raw from the machine. Since DDR capacity varies by ~500 bytes to ~14 MB
across machines (due to OS/driver memory overhead), the string representation
differed on every machine restart, producing different SHA-256 hashes and
causing cache misses on every MAST job preemption/retry.

The topology hash component (lines 1715-1737) already rounded device storage
to the nearest 100 GB, but `_last_reserved_topology` bypassed this rounding.
Additionally, `hash_planner_context_inputs_str()` included the raw topology
without any rounding at all.

This diff:
- Extracts `_topology_hash_components()` — a single helper that normalizes any
  Topology by rounding device storage. Used for both the raw topology AND
  `_last_reserved_topology`.
- Extracts `_shard_hash_components()` — explicit field extraction from `Shard`
  instead of relying on `__repr__()`, protecting against future fields breaking
  the hash.
- Extracts `_build_hashable_list()` — shared by both `hash_planner_context_inputs`
  and `hash_planner_context_inputs_str` so they can never drift apart.
- Updates existing test mocks to use real `Topology` objects for
  `_last_reserved_topology` (previously used the string `"mock_topology"`).
- Adds `TestHashStabilityAcrossMachines` regression tests using real DDR values
  from production.

Note: This changes the hash value for all existing cached plans. Existing
Manifold-cached plans will miss on the first attempt after deployment.

Reviewed By: aporialiao

Differential Revision: D99696296


