### PR TITLE
Fix ManagedCollisionCollection FX graph split: move feature permute from LOCAL to INPUT_DIST (#4194)

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -77,6 +77,18 @@ from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 from torchrec.streamable import Multistreamable
 
 
+@torch.fx.wrap
+def input_dist_permute(
+    features: KeyedJaggedTensor,
+    features_order: List[int],
+    features_order_tensor: torch.Tensor,
+) -> KeyedJaggedTensor:
+    return features.permute(
+        features_order,
+        features_order_tensor,
+    )
+
+
 @dataclass
 class EmbeddingCollectionContext(Multistreamable):
     sharding_contexts: List[
@@ -723,10 +735,9 @@ class ShardedManagedCollisionCollection(
             # skip_permute added since these were used earlier in `mc_embeddingbag`
             if not skip_permute and self._features_order:
                 original_features = features
-                features = features.permute(
-                    #  `Union[Module, Tensor]`.
+                features = input_dist_permute(
+                    features,
                     self._features_order,
-                    #  but got `Union[Module, Tensor]`.
                     # pyrefly: ignore[bad-argument-type]
                     self._features_order_tensor,
                 )
@@ -1502,7 +1513,8 @@ class ShardedQuantManagedCollisionCollection(
 
         with torch.no_grad():
             if self._features_order:
-                features = features.permute(
+                features = input_dist_permute(
+                    features,
                     self._features_order,
                     # pyrefly: ignore[bad-argument-type]
                     self._features_order_tensor,

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -25,8 +25,19 @@ from torchrec.distributed.mc_embedding_modules import (
     BaseShardedManagedCollisionEmbeddingCollection,
 )
 from torchrec.distributed.mc_modules import (
+    _cat_jagged_values,
+    _fx_global_to_local_index,
+    _fx_jt_dict_add_offset,
+    _get_length_per_key,
+    create_mc_sharding,
+    EmbeddingCollectionContext,
+    input_dist_permute,
     ManagedCollisionCollectionContext,
+    ManagedCollisionCollectionSharder,
     ShardedManagedCollisionCollection,
+    ShardedMCCRemapper,
+    ShardedQuantManagedCollisionCollection,
+    update_jagged_tensor_dict,
 )
 from torchrec.distributed.model_parallel import DMPCollection
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
@@ -47,6 +58,7 @@ from torchrec.distributed.types import (
     ShardedTensor,
     ShardingEnv,
     ShardingPlan,
+    ShardingType,
 )
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.embedding_modules import EmbeddingCollection
@@ -1880,3 +1892,236 @@ class ShardedMCECWith2DSharding(MultiProcessTestBase):
             backend=backend,
             kjt_input_per_rank=kjt_input_per_rank,
         )
+
+
+class DummyMCModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class TestInputDistPermute(unittest.TestCase):
+    def _create_kjt(self) -> KeyedJaggedTensor:
+        return KeyedJaggedTensor(
+            keys=["f0", "f1", "f2"],
+            values=torch.tensor([10, 20, 30, 40, 50, 60]),
+            lengths=torch.tensor([2, 1, 1, 1, 0, 1]),
+        )
+
+    def test_input_dist_permute_correctness(self) -> None:
+        kjt = self._create_kjt()
+        features_order = [2, 0, 1]
+        features_order_tensor = torch.tensor(features_order, dtype=torch.int32)
+
+        result = input_dist_permute(kjt, features_order, features_order_tensor)
+        expected = kjt.permute(features_order, features_order_tensor)
+
+        self.assertEqual(result.keys(), expected.keys())
+        torch.testing.assert_close(result.values(), expected.values())
+        torch.testing.assert_close(result.lengths(), expected.lengths())
+
+    def test_input_dist_permute_fx_node_type(self) -> None:
+        _features_order_tensor = torch.tensor([2, 0, 1], dtype=torch.int32)
+
+        class _Module(torch.nn.Module):
+            def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+                return input_dist_permute(features, [2, 0, 1], _features_order_tensor)
+
+        tracer = torch.fx.Tracer(
+            autowrap_functions=(input_dist_permute,),
+            autowrap_modules=(torch.fx,),
+        )
+        graph = tracer.trace(_Module())
+
+        found = any(
+            node.op == "call_function"
+            and hasattr(node.target, "__name__")
+            and node.target.__name__ == "input_dist_permute"
+            for node in graph.nodes
+        )
+        self.assertTrue(found)
+
+    def test_input_dist_permute_identity_order(self) -> None:
+        kjt = self._create_kjt()
+        features_order = [0, 1, 2]
+        features_order_tensor = torch.tensor(features_order, dtype=torch.int32)
+
+        result = input_dist_permute(kjt, features_order, features_order_tensor)
+
+        self.assertEqual(result.keys(), kjt.keys())
+        torch.testing.assert_close(result.values(), kjt.values())
+
+    def test_input_dist_permute_subset(self) -> None:
+        kjt = self._create_kjt()
+        result = input_dist_permute(kjt, [1], torch.tensor([1], dtype=torch.int32))
+
+        self.assertEqual(result.keys(), ["f1"])
+
+
+class TestMCModuleUtilityFunctions(unittest.TestCase):
+    def test_fx_global_to_local_index(self) -> None:
+        feature_dict = {
+            "t_a": JaggedTensor(
+                values=torch.tensor([100, 200]), lengths=torch.tensor([2])
+            ),
+            "t_b": JaggedTensor(values=torch.tensor([500]), lengths=torch.tensor([1])),
+        }
+        result = _fx_global_to_local_index(feature_dict, {"t_a": 100, "t_b": 500})
+
+        torch.testing.assert_close(result["t_a"].values(), torch.tensor([0, 100]))
+        torch.testing.assert_close(result["t_b"].values(), torch.tensor([0]))
+
+    def test_fx_jt_dict_add_offset(self) -> None:
+        feature_dict = {
+            "t_a": JaggedTensor(
+                values=torch.tensor([0, 10]), lengths=torch.tensor([2])
+            ),
+        }
+        result = _fx_jt_dict_add_offset(feature_dict, {"t_a": 100})
+
+        torch.testing.assert_close(result["t_a"].values(), torch.tensor([100, 110]))
+
+    def test_get_length_per_key(self) -> None:
+        kjt = KeyedJaggedTensor(
+            keys=["f0", "f1", "f2"],
+            values=torch.tensor([1, 2, 3, 4, 5, 6]),
+            lengths=torch.tensor([2, 1, 1, 1, 0, 1]),
+        )
+        self.assertEqual(_get_length_per_key(kjt).tolist(), [3, 2, 1])
+
+    def test_cat_jagged_values(self) -> None:
+        jd = {
+            "a": JaggedTensor(values=torch.tensor([1, 2]), lengths=torch.tensor([2])),
+            "b": JaggedTensor(values=torch.tensor([3]), lengths=torch.tensor([1])),
+        }
+        torch.testing.assert_close(_cat_jagged_values(jd), torch.tensor([1, 2, 3]))
+
+    def test_update_jagged_tensor_dict(self) -> None:
+        jt_a = JaggedTensor(values=torch.tensor([1]), lengths=torch.tensor([1]))
+        jt_b = JaggedTensor(values=torch.tensor([2]), lengths=torch.tensor([1]))
+        result = update_jagged_tensor_dict({"a": jt_a}, {"b": jt_b})
+
+        self.assertIn("a", result)
+        self.assertIn("b", result)
+
+    def test_create_mc_sharding_unsupported(self) -> None:
+        from unittest.mock import MagicMock
+
+        with self.assertRaises(ValueError):
+            create_mc_sharding(
+                sharding_type=ShardingType.TABLE_WISE.value,
+                sharding_infos=[],
+                env=MagicMock(),
+            )
+
+
+class TestMCModuleContexts(unittest.TestCase):
+    def test_embedding_collection_context_defaults(self) -> None:
+        ctx = EmbeddingCollectionContext(sharding_contexts=[])
+
+        self.assertEqual(ctx.input_features, [])
+        self.assertIsNone(ctx.inverse_indices)
+        self.assertFalse(ctx.variable_batch_per_feature)
+
+    def test_mcc_context_is_subclass(self) -> None:
+        ctx = ManagedCollisionCollectionContext(sharding_contexts=[])
+
+        self.assertIsInstance(ctx, EmbeddingCollectionContext)
+
+
+class TestMCModuleSharder(unittest.TestCase):
+    def test_sharding_types(self) -> None:
+        sharder = ManagedCollisionCollectionSharder()
+
+        self.assertEqual(sharder.sharding_types("cuda"), [ShardingType.ROW_WISE.value])
+
+    def test_module_type(self) -> None:
+        sharder = ManagedCollisionCollectionSharder()
+
+        self.assertEqual(sharder.module_type, ManagedCollisionCollection)
+
+    def test_shardable_parameters_raises(self) -> None:
+        from unittest.mock import MagicMock
+
+        sharder = ManagedCollisionCollectionSharder()
+
+        with self.assertRaises(NotImplementedError):
+            sharder.shardable_parameters(MagicMock())
+
+
+class TestMCCRemapperUnit(unittest.TestCase):
+    def test_init_feature_to_offset(self) -> None:
+        mc_modules = torch.nn.ModuleDict({"table_a": DummyMCModule()})
+
+        remapper = ShardedMCCRemapper(
+            table_feature_splits=[2],
+            fns=["f0", "f1"],
+            managed_collision_modules=mc_modules,
+            shard_metadata={"table_a": [100, 50]},
+        )
+
+        self.assertEqual(remapper._feature_to_offset["f0"], 100)
+        self.assertEqual(remapper._feature_to_offset["f1"], 100)
+
+    def test_global_to_local_index(self) -> None:
+        mc_modules = torch.nn.ModuleDict({"table_a": DummyMCModule()})
+        remapper = ShardedMCCRemapper(
+            table_feature_splits=[1],
+            fns=["f0"],
+            managed_collision_modules=mc_modules,
+            shard_metadata={"table_a": [100, 50]},
+        )
+
+        jt = JaggedTensor(values=torch.tensor([150, 175]), lengths=torch.tensor([1, 1]))
+        result = remapper.global_to_local_index({"table_a": jt})
+
+        torch.testing.assert_close(result["table_a"].values(), torch.tensor([50, 75]))
+
+
+class TestShardedQuantMCCOutputDistUnit(unittest.TestCase):
+    def _make_sqmcc(
+        self, feature_names: list[str]
+    ) -> ShardedQuantManagedCollisionCollection:
+        # pyre-ignore[20]
+        obj = object.__new__(ShardedQuantManagedCollisionCollection)
+        obj._feature_names = feature_names
+        return obj
+
+    def test_output_dist_empty(self) -> None:
+        sqmcc = self._make_sqmcc(["f0"])
+        ctx = ManagedCollisionCollectionContext(sharding_contexts=[])
+
+        result = sqmcc.output_dist(ctx, KJTList([]))
+
+        self.assertEqual(result.keys(), [])
+
+    def test_output_dist_single(self) -> None:
+        sqmcc = self._make_sqmcc(["f0", "f1"])
+        ctx = ManagedCollisionCollectionContext(sharding_contexts=[])
+        kjt = KeyedJaggedTensor(
+            keys=["f0", "f1"],
+            values=torch.tensor([1, 2, 3]),
+            lengths=torch.tensor([2, 1]),
+        )
+
+        result = sqmcc.output_dist(ctx, KJTList([kjt]))
+
+        self.assertEqual(result.keys(), ["f0", "f1"])
+        torch.testing.assert_close(result.values(), torch.tensor([1, 2, 3]))
+
+    def test_compute_raises(self) -> None:
+        sqmcc = self._make_sqmcc(["f0"])
+        ctx = ManagedCollisionCollectionContext(sharding_contexts=[])
+
+        with self.assertRaises(NotImplementedError):
+            sqmcc.compute(ctx, 0, KJTList([]))
+
+    def test_create_context(self) -> None:
+        sqmcc = self._make_sqmcc(["f0"])
+        ctx = sqmcc.create_context()
+
+        self.assertIsInstance(ctx, ManagedCollisionCollectionContext)
+
+    def test_unsharded_module_type(self) -> None:
+        sqmcc = self._make_sqmcc(["f0"])
+
+        self.assertEqual(sqmcc.unsharded_module_type, ManagedCollisionCollection)


### PR DESCRIPTION
Summary:

$(cat <<EOF
During TGIF FX graph splitting for Distributed Inference (DI), the `ec_ro._managed_collision_collection._features_order_tensor` permute operation was incorrectly placed in the LOCAL graph instead of the INPUT_DIST graph. This caused the local net to be inconsistent between HH publishing and standalone serving, preventing reuse of existing dump traffic for load test / serving eval experiments.

**Root cause:** `ManagedCollisionCollection` used a raw `features.permute()` call which traced as `call_method[target=permute]` in the FX graph. Unlike `EmbeddingBagCollection` (which uses a `torch.fx.wrap` wrapper), this raw call_method had no matching tag rule and defaulted to the LOCAL graph.

**Fix (3 parts):**

1. **TorchRec (`mc_modules.py`):** Added `torch.fx.wrap` wrapper function `input_dist_permute()` (same pattern as `quant_embedding.py`). Updated both `ShardedManagedCollisionCollection.input_dist()` (training) and `ShardedQuantManagedCollisionCollection.input_dist()` (quant/inference) to use it instead of raw `features.permute()`. The wrapper traces as `call_function[target=input_dist_permute]`, which is matchable by the TGIF split pass tag rules.

2. **TGIF (`tgif_split_pass.py`):** Added `ShardedQuantManagedCollisionCollection` handling in `enable_input_dist()` to register `input_dist_permute`, `_fx_trec_get_feature_length`, `_fx_trec_unwrap_optional_tensor` as INPUT_DIST tag rules, and `InferRwSparseFeaturesDist` as a leaf module. This is needed because the existing tag rules are only registered under the `ShardedQuantEmbeddingCollection` branch (exact type check).

3. **BUCK:** Updated torch dependency from `//caffe2:torch` to `//caffe2:_torch` in `tgif/lib/BUCK` and `tgif/lib/tests/BUCK`. Added `//torchrec/distributed/sharding:rw_sharding` dep for tests.

After this fix, the MCC permute will appear as `call_function[target=input_dist_permute]` in the FX graph, be tagged as INPUT_DIST, and placed in the `input_dist` subgraph — consistent with `ebc_ro`, `ebc_nro`, and `uhm_preproc._sparse_arch`. The local net will be consistent for HH publishing.
EOF
)

Reviewed By: zhangruiskyline

Differential Revision: D103001697


