### PR TITLE
feat: add per-table table_assignment event (#4076)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -368,4 +368,17 @@ def log_itep_itp_info(
     pass
 
 
+def log_kernel_changed(
+    table_name: str = "",
+    action: str = "",
+    reason: str = "",
+    new_kernels: Optional[list] = None,  # type: ignore[type-arg]
+    table_height: Optional[int] = None,
+    cache_ratio: Optional[float] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -381,4 +381,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -259,6 +259,17 @@ def log_stats_match(
     pass
 
 
+def log_cacheability_resolved(
+    table_name: str = "",
+    table_height: int = 0,
+    cacheability: float = 0.0,
+    expected_lookups: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_clf_computed(
     table_name: str = "",
     table_height: int = 0,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -103,22 +103,26 @@ try:
         log_planner_config,
         log_planning_result,
         log_storage_reservation,
+        log_table_assignment,
     )
 except Exception:
     torch._C._log_api_usage_once(
         "torchrec.distributed.planner.planners.import_failure.logging_handlers"
     )
 
-    def log_offloading_summary(*args, **kwargs) -> None:
+    def log_offloading_summary(*args: object, **kwargs: object) -> None:
         pass
 
-    def log_planner_config(*args, **kwargs) -> None:
+    def log_planner_config(*args: object, **kwargs: object) -> None:
         pass
 
-    def log_planning_result(*args, **kwargs) -> None:
+    def log_planning_result(*args: object, **kwargs: object) -> None:
         pass
 
-    def log_storage_reservation(*args, **kwargs) -> None:
+    def log_storage_reservation(*args: object, **kwargs: object) -> None:
+        pass
+
+    def log_table_assignment(*args: object, **kwargs: object) -> None:
         pass
 
 
@@ -784,6 +788,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:


### PR DESCRIPTION
Summary:

Log the planner's final per-table assignment (compute_kernel, sharding_type, CLF, HBM/DDR) after planning completes. One Scuba event per table in best_plan, called from both OSS and LP planners next to log_offloading_summary.

Reviewed By: hammad45, eugeneshulgameta

Differential Revision: D97985051


