### PR TITLE
Shutdown metric module on training loop exception

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+import atexit
 import concurrent
 import logging
 import queue
@@ -86,6 +87,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         super().__init__(*args, **kwargs)
         self._model_out_device = model_out_device
         self._shutdown_event: threading.Event = threading.Event()
+        self._compute_shutdown_event: threading.Event = threading.Event()
+        self._shutdown_complete: bool = False
         self._captured_exception_event: threading.Event = threading.Event()
         self._captured_exception: Optional[Exception] = None
 
@@ -130,6 +133,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         self.update_thread.start()
         self.compute_thread.start()
+
+        atexit.register(self.shutdown)
 
         logger.info(
             f"CPUOffloadedRecMetricModule initialization complete with {model_out_device.type=}, {update_queue_size=}, {compute_queue_size=}."
@@ -193,11 +198,13 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
             if transfer_completed_event is not None:
                 transfer_completed_event.synchronize()
+
             labels, predictions, weights, required_inputs = parse_task_model_outputs(
                 self.rec_tasks,
                 cpu_model_out,
                 self.get_required_inputs(),
             )
+
             if required_inputs:
                 metric_update_job.kwargs["required_inputs"] = required_inputs
 
@@ -216,16 +223,51 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     @override
     def shutdown(self) -> None:
         """
-        Stop the worker thread gracefully, processing all remaining queue items.
+        Stop the worker threads gracefully with two-phase shutdown to ensure
+        all queued work is processed.
+
+        Phase 1: Signal the update thread to stop, wait for it to flush remaining
+        update jobs and synchronization markers (which may enqueue compute jobs).
+
+        Phase 2: Signal the compute thread to stop, wait for it to flush all
+        remaining compute jobs (including those enqueued during phase 1).
+
+        Idempotent: safe to call multiple times (e.g. explicit call + atexit).
         """
 
-        logger.info("Gracefully shutting down CPUOffloadedRecMetricModule...")
-        self._shutdown_event.set()
+        if self._shutdown_complete:
+            return
 
+        logger.info(
+            f"Gracefully shutting down CPUOffloadedRecMetricModule... "
+            f"update_queue={self.update_queue.qsize()}, "
+            f"compute_queue={self.compute_queue.qsize()}"
+        )
+
+        # Phase 1: Stop update thread and wait for it to flush.
+        # Timeout scales with queue size: 30s base + ~50ms per queued item.
+        self._shutdown_event.set()
+        update_timeout = 30.0 + self.update_queue.qsize() * 0.05
         if self.update_thread.is_alive():
-            self.update_thread.join(timeout=30.0)
+            self.update_thread.join(timeout=update_timeout)
+        logger.info(
+            f"Update thread: alive={self.update_thread.is_alive()}, "
+            f"update_queue_remaining={self.update_queue.qsize()}, "
+            f"timeout={update_timeout:.1f}s"
+        )
+
+        # Phase 2: Stop compute thread. All compute jobs from update thread
+        # flush are now enqueued, so the compute thread can safely drain.
+        # Timeout scales with queue size: 30s base + ~60s per compute job.
+        self._compute_shutdown_event.set()
+        compute_timeout = 30.0 + self.compute_queue.qsize() * 60.0
         if self.compute_thread.is_alive():
-            self.compute_thread.join(timeout=30.0)
+            self.compute_thread.join(timeout=compute_timeout)
+        logger.info(
+            f"Compute thread: alive={self.compute_thread.is_alive()}, "
+            f"compute_queue_remaining={self.compute_queue.qsize()}, "
+            f"timeout={compute_timeout:.1f}s"
+        )
 
         self.update_job_time_logger.log_percentiles()
         self.update_queue_size_logger.log_percentiles()
@@ -242,7 +284,17 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             raise RecMetricException(
                 f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
             )
+
+        # Re-raise any exception captured by a worker thread. This covers
+        # the case where a thread crashes (e.g. GLOO "Connection reset by
+        # peer") and is already dead by the time shutdown() runs, so the
+        # is_alive() checks above pass but the job should still fail.
+        if self._captured_exception_event.is_set():
+            assert self._captured_exception is not None
+            raise self._captured_exception
+
         logger.info("CPUOffloadedRecMetricModule has been successfully shutdown.")
+        self._shutdown_complete = True
 
     @override
     def compute(self) -> DeferrableMetrics:
@@ -287,7 +339,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         """
 
         with record_function("## CPUOffloadedRecMetricModule:sync_marker ##"):
-            self.compute_count += 1
             if not self.rec_metrics:
                 raise RecMetricException("No metrics to compute.")
 
@@ -344,6 +395,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                     (time.time() - compute_start_ms) * 1000
                 )
                 self.compute_count += 1
+
                 self._adjust_compute_interval()
                 return computed_metrics
 
@@ -365,7 +417,15 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 raise e
 
         remaining = self._flush_remaining_work(self.update_queue)
-        logger.info(f"Flushed {remaining} remaining items during shutdown.")
+        logger.info(f"Flushed {remaining} remaining update items during shutdown.")
+
+        # Enqueue a final SynchronizationMarker so the compute thread publishes
+        # any updates that occurred after the last compute interval.
+        if self.rec_metrics:
+            # pyrefly: ignore[implicit-import]
+            final_future = concurrent.futures.Future()
+            self._process_synchronization_marker(SynchronizationMarker(final_future))
+            logger.info("Enqueued final SynchronizationMarker for remaining updates.")
 
     def _compute_loop(self) -> None:
         """
@@ -374,9 +434,22 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         torch.multiprocessing._set_thread_name(metric_compute_thread_name)
         logger.info(f"Started thread {torch.multiprocessing._get_thread_name()}")
 
-        while not self._shutdown_event.is_set():
+        while not self._compute_shutdown_event.is_set():
             try:
                 self._do_work(self.compute_queue)
+            except RuntimeError as e:
+                # During shutdown, GLOO errors (RuntimeError) are expected
+                # because other ranks may have already exited.
+                if (
+                    self._compute_shutdown_event.is_set()
+                    or self._shutdown_event.is_set()
+                ):
+                    logger.warning(f"Ignoring compute error during shutdown: {e}")
+                    break
+                logger.exception(f"Exception in compute loop: {e}")
+                self._captured_exception = e
+                self._captured_exception_event.set()
+                raise e
             except Exception as e:
                 logger.exception(f"Exception in compute loop: {e}")
                 self._captured_exception = e
@@ -439,8 +512,16 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             elif isinstance(job, SynchronizationMarker):
                 self._process_synchronization_marker(job)
             elif isinstance(job, MetricComputeJob):
-                computed_metrics = self._process_metric_compute_job(job)
-                job.future.set_result(computed_metrics)
+                # During shutdown, GLOO all_gather may fail with
+                # "Connection reset by peer" if other ranks have already
+                # exited. This is expected -- log and continue so the
+                # remaining queue items can be drained.
+                try:
+                    computed_metrics = self._process_metric_compute_job(job)
+                    job.future.set_result(computed_metrics)
+                except RuntimeError as e:
+                    logger.warning(f"Ignoring compute error during shutdown flush: {e}")
+                    job.future.set_exception(e)
             items_processed += 1
             metric_job_queue.task_done()
         return items_processed

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -11,14 +11,18 @@ import logging
 import queue
 import threading
 import time
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 import torch
 from torch import distributed as dist
 from torch.profiler import record_function
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
-from torchrec.metrics.deferrable_metrics import DeferrableMetrics
+from torchrec.metrics.deferrable_metrics import (
+    DeferrableMetrics,
+    device_supports_async,
+    transfer_tensors_to_cpu,
+)
 from torchrec.metrics.metric_job_types import (
     MetricComputeJob,
     MetricUpdateJob,
@@ -167,41 +171,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         except queue.Full:
             raise RecMetricException("update metric queue is full.")
 
-    def _transfer_to_cpu(
-        self,
-        model_out: Dict[str, torch.Tensor],
-    ) -> Tuple[Dict[str, torch.Tensor], torch.cuda.Event]:
-        """
-        Create a copy of model_out on CPU and return the copy. A cuda event
-        is created to track when the copy is completed.
-
-
-        Args:
-            model_out: intermediate model outputs to be used for metric updates
-        """
-
-        transfer_completed_event = torch.cuda.Event()
-        cpu_model_out = self._move_output_to_cpu(model_out)
-        transfer_completed_event.record()
-
-        return (
-            cpu_model_out,
-            transfer_completed_event,
-        )
-
-    def _move_output_to_cpu(
-        self, output: Dict[str, torch.Tensor]
-    ) -> Dict[str, torch.Tensor]:
-        """
-        Move all tensors in output to CPU and preserve dictionary structure.
-        Args:
-            output: tensors to be moved to CPU
-        """
-        return {
-            k: tensor.to(device="cpu", non_blocking=True)
-            for k, tensor in output.items()
-        }
-
     @EventLoggingHandler.event_logger(
         TorchrecComponent.REC_METRICS, n=100, add_wait_counter=True
     )
@@ -218,8 +187,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         with record_function("## CPUOffloadedRecMetricModule:update ##"):
             start_time = time.time()
             cpu_model_out, transfer_completed_event = (
-                self._transfer_to_cpu(metric_update_job.model_out)
-                if self._model_out_device.type == "cuda"
+                transfer_tensors_to_cpu(metric_update_job.model_out)
+                if device_supports_async(self._model_out_device)
                 else (metric_update_job.model_out, None)
             )
             if transfer_completed_event is not None:

--- a/torchrec/metrics/deferrable_metrics.py
+++ b/torchrec/metrics/deferrable_metrics.py
@@ -21,7 +21,9 @@ free-threaded Python 3.13t), a threading.Lock would be needed.
 import logging
 from collections.abc import Iterator, Mapping
 from concurrent.futures import Future
-from typing import Any, Callable
+from typing import Any, Callable, Tuple
+
+import torch
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -148,13 +150,17 @@ class DeferrableMetrics(Mapping[str, Any]):
         if self._resolved:
             self._data.update(dict_other)
         elif self._future is not None:
+            cpu_dict, event = transfer_tensors_to_cpu(dict_other)
+
             original_future = self._future
             merged_future: Future[dict[str, Any]] = Future()
 
             def _on_complete(f: Future[dict[str, Any]]) -> None:
                 try:
+                    if event is not None:
+                        event.synchronize()
                     result = dict(f.result())
-                    result.update(dict_other)
+                    result.update(cpu_dict)
                     merged_future.set_result(result)
                 except Exception as e:
                     merged_future.set_exception(e)
@@ -192,3 +198,48 @@ class DeferrableMetrics(Mapping[str, Any]):
         if self._resolved:
             return f"DeferrableMetrics(resolved, {len(self._data)} keys)"
         return "DeferrableMetrics(pending)"
+
+
+def device_supports_async(device: torch.device) -> bool:
+    """Check if a device supports non-blocking async transfers (CUDA events)."""
+    return device.type == "cuda"
+
+
+def transfer_tensors_to_cpu(
+    tensors: dict[str, Any],
+) -> Tuple[dict[str, Any], "torch.cuda.Event | None"]:
+    """Transfer GPU tensors to CPU using non-blocking copies.
+
+    Returns the CPU tensor dict and a CUDA event that tracks completion.
+    For CPU-only inputs, returns the dict as-is with None event.
+    Non-tensor values are preserved unchanged.
+
+    Records the CUDA event on the source tensor's device stream (not the
+    default device) to avoid metric corruption on non-rank-0 processes.
+    """
+    has_cuda = any(
+        isinstance(v, torch.Tensor) and v.device.type == "cuda"
+        for v in tensors.values()
+    )
+    if not has_cuda:
+        return tensors, None
+
+    # Detect source device from first CUDA tensor
+    source_device: torch.device | None = None
+    for v in tensors.values():
+        if isinstance(v, torch.Tensor) and v.device.type == "cuda":
+            source_device = v.device
+            break
+
+    cpu_tensors = {
+        k: v.to(device="cpu", non_blocking=True) if isinstance(v, torch.Tensor) else v
+        for k, v in tensors.items()
+    }
+
+    # Record event on the source tensor's device, not the default device
+    assert source_device is not None
+    with torch.cuda.device(source_device):
+        event = torch.cuda.Event()
+        event.record()
+
+    return cpu_tensors, event

--- a/torchrec/metrics/metric_state_snapshot.py
+++ b/torchrec/metrics/metric_state_snapshot.py
@@ -10,6 +10,7 @@
 import copy
 from typing import Any, cast, Dict, Optional
 
+import torch
 from torch import nn
 from torchrec.metrics.rec_metric import (
     RecComputeMode,
@@ -105,7 +106,21 @@ def _load_into_reduced_states(
         reduction_fn = computation._reductions[attr_name]
         if callable(reduction_fn) and isinstance(original_value, list):
             reduced_value = reduction_fn(original_value)
+            # Clone tensors in the reduced list to prevent race conditions
+            if isinstance(reduced_value, list):
+                reduced_value = [
+                    v.clone() if isinstance(v, torch.Tensor) else v
+                    for v in reduced_value
+                ]
+            elif isinstance(reduced_value, torch.Tensor):
+                reduced_value = reduced_value.clone()
         else:
-            reduced_value = original_value
+            # Clone tensors to prevent race condition between update and compute threads.
+            # Without cloning, the compute thread may read corrupted values if the
+            # update thread modifies the original tensor after snapshot creation.
+            if isinstance(original_value, torch.Tensor):
+                reduced_value = original_value.clone()
+            else:
+                reduced_value = original_value
 
         reduced_states[cache_key] = reduced_value

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -12,6 +12,7 @@
 import abc
 import inspect
 import itertools
+import logging
 import math
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -69,6 +70,8 @@ ComputeIterType = Iterator[
 ]
 
 MAX_BUFFER_COUNT = 1000
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class RecMetricException(Exception):

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -22,6 +22,7 @@ from torchrec.metrics.cpu_offloaded_metric_module import (
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
 )
+from torchrec.metrics.deferrable_metrics import transfer_tensors_to_cpu
 from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
 from torchrec.metrics.metrics_config import DefaultMetricsConfig
 from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
@@ -107,7 +108,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             "task1-weight": torch.tensor([5.0, 1.0, 0.0]).to("cuda:0"),
         }
 
-        cpu_output, transfer_event = self.cpu_module._transfer_to_cpu(output)
+        cpu_output, transfer_event = transfer_tensors_to_cpu(output)
+        self.assertIsNotNone(transfer_event)
+        assert transfer_event is not None
         wait_until_true(transfer_event.query)
 
         self.assertEqual(len(cpu_output), 3)
@@ -521,6 +524,59 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
         cpu_module_indexed.shutdown()
 
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least 2 GPUs",
+    )
+    def test_transfer_tensors_to_cpu_event_on_source_device_stream(self) -> None:
+        """
+        Regression test for ZORM metric corruption on non-rank-0 processes.
+
+        Bug: transfer_tensors_to_cpu recorded the CUDA event on cuda:0 (default)
+        instead of the source tensor's device (cuda:N), making event.synchronize()
+        a no-op on non-rank-0 processes.
+
+        Verifies the event tracks cuda:1's stream via event.query(): with the bug,
+        the event on idle cuda:0 completes immediately; with the fix, it stays
+        pending behind cuda:1's queued work.
+        """
+        with torch.cuda.device(0):
+            source_tensors = {
+                "predictions": torch.ones(1024, device="cuda:1") * 3.14,
+                "labels": torch.ones(1024, device="cuda:1"),
+                "weights": torch.ones(1024, device="cuda:1") * 2.0,
+            }
+
+            busy = torch.randn(8192, 8192, device="cuda:1")
+            for _ in range(50):
+                busy = busy @ busy
+
+            cpu_tensors, event = transfer_tensors_to_cpu(source_tensors)
+            self.assertIsNotNone(event)
+            assert event is not None
+
+            self.assertFalse(
+                event.query(),
+                "CUDA event completed immediately — it was recorded on the "
+                "wrong stream (cuda:0 instead of cuda:1).",
+            )
+
+            event.synchronize()
+            torch.testing.assert_close(
+                cpu_tensors["predictions"],
+                torch.ones(1024) * 3.14,
+            )
+            torch.testing.assert_close(
+                cpu_tensors["labels"],
+                torch.ones(1024),
+            )
+            torch.testing.assert_close(
+                cpu_tensors["weights"],
+                torch.ones(1024) * 2.0,
+            )
+
+    # pyre-ignore[56]
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",
@@ -564,11 +620,13 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         )
 
         transfer_call_info: list = []
-        original_transfer_to_cpu = offloaded_module._transfer_to_cpu
+        original_transfer = transfer_tensors_to_cpu
 
-        def tracking_transfer_to_cpu(model_out: dict) -> tuple:
+        def tracking_transfer(
+            tensors: dict,
+        ) -> tuple:
             transfer_call_info.append(threading.current_thread().name)
-            return original_transfer_to_cpu(model_out)
+            return original_transfer(tensors)
 
         model_out = {
             "task1-prediction": torch.tensor([0.5, 0.7]),
@@ -580,10 +638,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             for tensor in model_out.values():
                 self.assertEqual(tensor.device.type, "cuda")
 
-        with patch.object(
-            offloaded_module,
-            "_transfer_to_cpu",
-            side_effect=tracking_transfer_to_cpu,
+        with patch(
+            "torchrec.metrics.cpu_offloaded_metric_module.transfer_tensors_to_cpu",
+            side_effect=tracking_transfer,
         ):
             offloaded_module.update(model_out)
             wait_until_true(offloaded_metric.update_called)
@@ -592,7 +649,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.assertEqual(
                 len(transfer_call_info),
                 1,
-                "_transfer_to_cpu should be called exactly once for CUDA device",
+                "transfer_tensors_to_cpu should be called exactly once for CUDA device",
             )
             self.assertEqual(
                 transfer_call_info[0],
@@ -604,7 +661,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.assertEqual(
                 len(transfer_call_info),
                 0,
-                "_transfer_to_cpu should NOT be called when device is CPU",
+                "transfer_tensors_to_cpu should NOT be called when device is CPU",
             )
 
         self.assertTrue(offloaded_metric.predictions_update_calls is not None)

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -258,6 +258,16 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         self.assertFalse(self.cpu_module.update_thread.is_alive())
         self.assertFalse(self.cpu_module.compute_thread.is_alive())
 
+    def test_double_shutdown_is_idempotent(self) -> None:
+        self.cpu_module.shutdown()
+        self.assertFalse(self.cpu_module.update_thread.is_alive())
+        self.assertFalse(self.cpu_module.compute_thread.is_alive())
+
+        # Second call should be a no-op, not raise
+        self.cpu_module.shutdown()
+        self.assertFalse(self.cpu_module.update_thread.is_alive())
+        self.assertFalse(self.cpu_module.compute_thread.is_alive())
+
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -689,6 +689,28 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
     def test_no_dtoh_transfer_for_cpu_device(self) -> None:
         self._run_dtoh_transfer_test(use_cuda=False)
 
+    def test_compute_count_increments_once_per_async_compute(self) -> None:
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        self.assertEqual(self.cpu_module.compute_count, 0)
+
+        for expected_count in range(1, 4):
+            for _ in range(3):
+                self.cpu_module.update(model_out)
+
+            deferrable = self.cpu_module.async_compute()
+            result_event = threading.Event()
+            deferrable.subscribe(callback=lambda _, e=result_event: e.set())
+            self.assertTrue(
+                result_event.wait(timeout=15.0),
+                f"async_compute #{expected_count} did not complete",
+            )
+            self.assertEqual(self.cpu_module.compute_count, expected_count)
+
     def test_generate_metric_module_creates_cpu_offloaded_module(self) -> None:
         module_kwargs = {
             "model_out_device": torch.device("cpu"),

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -12,7 +12,12 @@ from collections.abc import Mapping
 from concurrent.futures import Future
 from unittest.mock import patch
 
-from torchrec.metrics.deferrable_metrics import DeferrableMetrics
+import torch
+from torchrec.metrics.deferrable_metrics import (
+    DeferrableMetrics,
+    device_supports_async,
+    transfer_tensors_to_cpu,
+)
 
 
 class TestDeferrableMetrics(unittest.TestCase):
@@ -255,3 +260,59 @@ class TestDeferrableMetrics(unittest.TestCase):
         with self.assertRaises(ValueError):
             dm.resolve()
         self.assertFalse(dm.is_resolved())
+
+    def test_future_backed_update_dict_with_dtoh(self) -> None:
+        f: Future[dict] = Future()
+        dm = DeferrableMetrics(f)
+        dm.update({"cpu_val": torch.tensor([1.0])})
+        f.set_result({"original": torch.tensor([2.0])})
+        received: list[dict] = []
+        dm.subscribe(lambda d: received.append(d))
+        self.assertEqual(len(received), 1)
+        torch.testing.assert_close(received[0]["original"], torch.tensor([2.0]))
+        torch.testing.assert_close(received[0]["cpu_val"], torch.tensor([1.0]))
+        self.assertEqual(received[0]["cpu_val"].device.type, "cpu")
+
+
+class TransferTensorsToCpuTest(unittest.TestCase):
+
+    def test_cpu_tensors_passthrough(self) -> None:
+        tensors: dict[str, torch.Tensor] = {
+            "predictions": torch.tensor([1.0, 2.0]),
+            "labels": torch.tensor([0.0, 1.0]),
+        }
+        cpu_tensors, event = transfer_tensors_to_cpu(tensors)
+        self.assertEqual(len(cpu_tensors), 2)
+        self.assertIsNone(event)
+        for key, tensor in cpu_tensors.items():
+            self.assertEqual(tensor.device.type, "cpu")
+            torch.testing.assert_close(tensor, tensors[key])
+
+    def test_non_tensor_values_preserved(self) -> None:
+        # pyre-ignore[6]
+        tensors: dict[str, torch.Tensor] = {
+            "predictions": torch.tensor([1.0]),
+            "name": "task1",
+            "count": 42,
+        }
+        cpu_tensors, event = transfer_tensors_to_cpu(tensors)
+        self.assertEqual(cpu_tensors["name"], "task1")
+        self.assertEqual(cpu_tensors["count"], 42)
+        torch.testing.assert_close(cpu_tensors["predictions"], torch.tensor([1.0]))
+
+    def test_empty_dict(self) -> None:
+        cpu_tensors, event = transfer_tensors_to_cpu({})
+        self.assertEqual(len(cpu_tensors), 0)
+        self.assertIsNone(event)
+
+
+class DeviceSupportsAsyncTest(unittest.TestCase):
+
+    def test_cuda_device_supported(self) -> None:
+        self.assertTrue(device_supports_async(torch.device("cuda")))
+
+    def test_cuda_indexed_device_supported(self) -> None:
+        self.assertTrue(device_supports_async(torch.device("cuda:1")))
+
+    def test_cpu_device_not_supported(self) -> None:
+        self.assertFalse(device_supports_async(torch.device("cpu")))


### PR DESCRIPTION
Summary:
Added metric module shutdown to the Pyper training loop exception path.
`on_train_end()` handles the happy path, but exceptions skip it, leaving
ZORM background threads (update + compute) running. `shutdown()` is
idempotent so double-calls from both paths are safe.

Differential Revision: D98171457


