### PR TITLE
Update tbe.monitoring import in torchrec/distributed/types.py

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -29,13 +29,13 @@ from typing import (
     Union,
 )
 
-from fbgemm_gpu.runtime_monitor import TBEStatsReporterConfig
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
     KVZCHTBEConfig,
     MultiPassPrefetchConfig,
 )
+from fbgemm_gpu.tbe.monitoring import TBEStatsReporterConfig
 from torch.autograd.profiler import record_function
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.distributed_c10d import _get_object_coll_device


### PR DESCRIPTION
Summary:
Migrate TBEStatsReporterConfig import from fbgemm_gpu.runtime_monitor to
fbgemm_gpu.tbe.monitoring in torchrec/distributed/types.py.

Reviewed By: cthi

Differential Revision: D99748581


