### PR TITLE
feat: add per-table table_assignment event

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -279,4 +279,28 @@ def log_clf_computed(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -303,4 +303,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -258,6 +258,17 @@ def log_stats_match(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_clf_computed(
     table_name: str = "",
     table_height: int = 0,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -98,6 +98,7 @@ from torchrec.distributed.logging_handlers import (
     log_planner_config,
     log_planning_result,
     log_storage_reservation,
+    log_table_assignment,
 )
 
 
@@ -763,6 +764,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:


### PR DESCRIPTION
Summary: Log the planner's final per-table assignment (compute_kernel, sharding_type, CLF, HBM/DDR) after planning completes. One Scuba event per table in best_plan, called from both OSS and LP planners next to log_offloading_summary.

Differential Revision: D97985051


