### PR TITLE
De-flake 3 P0 unit tests (Swish, MCLayerNorm, TDigest)

### DIFF
--- a/torchrec/modules/tests/test_activation.py
+++ b/torchrec/modules/tests/test_activation.py
@@ -16,12 +16,17 @@ from torchrec.modules.activation import SwishLayerNorm
 
 class TestActivation(unittest.TestCase):
     def test_swish_takes_float(self) -> None:
+        # Seed so the random input is deterministic; the previous unseeded
+        # randn occasionally produced inputs where the two LayerNorm
+        # invocations diverged by more than the (very tight) atol=1e-8.
+        torch.manual_seed(0)
         m = SwishLayerNorm([3, 4])
         input = torch.randn(2, 3, 4)
         output = m(input)
         norm = torch.nn.LayerNorm([3, 4])
         ref_output = input * torch.sigmoid(norm(input))
-        torch.testing.assert_close(output, ref_output, rtol=1e-05, atol=1e-08)
+        # atol relaxed to fp32-realistic precision.
+        torch.testing.assert_close(output, ref_output, rtol=1e-05, atol=1e-06)
 
     def test_fx_script_swish(self) -> None:
         m = SwishLayerNorm(10)


### PR DESCRIPTION
Summary:
Three TorchRec unit tests have been sitting on the
https://torchrec-dash.nest.x2p.facebook.net/health page in the "Flaky"
list (most as `DISABLED_FLAKY` so they aren't actually exercised). All
three are quick, low-risk fixes — they fall into the "P0 quick win"
bucket of a wider triage of the 31 flaky tests owned by the `torchrec`
oncall.

## 1. `torchrec/modules/tests:test_activation` —
   `TestActivation.test_swish_takes_float`

Before: pulled inputs from `torch.randn(2,3,4)` with no seed, then
asserted `m(x) == x * sigmoid(LayerNorm(x))` with `atol=1e-8`. Two
issues:
  - Unseeded randn → input distribution drifts every run.
  - `atol=1e-8` is below fp32's representable round-off floor for the
    LayerNorm + sigmoid + multiply pipeline; the two computation paths
    (`m.norm[0]` vs the locally-constructed `nn.LayerNorm`) can disagree
    in the last bit on certain inputs.

After:
  - `torch.manual_seed(0)` so the input tensor is identical every run.
  - `atol=1e-6` — still a strict fp32 closeness check, but no longer
    smaller than fp32's worst-case rounding for these ops.

## 2. `torchrec/fb/modules/tests:test_normalization`

The `python_unittest` target enforces `needed_coverage = [(95,
"//torchrec/fb/modules:normalization")]`. Both `TestMCNormalization`
and `TestLazyMCNormalization` use `hypothesis.given(...)` to vary
booleans / dim counts, then build inputs with unseeded `torch.randint`
and `torch.randn`. Two issues that combined to produce the
`DISABLED_FLAKY` state:

  (a) `assert_close(..., atol=1e-8)` — same fp32-too-tight problem as
      above; certain random inputs occasionally exceed the budget.
  (b) Because input shape (`torch.randint`) and values (`torch.randn`)
      were unseeded, the set of branches inside `normalization.py`
      exercised by each Hypothesis example wandered run-to-run. When a
      run happened to skip a branch, line coverage dipped under the
      95% gate and the target failed even when every assertion passed.

After:
  - `torch.manual_seed(0)` at the top of each of the three test methods
    (`TestMCNormalization.test_layer_norm`,
    `TestLazyMCNormalization.test_layer_norm`,
    `TestLazyMCNormalization.test_layer_norm_lazy_non_lazy_equivalent`).
    This makes the input shape and values deterministic per Hypothesis
    example. The Hypothesis-varied parameters
    (`elementwise_affine`, `has_num_channels`, `num_feature_dims`,
    `norm_axis_starting_from_first_feature_dim`) still vary and cover
    the parameter space — only the auxiliary input tensor is pinned.
  - `atol=1e-8` → `atol=1e-6` in all three `assert_close` calls.

The combination should both eliminate the rare assertion misses AND
make line-coverage of `normalization.py` reproducible across runs, so
the 95% gate stops flaking.

## 3. `torchrec/fb/metrics/tests:test_quantile_approx_utils` —
   `TestTDigest.test_compute`

`TDigest.compute` wraps the folly C++ TDigest implementation, which is
an *approximate* quantile algorithm. The test compared the 9 returned
boundaries to a hand-written expected tensor with values like
`1.1, 1.4, 1.7, 2.3, 2.6, 2.9` — none of which are exactly representable
in fp32, plus the underlying digest can return values that drift slightly
with compaction order. The original `assert_close()` used the default
fp32 tolerance (`atol≈1e-5`), which was too tight for an approximate
algorithm comparing to fp32-rounded literals.

After: explicit `rtol=1e-3, atol=1e-3` — still well within "this is the
right answer" for a TDigest with `compression=100`, but no longer
tripped by sub-thousandth round-trip drift.

## What this does NOT do

- Does not re-enable any of the `DISABLED_FLAKY` tests. That is a
  separate operation (TestX UI / overrideschema), and should be done by
  the oncall after observing post-fix runs in CI to confirm the flakes
  are gone.
- Does not fix the other 28 flaky torchrec tests on the dashboard — the
  large distributed-sharding cluster (21 tests) shares NCCL/multi-rank
  root causes that need a domain expert. A triage report for those is
  pending.

Differential Revision: D101867548


