### PR TITLE
feat: add per-table kernel_changed event (#4075)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -368,4 +368,17 @@ def log_itep_itp_info(
     pass
 
 
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -259,6 +259,17 @@ def log_stats_match(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_clf_computed(
     table_name: str = "",
     table_height: int = 0,


### PR DESCRIPTION
Summary:

Log per-table kernel change decisions (promoted_to_hbm, demoted_to_uvm, zero_height) from adjust_noncacheable_table and update_cache_params_helper in sparsenn_configs.py.

Reviewed By: eugeneshulgameta, hammad45

Differential Revision: D97968836


