### PR TITLE
Fix VBE merging crash for DP tables with multi-TBE groups

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -787,7 +787,15 @@ class GroupedPooledEmbeddingsLookup(
         splits = []
         for config, features in zip(self.grouped_configs, features_by_group):
             embedding_dim_per_key = config.embedding_dims()
-            stride_per_rank_per_key = list(zip(*features.stride_per_key_per_rank()))
+            stride_per_key_per_rank = features.stride_per_key_per_rank()
+            stride_per_rank_per_key = list(zip(*stride_per_key_per_rank))
+            n_ranks = len(stride_per_rank_per_key)
+            if n_ranks != self._world_size and n_ranks > 0:
+                raise ValueError(
+                    f"stride_per_key_per_rank has {n_ranks} ranks but "
+                    f"world_size is {self._world_size}. "
+                    f"keys={features.keys()}"
+                )
             splits.append(
                 [
                     stride * dim
@@ -995,9 +1003,23 @@ class GroupedPooledEmbeddingsLookup(
 
         features_by_group = sparse_features.split(self._feature_splits)
 
-        # If VBE is enabled and mulitple TBEs are involved, we need to merge the
-        # output
+        # If VBE is enabled and multiple TBEs are involved, we need to merge
+        # the output. The pre-allocated merging path requires TBE modules that
+        # support vbe_output/vbe_output_offsets (SplitTable, SSD). Dense TBE
+        # modules create their own output, so use simple concatenation instead.
         if is_vbe_enabled and len(self._emb_modules) > 1:
+            n_dense = sum(
+                isinstance(m, BatchedDenseEmbeddingBag) for m in self._emb_modules
+            )
+            if n_dense == len(self._emb_modules):
+                embeddings = self._forward(features_by_group)
+                return torch.cat(embeddings, dim=0)
+            elif n_dense > 0:
+                raise ValueError(
+                    f"VBE merging does not support mixed Dense and Split/SSD "
+                    f"TBE modules. Got {n_dense} Dense out of "
+                    f"{len(self._emb_modules)} total modules."
+                )
             return self._forward_with_vbe_merging(
                 features_by_group, device=sparse_features.device()
             )

--- a/torchrec/distributed/tests/test_embedding_lookup.py
+++ b/torchrec/distributed/tests/test_embedding_lookup.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import MagicMock
+
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.modules.embedding_configs import DataType, PoolingType
+
+
+def _make_config(
+    num_tables: int = 1,
+    features_per_table: int = 2,
+    local_cols: int = 16,
+) -> GroupedEmbeddingConfig:
+    tables = []
+    feat_idx = 0
+    for t in range(num_tables):
+        feature_names = [f"feature_{feat_idx + j}" for j in range(features_per_table)]
+        feat_idx += features_per_table
+        tables.append(
+            ShardedEmbeddingTable(
+                name=f"table_{t}",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                is_weighted=False,
+                has_feature_processor=False,
+                compute_kernel=EmbeddingComputeKernel.DENSE,
+                embedding_dim=local_cols,
+                local_cols=local_cols,
+                num_embeddings=100,
+                feature_names=feature_names,
+            )
+        )
+    return GroupedEmbeddingConfig(
+        data_type=DataType.FP32,
+        pooling=PoolingType.SUM,
+        is_weighted=False,
+        has_feature_processor=False,
+        compute_kernel=EmbeddingComputeKernel.DENSE,
+        embedding_tables=tables,
+    )
+
+
+def _make_features_mock(
+    stride_per_key_per_rank: list[list[int]],
+    keys: list[str],
+) -> MagicMock:
+    mock = MagicMock()
+    mock.stride_per_key_per_rank.return_value = stride_per_key_per_rank
+    mock.keys.return_value = keys
+    return mock
+
+
+def _make_lookup_mock(
+    grouped_configs: list[GroupedEmbeddingConfig],
+    world_size: int,
+) -> MagicMock:
+    mock = MagicMock(spec=GroupedPooledEmbeddingsLookup)
+    mock.grouped_configs = grouped_configs
+    mock._world_size = world_size
+    return mock
+
+
+class VbeSplitsTest(unittest.TestCase):
+    def test_vbe_splits_normal_cases(self) -> None:
+        with self.subTest("ranks_match_world_size"):
+            config = _make_config(num_tables=1, features_per_table=2, local_cols=16)
+            features = _make_features_mock(
+                stride_per_key_per_rank=[[2, 3], [1, 4]],
+                keys=["feature_0", "feature_1"],
+            )
+            lookup = _make_lookup_mock([config], world_size=2)
+            result = GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
+            self.assertEqual(result[0], [32, 16, 48, 64])
+
+        with self.subTest("world_size_one"):
+            config = _make_config(num_tables=1, features_per_table=2, local_cols=16)
+            features = _make_features_mock(
+                stride_per_key_per_rank=[[4], [6]],
+                keys=["feature_0", "feature_1"],
+            )
+            lookup = _make_lookup_mock([config], world_size=1)
+            result = GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
+            self.assertEqual(result[0], [64, 96])
+
+        with self.subTest("multiple_tables_single_group"):
+            config = _make_config(num_tables=2, features_per_table=1, local_cols=16)
+            features = _make_features_mock(
+                stride_per_key_per_rank=[[3, 2], [7, 5]],
+                keys=["feature_0", "feature_1"],
+            )
+            lookup = _make_lookup_mock([config], world_size=2)
+            result = GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
+            self.assertEqual(result[0], [48, 112, 32, 80])
+
+        with self.subTest("multi_tbe_groups"):
+            config_a = _make_config(num_tables=1, features_per_table=2, local_cols=16)
+            config_b = _make_config(num_tables=1, features_per_table=1, local_cols=32)
+            features_a = _make_features_mock(
+                stride_per_key_per_rank=[[2, 3], [1, 4]],
+                keys=["feature_0", "feature_1"],
+            )
+            features_b = _make_features_mock(
+                stride_per_key_per_rank=[[5, 2]],
+                keys=["feature_2"],
+            )
+            lookup = _make_lookup_mock([config_a, config_b], world_size=2)
+            result = GroupedPooledEmbeddingsLookup._vbe_splits(
+                lookup, [features_a, features_b]
+            )
+            self.assertEqual(len(result), 2)
+            self.assertEqual(result[0], [32, 16, 48, 64])
+            self.assertEqual(result[1], [160, 64])
+
+    def test_vbe_splits_rank_mismatch_error(self) -> None:
+        with self.subTest("n_ranks_greater_than_world_size"):
+            config = _make_config(num_tables=1, features_per_table=2, local_cols=16)
+            features = _make_features_mock(
+                stride_per_key_per_rank=[[2, 3, 1], [1, 4, 2]],
+                keys=["feature_0", "feature_1"],
+            )
+            lookup = _make_lookup_mock([config], world_size=2)
+            with self.assertRaises(ValueError) as ctx:
+                GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
+            self.assertIn("3 ranks", str(ctx.exception))
+            self.assertIn("world_size is 2", str(ctx.exception))
+
+        with self.subTest("n_ranks_less_than_world_size"):
+            config = _make_config(num_tables=1, features_per_table=2, local_cols=16)
+            features = _make_features_mock(
+                stride_per_key_per_rank=[[2], [1]],
+                keys=["feature_0", "feature_1"],
+            )
+            lookup = _make_lookup_mock([config], world_size=4)
+            with self.assertRaises(ValueError) as ctx:
+                GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
+            self.assertIn("1 ranks", str(ctx.exception))
+            self.assertIn("world_size is 4", str(ctx.exception))


### PR DESCRIPTION
Summary:
`GroupedPooledEmbeddingsLookup._forward_with_vbe_merging` crashes with `ValueError: expected sequence of length N at dim 1 (got 0)` when a `GroupedPooledEmbeddingsLookup` has multiple TBE modules and VBE (Variable Batch per Embedding) is enabled.

**Root cause (confirmed via diagnostic run f1070151941):** Data Parallel (DP) dense embedding tables are grouped into separate TBE modules (by compute kernel). When VBE is enabled, the multi-TBE merging path is triggered. This path pre-allocates a shared output tensor and uses `vbe_output_offsets` to let each TBE write its portion. But `DenseTableBatchedEmbeddingBagsCodegen` does not support `vbe_output`/`vbe_output_offsets` — it creates its own output tensor, silently discarding the pre-allocated buffer. With multiple Dense TBE groups, only the last group's output survives.

Additionally, DP tables report `stride_per_key_per_rank` with only 1 rank entry (uniform batch). The previous code had no guard for stride rank count mismatches, producing ragged offset tensors that crash `torch.tensor()`.

**Fix (two changes):**

1. **Dense TBE VBE routing:** In `forward()`, when VBE is enabled with multiple TBE modules: if all modules are `BatchedDenseEmbeddingBag`, bypass the pre-allocated merging path and use `torch.cat(dim=0)` on individual outputs instead. Dense TBE produces local-rank 1D output in feature order — concatenation preserves this layout. For mixed Dense + Split/SSD modules, raise a clear `ValueError` since no valid merging strategy exists.

2. **Stride rank count validation:** In `_vbe_splits()`, raise a `ValueError` when the transposed stride data has a different number of ranks than `world_size`. This replaces the previous silent failure (ragged offsets → opaque `torch.tensor` crash) with an actionable error message.

**NE safety:** No embeddings are dropped. Dense TBE concatenation produces the same 1D output layout as a single Dense TBE (features in order, rank-major within each feature). Non-Dense TBE groups are completely unaffected — the pre-allocated merging path is unchanged.

**No behavioral change for existing models:** The Dense TBE routing only activates when `is_vbe_enabled and len(emb_modules) > 1 and all modules are BatchedDenseEmbeddingBag`. Models without VBE, with single-TBE groups, or with Split/SSD modules follow the exact same code paths as before.

Reviewed By: kausv

Differential Revision: D101844975


