### PR TITLE
KJT record_stream and clear_storage: cover _inverse_indices and _jt_dict (#4171)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2015,6 +2015,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         # legacy attribute, for backward compatabilibity
         self._variable_stride_per_key: Optional[bool] = None
 
+        # gates `_maybe_warn_cache_device_mismatch` to fire at most once per
+        # KeyedJaggedTensor instance (see `record_stream`/`clear_storage`).
+        self._cache_mismatch_warned: bool = False
+
         # validation logic
         if not torch.jit.is_scripting():
             _assert_tensor_has_no_elements_or_has_integers(offsets, "offsets")
@@ -2223,7 +2227,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         self._offset_per_key = kjt._offset_per_key
         self._index_per_key = kjt._index_per_key
         self._stride_per_key = kjt._stride_per_key
-        self._jt_dict = kjt._jt_dict
+        # Drop any cached per-key JaggedTensors: they reference tensors owned by
+        # `kjt` (potentially on a different device), so reusing them on `self`
+        # would leak foreign storage into operations like `record_stream()`.
+        self._jt_dict = None
 
         # tensor in-place copy
         self._values.copy_(kjt._values, non_blocking=non_blocking)
@@ -3048,19 +3055,55 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         self._jt_dict = jt_dict
 
     @torch.jit.unused
+    def _maybe_warn_cache_device_mismatch(self, field: str) -> None:
+        # Caches (`_jt_dict`, `_inverse_indices`) are normally device-consistent
+        # with `_values` because `to()`/`copy_()`/`pin_memory()` invalidate or
+        # migrate them. Construction paths that bypass those — direct ctor with
+        # mixed-device fields, FX tracing replays, deserialization round-trips,
+        # post-construction private-attribute mutation — can leave them stale.
+        # `record_stream`/`clear_storage` skip stale entries instead of touching
+        # foreign-device tensors; this hook surfaces that skip exactly once per
+        # instance so the underlying upstream bug is observable.
+        if self._cache_mismatch_warned:
+            return
+        self._cache_mismatch_warned = True
+        torch._C._log_api_usage_once("torchrec.sparse.kjt.cache_device_mismatch")
+        logger.warning(
+            "KeyedJaggedTensor cache field '%s' contains tensors on a "
+            "different device than self._values (%s); skipping. This usually "
+            "means the cache survived a device migration that bypassed "
+            "to() / copy_() / pin_memory().",
+            field,
+            self._values.device,
+        )
+
+    @torch.jit.unused
     #  inconsistently.
     # pyrefly: ignore[bad-override]
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         self._values.record_stream(stream)
         weights = self._weights
-        lengths = self._lengths
-        offsets = self._offsets
         if weights is not None:
             weights.record_stream(stream)
+        lengths = self._lengths
         if lengths is not None:
             lengths.record_stream(stream)
+        offsets = self._offsets
         if offsets is not None:
             offsets.record_stream(stream)
+        inverse_indices = self._inverse_indices
+        if inverse_indices is not None:
+            if inverse_indices[1].device == self._values.device:
+                inverse_indices[1].record_stream(stream)
+            else:
+                self._maybe_warn_cache_device_mismatch("inverse_indices")
+        jt_dict = self._jt_dict
+        if jt_dict is not None:
+            for jt in jt_dict.values():
+                if jt._values.device != self._values.device:
+                    self._maybe_warn_cache_device_mismatch("jt_dict")
+                    continue
+                jt.record_stream(stream)
 
     def to(
         self,
@@ -3090,7 +3133,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offset_per_key = self._offset_per_key
         index_per_key = self._index_per_key
         stride_per_key = self._stride_per_key
-        jt_dict = self._jt_dict
         inverse_indices = self._inverse_indices
         if inverse_indices is not None:
             inverse_indices = (
@@ -3126,7 +3168,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             lengths_offset_per_key=lengths_offset_per_key,
             offset_per_key=offset_per_key,
             index_per_key=index_per_key,
-            jt_dict=jt_dict,
+            jt_dict=None,
             inverse_indices=inverse_indices,
         )
 
@@ -3220,6 +3262,27 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         if self._weights is not None:
             size += self._weights.element_size() * self._weights.numel()
             self._weights.untyped_storage().resize_(0)
+        if self._inverse_indices is not None:
+            inv_tensor = self._inverse_indices[1]
+            if inv_tensor.device == self._values.device:
+                size += inv_tensor.element_size() * inv_tensor.numel()
+                inv_tensor.untyped_storage().resize_(0)
+            else:
+                self._maybe_warn_cache_device_mismatch("inverse_indices")
+        if self._jt_dict is not None:
+            # Cached JaggedTensors share `values`/`lengths`/`weights` storage
+            # with the parent KJT (already released above), but their `offsets`
+            # are freshly allocated by `to_dict()` and must be released here.
+            for jt in self._jt_dict.values():
+                jt_offsets = jt._offsets
+                if jt_offsets is None:
+                    continue
+                if jt_offsets.device != self._values.device:
+                    self._maybe_warn_cache_device_mismatch("jt_dict")
+                    continue
+                size += jt_offsets.element_size() * jt_offsets.numel()
+                jt_offsets.untyped_storage().resize_(0)
+            self._jt_dict = None
         return size
 
     def dist_tensors(self) -> List[torch.Tensor]:

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -10,6 +10,7 @@
 
 import unittest
 from typing import List, Tuple
+from unittest import mock
 
 import torch
 import torch.utils._pytree as pytree
@@ -1060,6 +1061,45 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         ).to(torch.device("cuda"))
         j.record_stream(torch.cuda.current_stream())
 
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_inverse_indices(self) -> None:
+        # record_stream is a CUDA allocator hint with no Python-observable state
+        # change. We verify it doesn't raise and tensors remain accessible.
+        inverse_indices_tensor = torch.tensor([0, 1, 0, 1], device="cuda")
+        kjt = KeyedJaggedTensor(
+            keys=["index_0", "index_1"],
+            values=torch.arange(6, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1, 1, 2], device="cuda"),
+            inverse_indices=(["index_0", "index_1"], inverse_indices_tensor),
+        )
+        kjt.record_stream(torch.cuda.current_stream())
+        self.assertEqual(kjt.values().numel(), 6)
+        self.assertEqual(kjt.inverse_indices()[1].numel(), 4)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_jt_dict(self) -> None:
+        # record_stream is a CUDA allocator hint with no Python-observable state
+        # change. We verify it doesn't raise and tensors remain accessible.
+        kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=["index_0", "index_1"],
+        ).to(torch.device("cuda"))
+        jt_dict = kjt.to_dict()
+        self.assertIsNotNone(kjt._jt_dict)
+        kjt.record_stream(torch.cuda.current_stream())
+        self.assertEqual(kjt.values().numel(), 8)
+        self.assertIn("index_0", jt_dict)
+        self.assertIn("index_1", jt_dict)
+        self.assertEqual(jt_dict["index_0"].values().numel(), 3)
+        self.assertEqual(jt_dict["index_1"].values().numel(), 5)
+
     def test_equality(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -1574,6 +1614,32 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertTrue(result_kjt.values().is_cuda)
         self.assertTrue(result_kjt.lengths().is_cuda)
 
+    def test_copy_invalidates_jt_dict(self) -> None:
+        # `copy_()` must drop any cached _jt_dict on the destination because the
+        # cached JaggedTensors reference the source KJT's tensors (potentially
+        # on a different device). Reusing them would leak foreign storage into
+        # operations like `record_stream()`.
+        keys = ["index_0", "index_1"]
+        source_kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=keys,
+        )
+        source_kjt.to_dict()
+        self.assertIsNotNone(source_kjt._jt_dict)
+
+        dest_kjt = KeyedJaggedTensor(
+            values=torch.zeros(8, dtype=torch.float),
+            keys=keys,
+            lengths=torch.tensor([2, 0, 1, 1, 1, 3]),
+        )
+        dest_kjt.to_dict()
+        dest_jt_dict_before = dest_kjt._jt_dict
+        self.assertIsNotNone(dest_jt_dict_before)
+
+        dest_kjt.copy_(source_kjt)
+        self.assertIsNone(dest_kjt._jt_dict)
+
     def test_clear_storage(self) -> None:
         kjt = KeyedJaggedTensor(
             values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
@@ -1590,6 +1656,171 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertEqual(kjt._values.untyped_storage().nbytes(), 0)
         self.assertEqual(kjt._lengths.untyped_storage().nbytes(), 0)
         self.assertEqual(kjt._weights.untyped_storage().nbytes(), 0)
+
+    def test_clear_storage_inverse_indices(self) -> None:
+        inverse_indices_tensor = torch.tensor([0, 1, 0, 1])
+        kjt = KeyedJaggedTensor(
+            values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            keys=["index_0", "index_1"],
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+            inverse_indices=(["index_0", "index_1"], inverse_indices_tensor),
+        )
+        self.assertGreater(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertGreater(inverse_indices_tensor.untyped_storage().nbytes(), 0)
+        kjt.clear_storage()
+        self.assertEqual(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertEqual(inverse_indices_tensor.untyped_storage().nbytes(), 0)
+
+    def test_clear_storage_jt_dict(self) -> None:
+        # `to_dict()` materializes per-key offset tensors that are NOT views
+        # into the parent KJT's storage. `clear_storage()` must release those
+        # cached offsets and drop the dict, otherwise HBM reclamation leaks.
+        kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=["index_0", "index_1"],
+        )
+        jt_dict = kjt.to_dict()
+        cached_offsets = [jt._offsets for jt in jt_dict.values()]
+        for offsets in cached_offsets:
+            self.assertIsNotNone(offsets)
+            assert offsets is not None
+            self.assertGreater(offsets.untyped_storage().nbytes(), 0)
+
+        kjt.clear_storage()
+        self.assertIsNone(kjt._jt_dict)
+        for offsets in cached_offsets:
+            assert offsets is not None
+            self.assertEqual(offsets.untyped_storage().nbytes(), 0)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_skips_cpu_inverse_indices_in_cuda_kjt(self) -> None:
+        # Stale `_inverse_indices` on a foreign device (e.g., FX-replay or
+        # direct ctor with mixed devices) must not be passed to record_stream.
+        # CPU tensors don't have streams; record_stream(cuda_stream) on a CPU
+        # tensor raises. The KJT must skip the foreign entry instead.
+        cpu_inverse_indices = torch.tensor([0, 1, 0, 1])
+        cuda_kjt = KeyedJaggedTensor(
+            keys=["index_0", "index_1"],
+            values=torch.arange(6, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1, 1, 2], device="cuda"),
+        )
+        cuda_kjt._inverse_indices = (["index_0", "index_1"], cpu_inverse_indices)
+        cuda_kjt.record_stream(torch.cuda.current_stream())
+        self.assertGreater(cpu_inverse_indices.untyped_storage().nbytes(), 0)
+        self.assertEqual(cuda_kjt.values().numel(), 6)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_skips_cpu_jt_dict_in_cuda_kjt(self) -> None:
+        # Stale `_jt_dict` whose entries live on a foreign device must not be
+        # passed to record_stream — `JaggedTensor.record_stream` would call
+        # `record_stream` on CPU tensors and raise. The KJT must skip them.
+        cpu_jt = JaggedTensor(
+            values=torch.arange(3, dtype=torch.float),
+            lengths=torch.tensor([2, 1]),
+        )
+        cuda_kjt = KeyedJaggedTensor(
+            keys=["index_0"],
+            values=torch.arange(3, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1], device="cuda"),
+        )
+        cuda_kjt._jt_dict = {"index_0": cpu_jt}
+        cuda_kjt.record_stream(torch.cuda.current_stream())
+        self.assertGreater(cpu_jt._values.untyped_storage().nbytes(), 0)
+        self.assertEqual(cuda_kjt.values().numel(), 3)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_clear_storage_skips_foreign_device_inverse_indices(self) -> None:
+        # `clear_storage` must not `resize_(0)` the storage of an
+        # `_inverse_indices` tensor it doesn't own (i.e., one on a different
+        # device than `_values`); doing so corrupts the foreign owner.
+        cpu_inverse_indices = torch.tensor([0, 1, 0, 1])
+        cuda_kjt = KeyedJaggedTensor(
+            keys=["index_0", "index_1"],
+            values=torch.arange(6, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1, 1, 2], device="cuda"),
+        )
+        cuda_kjt._inverse_indices = (["index_0", "index_1"], cpu_inverse_indices)
+        self.assertGreater(cuda_kjt._values.untyped_storage().nbytes(), 0)
+        self.assertGreater(cpu_inverse_indices.untyped_storage().nbytes(), 0)
+        cuda_kjt.clear_storage()
+        self.assertEqual(cuda_kjt._values.untyped_storage().nbytes(), 0)
+        self.assertGreater(cpu_inverse_indices.untyped_storage().nbytes(), 0)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_clear_storage_skips_foreign_device_jt_dict(self) -> None:
+        # `clear_storage` must not free the offset storage of a `_jt_dict`
+        # entry on a foreign device — that storage isn't ours to release.
+        cpu_offsets = torch.tensor([0, 2, 3])
+        cpu_jt = JaggedTensor(
+            values=torch.arange(3, dtype=torch.float),
+            lengths=torch.tensor([2, 1]),
+            offsets=cpu_offsets,
+        )
+        cuda_kjt = KeyedJaggedTensor(
+            keys=["index_0"],
+            values=torch.arange(3, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1], device="cuda"),
+        )
+        cuda_kjt._jt_dict = {"index_0": cpu_jt}
+        self.assertGreater(cpu_offsets.untyped_storage().nbytes(), 0)
+        cuda_kjt.clear_storage()
+        self.assertGreater(cpu_offsets.untyped_storage().nbytes(), 0)
+        # `clear_storage` always drops the dict, even when entries are skipped.
+        self.assertIsNone(cuda_kjt._jt_dict)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_cache_mismatch_warning_emitted_once(self) -> None:
+        # `_maybe_warn_cache_device_mismatch` is per-instance one-shot. A
+        # training loop with the same misbehaving KJT going through multiple
+        # record_stream / clear_storage calls must produce exactly one warning
+        # and one PyTorch API-usage event.
+        cuda_kjt = KeyedJaggedTensor(
+            keys=["index_0"],
+            values=torch.arange(3, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1], device="cuda"),
+        )
+        cuda_kjt._inverse_indices = (
+            ["index_0"],
+            torch.tensor([0, 1, 0]),
+        )
+        cuda_kjt._jt_dict = {
+            "index_0": JaggedTensor(
+                values=torch.arange(3, dtype=torch.float),
+                lengths=torch.tensor([2, 1]),
+            )
+        }
+        with mock.patch("torch._C._log_api_usage_once") as mock_api_usage:
+            with self.assertLogs(level="WARNING") as captured_logs:
+                cuda_kjt.record_stream(torch.cuda.current_stream())
+                cuda_kjt.record_stream(torch.cuda.current_stream())
+                cuda_kjt.clear_storage()
+
+        warning_records = [
+            r for r in captured_logs.records if "KeyedJaggedTensor" in r.getMessage()
+        ]
+        self.assertEqual(len(warning_records), 1)
+        api_usage_calls = [
+            c
+            for c in mock_api_usage.call_args_list
+            if c.args and c.args[0] == "torchrec.sparse.kjt.cache_device_mismatch"
+        ]
+        self.assertEqual(len(api_usage_calls), 1)
 
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):


### PR DESCRIPTION
Summary:

`KeyedJaggedTensor.record_stream()` only covered `_values`, `_weights`, `_lengths`, `_offsets`. Two tensor-bearing fields were missing:

1. `_inverse_indices` — a `Tuple[List[str], torch.Tensor]` where `[1]` is a GPU tensor used by VBE pipelines. Without `record_stream`, the caching allocator can recycle this memory while another CUDA stream is still reading it.

2. `_jt_dict` — a `Dict[str, JaggedTensor]` cache where each JaggedTensor holds GPU tensors. Without `record_stream`, consumers of `to_dict()` have unprotected tensor references.

Similarly, `clear_storage()` frees tensor backing memory via `untyped_storage().resize_(0)` but missed both `_inverse_indices[1]` and the per-key `offsets` tensors freshly allocated by `to_dict()` and held in `_jt_dict`, leaving live GPU allocations not tracked as freed.

This is a speculative fix for the #1 failure class on AMD (Athena/MI350X) hardware: 192 FAILURE events over 90 days with "Detected tensor(s) in the cudagraph pool not tracked as outputs." The untracked `_inverse_indices` tensor in the CUDAGraph pool is a plausible root cause.

### Cache-invalidation behavioral changes

Adding `_jt_dict` to `record_stream` exposed a latent bug: `copy_()` and `to()` were forwarding the cached `_jt_dict` from the source KJT, so the cache held tensors on a *foreign* device. The old `record_stream` only touched the owned tensors that `to()`/`copy_()` correctly migrate, so this was harmless — but iterating the stale cache and calling `record_stream` on its CPU-resident JTs raises `NotImplementedError: aten::record_stream from CPU backend`.

To fix:
- `copy_()` now drops `_jt_dict` (sets to `None`) instead of forwarding it.
- `to()` now passes `jt_dict=None` to the destination KJT instead of forwarding the source's cache. Matches what `pin_memory()` already does. The cache is rebuilt lazily on the next `to_dict()` access; recompute cost is negligible (Python dict construction over O(num_keys), no kernel launches).

### Device-mismatch defensive branches + observability

`record_stream` and `clear_storage` now skip cache entries whose tensors live on a different device than `self._values` (instead of raising or corrupting foreign storage). This shouldn't happen on the happy path — `to()`/`copy_()`/`pin_memory()` invalidate or migrate the caches — but construction paths that bypass them (direct ctor with mixed-device fields, FX-replay, deserialization round-trips, post-construction private-attribute mutation) can leave the caches stale.

When a stale cache is detected, a new helper `_maybe_warn_cache_device_mismatch` fires:
- A `logger.warning` (once per KJT instance, gated by `_cache_mismatch_warned`).
- `torch._C._log_api_usage_once("torchrec.sparse.kjt.cache_device_mismatch")` so the upstream bug rate is observable in Scuba.

Reviewed By: kausv

Differential Revision: D102543499


