### PR TITLE
feat: add search_space_summary event after enumeration (#4079)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -391,6 +391,11 @@ def log_table_constraints(constraints: Optional[Dict] = None, planner_type: str 
     pass
 
 
+def log_search_space_summary(search_space: List, planner_type: str = "", technique: OptimizationTechnique = OptimizationTechnique.NONE) -> None:  # type: ignore[type-arg]
+    """No-op OSS stub."""
+    pass
+
+
 def log_proposer_result(
     planner_type: str = "",
     proposer_name: str = "",

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -101,6 +101,7 @@ try:
         log_planner_config,
         log_planning_result,
         log_proposer_result,
+        log_search_space_summary,
         log_storage_reservation,
         log_table_assignment,
         log_table_constraints,
@@ -123,6 +124,9 @@ except Exception:
         pass
 
     def log_proposer_result(*args, **kwargs) -> None:
+        pass
+
+    def log_search_space_summary(*args, **kwargs) -> None:
         pass
 
     def log_storage_reservation(*args, **kwargs) -> None:
@@ -639,6 +643,8 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         if not search_space:
             # No shardable parameters
             return ShardingPlan({})
+
+        log_search_space_summary(search_space, self.__class__.__name__)
 
         loaded_sharding_options = None
         loaded_best_plan: List[ShardingOption] = []


### PR DESCRIPTION
Summary:

Log the search space shape after enumerate() in planners — total options, num tables, available sharding types and compute kernels.

Reviewed By: ShatianWang, eugeneshulgameta

Differential Revision: D98066936


