### PR TITLE
support KJT in FirstGradTensorFinder (#4195)

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -81,6 +81,7 @@ from torchrec.distributed.comm_ops import Request
 from torchrec.distributed.embedding import EmbeddingCollectionAwaitable
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionAwaitable
 from torchrec.distributed.types import NoWait, ShardingType
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
 if TYPE_CHECKING:
@@ -136,7 +137,10 @@ class FirstGradTensorFinder:
     Finds the first tensor with ``requires_grad=True`` from a module's
     forward output (or input if ``use_input=True``).
 
-    Handles single tensors, tuples/lists, dicts, and nested combinations.
+    Handles single tensors, tuples/lists, dicts, nested combinations, and
+    ``(Keyed)JaggedTensor`` whose ``weights`` field carries the gradient
+    (e.g. ``PositionWeightedModuleCollection`` outputs a KJT whose weights
+    are the trainable position parameters).
     """
 
     use_input: bool = False
@@ -145,6 +149,12 @@ class FirstGradTensorFinder:
         if isinstance(data, torch.Tensor):
             if data.requires_grad:
                 return data
+        elif isinstance(data, (KeyedJaggedTensor, JaggedTensor)):
+            # KJT/JT carry their grad-tracking tensor in the optional
+            # `weights` field (e.g. PositionWeightedModuleCollection).
+            weights = data.weights_or_none()
+            if weights is not None and weights.requires_grad:
+                return weights
         elif isinstance(data, (tuple, list)):
             for item in data:
                 t = self._search(item)

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -31,6 +31,7 @@ from torchrec.distributed.train_pipeline.backward_injection import (
 )
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 tc = unittest.TestCase()
 tc.maxDiff = None
@@ -66,6 +67,52 @@ class InjectionSiteTest(unittest.TestCase):
         grad = torch.tensor([1.0], requires_grad=True)
         self.assertIs(finder(grad, torch.tensor([0.0])), grad)
         self.assertIsNone(finder(torch.tensor([0.0]), grad))
+
+    def test_first_grad_tensor_finder_kjt_weights(self) -> None:
+        """KJT/JT carry the grad-tracking tensor in the optional weights field
+        (e.g. the output of PositionWeightedModuleCollection)."""
+        finder = FirstGradTensorFinder()
+
+        weights = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        kjt = KeyedJaggedTensor(
+            keys=["f1"],
+            values=torch.tensor([1, 2, 3], dtype=torch.int64),
+            lengths=torch.tensor([2, 1], dtype=torch.int64),
+            weights=weights,
+        )
+        self.assertIs(finder(None, kjt), weights)
+
+        # Also matches when nested inside containers.
+        nested = (torch.tensor([0.0]), {"k": [kjt]})
+        self.assertIs(finder(None, nested), weights)
+
+        # JaggedTensor with grad-requiring weights also resolves.
+        jt_weights = torch.tensor([0.5, 0.6], requires_grad=True)
+        jt = JaggedTensor(
+            values=torch.tensor([1, 2], dtype=torch.int64),
+            lengths=torch.tensor([1, 1], dtype=torch.int64),
+            weights=jt_weights,
+        )
+        self.assertIs(finder(None, jt), jt_weights)
+
+    def test_first_grad_tensor_finder_kjt_no_weights(self) -> None:
+        """KJT/JT with no weights or non-grad weights yield no match."""
+        finder = FirstGradTensorFinder()
+
+        kjt_no_weights = KeyedJaggedTensor(
+            keys=["f1"],
+            values=torch.tensor([1, 2, 3], dtype=torch.int64),
+            lengths=torch.tensor([2, 1], dtype=torch.int64),
+        )
+        self.assertIsNone(finder(None, kjt_no_weights))
+
+        kjt_inert_weights = KeyedJaggedTensor(
+            keys=["f1"],
+            values=torch.tensor([1, 2, 3], dtype=torch.int64),
+            lengths=torch.tensor([2, 1], dtype=torch.int64),
+            weights=torch.tensor([1.0, 2.0, 3.0]),  # requires_grad=False
+        )
+        self.assertIsNone(finder(None, kjt_inert_weights))
 
     def test_register_hook_nonexistent_raises(self) -> None:
         site = InjectionSite(


### PR DESCRIPTION
Summary:

`FirstGradTensorFinder` walks a module's forward output to locate a
`requires_grad` tensor onto which a backward hook can be attached. It
currently only descends through tensors, tuples/lists, and dicts —
which means it cannot find a grad tensor when the module's output is a
`KeyedJaggedTensor` (or `JaggedTensor`) whose grad-tracking tensor is
the optional `weights` field.

This is exactly the case for `PositionWeightedModuleCollection`, whose
`forward` returns a `KJT` whose `weights` are derived from the
trainable `position_weights` (an `nn.ParameterDict`). Without this
diff, attempting to register a backward injection site at a
`PositionWeightedModuleCollection` raises `RuntimeError: no
grad-requiring tensor in output`.

### Changes

**`fbcode/torchrec/distributed/train_pipeline/backward_injection.py`**
- Imported `KeyedJaggedTensor` and `JaggedTensor` from
  `torchrec.sparse.jagged_tensor`.
- Added a `KeyedJaggedTensor`/`JaggedTensor` branch in
  `FirstGradTensorFinder._search` that returns
  `data.weights_or_none()` when it is non-`None` and `requires_grad`.
- Updated the docstring to mention the KJT/JT case.
- All other code paths (tensor / tuple / list / dict) are unchanged.

**`fbcode/torchrec/distributed/train_pipeline/tests/test_backward_injection.py`**
- Imported `KeyedJaggedTensor` and `JaggedTensor`.
- Added `test_first_grad_tensor_finder_kjt_weights`: verifies that the
  finder returns the `weights` tensor for both KJT and JT, and also
  works when the KJT is nested inside a tuple/dict combination.
- Added `test_first_grad_tensor_finder_kjt_no_weights`: verifies that
  the finder returns `None` for a KJT with no weights or with weights
  whose `requires_grad` is `False`

Differential Revision: D103025120


