### PR TITLE
Use spawn for SplitsAllToAllCollectiveTagTest to fix env-propagation bug

### DIFF
--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -1642,6 +1642,14 @@ class CollectiveTagFromTest(unittest.TestCase):
 
 
 class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
+    def __init__(self, methodName: str = "runTest") -> None:
+        # Force spawn: forkserver caches the env from when it was first
+        # started, so TORCHREC_VALIDATE_COLLECTIVES=1 set in setUp does not
+        # propagate to workers that fork from a forkserver booted by an
+        # earlier test in the file. Mirrors the py3.14 remediation in
+        # MultiProcessTestBase.__init__.
+        super().__init__(methodName, mp_init_mode="spawn")
+
     def setUp(self) -> None:
         super().setUp()
         os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "1"


### PR DESCRIPTION
Summary:
The 8 multi-process tests in `SplitsAllToAllCollectiveTagTest` that depend on `TORCHREC_VALIDATE_COLLECTIVES=1` fail on the open-source `meta-pytorch/torchrec` GitHub Actions CI (`unittest_ci_gpu (cu126, linux.g5.12xlarge.nvidia.gpu, 3.10, py310, ...)`). All 8 fail with either `assert _splits_awaitable._tag_appended is True` or `Expected RuntimeError for ... mismatch`, indicating that validation never engaged in the workers.

Root cause: `MultiProcessTestBase` uses `multiprocessing.get_context("forkserver")` by default. The forkserver is started lazily on first use — by whichever multi-process test runs first in `test_dist_data.py` — and forks all subsequent workers from a snapshot of the env taken at that moment. When `SplitsAllToAllCollectiveTagTest.setUp` later mutates `os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "1"`, the change does not reach the forkserver, so `_validate_collectives_enabled()` returns False in the workers, `_tag_appended` stays False, no tag is appended, and validation never raises on mismatch. This is the same forkserver-env-caching pattern already documented in `MultiProcessTestBase.__init__` for Python 3.14.

Internal Buck/TestPilot CI did not catch this because each test method runs in its own process — every test gets a fresh forkserver started after `setUp`, so the env propagates. Pytest on GitHub shares one process across the file, so the forkserver is reused across tests with stale env.

Fix: override `mp_init_mode="spawn"` in this test class. Spawn re-reads `os.environ` per worker, so `setUp` mutations propagate correctly. Mirrors the existing py3.14 remediation in the parent class.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: torchrec

Differential Revision: D103319724


