### PR TITLE
Add LazyStr utility to defer expensive log message evaluation

### DIFF
--- a/torchrec/distributed/logger.py
+++ b/torchrec/distributed/logger.py
@@ -77,6 +77,31 @@ from typing_extensions import ParamSpec
 # Module exports - intentionally empty as these are internal utilities
 __all__: list[str] = []
 
+
+class LazyStr:
+    """Lazy string wrapper that defers evaluation until the string is needed.
+
+    Wraps a callable that produces a string. The callable is only invoked
+    when ``__str__`` is called, which happens when the logging framework
+    formats the message. If the log level is not active, the callable is
+    never evaluated.
+
+    Usage::
+
+        logger.debug(LazyStr(lambda: f"freed {expensive()} KJTs"))
+    """
+
+    # Use __slots__ to avoid per-instance __dict__, saving memory and
+    # speeding up attribute access since these may be created frequently.
+    __slots__ = ("_fn",)
+
+    def __init__(self, fn: Callable[[], str]) -> None:
+        self._fn = fn
+
+    def __str__(self) -> str:
+        return self._fn()
+
+
 # Some inputs like can get extremely large.
 # Adding logic to limit the input size by truncating any args larger than this size
 ARG_SIZE_LIMIT = 800000

--- a/torchrec/distributed/tests/test_logger.py
+++ b/torchrec/distributed/tests/test_logger.py
@@ -20,6 +20,9 @@ from torchrec.distributed.logger import (
     _get_or_create_logger,
     _torchrec_method_logger,
     ARG_SIZE_LIMIT,
+    LazyStr,
+    one_time_logger,
+    one_time_rank0_logger,
 )
 from torchrec.distributed.logging_handlers import _log_handlers, SingleRankStaticLogger
 
@@ -339,3 +342,46 @@ class TestLoggerUtils(unittest.TestCase):
                     self.assertEqual(msg_dict["group"], str(mock_process_group))
                     self.assertEqual(msg_dict["world_size"], "8")
                     self.assertEqual(msg_dict["rank"], "3")
+
+
+class TestLazyStr(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.count = 0
+
+        def counter() -> str:
+            self.count += 1
+            return f"call_{self.count}"
+
+        self.lazy_msg = LazyStr(counter)
+
+    def test_str_calls_fn(self) -> None:
+        """Test that __str__ invokes the wrapped callable."""
+        self.assertEqual(str(self.lazy_msg), "call_1")
+
+    def test_fn_not_called_until_str(self) -> None:
+        """Test that the callable is not evaluated at construction time."""
+        self.assertEqual(self.count, 0)
+        logging.info(self.lazy_msg)
+        self.assertEqual(self.count, 1)
+
+    def test_fn_called_each_time(self) -> None:
+        """Test that __str__ calls the callable on every invocation."""
+        self.assertEqual(str(self.lazy_msg), "call_1")
+        self.assertEqual(str(self.lazy_msg), "call_2")
+        logging.info("%s", self.lazy_msg)
+        self.assertEqual(self.count, 3)
+
+    def test_skipped_when_log_level_inactive(self) -> None:
+        """Test that LazyStr defers evaluation when log level filters the message."""
+        one_time_rank0_logger.setLevel(logging.INFO)
+        self.assertEqual(str(self.lazy_msg), "call_1")
+        for _ in range(3):
+            one_time_rank0_logger.debug(self.lazy_msg)
+        self.assertEqual(self.count, 1)
+
+    def test_with_one_time_logger(self) -> None:
+        """Test that LazyStr works with one_time_logger (Cap1Logger)."""
+        for _ in range(3):
+            one_time_logger.info(self.lazy_msg)
+        self.assertLess(self.count, 2)


### PR DESCRIPTION
Summary:
## 1. Context
TorchRec's distributed logging infrastructure (one_time_logger, one_time_rank0_logger, etc.) is used extensively in training pipelines. When debug-level logging constructs expensive strings (e.g., iterating module contexts to build diagnostic messages), the string formatting cost is paid even when the log level is inactive. There was no utility to defer this evaluation.

## 2. Approach
1. **`LazyStr` wrapper class**: Wraps a callable that produces a string. The callable is only invoked when `__str__` is called, which the logging framework does during message formatting. If the log level filters the message before formatting, the callable is never evaluated.
2. **Lightweight implementation**: Uses `__slots__` to avoid per-instance `__dict__`, keeping memory overhead minimal since these objects may be created on hot paths.

## 3. Results
* Test: `buck2 test fbcode//torchrec/distributed/tests:test_logger -- TestLazyStr` — 5 tests pass

## 4. Usage
```
def expansive_stats() -> str:
    stats = get_some_stats()
    return f"{stats}"

# expansive_stats() is only called once in logger.emit()
one_time_logger.info(LazyStr(expansive_stats))
```


## 5. Changes
1. **`logger.py`**: Add `LazyStr` class with `__slots__`, `__init__`, and `__str__` that defers callable evaluation.
2. **`tests/test_logger.py`**: Add `TestLazyStr` test class with 5 tests covering: basic `__str__` behavior, deferred evaluation, per-call invocation, log-level filtering, and integration with `one_time_logger`.

Differential Revision: D100213446


