### PR TITLE
Remove JustKnobs gate for module_id_cache in DMP

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -423,12 +423,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         return copy_dmp
 
     def _init_dmp(self, module: nn.Module) -> nn.Module:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_module_id_cache_for_dmp_shard_modules"
-        ):
-            module_id_cache: Optional[Dict[int, ShardedModule]] = {}
-        else:
-            module_id_cache = None
+        module_id_cache: Dict[int, ShardedModule] = {}
         return self._shard_modules_impl(module, module_id_cache=module_id_cache)
 
     def _init_delta_tracker(
@@ -454,12 +449,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         )
 
     def _init_optim(self, module: nn.Module) -> CombinedOptimizer:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_module_id_cache_for_dmp_shard_modules"
-        ):
-            module_id_cache: Optional[Dict[int, KeyedOptimizer]] = {}
-        else:
-            module_id_cache = None
+        module_id_cache: Dict[int, KeyedOptimizer] = {}
         return CombinedOptimizer(
             # pyre-ignore [6]
             self._fused_optim_impl(module, [], module_id_cache=module_id_cache)


### PR DESCRIPTION
Summary:
## 1. Context
The `module_id_cache` in `DistributedModelParallel` prevents duplicate sharding and duplicate optimizer collection when the same module appears at multiple paths in the model graph. It was originally gated behind a JustKnobs flag (`pytorch/torchrec:enable_module_id_cache_for_dmp_shard_modules`) to allow safe rollout. The feature has been fully rolled out and the JustKnobs gate is no longer needed.

## 2. Approach
1. **Remove JustKnobs conditional**: Replace the `justknobs_check` + conditional `None` fallback with unconditionally creating the `module_id_cache` dict in both `_init_dmp` and `_init_optim`.

## 3. Results
No behavioral change — the cache was already enabled via JustKnobs. This is a cleanup-only diff.

## 4. Analysis
1. **Risk**: Low. This only removes dead conditional branches; the enabled code path is unchanged.
2. **Backward compatibility**: No public API changes. The `module_id_cache` parameter on internal methods (`_shard_modules_impl`, `_fused_optim_impl`) still accepts `Optional[Dict]`, so downstream callers are unaffected.

## 5. Changes
1. **`torchrec/distributed/model_parallel.py`**: Remove `justknobs_check("pytorch/torchrec:enable_module_id_cache_for_dmp_shard_modules")` conditional in `_init_dmp` and `_init_optim`, always initializing `module_id_cache` as an empty dict.

Reviewed By: spmex

Differential Revision: D99678928


