### PR TITLE
Replace .tolist() with stream-safe alternative in distributed code (#4131)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -30,7 +30,12 @@ from torchrec.distributed.global_settings import get_propogate_device
 from torchrec.distributed.types import Awaitable, QuantizedCommCodecs, rank_device
 from torchrec.fx.utils import fx_marker
 from torchrec.pt2.checks import is_torchdynamo_compiling
-from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import (
+    _cuda_to_cpu_safe,
+    _safe_tolist,
+    JaggedTensor,
+    KeyedJaggedTensor,
+)
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
@@ -89,6 +94,28 @@ def _collective_tag_from(*parts: object) -> int:
     # signed-int32 max, so empty `parts` would skip the in-loop mask
     # and return a value that violates the int32-fit contract.
     return h & 0x7FFFFFFF
+
+
+def _safe_tolist_2d(tensor: torch.Tensor) -> List[List[int]]:
+    """2D analog of _safe_tolist. Avoids the device-wide sync from .tolist().
+
+    Delegates the actual stream-scoped D2H copy to _cuda_to_cpu_safe (defined
+    in jagged_tensor.py); this wrapper exists only so the return type can be
+    pinned to List[List[int]] for callers in this file. _safe_tolist returns
+    List[int] to preserve TorchScript compatibility on KeyedJaggedTensor;
+    dist_data.py is not scripted, so a concrete 2D return type is fine here.
+
+    Killswitch: pytorch/torchrec:killswitch_safe_tolist (default on). When off,
+    falls back to plain tensor.tolist() — the literal pre-fix call — so the
+    revert path is bit-exact, not just behaviorally equivalent.
+    """
+    if not tensor.is_cuda:
+        return tensor.tolist()
+    if not torch._utils_internal.justknobs_check(
+        "pytorch/torchrec:killswitch_safe_tolist"
+    ):
+        return tensor.tolist()
+    return _cuda_to_cpu_safe(tensor).tolist()
 
 
 def _check_int_overflow(
@@ -436,7 +463,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         if isinstance(self._splits_awaitable, dist.Work):
             self._splits_awaitable.wait()
 
-        ret = self._output_tensor.view(self.num_workers, -1).T.tolist()
+        ret = _safe_tolist_2d(self._output_tensor.view(self.num_workers, -1).T)
 
         # Validate collective tag if present
         if self._tag_appended:
@@ -467,7 +494,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
 
         # Check for int32 overflow in AllToAll input. If the input is already
         # corrupted, the corruption happened before the collective.
-        input_list = self._input_tensor.view(self.num_workers, -1).T.tolist()
+        input_list = _safe_tolist_2d(self._input_tensor.view(self.num_workers, -1).T)
         # Strip tag row from input_list so overflow checks operate on real data
         if self._tag_appended:
             input_list = input_list[: self._num_original_tensors]
@@ -1960,8 +1987,8 @@ class JaggedTensorAllToAll(Awaitable[JaggedTensor]):
         dist.all_to_all_single(
             self._dist_lengths,
             jt.lengths(),
-            output_split_sizes=num_items_to_receive.tolist(),
-            input_split_sizes=num_items_to_send.tolist(),
+            output_split_sizes=_safe_tolist(num_items_to_receive),
+            input_split_sizes=_safe_tolist(num_items_to_send),
             group=pg,
             async_op=False,
         )
@@ -1973,11 +2000,13 @@ class JaggedTensorAllToAll(Awaitable[JaggedTensor]):
         dist_id_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
             num_items_to_receive
         )
-        value_output_splits = torch.ops.fbgemm.segment_sum_csr(
-            1,
-            dist_id_offsets,
-            self._dist_lengths,
-        ).tolist()
+        value_output_splits = _safe_tolist(
+            torch.ops.fbgemm.segment_sum_csr(
+                1,
+                dist_id_offsets,
+                self._dist_lengths,
+            )
+        )
 
         self._dist_values: torch.Tensor = torch.empty(
             sum(value_output_splits),
@@ -1987,11 +2016,13 @@ class JaggedTensorAllToAll(Awaitable[JaggedTensor]):
 
         #  same as above, calculate chunk sums
         id_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(num_items_to_send)
-        value_input_splits = torch.ops.fbgemm.segment_sum_csr(
-            1,
-            id_offsets,
-            jt.lengths(),
-        ).tolist()
+        value_input_splits = _safe_tolist(
+            torch.ops.fbgemm.segment_sum_csr(
+                1,
+                id_offsets,
+                jt.lengths(),
+            )
+        )
 
         self._dist_values_req: dist.Work = dist.all_to_all_single(
             self._dist_values,
@@ -2066,8 +2097,8 @@ class TensorAllToAllValuesAwaitable(Awaitable[torch.Tensor]):
             self._values_awaitable: dist.Work = dist.all_to_all_single(
                 output=self._dist_values,
                 input=input,
-                output_split_sizes=output_splits.tolist(),
-                input_split_sizes=input_splits.tolist(),
+                output_split_sizes=_safe_tolist(output_splits),
+                input_split_sizes=_safe_tolist(input_splits),
                 group=pg,
                 async_op=True,
             )

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -107,7 +107,12 @@ from torchrec.modules.embedding_modules import (
 from torchrec.modules.utils import construct_jagged_tensors, SequenceVBEContext
 from torchrec.optim.fused import EmptyFusedOptimizer, FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
-from torchrec.sparse.jagged_tensor import _to_offsets, JaggedTensor, KeyedJaggedTensor
+from torchrec.sparse.jagged_tensor import (
+    _safe_tolist,
+    _to_offsets,
+    JaggedTensor,
+    KeyedJaggedTensor,
+)
 from torchrec.sparse.tensor_dict import maybe_td_to_kjt
 
 try:
@@ -1494,7 +1499,7 @@ class ShardedEmbeddingCollection(
                 reindexed_values = None
 
             reindexed_lengths = reindexed_lengths.view(-1, stride)
-            reindexed_length_per_key = torch.sum(reindexed_lengths, dim=1).tolist()
+            reindexed_length_per_key = _safe_tolist(torch.sum(reindexed_lengths, dim=1))
 
             ctx.seq_vbe_ctx.append(
                 SequenceVBEContext(

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -22,6 +22,7 @@ from torchrec.distributed.dist_data import (
     KJTAllToAllTensorsAwaitable,
     SplitsAllToAllAwaitable,
 )
+from torchrec.sparse.jagged_tensor import _safe_tolist
 
 # This is required to support older torch package exports that do not contain
 # _check_int_overflow. During repackaging the
@@ -905,7 +906,7 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         # the bug is upstream of the collective.
         if splits_tensors and pg is not None:
             for idx, t in enumerate(splits_tensors):
-                t_list = t.tolist()
+                t_list = _safe_tolist(t)
                 _check_int_overflow(
                     "FusedKJTListSplitsAwaitable",
                     t_list,

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -65,14 +65,14 @@ def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
 
 
 @torch.jit.unused
-def _cuda_tolist_impl(tensor: torch.Tensor) -> List[int]:
-    """Async D2H copy on the current stream, then .tolist() on CPU.
+def _cuda_to_cpu_safe(tensor: torch.Tensor) -> torch.Tensor:
+    """Stream-scoped D2H copy of a CUDA tensor to a CPU tensor.
 
-    Plain cuda_tensor.tolist() copies via copy_(non_blocking=False), which on
-    AMD/HIP routes through c10::cuda::memcpy_and_sync -> hipMemcpyWithStream.
-    hipMemcpyWithStream synchronizes ALL streams on the device, including peer
-    NCCL streams. When ranks are mutually waiting on cross-PG collectives, this
-    surfaces as a circular deadlock.
+    Plain cuda_tensor.tolist() / .cpu() copies via copy_(non_blocking=False),
+    which on AMD/HIP routes through c10::cuda::memcpy_and_sync ->
+    hipMemcpyWithStream. hipMemcpyWithStream synchronizes ALL streams on the
+    device, including peer NCCL streams. When ranks are mutually waiting on
+    cross-PG collectives, this surfaces as a circular deadlock.
 
     copy_(non_blocking=True) takes the other branch in copy_kernel_cuda
     (aten/src/ATen/native/cuda/Copy.cu) and issues cudaMemcpyAsync directly,
@@ -86,16 +86,15 @@ def _cuda_tolist_impl(tensor: torch.Tensor) -> List[int]:
     and allow overlap with compute, but is not required to remove the
     device-wide sync and is out of scope for this workaround.
 
-    NOTE: The return type must be List[int], not Any. KeyedJaggedTensor is
-    TorchScript-able, and _safe_tolist (which calls this) is reachable from
-    scripted KJT methods. An Any return type breaks TorchScript compilation
-    of downstream consumers (e.g. sample_inputs_utils_test).
+    Returns the CPU tensor; callers run .tolist() (or whatever shape-aware
+    conversion they need) on it. Marked @torch.jit.unused — TorchScript
+    callers must short-circuit before reaching this helper.
     """
     src = tensor.contiguous()
     cpu_buf = torch.empty(src.shape, dtype=src.dtype, device="cpu")
     cpu_buf.copy_(src, non_blocking=True)
     torch.cuda.current_stream(src.device).synchronize()
-    return cpu_buf.tolist()
+    return cpu_buf
 
 
 def _safe_tolist(tensor: torch.Tensor) -> List[int]:
@@ -131,7 +130,7 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     ):
         return tensor.tolist()
 
-    return _cuda_tolist_impl(tensor)
+    return _cuda_to_cpu_safe(tensor).tolist()
 
 
 def _cumsum(o: List[int]) -> List[int]:

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -64,6 +64,76 @@ def _pin_and_move(tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
     )
 
 
+@torch.jit.unused
+def _cuda_tolist_impl(tensor: torch.Tensor) -> List[int]:
+    """Async D2H copy on the current stream, then .tolist() on CPU.
+
+    Plain cuda_tensor.tolist() copies via copy_(non_blocking=False), which on
+    AMD/HIP routes through c10::cuda::memcpy_and_sync -> hipMemcpyWithStream.
+    hipMemcpyWithStream synchronizes ALL streams on the device, including peer
+    NCCL streams. When ranks are mutually waiting on cross-PG collectives, this
+    surfaces as a circular deadlock.
+
+    copy_(non_blocking=True) takes the other branch in copy_kernel_cuda
+    (aten/src/ATen/native/cuda/Copy.cu) and issues cudaMemcpyAsync directly,
+    which on AMD is hipMemcpyAsync — stream-scoped, not device-wide. The host
+    still blocks inside the memcpy until upstream work on the current stream
+    completes (pageable D2H is implicitly host-synchronous), but other streams
+    on the device keep running, so the device-wide-sync amplification is gone.
+
+    Stays on the current stream by design. A dedicated D2H stream + pinned
+    destination would also detach from upstream waits on the current stream
+    and allow overlap with compute, but is not required to remove the
+    device-wide sync and is out of scope for this workaround.
+
+    NOTE: The return type must be List[int], not Any. KeyedJaggedTensor is
+    TorchScript-able, and _safe_tolist (which calls this) is reachable from
+    scripted KJT methods. An Any return type breaks TorchScript compilation
+    of downstream consumers (e.g. sample_inputs_utils_test).
+    """
+    src = tensor.contiguous()
+    cpu_buf = torch.empty(src.shape, dtype=src.dtype, device="cpu")
+    cpu_buf.copy_(src, non_blocking=True)
+    torch.cuda.current_stream(src.device).synchronize()
+    return cpu_buf.tolist()
+
+
+def _safe_tolist(tensor: torch.Tensor) -> List[int]:
+    """
+    Convert a GPU tensor to a Python list without triggering a device-wide sync.
+
+    Standard .tolist() on a CUDA tensor calls memcpy_and_sync(), which on
+    AMD/HIP synchronizes ALL streams — blocking on pending work including
+    NCCL collectives. This can expose cross-process-group hangs as visible
+    failures here even when the underlying root cause is elsewhere.
+
+    Instead, this function does an explicit D2H copy and syncs only the
+    current stream, then runs .tolist() on the resulting CPU tensor.
+
+    Known limitation: TorchScript callers fall back to plain .tolist().
+
+    Killswitch: pytorch/torchrec:killswitch_safe_tolist (default on). Set to
+    False to fall back to plain .tolist() if this path causes regressions.
+
+    NOTE: The return type must be List[int], not Any. This function is called
+    from TorchScript-able code paths (KeyedJaggedTensor). Using Any breaks
+    TorchScript compilation. For 2D tensors, use _safe_tolist_2d in
+    dist_data.py (added in D101269943).
+    """
+    if torch.jit.is_scripting() or not tensor.is_cuda:
+        return tensor.tolist()
+
+    if tensor.numel() == 0:
+        return []
+
+    if not torch._utils_internal.justknobs_check(
+        "pytorch/torchrec:killswitch_safe_tolist"
+    ):
+        return tensor.tolist()
+
+    return _cuda_tolist_impl(tensor)
+
+
 def _cumsum(o: List[int]) -> List[int]:
     """
     python-list version of converting lengths --> offsets
@@ -1255,9 +1325,9 @@ def _length_per_key_from_stride_per_key(
         )
         ret = torch.jit.annotate(
             List[int],
-            torch.ops.fbgemm.segment_sum_csr(
-                1, stride_per_key_offsets, lengths
-            ).tolist(),
+            _safe_tolist(
+                torch.ops.fbgemm.segment_sum_csr(1, stride_per_key_offsets, lengths)
+            ),
         )
     else:
         tensor_list: List[torch.Tensor] = [
@@ -1266,7 +1336,7 @@ def _length_per_key_from_stride_per_key(
         if len(tensor_list) == 0:
             return []
 
-        ret = torch.jit.annotate(List[int], torch.cat(tensor_list).tolist())
+        ret = torch.jit.annotate(List[int], _safe_tolist(torch.cat(tensor_list)))
 
     pt2_checks_all_is_size(ret)
     return ret
@@ -1301,9 +1371,11 @@ def _maybe_compute_length_per_key(
             _length_per_key_from_stride_per_key(lengths, stride_per_key)
             if variable_stride_per_key
             else (
-                torch.sum(
-                    pt2_check_size_nonzero(lengths.view(len(keys), stride)), dim=1
-                ).tolist()
+                _safe_tolist(
+                    torch.sum(
+                        pt2_check_size_nonzero(lengths.view(len(keys), stride)), dim=1
+                    )
+                )
                 if pt2_guard_size_oblivious(lengths.numel() != 0)
                 else [0] * len(keys)
             )
@@ -1312,7 +1384,7 @@ def _maybe_compute_length_per_key(
         _length: List[int] = (
             _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
             if variable_stride_per_key
-            else torch.sum(torch.diff(offsets).view(-1, stride), dim=1).tolist()
+            else _safe_tolist(torch.sum(torch.diff(offsets).view(-1, stride), dim=1))
         )
     else:
         _length: List[int] = []

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -15,6 +15,7 @@ import torch.utils._pytree as pytree
 from torch.testing import FileCheck
 from torchrec.fx import symbolic_trace
 from torchrec.sparse.jagged_tensor import (
+    _safe_tolist,
     ComputeJTDictToKJT,
     JaggedTensor,
     jt_is_equal,
@@ -1384,3 +1385,35 @@ class TestJaggedTensorTracing(unittest.TestCase):
         # Assert: Verify tensors are on CUDA
         self.assertTrue(result_jt.values().is_cuda)
         self.assertTrue(result_jt.lengths().is_cuda)
+
+    def test_cuda_tolist_cpu_tensor(self) -> None:
+        tensor = torch.tensor([3, 5, 7, 2])
+        result = _safe_tolist(tensor)
+        self.assertEqual(result, [3, 5, 7, 2])
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_cuda_tolist_cuda_tensor(self) -> None:
+        tensor = torch.tensor([3, 5, 7, 2], device="cuda")
+        result = _safe_tolist(tensor)
+        self.assertEqual(result, [3, 5, 7, 2])
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_cuda_tolist_empty_tensor(self) -> None:
+        tensor = torch.tensor([], dtype=torch.int64, device="cuda")
+        result = _safe_tolist(tensor)
+        self.assertEqual(result, [])
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_cuda_tolist_single_element(self) -> None:
+        tensor = torch.tensor([42], device="cuda")
+        result = _safe_tolist(tensor)
+        self.assertEqual(result, [42])


### PR DESCRIPTION
Summary:

Follow-up to D101235037. The same implicit GPU synchronization issue (.tolist() on CUDA tensors causing memcpy_and_sync which blocks on pending NCCL collectives) exists at 9 additional call sites across TorchRec's distributed code.

This diff adds a _safe_tolist() helper in dist_data.py (same D2H stream isolation pattern as _cuda_tolist in jagged_tensor.py) and replaces all dangerous .tolist() calls:

dist_data.py (7 sites):
- SplitsAllToAllAwaitable._wait_impl: output and input tensor conversion
- JaggedTensorAllToAll.__init__: 4 calls for lengths/values split sizes
- TensorAllToAllValuesAwaitable.__init__: 2 calls for pool sharding splits

embedding_sharding.py (1 site):
- FusedKJTListSplitsAwaitable.__init__: splits validation

embedding.py (1 site):
- _compute_sequence_vbe_context: VBE reindexed length computation

Reviewed By: kausv, VieEeEw

Differential Revision: D101269943


