### PR TITLE
feat: add per-proposer proposer_result event and winning_proposer to planning_result

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -635,10 +635,24 @@ def group_tables(
     ]
     assert all(table_weightedness) or not any(table_weightedness)
 
+    # Detect EMO at job level: check ALL tables across ALL ranks
+    from torchrec.distributed.logging_handlers import (
+        detect_technique,
+        log_tbe_composition,
+    )
+
+    _tbe_technique = detect_technique([t for tables in tables_per_rank for t in tables])
+
     grouped_embedding_configs_by_rank: List[List[GroupedEmbeddingConfig]] = []
-    for tables in tables_per_rank:
+    for rank, tables in enumerate(tables_per_rank):
         grouped_embedding_configs = _group_tables_per_rank(tables)
         grouped_embedding_configs_by_rank.append(grouped_embedding_configs)
+        if grouped_embedding_configs:
+            log_tbe_composition(
+                grouped_embedding_configs,
+                rank,
+                technique=_tbe_technique,
+            )
 
     return grouped_embedding_configs_by_rank
 

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -313,4 +313,9 @@ def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str 
     pass
 
 
+def log_tbe_composition(grouped_configs: List, rank: int = 0, technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -318,4 +318,9 @@ def log_tbe_composition(grouped_configs: List, rank: int = 0, technique: Optimiz
     pass
 
 
+def log_search_space_summary(search_space: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -279,4 +279,28 @@ def log_clf_computed(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -303,4 +303,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -308,4 +308,9 @@ def log_table_assignment(best_plan: List, planner_type: str = "", technique: Opt
     pass
 
 
+def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -258,6 +258,17 @@ def log_stats_match(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_clf_computed(
     table_name: str = "",
     table_height: int = 0,

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -323,4 +323,18 @@ def log_search_space_summary(search_space: List, planner_type: str = "", techniq
     pass
 
 
+def log_proposer_result(
+    planner_type: str = "",
+    proposer_name: str = "",
+    proposer_index: int = 0,
+    num_proposals: int = 0,
+    num_plans: int = 0,
+    best_perf_rating: Optional[float] = None,
+    is_winning_proposer: bool = False,
+    technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -98,6 +98,7 @@ from torchrec.distributed.logging_handlers import (
     log_planner_config,
     log_planning_result,
     log_storage_reservation,
+    log_table_assignment,
 )
 
 
@@ -763,6 +764,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -97,6 +97,7 @@ from torchrec.distributed.logging_handlers import (
     log_offloading_summary,
     log_planner_config,
     log_planning_result,
+    log_search_space_summary,
     log_storage_reservation,
     log_table_assignment,
     log_table_constraints,
@@ -624,6 +625,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         if not search_space:
             # No shardable parameters
             return ShardingPlan({})
+
+        log_search_space_summary(search_space, self.__class__.__name__)
 
         loaded_sharding_options = None
         loaded_best_plan: List[ShardingOption] = []

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -94,9 +94,11 @@ except Exception:
 
 
 from torchrec.distributed.logging_handlers import (
+    detect_technique,
     log_offloading_summary,
     log_planner_config,
     log_planning_result,
+    log_proposer_result,
     log_search_space_summary,
     log_storage_reservation,
     log_table_assignment,
@@ -589,6 +591,10 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
         )
 
+        _technique = detect_technique(
+            list(self._constraints.values()) if self._constraints else []
+        )
+
         dense_storage = getattr(self._storage_reservation, "_dense_storage", None)
         kjt_storage = getattr(self._storage_reservation, "_kjt_storage", None)
         log_storage_reservation(
@@ -599,6 +605,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             original_hbm_per_rank=self._topology.devices[0].storage.hbm,
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
+            technique=_technique,
         )
 
         log_planner_config(
@@ -613,10 +620,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 "num_table_constraints": (
                     str(len(self._constraints)) if self._constraints else "0"
                 ),
-            }
+            },
+            technique=_technique,
         )
         if self._constraints:
-            log_table_constraints(self._constraints, self.__class__.__name__)
+            log_table_constraints(
+                self._constraints, self.__class__.__name__, technique=_technique
+            )
 
         search_space = self._enumerator.enumerate(
             module=module,
@@ -626,7 +636,9 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             # No shardable parameters
             return ShardingPlan({})
 
-        log_search_space_summary(search_space, self.__class__.__name__)
+        log_search_space_summary(
+            search_space, self.__class__.__name__, technique=_technique
+        )
 
         loaded_sharding_options = None
         loaded_best_plan: List[ShardingOption] = []
@@ -662,7 +674,10 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 proposer.load(search_space=search_space, enumerator=self._enumerator)
 
             start = time.time()
-            for proposer in self._proposers:
+            for proposer_idx, proposer in enumerate(self._proposers):
+                proposer_num_proposals = 0
+                proposer_num_plans = 0
+                proposer_best_perf: Optional[float] = None
                 proposal = proposer.propose()
 
                 while proposal:
@@ -687,6 +702,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                         continue
 
                     self._num_proposals += 1
+                    proposer_num_proposals += 1
                     try:
                         # plan is just proposal where shard.rank is populated
                         plan = self._partitioner.partition(
@@ -694,7 +710,13 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                             storage_constraint=storage_constraint,
                         )
                         self._num_plans += 1
+                        proposer_num_plans += 1
                         perf_rating = self._perf_model.rate(plan=plan)
+                        if (
+                            proposer_best_perf is None
+                            or perf_rating < proposer_best_perf
+                        ):
+                            proposer_best_perf = perf_rating
                         if perf_rating < best_perf_rating:
                             best_perf_rating = perf_rating
                             best_plan = copy.deepcopy(plan)
@@ -733,6 +755,17 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     reset_shard_rank(proposal)
                     proposal = proposer.propose()
 
+                log_proposer_result(
+                    planner_type=self.__class__.__name__,
+                    proposer_name=proposer.__class__.__name__,
+                    proposer_index=proposer_idx,
+                    num_proposals=proposer_num_proposals,
+                    num_plans=proposer_num_plans,
+                    best_perf_rating=proposer_best_perf,
+                    is_winning_proposer=False,
+                    technique=_technique,
+                )
+
         if best_plan:
             for callback in self._callbacks:
                 best_plan = callback(best_plan)
@@ -765,12 +798,17 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
 
             log_planning_result(
                 planner_type=self.__class__.__name__,
+                technique=_technique,
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),
             )
 
-            log_offloading_summary(best_plan, self.__class__.__name__)
-            log_table_assignment(best_plan, self.__class__.__name__)
+            log_offloading_summary(
+                best_plan, self.__class__.__name__, technique=_technique
+            )
+            log_table_assignment(
+                best_plan, self.__class__.__name__, technique=_technique
+            )
 
             return sharding_plan
         else:
@@ -833,6 +871,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
 
             log_planning_result(
                 planner_type=self.__class__.__name__,
+                technique=_technique,
                 error_message=str(last_planner_error),
                 num_proposals=str(self._num_proposals),
                 num_plans=str(self._num_plans),

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -99,6 +99,7 @@ from torchrec.distributed.logging_handlers import (
     log_planning_result,
     log_storage_reservation,
     log_table_assignment,
+    log_table_constraints,
 )
 
 
@@ -613,6 +614,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 ),
             }
         )
+        if self._constraints:
+            log_table_constraints(self._constraints, self.__class__.__name__)
 
         search_space = self._enumerator.enumerate(
             module=module,


### PR DESCRIPTION
Summary: Log per-proposer stats (proposals, plans, best perf rating, is_winning) after each proposer exhausts in the OSS planner loop. Also adds winning_proposer to the planning_result event.

Differential Revision: D98067922


