### PR TITLE
[detailed][memory] Prototype for Unified EMO + EMS (#4099)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/prefetch_emo_ems.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_emo_ems.yml
@@ -1,5 +1,8 @@
-# this is a very basic sparse data dist config
-# runs on 2 ranks, showing traces with reasonable workloads
+# Unified EMO + EMS benchmark config
+# Combines fused_uvm_caching (EMO) with embedding memory stashing (EMS).
+# During forward, the EMO cache (lxu_cache_weights) is flushed + freed.
+# Before backward, the cache is restored via re-prefetch from UVM,
+# and batch_i+1 is prefetched for the next forward.
 RunOptions:
   world_size: 2
   num_batches: 10
@@ -7,13 +10,13 @@ RunOptions:
   num_profiles: 1
   sharding_type: table_wise
   profile_dir: "."
-  name: "prefetch_emo"
+  name: "prefetch_emo_ems"
   memory_snapshot: True
   loglevel: "INFO"
-  sync_batch: True
-  # export_stacks: True # enable this to export stack traces
 PipelineConfig:
-  pipeline: "prefetch"  # "sparse"
+  pipeline: "prefetch-ems"
+  kwargs:
+    site_fqn: "over.overarch.0"
 ModelInputConfig:
   num_float_features: 100
   feature_pooling_avg: 30
@@ -41,13 +44,14 @@ EmbeddingTablesConfig:
         embedding_dim: 512
         num_embeddings: 10_000_000
         feature_names: ["additional_0_1"]
+        stash_weights: true
     - []
     - - name: skipped_table
         embedding_dim: 128
         num_embeddings: 100_000
         feature_names: ["additional_2_1"]
 PlannerConfig:
-  pooling_factors: [30.0]  # Default pooling factor (no ModelInputConfig.feature_pooling_avg specified)
+  pooling_factors: [30.0]
   additional_constraints:
     large_table:
       compute_kernels: [fused_uvm_caching]

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,8 +14,12 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
-from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+)
 from torchrec.distributed.logger import capped_logger, one_time_rank0_logger
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -47,6 +51,7 @@ class MemoryStashingManager:
     _device_to_host_stream: Optional[torch.cuda.Stream] = None
     _embedding_weight_restore_callbacks: List[Callable[..., None]] = []
     _optimizer_state_restore_callbacks: List[Callable[..., None]] = []
+    _emo_cache_restore_callbacks: List[Callable[..., None]] = []
     _stash_executor: Optional[ThreadPoolExecutor] = None
 
     @classmethod
@@ -96,6 +101,7 @@ class MemoryStashingManager:
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
         cls._optimizer_state_restore_callbacks.clear()
+        cls._emo_cache_restore_callbacks.clear()
         if cls._stash_executor is not None:
             cls._stash_executor.shutdown(wait=False)
             cls._stash_executor = None
@@ -362,6 +368,171 @@ class MemoryStashingManager:
 
         await_restore, restore = cls._stash_tensors(tensors, label="embedding")
         cls._embedding_weight_restore_callbacks.append(restore)
+        return await_restore, restore
+
+    @classmethod
+    def restore_emo_cache(
+        cls,
+        _grad: Optional[torch.Tensor] = None,
+        sync_event: Optional[torch.cuda.Event] = None,
+    ) -> None:
+        """Pop and call all EMO cache restore callbacks."""
+        one_time_rank0_logger.info(
+            f"restore_emo_cache: invoking {len(cls._emo_cache_restore_callbacks)} callbacks"
+        )
+        while cls._emo_cache_restore_callbacks:
+            cls._emo_cache_restore_callbacks.pop()(None, sync_event)
+
+    @classmethod
+    def stash_emo_cache(
+        cls,
+        lookup: nn.Module,
+        features: KeyedJaggedTensor,
+    ) -> Optional[
+        Tuple[
+            Callable[[Optional[torch.Tensor]], None],
+            Callable[[Optional[torch.Tensor]], None],
+        ]
+    ]:
+        """
+        Stash EMO cache (lxu_cache_weights) for MANAGED_CACHING TBE modules.
+
+        For tables using ``fused_uvm_caching`` (EMO), the actual HBM consumer
+        is ``lxu_cache_weights``, not ``weights_dev``. This method:
+
+        1. Flushes dirty cache lines back to ``weights_uvm`` (the authoritative
+           copy in host DDR).
+        2. Frees ``lxu_cache_weights`` HBM via ``resize_(0)``.
+        3. Returns restore callbacks that re-allocate the cache, reset cache
+           state, and re-prefetch the current batch rows so the TBE backward
+           (fused backward+optimizer) can update the correct cache slots.
+
+        Batch_i+1 prefetch is handled separately by the pipeline via
+        ``_restore_and_prefetch_embeddings`` which calls
+        ``sharded_module.prefetch()`` after this restore completes.
+
+        Args:
+            lookup: A lookup module (e.g., GroupedPooledEmbeddingsLookup)
+                containing TBE modules with MANAGED_CACHING tables.
+            features: The KeyedJaggedTensor used in the current forward pass.
+                Captured for re-prefetch at restore time.
+
+        Returns:
+            A tuple of (await_restore, restore) callbacks, or None if no
+            EMO caches were stashed.
+        """
+        # Handle DDP wrapper
+        module = lookup.module if hasattr(lookup, "module") else lookup
+
+        if not hasattr(module, "_emb_modules"):
+            return None
+
+        feature_splits = getattr(module, "_feature_splits", None)
+        if feature_splits is None:
+            return None
+
+        features_by_group = features.split(feature_splits)
+
+        # Collect EMO TBE modules and their features
+        # Each entry: (tbe_inner, group_features)
+        emo_stash_data: List[Tuple[Any, KeyedJaggedTensor]] = []
+
+        # pyre-ignore[16]: _emb_modules is dynamically set by lookup modules
+        for emb_module, group_features in zip(module._emb_modules, features_by_group):
+            config = getattr(emb_module, "_config", None)
+            if not isinstance(config, GroupedEmbeddingConfig):
+                continue
+
+            has_emo = any(
+                t.compute_kernel == EmbeddingComputeKernel.FUSED_UVM_CACHING
+                for t in config.embedding_tables
+            )
+            if not has_emo:
+                continue
+
+            inner = getattr(emb_module, "_emb_module", None)
+            if inner is None:
+                continue
+
+            if (
+                not hasattr(inner, "lxu_cache_weights")
+                or inner.lxu_cache_weights.numel() == 0
+            ):
+                continue
+
+            emo_stash_data.append((inner, group_features))
+
+        if not emo_stash_data:
+            return None
+
+        with record_function(f"## stash_emo_cache ({len(emo_stash_data)} TBEs) ##"):
+            orig_cache_sizes: List[int] = []
+            for inner, _group_features in emo_stash_data:
+                inner.flush()
+                orig_cache_sizes.append(
+                    inner.lxu_cache_weights.untyped_storage().size()
+                )
+                inner.lxu_cache_weights.untyped_storage().resize_(0)
+
+        total_freed_mb = sum(orig_cache_sizes) / (1024**2)
+        capped_logger.info(
+            f"stash_emo_cache: freed {len(emo_stash_data)} EMO caches, "
+            f"total {total_freed_mb:.2f} MB"
+        )
+
+        def restore(
+            _grad: Optional[torch.Tensor] = None,
+            sync_event: Optional[torch.cuda.Event] = None,
+        ) -> None:
+            """Restore EMO caches and re-prefetch batch_i for backward."""
+            with record_function(
+                f"## restore_emo_cache ({len(emo_stash_data)} TBEs) ##"
+            ):
+                for (tbe, group_features), orig_cache_size in zip(
+                    emo_stash_data, orig_cache_sizes
+                ):
+                    # Step 1: Re-allocate cache HBM
+                    tbe.lxu_cache_weights.untyped_storage().resize_(orig_cache_size)
+
+                    # Step 2: Invalidate all cache slots and reset LRU/LFU
+                    tbe.reset_cache_states()
+
+                    # Step 3: Clear stale prefetch state
+                    tbe.lxu_cache_locations_list.clear()
+                    if hasattr(tbe, "timesteps_prefetched"):
+                        tbe.timesteps_prefetched.clear()
+
+                    # Step 4: Reset locking counter for prefetch_pipeline
+                    if (
+                        hasattr(tbe, "lxu_cache_locking_counter")
+                        and tbe.lxu_cache_locking_counter is not None
+                        and tbe.lxu_cache_locking_counter.numel() > 0
+                    ):
+                        tbe.lxu_cache_locking_counter.fill_(0)
+
+                    # Step 5: Re-prefetch batch_i rows for backward.
+                    # With prefetch_pipeline=True, this locks batch_i slots.
+                    tbe.prefetch(
+                        indices=group_features.values(),
+                        offsets=group_features.offsets(),
+                    )
+
+                    # Step 6: Consume batch_i's prefetch state — pop cache
+                    # locations for backward and the corresponding timestep
+                    # so they stay in sync with lxu_cache_locations_list.
+                    if tbe.lxu_cache_locations_list:
+                        tbe.lxu_cache_locations = tbe.lxu_cache_locations_list.pop(0)
+                    if (
+                        hasattr(tbe, "timesteps_prefetched")
+                        and tbe.timesteps_prefetched
+                    ):
+                        tbe.timesteps_prefetched.pop(0)
+
+        def await_restore(_grad: Optional[torch.Tensor] = None) -> None:
+            """No-op: re-prefetch runs synchronously on the current stream."""
+            pass
+
+        cls._emo_cache_restore_callbacks.append(restore)
         return await_restore, restore
 
     @classmethod

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -20,6 +20,7 @@ from torchrec.distributed.train_pipeline import (
 from torchrec.distributed.train_pipeline.experimental_pipelines import (
     EvalPipelineCPUSparse,
     TrainEvalHybridPipelineBase,
+    TrainPipelinePrefetchEMS,
     TrainPipelineSparseDistBwdOpt,
     TrainPipelineSparseDistEmbStash,
     TrainPipelineSparseDistOptStash,
@@ -73,7 +74,7 @@ class PipelineConfig:
             for key in ("site_fqn", "sharding_type"):
                 if key in kwargs:
                     kwargs.pop(key)
-        if self.pipeline in ("sparse-emb-stash",):
+        if self.pipeline in ("sparse-emb-stash", "prefetch-ems"):
             kwargs.pop("sharding_type", None)
         if self.pipeline in ("base", "eval-sdd"):
             kwargs.pop("pipeline_postproc", None)
@@ -131,6 +132,7 @@ class PipelineConfig:
             "sparse-bwd-opt": TrainPipelineSparseDistBwdOpt,
             "sparse-opt-stash": TrainPipelineSparseDistOptStash,
             "sparse-emb-stash": TrainPipelineSparseDistEmbStash,
+            "prefetch-ems": TrainPipelinePrefetchEMS,
             "eval-cpu-sparse": EvalPipelineCPUSparse,
         }
 

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -1133,3 +1133,152 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
                 MemoryStashingManager.restore_embedding_weights()
 
         self.register_backward_hook(self._injection_site, work)
+
+
+class TrainPipelinePrefetchEMS(TrainPipelineSparseDistEmbStash[In, Out]):
+    """
+    Extends TrainPipelineSparseDistEmbStash with unified EMO + EMS support.
+
+    For tables using ``fused_uvm_caching`` (EMO), the standard embedding
+    stash is a no-op because ``weights_dev`` is empty — the actual HBM
+    consumer is ``lxu_cache_weights``. This pipeline enables time-sharing
+    HBM between the embedding cache and dense compute by:
+
+    1. After forward: flushing dirty cache lines to ``weights_uvm``, then
+       freeing ``lxu_cache_weights`` HBM via ``resize_(0)`` on the D2H
+       stream (overlaps with dense forward).
+    2. During dense forward/backward: cache HBM is available for activations.
+    3. Before backward: restoring the cache and re-prefetching on the main
+       stream.
+
+    Timeline per iteration::
+
+        default stream:   forward ── restore+prefetch ── backward ── opt
+        d2h stream:            stash (flush+free) ──┘
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        device: torch.device,
+        site_fqn: Union[str, InjectionSite],
+        execute_all_batches: bool = True,
+        apply_jit: bool = False,
+        context_type: Type[TrainPipelineContext] = TrainPipelineContext,
+        pipeline_postproc: bool = False,
+        custom_model_fwd: Optional[
+            Callable[[Optional[In]], Tuple[torch.Tensor, Out]]
+        ] = None,
+        dmp_collection_sync_interval_batches: Optional[int] = 1,
+        enqueue_batch_after_forward: bool = False,
+        enable_inplace_copy_batch: bool = False,
+        free_features_storage_early: bool = False,
+    ) -> None:
+        super().__init__(
+            model=model,
+            optimizer=optimizer,
+            device=device,
+            site_fqn=site_fqn,
+            execute_all_batches=execute_all_batches,
+            apply_jit=apply_jit,
+            context_type=context_type,
+            pipeline_postproc=pipeline_postproc,
+            custom_model_fwd=custom_model_fwd,
+            dmp_collection_sync_interval_batches=dmp_collection_sync_interval_batches,
+            enqueue_batch_after_forward=enqueue_batch_after_forward,
+            enable_inplace_copy_batch=enable_inplace_copy_batch,
+            free_features_storage_early=free_features_storage_early,
+        )
+
+    def _restore_and_prefetch(self) -> None:
+        """
+        Restore stashed embedding weights and EMO caches (batch_i), then
+        prefetch batch_i+1 for the next forward pass.
+
+        Runs on the main stream before backward.
+        """
+        # Step 1: Restore stashed weights and EMO caches (re-prefetch batch_i)
+        MemoryStashingManager.restore_embedding_weights()
+        MemoryStashingManager.restore_emo_cache()
+
+        # Step 2: Prefetch batch_i+1 for next forward
+        if len(self.batches) < 2:
+            return
+
+        context_next = self.contexts[1]
+        for sharded_module in self._pipelined_modules:
+            forward = sharded_module.forward
+            # pyre-ignore[16]: _name is set by PipelinedForward
+            name = forward._name
+            if name not in context_next.input_dist_tensors_requests:
+                continue
+
+            # Peek at the awaitable — materialize if needed, but don't pop.
+            # Store back as LazyNoWait so PipelinedForward.__call__ can
+            # still consume it in the next iteration.
+            request = context_next.input_dist_tensors_requests[name]
+            if isinstance(request, LazyNoWait):
+                data = request._obj
+            else:
+                data = request.wait()
+                context_next.input_dist_tensors_requests[name] = LazyNoWait(data)
+
+            module_context = context_next.module_contexts.get(name)
+            sharded_module.prefetch(ctx=module_context, dist_input=data)
+
+    def progress(self, dataloader_iter: Iterator[In]) -> Out:
+        self._state = PipelineState.IDLE
+        if not self._model_attached:
+            self.attach(self._model)
+
+        self.fill_pipeline(dataloader_iter)
+
+        if not self.batches:
+            raise StopIteration
+
+        self._set_module_context(self.contexts[0])
+
+        if self._model.training:
+            with record_function("## zero_grad ##"):
+                self._optimizer.zero_grad()
+
+        self._wait_for_batch()
+
+        if len(self.batches) >= 2:
+            self.start_sparse_data_dist(self.batches[1], self.contexts[1])
+
+        if not self._enqueue_batch_after_forward:
+            self.enqueue_batch(dataloader_iter)
+
+        # forward — stash_emo_cache fires inside ShardedEBC.compute()
+        # on the d2h stream (overlaps with dense forward)
+        with record_function(f"## forward {self.contexts[0].index} ##"):
+            self._state = PipelineState.CALL_FWD
+            losses, output = self._model_fwd(self.batches[0])
+
+        if self._enqueue_batch_after_forward:
+            self.enqueue_batch(dataloader_iter)
+
+        if len(self.batches) >= 2:
+            self.wait_sparse_data_dist(self.contexts[1])
+
+        # Restore + prefetch on main stream before backward.
+        with record_function("## restore_and_prefetch ##"):
+            self._restore_and_prefetch()
+
+        if self._model.training:
+            self._state = PipelineState.CALL_BWD
+            self._backward(losses)
+
+            self.sync_embeddings(
+                self._model,
+                self._dmp_collection_sync_interval_batches,
+                self.contexts[0],
+            )
+
+            with record_function(f"## optimizer {self.contexts[0].index} ##"):
+                self._optimizer.step()
+
+        self.dequeue_batch()
+        return output


### PR DESCRIPTION
Summary:

# Prototype for Unified EMO+EMS

## TL;DR

- We prototyped a [unified EMO+EMS design](https://docs.google.com/document/d/15YaXGbYuq_XeKzYft1Q7NwZovQA9nHtKXwZUn94gdwE/edit?tab=t.0) ([#4100](https://github.com/meta-pytorch/torchrec/pull/4100)) that combines the strengths of both EMO and EMS:
  - Requires fewer HBM transfers than EMS (only the cache portion, not the full table), making it more feasible for non-GH (Grace Hopper) devices like H100 or MI300.
  - Avoids the memory peak (fwd-bwd) in the training cycle, making the design less sensitive to cache load factor — the main tradeoff in standalone EMO.
- The goal is near-zero HBM overhead for embedding tables, with on-par performance to all-on-HBM sparse-data-dist (SDD) pipeline.
- This work demonstrates the feasibility of unified EMO+EMS. Further work is needed to optimize multi-stream overlap and timing/trigger tuning to fully hide the UVM transfer overhead.

## 1\. Approach

1. **Stash** (after embedding forward): call flush() to write dirty cache lines back to weights\_uvm, then resize\_(0) on lxu\_cache\_weights to free HBM. Implemented in MemoryStashingManager.stash\_emo\_cache().
2. **Restore** (before sparse backward): resize lxu\_cache\_weights back to original size, reset\_cache\_states(), re-prefetch batch\_i rows for backward, update lxu\_cache\_locations so the fused backward+optimizer writes to the correct cache slots. Implemented in MemoryStashingManager.restore\_emo\_cache().
3. **Prefetch batch\_i+1** (before backward): call sharded\_module.prefetch() with the next batch's features so the cache is warm for the next forward. The prefetch\_pipeline locking counter prevents eviction of batch\_i rows.
4. **Pipeline**: TrainPipelinePrefetchEMS extends TrainPipelineSparseDistEmbStash, overrides progress() to call restore + prefetch between wait\_sparse\_data\_dist and backward.

| Operation | Direction | Bottleneck | Bandwidth |
| :---- | :---- | :---- | :---- |
| flush (dirty cache → UVM) | HBM → DDR | PCIe | ~50-60 GB/s |
| on-HBM embedding lookup | HBM read/write | HBM | ~2-3 TB/s |
| prefetch (UVM → cache) | DDR → HBM | PCIe | ~50-60 GB/s |

<img width="920" height="465" alt="image" src="https://github.com/user-attachments/assets/cc116137-083f-4205-8b77-3e11b89d4531" />


## 2\. Benchmark

### 2.1. Setup

#### Required additional changes for Unified EMO+EMS

The EMO stash call needs to be wired into the embedding modules. In both [embeddingbag.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/embeddingbag.py#L1882) (ShardedEmbeddingBagCollection.compute\_and\_output\_dist()) and [embedding.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/embedding.py#L1614) (ShardedEmbeddingCollection.compute\_and\_output\_dist()), add the following after the existing stash\_embedding\_weights call inside the MemoryStashingManager.is\_enabled() block:

```python
if MemoryStashingManager.is_enabled():
    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
    if stash_result is not None:
        await_restore, _ = stash_result
        embs.register_hook(await_restore)
    emo_result = MemoryStashingManager.stash_emo_cache(lookup, features)
    if emo_result is not None:
        emo_await_restore, _ = emo_result
        embs.register_hook(emo_await_restore)
```

#### Model

TestSparseNN on 2 ranks, batch\_size=32768, pooling\_factor=30.

| Table group | Count | Emb dim | Hash size | Compute kernel | Sharding | Total storage |
| :---- | :---- | :---- | :---- | :---- | :---- | :---- |
| unweighted | 30 | 256 | 100K | fused | TW | 5.19 GB HBM |
| weighted | 40 | 256 | 100K | fused | TW | 6.92 GB HBM |
| FP16\_table | 1 | 512 | 100K | fused | TW | 0.173 GB HBM |
| large\_table | 1 | 512 | 10M | fused\_uvm\_caching / fused\_uvm / fused | RW | 19.073 GB |

Per feature per rank indices: 32768 × 30 = ~0.98M.

### 2.2. Repro

All benchmarks use the same model and table config. Only the pipeline, compute kernel, and cache settings vary.

| Name | Pipeline | Description | Load factor |
| :---- | :---- | :---- | :---- |
| prefetch\_ems\_0.2 | prefetch-ems | Unified EMO+EMS, fused\_uvm\_caching | 0.2 |
| prefetch\_ems\_0.4 | prefetch-ems | Unified EMO+EMS, fused\_uvm\_caching | 0.4 |
| prefetch\_emo\_0.2 | prefetch | Standard EMO, fused\_uvm\_caching | 0.2 |
| prefetch\_emo\_0.4 | prefetch | Standard EMO, fused\_uvm\_caching | 0.4 |
| sdd\_fused\_uvm | sparse | UVM without caching, fused\_uvm | — |
| sdd\_fused | sparse | All HBM, fused | — |

* Run commands:

```bash
# prefetch_ems_0.2: use prefetch_emo_ems.yml as-is (load_factor: 0.2)
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo_ems.yml \
  --name=prefetch_ems_0.2

# prefetch_ems_0.4: change load_factor to 0.4 in prefetch_emo_ems.yml
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo_ems.yml \
  --name=prefetch_ems_0.4

# prefetch_emo_0.2: use prefetch_emo.yml as-is (load_factor: 0.2)
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo.yml \
  --name=prefetch_emo_0.2

# prefetch_emo_0.4: change load_factor to 0.4 in prefetch_emo.yml
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo.yml \
  --name=prefetch_emo_0.4

# sdd_fused_uvm: change compute_kernels to [fused_uvm] in yml
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo.yml \
  --pipeline=sparse \
  --name=sdd_fused_uvm

# sdd_fused: change compute_kernels to [fused] in yml
python torchrec/distributed/benchmark/benchmark_train_pipeline.py \
  --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo.yml \
  --pipeline=sparse \
  --name=sdd_fused
```

### 2.3. Results
* metrics

| Name | GPU Runtime (P90) | CPU Runtime (P90) | GPU Peak Mem alloc (P90) | GPU Peak Mem reserved (P90) |
| :---- | :---- | :---- | :---- | :---- |
| prefetch\_ems\_0.2 | 3731.58 ms | 3200.49 ms | 17.64 GB | 29.28 GB |
| prefetch\_ems\_0.4 | 3256.64 ms | 3103.83 ms | 19.61 GB | 31.24 GB |
| prefetch\_emo\_0.2 | 4673.33 ms | 4109.34 ms | 18.34 GB | 27.00 GB |
| prefetch\_emo\_0.4 | 3122.24 ms | 3206.71 ms | 20.31 GB | 28.96 GB |
| sdd\_fused\_uvm | 3743.76 ms | 3505.76 ms | 16.34 GB | 25.54 GB |
| sdd\_fused | 2855.41 ms | 2950.84 ms | 26.10 GB | 35.25 GB |

* Artifacts: [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368)

| Name | Perf Doctor | Perfetto | Memory Visualizer |
| :---- | :---- | :---- | :---- |
| prefetch\_ems\_0.2 | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-prefetch_ems_0.2-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-prefetch_ems_0.2-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-prefetch_ems_0.2-rank0.pickle) |
| prefetch\_ems\_0.4 | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-prefetch_ems_0.4-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-prefetch_ems_0.4-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-prefetch_ems_0.4-rank0.pickle) |
| prefetch\_emo\_0.2 | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-prefetch_emo_0.2-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-prefetch_emo_0.2-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-prefetch_emo_0.2-rank0.pickle) |
| prefetch\_emo\_0.4 | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-prefetch_emo_0.4-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-prefetch_emo_0.4-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-prefetch_emo_0.4-rank0.pickle) |
| sdd\_fused\_uvm | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-sdd_fused_uvm-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-sdd_fused_uvm-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-sdd_fused_uvm-rank0.pickle) |
| sdd\_fused | [trace](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D100561368/trace-sdd_fused-rank0.json.gz&bucket=torchrec_benchmark_traces) | [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D100561368/trace-sdd_fused-rank0.json.gz&bucket=torchrec_benchmark_traces) | [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D100561368/memory-sdd_fused-rank0.pickle) |

## 3\. Analysis (large\_table)

large\_table: 10M rows, dim=512, FP32, row\_wise sharding across 2 ranks (each rank holds 5M rows).

### 3.1. Memory

```
UVM weights per rank:                    5M * 512 * 4 bytes = 9.54 GB  (weights_uvm in DDR)

With cache_load_factor=0.2:
  EMO cache per rank:                    5M * 0.2 * 512 * 4 bytes = 1.91 GB  (lxu_cache_weights in HBM)

With cache_load_factor=0.4:
  EMO cache per rank:                    5M * 0.4 * 512 * 4 bytes = 3.81 GB  (lxu_cache_weights in HBM)
```

With unified EMO+EMS, the cache is freed during dense compute:

```
                                         load_factor=0.2    load_factor=0.4
During dense forward + backward:         0 GB (freed)       0 GB (freed)
During restore + sparse backward:        1.91 GB            3.81 GB
HBM freed during dense compute:          1.91 GB/rank       3.81 GB/rank
```

This is significant — dense forward/backward is often the peak HBM consumer due to activations. Freeing 2-4 GB of cache HBM during that phase can be the difference between fitting a model and OOMing.

Note: The indices per batch is about 0.98M, so the embedding fetched from the table in each batch is about 0.98M \* 512 \* 4 bytes = ~1.91 GB. The ideal cache size should be two batches of embeddings, adjusted by the similarity (unique indices across two batches plus some buffer) — otherwise there would be cache misses. In the benchmark, the indices are totally random, so almost no overlap (\<20%) between batches. That's why we use load\_factor=0.2 and 0.4: load\_factor=0.2 roughly fits one batch, load\_factor=0.4 roughly fits two batches.

| SDD-fused: 9.5 GB static embedding table | EMO-0.2: 1.9 GB static embedding cache | EMO-EMS-0.4: 3.8 GB cache after bwd pass|
| -- | -- | -- |
|<img width="2546" height="927" alt="image" src="https://github.com/user-attachments/assets/633efb84-ad56-4b8a-bb25-e4cbe5b61107" />|<img width="2548" height="906" alt="image" src="https://github.com/user-attachments/assets/116e6f11-a4cc-406f-a86b-9cd60b268af5" />|<img width="2547" height="1120" alt="image" src="https://github.com/user-attachments/assets/becd49af-95bd-4224-8ccf-444285fc7996" />|


### 3.2. Runtime

Per-batch embedding data for large\_table: ~1.91 GB (0.98M indices \* 512 \* 4 bytes).

| Operation | Data size | Bandwidth | Estimated time |
| :---- | :---- | :---- | :---- |
| flush (dirty cache → UVM) | 1.91 GB | ~50 GB/s (PCIe) | ~38 ms |
| prefetch batch\_i (UVM → cache) | 1.91 GB | ~50 GB/s (PCIe) | ~38 ms |
| prefetch batch\_i+1 (UVM → cache) | 1.91 GB | ~50 GB/s (PCIe) | ~38 ms |
| on-HBM embedding lookup (fwd or bwd) | 1.91 GB | ~2 TB/s (HBM) | ~1 ms |

Total EMO+EMS overhead per iteration: flush + 2x prefetch = ~114 ms, compared to ~1 ms for pure on-HBM lookup. The flush and prefetch can overlap with dense compute on separate CUDA streams.

Trace screenshots (embedding lookup time: fwd + bwd):

|SDD-fused: 2.07 ms|SDD-fused\_uvm: 37 ms|EMO-0.4: 1.1 ms + 29 ms|
| -- | -- | -- |
|<img width="2326" height="827" alt="image" src="https://github.com/user-attachments/assets/8e76f0f0-aa1c-4097-8daf-133c6a2de865" />|<img width="2327" height="795" alt="image" src="https://github.com/user-attachments/assets/24c171dd-77d7-432a-aa3c-68c756d9ab59" />|<img width="2329" height="866" alt="image" src="https://github.com/user-attachments/assets/13138467-596a-42f8-9fa0-125952435dd1" />|

|EMO-0.2: 18 ms + 27 ms|EMO+EMS-0.2: 25 ms + 36 ms|EMO+EMS-0.4: 1.4 ms + 36 ms|
| -- | -- | -- |
|<img width="2329" height="777" alt="image" src="https://github.com/user-attachments/assets/af32ca6b-30eb-4a10-be85-6330d37e35a6" />|<img width="2330" height="835" alt="image" src="https://github.com/user-attachments/assets/1a409015-bb6b-4903-a8b0-c1152e1c8537" />|<img width="2323" height="832" alt="image" src="https://github.com/user-attachments/assets/5f3119f1-01ce-4804-a5a9-0dcbe1c7c0c2" />|

Observations:
1. Pure HBM embedding lookup is ~1 ms per batch (SDD-fused, and EMO/EMO+EMS with sufficient cache).
2. UVM access is ~30-40 ms per batch (SDD-fused\_uvm, flush, and prefetch) — bounded by PCIe bandwidth.
3. With load\_factor=0.2, the cache only fits ~1 batch of embeddings, so embedding lookup slows to ~18-25 ms due to cache misses (EMO-0.2, EMO+EMS-0.2).
4. With load\_factor=0.4, the cache fits ~2 batches, so embedding lookup is on-par with pure HBM (~1 ms) in both EMO-0.4 and EMO+EMS-0.4.
5. EMO+EMS adds ~36 ms overhead for the restore+prefetch step (visible in EMO+EMS-0.4 bwd), which is consistent with the estimated ~38 ms per UVM prefetch.

Comparison of EMO+EMS-0.4 vs EMO-0.4:

| | EMO-0.4 | EMO+EMS-0.4 |
| :---- | :---- | :---- |
| Embedding lookup | ~1 ms (pure HBM) | ~1 ms (pure HBM) |
| Cache HBM at peak | 3.8 GB (permanent) | 0 GB (freed before peak) |
| UVM transfers per iter | 1 prefetch (~38 ms) | 1 flush + 2 prefetch (~114 ms) |
| Overlap potential | prefetch overlaps with dense fwd | flush + prefetch overlap with dense fwd/bwd and comms |

With sufficient cache (0.4x), both achieve pure HBM embedding lookup speed. The key tradeoff: EMO+EMS eliminates 3.8 GB of cache HBM at the memory peak, at the cost of 2x more UVM transfers per iteration (flush + 2 prefetches vs 1 prefetch). Since stash and restore run on separate streams, this overhead can overlap with dense compute and device-to-device comms, potentially hiding the latency entirely.

## 4\. Next Steps

1. **Wire stash\_emo\_cache into production code** — integrate the stash\_emo\_cache call into embeddingbag.py and embedding.py (currently requires manual patching, see 2.1).
2. **Selective flush** — currently flush() scans the entire cache, but only batch\_i rows are dirty (batch\_i+1 was only read by forward). A selective flush that only writes back the dirty batch would reduce the scan overhead.
3. **Stream overlap** — run flush on d2h stream and restore+prefetch on a prefetch stream to overlap with dense compute. Measure how much of the ~114 ms overhead is hidden.
4. **Smaller cache allocation** — since the cache only needs to hold 2 batches of rows, reduce cache\_sets at init time based on expected batch size. This requires FBGEMM changes but would further reduce HBM usage.
5. **Correctness validation** — verify numerics match between EMO and EMO+EMS by comparing training loss across iterations on a real model.
6. **Restore timing/trigger tuning** — the restore+prefetch currently runs synchronously before backward. Tuning when and how the restore is triggered (e.g., backward hook at the injection site, separate stream, or integration with the prefetch pipeline) could better overlap with dense backward and hide more latency.

Differential Revision: D100561368


