### PR TITLE
Optimizer config and MRS wrapper for shampoo v3 in MVAI

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -70,6 +70,7 @@ class OptimType(Enum):
     SHAMPOO_V2_MRS = "SHAMPOO_V2_MRS"
     SHAMPOO_MRS = "SHAMPOO_MRS"
     MUON = "MUON"
+    SHAMPOO_V3_MRS = "SHAMPOO_V3_MRS"
 
 
 @unique


### PR DESCRIPTION
Summary:
## Summary

`[mvai][shampoo][v3] Optimizer config and MRS wrapper for shampoo v3 in MVAI`

This diff introduces the initial scaffolding for Shampoo V3 support in MVAI:

- **`ShampooV3Config`** (`fbcode/minimal_viable_ai/core/model_family_api/optimizer_configs.py`): a thin pass-through dataclass that holds the V3 backend's own dataclasses (preconditioner, grafting, iterate-averaging, distributed, weight-decay-type, PT2 compile, and runtime configs) directly, instead of re-hoisting individual fields like `ShampooV2Config` does. Includes an inline migration guide documenting the field-by-field translation from `ShampooV2Config` → `ShampooV3Config` (removed knobs, replacements, and net-new V3 options).
- **`V3MRSDistributedShampoo`** (`fbcode/torchrec/fb/optim/shampoo_wrapper.py`): an MRS wrapper subclass that adds the `mrs_class_exception_decorator` and Clippy update-direction shrinkage on top of the V3 `DistributedShampoo`. Asserts that legacy V2-only knobs (`exponent_multiplier`, `inv_root_override`) remain at defaults so V2 call sites don't silently break when migrating.
- **Optimizer plumbing** (`fbcode/minimal_viable_ai/core/model_family_api/optimizer.py`) to wire `ShampooV3Config` through the MFA optimizer factory into `V3MRSDistributedShampoo`.
- **Unit tests** (`fbcode/minimal_viable_ai/core/model_family_api/tests/optimizer_test.py`) covering the new config and wrapper paths.
- Minor touch in `fbcode/torchrec/distributed/embedding_types.py` to expose what V3 needs.

### Changes still needed

1. Incorporate `ClassicalMomentumConfig` in the wrapper (currently the iterate-averaging path is plumbed generically; need to ensure the classical-momentum config is accepted, validated, and forwarded to the V3 backend).
2. Re-link the wrapper and config to the new **V3 folder** instead of `hpc.optimizers.distributed_shampoo.dev`, and update the `ShampooV3Config` docstring / migration guide imports to reference the V3 module paths.

Reviewed By: renyiryry

Differential Revision: D102011378


