### PR TITLE
Add DCP checkpoint save/load to model lifecycle benchmark

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_model_lifecycle.py
+++ b/torchrec/distributed/benchmark/benchmark_model_lifecycle.py
@@ -42,6 +42,7 @@ from typing import List, Optional
 
 import torch
 from torch.autograd.profiler import record_function
+from torch.distributed.checkpoint import load as dcp_load, save as dcp_save
 from torchrec.distributed.benchmark.base import (
     BenchFuncConfig,
     benchmark_func,
@@ -104,6 +105,9 @@ class RunOptions(BenchFuncConfig):
     local_world_size: Optional[int] = None
     workflow: str = "model_init"
     run_forward: bool = True
+    checkpoint_id: str = "/tmp/benchmark_checkpoint"
+    save_checkpoint: bool = True
+    load_checkpoint: bool = True
 
 
 def _setup(
@@ -202,17 +206,25 @@ def model_init_runner(
                     )
                 )
 
+            with record_function("## checkpoint_save ##"):
+                state_dict = sharded_model.state_dict()
+                if run_option.save_checkpoint:
+                    dcp_save(state_dict, checkpoint_id=run_option.checkpoint_id)
+
+            with record_function("## checkpoint_load ##"):
+                if run_option.load_checkpoint:
+                    state_dict = sharded_model.state_dict()
+                    dcp_load(state_dict, checkpoint_id=run_option.checkpoint_id)
+                    # pyrefly: ignore[bad-argument-type]
+                    sharded_model.load_state_dict(dict(state_dict))
+                else:
+                    # pyrefly: ignore[bad-argument-type]
+                    sharded_model.load_state_dict(dict(state_dict))
+
             with record_function("## forward ##"):
                 if run_option.run_forward:
                     batch = bench_inputs[0]
                     sharded_model(batch.to(ctx.device))
-
-            with record_function("## checkpoint_save ##"):
-                state_dict = sharded_model.state_dict()
-
-            with record_function("## checkpoint_load ##"):
-                # pyrefly: ignore[bad-argument-type]
-                sharded_model.load_state_dict(dict(state_dict))
 
             torch.cuda.synchronize()
 
@@ -292,6 +304,21 @@ def quant_model_init1_runner(
                     )
                 )
 
+            with record_function("## checkpoint_save ##"):
+                state_dict = sharded_model.state_dict()
+                if run_option.save_checkpoint:
+                    dcp_save(state_dict, checkpoint_id=run_option.checkpoint_id)
+
+            with record_function("## checkpoint_load ##"):
+                if run_option.load_checkpoint:
+                    state_dict = sharded_model.state_dict()
+                    dcp_load(state_dict, checkpoint_id=run_option.checkpoint_id)
+                    # pyrefly: ignore[bad-argument-type]
+                    sharded_model.load_state_dict(dict(state_dict))
+                else:
+                    # pyrefly: ignore[bad-argument-type]
+                    sharded_model.load_state_dict(dict(state_dict))
+
             with record_function("## quantize ##"):
                 quant_utils = EmbeddingQuantizationUtils()
                 quant_utils.quantize_embedding_modules(
@@ -302,13 +329,6 @@ def quant_model_init1_runner(
                 if run_option.run_forward:
                     batch = bench_inputs[0]
                     sharded_model(batch.to(ctx.device))
-
-            # with record_function("## checkpoint_save ##"):
-            #     state_dict = sharded_model.state_dict()
-
-            # with record_function("## checkpoint_load ##"):
-            #     # pyrefly: ignore[bad-argument-type]
-            #     sharded_model.load_state_dict(dict(state_dict))
 
             torch.cuda.synchronize()
 


### PR DESCRIPTION
Summary:
Integrate DCP (Distributed Checkpoint) save and load into the model lifecycle benchmark. Changes include:
- Add `checkpoint_id`, `save_checkpoint`, and `load_checkpoint` options to `BenchmarkRunOption`
- Replace in-memory state_dict round-trip with actual `dcp_save`/`dcp_load` calls when enabled
- Move forward pass after checkpoint load to better reflect real model lifecycle ordering
- Add checkpoint save/load steps to the eval workflow (previously commented out)

The load checkpoint workflow (`quant_model_init1`) loads a full-precision checkpoint, then quantizes the model before running forward.

Generate checkpoint (full precision):
```
python -m torchrec.distributed.benchmark.benchmark_model_lifecycle \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=save_model_ckpt \
    --num_benchmarks=0
```

<img width="5082" height="2600" alt="image" src="https://github.com/user-attachments/assets/fa82bd44-de9e-46b3-9f65-6a58b4e4e1bf" />

Load checkpoint and quantize:
```
python -m torchrec.distributed.benchmark.benchmark_model_lifecycle \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml \
    --name=load_model_ckpt \
    --num_benchmarks=0 \
    --workflow=quant_model_init1 \
    --save_checkpoint=False
```

<img width="5084" height="2556" alt="image" src="https://github.com/user-attachments/assets/6fd41291-09b4-4090-8ee9-3c8771c0cae1" />

Differential Revision: D102863895


