### PR TITLE
Fix device mismatch in KJT permute for fbgemm sparse ops

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2798,7 +2798,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 permuted_values,
                 permuted_weights,
             ) = torch.ops.fbgemm.permute_2D_sparse_data_input1D(
-                indices_tensor,
+                indices_tensor.to(self.device()),
                 self.lengths(),
                 self.values(),
                 self.stride(),
@@ -2811,7 +2811,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 permuted_values,
                 permuted_weights,
             ) = torch.ops.fbgemm.permute_2D_sparse_data(
-                indices_tensor,
+                indices_tensor.to(self.device()),
                 self.lengths().view(len(self._keys), -1),
                 self.values(),
                 self.weights_or_none(),


### PR DESCRIPTION
Summary:
The `permute_2D_sparse_data` and `permute_2D_sparse_data_input1D` fbgemm ops require all input tensors to be on the same device. When `ShardedEmbeddingBagCollection` creates `_features_order_tensor` on the model device (CUDA) but the KJT input data is on CPU, the call to `permute_2D_sparse_data` fails with `RuntimeError: permute must be a CPU tensor; it is currently on device CUDA`.

This adds `.to(self.device())` on the `indices_tensor` before passing it to both fbgemm permute ops in `KeyedJaggedTensor.permute()`, ensuring the permute indices always match the KJT data device. This is a no-op when devices already match.

Differential Revision: D102231409


