### PR TITLE
Disable shape_padding in TorchRec TrainPipelineSparseDist family + TrainPipelinePT2 to prevent cross-PG deadlock on AMD (#4128)

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -513,6 +513,15 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
                 # pyrefly: ignore [bad-assignment]
                 torch._dynamo.config.skip_torchrec = False
 
+                # On AMD (ROCm), disable shape padding benchmarking to prevent
+                # cross-PG deadlock: benchmark_gpu() calls cuda.synchronize()
+                # which blocks on pending NCCL collectives. The deadlock has
+                # only been observed on AMD MI350X (maz5); leave the default
+                # in place on NVIDIA so the perf optimization continues to
+                # apply where it's safe.
+                if torch.version.hip is not None:
+                    torch._inductor.config.shape_padding = False
+
                 # Importing only before compilation to not slow-done train_pipelines import
                 torch.ops.import_module("fbgemm_gpu.sparse_ops")
 
@@ -593,6 +602,18 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
     ) -> None:
+        # On AMD (ROCm), disable inductor shape padding to prevent cross-PG
+        # deadlock: should_pad_mm benchmarks GEMM kernels via benchmark_gpu(),
+        # which calls cuda.synchronize() and blocks on pending NCCL collectives
+        # from other process groups (e.g. mesh_shard + mesh_replicate).
+        # Observed on AMD MI350X. Set in the parent class so all subclasses
+        # (e.g. TrainPipelineSparseDistCompAutograd, APS subclasses) inherit
+        # the guard; pipelines that never compile are unaffected since this
+        # inductor config is only consulted during compilation.
+        if torch.version.hip is not None:
+            # pyrefly: ignore [implicit-import]
+            torch._inductor.config.shape_padding = False
+
         self._model = model
         self._optimizer = optimizer
         self._device = device


### PR DESCRIPTION
Summary:

torch.compile's should_pad_mm heuristic benchmarks GPU kernels via benchmark_gpu(), which calls torch.cuda.synchronize(). This device-wide sync blocks on pending NCCL collectives from other process groups, causing a circular deadlock in distributed training with multiple PGs (e.g. mesh_shard + mesh_replicate). The deadlock has only been observed on AMD MI350X (maz5 datacenter); the workaround is scoped to AMD/ROCm builds via `torch.version.hip is not None` so NVIDIA jobs continue to benefit from the shape_padding optimization.

**Scope (revised from V1).** The original version of this diff patched `TrainPipelinePT2` and `TrainPipelineSparseDistCompAutograd` directly. Investigating a separate APS MI350X deadlock (aps-f1047838053-1051220392) revealed that APS's `TrainPipelineCustomizedOrderSparseDist` — and other subclasses — inherit from `TrainPipelineSparseDist`, not from either of the two originally patched classes, so they would not have received the fix. This revision lifts the guard into `TrainPipelineSparseDist.__init__` so the entire subclass family (CompAutograd, Lite, APS-internal subclasses) inherits it by construction; the now-redundant block in `TrainPipelineSparseDistCompAutograd` is removed. `TrainPipelinePT2` is a sibling of `TrainPipelineSparseDist` (both descend from `TrainPipeline` via `TrainPipelineBase`) so its block is retained.

**Blast radius.** Sampled n=8 MI350X jobs in the `ads_global_tc_hw_onboard_amd_productionization` tenant: 8/8 use a `TrainPipelineSparseDist` family pipeline (7× `pipeline_type: customized-order-sparse-dist`, 1× `pipeline_type: sparse-dist`); 0/8 use `pipeline_type: pt2`; 0/8 have `pt2_warmup_settings.enable: true`. Two takeaways: (a) the V1 scope missed the dominant AMD code path entirely; (b) setting `shape_padding=False` is a runtime no-op for the 8/8 sampled jobs because the inductor config is only consulted during compilation. The only jobs whose runtime behavior changes are those that actually invoke `torch.compile` on AMD MI350X — which are exactly the jobs at risk of the deadlock.

This matches the precedent set by Simple FSDP (`set_configs_for_simple_fsdp`), which also unconditionally disables `shape_padding` for all of its users without reported regressions. The PyTorch-level fix for the underlying inductor cross-PG sync issue is tracked at T265196534.

Reviewed By: TroyGarden

Differential Revision: D101241634


