### PR TITLE
[detailed][distributed] Different collective execution order across ranks

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -706,6 +706,94 @@ def shared_memory_across_process(
             )
 
 
+def multi_async_comms(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Rank 0 and rank 1 issue two different collectives (a2a_single + all_reduce)
+    in different CPU-side order. The a2a uses ctx.pg and the all_reduce uses
+    a separate process group, so they have independent NCCL communicators.
+
+    Rank 0: a2a → compute → all_reduce
+    Rank 1: all_reduce → compute → a2a
+
+    The two collectives operate on different-sized tensors
+    (input_a: num_concat, input_b: num_concat*2).
+    """
+    with record_function("## setup ##"):
+        rank = ctx.rank
+        ar_pg = multi_async_comms._ar_pg  # pyrefly: ignore[missing-attribute]
+        # Warm up the NCCL communicator so subsequent ops are truly async;
+        # the first collective on a new pg blocks for ncclCommInitRank
+        dist.barrier(group=ar_pg)
+
+    with record_function("## pre-comms compute ##"):
+        input_a = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        input_b = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat * 2, ctx=ctx)
+
+    def do_a2a(
+        input_tensor: torch.Tensor,
+        label: str,
+    ) -> tuple[torch.Tensor, dist.Work]:
+        out = torch.zeros_like(input_tensor)
+        with record_function(f"## rank {rank}: {label} ##"):
+            req = dist.all_to_all_single(
+                output=out,
+                input=input_tensor,
+                group=ctx.pg,
+                async_op=True,
+            )
+        return out, req
+
+    def do_all_reduce(
+        input_tensor: torch.Tensor,
+        label: str,
+    ) -> tuple[torch.Tensor, dist.Work]:
+        out = input_tensor.clone()
+        with record_function(f"## rank {rank}: {label} ##"):
+            req = dist.all_reduce(
+                out,
+                op=dist.ReduceOp.SUM,
+                group=ar_pg,
+                async_op=True,
+            )
+        return out, req
+
+    if rank == 0:
+        out_a, req_a = do_a2a(input_a, "a2a")
+        with record_function("## irrelevant compute ##"):
+            _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        out_b, req_b = do_all_reduce(input_b, "all_reduce")
+    else:
+        out_b, req_b = do_all_reduce(input_b, "all_reduce")
+        with record_function("## irrelevant compute ##"):
+            _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        out_a, req_a = do_a2a(input_a, "a2a")
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        req_a.wait()
+        req_b.wait()
+        checks_a = _validate(out_a, ctx)
+        # all_reduce(SUM) of values from rank 0 in (0,1) and rank 1 in (1,2)
+        # produces sums in (1,3), so int values >= 1
+        checks_b = torch.all(out_b.to(torch.int) >= 1)
+        checks = DeviceToHostTensorAwaitable(checks_a & checks_b)
+
+    with record_function("## post-comms compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=out_a[0])
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
 # single-rank runner
 def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) -> None:
     if arg.backend == "nccl":
@@ -757,6 +845,12 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = single_thread_copy
             case "shared_memory_across_process":
                 func = shared_memory_across_process
+            case "multi_async_comms":
+                func = multi_async_comms
+                # pyrefly: ignore[missing-attribute]
+                multi_async_comms._ar_pg = dist.new_group(
+                    ranks=list(range(ctx.world_size))
+                )
             case _:
                 raise ValueError(f"Unknown benchmark name: {arg.name}")
 


### PR DESCRIPTION
Summary:
## 1. Context
A production cross-PG deadlock was observed on AMD MI350X (maz5, April 16 2026) during PT2 warmup in a TorchRec training job ([RCA doc](https://docs.google.com/document/d/1fXyJlyv6-MYuipP4KXThfhOTAuOWQZpozaNp5goF9Lc/edit)). The root cause was **rank-divergent collective ordering across two process groups** (`mesh_shard` for all_to_all, `mesh_replicate` for allreduce_coalesced) combined with implicit GPU synchronization (`tolist()` → `memcpy_and_sync`, `should_pad_mm` → `cuda.synchronize()`). Ranks 6/7 fell behind in the forward pass and hit a GPU sync while NCCL collectives were still pending in the HIP stream, creating a circular dependency where no rank could make progress.

The deadlock mechanism: 62 ranks scheduled `mesh_shard` A2A #11 then blocked in `torch.compile`'s `cuda.synchronize()` waiting for that A2A to complete. Ranks 6/7 hadn't scheduled their side of that A2A yet — they were blocked on `mesh_replicate` allreduce via `.tolist()` → `memcpy_and_sync`. But `mesh_replicate`'s peers were the same 62 ranks stuck in `should_pad_mm`. Circular wait → deadlock.

This benchmark reproduces the core pattern: two different collectives (a2a + all_reduce) on separate process groups, issued in rank-divergent order. It demonstrates that the pattern works when no implicit GPU synchronization intervenes, but highlights the fragility — any `cuda.synchronize()`, `.tolist()`, `.item()`, or device-to-host copy between collectives can trigger the same deadlock seen in production.

## 2. Demo
Adds a `multi_async_comms` benchmark where rank 0 and rank 1 issue two collectives (`all_to_all_single` + `all_reduce`) in opposite CPU-side order on separate process groups, with compute interleaved. Rank 0 starts with a2a then all_reduce; rank 1 starts with all_reduce then a2a. The two collectives use different tensor sizes to be distinguishable in profiler traces.
Both ranks complete successfully with no deadlock — the collectives finish in different order but match correctly via separate process groups. However, if we call cuda.synchronize() in the middle of irrelevant compute (between two collectives), the program will just hang.

||rank 0|rank 1|
|--|--|--|
|execution order|a2a (stream 27) → compute → all_reduce (stream 23)|all_reduce (stream 7) → compute → a2a (stream 27)|
|trace|<img width="2486" height="1060" alt="image" src="https://github.com/user-attachments/assets/e39f717b-ff86-40fd-b9d6-c4db729c1afb" />|<img width="2686" height="1086" alt="image" src="https://github.com/user-attachments/assets/6d3a7b9c-0f78-48e0-929a-3056642b576e" />|

```
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=multi_async_comms --all_rank_traces=True
```
[multi-collectives.zip](https://github.com/user-attachments/files/26953383/multi-collectives.zip)

## 3. Analysis
1. **Root cause — inconsistent execution order**: The fundamental issue is that different ranks can reach the same set of collectives in different order. In a pipelined training loop, per-rank scheduling variance (different microbatch readiness, conditional computation paths, async prefetching) means rank A may issue collective X before Y, while rank B issues Y before X. This inconsistency is the root cause — everything else (implicit GPU syncs, cross-PG dependencies) are contributing factors that turn the inconsistency into a deadlock.
2. **Likely alternative — collective skipped entirely**: Rather than execution order being swapped, it is more likely that the 62 ranks never issued the `mesh_replicate` allreduce at all during that iteration — e.g., a conditional code path (PT2 warmup, `torch.compile` graph capture) caused those ranks to skip the allreduce while ranks 6/7 still expected it. A missing collective is a degenerate case of inconsistent ordering: one side issues it, the other never does, so the waiting side blocks forever. The Flight Recorder evidence supports this: `mesh_shard` had completed 10 all-to-all ops successfully (failure at SeqNum=11), while `mesh_replicate` timed out at SeqNum=1 — meaning the allreduce was never successfully executed even once, strongly suggesting it was skipped rather than reordered.
3. **Implicit GPU sync is inefficient even without deadlock**: `.tolist()` triggers `memcpy_and_sync`, which performs a device-wide stream synchronize. Even when collective ordering is consistent and no deadlock occurs, this unnecessarily blocks the CPU thread until the entire GPU stream drains — including any pending NCCL kernels and compute. This stalls the CPU from enqueuing further work, creating a pipeline bubble that hurts throughput regardless of correctness. The same applies to `.item()`, `cuda.synchronize()`, and any other implicit device-to-host sync in the critical path.
When both issues are present — inconsistent ordering across ranks plus implicit GPU syncs in the critical path — the result is a cross-PG deadlock, as seen in the production incident:

```
┌──────────────────┐         ┌──────────────────────────┐
│  Ranks 6, 7      │         │  Ranks 0-5, 8-63         │
│                  │         │                          │
│  .tolist()       │         │  should_pad_mm()         │
│    ↓             │         │    ↓                     │
│  memcpy_and_sync │         │  cuda.synchronize()      │
│    ↓             │         │    ↓                     │
│  BLOCKED on      │         │  BLOCKED on              │
│  mesh_replicate  │←────────│  mesh_shard A2A #11      │
│  allreduce #1    │         │  (waiting for ranks 6/7) │
│    ↓             │         │                          │
│  Needs peers     │─────────→  Peers are stuck above   │
│  to finish       │         │                          │
└──────────────────┘         └──────────────────────────┘
         ↑                              │
         └──────── CIRCULAR ────────────┘
```

### 3.1 NVIDIA vs AMD: why the same code deadlocks only on AMD

<img width="3242" height="1040" alt="image" src="https://github.com/user-attachments/assets/89b5179a-08b8-43fc-bcb6-7656241d9751" />

The diagram above shows the multi-stream timeline for both rank groups (6,7 and 1-5,8-63), each with a main cuda stream, `mesh_shard` stream, and `mesh_replicate` stream. The execution order of `all_to_all` and `all_reduce` is swapped between the two rank groups.

- **Left (NVIDIA)**: `.tolist()` calls `cudaMemcpyAsync` + `cudaStreamSynchronize` on the **current stream only**. The main stream blocks until its D2H copy completes, but NCCL collectives on `mesh_shard` and `mesh_replicate` streams continue to make progress. No deadlock — the collectives complete independently on their own streams.
- **Right (AMD)**: `.tolist()` triggers a **device-wide** `hipDeviceSynchronize` that blocks until **all streams** drain. This means the main stream cannot return from `.tolist()` until the pending NCCL collectives on `mesh_shard` and `mesh_replicate` streams also complete. But those collectives need the peer ranks to participate — and the peers are stuck in their own device-wide sync (`cuda.synchronize()` from `should_pad_mm`). Circular wait → deadlock.

The key difference: on NVIDIA, inconsistent collective ordering combined with `.tolist()` causes CPU blocking and pipeline bubbles (stream-scoped sync stalls until the current stream drains), but does not deadlock because other streams can still progress. On AMD, the same code escalates to a device-wide sync that blocks all streams, turning the performance problem into a deadlock.

Differential Revision: D101184386


