### PR TITLE
feat: add per-table table_constraints event (#4162)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -381,4 +381,9 @@ def log_kernel_changed(
     pass
 
 
+def log_table_assignment(best_plan: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -386,4 +386,9 @@ def log_table_assignment(best_plan: List, planner_type: str = "", technique: Opt
     pass
 
 
+def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -104,6 +104,7 @@ try:
         log_planning_result,
         log_storage_reservation,
         log_table_assignment,
+        log_table_constraints,
     )
 except Exception:
     torch._C._log_api_usage_once(
@@ -123,6 +124,9 @@ except Exception:
         pass
 
     def log_table_assignment(*args, **kwargs) -> None:
+        pass
+
+    def log_table_constraints(*args, **kwargs) -> None:
         pass
 
 
@@ -637,6 +641,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 ),
             }
         )
+        if self._constraints:
+            log_table_constraints(self._constraints, self.__class__.__name__)
 
         search_space = self._enumerator.enumerate(
             module=module,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -103,6 +103,7 @@ try:
         log_planner_config,
         log_planning_result,
         log_storage_reservation,
+        log_table_assignment,
     )
 except Exception:
     torch._C._log_api_usage_once(
@@ -119,6 +120,9 @@ except Exception:
         pass
 
     def log_storage_reservation(*args, **kwargs) -> None:
+        pass
+
+    def log_table_assignment(*args, **kwargs) -> None:
         pass
 
 
@@ -784,6 +788,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             )
 
             log_offloading_summary(best_plan, self.__class__.__name__)
+            log_table_assignment(best_plan, self.__class__.__name__)
 
             return sharding_plan
         else:


### PR DESCRIPTION
Summary:

Log the parameter constraints passed to the planner per table (compute_kernels, sharding_types, initial CLF, enforce_hbm, SSD offloading). Emitted right after planner_config, before enumerate(), from both OSS and LP planners.

Reviewed By: eugeneshulgameta, hammad45

Differential Revision: D98000171


