### PR TITLE
Remove duplicate shebang lines (#4138)

### DIFF
--- a/torchrec/modules/fused_embedding_modules.py
+++ b/torchrec/modules/fused_embedding_modules.py
@@ -7,8 +7,6 @@
 
 # pyre-strict
 
-#!/usr/bin/env python3
-
 import copy
 import itertools
 from collections import defaultdict

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -7,8 +7,6 @@
 
 # pyre-strict
 
-#!/usr/bin/env python3
-
 import abc
 from logging import getLogger, Logger
 from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
@@ -1299,7 +1297,7 @@ class MCHManagedCollisionModule(ManagedCollisionModule):
         ]
 
         # NOTE evicted ids for emb reset
-        # if evicted flag is already set, then existing evicted ids havent been
+        # if evicted flag is already set, then existing evicted ids haven't been
         # consumed by evict(). append new evicted ids to the list
         if self._evicted:
             self._evicted_emb_indices = torch.unique(

--- a/torchrec/modules/regroup.py
+++ b/torchrec/modules/regroup.py
@@ -7,8 +7,6 @@
 
 # pyre-strict
 
-#!/usr/bin/env python3
-
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch


### PR DESCRIPTION
Summary:

Remove duplicate `#!/usr/bin/env python3` lines that appeared after the
`# pyre-strict` directive in two files:
- torchrec/modules/fused_embedding_modules.py
- torchrec/modules/regroup.py

Differential Revision: D98011674


