### PR TITLE
Tighten _collective_tag_from: NUL separator and standard FNV-1a mixing (#4177)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -83,16 +83,26 @@ def _collective_tag_from(*parts: object) -> int:
     The current call sites use int64 splits tensors, so a wider hash is
     available in principle. The int32 cap is intentional forward-compat:
     it guarantees the tag fits in any reasonable signed-integer splits dtype
-    without wrapping negative. 31 bits (~2.1B buckets) leaves collision risk
+    without wrapping negative. Mixing runs in full 32-bit FNV-1a state and is
+    narrowed to 31 bits only at return; ~2.1B buckets leaves collision risk
     negligible for the small number of distinct collective sites in flight
     per process group.
     """
+    # NUL separator (not ",") so str() of parts that themselves contain commas
+    # cannot collide with a different parts arity. Collective identifier parts
+    # (Python identifiers, sharding plan ints, container reprs) never contain
+    # \x00, so this separator is unambiguous in practice.
+    #
+    # In-loop mask is 0xFFFFFFFF (full 32-bit FNV-1a state); narrowing to
+    # signed int32 happens once at return. Masking to 31 bits inside the loop
+    # would discard bit 31 every iteration and weaken the avalanche relative
+    # to the reference algorithm without any benefit.
     h = 0x811C9DC5
-    for b in ",".join(str(p) for p in parts).encode():
-        h = ((h ^ b) * 0x01000193) & 0x7FFFFFFF
-    # Mask after the loop too: the FNV-1a seed (0x811C9DC5) exceeds
-    # signed-int32 max, so empty `parts` would skip the in-loop mask
-    # and return a value that violates the int32-fit contract.
+    for b in "\x00".join(str(p) for p in parts).encode():
+        h = ((h ^ b) * 0x01000193) & 0xFFFFFFFF
+    # Post-loop mask still handles the empty-parts case: the FNV-1a seed
+    # (0x811C9DC5) exceeds signed-int32 max, so without this mask an empty
+    # call would violate the int32-fit contract.
     return h & 0x7FFFFFFF
 
 

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -1629,6 +1629,17 @@ class CollectiveTagFromTest(unittest.TestCase):
             _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3),
         )
 
+    def test_separator_is_unambiguous(self) -> None:
+        # Regression: with a "," separator, _collective_tag_from("a", "b") and
+        # _collective_tag_from("a,b") both serialize to the bytes b"a,b" and
+        # collide, silently disabling validation for any future call site that
+        # passes raw strings containing commas. The NUL separator avoids the
+        # collision because collective identifier parts cannot contain \x00.
+        self.assertNotEqual(
+            _collective_tag_from("a", "b"),
+            _collective_tag_from("a,b"),
+        )
+
 
 class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
     def setUp(self) -> None:


### PR DESCRIPTION
Summary:

Two reviewer-flagged improvements to the `_collective_tag_from` helper added in D101254817. Both are latent-fragility fixes — neither is an active bug today — but each is a one-line change that aligns the implementation with reference behavior, so worth taking now before new call sites accumulate.

1. Use `\x00` as the part separator instead of `,`. With the comma separator, `_collective_tag_from("a", "b")` and `_collective_tag_from("a,b")` both serialize to the bytes `b"a,b"` and produce the same hash. Today's call sites are safe by accident — `input.keys()` and `tuple(self._splits)` carry their own brackets/parens in `str()` — but a future caller that passes raw strings (e.g., flattening a list into varargs) would silently collide, and the failure mode is the worst possible: validation appears to be working but doesn't catch real mismatches. NUL is unambiguous in practice because collective identifier parts (Python identifiers, sharding plan ints, container reprs) never contain `\x00`.

2. Use `& 0xFFFFFFFF` inside the FNV-1a loop, narrow to `& 0x7FFFFFFF` only at return. Reference FNV-1a 32-bit operates on full 32-bit state inside the loop; masking to 31 bits per iteration discards bit 31 each round and weakens the avalanche. The split (32-bit mixing, 31-bit final) preserves standard FNV-1a state evolution while still satisfying the int32-fit contract that `SplitsAllToAllAwaitable` relies on. The post-loop mask still handles the empty-parts case (FNV-1a seed 0x811C9DC5 exceeds signed-int32 max).

No persistence concern from the hash output change: tags are computed per-call and consumed in the same all2all, never stored. As long as all ranks run the same version they compute the same tag, which is the only invariant the validation depends on.

Reviewed By: Ali-Tehrani

Differential Revision: D102094132


