### PR TITLE
Conditionally import non-OSS packages

### DIFF
--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -39,8 +39,12 @@ from torchrec.distributed.types import (
     ShardingPlanner,
     ShardingType,
 )
-from torchrec.fb.distributed.planner.lp_planner import LinearProgrammingPlanner
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
+
+try:
+    from torchrec.fb.distributed.planner.lp_planner import LinearProgrammingPlanner
+except ImportError:
+    LinearProgrammingPlanner = None  # Not available in OSS
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -243,6 +247,11 @@ class PlannerConfig:
                 storage_reservation=storage_reservation,
             )
         elif self.planner_type == "lp":
+            if LinearProgrammingPlanner is None:
+                raise RuntimeError(
+                    "LinearProgrammingPlanner is not available in OSS. "
+                    "Use planner_type='embedding' or 'hetero' instead."
+                )
             return LinearProgrammingPlanner(
                 topology=topology,
                 batch_size=self.batch_size,


### PR DESCRIPTION
Summary:
`sharding_config.py` imports `LinearProgrammingPlanner` from `torchrec.fb`, which is not available in the OSS build. This causes the CI Benchmark Nightly job to fail with an `ImportError` when running against the open-source torchrec package.

Wrap the internal import in a `try/except ImportError` block so the module loads cleanly in OSS, and raise a clear `RuntimeError` at the usage site if someone actually tries to use the `"lp"` planner type without the internal dependency.

**Note:** This is a stopgap fix to unblock CI. A follow-up should refactor the planner dispatch (e.g., a registry or plugin pattern) so internal-only planners are cleanly separated rather than guarded by a runtime `None` check.

Differential Revision: D100438725


