### PR TITLE
Add logging for clear_input_dist_tensors size (#4166)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -646,21 +646,27 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
                 self._output_tensors.append(output_tensor)
                 self._awaitables.append(awaitable)
 
-    def clear_inputs(self) -> None:
+    def clear_inputs(self) -> int:
         """
         Clears input KJT tensors after wait.
+
+        Returns:
+            Total bytes freed.
         """
         if self._workers == 1 or is_torchdynamo_compiling():
-            return
+            return 0
 
         # Wait for all-to-all collectives to complete before freeing input storage.
         for awaitable in self._awaitables:
             awaitable.wait()
 
+        size = 0
         for tensor in self._input_tensors:
+            size += tensor.element_size() * tensor.numel()
             tensor.storage().resize_(0)
 
         self._input_tensors.clear()
+        return size
 
     def _wait_impl(self) -> KeyedJaggedTensor:
         """

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -232,11 +232,22 @@ def _clear_input_dist_tensors(context: TrainPipelineContext) -> None:
     complete and frees the input tensor storage early, before _wait_impl() is
     called during the model forward pass.
     """
+    size = 0
     for request in context.input_dist_tensors_requests.values():
         if isinstance(request, KJTListAwaitable):
             for awaitable in request.awaitables:
                 if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
-                    awaitable.clear_inputs()
+                    size += awaitable.clear_inputs()
+    if size > 0:
+
+        def get_size() -> str:
+            msg: str = (
+                f"clear_input_dist_tensors freed {size / 1024**3:.2f} GB ({size} bytes)"
+            )
+            logger.info(msg)
+            return msg
+
+        one_time_logger.info(LazyStr(get_size))
 
 
 def _start_data_dist(


### PR DESCRIPTION
Summary:

Add one-time logging to the `clear_data_dist_inputs` technique (AllToAll input tensor early freeing) to track how much GPU HBM is freed, matching the existing logging pattern for `inplace_copy_batch` (D101420284) and `free_features_storage_early`.

Changes:
1. `dist_data.py`: `KJTAllToAllTensorsAwaitable.clear_inputs()` now returns the total bytes freed. Computes `element_size() * numel()` for each input tensor before `storage().resize_(0)`. Return type changed from `None` to `int` (backward compatible — callers that ignored the return value continue to work).
2. `utils.py`: `_clear_input_dist_tensors()` accumulates the size returned by each `clear_inputs()` call and emits a one-time log via `one_time_logger` + `LazyStr`: `clear_input_dist_tensors X.XX GB`.

Performance: Zero steady-state overhead — size computation uses O(1) tensor metadata reads (`element_size() * numel()`), and `one_time_logger` caps at 1 emission per call site.

Context: The HBM Tax Audit post (https://docs.google.com/document/d/1Odt6oJJgvPDeVSQmQqrl3iUAl2yu_HPUVLJ92EqDiTI/edit?tab=t.0#heading=h.fsrrm7usmsx8) identified `clear_data_dist_inputs` as saving ~1x permuted KJT size. This logging gives visibility into that saving, similar to D101420284 for inplace_copy_batch.

Reviewed By: Fiery, TroyGarden

Differential Revision: D102179075


