### PR TITLE
Add FixedAbsoluteStorageReservation for absolute GB HBM reservation (#4182)

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -35,6 +35,7 @@ from torchrec.distributed.planner.shard_estimators import (
     get_num_poolings,
 )
 from torchrec.distributed.planner.storage_reservations import (
+    FixedAbsoluteStorageReservation,
     FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
     InferenceStorageReservation,
@@ -207,7 +208,8 @@ class EmbeddingStats(Stats):
         compute_kernels_to_storage = defaultdict(lambda: Storage(0, 0, 0))
 
         reserved_hbm_percent, dense_storage, kjt_storage = _compute_storage(
-            storage_reservation=storage_reservation
+            storage_reservation=storage_reservation,
+            topology=topology,
         )
 
         for sharding_option in best_plan:
@@ -1030,19 +1032,27 @@ def _format_perf_breakdown(perf: Perf) -> str:
 
 def _compute_storage(
     storage_reservation: StorageReservation,
+    topology: Optional[Topology] = None,
 ) -> Tuple[float, Storage, Storage]:
-    reserved_hbm_percent = (
-        storage_reservation._percentage
-        if isinstance(
-            storage_reservation,
-            (
-                FixedPercentageStorageReservation,
-                HeuristicalStorageReservation,
-                InferenceStorageReservation,
-            ),
+    if (
+        isinstance(storage_reservation, FixedAbsoluteStorageReservation)
+        and topology is not None
+        and topology.devices[0].storage.hbm > 0
+    ):
+        reserved_hbm_percent = (
+            storage_reservation._hbm_reserved_bytes / topology.devices[0].storage.hbm
         )
-        else 0.0
-    )
+    elif isinstance(
+        storage_reservation,
+        (
+            FixedPercentageStorageReservation,
+            HeuristicalStorageReservation,
+            InferenceStorageReservation,
+        ),
+    ):
+        reserved_hbm_percent = storage_reservation._percentage
+    else:
+        reserved_hbm_percent = 0.0
 
     dense_storage = (
         storage_reservation._dense_storage

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -11,6 +11,7 @@ import copy
 import logging
 import math
 import warnings
+from enum import Enum, unique
 from typing import Dict, List, Optional, Set, Tuple
 
 from torch import nn
@@ -23,11 +24,22 @@ from torchrec.distributed.planner.types import (
     StorageReservation,
     Topology,
 )
-from torchrec.distributed.planner.utils import sharder_name, storage_repr_in_gb
+from torchrec.distributed.planner.utils import (
+    gb_to_bytes,
+    sharder_name,
+    storage_repr_in_gb,
+)
 from torchrec.distributed.types import get_tensor_size_bytes, ModuleSharder
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+@unique
+class StorageReservationType(str, Enum):
+    HEURISTIC = "heuristic"
+    FIXED_PERCENTAGE = "fixed_percentage"
+    FIXED_ABSOLUTE = "fixed_absolute"
 
 
 def _get_module_size(module: nn.Module, multiplier: float) -> int:
@@ -125,6 +137,11 @@ def _reserve_storage_percentage(topology: Topology, percent: float) -> None:
         device.storage.hbm = int((1 - percent) * device.storage.hbm)
 
 
+def _reserve_storage_absolute(topology: Topology, hbm_bytes: int) -> None:
+    for device in topology.devices:
+        device.storage.hbm = max(0, device.storage.hbm - hbm_bytes)
+
+
 def _get_batch_inputs_and_shardable_parameters(
     module: nn.Module,
     sharders: List[ModuleSharder[nn.Module]],
@@ -212,6 +229,41 @@ class FixedPercentageStorageReservation(StorageReservation):
     def last_reserved_topology(self) -> Optional[Topology]:
         "Returns a copy of the cached value of the most recent output from the reserve() method."
         return copy.deepcopy(self._last_reserved_topology)
+
+
+class FixedAbsoluteStorageReservation(FixedPercentageStorageReservation):
+    """
+    Reserves a fixed absolute amount of HBM storage on each device, rather
+    than a percentage of total HBM. Useful when the non-sharded memory footprint is
+    known in advance and does not scale with device capacity.
+
+    Args:
+        hbm_reserved_bytes (int): the amount of HBM to reserve per device, in bytes.
+    """
+
+    def __init__(self, hbm_reserved_bytes: int) -> None:
+        assert hbm_reserved_bytes >= 0
+        super().__init__(percentage=0.0)
+        self._hbm_reserved_bytes: int = hbm_reserved_bytes
+
+    @classmethod
+    def from_gb(cls, hbm_reserved_gb: float) -> "FixedAbsoluteStorageReservation":
+        return cls(hbm_reserved_bytes=gb_to_bytes(hbm_reserved_gb))
+
+    def reserve(
+        self,
+        topology: Topology,
+        batch_size: int,
+        module: nn.Module,
+        sharders: List[ModuleSharder[nn.Module]],
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    ) -> Topology:
+        reserved_topology = super().reserve(
+            topology, batch_size, module, sharders, constraints
+        )
+        _reserve_storage_absolute(reserved_topology, self._hbm_reserved_bytes)
+        self._last_reserved_topology = reserved_topology
+        return reserved_topology
 
 
 class HeuristicalStorageReservation(StorageReservation):

--- a/torchrec/distributed/planner/tests/test_storage_reservations.py
+++ b/torchrec/distributed/planner/tests/test_storage_reservations.py
@@ -20,10 +20,12 @@ from torchrec.distributed.planner.storage_reservations import (
     _get_batch_inputs_and_shardable_parameters,
     _get_kjt_storage,
     _get_module_size,
+    FixedAbsoluteStorageReservation,
     FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
 )
 from torchrec.distributed.planner.types import PlannerError, PlannerErrorType, Topology
+from torchrec.distributed.planner.utils import gb_to_bytes
 from torchrec.distributed.test_utils.test_model import TestTowerInteraction
 from torchrec.distributed.types import ModuleSharder
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -474,3 +476,118 @@ class TestFixedPercentageStorageReservation(unittest.TestCase):
 
         expected_hbm = int((1 - 0.25) * topology.devices[0].storage.hbm)
         self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
+
+
+class TestFixedAbsoluteStorageReservation(unittest.TestCase):
+    def _create_model_and_sharders(
+        self,
+    ) -> tuple[TestModel, List[ModuleSharder[nn.Module]]]:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=10,
+                name="table_0",
+                feature_names=["feature_0"],
+            )
+        ]
+        ebc = EmbeddingBagCollection(tables)
+        model = TestModel(shardable_sparse=ebc)
+        sharders = cast(
+            List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()]
+        )
+        return model, sharders
+
+    def test_reserves_absolute_bytes(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reserved_bytes = gb_to_bytes(2.5)
+        reservation = FixedAbsoluteStorageReservation(hbm_reserved_bytes=reserved_bytes)
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        expected_hbm = hbm_cap - reserved_bytes
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
+        self.assertEqual(reserved_topology.devices[1].storage.hbm, expected_hbm)
+
+    def test_from_gb(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = FixedAbsoluteStorageReservation.from_gb(2.0)
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        expected_hbm = hbm_cap - gb_to_bytes(2.0)
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
+
+    def test_zero_bytes_matches_no_reservation(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = FixedAbsoluteStorageReservation(hbm_reserved_bytes=0)
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, hbm_cap)
+
+    def test_kjt_storage_is_computed(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        topology = Topology(world_size=2, compute_device="cuda")
+
+        reservation = FixedAbsoluteStorageReservation.from_gb(1.0)
+
+        self.assertIsNone(reservation._kjt_storage)
+
+        reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertIsNotNone(reservation._kjt_storage)
+        self.assertGreater(reservation._kjt_storage.hbm, 0)
+
+    def test_last_reserved_topology_returns_copy(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = FixedAbsoluteStorageReservation.from_gb(2.0)
+
+        self.assertIsNone(reservation.last_reserved_topology)
+
+        reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        cached = reservation.last_reserved_topology
+        self.assertIsNotNone(cached)
+        expected_hbm = hbm_cap - gb_to_bytes(2.0)
+        self.assertEqual(cached.devices[0].storage.hbm, expected_hbm)
+
+    def test_negative_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            FixedAbsoluteStorageReservation(hbm_reserved_bytes=-1)

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -38,7 +38,10 @@ from torchrec.distributed.model_parallel import HybridEvalDMP
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.planner.constants import POOLING_FACTOR
 from torchrec.distributed.planner.storage_reservations import (
+    FixedAbsoluteStorageReservation,
+    FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
+    StorageReservationType,
 )
 from torchrec.distributed.planner.types import CacheParams, ParameterConstraints
 from torchrec.distributed.sharding_plan import get_default_sharders
@@ -88,6 +91,11 @@ class PlannerConfig:
     additional_constraints: Dict[str, Any] = field(default_factory=dict)
     # Storage reservation percentage (0.0 to 1.0) for planner memory estimation
     storage_reservation_percentage: float = 0.15
+    storage_reservation_type: StorageReservationType = (
+        StorageReservationType.FIXED_ABSOLUTE
+    )
+    # Absolute HBM to reserve per device in GB (used when storage_reservation_type="fixed_absolute")
+    storage_reservation_hbm_gb: float = 2.0
     # Hardware configuration for topology (dict with keys: hbm_cap, ddr_cap, etc.)
     hardware: Optional[Dict[str, Any]] = None
 
@@ -243,14 +251,26 @@ class PlannerConfig:
             )
             constraints[name] = cons
 
-        # Create storage reservation if percentage > 0
-        storage_reservation = (
-            HeuristicalStorageReservation(
+        # Create storage reservation based on type
+        storage_reservation = None
+        if self.storage_reservation_type == StorageReservationType.FIXED_ABSOLUTE:
+            if self.storage_reservation_hbm_gb is None:
+                raise ValueError(
+                    "storage_reservation_hbm_gb must be set when "
+                    "storage_reservation_type=FIXED_ABSOLUTE"
+                )
+            storage_reservation = FixedAbsoluteStorageReservation.from_gb(
+                self.storage_reservation_hbm_gb
+            )
+        elif self.storage_reservation_type == StorageReservationType.FIXED_PERCENTAGE:
+            storage_reservation = FixedPercentageStorageReservation(
                 percentage=self.storage_reservation_percentage
             )
-            if self.storage_reservation_percentage > 0
-            else None
-        )
+        elif self.storage_reservation_type == StorageReservationType.HEURISTIC:
+            if self.storage_reservation_percentage > 0:
+                storage_reservation = HeuristicalStorageReservation(
+                    percentage=self.storage_reservation_percentage
+                )
 
         if self.planner_type == "embedding":
             return EmbeddingShardingPlanner(


### PR DESCRIPTION
Summary:

FixedPercentageStorageReservation reserves a percentage of total HBM, but users often know the exact amount of memory their non-sharded model components need. This diff adds FixedAbsoluteStorageReservation, which reserves a fixed amount of HBM per device (in bytes) rather than a percentage of total HBM. A `from_gb()` classmethod is provided for convenience.

Changes:
- Added `_reserve_storage_absolute()` helper and `FixedAbsoluteStorageReservation` class (inherits from `FixedPercentageStorageReservation` with `percentage=0.0`) in `storage_reservations.py`. Default constructor takes bytes; `from_gb()` classmethod converts GB to bytes.
- Added `StorageReservationType` enum and `storage_reservation_hbm_gb` field to `PlannerConfig` in `sharding_config.py`, enabling selection via YAML config (`storage_reservation_type: "fixed_absolute"`, `storage_reservation_hbm_gb: 2.0`)
- Updated `_compute_storage()` in `stats.py` to accept topology and compute equivalent HBM percentage for accurate stats logging
- Updated Scuba logger in `sharding_plan_logger.py` with explicit isinstance branches so it reports `"FixedAbsoluteStorageReservation(2.0 GB)"` and correct absolute byte totals

Differential Revision: D102690150


