### PR TITLE
Deduplicate tensor_size logging in RecMetric._update (#4082)

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -7,8 +7,6 @@
 
 # pyre-strict
 
-#!/usr/bin/env python3
-
 import abc
 import inspect
 import itertools
@@ -396,6 +394,7 @@ class RecMetric(nn.Module, abc.ABC):
             self.LABELS: [],
             self.WEIGHTS: [],
         }
+        self._fused_update_log_tensors: List[bool] = []
         #  Dict[str, Any]]`.
         # pyrefly: ignore[bad-assignment]
         self.enable_pt2_compile: bool = kwargs.get("enable_pt2_compile", False)
@@ -566,10 +565,13 @@ class RecMetric(nn.Module, abc.ABC):
         ):
             return
         fused_arguments = self._fuse_update_buffers()
+        log_tensors = any(self._fused_update_log_tensors)
+        self._fused_update_log_tensors.clear()
         self._update(
             predictions=fused_arguments[self.PREDICTIONS],
             labels=fused_arguments[self.LABELS],
             weights=fused_arguments.get(self.WEIGHTS, None),
+            _log_tensors=log_tensors,
         )
 
     def _create_default_weights(self, predictions: torch.Tensor) -> torch.Tensor:
@@ -623,8 +625,30 @@ class RecMetric(nn.Module, abc.ABC):
                 f"{name}_numel": str({k: v.numel() for k, v in tensor.items()}),
             }
 
+    @torch.compiler.disable
+    def _log_tensor_sizes(
+        self,
+        predictions: RecModelOutput,
+        labels: RecModelOutput,
+        weights: Optional[RecModelOutput],
+    ) -> None:
+        """Log tensor size metadata for debugging."""
+        metadata: Dict[str, str] = {}
+        metadata.update(self._get_tensor_size_metadata("predictions", predictions))
+        metadata.update(self._get_tensor_size_metadata("labels", labels))
+        if weights is not None:
+            metadata.update(self._get_tensor_size_metadata("weights", weights))
+        # n_batch_log_event samples every 1000 calls to avoid logging to Scuba every batch.
+        EventLoggingHandler.n_batch_log_event(
+            component=TorchrecComponent.REC_METRICS.value,
+            event_name="update",
+            event_type=EventType.INFO,
+            metadata=metadata,
+        )
+
     def _update_fused(
         self,
+        log_tensors: bool,
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: Optional[RecModelOutput],
@@ -680,6 +704,9 @@ class RecMetric(nn.Module, abc.ABC):
         else:
             assert isinstance(weights, torch.Tensor)
             weights = weights.view(len(self._tasks), -1)
+        # Log post-transformation tensor sizes for FUSED mode.
+        if log_tensors:
+            self._log_tensor_sizes(predictions, labels, weights)
         if self._should_validate_update:
             # has_valid_weights is a tensor of bool whose length equals to the number
             # of tasks. Each value in it is corresponding to whether the weights
@@ -710,6 +737,7 @@ class RecMetric(nn.Module, abc.ABC):
 
     def _update_unfused(
         self,
+        log_tensors: bool,
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: Optional[RecModelOutput],
@@ -720,6 +748,9 @@ class RecMetric(nn.Module, abc.ABC):
         Iterates over tasks and updates each metric computation independently.
         """
         original_required_inputs = kwargs.get("required_inputs")
+        # Log pre-iteration tensor sizes for UNFUSED mode.
+        if log_tensors:
+            self._log_tensor_sizes(predictions, labels, weights)
         for task, metric_ in zip(self._tasks, self._metrics_computations):
             if task.name not in predictions:
                 continue
@@ -808,20 +839,10 @@ class RecMetric(nn.Module, abc.ABC):
         predictions: RecModelOutput,
         labels: RecModelOutput,
         weights: Optional[RecModelOutput],
+        _log_tensors: bool = True,
         **kwargs: Dict[str, Any],
     ) -> None:
-        metadata: Dict[str, str] = {}
-        metadata.update(self._get_tensor_size_metadata("predictions", predictions))
-        metadata.update(self._get_tensor_size_metadata("labels", labels))
-        if weights is not None:
-            metadata.update(self._get_tensor_size_metadata("weights", weights))
-        # n_batch_log_event samples every 1000 calls to avoid logging to Scuba every batch.
-        EventLoggingHandler.n_batch_log_event(
-            component=TorchrecComponent.REC_METRICS.value,
-            event_name="update",
-            event_type=EventType.INFO,
-            metadata=metadata,
-        )
+        log_tensors: bool = _log_tensors
         with torch.no_grad():
             if self._should_clone_update_inputs:
                 predictions, labels, weights, kwargs = self.clone_update_inputs(
@@ -832,9 +853,11 @@ class RecMetric(nn.Module, abc.ABC):
                 RecComputeMode.FUSED_TASKS_COMPUTATION,
                 RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION,
             ]:
-                self._update_fused(predictions, labels, weights, **kwargs)
+                self._update_fused(log_tensors, predictions, labels, weights, **kwargs)
             else:
-                self._update_unfused(predictions, labels, weights, **kwargs)
+                self._update_unfused(
+                    log_tensors, predictions, labels, weights, **kwargs
+                )
 
     @pt2_compile_callable
     def update(
@@ -846,15 +869,21 @@ class RecMetric(nn.Module, abc.ABC):
         **kwargs: Dict[str, Any],
     ) -> None:
         with record_function(f"## {self.__class__.__name__}:update ##"):
+            log_tensors = bool(kwargs.pop("_log_tensors", True))
             if self._fused_update_limit > 0:
                 self._update_buffers[self.PREDICTIONS].append(predictions)
                 self._update_buffers[self.LABELS].append(labels)
                 if weights is not None:
                     self._update_buffers[self.WEIGHTS].append(weights)
+                self._fused_update_log_tensors.append(log_tensors)
                 self._check_fused_update(force=False)
             else:
                 self._update(
-                    predictions=predictions, labels=labels, weights=weights, **kwargs
+                    predictions=predictions,
+                    labels=labels,
+                    weights=weights,
+                    _log_tensors=log_tensors,
+                    **kwargs,
                 )
 
     # The implementation of compute is very similar to local_compute, but compute overwrites
@@ -1001,13 +1030,17 @@ class RecMetricList(nn.Module):
         *,
         predictions: RecModelOutput,
         labels: RecModelOutput,
-        weights: RecModelOutput,
+        weights: Optional[RecModelOutput],
         **kwargs: Dict[str, Any],
     ) -> None:
-        for metric in self.rec_metrics:
+        for i, metric in enumerate(self.rec_metrics):
             # pyrefly: ignore[not-callable]
             metric.update(
-                predictions=predictions, labels=labels, weights=weights, **kwargs
+                predictions=predictions,
+                labels=labels,
+                weights=weights,
+                _log_tensors=(i == 0),
+                **kwargs,
             )
 
     def compute(self) -> Dict[str, torch.Tensor]:

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -16,7 +16,7 @@ from torchrec.metrics.metrics_config import BatchSizeStage, DefaultTaskInfo, Rec
 from torchrec.metrics.model_utils import parse_task_model_outputs
 from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.ne import NEMetric
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
 from torchrec.metrics.test_utils import gen_test_batch, gen_test_tasks
 
 
@@ -449,3 +449,137 @@ class RecMetricTensorSizeLoggingTest(unittest.TestCase):
             weights=weights,
             required_inputs=required_inputs,
         )
+
+    @patch(
+        "torchrec.metrics.rec_metric.EventLoggingHandler.n_batch_log_event",
+    )
+    def test_update_deduplicates_across_unfused_metrics(
+        self, mock_log_event: Any
+    ) -> None:
+        """Verify logging fires once when multiple UNFUSED metrics process the same batch."""
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        mse = MSEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        metric_list = RecMetricList([ne, mse])
+        model_output = gen_test_batch(128)
+        labels, predictions, weights, _ = parse_task_model_outputs(
+            [DefaultTaskInfo], model_output
+        )
+        metric_list.update(predictions=predictions, labels=labels, weights=weights)
+
+        mock_log_event.assert_called_once()
+
+    @patch(
+        "torchrec.metrics.rec_metric.EventLoggingHandler.n_batch_log_event",
+    )
+    def test_update_deduplicates_across_fused_metrics(
+        self, mock_log_event: Any
+    ) -> None:
+        """Verify logging fires once when multiple FUSED metrics process the same batch."""
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        mse = MSEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        metric_list = RecMetricList([ne, mse])
+        model_output = gen_test_batch(128)
+        labels, predictions, weights, _ = parse_task_model_outputs(
+            [DefaultTaskInfo], model_output
+        )
+        metric_list.update(predictions=predictions, labels=labels, weights=weights)
+
+        mock_log_event.assert_called_once()
+
+    @patch(
+        "torchrec.metrics.rec_metric.EventLoggingHandler.n_batch_log_event",
+    )
+    def test_fused_update_logs_post_transformation_shapes(
+        self, mock_log_event: Any
+    ) -> None:
+        """Verify that in FUSED mode, logged shapes reflect the stacked
+        (n_tasks, batch_size) tensors, not the original dict."""
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        model_output = gen_test_batch(128)
+        labels, predictions, weights, _ = parse_task_model_outputs(
+            [DefaultTaskInfo], model_output
+        )
+        ne.update(predictions=predictions, labels=labels, weights=weights)
+
+        mock_log_event.assert_called_once()
+        metadata = mock_log_event.call_args[1]["metadata"]
+        # FUSED mode stacks per-task tensors into a single tensor,
+        # so the shape should be reported (not a dict of numels).
+        self.assertIn("predictions_shape", metadata)
+        self.assertIn("labels_shape", metadata)
+
+    @patch(
+        "torchrec.metrics.rec_metric.EventLoggingHandler.n_batch_log_event",
+    )
+    def test_fused_update_limit_deduplicates_logging(self, mock_log_event: Any) -> None:
+        """Verify that when fused_update_limit > 0, the buffered flush
+        still respects the _log_tensors flag from RecMetricList."""
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=5,
+        )
+        mse = MSEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=64,
+            tasks=[DefaultTaskInfo],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=5,
+        )
+        metric_list = RecMetricList([ne, mse])
+        model_output = gen_test_batch(128)
+        labels, predictions, weights, _ = parse_task_model_outputs(
+            [DefaultTaskInfo], model_output
+        )
+        # Send 5 batches to trigger the fused update flush.
+        for _ in range(5):
+            metric_list.update(predictions=predictions, labels=labels, weights=weights)
+
+        # Only the first metric (ne) should have logged, not both.
+        mock_log_event.assert_called_once()


### PR DESCRIPTION
Summary:

The tensor size metadata logging added in D99310045 was placed in RecMetric._update(), which is called once per metric type (NE, AUC, etc.) per batch. Since RecMetricList.update() iterates over all metrics with the same predictions/labels/weights, this produced N duplicate log entries per batch where N = number of rec metrics.

This diff deduplicates the logging by passing a `_log_tensors` flag from RecMetricList.update(), where only the first metric (i == 0) logs tensor sizes. The flag flows through kwargs to _update(), which pops it and passes it to _update_fused()/_update_unfused() to conditionally call _log_tensor_sizes(). This replaces a previous approach that used class-level mutable state (a Set tracking batch IDs), which had thread-safety concerns with CPUOffloadedRecMetricModule and unnecessary complexity.

The logging remains inside _update_fused() and _update_unfused() so that logged shapes reflect post-transformation tensors (e.g., the stacked (n_tasks, batch_size) shape in FUSED mode), while direct callers of RecMetric.update() default to logging (backward compatible).

Reviewed By: jeffkbkim

Differential Revision: D100195100


