### PR TITLE
KJT: centralize tensor enumeration in _all_tensors() helper (#4172)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2152,7 +2152,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         self._offset_per_key = kjt._offset_per_key
         self._index_per_key = kjt._index_per_key
         self._stride_per_key = kjt._stride_per_key
-        self._jt_dict = kjt._jt_dict
+        # Drop any cached per-key JaggedTensors: they reference tensors owned by
+        # `kjt` (potentially on a different device), so reusing them on `self`
+        # would leak foreign storage into operations like `record_stream()`.
+        self._jt_dict = None
 
         # tensor in-place copy
         self._values.copy_(kjt._values, non_blocking=non_blocking)
@@ -2975,14 +2978,21 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
         self._values.record_stream(stream)
         weights = self._weights
-        lengths = self._lengths
-        offsets = self._offsets
         if weights is not None:
             weights.record_stream(stream)
+        lengths = self._lengths
         if lengths is not None:
             lengths.record_stream(stream)
+        offsets = self._offsets
         if offsets is not None:
             offsets.record_stream(stream)
+        inverse_indices = self._inverse_indices
+        if inverse_indices is not None:
+            inverse_indices[1].record_stream(stream)
+        jt_dict = self._jt_dict
+        if jt_dict is not None:
+            for jt in jt_dict.values():
+                jt.record_stream(stream)
 
     def to(
         self,
@@ -3012,7 +3022,6 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         offset_per_key = self._offset_per_key
         index_per_key = self._index_per_key
         stride_per_key = self._stride_per_key
-        jt_dict = self._jt_dict
         inverse_indices = self._inverse_indices
         if inverse_indices is not None:
             inverse_indices = (
@@ -3048,7 +3057,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             lengths_offset_per_key=lengths_offset_per_key,
             offset_per_key=offset_per_key,
             index_per_key=index_per_key,
-            jt_dict=jt_dict,
+            jt_dict=None,
             inverse_indices=inverse_indices,
         )
 
@@ -3142,6 +3151,20 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         if self._weights is not None:
             size += self._weights.element_size() * self._weights.numel()
             self._weights.untyped_storage().resize_(0)
+        if self._inverse_indices is not None:
+            inv_tensor = self._inverse_indices[1]
+            size += inv_tensor.element_size() * inv_tensor.numel()
+            inv_tensor.untyped_storage().resize_(0)
+        if self._jt_dict is not None:
+            # Cached JaggedTensors share `values`/`lengths`/`weights` storage
+            # with the parent KJT (already released above), but their `offsets`
+            # are freshly allocated by `to_dict()` and must be released here.
+            for jt in self._jt_dict.values():
+                jt_offsets = jt._offsets
+                if jt_offsets is not None:
+                    size += jt_offsets.element_size() * jt_offsets.numel()
+                    jt_offsets.untyped_storage().resize_(0)
+            self._jt_dict = None
         return size
 
     def dist_tensors(self) -> List[torch.Tensor]:

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2973,22 +2973,32 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         return _jt_dict
 
     @torch.jit.unused
+    def _owned_tensors(self) -> List[torch.Tensor]:
+        """Returns tensors with independent storage owned by this KJT.
+
+        Used by clear_storage for byte accounting and storage freeing.
+        Excludes _jt_dict tensors because they are views sharing storage
+        with _values/_weights/_lengths. When adding a new tensor field
+        to KJT, add it here and all lifetime-management methods pick it
+        up automatically.
+        """
+        tensors = [self._values]
+        if self._weights is not None:
+            tensors.append(self._weights)
+        if self._lengths is not None:
+            tensors.append(self._lengths)
+        if self._offsets is not None:
+            tensors.append(self._offsets)
+        if self._inverse_indices is not None:
+            tensors.append(self._inverse_indices[1])
+        return tensors
+
+    @torch.jit.unused
     #  inconsistently.
     # pyrefly: ignore[bad-override]
     def record_stream(self, stream: torch.cuda.streams.Stream) -> None:
-        self._values.record_stream(stream)
-        weights = self._weights
-        if weights is not None:
-            weights.record_stream(stream)
-        lengths = self._lengths
-        if lengths is not None:
-            lengths.record_stream(stream)
-        offsets = self._offsets
-        if offsets is not None:
-            offsets.record_stream(stream)
-        inverse_indices = self._inverse_indices
-        if inverse_indices is not None:
-            inverse_indices[1].record_stream(stream)
+        for tensor in self._owned_tensors():
+            tensor.record_stream(stream)
         jt_dict = self._jt_dict
         if jt_dict is not None:
             for jt in jt_dict.values():
@@ -3134,27 +3144,16 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
     @torch.jit.unused
     def clear_storage(self) -> int:
         """
-        Frees the underlying storage of all internal tensors (_values, _lengths,
-        _offsets, _weights) by resizing their untyped storage to zero.
+        Frees the underlying storage of all internal tensors by resizing
+        their untyped storage to zero.
 
         The Python KJT object remains alive but its tensor data is released,
         allowing GPU HBM to be reclaimed early.
         """
-        size = self._values.element_size() * self._values.numel()
-        self._values.untyped_storage().resize_(0)
-        if self._lengths is not None:
-            size += self._lengths.element_size() * self._lengths.numel()
-            self._lengths.untyped_storage().resize_(0)
-        if self._offsets is not None:
-            size += self._offsets.element_size() * self._offsets.numel()
-            self._offsets.untyped_storage().resize_(0)
-        if self._weights is not None:
-            size += self._weights.element_size() * self._weights.numel()
-            self._weights.untyped_storage().resize_(0)
-        if self._inverse_indices is not None:
-            inv_tensor = self._inverse_indices[1]
-            size += inv_tensor.element_size() * inv_tensor.numel()
-            inv_tensor.untyped_storage().resize_(0)
+        size = 0
+        for tensor in self._owned_tensors():
+            size += tensor.element_size() * tensor.numel()
+            tensor.untyped_storage().resize_(0)
         if self._jt_dict is not None:
             # Cached JaggedTensors share `values`/`lengths`/`weights` storage
             # with the parent KJT (already released above), but their `offsets`

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1632,6 +1632,35 @@ class TestKeyedJaggedTensor(unittest.TestCase):
             assert offsets is not None
             self.assertEqual(offsets.untyped_storage().nbytes(), 0)
 
+    def test_clear_storage_no_double_count_jt_dict(self) -> None:
+        # `_jt_dict`'s cached values/weights/lengths are views sharing storage
+        # with the parent KJT, so they must not be counted again. The cached
+        # offsets ARE freshly allocated by `to_dict()` and are counted exactly
+        # once — accounted for separately from `_owned_tensors()`.
+        kjt = KeyedJaggedTensor(
+            values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            keys=["index_0", "index_1"],
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+            weights=torch.Tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        )
+        assert kjt._lengths is not None
+        assert kjt._weights is not None
+        owned_size = (
+            kjt._values.element_size() * kjt._values.numel()
+            + kjt._lengths.element_size() * kjt._lengths.numel()
+            + kjt._weights.element_size() * kjt._weights.numel()
+        )
+        # Populate _jt_dict — values/lengths/weights are views; offsets are fresh
+        jt_dict = kjt.to_dict()
+        self.assertIsNotNone(kjt._jt_dict)
+        cached_offsets_size = sum(
+            jt._offsets.element_size() * jt._offsets.numel()
+            for jt in jt_dict.values()
+            if jt._offsets is not None
+        )
+        actual_size = kjt.clear_storage()
+        self.assertEqual(actual_size, owned_size + cached_offsets_size)
+
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):
     def test_scriptable_forward(self) -> None:

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1000,6 +1000,45 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         ).to(torch.device("cuda"))
         j.record_stream(torch.cuda.current_stream())
 
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_inverse_indices(self) -> None:
+        # record_stream is a CUDA allocator hint with no Python-observable state
+        # change. We verify it doesn't raise and tensors remain accessible.
+        inverse_indices_tensor = torch.tensor([0, 1, 0, 1], device="cuda")
+        kjt = KeyedJaggedTensor(
+            keys=["index_0", "index_1"],
+            values=torch.arange(6, device="cuda", dtype=torch.float),
+            lengths=torch.tensor([2, 1, 1, 2], device="cuda"),
+            inverse_indices=(["index_0", "index_1"], inverse_indices_tensor),
+        )
+        kjt.record_stream(torch.cuda.current_stream())
+        self.assertEqual(kjt.values().numel(), 6)
+        self.assertEqual(kjt.inverse_indices()[1].numel(), 4)
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_record_stream_jt_dict(self) -> None:
+        # record_stream is a CUDA allocator hint with no Python-observable state
+        # change. We verify it doesn't raise and tensors remain accessible.
+        kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=["index_0", "index_1"],
+        ).to(torch.device("cuda"))
+        jt_dict = kjt.to_dict()
+        self.assertIsNotNone(kjt._jt_dict)
+        kjt.record_stream(torch.cuda.current_stream())
+        self.assertEqual(kjt.values().numel(), 8)
+        self.assertIn("index_0", jt_dict)
+        self.assertIn("index_1", jt_dict)
+        self.assertEqual(jt_dict["index_0"].values().numel(), 3)
+        self.assertEqual(jt_dict["index_1"].values().numel(), 5)
+
     def test_equality(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
@@ -1514,6 +1553,32 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertTrue(result_kjt.values().is_cuda)
         self.assertTrue(result_kjt.lengths().is_cuda)
 
+    def test_copy_invalidates_jt_dict(self) -> None:
+        # `copy_()` must drop any cached _jt_dict on the destination because the
+        # cached JaggedTensors reference the source KJT's tensors (potentially
+        # on a different device). Reusing them would leak foreign storage into
+        # operations like `record_stream()`.
+        keys = ["index_0", "index_1"]
+        source_kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=keys,
+        )
+        source_kjt.to_dict()
+        self.assertIsNotNone(source_kjt._jt_dict)
+
+        dest_kjt = KeyedJaggedTensor(
+            values=torch.zeros(8, dtype=torch.float),
+            keys=keys,
+            lengths=torch.tensor([2, 0, 1, 1, 1, 3]),
+        )
+        dest_kjt.to_dict()
+        dest_jt_dict_before = dest_kjt._jt_dict
+        self.assertIsNotNone(dest_jt_dict_before)
+
+        dest_kjt.copy_(source_kjt)
+        self.assertIsNone(dest_kjt._jt_dict)
+
     def test_clear_storage(self) -> None:
         kjt = KeyedJaggedTensor(
             values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
@@ -1530,6 +1595,42 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         self.assertEqual(kjt._values.untyped_storage().nbytes(), 0)
         self.assertEqual(kjt._lengths.untyped_storage().nbytes(), 0)
         self.assertEqual(kjt._weights.untyped_storage().nbytes(), 0)
+
+    def test_clear_storage_inverse_indices(self) -> None:
+        inverse_indices_tensor = torch.tensor([0, 1, 0, 1])
+        kjt = KeyedJaggedTensor(
+            values=torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            keys=["index_0", "index_1"],
+            lengths=torch.IntTensor([1, 0, 2, 3]),
+            inverse_indices=(["index_0", "index_1"], inverse_indices_tensor),
+        )
+        self.assertGreater(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertGreater(inverse_indices_tensor.untyped_storage().nbytes(), 0)
+        kjt.clear_storage()
+        self.assertEqual(kjt._values.untyped_storage().nbytes(), 0)
+        self.assertEqual(inverse_indices_tensor.untyped_storage().nbytes(), 0)
+
+    def test_clear_storage_jt_dict(self) -> None:
+        # `to_dict()` materializes per-key offset tensors that are NOT views
+        # into the parent KJT's storage. `clear_storage()` must release those
+        # cached offsets and drop the dict, otherwise HBM reclamation leaks.
+        kjt = KeyedJaggedTensor.from_offsets_sync(
+            offsets=torch.tensor([0, 2, 2, 3, 4, 5, 8]),
+            values=torch.arange(8, dtype=torch.float),
+            keys=["index_0", "index_1"],
+        )
+        jt_dict = kjt.to_dict()
+        cached_offsets = [jt._offsets for jt in jt_dict.values()]
+        for offsets in cached_offsets:
+            self.assertIsNotNone(offsets)
+            assert offsets is not None
+            self.assertGreater(offsets.untyped_storage().nbytes(), 0)
+
+        kjt.clear_storage()
+        self.assertIsNone(kjt._jt_dict)
+        for offsets in cached_offsets:
+            assert offsets is not None
+            self.assertEqual(offsets.untyped_storage().nbytes(), 0)
 
 
 class TestKeyedJaggedTensorScripting(unittest.TestCase):


### PR DESCRIPTION
Summary:

Refactors `record_stream` and `clear_storage` to delegate to a single `_all_tensors()` method that returns every GPU-backed tensor owned by the KJT. This ensures all lifetime-management methods (`record_stream`, `clear_storage`) automatically cover the same set of tensors.

Previously, each method independently enumerated `_values`, `_weights`, `_lengths`, `_offsets`, `_inverse_indices`, and `_jt_dict`. When new tensor fields were added (like `_inverse_indices`), the enumeration lists drifted — which is exactly the bug D102543499 fixed.

With this change, adding a new tensor field to KJT requires updating only `_all_tensors()`, and all downstream methods pick it up automatically.

Differential Revision: D102543808


