### PR TITLE
Add FP8 rowwise padding to quantized AllToAll pooled embeddings (#4153)

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -7,15 +7,17 @@
 
 # pyre-strict
 
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple, TypeVar, Union
+from typing import Any, cast, List, Optional, Tuple, TypeVar, Union
 
 import torch
 import torch.distributed as dist
 import torch.distributed._functional_collectives
+from fbgemm_gpu.split_embedding_configs import SparseType
 from torch import Tensor
 from torch.autograd import Function
 from torch.autograd.profiler import record_function
@@ -70,6 +72,10 @@ def torchrec_use_sync_collectives():
     set_use_sync_collectives(True)
     yield
     set_use_sync_collectives(original_use_sync_collectives)
+
+
+def _is_fp8_rowwise_padding_enabled() -> bool:
+    return bool(int(os.environ.get("TORCHREC_ENABLE_FP8_ROWWISE_PADDING", 0)))
 
 
 """
@@ -165,7 +171,7 @@ class Request(Awaitable[W]):
 
 
 @dataclass
-class All2AllPooledInfo(object):
+class All2AllPooledInfo:
     """
     The data class that collects the attributes when calling the `alltoall_pooled`
     operation.
@@ -191,7 +197,7 @@ class All2AllPooledInfo(object):
 
 
 @dataclass
-class VariableBatchAll2AllPooledInfo(object):
+class VariableBatchAll2AllPooledInfo:
     """
     The data class that collects the attributes when calling the
     `variable_batch_alltoall_pooled` operation.
@@ -216,7 +222,7 @@ class VariableBatchAll2AllPooledInfo(object):
 
 
 @dataclass
-class All2AllSequenceInfo(object):
+class All2AllSequenceInfo:
     """
     The data class that collects the attributes when calling the `alltoall_sequence`
     operation.
@@ -247,7 +253,7 @@ class All2AllSequenceInfo(object):
 
 
 @dataclass
-class All2AllVInfo(object):
+class All2AllVInfo:
     """
     The data class that collects the attributes when calling the `alltoallv` operation.
 
@@ -277,7 +283,7 @@ class All2AllVInfo(object):
 
 
 @dataclass
-class ReduceScatterInfo(object):
+class ReduceScatterInfo:
     """
     The data class that collects the attributes when calling the `reduce_scatter_pooled`
     operation.
@@ -293,7 +299,7 @@ class ReduceScatterInfo(object):
 
 
 @dataclass
-class ReduceScatterBaseInfo(object):
+class ReduceScatterBaseInfo:
     """
     The data class that collects the attributes when calling the
     `reduce_scatter_base_pooled` operation.
@@ -307,7 +313,7 @@ class ReduceScatterBaseInfo(object):
 
 
 @dataclass
-class AllGatherBaseInfo(object):
+class AllGatherBaseInfo:
     """
     The data class that collects the attributes when calling the
     `all_gatther_base_pooled` operation.
@@ -321,7 +327,7 @@ class AllGatherBaseInfo(object):
 
 
 @dataclass
-class ReduceScatterVInfo(object):
+class ReduceScatterVInfo:
     """
     The data class that collects the attributes when calling the `reduce_scatter_v_pooled`
     operation.
@@ -344,7 +350,7 @@ class ReduceScatterVInfo(object):
 
 
 @dataclass
-class All2AllDenseInfo(object):
+class All2AllDenseInfo:
     """
     The data class that collects the attributes when calling the `alltoall_dense`
     operation.
@@ -552,30 +558,47 @@ def all2all_pooled_sync(
 
     assert B_global == sum(batch_size_per_rank)
 
-    sharded_input_embeddings = input_embeddings.view(-1)
-
     if a2ai.codecs is not None:
         codecs = none_throws(a2ai.codecs)
         qcomm_ctx = codecs.forward.create_context()
+        # Compute padding for quantized comm (e.g. FP8 rowwise, MX4) to ensure
+        # dim_sum per rank is aligned to the quantization group size.
+        # Mirrors the padding logic in All2All_Pooled_Req.forward().
+        padded_D_local_sum, padding_size = codecs.forward.padded_size(
+            input_embeddings, dim_sum_per_rank, my_rank, qcomm_ctx
+        )
+
+        if padding_size == 0:
+            sharded_input_embeddings = input_embeddings.view(-1)
+        else:
+            sharded_input_embeddings = torch.nn.functional.pad(
+                input_embeddings, (0, padding_size)
+            )
         sharded_input_embeddings = codecs.forward.encode(
             sharded_input_embeddings,
             qcomm_ctx,
+        )
+        padded_dim_sum_per_rank = (
+            qcomm_ctx.padded_dim_sum_per_rank
+            if qcomm_ctx is not None and qcomm_ctx.padded_dim_sum_per_rank is not None
+            else dim_sum_per_rank
         )
         output_split_sizes = [
             codecs.forward.calc_quantized_size(
                 B_local * D_rank_sum,
                 qcomm_ctx,
             )
-            for D_rank_sum in dim_sum_per_rank
+            for D_rank_sum in padded_dim_sum_per_rank
         ]
         input_split_sizes = [
             codecs.forward.calc_quantized_size(
-                D_local_sum * B_rank,
+                padded_D_local_sum * B_rank,
                 qcomm_ctx,
             )
             for B_rank in batch_size_per_rank
         ]
     else:
+        sharded_input_embeddings = input_embeddings.view(-1)
         output_split_sizes = [B_local * D_rank_sum for D_rank_sum in dim_sum_per_rank]
         input_split_sizes = [D_local_sum * B_rank for B_rank in batch_size_per_rank]
         qcomm_ctx = None
@@ -597,16 +620,49 @@ def all2all_pooled_sync(
             qcomm_ctx,
         )
 
+    padded_dim_sum_per_rank = (
+        qcomm_ctx.padded_dim_sum_per_rank
+        if qcomm_ctx is not None and qcomm_ctx.padded_dim_sum_per_rank is not None
+        else dim_sum_per_rank
+    )
+
     if is_torchdynamo_compiling():
         # Default implementation fails on backward with unbacked symints in full Ads model compilation.
         # This is workaround to do desired split-cat under tracing in custom_op.
         # TODO: Remove when pt2 symbolic shapes default split - cat can be compiled forward and backward with unbacked symints
+        if qcomm_ctx is not None and qcomm_ctx.padded_dim_sum_per_rank is not None:
+            # When FP8 rowwise padding is applied, the output tensor contains
+            # padded data. Remove padding per-rank before the split-cat op.
+            outputs_by_rank = sharded_output_embeddings.split(
+                [B_local * D_rank_sum for D_rank_sum in padded_dim_sum_per_rank]
+            )
+            sharded_output_embeddings = torch.cat(
+                [
+                    output.view(B_local, -1)[:, :dim_sum].reshape(-1)
+                    for output, dim_sum in zip(outputs_by_rank, dim_sum_per_rank)
+                ]
+            )
         return torch.ops.torchrec._split_1d_cat_2d(
             sharded_output_embeddings, B_local, dim_sum_per_rank
         )
 
-    outputs_by_rank = sharded_output_embeddings.split(output_split_sizes)
-    return torch.cat([output.view(B_local, -1) for output in outputs_by_rank], dim=1)
+    outputs_by_rank = sharded_output_embeddings.split(
+        [B_local * D_rank_sum for D_rank_sum in padded_dim_sum_per_rank]
+    )
+    if qcomm_ctx is not None and qcomm_ctx.padded_dim_sum_per_rank is not None:
+        # Remove padding added for quantization alignment.
+        # Mirrors the unpadding logic in All2All_Pooled_Wait.forward().
+        outputs_by_rank = [
+            output.view(B_local, -1)[:, :dim_sum]
+            for output, dim_sum in zip(outputs_by_rank, dim_sum_per_rank)
+        ]
+    return torch.cat(
+        [
+            output.view(B_local, dim)
+            for output, dim in zip(outputs_by_rank, dim_sum_per_rank)
+        ],
+        dim=1,
+    )
 
 
 def variable_batch_alltoall_pooled(
@@ -680,10 +736,50 @@ def variable_batch_all2all_pooled_sync(
 
     sharded_input_embeddings = input_embeddings.view(-1)
     qcomm_ctx = None
+    unpadded_output_split_sizes = output_split_sizes
 
     if a2ai.codecs is not None:
         codecs = none_throws(a2ai.codecs)
         qcomm_ctx = codecs.forward.create_context()
+
+        # For FP8 rowwise quantization, pad each split to be a multiple
+        # of row_dim so that calc_quantized_size does not assert.
+        # Mirrors the padded_size() logic used in the fixed-batch path.
+        if (
+            qcomm_ctx is not None
+            and qcomm_ctx.row_dim > 0
+            # pyrefly: ignore[missing-attribute] - codecs.forward is typed as
+            # QuantizedCommCodec (base) but at runtime is the fbgemm concrete
+            # class which has _comm_precision.
+            and codecs.forward._comm_precision == SparseType.FP8
+            and _is_fp8_rowwise_padding_enabled()
+        ):
+            row_dim = qcomm_ctx.row_dim
+            unpadded_input_split_sizes = list(input_split_sizes)
+            input_split_sizes = [
+                split + (row_dim - split % row_dim) % row_dim
+                for split in unpadded_input_split_sizes
+            ]
+            unpadded_output_split_sizes = list(output_split_sizes)
+            output_split_sizes = [
+                split + (row_dim - split % row_dim) % row_dim
+                for split in output_split_sizes
+            ]
+            if any(
+                p > o for p, o in zip(input_split_sizes, unpadded_input_split_sizes)
+            ):
+                chunks = sharded_input_embeddings.split(unpadded_input_split_sizes)
+                sharded_input_embeddings = torch.cat(
+                    [
+                        torch.nn.functional.pad(chunk, (0, p - o))
+                        for chunk, p, o in zip(
+                            chunks,
+                            input_split_sizes,
+                            unpadded_input_split_sizes,
+                        )
+                    ]
+                )
+
         sharded_input_embeddings = codecs.forward.encode(
             sharded_input_embeddings,
             qcomm_ctx,
@@ -730,6 +826,25 @@ def variable_batch_all2all_pooled_sync(
             sharded_output_embeddings,
             qcomm_ctx,
         )
+        if (
+            qcomm_ctx is not None
+            and qcomm_ctx.row_dim > 0
+            # pyrefly: ignore[missing-attribute]
+            and codecs.forward._comm_precision == SparseType.FP8
+            and _is_fp8_rowwise_padding_enabled()
+        ):
+            row_dim = qcomm_ctx.row_dim
+            padded_output_splits = [
+                split + (row_dim - split % row_dim) % row_dim
+                for split in unpadded_output_split_sizes
+            ]
+            chunks = sharded_output_embeddings.split(padded_output_splits)
+            sharded_output_embeddings = torch.cat(
+                [
+                    chunk[:orig]
+                    for chunk, orig in zip(chunks, unpadded_output_split_sizes)
+                ]
+            )
     return sharded_output_embeddings
 
 
@@ -1302,7 +1417,9 @@ class All2All_Pooled_Req(Function):
             if padding_size == 0:
                 sharded_input_embeddings = input_embeddings.view(-1)
             else:
-                sharded_input_embeddings = input_embeddings
+                sharded_input_embeddings = torch.nn.functional.pad(
+                    input_embeddings, (0, padding_size)
+                )
             sharded_input_embeddings = codecs.forward.encode(
                 sharded_input_embeddings,
                 qcomm_ctx,
@@ -1573,6 +1690,42 @@ class Variable_Batch_All2All_Pooled_Req(Function):
         if a2ai.codecs is not None:
             codecs = none_throws(a2ai.codecs)
             qcomm_ctx = codecs.forward.create_context()
+
+            # For FP8 rowwise quantization, pad each split to be a
+            # multiple of row_dim so calc_quantized_size does not assert.
+            # Mirrors the padded_size() logic used in the fixed-batch path.
+            if (
+                qcomm_ctx is not None
+                and qcomm_ctx.row_dim > 0
+                # pyrefly: ignore[missing-attribute]
+                and codecs.forward._comm_precision == SparseType.FP8
+                and _is_fp8_rowwise_padding_enabled()
+            ):
+                row_dim = qcomm_ctx.row_dim
+                unpadded_input_split_sizes = list(input_split_sizes)
+                input_split_sizes = [
+                    split + (row_dim - split % row_dim) % row_dim
+                    for split in unpadded_input_split_sizes
+                ]
+                output_split_sizes = [
+                    split + (row_dim - split % row_dim) % row_dim
+                    for split in output_split_sizes
+                ]
+                if any(
+                    p > o for p, o in zip(input_split_sizes, unpadded_input_split_sizes)
+                ):
+                    chunks = sharded_input_embeddings.split(unpadded_input_split_sizes)
+                    sharded_input_embeddings = torch.cat(
+                        [
+                            torch.nn.functional.pad(chunk, (0, p - o))
+                            for chunk, p, o in zip(
+                                chunks,
+                                input_split_sizes,
+                                unpadded_input_split_sizes,
+                            )
+                        ]
+                    )
+
             sharded_input_embeddings = codecs.forward.encode(
                 sharded_input_embeddings,
                 qcomm_ctx,
@@ -1677,6 +1830,26 @@ class Variable_Batch_All2All_Pooled_Wait(Function):
                 sharded_output_embeddings,
                 myreq.qcomm_ctx,
             )
+            if (
+                myreq.qcomm_ctx is not None
+                and myreq.qcomm_ctx.row_dim > 0
+                # pyrefly: ignore[missing-attribute]
+                and codecs.forward._comm_precision == SparseType.FP8
+                # pyrefly: ignore[missing-attribute]
+                and a2ai.output_splits is not None
+                and _is_fp8_rowwise_padding_enabled()
+            ):
+                row_dim = myreq.qcomm_ctx.row_dim
+                # pyrefly: ignore[missing-attribute]
+                unpadded_splits: List[int] = cast(List[int], a2ai.output_splits)
+                padded_splits = [
+                    split + (row_dim - split % row_dim) % row_dim
+                    for split in unpadded_splits
+                ]
+                chunks = sharded_output_embeddings.split(padded_splits)
+                sharded_output_embeddings = torch.cat(
+                    [chunk[:orig] for chunk, orig in zip(chunks, unpadded_splits)]
+                )
         # the return result is a 1-d tensor, like: f_0_s_0, f_0_s1, ..., f_n_s_0, f_n_s_k
         # f_0, f_1, ... , f_n are ordered by features on each rank
         # pyrefly: ignore[bad-return]

--- a/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
+++ b/torchrec/distributed/tests/test_fbgemm_qcomm_codec.py
@@ -7,8 +7,10 @@
 
 # pyre-strict
 
+import os
 import unittest
 from typing import Optional, Tuple
+from unittest.mock import patch
 
 import hypothesis.strategies as st
 import torch
@@ -94,6 +96,377 @@ class QuantizationCommCodecTest(unittest.TestCase):
             rtol=rtol,
             atol=atol,
         )
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_padding(self) -> None:
+        """Verify FP8 rowwise padding handles non-aligned dim_sum per rank.
+
+        Reproduces the production crash:
+            RuntimeError: input_len N is not a multiple of row dim 256
+        which occurs when B_local * D_rank_sum % row_dim != 0 during
+        FP8-quantized AllToAll with small eval batch sizes and column-based
+        sharding that produces irregular D_rank_sum values.
+        """
+        row_dim = 256
+        batch_size = 16
+        # Non-aligned dims: 259 % 256 = 3, 131 % 256 = 131
+        # Without padding: 16 * 259 = 4144, 4144 % 256 = 48 → crash
+        dim_sum_per_rank = [259, 131]
+        my_rank = 0
+        dim_sum = dim_sum_per_rank[my_rank]
+
+        input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+
+        # padded_size pads 259 → 512, 131 → 256 (next multiples of 256)
+        padded_dim, padding_size = quant_codec.forward.padded_size(
+            input_tensor, dim_sum_per_rank, my_rank, ctx
+        )
+
+        self.assertEqual(padded_dim, 512)
+        self.assertEqual(padding_size, 253)
+        # `create_context()` returns the generic `QuantizationContext` type parameter
+        # of `QuantizedCommCodec[QuantizationContext]`, which pyrefly resolves to
+        # `object`. Ignore `missing-attribute` for attribute access and `not-iterable`
+        # when iterating over `padded_dim_sum_per_rank` (typed `list[int] | None`).
+        # pyrefly: ignore[missing-attribute]
+        self.assertIsNotNone(ctx.padded_dim_sum_per_rank)
+        # pyrefly: ignore[missing-attribute]
+        self.assertEqual(ctx.padded_dim_sum_per_rank, [512, 256])
+        # pyrefly: ignore[not-iterable]
+        self.assertTrue(all(d % row_dim == 0 for d in ctx.padded_dim_sum_per_rank))
+
+        # calc_quantized_size must not crash with padded dims
+        # Without padding, calc_quantized_size(16 * 259 = 4144) would assert
+        # because 4144 % 256 = 48.
+        # pyrefly: ignore[not-iterable]
+        for padded_d in ctx.padded_dim_sum_per_rank:
+            size = quant_codec.forward.calc_quantized_size(batch_size * padded_d, ctx)
+            self.assertGreater(size, 0)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_2d_tensor_padding(self) -> None:
+        """Verify 2D tensor is padded along dim 1 before FP8 encoding.
+
+        Without F.pad(input_embeddings, (0, padding_size)), the 2D tensor
+        has D_local_sum not aligned to row_dim. encode() calls
+        view(-1, row_dim) which fails, or produces a tensor whose size
+        doesn't match the padded split sizes (Split sizes mismatch error).
+        """
+        row_dim = 256
+        batch_size = 16
+        dim_sum = 259  # not a multiple of 256
+        dim_sum_per_rank = [dim_sum, 131]
+        my_rank = 0
+
+        input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+
+        _, padding_size = quant_codec.forward.padded_size(
+            input_tensor, dim_sum_per_rank, my_rank, ctx
+        )
+        self.assertGreater(padding_size, 0)
+
+        # Pad the tensor (the fix)
+        padded_tensor = torch.nn.functional.pad(input_tensor, (0, padding_size))
+        self.assertEqual(padded_tensor.shape[1], 512)  # 259 + 253 = 512
+        self.assertEqual(padded_tensor.shape[1] % row_dim, 0)
+
+        # Total elements must align for view(-1, row_dim) in _quantize_tensor
+        self.assertEqual(padded_tensor.numel() % row_dim, 0)
+
+        # Without padding, total elements would NOT align
+        self.assertNotEqual(input_tensor.numel() % row_dim, 0)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_variable_batch_split_padding(self) -> None:
+        """Verify per-split padding for variable batch FP8 quantized AllToAll.
+
+        In the variable batch path, splits are sum(batch_size_j * emb_dim_j)
+        per rank. Each split must be padded individually to a multiple of
+        row_dim. The sum of individually quantized padded splits must equal
+        the quantized size of the total padded tensor.
+        """
+        row_dim = 256
+        # Real failing input_len values from production
+        original_splits = [549408, 555760, 558000, 562048]
+
+        # None are multiples of 256
+        for split in original_splits:
+            self.assertNotEqual(split % row_dim, 0)
+
+        # Pad each split individually
+        padded_splits = [
+            split + (row_dim - split % row_dim) % row_dim for split in original_splits
+        ]
+
+        # All padded splits must be multiples of row_dim
+        for ps in padded_splits:
+            self.assertEqual(ps % row_dim, 0)
+
+        # Padded total >= original total
+        self.assertGreaterEqual(sum(padded_splits), sum(original_splits))
+
+        # calc_quantized_size must not crash on padded splits
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+        for ps in padded_splits:
+            size = quant_codec.forward.calc_quantized_size(ps, ctx)
+            self.assertGreater(size, 0)
+
+        # Critical invariant: sum of individually quantized splits ==
+        # quantized size of total. If this fails, AllToAll crashes with
+        # "Split sizes doesn't match total dim 0 size".
+        q_splits = [
+            quant_codec.forward.calc_quantized_size(ps, ctx) for ps in padded_splits
+        ]
+        q_total = quant_codec.forward.calc_quantized_size(sum(padded_splits), ctx)
+        self.assertEqual(sum(q_splits), q_total)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_no_padding_crashes(self) -> None:
+        """Without FP8 padding, calc_quantized_size crashes on non-aligned dims."""
+        row_dim = 256
+        batch_size = 16
+        dim_sum = 259  # 259 % 256 = 3, not aligned
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+
+        # Directly calling calc_quantized_size without padding must fail
+        unpadded_input_len = batch_size * dim_sum  # 16 * 259 = 4144
+        self.assertNotEqual(unpadded_input_len % row_dim, 0)
+        with self.assertRaises((AssertionError, RuntimeError)):
+            quant_codec.forward.calc_quantized_size(unpadded_input_len, ctx)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_padding_varied_shapes(self) -> None:
+        """Verify padded_size works across production failure shapes and row_dims."""
+        test_cases = [
+            # (name, batch_size, dim_sum_per_rank, row_dim)
+            # Production failures - tiny input_len (jobs 1072421796+)
+            ("tiny_input_len_8", 1, [8, 16], 256),
+            # Production failures - small input_len (job 1073124510)
+            ("small_input_len_64", 1, [64, 32], 256),
+            # Production failures - medium (jobs 1071926714+, 15.4% of failures)
+            ("medium_input_len_6464", 16, [404, 131], 256),
+            # Production failures - medium (job 1073949094)
+            ("medium_input_len_142016", 16, [8876, 9404], 256),
+            # Variable row_dim (requested by reviewer)
+            ("row_dim_32", 16, [259, 131], 32),
+            ("row_dim_128", 16, [259, 131], 128),
+            ("row_dim_128_small_batch", 1, [64, 32], 128),
+            # Edge: minimal dim_sum
+            ("minimal_dim_sum", 1, [1, 1], 256),
+            # Edge: already-aligned dims, no padding needed
+            ("already_aligned", 16, [256, 512], 256),
+            # Edge: off-by-one from alignment
+            ("off_by_one", 16, [257, 255], 256),
+        ]
+        for name, batch_size, dim_sum_per_rank, row_dim in test_cases:
+            with self.subTest(name=name):
+                my_rank = 0
+                dim_sum = dim_sum_per_rank[my_rank]
+                input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+                quant_codec = get_qcomm_codecs(
+                    QCommsConfig(
+                        forward_precision=CommType.FP8,
+                        fp8_quantize_dim=row_dim,
+                    )
+                )
+                ctx = quant_codec.forward.create_context()
+
+                padded_dim, padding_size = quant_codec.forward.padded_size(
+                    input_tensor, dim_sum_per_rank, my_rank, ctx
+                )
+
+                self.assertEqual(padded_dim % row_dim, 0)
+                self.assertGreaterEqual(padded_dim, dim_sum)
+                self.assertEqual(padded_dim, dim_sum + padding_size)
+                # `ctx` is typed as `object` because `create_context()` returns the
+                # generic context parameter of `QuantizedCommCodec`. Ignore both
+                # `missing-attribute` for attribute access and `not-iterable` for
+                # iteration over `padded_dim_sum_per_rank` (typed `list[int] | None`).
+                # pyrefly: ignore[missing-attribute]
+                self.assertIsNotNone(ctx.padded_dim_sum_per_rank)
+                # pyrefly: ignore[not-iterable]
+                for d in ctx.padded_dim_sum_per_rank:
+                    self.assertEqual(d % row_dim, 0)
+
+                # pyrefly: ignore[not-iterable]
+                for padded_d in ctx.padded_dim_sum_per_rank:
+                    size = quant_codec.forward.calc_quantized_size(
+                        batch_size * padded_d, ctx
+                    )
+                    self.assertGreater(size, 0)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_variable_batch_split_padding_production_shapes(
+        self,
+    ) -> None:
+        """Verify per-split padding with production input_len values and varied row_dims."""
+        split_test_cases = [
+            # (name, original_splits, row_dim)
+            # Tiny splits (jobs 1072421796+, 8 jobs)
+            ("tiny_splits", [8, 8, 8, 8], 256),
+            # Small splits (job 1073124510)
+            ("small_splits", [64, 64, 64, 64], 256),
+            # Medium splits (jobs 1071926714+, 15.4% of failures)
+            ("medium_splits_6464", [6464, 6464, 6464, 6464], 256),
+            # Large variable splits (jobs 1073697055+)
+            ("large_splits_3M", [3150912, 3195328, 3209792, 3232192], 256),
+            # Large mixed splits (jobs 1073700557+)
+            ("large_mixed_splits_3M", [3242560, 3275200, 2848640, 2732224], 256),
+            # ~150K splits (job 1073949094)
+            ("splits_150K", [142016, 150464], 256),
+            # ~350K splits (job 1073034519)
+            ("splits_350K", [332976, 345080, 376008, 389112], 256),
+            # ~400K splits (job 1073034352)
+            ("splits_400K", [399960, 406384, 413344, 417880, 441560], 256),
+            # Variable row_dim (requested by reviewer)
+            ("row_dim_32", [549408, 555760, 558000, 562048], 32),
+            ("row_dim_128", [549408, 555760, 558000, 562048], 128),
+            # Edge: already aligned, no padding
+            ("already_aligned", [256, 512, 1024], 256),
+            # Edge: single-element splits
+            ("minimal_splits", [1, 2, 3], 256),
+        ]
+        for name, original_splits, row_dim in split_test_cases:
+            with self.subTest(name=name):
+                padded_splits = [
+                    split + (row_dim - split % row_dim) % row_dim
+                    for split in original_splits
+                ]
+
+                for ps in padded_splits:
+                    self.assertEqual(ps % row_dim, 0)
+
+                self.assertGreaterEqual(sum(padded_splits), sum(original_splits))
+
+                quant_codec = get_qcomm_codecs(
+                    QCommsConfig(
+                        forward_precision=CommType.FP8,
+                        fp8_quantize_dim=row_dim,
+                    )
+                )
+                ctx = quant_codec.forward.create_context()
+                for ps in padded_splits:
+                    size = quant_codec.forward.calc_quantized_size(ps, ctx)
+                    self.assertGreater(size, 0)
+
+                q_splits = [
+                    quant_codec.forward.calc_quantized_size(ps, ctx)
+                    for ps in padded_splits
+                ]
+                q_total = quant_codec.forward.calc_quantized_size(
+                    sum(padded_splits), ctx
+                )
+                self.assertEqual(sum(q_splits), q_total)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "1"})
+    def test_fp8_rowwise_padding_flag_enabled(self) -> None:
+        """When flag is set to '1', FP8 padding should be applied."""
+        row_dim = 256
+        batch_size = 16
+        dim_sum_per_rank = [259, 131]
+        my_rank = 0
+        dim_sum = dim_sum_per_rank[my_rank]
+
+        input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+
+        padded_dim, padding_size = quant_codec.forward.padded_size(
+            input_tensor, dim_sum_per_rank, my_rank, ctx
+        )
+
+        self.assertGreater(padding_size, 0)
+        self.assertEqual(padded_dim % row_dim, 0)
+        self.assertEqual(padded_dim, dim_sum + padding_size)
+
+    @patch.dict(os.environ, {"TORCHREC_ENABLE_FP8_ROWWISE_PADDING": "0"})
+    def test_fp8_rowwise_padding_flag_disabled(self) -> None:
+        """When flag is set to '0', FP8 padding should NOT be applied."""
+        row_dim = 256
+        batch_size = 16
+        dim_sum_per_rank = [259, 131]
+        my_rank = 0
+        dim_sum = dim_sum_per_rank[my_rank]
+
+        input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+
+        quant_codec = get_qcomm_codecs(
+            QCommsConfig(
+                forward_precision=CommType.FP8,
+                fp8_quantize_dim=row_dim,
+            )
+        )
+        ctx = quant_codec.forward.create_context()
+
+        padded_dim, padding_size = quant_codec.forward.padded_size(
+            input_tensor, dim_sum_per_rank, my_rank, ctx
+        )
+
+        self.assertEqual(padding_size, 0)
+        self.assertEqual(padded_dim, dim_sum)
+
+    def test_fp8_rowwise_padding_flag_default(self) -> None:
+        """When env var is not set, FP8 padding should NOT be applied (default off)."""
+        env = os.environ.copy()
+        env.pop("TORCHREC_ENABLE_FP8_ROWWISE_PADDING", None)
+        with patch.dict(os.environ, env, clear=True):
+            row_dim = 256
+            batch_size = 16
+            dim_sum_per_rank = [259, 131]
+            my_rank = 0
+            dim_sum = dim_sum_per_rank[my_rank]
+
+            input_tensor = torch.rand((batch_size, dim_sum), requires_grad=False)
+
+            quant_codec = get_qcomm_codecs(
+                QCommsConfig(
+                    forward_precision=CommType.FP8,
+                    fp8_quantize_dim=row_dim,
+                )
+            )
+            ctx = quant_codec.forward.create_context()
+
+            padded_dim, padding_size = quant_codec.forward.padded_size(
+                input_tensor, dim_sum_per_rank, my_rank, ctx
+            )
+
+            self.assertEqual(padding_size, 0)
+            self.assertEqual(padded_dim, dim_sum)
 
     @settings(deadline=4000)
     @given(


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5673


X-link: https://github.com/facebookresearch/FBGEMM/pull/2615

FP8 rowwise quantization requires `input_len % row_dim == 0` for the per-row reshape. This crashes during eval when `B_local * D_rank_sum` is not divisible by `fp8_quantize_row_dim` (typically 256) caused by small eval batch sizes combined with irregular per-rank embedding dimension sums from column-based sharding.

Here is an example of failed job = f1068622657

The fix adds FP8 padding mirroring the existing MX4 padding pattern:

1. `quantize_comm.py`: Extend `padded_size`() with an FP8 branch that pads each rank's `D_rank_sum` to the next multiple of row_dim.
1. `comm_ops.py` (fixed-batch paths): Wire `padded_size()` into `all2all_pooled_sync()` (which was missing it) and fix `All2All_Pooled_Req.forward()`. Both paths now pad the 2D tensor with `F.pad(input_embeddings, (0, padding_size))` before encoding, use `padded_dim_sum_per_rank` for split sizes, and strip padding after decoding.
1. `comm_ops.py` (variable-batch paths): Add per-split padding to `variable_batch_all2all_pooled_sync()` and `Variable_Batch_All2All_Pooled_Req.forward()`. Each split is padded to the next multiple of `row_dim`, the 1D tensor is padded to match, and the output is truncated after decoding.

Padding is zero-filled before communication and stripped after. No impact on model output.

Reviewed By: spcyppt

Differential Revision: D100069631


