### PR TITLE
Guard _safe_tolist JK check with is_torchdynamo_compiling (#4201)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -142,7 +142,9 @@ def _safe_tolist_2d(tensor: torch.Tensor) -> List[List[int]]:
     """
     if not tensor.is_cuda:
         return tensor.tolist()
-    if not torch._utils_internal.justknobs_check(
+    # During torch.compile tracing, fall back to plain .tolist()
+    # (see _safe_tolist in jagged_tensor.py for details).
+    if is_torchdynamo_compiling() or not torch._utils_internal.justknobs_check(
         "pytorch/torchrec:killswitch_safe_tolist"
     ):
         return tensor.tolist()

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -125,7 +125,13 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     if tensor.numel() == 0:
         return []
 
-    if not torch._utils_internal.justknobs_check(
+    # During torch.compile tracing, skip the JK check and _cuda_to_cpu_safe
+    # and fall back to plain .tolist(). justknobs_check calls pyjk.check()
+    # (a Cython function) which can raise SystemError in sandbox/RE
+    # environments. The resulting exception captures a reference to the pyjk
+    # module that cannot be pickled by the multiprocessing pool used in
+    # distributed tests, masking the real error behind MaybeEncodingError.
+    if is_torchdynamo_compiling() or not torch._utils_internal.justknobs_check(
         "pytorch/torchrec:killswitch_safe_tolist"
     ):
         return tensor.tolist()


### PR DESCRIPTION
Summary:

_safe_tolist and _safe_tolist_2d call justknobs_check() which internally calls pyjk.check() (Cython). In RE/sandbox environments during torch.compile tracing, pyjk.check() raises SystemError because Configerator is unavailable. The exception traceback captures a reference to the pyjk module, which cannot be pickled by the multiprocessing pool in distributed tests. This surfaces as MaybeEncodingError("cannot pickle 'module' object"), masking the real error.

Adding is_torchdynamo_compiling() guard before the JK check skips both justknobs_check and _cuda_to_cpu_safe during compilation, falling back to plain .tolist() — matching pre-D101235037 behavior. At runtime (not compiling), the safe D2H copy path is preserved.

Fixes both:
- fbcode//torchrec/fb/ads/distributed/tests:test_pt2_multiprocess
- fbcode//torchrec/distributed/tests:test_pt2_multiprocess

Reviewed By: kaanbaloglu

Differential Revision: D103208450


