### PR TITLE
Add missing pyre-strict header to debug_embedding_modules.py

### DIFF
--- a/torchrec/modules/debug_embedding_modules.py
+++ b/torchrec/modules/debug_embedding_modules.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 from typing import Dict, List, Tuple
 
 import torch


### PR DESCRIPTION
Summary:
Add `# pyre-strict` header to `torchrec/modules/debug_embedding_modules.py`
for consistency with all other modules in the `torchrec/modules/` directory.

Differential Revision: D98011671


