### PR TITLE
Adding logger to detect Topology creation via TopologyFactory and Issue Warnings (#4189)

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -10,7 +10,7 @@
 import unittest
 from copy import deepcopy
 from typing import cast, Dict, Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from torch import multiprocessing
@@ -1376,6 +1376,44 @@ class TestKernelConfig(unittest.TestCase):
                 config.validate()
             self.assertIn("compute_device must be one of", str(context.exception))
             self.assertIn("invalid_device", str(context.exception))
+
+
+class TestTopologyCreatedByFactory(unittest.TestCase):
+    """Tests for the created_by_factory flag on Topology."""
+
+    @patch("torchrec.distributed.planner.types.logging")
+    def test_direct_construction_sets_flag_false(self, mock_logging: MagicMock) -> None:
+        topology = Topology(world_size=2, compute_device="cuda")
+        self.assertFalse(topology._created_by_factory)
+
+    @patch("torchrec.distributed.planner.types.logging")
+    def test_direct_construction_logs_warning(self, mock_logging: MagicMock) -> None:
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        Topology(world_size=2, compute_device="cuda")
+        mock_logger.warning.assert_called_once()
+        self.assertIn("TopologyFactory", mock_logger.warning.call_args[0][0])
+
+    def test_factory_creation_sets_flag_true(self) -> None:
+        trainer_config = TrainerConfig(world_size=2, local_world_size=2)
+        kernel_config = KernelConfig(compute_device="cuda")
+        topology = TopologyFactory.create_topology(
+            trainer_config=trainer_config,
+            kernel_config=kernel_config,
+        )
+        self.assertTrue(topology._created_by_factory)
+
+    @patch("torchrec.distributed.planner.types.logging")
+    def test_explicit_flag_true_suppresses_warning(
+        self, mock_logging: MagicMock
+    ) -> None:
+        mock_logger = MagicMock()
+        mock_logging.getLogger.return_value = mock_logger
+        topology = Topology(
+            world_size=2, compute_device="cuda", created_by_factory=True
+        )
+        self.assertTrue(topology._created_by_factory)
+        mock_logger.warning.assert_not_called()
 
 
 class TestTopologyFactory(unittest.TestCase):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -9,6 +9,7 @@
 
 import abc
 import hashlib
+import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -662,6 +663,7 @@ class TopologyFactory:
             TopologyFactory._add_comms_params(topology_kwargs, hardware, kernel)
 
             one_time_rank0_logger.info("TopologyFactor.create_topology called.")
+            topology_kwargs["created_by_factory"] = True
             return Topology(**topology_kwargs)
         except Exception as e:
             one_time_logger.error(f"TopologyFactor.create_topology failed: {e}")
@@ -814,6 +816,7 @@ class Topology:
         weighted_feature_bwd_compute_multiplier: float = WEIGHTED_FEATURE_BWD_COMPUTE_MULTIPLIER,
         uneven_sharding_perf_multiplier: float = 1.0,
         generalized_comms_bandwidths: Optional[GeneralizedCommsBandwidth] = None,
+        created_by_factory: bool = False,
     ) -> None:
         """
         Representation of a network of devices in a cluster.
@@ -905,6 +908,14 @@ class Topology:
             weighted_feature_bwd_compute_multiplier
         )
         self._uneven_sharding_perf_multiplier = uneven_sharding_perf_multiplier
+        self._created_by_factory: bool = created_by_factory
+
+        if not self._created_by_factory:
+            logging.getLogger(__name__).warning(
+                "The topology was constructed directly rather than via TopologyFactory.create_topology(). "
+                "Please use TopologyFactory to ensure proper hardware configuration resolution and validation; "
+                "otherwise, the job will fail."
+            )
 
     @property
     def compute_device(self) -> str:


### PR DESCRIPTION
Summary:

This diff adds detection and logging for `Topology` objects that are constructed directly rather than through `TopologyFactory.create_topology()`.

Changes:
- Added a `_created_by_factory` flag to `Topology.__init__()` (defaults to `False`)
- `TopologyFactory.create_topology()` now sets `_created_by_factory=True` when creating topologies
- When `Topology` is constructed directly (bypassing the factory), a warning is logged advising users to use `TopologyFactory` for proper hardware configuration resolution and validation
- Added `topology_created_by_factory` field to the sharding plan Scuba logger to track factory adoption across the fleet

Reviewed By: nipung90

Differential Revision: D102823130


