### PR TITLE
Fix ThroughputMetric batch_size in train-eval phase transitions

### DIFF
--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -178,6 +178,9 @@ class ThroughputMetric(nn.Module):
         )
         self._steps = 0
 
+    def set_batch_size(self, batch_size: int) -> None:
+        self._batch_size = batch_size
+
     def _get_batch_size(self) -> int:
         # No batch size stages, use the default batch size
         if not self._batch_size_stages:


### PR DESCRIPTION
Summary:
`ThroughputMetric` computes `total_examples` as `batch_size * world_size` per step, but the `batch_size` is set once during init from the training config and never updated when transitioning to eval. If train and eval use different batch sizes (e.g., train=512, eval=2048), `total_examples` during eval is miscalculated — in the search engagement MTML case, undercounted by 4x (~112M reported vs ~448M actual).

This affects any combined flow (`train-eval`, `train-eval-tune`, `train-publish-eval`, `eval-train-publish`, in-train eval) where the eval config specifies a different batch_size than training. Multiple model teams are affected (search_engagement_mtml, main_feed_mtml, marketplace/tab_cvr_mtml, wpr/fbr/vdd).

The fix passes the correct `batch_size` to `_reset_metrics()` at each phase transition, updating the `ThroughputMetric._batch_size` accordingly.

Differential Revision: D100217677


