### PR TITLE
Restore @property decorator on last_reserved_topology in storage_reservations.py

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -385,6 +385,6 @@ class InferenceStorageReservation(StorageReservation):
 
         return reserved_topology
 
-    # pyrefly: ignore[bad-override]
+    @property
     def last_reserved_topology(self) -> Optional[Topology]:
         return copy.deepcopy(self._last_reserved_topology)


### PR DESCRIPTION
Summary: The property decorator on last_reserved_topology was incorrectly replaced with a pyrefly ignore comment. This restores the decorator so the method works correctly as a property.

Reviewed By: TroyGarden

Differential Revision: D101487845


