### PR TITLE
Fix Torchrec repackaging compatiblity issues.

### DIFF
--- a/torchrec/distributed/train_pipeline/pipeline_stage.py
+++ b/torchrec/distributed/train_pipeline/pipeline_stage.py
@@ -28,7 +28,14 @@ import torch
 from torch.profiler import record_function
 from torch.utils.hooks import RemovableHandle
 from torchrec.distributed.dist_data import KJTAllToAllTensorsAwaitable
-from torchrec.distributed.logger import one_time_rank0_logger
+
+try:
+    from torchrec.distributed.logger import one_time_rank0_logger
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.pipeline_stage.import_failure.logger"
+    )
+    one_time_rank0_logger = logging.getLogger(__name__)
 from torchrec.distributed.model_parallel import ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
     EmbeddingTrainPipelineContext,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -26,6 +26,7 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -37,8 +38,60 @@ from torchrec.distributed.embedding import EmbeddingCollectionAwaitable  # noqa:
 from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionAwaitable,  # noqa: F401
 )
-from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
-from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+
+try:
+    from torchrec.distributed.logger import (
+        LazyStr,
+        one_time_logger,
+        one_time_rank0_logger,
+    )
+except Exception:
+    # Safety measure against torch package issues: old packages may not have
+    # these symbols in their archived torchrec.distributed.logger
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.train_pipelines.import_failure.logger"
+    )
+    one_time_logger = logging.getLogger(__name__)
+    one_time_rank0_logger = logging.getLogger(__name__)
+
+    class LazyStr:  # pyre-ignore[11]
+        def __init__(self, fn: Any) -> None:
+            self._fn = fn
+
+        def __str__(self) -> str:
+            return self._fn()
+
+
+try:
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.train_pipelines.import_failure.logging_handlers"
+    )
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+        from enum import Enum as _Enum
+
+        class TorchrecComponent(_Enum):
+            TRAIN_PIPELINE = "train_pipeline"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def event_logger(*args: object, **kwargs: object) -> Callable:
+                def decorator(func: Callable) -> Callable:
+                    return func
+
+                return decorator
+
+
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.backward_injection import (
     BackwardHookWork,

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -38,7 +38,29 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
-from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
+
+try:
+    from torchrec.distributed.logger import (
+        LazyStr,
+        one_time_logger,
+        one_time_rank0_logger,
+    )
+except Exception:
+    # Safety measure against torch package issues: old packages may not have
+    # LazyStr/one_time_logger in their archived torchrec.distributed.logger
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.utils.import_failure.logger"
+    )
+
+    class LazyStr:  # pyre-ignore[11]: Annotation for no-op fallback
+        def __init__(self, fn: Any) -> None:
+            self._fn = fn
+
+        def __str__(self) -> str:
+            return self._fn()
+
+    one_time_logger = logging.getLogger(__name__)
+    one_time_rank0_logger = logging.getLogger(__name__)
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
     EmbeddingTrainPipelineContext,


### PR DESCRIPTION
Summary:
Previous torchrec changes will break model publish on certain models with distributed_transform enabled, these changes slipped through because the repackaging models were outdated. 
It caused S650452. 
This diff adds try catch block on the import of such modules.

Differential Revision: D101693348


