### PR TITLE
Fix _batch_tensor_size to handle dataclass batches

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -8,6 +8,7 @@
 # pyre-strict
 import contextlib
 import copy
+import dataclasses
 import logging
 from collections import defaultdict, deque
 from concurrent.futures import Future
@@ -94,18 +95,19 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _batch_tensor_size(batch: Any) -> int:
-    """Compute total tensor storage size in bytes for a batch.
-
-    Uses pytree to flatten the batch into leaf tensors, then sums
-    element_size() * numel() for each. All operations are O(1) tensor
-    metadata reads — no data is accessed.
-    """
+    """Compute total tensor storage size in bytes for a batch."""
+    if isinstance(batch, torch.Tensor):
+        return batch.element_size() * batch.numel()
     leaves, _ = tree_flatten(batch)
-    return sum(
-        leaf.element_size() * leaf.numel()
-        for leaf in leaves
-        if isinstance(leaf, torch.Tensor)
-    )
+    if len(leaves) == 1 and leaves[0] is batch:
+        # pytree didn't decompose it — try dataclass fields
+        if dataclasses.is_dataclass(batch) and not isinstance(batch, type):
+            return sum(
+                _batch_tensor_size(getattr(batch, f.name))
+                for f in dataclasses.fields(batch)
+            )
+        return 0
+    return sum(_batch_tensor_size(leaf) for leaf in leaves)
 
 
 def _to_device(


### PR DESCRIPTION
Summary:
I noticed on scuba inplace copy batch was only logging 0.0 GB being stored, this is incorrect. 


`_batch_tensor_size` was returning 0 for all batches because `tree_flatten` does not decompose dataclass types that are not registered with pytree. The typical production batch type (e.g. `ModelInput`) is a dataclass extending `Pipelineable` with no pytree registration -- `tree_flatten` treated it as an opaque leaf, and since it is not a `torch.Tensor`, it was filtered out, yielding 0 bytes. This caused all `inplace_copy_batch size` Scuba logs (D101420284) to report `0.00 GB`.

Fix: make `_batch_tensor_size` recursive. First check if the input is a plain tensor (short-circuit). If `tree_flatten` returns the input unchanged, fall back to walking dataclass fields via `dataclasses.fields()`. This handles the full hierarchy: dataclass batch -> KJT/KeyedTensor fields (pytree-registered) -> leaf tensors.

Differential Revision: D102049994


