### PR TITLE
Add collective tag validation to detect all2all mismatches early (#4132)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -10,7 +10,7 @@
 import itertools
 import logging
 import os
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -60,6 +60,35 @@ _DTYPE_MAX: Dict[torch.dtype, int] = {
 }
 
 _TORCHREC_OVERFLOW_DEBUG: bool = os.environ.get("TORCHREC_OVERFLOW_DEBUG", "0") == "1"
+
+
+def _validate_collectives_enabled() -> bool:
+    # Read on each call so the env var can be flipped at runtime (e.g. by job
+    # config that loads after import) and so tests can patch with mock.patch
+    # instead of mutating module state.
+    return os.environ.get("TORCHREC_VALIDATE_COLLECTIVES", "0") == "1"
+
+
+def _collective_tag_from(*parts: object) -> int:
+    """Compute a deterministic collective tag from identifying parts.
+
+    Returns a non-negative value that fits in signed int32. Uses FNV-1a
+    (deterministic across processes, unlike hash()).
+
+    The current call sites use int64 splits tensors, so a wider hash is
+    available in principle. The int32 cap is intentional forward-compat:
+    it guarantees the tag fits in any reasonable signed-integer splits dtype
+    without wrapping negative. 31 bits (~2.1B buckets) leaves collision risk
+    negligible for the small number of distinct collective sites in flight
+    per process group.
+    """
+    h = 0x811C9DC5
+    for b in ",".join(str(p) for p in parts).encode():
+        h = ((h ^ b) * 0x01000193) & 0x7FFFFFFF
+    # Mask after the loop too: the FNV-1a seed (0x811C9DC5) exceeds
+    # signed-int32 max, so empty `parts` would skip the in-loop mask
+    # and return a value that violates the int32-fit contract.
+    return h & 0x7FFFFFFF
 
 
 def _check_int_overflow(
@@ -326,9 +355,37 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         self,
         input_tensors: List[torch.Tensor],
         pg: dist.ProcessGroup,
+        collective_tag: Optional[int] = None,
+        collective_tag_parts: Optional[Tuple[object, ...]] = None,
     ) -> None:
         super().__init__()
         self.num_workers: int = pg.size()
+        self._collective_tag = collective_tag
+        self._collective_tag_parts = collective_tag_parts
+        self._num_original_tensors = len(input_tensors)
+
+        # Append tag tensor for collective mismatch validation.
+        # Requires non-empty input_tensors to inherit device/dtype.
+        self._tag_appended: bool = False
+        if (
+            collective_tag is not None
+            and _validate_collectives_enabled()
+            and input_tensors
+        ):
+            dtype = input_tensors[0].dtype
+            if collective_tag > torch.iinfo(dtype).max:
+                raise ValueError(
+                    f"Collective tag {collective_tag} exceeds {dtype} range "
+                    f"(max={torch.iinfo(dtype).max}). "
+                    f"Splits tensors should be int32 or int64."
+                )
+            tag_tensor = torch.tensor(
+                [collective_tag] * self.num_workers,
+                device=input_tensors[0].device,
+                dtype=dtype,
+            )
+            input_tensors = input_tensors + [tag_tensor]
+            self._tag_appended = True
 
         if is_torchdynamo_compiling():
             # TODO(ivankobzarev) Remove this dynamo condition once dynamo functional collectives remapping does not emit copy_
@@ -381,9 +438,39 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
 
         ret = self._output_tensor.view(self.num_workers, -1).T.tolist()
 
+        # Validate collective tag if present
+        if self._tag_appended:
+            tag_row = ret[-1]
+            ret = ret[: self._num_original_tensors]
+            expected = self._collective_tag
+            if any(tag != expected for tag in tag_row):
+                label = (
+                    str(self._collective_tag_parts)
+                    if self._collective_tag_parts
+                    else "unknown"
+                )
+                raise RuntimeError(
+                    f"All2All collective mismatch detected (collective={label!r}): "
+                    f"expected tag {expected} but received tags {tag_row} from "
+                    f"peers. This indicates ranks are calling different "
+                    f"collectives on the same process group.\n"
+                    f"To debug: identify the rank whose tag differs from this "
+                    f"one, then compare its collective inputs (e.g. "
+                    f"input.keys(), splits, sharding plan) against this rank's. "
+                    f"Common causes: (1) divergent feature lists across ranks, "
+                    f"(2) a rank skipping the collective via early return or "
+                    f"data exhaustion, (3) sharding plan inconsistency. Do NOT "
+                    f"disable the check via TORCHREC_VALIDATE_COLLECTIVES — "
+                    f"the underlying mismatch will still cause silent data "
+                    f"corruption or an NCCL hang downstream."
+                )
+
         # Check for int32 overflow in AllToAll input. If the input is already
         # corrupted, the corruption happened before the collective.
         input_list = self._input_tensor.view(self.num_workers, -1).T.tolist()
+        # Strip tag row from input_list so overflow checks operate on real data
+        if self._tag_appended:
+            input_list = input_list[: self._num_original_tensors]
         if input_list:
             _check_int_overflow(
                 "SplitsAllToAllAwaitable",
@@ -688,9 +775,25 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
                 keys=keys,
             )
 
+        collective_tag: Optional[int] = None
+        tag_parts: Optional[Tuple[object, ...]] = None
+        if _validate_collectives_enabled():
+            # Identity components, all rank-invariant by contract:
+            # - input.keys(): pre-AllToAll feature list (NOT local `keys`,
+            #   which is the post-AllToAll subset and differs per rank).
+            # - tuple(self._splits): the sharding plan — feature-to-rank
+            #   assignment from the constructor, documented as "Same for
+            #   all ranks." Including this catches divergent sharding
+            #   plans that have the same key set; without it, a config
+            #   bug giving ranks different splits would compute the same
+            #   tag and silently corrupt the all2all.
+            tag_parts = ("KJTAllToAllSplits", input.keys(), tuple(self._splits))
+            collective_tag = _collective_tag_from(*tag_parts)
         self._splits_awaitable = SplitsAllToAllAwaitable(
             input_tensors,
             self._pg,
+            collective_tag=collective_tag,
+            collective_tag_parts=tag_parts,
         )
 
     def _wait_impl(self) -> KJTAllToAllTensorsAwaitable:

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -17,6 +17,8 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 import torch
 from torch import distributed as dist, nn
 from torchrec.distributed.dist_data import (
+    _collective_tag_from,
+    _validate_collectives_enabled,
     KJTAllToAllTensorsAwaitable,
     SplitsAllToAllAwaitable,
 )
@@ -914,10 +916,45 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                     dtype=t.dtype,
                 )
 
+        collective_tag: Optional[int] = None
+        tag_parts: Optional[Tuple[object, ...]] = None
+        if _validate_collectives_enabled():
+            # Per-request rank-invariant identity, mirroring the tightening
+            # applied to KJTAllToAllSplitsAwaitable. A structural-only tag
+            # (e.g., len(splits_tensors) + self._lengths) collapses on real
+            # models: any two EBCs with identical KJT shape and sharding
+            # type produce the same `_lengths` vector, so a code-path
+            # divergence that fuses different module sets across ranks
+            # would compute the same tag and silently corrupt the all2all.
+            #
+            # Use aw._input.keys() (PRE-AllToAll keys, rank-invariant) —
+            # NOT aw.keys, which is the post-AllToAll local subset. Use
+            # tuple(aw.splits) for the per-request sharding plan
+            # (rank-invariant by KJTAllToAll's documented contract).
+            # Position-preserving: a None placeholder for non-meta
+            # awaitables keeps reordering detectable.
+            tag_parts = (
+                "FusedKJTListSplits",
+                tuple(
+                    (
+                        (
+                            tuple(aw._input.keys()),
+                            tuple(aw.splits),
+                            len(aw.splits_tensors),
+                        )
+                        if isinstance(aw, KJTSplitsAllToAllMeta)
+                        else None
+                    )
+                    for aw in self._awaitables
+                ),
+            )
+            collective_tag = _collective_tag_from(*tag_parts)
         self._splits_awaitable: Optional[SplitsAllToAllAwaitable] = (
             SplitsAllToAllAwaitable(
                 input_tensors=splits_tensors,
                 pg=pg,
+                collective_tag=collective_tag,
+                collective_tag_parts=tag_parts,
             )
             if splits_tensors and pg is not None
             else None

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -8,15 +8,29 @@
 # pyre-strict
 
 import itertools
+import os
 import random
 import unittest
-from typing import Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
+import unittest.mock
+from typing import (
+    cast,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import hypothesis.strategies as st
 import torch
 import torch.distributed as dist
 from hypothesis import given, settings
+from pyre_extensions import none_throws
 from torchrec.distributed.dist_data import (
+    _collective_tag_from,
     _get_recat,
     JaggedTensorAllToAll,
     KJTAllToAll,
@@ -25,7 +39,13 @@ from torchrec.distributed.dist_data import (
     PooledEmbeddingsAllToAll,
     PooledEmbeddingsReduceScatter,
     SequenceEmbeddingsAllToAll,
+    SplitsAllToAllAwaitable,
     VariableBatchPooledEmbeddingsAllToAll,
+)
+from torchrec.distributed.embedding_sharding import (
+    FusedKJTListSplitsAwaitable,
+    KJTListSplitsAwaitable,
+    KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
@@ -36,6 +56,7 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
+from torchrec.distributed.types import Awaitable, NullShardingContext
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
@@ -1549,3 +1570,611 @@ class GetRecatOverflowTest(unittest.TestCase):
         )
         self.assertIsNotNone(result)
         self.assertEqual(result.dtype, torch.int32)
+
+
+class CollectiveTagFromTest(unittest.TestCase):
+    # Single-process unit tests for the _collective_tag_from helper.
+    _INT32_MAX = 0x7FFFFFFF
+
+    def test_empty_parts_fits_signed_int32(self) -> None:
+        # Regression: the FNV-1a seed (0x811C9DC5) exceeds signed-int32 max,
+        # so a previous implementation that only masked inside the loop body
+        # returned the raw seed when parts was empty, violating the docstring's
+        # int32-fit contract and risking overflow in callers that assign the
+        # tag to an int32 splits tensor.
+        tag = _collective_tag_from()
+        self.assertGreaterEqual(tag, 0)
+        self.assertLessEqual(tag, self._INT32_MAX)
+
+    def test_various_parts_all_fit_signed_int32(self) -> None:
+        # Sanity: a range of realistic call shapes all stay within int32.
+        # Mirrors the actual tag shapes used by the two production call sites
+        # (KJTAllToAllSplitsAwaitable, FusedKJTListSplitsAwaitable). If FNV-1a's
+        # mixing changes or one of the call sites grows a new identity field,
+        # this catches a regression across both.
+        cases = [
+            # KJTAllToAllSplits production shape: (name, keys, tuple(splits))
+            ("KJTAllToAllSplits", ["f0", "f1"], (1, 1)),
+            # FusedKJTListSplits production shape: (name, tuple of per-request
+            # entries — meta entries are (keys, splits, count); non-meta is None).
+            (
+                "FusedKJTListSplits",
+                (
+                    (("f0", "f1"), (1, 1), 2),
+                    None,
+                    (("f2",), (1,), 1),
+                ),
+            ),
+            # Boundary: empty keys / empty splits
+            ("KJTAllToAllSplits", [], ()),
+            # Boundary: empty fused awaitables list
+            ("FusedKJTListSplits", ()),
+            # Long single string — guards against FNV-1a length-related issues
+            ("x" * 1024,),
+        ]
+        for parts in cases:
+            with self.subTest(parts=parts):
+                tag = _collective_tag_from(*parts)
+                self.assertGreaterEqual(tag, 0)
+                self.assertLessEqual(tag, self._INT32_MAX)
+
+    def test_deterministic(self) -> None:
+        # Determinism is the main reason this exists instead of hash().
+        # If the implementation accidentally introduces nondeterminism
+        # (e.g., switching to hash() under PYTHONHASHSEED randomization),
+        # different ranks would compute different tags and the validation
+        # would false-positive.
+        self.assertEqual(
+            _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3),
+            _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3),
+        )
+
+
+class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "1"
+
+    def tearDown(self) -> None:
+        os.environ.pop("TORCHREC_VALIDATE_COLLECTIVES", None)
+        super().tearDown()
+
+    @classmethod
+    def _run_test_matching_tags(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([rank] * world_size, dtype=torch.int64),
+            torch.tensor([rank + 1] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=42,
+            collective_tag_parts=("test_matching",),
+        )
+        result = awaitable.wait()
+        # Tag row should be stripped — only 2 original rows returned
+        assert len(result) == 2
+        # Row 0: each rank sent its rank number
+        assert result[0] == list(range(world_size))
+        # Row 1: each rank sent rank+1
+        assert result[1] == list(range(1, world_size + 1))
+        dist.destroy_process_group()
+
+    @classmethod
+    def _run_test_mismatched_tags(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=rank,  # rank 0 -> tag 0, rank 1 -> tag 1
+            collective_tag_parts=("test_mismatched",),
+        )
+        try:
+            awaitable.wait()
+            raise AssertionError("Expected RuntimeError for mismatched tags")
+        except RuntimeError as e:
+            msg = str(e).lower()
+            assert "collective mismatch" in msg
+            assert "test_mismatched" in msg
+        dist.destroy_process_group()
+
+    @classmethod
+    def _run_test_no_tag(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([rank] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            # No collective_tag — backward compatible
+        )
+        result = awaitable.wait()
+        assert len(result) == 1
+        assert result[0] == list(range(world_size))
+        dist.destroy_process_group()
+
+    def test_matching_tags_succeed(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_matching_tags,
+            world_size=2,
+            backend="gloo",
+        )
+
+    def test_mismatched_tags_raise(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_mismatched_tags,
+            world_size=2,
+            backend="gloo",
+        )
+
+    def test_no_tag_passthrough(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_no_tag,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_tag_does_not_corrupt_overflow_check(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        import torchrec.distributed.dist_data as dd
+
+        dd._TORCHREC_OVERFLOW_DEBUG = True
+
+        overflow_value = 2**31 + 1  # exceeds int32 max
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+            # Last row has overflow values — overflow check must catch this
+            torch.tensor([overflow_value] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=42,  # small tag — would NOT trigger overflow
+            collective_tag_parts=("test_overflow",),
+        )
+        try:
+            awaitable.wait()
+            raise AssertionError(
+                "Expected RuntimeError for int32 overflow in real data"
+            )
+        except RuntimeError as e:
+            # Should detect overflow in the real data, not skip it
+            # because the tag row (value=42) was checked instead
+            assert "corrupted" in str(e).lower()
+        dist.destroy_process_group()
+
+    def test_tag_does_not_corrupt_overflow_check(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_tag_does_not_corrupt_overflow_check,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_kjt_all_to_all_emits_tag(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        kjt = KeyedJaggedTensor(
+            keys=["f0", "f1"],
+            values=torch.tensor([1, 2, 3, 4], dtype=torch.int64),
+            lengths=torch.tensor([1, 1, 1, 1], dtype=torch.int64),
+        )
+        kjt_a2a = KJTAllToAll(
+            pg=none_throws(dist.group.WORLD),
+            splits=[1, 1],
+        )
+        splits_aw = kjt_a2a(kjt)
+        assert splits_aw._splits_awaitable._tag_appended is True
+        result = splits_aw.wait().wait()
+        assert isinstance(result, KeyedJaggedTensor)
+        dist.destroy_process_group()
+
+    def test_kjt_all_to_all_emits_tag(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_kjt_all_to_all_emits_tag,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_fused_kjt_list_splits_emits_tag(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        kjt = KeyedJaggedTensor(
+            keys=["f0"],
+            values=torch.tensor([1, 2], dtype=torch.int64),
+            lengths=torch.tensor([1, 1], dtype=torch.int64),
+        )
+        meta = KJTSplitsAllToAllMeta(
+            pg=none_throws(dist.group.WORLD),
+            _input=kjt,
+            splits=[1],
+            splits_tensors=[
+                torch.tensor([1] * world_size, dtype=torch.int64),
+            ],
+            input_splits=[[1] * world_size],
+            input_tensors=[kjt.lengths()],
+            labels=["lengths"],
+            keys=["f0"],
+            device=torch.device("cpu"),
+            stagger=1,
+        )
+        request = KJTListSplitsAwaitable(
+            awaitables=cast(List[Awaitable[Awaitable[KeyedJaggedTensor]]], [meta]),
+            ctx=NullShardingContext(),
+        )
+        fused = FusedKJTListSplitsAwaitable(
+            requests=[request],
+            contexts=[NullShardingContext()],
+            pg=none_throws(dist.group.WORLD),
+        )
+        assert fused._splits_awaitable is not None
+        assert fused._splits_awaitable._tag_appended is True
+        fused._splits_awaitable.wait()
+        dist.destroy_process_group()
+
+    def test_fused_kjt_list_splits_emits_tag(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_fused_kjt_list_splits_emits_tag,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_tag_not_appended_when_validation_disabled(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([rank] * world_size, dtype=torch.int64),
+        ]
+        with unittest.mock.patch.dict(
+            os.environ, {"TORCHREC_VALIDATE_COLLECTIVES": "0"}
+        ):
+            awaitable = SplitsAllToAllAwaitable(
+                input_tensors=input_tensors,
+                pg=none_throws(dist.group.WORLD),
+                collective_tag=42,
+            )
+            assert awaitable._tag_appended is False
+            result = awaitable.wait()
+        assert len(result) == 1
+        assert result[0] == list(range(world_size))
+        dist.destroy_process_group()
+
+    def test_tag_not_appended_when_validation_disabled(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_tag_not_appended_when_validation_disabled,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_realistic_mismatched_tags(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        tag = (
+            _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3)
+            if rank == 0
+            else _collective_tag_from("FusedKJTListSplits", 2, [3, 3])
+        )
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=tag,
+            collective_tag_parts=(f"rank{rank}_collective",),
+        )
+        try:
+            awaitable.wait()
+            raise AssertionError("Expected RuntimeError for mismatched tags")
+        except RuntimeError as e:
+            msg = str(e).lower()
+            assert "collective mismatch" in msg
+            assert f"rank{rank}_collective" in str(e)
+        dist.destroy_process_group()
+
+    def test_realistic_mismatched_tags_raise(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_realistic_mismatched_tags,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_feature_keys_divergence_raises(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        # Simulates the realistic bug class: both ranks reach the same call
+        # site (KJTAllToAllSplits) with the same len(input_splits), but their
+        # input.keys() diverge. The tag must distinguish on input.keys() so the
+        # mismatch is caught instead of corrupting the all2all silently.
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        keys = ["f0", "f1"] if rank == 0 else ["f0", "f2"]
+        input_splits_len = 3
+        tag = _collective_tag_from("KJTAllToAllSplits", keys, input_splits_len)
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=tag,
+            collective_tag_parts=("KJTAllToAllSplits", keys, input_splits_len),
+        )
+        try:
+            awaitable.wait()
+            raise AssertionError(
+                "Expected RuntimeError for keys divergence at same call site"
+            )
+        except RuntimeError as e:
+            assert "collective mismatch" in str(e).lower()
+            assert "KJTAllToAllSplits" in str(e)
+        dist.destroy_process_group()
+
+    def test_feature_keys_divergence_raises(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_feature_keys_divergence_raises,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_splits_divergence_raises(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        # Companion to test_feature_keys_divergence_raises: same call site,
+        # same keys, but the per-feature sharding plan (`splits`) diverges
+        # across ranks. This is a config-bug class — the planner is supposed
+        # to produce the same plan on every rank — but it's exactly the
+        # silent-corruption mode the validation must catch. The tag must
+        # therefore include the splits identity, not just len(splits).
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        keys = ["f0", "f1"]  # rank-invariant
+        splits = (2, 0) if rank == 0 else (1, 1)  # divergent plan
+        tag = _collective_tag_from("KJTAllToAllSplits", keys, splits)
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=tag,
+            collective_tag_parts=("KJTAllToAllSplits", keys, splits),
+        )
+        try:
+            awaitable.wait()
+            raise AssertionError(
+                "Expected RuntimeError for splits divergence at same call site"
+            )
+        except RuntimeError as e:
+            assert "collective mismatch" in str(e).lower()
+            assert "KJTAllToAllSplits" in str(e)
+        dist.destroy_process_group()
+
+    def test_splits_divergence_raises(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_splits_divergence_raises,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_fused_splits_divergence_raises(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        # FusedKJTListSplits-layer counterpart to test_splits_divergence_raises.
+        # Both ranks reach FusedKJTListSplitsAwaitable with the same structural
+        # arity (1 request, 1 splits tensor each) but their per-request
+        # sharding plan diverges. With the old structural-only tag
+        # ("FusedKJTListSplits", len(splits_tensors), self._lengths) these
+        # would collide; with the tightened per-request identity
+        # (keys, splits, len(splits_tensors)) the tag detects the divergence.
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        # Construct a KJTSplitsAllToAllMeta whose `splits` differs per rank.
+        # Everything else is rank-invariant: same keys, same shape.
+        kjt = KeyedJaggedTensor(
+            keys=["f0", "f1"],
+            values=torch.tensor([1, 2], dtype=torch.int64),
+            lengths=torch.tensor([1, 1], dtype=torch.int64),
+        )
+        splits = [2, 0] if rank == 0 else [1, 1]  # divergent sharding plan
+        meta = KJTSplitsAllToAllMeta(
+            pg=none_throws(dist.group.WORLD),
+            _input=kjt,
+            splits=splits,
+            splits_tensors=[
+                torch.tensor([1] * world_size, dtype=torch.int64),
+            ],
+            input_splits=[[1] * world_size],
+            input_tensors=[kjt.lengths()],
+            labels=["lengths"],
+            keys=["f0", "f1"],
+            device=torch.device("cpu"),
+            stagger=1,
+        )
+        request = KJTListSplitsAwaitable(
+            awaitables=cast(List[Awaitable[Awaitable[KeyedJaggedTensor]]], [meta]),
+            ctx=NullShardingContext(),
+        )
+        fused = FusedKJTListSplitsAwaitable(
+            requests=[request],
+            contexts=[NullShardingContext()],
+            pg=none_throws(dist.group.WORLD),
+        )
+        try:
+            none_throws(fused._splits_awaitable).wait()
+            raise AssertionError(
+                "Expected RuntimeError for fused splits divergence at same call site"
+            )
+        except RuntimeError as e:
+            assert "collective mismatch" in str(e).lower()
+            assert "FusedKJTListSplits" in str(e)
+        dist.destroy_process_group()
+
+    def test_fused_splits_divergence_raises(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_fused_splits_divergence_raises,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_fused_cross_type_divergence_raises(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        # Cross-type variant: both ranks reach FusedKJTListSplitsAwaitable with
+        # the same total number of splits tensors (1 — only the meta entry
+        # contributes; the non-meta entry contributes 0), so the underlying
+        # SplitsAllToAllAwaitable input shape matches and the all2all itself
+        # can run. But the per-position TYPE in `_awaitables` differs across
+        # ranks (meta vs non-meta swap). The position-preserving `None`
+        # placeholder in the tag must distinguish these so the divergence is
+        # caught — without it (e.g., if the production code filtered non-metas
+        # out before tagging), the two ranks would compute the same tag and
+        # silently corrupt the fused splits-all2all.
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        kjt = KeyedJaggedTensor(
+            keys=["f0"],
+            values=torch.tensor([1, 2], dtype=torch.int64),
+            lengths=torch.tensor([1, 1], dtype=torch.int64),
+        )
+        meta = KJTSplitsAllToAllMeta(
+            pg=none_throws(dist.group.WORLD),
+            _input=kjt,
+            splits=[1],
+            splits_tensors=[
+                torch.tensor([1] * world_size, dtype=torch.int64),
+            ],
+            input_splits=[[1] * world_size],
+            input_tensors=[kjt.lengths()],
+            labels=["lengths"],
+            keys=["f0"],
+            device=torch.device("cpu"),
+            stagger=1,
+        )
+        # Stub Awaitable that's intentionally NOT a KJTSplitsAllToAllMeta.
+        # spec=Awaitable makes isinstance(non_meta, Awaitable) succeed and
+        # isinstance(non_meta, KJTSplitsAllToAllMeta) fail — the only two
+        # checks production code performs on entries of `_awaitables` during
+        # tag construction. We never reach FusedKJTListSplitsAwaitable._wait_impl
+        # (which would call non_meta.wait()) because the test triggers only
+        # the splits stage via _splits_awaitable.wait().
+        non_meta = unittest.mock.MagicMock(spec=Awaitable)
+
+        # Rank 0 has [meta, non_meta]; rank 1 has [non_meta, meta]. Both
+        # contribute the same single splits tensor to the all2all (only the
+        # meta does), so the collective input shape matches across ranks.
+        if rank == 0:
+            mixed = [meta, non_meta]
+        else:
+            mixed = [non_meta, meta]
+
+        request = KJTListSplitsAwaitable(
+            awaitables=cast(List[Awaitable[Awaitable[KeyedJaggedTensor]]], mixed),
+            ctx=NullShardingContext(),
+        )
+        fused = FusedKJTListSplitsAwaitable(
+            requests=[request],
+            contexts=[NullShardingContext()],
+            pg=none_throws(dist.group.WORLD),
+        )
+        try:
+            none_throws(fused._splits_awaitable).wait()
+            raise AssertionError(
+                "Expected RuntimeError for cross-type _awaitables divergence"
+            )
+        except RuntimeError as e:
+            assert "collective mismatch" in str(e).lower()
+            assert "FusedKJTListSplits" in str(e)
+        dist.destroy_process_group()
+
+    def test_fused_cross_type_divergence_raises(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_fused_cross_type_divergence_raises,
+            world_size=2,
+            backend="gloo",
+        )
+
+    def test_tag_raises_on_small_dtype(self) -> None:
+        with unittest.mock.patch.dict(
+            os.environ, {"TORCHREC_VALIDATE_COLLECTIVES": "1"}
+        ):
+            mock_pg = unittest.mock.MagicMock()
+            mock_pg.size.return_value = 2
+
+            large_tag = 0x7FFF_FFFF  # max signed int32, exceeds int16 range
+            input_tensors = [torch.tensor([1, 1], dtype=torch.int16)]
+            with self.assertRaises(ValueError) as ctx:
+                SplitsAllToAllAwaitable(
+                    input_tensors=input_tensors,
+                    pg=mock_pg,
+                    collective_tag=large_tag,
+                )
+            self.assertIn("exceeds", str(ctx.exception).lower())


### PR DESCRIPTION
Summary:

NCCL collectives are matched purely by order within a process group, not by semantic identity. When ranks call different collectives on the same PG (due to conditional code paths, data exhaustion asymmetry, or configuration errors), NCCL silently matches the wrong collectives, causing either silent data corruption or an NCCL timeout that is extremely difficult to debug.

This diff adds a collective_tag parameter to SplitsAllToAllAwaitable that appends a small tag integer to the splits tensor. After the all2all completes, each rank verifies that the tags received from all peers match its own. A mismatch triggers an immediate, descriptive error instead of a silent hang.

The validation is off by default to avoid overhead in production. Enable it by setting TORCHREC_VALIDATE_COLLECTIVES=1. When enabled, the overhead is one extra int64 per rank in the splits all2all — negligible.

Changes:
- Add `_validate_collectives_enabled()` in dist_data.py that reads `TORCHREC_VALIDATE_COLLECTIVES` on each call (off by default). Reading on every call means the flag can be flipped at runtime by job config that loads after import, and tests can patch via `mock.patch.dict(os.environ, ...)`.
- Add `_collective_tag_from()` for deterministic tag computation (FNV-1a hash, masked to signed int32). The mask is applied both inside the loop and once more after the loop — without the post-loop mask, empty `parts` would return the raw FNV-1a seed (`0x811C9DC5`), which exceeds signed-int32 max and violates the int32-fit contract.
- Add `collective_tag` and `collective_tag_parts` parameters to `SplitsAllToAllAwaitable` with tag append/validate/strip logic. Raises `ValueError` if the tag exceeds the splits-tensor dtype range.
- Use `_tag_appended` instance var to avoid inconsistency between `__init__` and `_wait_impl`. Strip tag row from `input_list` before overflow checks so the new tensor doesn't corrupt the existing validation.
- Wire tag from `KJTAllToAllSplitsAwaitable` using the rank-invariant identity `("KJTAllToAllSplits", input.keys(), tuple(self._splits))`. `input.keys()` is the PRE-AllToAll feature list (NOT local `keys`, which is the post-AllToAll subset and differs per rank). `tuple(self._splits)` is the sharding plan, documented as "Same for all ranks" — including it catches divergent sharding plans that share the same key set.
- Wire tag from `FusedKJTListSplitsAwaitable` using the same per-request identity pattern: for each `KJTSplitsAllToAllMeta` awaitable the tag includes `(tuple(aw._input.keys()), tuple(aw.splits), len(aw.splits_tensors))`, with a `None` placeholder for non-meta awaitables (position-preserving so request reordering is detectable). A structural-only tag would collapse across same-shape EBCs — any two modules with identical KJT shape and sharding type produce the same `_lengths` vector — so a code-path divergence that fuses different module sets across ranks would compute the same tag and silently corrupt the all2all.
- Add 12 unit tests in `SplitsAllToAllCollectiveTagTest` (multi-process): matching tags, mismatched tags, no-tag backward compat, overflow-check integrity, KJTAllToAll end-to-end, FusedKJTList end-to-end, validation-disabled passthrough, realistic mismatched tags across call sites, feature-keys divergence (KJTAllToAll), splits divergence (KJTAllToAll), splits divergence (FusedKJTList), and dtype-overflow `ValueError`.
- Add 3 unit tests in `CollectiveTagFromTest` (single-process): empty-parts result fits signed int32 (regression for the seed-overflow fix), various-parts results all fit signed int32, deterministic across calls.

Reviewed By: kausv

Differential Revision: D101254817
