### PR TITLE
Emit Scuba event on collective tag mismatch (#4206)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -20,6 +20,7 @@ from torchrec.distributed.comm_ops import (
     all_gather_base_pooled,
     alltoall_pooled,
     alltoall_sequence,
+    pg_name,
     reduce_scatter_base_pooled,
     reduce_scatter_v_per_feature_pooled,
     reduce_scatter_v_pooled,
@@ -68,11 +69,27 @@ try:
 except OSError:
     pass
 
-# OSS
+# Event logging is optional: torch.package inference bundles strip
+# logging_handlers, and OSS users get the no-op stub. Catch broad Exception
+# (not just ImportError) to match the defensive idiom in
+# torchrec/distributed/train_pipeline/train_pipelines.py — a degraded
+# telemetry dependency must not break dist_data import.
 try:
-    pass
-except ImportError:
-    pass
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+    from torchrec.distributed.logging_utils import EventType
+
+    _HAS_EVENT_LOGGER: bool = True
+except Exception:
+    # Track via _log_api_usage_once so we can quantify the torch.package /
+    # OSS callers still missing logging_handlers and remove this try/except
+    # once those exports are updated.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.dist_data.import_failure.logging_handlers"
+    )
+    _HAS_EVENT_LOGGER: bool = False
 
 
 logger: logging.Logger = logging.getLogger()
@@ -427,6 +444,11 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         # Append tag tensor for collective mismatch validation.
         # Requires non-empty input_tensors to inherit device/dtype.
         self._tag_appended: bool = False
+        # PG identity, populated only when validation is enabled.
+        self._pg_name: str = ""
+        self._pg_rank: int = -1
+        # PG-local index -> global rank, for the mismatch event.
+        self._pg_global_ranks: List[int] = []
         if (
             collective_tag is not None
             and _validate_collectives_enabled()
@@ -446,6 +468,11 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
             )
             input_tensors = input_tensors + [tag_tensor]
             self._tag_appended = True
+            self._pg_name = pg_name(pg)
+            self._pg_rank = pg.rank()
+            self._pg_global_ranks = [
+                dist.get_global_rank(pg, i) for i in range(self.num_workers)
+            ]
 
         if is_torchdynamo_compiling():
             # TODO(ivankobzarev) Remove this dynamo condition once dynamo functional collectives remapping does not emit copy_
@@ -491,6 +518,52 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
                     async_op=not is_torchdynamo_compiling(),
                 )
 
+    def _log_mismatch_event(
+        self,
+        label: str,
+        expected: int,
+        tag_row: List[int],
+    ) -> None:
+        if not _HAS_EVENT_LOGGER:
+            return
+        # Logging must not suppress the caller's diagnostic RuntimeError.
+        try:
+            # Emit both global and PG-local ranks (they differ on sub-PGs).
+            mismatched_pg_local = [i for i, t in enumerate(tag_row) if t != expected]
+            mismatched_global = [self._pg_global_ranks[i] for i in mismatched_pg_local]
+            global_rank = (
+                self._pg_global_ranks[self._pg_rank]
+                if 0 <= self._pg_rank < len(self._pg_global_ranks)
+                else -1
+            )
+            EventLoggingHandler.log_event(
+                component=TorchrecComponent.INPUT_DIST.value,
+                event_name="SplitsAllToAllAwaitable.collective_tag_mismatch",
+                event_type=EventType.FAILURE,
+                metadata={
+                    "collective_label": label,
+                    "collective_kind": str(
+                        self._collective_tag_parts[0]
+                        if self._collective_tag_parts
+                        else "unknown"
+                    ),
+                    "expected_tag": str(expected),
+                    "received_tags": str(tag_row),
+                    "mismatched_peer_global_ranks": str(mismatched_global),
+                    "mismatched_peer_pg_ranks": str(mismatched_pg_local),
+                    "pg_name": self._pg_name,
+                    "pg_rank": str(self._pg_rank),
+                    "global_rank": str(global_rank),
+                    "world_size": str(self.num_workers),
+                },
+                error_message=f"All2All collective mismatch on {label}",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to emit collective_tag_mismatch event; "
+                "skipping logging the event."
+            )
+
     def _wait_impl(self) -> List[List[int]]:
         # Can not use is_torchdynamo_compiling(), as every such condition should be independent for compilation with graph breaks.
         if isinstance(self._splits_awaitable, dist.Work):
@@ -502,13 +575,16 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         if self._tag_appended:
             tag_row = ret[-1]
             ret = ret[: self._num_original_tensors]
-            expected = self._collective_tag
+            # _tag_appended=True implies _collective_tag was not None.
+            assert self._collective_tag is not None
+            expected: int = self._collective_tag
             if any(tag != expected for tag in tag_row):
                 label = (
                     str(self._collective_tag_parts)
                     if self._collective_tag_parts
                     else "unknown"
                 )
+                self._log_mismatch_event(label, expected, tag_row)
                 raise RuntimeError(
                     f"All2All collective mismatch detected (collective={label!r}): "
                     f"expected tag {expected} but received tags {tag_row} from "

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -2197,3 +2197,222 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
                     collective_tag=large_tag,
                 )
             self.assertIn("exceeds", str(ctx.exception).lower())
+
+    @classmethod
+    def _run_test_mismatch_emits_scuba_event(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            awaitable = SplitsAllToAllAwaitable(
+                input_tensors=input_tensors,
+                pg=none_throws(dist.group.WORLD),
+                collective_tag=rank,  # divergent tag per rank → forces mismatch
+                collective_tag_parts=("scuba_test", "rank_specific"),
+            )
+            try:
+                awaitable.wait()
+                raise AssertionError("Expected RuntimeError for mismatched tags")
+            except RuntimeError:
+                pass
+            # log_event must fire exactly once on the failing rank.
+            assert (
+                mock_log_event.call_count == 1
+            ), f"expected 1 log_event call, got {mock_log_event.call_count}"
+            kwargs = mock_log_event.call_args.kwargs
+            assert kwargs["component"] == "input_dist"
+            assert (
+                kwargs["event_name"]
+                == "SplitsAllToAllAwaitable.collective_tag_mismatch"
+            )
+            # Only check the enum's string value to keep the test independent
+            # of how EventType is imported in the test module.
+            assert kwargs["event_type"].value == "FAILURE"
+            metadata = kwargs["metadata"]
+            assert metadata["expected_tag"] == str(rank)
+            assert metadata["pg_rank"] == str(rank)
+            assert metadata["world_size"] == str(world_size)
+            assert metadata["collective_kind"] == "scuba_test"
+            assert "scuba_test" in metadata["collective_label"]
+            # On WORLD, global rank and PG-local rank coincide.
+            assert metadata["global_rank"] == str(rank)
+            # Both lists are stringified; on a 2-rank job with divergent
+            # tags, every peer with a different tag appears.
+            assert metadata["mismatched_peer_global_ranks"].startswith("[")
+            assert metadata["mismatched_peer_pg_ranks"].startswith("[")
+        dist.destroy_process_group()
+
+    def test_mismatch_emits_scuba_event(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_mismatch_emits_scuba_event,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_mismatch_event_uses_global_ranks_on_subgroup(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        """Run on a 4-rank job; create a sub-PG of [1, 3]. On that sub-PG
+        the local ranks are 0 and 1 but global ranks are 1 and 3. Verify
+        that the Scuba event reports global ranks (actionable for triage),
+        not PG-local indices."""
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        # new_group is collective on WORLD, so every rank must call it,
+        # even ranks not in the resulting subgroup.
+        subgroup = dist.new_group(ranks=[1, 3], backend=backend)
+
+        if rank not in (1, 3):
+            # Non-members do not run the awaitable; just synchronize and exit.
+            dist.barrier()
+            dist.destroy_process_group()
+            return
+
+        # Ranks 1 and 3 run a collective on the subgroup with divergent
+        # tags so the mismatch path fires. PG-local ranks here are 0 and 1.
+        input_tensors = [torch.tensor([1, 1], dtype=torch.int64)]
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            awaitable = SplitsAllToAllAwaitable(
+                input_tensors=input_tensors,
+                pg=subgroup,
+                collective_tag=rank,  # divergent tag per rank → mismatch
+                collective_tag_parts=("subgroup_test",),
+            )
+            try:
+                awaitable.wait()
+                raise AssertionError("Expected RuntimeError for mismatched tags")
+            except RuntimeError:
+                pass
+
+            assert (
+                mock_log_event.call_count == 1
+            ), f"expected 1 log_event call, got {mock_log_event.call_count}"
+            metadata = mock_log_event.call_args.kwargs["metadata"]
+
+            # PG-local rank for rank 1 is 0; for rank 3 is 1.
+            expected_pg_rank = 0 if rank == 1 else 1
+            assert metadata["pg_rank"] == str(expected_pg_rank), (
+                f"expected pg_rank={expected_pg_rank}, " f"got {metadata['pg_rank']}"
+            )
+            # Global rank should be the actual global rank, not the PG-local.
+            assert metadata["global_rank"] == str(
+                rank
+            ), f"expected global_rank={rank}, got {metadata['global_rank']}"
+            # The peer is the OTHER member of [1, 3].
+            other_global = 3 if rank == 1 else 1
+            other_pg_local = 1 if rank == 1 else 0
+            assert metadata["mismatched_peer_global_ranks"] == str([other_global]), (
+                f"expected mismatched_peer_global_ranks=[{other_global}], "
+                f"got {metadata['mismatched_peer_global_ranks']}"
+            )
+            assert metadata["mismatched_peer_pg_ranks"] == str([other_pg_local]), (
+                f"expected mismatched_peer_pg_ranks=[{other_pg_local}], "
+                f"got {metadata['mismatched_peer_pg_ranks']}"
+            )
+
+        dist.barrier()  # keep WORLD alive while non-member ranks finish.
+        dist.destroy_process_group()
+
+    def test_mismatch_event_uses_global_ranks_on_subgroup(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_mismatch_event_uses_global_ranks_on_subgroup,
+            world_size=4,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_mismatch_raises_when_logger_unavailable(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        # Simulate OSS / inference bundle where logging_handlers is absent.
+        # The off-path must still raise the same RuntimeError unchanged.
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data._HAS_EVENT_LOGGER", False
+        ):
+            awaitable = SplitsAllToAllAwaitable(
+                input_tensors=input_tensors,
+                pg=none_throws(dist.group.WORLD),
+                collective_tag=rank,
+                collective_tag_parts=("logger_off",),
+            )
+            try:
+                awaitable.wait()
+                raise AssertionError("Expected RuntimeError for mismatched tags")
+            except RuntimeError as e:
+                assert "collective mismatch" in str(e).lower()
+                assert "logger_off" in str(e)
+        dist.destroy_process_group()
+
+    def test_mismatch_raises_when_logger_unavailable(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_mismatch_raises_when_logger_unavailable,
+            world_size=2,
+            backend="gloo",
+        )
+
+    @classmethod
+    def _run_test_mismatch_raises_when_logger_throws(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+
+        input_tensors = [
+            torch.tensor([1] * world_size, dtype=torch.int64),
+        ]
+        # If log_event itself throws (e.g. Scuba handler bug, metadata
+        # serialization failure), the diagnostic RuntimeError must still
+        # fire — telemetry must never suppress the actual error.
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data.EventLoggingHandler.log_event",
+            side_effect=RuntimeError("simulated scuba handler failure"),
+        ):
+            awaitable = SplitsAllToAllAwaitable(
+                input_tensors=input_tensors,
+                pg=none_throws(dist.group.WORLD),
+                collective_tag=rank,
+                collective_tag_parts=("logger_throws",),
+            )
+            try:
+                awaitable.wait()
+                raise AssertionError("Expected RuntimeError for mismatched tags")
+            except RuntimeError as e:
+                # Must surface the mismatch diagnostic, not the scuba failure.
+                assert (
+                    "collective mismatch" in str(e).lower()
+                ), f"expected mismatch diagnostic, got: {e}"
+                assert "logger_throws" in str(e)
+                assert "simulated scuba handler failure" not in str(e)
+        dist.destroy_process_group()
+
+    def test_mismatch_raises_when_logger_throws(self) -> None:
+        self._run_multi_process_test(
+            callable=self._run_test_mismatch_raises_when_logger_throws,
+            world_size=2,
+            backend="gloo",
+        )


### PR DESCRIPTION
Summary:

Follow-up to D101254817. The collective tag validator added in that diff raises a `RuntimeError` on each rank that detects a mismatch, but the failure only surfaces in the rank's stack trace. For fleet-wide visibility (frequency, which call sites, which jobs/PGs), this diff emits an `EventLoggingHandler.log_event` immediately before the raise, with structured metadata describing the mismatch.

Layering: `dist_data.py` imports from `torchrec.distributed.logging_handlers` (OSS no-op stub) and `torchrec.distributed.logging_utils` (pure-ABC leaf). The Meta-internal Scuba-backed handler at `torchrec/fb/distributed/logging_handlers.py` shadows the OSS module via `base_module = "torchrec.distributed"`, so OSS users get a no-op automatically and no `rfe.scubadata` symbol leaks into the OSS path. `logging_handlers` and `logging_utils` import nothing from `dist_data` — no circular import. The `try/except Exception` on the import handles `torch.package` inference bundles that strip `logging_handlers` AND any non-ImportError failure during the optional telemetry import — matching the defensive idiom in `train_pipelines.py` so a degraded logging dep cannot break `dist_data` import.

Bit-exactness: When the logger is unavailable (`_HAS_EVENT_LOGGER = False`) or the Meta `_should_log()` killswitch (`pytorch/torchrec:killswitch_event_logger`) is off, `log_event` is a no-op. The `raise RuntimeError(...)` runs unconditionally regardless of logger state — the existing failure path is unchanged.

PG identity (`pg_name`, `pg_rank`, and the `_pg_global_ranks` mapping) is captured in `__init__` only when validation is enabled, so the off path pays nothing. The `_pg_global_ranks` list (one entry per PG member, populated via `dist.get_global_rank`) is what lets the event report actionable global ranks even on non-WORLD sub-PGs.

Rank reporting: the Scuba event surfaces both global ranks (actionable for SRE triage) and PG-local indices (useful when reasoning about the collective's structure). On non-WORLD process groups the two differ — without the global mapping, peer indices would be PG-local and operators would have to manually resolve them to find the offending host.

Changes:
- Add defensive `try/except Exception` import for `EventLoggingHandler`, `TorchrecComponent`, and `EventType`. Set `_HAS_EVENT_LOGGER` accordingly.
- Add `pg_name` to the existing `comm_ops` import block.
- In `SplitsAllToAllAwaitable.__init__`: capture `self._pg_name`, `self._pg_rank`, and `self._pg_global_ranks` only when validation is enabled.
- In `SplitsAllToAllAwaitable._wait_impl`: emit `EventLoggingHandler.log_event(component=INPUT_DIST, event_name="SplitsAllToAllAwaitable.collective_tag_mismatch", event_type=FAILURE, metadata={...})` immediately before the existing `raise RuntimeError`. Metadata fields: `collective_label`, `collective_kind`, `expected_tag`, `received_tags`, `mismatched_peer_global_ranks` (actionable), `mismatched_peer_pg_ranks` (PG-local, for context), `pg_name`, `pg_rank` (PG-local), `global_rank` (this rank's global rank), `world_size`.
- BUCK: add `:logging_utils` and `//torchrec/fb/distributed:logging_handlers` to the `dist_data` target deps. The fb override provides the `torchrec.distributed.logging_handlers` namespace via `base_module`.
- Add 4 multi-process tests in `SplitsAllToAllCollectiveTagTest`:
  - `test_mismatch_emits_scuba_event` — mocks `log_event`, forces a mismatch on WORLD, asserts metadata payload (including the new `global_rank` and renamed `mismatched_peer_*` fields).
  - `test_mismatch_raises_when_logger_unavailable` — patches `_HAS_EVENT_LOGGER=False`, confirms the existing RuntimeError path is bit-exact.
  - `test_mismatch_raises_when_logger_throws` — `log_event` itself raises (e.g., Scuba handler bug); verifies the diagnostic RuntimeError still surfaces unchanged.
  - `test_mismatch_event_uses_global_ranks_on_subgroup` — 4-rank Gloo job with sub-PG of `[1, 3]`. Verifies the event reports global ranks (1, 3), not PG-local indices (0, 1) — the failure mode that motivated the global-rank addition.

Differential Revision: D102938675


