### PR TITLE
feat: add per-TBE tbe_composition event

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -635,10 +635,24 @@ def group_tables(
     ]
     assert all(table_weightedness) or not any(table_weightedness)
 
+    # Detect EMO at job level: check ALL tables across ALL ranks
+    from torchrec.distributed.logging_handlers import (
+        detect_technique,
+        log_tbe_composition,
+    )
+
+    _tbe_technique = detect_technique([t for tables in tables_per_rank for t in tables])
+
     grouped_embedding_configs_by_rank: List[List[GroupedEmbeddingConfig]] = []
-    for tables in tables_per_rank:
+    for rank, tables in enumerate(tables_per_rank):
         grouped_embedding_configs = _group_tables_per_rank(tables)
         grouped_embedding_configs_by_rank.append(grouped_embedding_configs)
+        if grouped_embedding_configs:
+            log_tbe_composition(
+                grouped_embedding_configs,
+                rank,
+                technique=_tbe_technique,
+            )
 
     return grouped_embedding_configs_by_rank
 

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -313,4 +313,9 @@ def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str 
     pass
 
 
+def log_tbe_composition(grouped_configs: List, rank: int = 0, technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -279,4 +279,28 @@ def log_clf_computed(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -303,4 +303,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -308,4 +308,9 @@ def log_table_assignment(best_plan: List, planner_type: str = "", technique: Opt
     pass
 
 
+def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -258,6 +258,17 @@ def log_stats_match(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_clf_computed(
     table_name: str = "",
     table_height: int = 0,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -98,6 +98,7 @@ from torchrec.distributed.logging_handlers import (
     log_planner_config,
     log_planning_result,
     log_storage_reservation,
+    log_table_assignment,
 )
 
 
@@ -763,6 +764,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -99,6 +99,7 @@ from torchrec.distributed.logging_handlers import (
     log_planning_result,
     log_storage_reservation,
     log_table_assignment,
+    log_table_constraints,
 )
 
 
@@ -613,6 +614,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 ),
             }
         )
+        if self._constraints:
+            log_table_constraints(self._constraints, self.__class__.__name__)
 
         search_space = self._enumerator.enumerate(
             module=module,


### PR DESCRIPTION
Summary: Log which tables get grouped into each TBE after group_tables() in embedding_sharding.py. One event per TBE on rank 0 with table names, compute kernels, total rows, dim sum, cache load factor, cache algorithm, cache precision, prefetch status.

Differential Revision: D98032608


