### PR TITLE
Remove JustKnobs gate for disable_none_context_fields (#4071)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -311,23 +311,6 @@ class EmbeddingCollectionContext(Multistreamable):
     table_name_to_unpruned_hash_sizes: Dict[str, int] = field(default_factory=dict)
     early_releasable_inputs: list[KeyedJaggedTensor] = field(default_factory=list)
 
-    def __post_init__(self) -> None:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:disable_none_context_fields"
-        ):
-            return
-        if self.sharding_contexts is None:
-            self.sharding_contexts = []  # pyrefly: ignore[bad-assignment]
-        if self.input_features is None:
-            self.input_features = []  # pyrefly: ignore[bad-assignment]
-        if self.reverse_indices is None:
-            self.reverse_indices = []  # pyrefly: ignore[bad-assignment]
-        if self.seq_vbe_ctx is None:
-            self.seq_vbe_ctx = []  # pyrefly: ignore[bad-assignment]
-        if self.table_name_to_unpruned_hash_sizes is None:
-            # pyrefly: ignore[bad-assignment]
-            self.table_name_to_unpruned_hash_sizes = {}
-
     def record_stream(self, stream: torch.Stream) -> None:
         for ctx in self.sharding_contexts:
             ctx.record_stream(stream)

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -1043,18 +1043,6 @@ class EmbeddingShardingContext(Multistreamable):
     batch_size_per_feature_pre_a2a: List[int] = field(default_factory=list)
     variable_batch_per_feature: bool = False
 
-    def __post_init__(self) -> None:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:disable_none_context_fields"
-        ):
-            return
-        if self.batch_size_per_rank is None:
-            self.batch_size_per_rank = []  # pyrefly: ignore[bad-assignment]
-        if self.batch_size_per_rank_per_feature is None:
-            self.batch_size_per_rank_per_feature = []  # pyrefly: ignore[bad-assignment]
-        if self.batch_size_per_feature_pre_a2a is None:
-            self.batch_size_per_feature_pre_a2a = []  # pyrefly: ignore[bad-assignment]
-
     def record_stream(self, stream: torch.Stream) -> None:
         pass
 

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -123,14 +123,11 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
     def input_dist(
         self, ctx: EmbeddingBagCollectionContext, features: KeyedJaggedTensor
     ) -> Awaitable[Awaitable[KJTList]]:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_rw_feature_processor"
-        ):
-            if not self.is_pipelined and self._row_wise_sharded:
-                # transform input to support row based sharding when not pipelined
-                modify_input_for_feature_processor(
-                    features, self._feature_processors, self._is_collection
-                )
+        if not self.is_pipelined and self._row_wise_sharded:
+            # transform input to support row based sharding when not pipelined
+            modify_input_for_feature_processor(
+                features, self._feature_processors, self._is_collection
+            )
         return self._embedding_bag_collection.input_dist(ctx, features)
 
     def apply_feature_processors_to_kjt_list(self, dist_input: KJTList) -> KJTList:
@@ -278,7 +275,6 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
         if compute_device_type in {"mtia"}:
             return [ShardingType.TABLE_WISE.value, ShardingType.COLUMN_WISE.value]
 
-        # No row wise because position weighted FP and RW don't play well together.
         types = [
             ShardingType.DATA_PARALLEL.value,
             ShardingType.TABLE_WISE.value,
@@ -286,15 +282,12 @@ class FeatureProcessedEmbeddingBagCollectionSharder(
             ShardingType.TABLE_COLUMN_WISE.value,
         ]
 
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_rw_feature_processor"
-        ):
-            types.extend(
-                [
-                    ShardingType.TABLE_ROW_WISE.value,
-                    ShardingType.ROW_WISE.value,
-                    ShardingType.GRID_SHARD.value,
-                ]
-            )
+        types.extend(
+            [
+                ShardingType.TABLE_ROW_WISE.value,
+                ShardingType.ROW_WISE.value,
+                ShardingType.GRID_SHARD.value,
+            ]
+        )
 
         return types

--- a/torchrec/distributed/sharding/sequence_sharding.py
+++ b/torchrec/distributed/sharding/sequence_sharding.py
@@ -41,17 +41,6 @@ class SequenceShardingContext(EmbeddingShardingContext):
     unbucketize_permute_tensor: Optional[torch.Tensor] = None
     lengths_after_input_dist: Optional[torch.Tensor] = None
 
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:disable_none_context_fields"
-        ):
-            return
-        if self.input_splits is None:
-            self.input_splits = []  # pyrefly: ignore[bad-assignment]
-        if self.output_splits is None:
-            self.output_splits = []  # pyrefly: ignore[bad-assignment]
-
     def record_stream(self, stream: torch.Stream) -> None:
         if self.features_before_input_dist is not None:
             # pyrefly: ignore[bad-argument-type]

--- a/torchrec/distributed/tests/test_fp_embeddingbag.py
+++ b/torchrec/distributed/tests/test_fp_embeddingbag.py
@@ -10,8 +10,7 @@
 import copy
 import unittest
 from operator import xor
-from typing import cast, List, Optional, Tuple
-from unittest.mock import patch
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -29,7 +28,6 @@ from torchrec.distributed.sharding_plan import (
     column_wise,
     construct_module_sharding_plan,
     data_parallel,
-    row_wise,
     table_wise,
 )
 from torchrec.distributed.test_utils.multi_process import (
@@ -42,12 +40,7 @@ from torchrec.distributed.tests.test_fp_embeddingbag_utils import (
     get_configs,
     get_kjt_inputs,
 )
-from torchrec.distributed.types import (
-    ModuleSharder,
-    ShardingEnv,
-    ShardingPlan,
-    ShardingType,
-)
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class
@@ -281,113 +274,4 @@ class ShardedEmbeddingBagCollectionParallelTest(MultiProcessTestBase):
             sharder=FeatureProcessedEmbeddingBagCollectionSharder(),
             backend=backend,
             use_fp_collection=use_fp_collection,
-        )
-
-
-class TestFeatureProcessorJKDisabledUnit(unittest.TestCase):
-    def test_sharding_types_excludes_row_wise_when_jk_disabled(self) -> None:
-        with patch(
-            "torch._utils_internal.justknobs_check",
-            return_value=False,
-        ):
-            sharder = FeatureProcessedEmbeddingBagCollectionSharder()
-            types = sharder.sharding_types(compute_device_type="cuda")
-
-        self.assertNotIn(ShardingType.ROW_WISE.value, types)
-        self.assertNotIn(ShardingType.TABLE_ROW_WISE.value, types)
-        self.assertNotIn(ShardingType.GRID_SHARD.value, types)
-
-        self.assertIn(ShardingType.TABLE_WISE.value, types)
-        self.assertIn(ShardingType.COLUMN_WISE.value, types)
-        self.assertIn(ShardingType.TABLE_COLUMN_WISE.value, types)
-
-    def test_sharding_types_includes_row_wise_when_jk_enabled(self) -> None:
-        with patch(
-            "torch._utils_internal.justknobs_check",
-            return_value=True,
-        ):
-            sharder = FeatureProcessedEmbeddingBagCollectionSharder()
-            types = sharder.sharding_types(compute_device_type="cuda")
-
-        self.assertIn(ShardingType.ROW_WISE.value, types)
-        self.assertIn(ShardingType.TABLE_ROW_WISE.value, types)
-        self.assertIn(ShardingType.GRID_SHARD.value, types)
-
-
-def _test_jk_disabled_non_pipelined(
-    tables: List[EmbeddingBagConfig],
-    rank: int,
-    world_size: int,
-    kjt_input_per_rank: List[KeyedJaggedTensor],
-    sharder: ModuleSharder[nn.Module],
-    backend: str,
-    local_size: Optional[int] = None,
-) -> None:
-    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        kjt_input_per_rank = [kjt.to(ctx.device) for kjt in kjt_input_per_rank]
-
-        sparse_arch = create_module_and_freeze(
-            tables,
-            use_fp_collection=False,
-            device=ctx.device,
-        )
-
-        module_sharding_plan = construct_module_sharding_plan(
-            sparse_arch._fp_ebc,
-            per_param_sharding={
-                "table_0": row_wise(),
-                "table_1": row_wise(),
-                "table_2": table_wise(rank=0),
-                "table_3": table_wise(rank=1),
-            },
-            local_size=ctx.local_size,
-            world_size=ctx.world_size,
-            device_type=ctx.device.type,
-            sharder=sharder,
-        )
-
-        with patch(
-            "torch._utils_internal.justknobs_check",
-            return_value=False,
-        ), patch(
-            "torchrec.distributed.fp_embeddingbag.modify_input_for_feature_processor"
-        ) as mock_modify_input:
-            sharded_model = DistributedModelParallel(
-                module=copy.deepcopy(sparse_arch),
-                plan=ShardingPlan({"_fp_ebc": module_sharding_plan}),
-                # pyrefly: ignore[bad-argument-type]
-                env=ShardingEnv.from_process_group(ctx.pg),
-                sharders=[sharder],
-                device=ctx.device,
-            )
-
-            _ = sharded_model(kjt_input_per_rank[ctx.rank])
-
-            mock_modify_input.assert_not_called()
-
-
-@skip_if_asan_class
-class TestFeatureProcessorJKDisabledNonPipelined(MultiProcessTestBase):
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
-    def test_jk_disabled_non_pipelined(self) -> None:
-        embedding_bag_config = get_configs()
-        kjt_input_per_rank = get_kjt_inputs()
-
-        self._run_multi_process_test(
-            callable=_test_jk_disabled_non_pipelined,
-            world_size=2,
-            tables=embedding_bag_config,
-            kjt_input_per_rank=kjt_input_per_rank,
-            sharder=cast(
-                ModuleSharder[nn.Module],
-                FeatureProcessedEmbeddingBagCollectionSharder(),
-            ),
-            backend=(
-                "nccl"
-                if (torch.cuda.is_available() and torch.cuda.device_count() >= 2)
-                else "gloo"
-            ),
         )

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -203,10 +203,7 @@ def _start_data_dist(
         # and this info was done in the _rewrite_model by tracing the
         # entire model to get the arg_info_list
         args, kwargs = forward.args.build_args_kwargs(batch)
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_rw_feature_processor"
-        ):
-            args, kwargs = module.preprocess_input(args, kwargs)
+        args, kwargs = module.preprocess_input(args, kwargs)
 
         # Start input distribution.
         module_ctx = module.create_context()

--- a/torchrec/sparse/jagged_tensor_validator.py
+++ b/torchrec/sparse/jagged_tensor_validator.py
@@ -166,10 +166,7 @@ def _validate_keys(kjt: KeyedJaggedTensor) -> bool:
                     f"lengths size must be divisible by keys size, but got {lengths_size} and {len(keys)}"
                 )
         else:
-            if torch._utils_internal.justknobs_check(
-                "pytorch/torchrec:killswitch_enable_vbe_kjt_validation"
-            ):
-                _validate_vbe_properties(kjt, lengths_size)
+            _validate_vbe_properties(kjt, lengths_size)
     return True
 
 


### PR DESCRIPTION
Summary:

Removes the fully-rolled-out `pytorch/torchrec:disable_none_context_fields` JustKnobs gate and the legacy `__post_init__` fallbacks that converted `None` fields to empty lists/dicts.

All affected dataclass fields already have `default_factory` set, so the None-to-empty-collection coercion was only needed for backward compatibility with callers passing `None` explicitly. With the knob fully rolled out, this dead code can be removed.

Affected classes:
- `SequenceShardingContext` (sequence_sharding.py)
- `EmbeddingCollectionContext` (embedding.py)
- `EmbeddingShardingContext` (embedding_sharding.py)

Differential Revision: D100057065


