### PR TITLE
Make data_copy_stream device-agnostic across codebase

### DIFF
--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -40,7 +40,7 @@ class ModelInput(Pipelineable):
         self,
         device: torch.device,
         non_blocking: bool = False,
-        data_copy_stream: Optional[torch.cuda.streams.Stream] = None,
+        data_copy_stream: Optional[torch.Stream] = None,
         dense_only: bool = False,
     ) -> "ModelInput":
         """
@@ -49,7 +49,7 @@ class ModelInput(Pipelineable):
         Args:
             device: Target device to move tensors to.
             non_blocking: Whether to perform asynchronous copies.
-            data_copy_stream: Optional CUDA stream for async data copies. When provided,
+            data_copy_stream: Optional device stream for async data copies. When provided,
                 tensors are pre-allocated on the target device and copied within this stream.
                 This enables pipelined data transfers with computation on other streams.
             dense_only: Whether to only move dense features (float_features, label, dummy)
@@ -64,7 +64,7 @@ class ModelInput(Pipelineable):
             batch_gpu = batch_cpu.to(device="cuda")
 
             # Async transfer with dedicated stream
-            copy_stream = torch.cuda.Stream()
+            copy_stream = torch.Stream(device_type="cuda")
             batch_gpu = batch_cpu.to(device="cuda", non_blocking=True, data_copy_stream=copy_stream)
 
             # Move only dense features to GPU, keep sparse on CPU
@@ -105,7 +105,8 @@ class ModelInput(Pipelineable):
                 )
         else:
             # Async copy using dedicated stream
-            current_stream = torch.cuda.current_stream(device)
+            device_module = torch.get_device_module(device)
+            current_stream = device_module.current_stream(device)
 
             # Pre-allocate dense tensors on target device
             float_features = torch.empty_like(self.float_features, device=device)
@@ -134,7 +135,7 @@ class ModelInput(Pipelineable):
                 )
 
             # Perform async copy in dedicated stream
-            with data_copy_stream:
+            with device_module.stream(data_copy_stream):
                 # Wait for current stream to finish memory allocation
                 data_copy_stream.wait_stream(current_stream)
 

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -951,7 +951,7 @@ class ModelInput(Pipelineable):
         self,
         device: torch.device,
         non_blocking: bool = False,
-        data_copy_stream: Optional[torch.cuda.streams.Stream] = None,
+        data_copy_stream: Optional[torch.Stream] = None,
     ) -> "ModelInput":
         """
         Move ModelInput to the specified device.
@@ -959,7 +959,7 @@ class ModelInput(Pipelineable):
         Args:
             device: Target device to move tensors to.
             non_blocking: Whether to perform asynchronous copies.
-            data_copy_stream: Optional CUDA stream for async data copies. When provided,
+            data_copy_stream: Optional device stream for async data copies. When provided,
                 tensors are pre-allocated on the target device and copied within this stream.
                 This enables pipelined data transfers with computation on other streams.
 
@@ -971,7 +971,7 @@ class ModelInput(Pipelineable):
             batch_gpu = batch_cpu.to(device="cuda")
 
             # Async transfer with dedicated stream
-            copy_stream = torch.cuda.Stream()
+            copy_stream = torch.Stream(device_type="cuda")
             batch_gpu = batch_cpu.to(device="cuda", non_blocking=True, data_copy_stream=copy_stream)
         """
         if data_copy_stream is None:
@@ -998,7 +998,8 @@ class ModelInput(Pipelineable):
             )
         else:
             # Async copy using dedicated stream
-            current_stream = torch.cuda.current_stream(device)
+            device_module = torch.get_device_module(device)
+            current_stream = device_module.current_stream(device)
 
             # Pre-allocate tensors on target device
             float_features = torch.empty_like(self.float_features, device=device)
@@ -1018,7 +1019,7 @@ class ModelInput(Pipelineable):
             )
 
             # Perform async copy in dedicated stream
-            with data_copy_stream:
+            with device_module.stream(data_copy_stream):
                 # Wait for current stream to finish memory allocation
                 data_copy_stream.wait_stream(current_stream)
 


### PR DESCRIPTION
Summary:
D102596846 fixed DefaultPipelineableInputMixin.to() to use device-agnostic torch.Stream instead of torch.cuda.streams.Stream. This diff applies the same fix to all other implementations of the to() method that accept data_copy_stream, and adds a unit test to prevent regression.

Changes:
- Updated type annotations from torch.cuda.streams.Stream to torch.Stream in 6 files
- Replaced torch.cuda.current_stream(device) with torch.get_device_module(device).current_stream(device)
- Replaced torch.cuda.stream(data_copy_stream) / with data_copy_stream: context managers with device_module.stream(data_copy_stream)
- Added test_data_copy_stream_type_is_device_agnostic unit test that inspects type hints and source code of DefaultPipelineableInputMixin.to() to prevent CUDA-specific stream APIs from being reintroduced

Differential Revision: D102690235


