### PR TITLE
[memory] Add model lifecycle benchmark with quantization workflows

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_model_lifecycle.py
+++ b/torchrec/distributed/benchmark/benchmark_model_lifecycle.py
@@ -35,7 +35,6 @@ OSS (external):
         --world_size=2 --batch_size=4096 --num_batches=5 --pipeline=sparse
 """
 
-import itertools
 import json
 import logging
 from dataclasses import dataclass
@@ -69,8 +68,9 @@ from torchrec.distributed.test_utils.table_config import (
     EmbeddingTablesConfig,
     TableExtendedConfigs,
 )
-from torchrec.metrics.metric_module import RecMetricModule
+from torchrec.distributed.utils import EmbeddingQuantizationUtils
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.types import DataType
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -103,6 +103,7 @@ class RunOptions(BenchFuncConfig):
     num_iters: Optional[int] = None
     local_world_size: Optional[int] = None
     workflow: str = "model_init"
+    run_forward: bool = True
 
 
 def _setup(
@@ -173,41 +174,142 @@ def model_init_runner(
         use_deterministic_algorithms=False,
     ) as ctx:
 
-        # --- The function to benchmark: full model lifecycle ---
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],
         ) -> None:
-            # Phase 1: Model creation
-            unsharded_model = model_config.generate_model(
-                tables=tables,
-                weighted_tables=weighted_tables,
-                dense_device=ctx.device,
-                mc_configs=(
-                    table_related_configs.mc_configs if table_related_configs else None
-                ),
-            )
-            planner = planner_config.generate_planner(
-                tables=tables + weighted_tables,
-            )
-            sharded_model, optimizer = (
-                sharding_config.generate_sharded_model_and_optimizer(
-                    model=unsharded_model,
-                    # pyrefly: ignore[bad-argument-type]
-                    pg=ctx.pg,
-                    device=ctx.device,
-                    planner=planner,
+            with record_function("## model_creation ##"):
+                # unsharded_model is created on meta device (sparse) and CPU (dense)
+                unsharded_model = model_config.generate_model(
+                    tables=tables,
+                    weighted_tables=weighted_tables,
+                    dense_device=ctx.device,
+                    mc_configs=(
+                        table_related_configs.mc_configs
+                        if table_related_configs
+                        else None
+                    ),
                 )
-            )
+                planner = planner_config.generate_planner(
+                    tables=tables + weighted_tables,
+                )
+                sharded_model, optimizer = (
+                    sharding_config.generate_sharded_model_and_optimizer(
+                        model=unsharded_model,
+                        # pyrefly: ignore[bad-argument-type]
+                        pg=ctx.pg,
+                        device=ctx.device,
+                        planner=planner,
+                    )
+                )
 
-            batch = bench_inputs[0]
-            out = sharded_model(batch.to(ctx.device))
+            with record_function("## forward ##"):
+                if run_option.run_forward:
+                    batch = bench_inputs[0]
+                    sharded_model(batch.to(ctx.device))
 
-            # # Phase 2: Checkpoint save
-            # state_dict = sharded_model.state_dict()
+            with record_function("## checkpoint_save ##"):
+                state_dict = sharded_model.state_dict()
 
-            # # Phase 3: Checkpoint load
-            # # pyre-ignore[6]: Expected OrderedDict but got Dict
-            # sharded_model.load_state_dict(dict(state_dict))
+            with record_function("## checkpoint_load ##"):
+                # pyrefly: ignore[bad-argument-type]
+                sharded_model.load_state_dict(dict(state_dict))
+
+            torch.cuda.synchronize()
+
+        result = benchmark_func(
+            # pyrefly: ignore[bad-argument-type]
+            bench_inputs=bench_inputs,
+            # pyrefly: ignore[bad-argument-type]
+            prof_inputs=bench_inputs,
+            func_to_benchmark=_func_to_benchmark,
+            benchmark_func_kwargs={},
+            sample_count=0,
+            **run_option.benchmark_func_kwargs(rank=rank),
+        )
+
+        if rank == 0:
+            logger.setLevel(logging.INFO)
+            if run_option.output_json:
+                print(json.dumps(result.to_dict(), indent=2))
+            else:
+                logger.info(result.prettify())
+                logger.info("\nMarkdown format:\n%s", result)
+
+        return result
+
+
+def quant_model_init1_runner(
+    rank: int,
+    world_size: int,
+    tables: List[EmbeddingBagConfig],
+    weighted_tables: List[EmbeddingBagConfig],
+    run_option: RunOptions,
+    model_config: BaseModelConfig,
+    pipeline_config: PipelineConfig,
+    input_config: ModelInputConfig,
+    planner_config: PlannerConfig,
+    sharding_config: ShardingConfig,
+    metric_config: RecMetricConfig,
+    table_related_configs: Optional[TableExtendedConfigs] = None,
+) -> BenchmarkResult:
+    """Shard a float model first, then quantize TBE kernels in-place."""
+
+    bench_inputs = _setup(run_option, input_config, tables, weighted_tables, rank)
+
+    with MultiProcessContext(
+        rank=rank,
+        world_size=world_size,
+        backend="cpu:gloo,cuda:nccl",
+        use_deterministic_algorithms=False,
+    ) as ctx:
+
+        def _func_to_benchmark(
+            bench_inputs: List[ModelInput],
+        ) -> None:
+            with record_function("## model_creation ##"):
+                unsharded_model = model_config.generate_model(
+                    tables=tables,
+                    weighted_tables=weighted_tables,
+                    dense_device=ctx.device,
+                    mc_configs=(
+                        table_related_configs.mc_configs
+                        if table_related_configs
+                        else None
+                    ),
+                )
+
+            with record_function("## shard ##"):
+                planner = planner_config.generate_planner(
+                    tables=tables + weighted_tables,
+                )
+                sharded_model, optimizer = (
+                    sharding_config.generate_sharded_model_and_optimizer(
+                        model=unsharded_model,
+                        # pyrefly: ignore[bad-argument-type]
+                        pg=ctx.pg,
+                        device=ctx.device,
+                        planner=planner,
+                    )
+                )
+
+            with record_function("## quantize ##"):
+                quant_utils = EmbeddingQuantizationUtils()
+                quant_utils.quantize_embedding_modules(
+                    sharded_model, converted_dtype=DataType.NFP8
+                )
+
+            with record_function("## forward ##"):
+                if run_option.run_forward:
+                    batch = bench_inputs[0]
+                    sharded_model(batch.to(ctx.device))
+
+            # with record_function("## checkpoint_save ##"):
+            #     state_dict = sharded_model.state_dict()
+
+            # with record_function("## checkpoint_load ##"):
+            #     # pyrefly: ignore[bad-argument-type]
+            #     sharded_model.load_state_dict(dict(state_dict))
+
             torch.cuda.synchronize()
 
         result = benchmark_func(
@@ -257,6 +359,8 @@ def main(
     match run_option.workflow:
         case "model_init":
             runner = model_init_runner
+        case "quant_model_init1":
+            runner = quant_model_init1_runner
         case _:
             raise ValueError(f"Unknown workflow {run_option.workflow}")
 


### PR DESCRIPTION
Summary:
## 1. Context

There is no dedicated benchmark for profiling the full model lifecycle in TorchRec — covering DMP construction, checkpoint save/load, forward pass, and quantization. The existing `benchmark_train_pipeline` only measures the steady-state pipeline loop with a pre-built model. To understand end-to-end costs for eval workflows (e.g., how long model init takes vs. checkpoint loading vs. quantization vs. forward), we need a benchmark that captures each phase inside the measured function.

## 2. Workflows

1. **`model_init`** (default): Float model eval lifecycle.
    - **Model creation**: Creates a non-sharded `TestSparseNN` with dense layers on CPU and sparse embeddings on `meta` device (no memory allocated for embeddings).
    - **Sharding**: `DistributedModelParallel` materializes the sparse weights from `meta` to GPU (HBM allocation happens here), then moves the dense weights from CPU to GPU.
    - **Forward**: Single forward pass — KJT redistribution via all-to-all, embedding lookups, pooled output all-to-all, and dense forward.
    - **Checkpoint**: `state_dict()` extracts weights, `load_state_dict()` restores them.
    - Profiling phases: `## model_creation ##` → `## forward ##` → `## checkpoint_save ##` → `## checkpoint_load ##`.

2. **`quant_model_init1`**: Shard-then-quantize eval lifecycle.
    - **Model creation + Sharding**: Same as `model_init` — sparse weights materialized from `meta` to GPU, dense moved from CPU to GPU.
    - **Quantization**: `EmbeddingQuantizationUtils.quantize_embedding_modules()` converts the TBE weight tensors in-place from FP32 to NFP8, avoiding a full model rebuild.
    - **Forward**: Forward pass through the quantized model. Works with NFP8 on training TBE kernels (INT8 requires inference TBE kernels).
    - Profiling phases: `## model_creation ##` → `## shard ##` → `## quantize ##` → `## forward ##` → `## checkpoint_save ##` → `## checkpoint_load ##`.
<img width="2552" height="1323" alt="image" src="https://github.com/user-attachments/assets/965bcfab-bb10-4e2b-94b4-564bc9ab7849" />

Key flags: `--run_forward` controls whether the forward pass is included. `--num_benchmarks=0` skips timing and only runs profiling. `--export_stacks=True` exports flamegraph-compatible stack files.

## 3. Results

* repro commands
```
# model_init — float model lifecycle with forward + checkpoint
python -m torchrec.distributed.benchmark.benchmark_model_lifecycle \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --num_benchmarks=0 \
  --export_stacks=True

# model_init — eval_dp_cpu config, profiling only
python -m torchrec.distributed.benchmark.benchmark_model_lifecycle \
  --yaml_config=torchrec/distributed/benchmark/yaml/eval_dp_cpu.yml \
  --num_benchmarks=0 \
  --run_forward=0

# quant_model_init1 — shard then quantize TBE kernels
python -m torchrec.distributed.benchmark.benchmark_model_lifecycle \
  --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
  --num_benchmarks=0 \
  --workflow=quant_model_init1 \
  --name=quant_model_init1
```

* trace [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D102372547)

|name|rank0 trace|rank0 memory|rank1 trace|rank1 memory|
|--|--|--|--|--|
|sparse_data_dist_base|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D102372547/trace-sparse_data_dist_base-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D102372547/trace-sparse_data_dist_base-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D102372547/memory-sparse_data_dist_base-rank0.pickle)|||
|eval_dp_cpu|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D102372547/trace-eval_dp_cpu-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D102372547/trace-eval_dp_cpu-rank0.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D102372547/memory-eval_dp_cpu-rank0.pickle)|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D102372547/trace-eval_dp_cpu-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D102372547/trace-eval_dp_cpu-rank1.json.gz&bucket=torchrec_benchmark_traces)|[memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D102372547/memory-eval_dp_cpu-rank1.pickle)|

## 4. Changes

1. **`benchmark_model_lifecycle.py`** (new): `benchmark_func`-based benchmark using `cmd_conf` + `run_multi_process_func`. A `--workflow` flag selects the runner. Each lifecycle phase is wrapped in `record_function` for clean profiling traces.
    - **`model_init_runner`** (`--workflow=model_init`): Float model lifecycle — model creation, DMP sharding, optional forward pass, checkpoint save/load.
    - **`quant_model_init1_runner`** (`--workflow=quant_model_init1`): Shard-then-quantize lifecycle — creates a float model, shards with regular sharders, then quantizes TBE kernels in-place via `EmbeddingQuantizationUtils.quantize_embedding_modules()`. Forward pass supported with NFP8.
    - **`--run_forward`** flag to include/exclude forward pass from the benchmark.
2. **`BUCK`**: Added `benchmark_model_lifecycle` `python_binary` target.

Differential Revision: D102372547


