### PR TITLE
Fix list-to-list copy in _load_from_state_dict for CW sharding

### DIFF
--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -355,6 +355,16 @@ class ShardedQuantEmbeddingModuleState(
                 for t in dst_tensor:
                     assert isinstance(t, torch.Tensor)
                     t.copy_(src_tensor)
+            elif isinstance(dst_tensor, list) and isinstance(src_tensor, list):
+                # sharded CW to sharded CW qscale, qbias (many to many)
+                assert len(dst_tensor) == len(src_tensor), (
+                    f"Mismatched list lengths: dst has {len(dst_tensor)} elements, "
+                    f"src has {len(src_tensor)} elements"
+                )
+                for dst_t, src_t in zip(dst_tensor, src_tensor):
+                    assert isinstance(dst_t, torch.Tensor)
+                    assert isinstance(src_t, torch.Tensor)
+                    dst_t.copy_(src_t)
             else:
                 dst_tensor.copy_(src_tensor)
 

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -297,6 +297,80 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
     )
+    def test_quant_pred_state_dict_cw_list_copy(self) -> None:
+        """Regression test: CW sharding with qsplitscalebias produces list-valued
+        qscale/qbias in state_dict. Copying between two identically-sharded models
+        must handle list-to-list copy (not just tensor-to-list)."""
+        device = torch.device("cuda:0")
+
+        model = TestSparseNN(
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+            num_float_features=10,
+            dense_device=device,
+            sparse_device=torch.device("meta"),
+        )
+        quant_model = quantize(
+            model,
+            inplace=True,
+            output_type=torch.half,
+            quant_state_dict_split_scale_bias=True,
+        )
+        model.training = False
+
+        sharder = cast(
+            ModuleSharder[torch.nn.Module],
+            TestQuantEBCSharder(
+                sharding_type=ShardingType.COLUMN_WISE.value,
+                kernel_type=EmbeddingComputeKernel.QUANT.value,
+            ),
+        )
+
+        dmp = DistributedModelParallel(
+            quant_model,
+            sharders=[sharder],
+            device=device,
+            env=ShardingEnv.from_local(world_size=2, rank=0),
+            init_data_parallel=False,
+        )
+
+        dmp_copy = DistributedModelParallel(
+            quant_model,
+            sharders=[
+                cast(
+                    ModuleSharder[torch.nn.Module],
+                    TestQuantEBCSharder(
+                        sharding_type=ShardingType.COLUMN_WISE.value,
+                        kernel_type=EmbeddingComputeKernel.QUANT.value,
+                    ),
+                )
+            ],
+            device=device,
+            env=ShardingEnv.from_local(world_size=2, rank=0),
+            init_data_parallel=False,
+        )
+
+        _, local_batch = ModelInput.generate(
+            batch_size=16,
+            world_size=1,
+            num_float_features=10,
+            tables=self.tables,
+            weighted_tables=self.weighted_tables,
+        )
+
+        # This triggers _load_from_state_dict where both src and dst
+        # qscale/qbias are List[Tensor] for CW sharding.
+        # pyrefly: ignore[bad-argument-type]
+        dmp_copy.load_state_dict(dmp.state_dict())
+        torch.testing.assert_close(
+            dmp(local_batch[0].to(device)).cpu(),
+            dmp_copy(local_batch[0].to(device)).cpu(),
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs available",
+    )
     @given(
         output_type=st.sampled_from(
             [


### PR DESCRIPTION
Summary:
When copying state between two identically-sharded quantized models using column_wise sharding with quant_state_dict_split_scale_bias=True, the weight_qscale and weight_qbias entries in the state dict are stored as List[torch.Tensor] (one tensor per CW shard). The _load_from_state_dict method was missing a branch for the case where both src and dst are lists, causing it to fall through to the generic `dst_tensor.copy_(src_tensor)` which fails with `AttributeError: 'list' object has no attribute 'copy_'`.

Added an `elif isinstance(dst_tensor, list) and isinstance(src_tensor, list)` branch that asserts equal lengths and copies element-by-element. Also added a deterministic regression test that hardcodes COLUMN_WISE + qsplitscalebias=True to ensure this path is always exercised (the existing Hypothesis-based test only picks 2 of 8 parameter combos per run).

Reviewed By: isururanawaka

Differential Revision: D102630783
