### PR TITLE
Add PECEmbeddingCollection skeleton with sharder and sharded module (#4200)

### DIFF
--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.embedding import (
+    EmbeddingCollectionContext,
+    EmbeddingCollectionSharder,
+    ShardedEmbeddingCollection,
+)
+from torchrec.distributed.embedding_types import (
+    BaseEmbeddingSharder,
+    KJTList,
+    ShardedEmbeddingModule,
+)
+from torchrec.distributed.types import (
+    Awaitable,
+    LazyAwaitable,
+    ParameterSharding,
+    QuantizedCommCodecs,
+    ShardingEnv,
+    ShardingType,
+)
+from torchrec.modules.pec_embedding_modules import (
+    OverlappingCheckerType,
+    PECEmbeddingCollection,
+)
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
+    """Per-module context for ShardedPECEmbeddingCollection.
+
+    Inherits from EmbeddingCollectionContext so it can be passed directly
+    to the inner ShardedEmbeddingCollection's compute/output_dist methods.
+    PEC-specific fields will be added in later diffs.
+    """
+
+    pass
+
+
+class ShardedPECEmbeddingCollection(
+    ShardedEmbeddingModule[
+        KJTList,  # CompIn
+        List[torch.Tensor],  # DistOut
+        Dict[str, JaggedTensor],  # Out
+        PECEmbeddingCollectionContext,  # ShrdCtx
+    ],
+):
+    """Sharded PEC Embedding Collection. Wraps ShardedEmbeddingCollection via composition."""
+
+    def __init__(
+        self,
+        module: PECEmbeddingCollection,
+        table_name_to_parameter_sharding: Dict[str, ParameterSharding],
+        ec_sharder: EmbeddingCollectionSharder,
+        env: ShardingEnv,
+        device: torch.device,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+
+        # Shard the inner EmbeddingCollection via composition
+        self._embedding_collection: ShardedEmbeddingCollection = ec_sharder.shard(
+            module._embedding_collection,
+            table_name_to_parameter_sharding,
+            env=env,
+            device=device,
+        )
+
+        # PEC config
+        self._checker_type: OverlappingCheckerType = module._checker_type
+
+    def create_context(self) -> PECEmbeddingCollectionContext:
+        return PECEmbeddingCollectionContext()
+
+    def input_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        features: KeyedJaggedTensor,
+    ) -> Awaitable[Awaitable[KJTList]]:
+        return self._embedding_collection.input_dist(ctx, features)
+
+    def compute(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        dist_input: KJTList,
+    ) -> List[torch.Tensor]:
+        return self._embedding_collection.compute(ctx, dist_input)
+
+    def output_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        output: List[torch.Tensor],
+    ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
+        return self._embedding_collection.output_dist(ctx, output)
+
+    def compute_and_output_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        input: KJTList,
+    ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
+        return self._embedding_collection.compute_and_output_dist(ctx, input)
+
+
+class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):
+    """Sharder for PECEmbeddingCollection. Enforces RW-only sharding."""
+
+    def __init__(
+        self,
+        ec_sharder: Optional[EmbeddingCollectionSharder] = None,
+        fused_params: Optional[Dict[str, Any]] = None,
+        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+    ) -> None:
+        super().__init__(fused_params, qcomm_codecs_registry)
+        self._embedding_collection_sharder: EmbeddingCollectionSharder = (
+            ec_sharder
+            or EmbeddingCollectionSharder(
+                fused_params=fused_params,
+                qcomm_codecs_registry=qcomm_codecs_registry,
+            )
+        )
+
+    def sharding_types(self, compute_device_type: str) -> List[str]:
+        return [ShardingType.ROW_WISE.value]
+
+    @property
+    def module_type(self) -> Type[PECEmbeddingCollection]:
+        return PECEmbeddingCollection
+
+    def shardable_parameters(
+        self, module: PECEmbeddingCollection
+    ) -> Dict[str, nn.Parameter]:
+        return self._embedding_collection_sharder.shardable_parameters(
+            module._embedding_collection
+        )
+
+    def shard(
+        self,
+        module: PECEmbeddingCollection,
+        params: Dict[str, ParameterSharding],
+        env: ShardingEnv,
+        device: Optional[torch.device] = None,
+        module_fqn: Optional[str] = None,
+    ) -> "ShardedPECEmbeddingCollection":
+        if device is None:
+            device = torch.device("cuda")
+        return ShardedPECEmbeddingCollection(
+            module,
+            params,
+            ec_sharder=self._embedding_collection_sharder,
+            env=env,
+            device=device,
+            qcomm_codecs_registry=self.qcomm_codecs_registry,
+        )

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+import copy
+import unittest
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.pec_embedding import (
+    PECEmbeddingCollectionSharder,
+    ShardedPECEmbeddingCollection,
+)
+from torchrec.distributed.shard import shard_modules
+from torchrec.distributed.sharding_plan import construct_module_sharding_plan, row_wise
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import (
+    ModuleSharder,
+    ShardingEnv,
+    ShardingPlan,
+    ShardingType,
+)
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.modules.embedding_modules import EmbeddingCollection
+from torchrec.modules.pec_embedding_modules import PECEmbeddingCollection
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+EMBEDDING_TABLES: List[EmbeddingConfig] = [
+    EmbeddingConfig(
+        name="table_0",
+        feature_names=["feature_0"],
+        embedding_dim=8,
+        num_embeddings=16,
+    ),
+    EmbeddingConfig(
+        name="table_1",
+        feature_names=["feature_1"],
+        embedding_dim=8,
+        num_embeddings=16,
+    ),
+]
+
+
+class PECEmbeddingCollectionTest(unittest.TestCase):
+    """Unit tests for PECEmbeddingCollection (unsharded) — no distributed setup."""
+
+    def test_forward(self) -> None:
+        ec = EmbeddingCollection(tables=EMBEDDING_TABLES, device=torch.device("cpu"))
+        pec = PECEmbeddingCollection(ec)
+
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
+        )
+        out: Dict[str, JaggedTensor] = pec(kjt)
+
+        self.assertIn("feature_0", out)
+        self.assertIn("feature_1", out)
+        self.assertEqual(out["feature_0"].values().shape[1], 8)
+        self.assertEqual(out["feature_1"].values().shape[1], 8)
+
+
+class PECEmbeddingCollectionSharderTest(unittest.TestCase):
+    """Unit tests for PECEmbeddingCollectionSharder — no distributed setup."""
+
+    def test_sharding_types_rw_only(self) -> None:
+        sharder = PECEmbeddingCollectionSharder()
+        types = sharder.sharding_types(compute_device_type="cuda")
+        self.assertEqual(types, [ShardingType.ROW_WISE.value])
+
+    def test_shardable_parameters(self) -> None:
+        ec = EmbeddingCollection(
+            tables=EMBEDDING_TABLES[:1], device=torch.device("cpu")
+        )
+        pec = PECEmbeddingCollection(ec)
+
+        sharder = PECEmbeddingCollectionSharder()
+        params = sharder.shardable_parameters(pec)
+
+        self.assertIn("table_0", params)
+        self.assertEqual(params["table_0"].shape, (16, 8))
+
+
+class PECSparseArch(nn.Module):
+    """Simple model wrapping PECEmbeddingCollection for sharded testing."""
+
+    def __init__(
+        self,
+        tables: List[EmbeddingConfig],
+        device: torch.device,
+    ) -> None:
+        super().__init__()
+        self._pec_ec: PECEmbeddingCollection = PECEmbeddingCollection(
+            EmbeddingCollection(tables=tables, device=device),
+        )
+
+    def forward(
+        self, kjt: KeyedJaggedTensor
+    ) -> Tuple[torch.Tensor, Dict[str, JaggedTensor]]:
+        ec_out = self._pec_ec(kjt)
+        pred = torch.cat(
+            [ec_out[key].values() for key in ["feature_0", "feature_1"]],
+            dim=0,
+        )
+        loss = pred.mean()
+        return loss, ec_out
+
+
+def _test_sharding(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    local_size: Optional[int] = None,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        kjt_input = kjt_input_per_rank[rank].to(ctx.device)
+        sparse_arch = PECSparseArch(tables, torch.device("meta"))
+
+        module_sharding_plan = construct_module_sharding_plan(
+            sparse_arch._pec_ec,
+            per_param_sharding={table.name: row_wise() for table in tables},
+            local_size=local_size,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+            sharder=sharder,
+        )
+
+        sharded_sparse_arch: PECSparseArch = shard_modules(  # pyre-ignore[9]
+            module=copy.deepcopy(sparse_arch),
+            plan=ShardingPlan({"_pec_ec": module_sharding_plan}),
+            env=ShardingEnv.from_process_group(ctx.pg),
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        assert isinstance(sharded_sparse_arch._pec_ec, ShardedPECEmbeddingCollection)
+        assert isinstance(
+            sharded_sparse_arch._pec_ec._embedding_collection,
+            ShardedEmbeddingCollection,
+        )
+
+        # Forward + backward, two iterations to exercise stateful components
+        for _ in range(2):
+            loss, _ = sharded_sparse_arch(kjt_input)
+            loss.backward()
+
+
+@skip_if_asan_class
+class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
+    """Multi-process tests for ShardedPECEmbeddingCollection."""
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_sharding_rw(self) -> None:
+        WORLD_SIZE = 2
+
+        kjt_input_per_rank = [
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
+                lengths=torch.LongTensor([2, 1, 1, 2]),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
+                lengths=torch.LongTensor([1, 2, 2, 1]),
+            ),
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_sharding,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=kjt_input_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )

--- a/torchrec/modules/pec_embedding_modules.py
+++ b/torchrec/modules/pec_embedding_modules.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+from enum import Enum
+from typing import Dict, List
+
+import torch.nn as nn
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.modules.embedding_modules import EmbeddingCollection
+from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+class OverlappingCheckerType(Enum):
+    """Type of overlap checker used for collision detection."""
+
+    BOOLEAN = "boolean"
+
+
+class PECEmbeddingCollection(nn.Module):
+    """Wraps an EmbeddingCollection with Prioritized Embedding Communication (PEC) config.
+
+    PEC optimizes embedding communication by detecting overlapping IDs between
+    consecutive batches. Overlapped embeddings are sent first (prioritized),
+    allowing the trainer to start computation earlier.
+
+    This unsharded module simply wraps an EmbeddingCollection and carries PEC
+    configuration. The actual PEC logic lives in the sharded version
+    (ShardedPECEmbeddingCollection).
+
+    Args:
+        embedding_collection: The EmbeddingCollection to wrap.
+        checker_type: Type of overlap checker. BOOLEAN uses a full boolean mask.
+
+    Example::
+
+        import torch
+        from torchrec.modules.embedding_configs import EmbeddingConfig
+        from torchrec.modules.embedding_modules import EmbeddingCollection
+        from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+        tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+        ]
+        ec = EmbeddingCollection(tables=tables, device=torch.device("cpu"))
+        pec = PECEmbeddingCollection(ec, checker_type=OverlappingCheckerType.BOOLEAN)
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0"],
+            values=torch.LongTensor([0, 1, 2]),
+            lengths=torch.LongTensor([2, 1]),
+        )
+        output = pec(kjt)
+        print(output["feature_0"].values().shape)
+    """
+
+    def __init__(
+        self,
+        embedding_collection: EmbeddingCollection,
+        checker_type: OverlappingCheckerType = OverlappingCheckerType.BOOLEAN,
+    ) -> None:
+        super().__init__()
+        self._embedding_collection = embedding_collection
+        self._checker_type = checker_type
+
+    @property
+    def embedding_collection(self) -> EmbeddingCollection:
+        return self._embedding_collection
+
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+    ) -> Dict[str, JaggedTensor]:
+        """Delegates to the inner EmbeddingCollection.
+
+        Args:
+            features: KJT of sparse features.
+
+        Returns:
+            Dict mapping feature names to JaggedTensors of embeddings.
+        """
+        return self._embedding_collection(features)
+
+    def embedding_configs(self) -> List[EmbeddingConfig]:
+        return self._embedding_collection.embedding_configs()
+
+    def embedding_dim(self) -> int:
+        return self._embedding_collection.embedding_dim()
+
+    def need_indices(self) -> bool:
+        return self._embedding_collection.need_indices()


### PR DESCRIPTION
Summary:

# Context

Adds the initial skeleton for Prioritized Embedding Communication (PEC) in TorchRec. PEC optimizes embedding all-to-all communication by detecting overlapping IDs between consecutive batches — overlapped embeddings are sent first, allowing the trainer to start computation earlier while non-overlapped embeddings are still in flight. See the [manuscript](https://arxiv.org/abs/2604.24073) for more information. 

# Skeleton
This diff introduces three major components:

**Non-sharded Module**: `PECEmbeddingCollection` (`modules/pec_embedding_modules.py`) — an unsharded `nn.Module` wrapper around `EmbeddingCollection` that carries PEC configuration (checker type: BOOLEAN). Forward and metadata methods delegate to the inner EC.

**Sharded Module**: `ShardedPECEmbeddingCollection` (`distributed/pec_embedding.py`) — the sharded variant. `input_dist`, `compute`, `output_dist`, and `compute_and_output_dist` all delegate to an inner `ShardedEmbeddingCollection` created via composition. `PECEmbeddingCollectionContext` inherits from `EmbeddingCollectionContext` so it can be passed directly to the inner EC without field loss (VBE, index dedup, etc.). PEC-specific fields will be added in later diffs.

**Sharder**: `PECEmbeddingCollectionSharder` — enforces ROW_WISE-only sharding and delegates shardable parameter discovery to `EmbeddingCollectionSharder`.

Reviewed By: TroyGarden

Differential Revision: D102411022


