### PR TITLE
Enable SDD Lite and RecMetric Benchmark In Nightly Jobs (#4204)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
@@ -13,6 +13,7 @@ PipelineConfig:
   pipeline: "sparse_lite"
 ModelInputConfig:
   feature_pooling_avg: 30
+  num_float_features: 10
 EmbeddingTablesConfig:
   num_unweighted_features: 90
   num_weighted_features: 80


### PR DESCRIPTION
Summary:

Add required parameter to enable sdd_lite benchmark to run

Reviewed By: spmex, jeffkbkim

Differential Revision: D103291018


