### PR TITLE
Add collision detection handler and factory

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import torch
+from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+@dataclass
+class CollisionResult:
+    """Output of detect_collisions for a single sharding group.
+
+    Contains overlap masks and remapped feature values. Remapped feature
+    values are KJT values shifted by per-table cumulative offsets so that
+    values from different tables occupy non-overlapping ranges, allowing a
+    single boolean mask to track overlap across all tables.
+
+    Example with two tables (table_0: 8 local rows, table_1: 8 local rows)::
+
+        table_0 offset = 0,  table_1 offset = 8
+        Raw values:      [3, 5]  (table_0)    [2, 7]  (table_1)
+        Remapped values: [3, 5]                [10, 15]
+
+    The pipeline saves `remapped_feature_values` from each batch and sets it
+    on the next batch's context as `prev_remapped_feature_values`.
+
+    Attributes:
+        forward_overlap_mask: Bool tensor, shape [num_values]. True at
+            position i means the i-th value in the current batch was also
+            present in the previous batch. Used to split the current batch
+            into overlapped (prioritized) and non-overlapped partitions.
+            All False for the first batch.
+        backward_overlap_mask: Bool tensor, shape [num_prev_values]. True
+            at position i means the i-th value from the previous batch is
+            also present in the current batch. Used to re-split the previous
+            batch's gradients during backward. None for the first batch.
+        remapped_feature_values: Tensor, shape [num_values]. Current batch's
+            feature values shifted by per-table cumulative offsets.
+    """
+
+    forward_overlap_mask: torch.Tensor
+    backward_overlap_mask: torch.Tensor | None
+    remapped_feature_values: torch.Tensor
+
+
+class BooleanMaskChecker:
+    """Boolean mask checker for overlap detection.
+
+    Maintains a boolean tensor of size `mask_size` (total local rows across
+    all tables). Each position corresponds to a remapped feature value.
+    `update` marks positions as seen; `check_overlap` checks them.
+    """
+
+    def __init__(self, device: torch.device, mask_size: int) -> None:
+        self._device = device
+        self._seen_values = torch.zeros(
+            mask_size,
+            dtype=torch.bool,
+            device=device,
+        )
+
+    def reset_mask(self) -> None:
+        self._seen_values.zero_()
+
+    def update(self, remapped_feature_values: torch.Tensor) -> None:
+        """Mark values as seen. Resets first (only current batch matters)."""
+        self.reset_mask()
+        self._seen_values[remapped_feature_values] = True
+
+    def check_overlap(
+        self,
+        remapped_feature_values: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return bool mask: True where values overlap with previously-seen values."""
+        return self._seen_values[remapped_feature_values]
+
+
+def split_features_by_values_mask(
+    features: KeyedJaggedTensor,
+    overlap_mask: torch.Tensor,
+) -> Tuple[KeyedJaggedTensor, KeyedJaggedTensor]:
+    """Split KJT into overlapped and nonoverlapped partitions by bool mask.
+
+    Uses fbgemm.asynchronous_complete_cumsum + fbgemm.segment_sum_csr to
+    compute per-segment lengths for each partition efficiently.
+
+    Args:
+        features: input KJT (after input dist, on sharder side)
+        overlap_mask: bool tensor of shape [num_values], True = overlapped
+
+    Returns:
+        (overlapped_kjt, nonoverlapped_kjt) with correct per-feature lengths
+    """
+    lengths = features.lengths()
+    values = features.values()
+    weights = features.weights_or_none()
+
+    # Compute per-segment nonoverlapped counts via segment_sum_csr
+    lengths_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
+
+    # 1 = nonoverlapped, 0 = overlapped
+    nol_indicator = (~overlap_mask).to(lengths.dtype)
+    nol_lengths = torch.ops.fbgemm.segment_sum_csr(
+        1,
+        lengths_cumsum,
+        nol_indicator,
+    )
+
+    # Split weights if present
+    ol_weights = None
+    nol_weights = None
+
+    if weights is not None:
+        ol_weights = weights[overlap_mask]
+        nol_weights = weights[~overlap_mask]
+
+    overlapped_kjt = KeyedJaggedTensor(
+        keys=features.keys(),
+        values=values[overlap_mask],
+        weights=ol_weights,
+        lengths=lengths - nol_lengths,
+    )
+    nonoverlapped_kjt = KeyedJaggedTensor(
+        keys=features.keys(),
+        values=values[~overlap_mask],
+        weights=nol_weights,
+        lengths=nol_lengths,
+    )
+    return overlapped_kjt, nonoverlapped_kjt
+
+
+class CollisionHandlerBase(abc.ABC):
+    """Interface for PEC collision detection handlers.
+
+    Subclasses implement sharding-specific overlap detection logic.
+    The pipeline passes prev_remapped_feature_values as an argument to detect_collisions
+    rather than storing cross-batch state internally.
+    """
+
+    @abc.abstractmethod
+    def detect_collisions(
+        self,
+        features: KeyedJaggedTensor,
+        prev_remapped_feature_values: torch.Tensor | None = None,
+    ) -> CollisionResult:
+        """Detect overlapping IDs between current and previous batch.
+
+        Args:
+            features: current batch features (after input dist)
+            prev_remapped_feature_values: previous batch's remapped_feature_values, None for first batch
+
+        Returns:
+            CollisionResult with forward/backward masks and remapped_feature_values
+        """
+        ...
+
+    @abc.abstractmethod
+    def reset(self) -> None:
+        """Reset internal state (e.g. at epoch boundary)."""
+        ...
+
+
+class RWCollisionHandler(CollisionHandlerBase):
+    """Row-wise collision handler for PEC.
+
+    Uses cumulative local_rows across all tables as the offset space for
+    BooleanMaskChecker. Each feature's IDs are offset by their table's
+    cumulative row position so that IDs from different tables don't collide.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        grouped_emb_configs: List[GroupedEmbeddingConfig],
+        table_name_to_config: Dict[str, EmbeddingConfig],
+        checker_type: OverlappingCheckerType = OverlappingCheckerType.BOOLEAN,
+    ) -> None:
+        assert (
+            checker_type == OverlappingCheckerType.BOOLEAN
+        ), f"Only BOOLEAN checker is supported, got {checker_type}"
+        self._device = device
+        self._feature_to_table_offset: Dict[str, int] = {}
+        self._input_features_offset: torch.Tensor = torch.empty(
+            0,
+            dtype=torch.int64,
+            device=device,
+        )
+
+        mask_size = 0
+        for conf in grouped_emb_configs:
+            for emb_table in conf.embedding_tables:
+                for fname in table_name_to_config[emb_table.name].feature_names:
+                    self._feature_to_table_offset[fname] = mask_size
+                mask_size += emb_table.local_rows
+
+        self._checker = BooleanMaskChecker(device, mask_size)
+
+    def _remap_feature_values(self, features: KeyedJaggedTensor) -> torch.Tensor:
+        if self._input_features_offset.numel() == 0:
+            offset_list = [
+                self._feature_to_table_offset[fname] for fname in features.keys()
+            ]
+            self._input_features_offset = torch.tensor(
+                offset_list,
+                device=self._device,
+                dtype=torch.int64,
+            ).reshape(1, -1)
+
+        per_feat_lengths = features.lengths().view(-1, features.stride()).sum(1)
+        offsets = torch.repeat_interleave(
+            self._input_features_offset,
+            per_feat_lengths.view(-1),
+            dim=1,
+        )
+        return features.values() + offsets.view(-1)
+
+    def detect_collisions(
+        self,
+        features: KeyedJaggedTensor,
+        prev_remapped_feature_values: torch.Tensor | None = None,
+    ) -> CollisionResult:
+        remapped_feature_values = self._remap_feature_values(features)
+
+        if prev_remapped_feature_values is not None:
+            forward_overlap_mask = self._checker.check_overlap(remapped_feature_values)
+            self._checker.update(remapped_feature_values)
+            backward_overlap_mask = self._checker.check_overlap(
+                prev_remapped_feature_values
+            )
+        else:
+            forward_overlap_mask = torch.zeros(
+                features.values().numel(),
+                dtype=torch.bool,
+                device=self._device,
+            )
+            backward_overlap_mask = None
+            self._checker.update(remapped_feature_values)
+
+        return CollisionResult(
+            forward_overlap_mask=forward_overlap_mask,
+            backward_overlap_mask=backward_overlap_mask,
+            remapped_feature_values=remapped_feature_values,
+        )
+
+    def reset(self) -> None:
+        self._checker.reset_mask()
+
+
+def create_collision_handler(
+    sharding_type: str,
+    device: torch.device,
+    grouped_emb_configs: List[GroupedEmbeddingConfig],
+    table_name_to_config: Dict[str, EmbeddingConfig],
+    checker_type: OverlappingCheckerType,
+) -> CollisionHandlerBase:
+    """Factory function to create a collision handler for a given sharding type."""
+    if sharding_type == "row_wise":
+        return RWCollisionHandler(
+            device=device,
+            grouped_emb_configs=grouped_emb_configs,
+            table_name_to_config=table_name_to_config,
+            checker_type=checker_type,
+        )
+    raise ValueError(
+        f"PEC collision detection does not support sharding type: {sharding_type}"
+    )

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -8,7 +8,10 @@
 
 # pyre-strict
 
-from typing import Any, Dict, List, Optional, Type
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Type
 
 import torch
 import torch.nn as nn
@@ -22,6 +25,11 @@ from torchrec.distributed.embedding_types import (
     KJTList,
     ShardedEmbeddingModule,
 )
+from torchrec.distributed.pec_collision_handlers import (
+    CollisionHandlerBase,
+    CollisionResult,
+    create_collision_handler,
+)
 from torchrec.distributed.types import (
     Awaitable,
     LazyAwaitable,
@@ -30,22 +38,19 @@ from torchrec.distributed.types import (
     ShardingEnv,
     ShardingType,
 )
-from torchrec.modules.pec_embedding_modules import (
-    OverlappingCheckerType,
-    PECEmbeddingCollection,
-)
+from torchrec.modules.pec_embedding_modules import PECEmbeddingCollection
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
+@dataclass
 class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
     """Per-module context for ShardedPECEmbeddingCollection.
 
     Inherits from EmbeddingCollectionContext so it can be passed directly
     to the inner ShardedEmbeddingCollection's compute/output_dist methods.
-    PEC-specific fields will be added in later diffs.
     """
 
-    pass
+    prev_remapped_feature_values: List[torch.Tensor] | None = None
 
 
 class ShardedPECEmbeddingCollection(
@@ -65,11 +70,10 @@ class ShardedPECEmbeddingCollection(
         ec_sharder: EmbeddingCollectionSharder,
         env: ShardingEnv,
         device: torch.device,
-        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+        qcomm_codecs_registry: Dict[str, QuantizedCommCodecs] | None = None,
     ) -> None:
         super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
 
-        # Shard the inner EmbeddingCollection via composition
         self._embedding_collection: ShardedEmbeddingCollection = ec_sharder.shard(
             module._embedding_collection,
             table_name_to_parameter_sharding,
@@ -77,8 +81,20 @@ class ShardedPECEmbeddingCollection(
             device=device,
         )
 
-        # PEC config
-        self._checker_type: OverlappingCheckerType = module._checker_type
+        self._collision_handlers: List[CollisionHandlerBase] = []
+        for (
+            sharding_type,
+            sharding,
+        ) in self._embedding_collection._sharding_type_to_sharding.items():
+            self._collision_handlers.append(
+                create_collision_handler(
+                    sharding_type=sharding_type,
+                    device=device,
+                    grouped_emb_configs=sharding._grouped_embedding_configs,  # pyre-ignore[16]
+                    table_name_to_config=self._embedding_collection._table_name_to_config,
+                    checker_type=module._checker_type,
+                )
+            )
 
     def create_context(self) -> PECEmbeddingCollectionContext:
         return PECEmbeddingCollectionContext()
@@ -111,15 +127,44 @@ class ShardedPECEmbeddingCollection(
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
         return self._embedding_collection.compute_and_output_dist(ctx, input)
 
+    def detect_collisions(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        dist_input: KJTList,
+    ) -> List[CollisionResult]:
+        """Detect collisions for each sharding group's features.
+
+        Reads ctx.prev_remapped_feature_values (set by the pipeline from the
+        previous batch's CollisionResult). Returns masks only — KJT splitting
+        is done externally via split_features_by_values_mask().
+
+        Args:
+            ctx: PEC context for this batch. Pipeline sets
+                ctx.prev_remapped_feature_values from the previous batch's
+                CollisionResult.remapped_feature_values (None for first batch).
+            dist_input: KJTList from input_dist (one KJT per sharding group)
+
+        Returns:
+            List of CollisionResult (one per sharding group, typically just one for RW)
+        """
+        prev_values = ctx.prev_remapped_feature_values
+        results: List[CollisionResult] = []
+        for i, (handler, features) in enumerate(
+            zip(self._collision_handlers, dist_input)
+        ):
+            prev = prev_values[i] if prev_values is not None else None
+            results.append(handler.detect_collisions(features, prev))
+        return results
+
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):
     """Sharder for PECEmbeddingCollection. Enforces RW-only sharding."""
 
     def __init__(
         self,
-        ec_sharder: Optional[EmbeddingCollectionSharder] = None,
-        fused_params: Optional[Dict[str, Any]] = None,
-        qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+        ec_sharder: EmbeddingCollectionSharder | None = None,
+        fused_params: Dict[str, Any] | None = None,
+        qcomm_codecs_registry: Dict[str, QuantizedCommCodecs] | None = None,
     ) -> None:
         super().__init__(fused_params, qcomm_codecs_registry)
         self._embedding_collection_sharder: EmbeddingCollectionSharder = (
@@ -149,11 +194,12 @@ class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]
         module: PECEmbeddingCollection,
         params: Dict[str, ParameterSharding],
         env: ShardingEnv,
-        device: Optional[torch.device] = None,
-        module_fqn: Optional[str] = None,
+        device: torch.device | None = None,
+        module_fqn: str | None = None,
     ) -> "ShardedPECEmbeddingCollection":
         if device is None:
             device = torch.device("cuda")
+
         return ShardedPECEmbeddingCollection(
             module,
             params,

--- a/torchrec/distributed/tests/test_pec_collision_handlers.py
+++ b/torchrec/distributed/tests/test_pec_collision_handlers.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+
+import torch
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.distributed.pec_collision_handlers import (
+    BooleanMaskChecker,
+    CollisionHandlerBase,
+    CollisionResult,
+    create_collision_handler,
+    RWCollisionHandler,
+    split_features_by_values_mask,
+)
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+def _make_grouped_configs(
+    tables: List[EmbeddingConfig],
+    local_rows: int,
+) -> List[GroupedEmbeddingConfig]:
+    """Create GroupedEmbeddingConfig with ShardedEmbeddingTables for testing."""
+    emb_tables = []
+    for table in tables:
+        shard_table = ShardedEmbeddingTable(
+            name=table.name,
+            embedding_dim=table.embedding_dim,
+            num_embeddings=table.num_embeddings,
+            feature_names=table.feature_names,
+            data_type=table.data_type,
+            has_feature_processor=False,
+            local_rows=local_rows,
+            local_cols=table.embedding_dim,
+            compute_kernel=None,  # pyre-ignore[6]
+            local_metadata=None,
+            global_metadata=None,
+            weight_init_max=None,
+            weight_init_min=None,
+        )
+        emb_tables.append(shard_table)
+    return [
+        GroupedEmbeddingConfig(
+            data_type=tables[0].data_type,
+            pooling=None,  # pyre-ignore[6]
+            is_weighted=False,
+            has_feature_processor=False,
+            compute_kernel=EmbeddingComputeKernel.DENSE,
+            embedding_tables=emb_tables,
+        )
+    ]
+
+
+def _make_table_name_to_config(
+    tables: List[EmbeddingConfig],
+) -> dict[str, EmbeddingConfig]:
+    return {t.name: t for t in tables}
+
+
+class BooleanMaskCheckerTest(unittest.TestCase):
+    """Unit tests for BooleanMaskChecker."""
+
+    def setUp(self) -> None:
+        self.checker = BooleanMaskChecker(torch.device("cpu"), mask_size=10)
+
+    def test_empty_mask(self) -> None:
+        values = torch.tensor([0, 3, 5], dtype=torch.long)
+
+        mask = self.checker.check_overlap(values)
+
+        self.assertTrue(torch.equal(mask, torch.tensor([False, False, False])))
+
+    def test_update_and_check(self) -> None:
+        self.checker.update(torch.tensor([1, 3, 5], dtype=torch.long))
+
+        mask = self.checker.check_overlap(torch.tensor([1, 3, 7], dtype=torch.long))
+
+        self.assertTrue(torch.equal(mask, torch.tensor([True, True, False])))
+
+    def test_update_resets_previous(self) -> None:
+        self.checker.update(torch.tensor([1, 2], dtype=torch.long))
+        self.checker.update(torch.tensor([3, 4], dtype=torch.long))
+
+        mask = self.checker.check_overlap(torch.tensor([1, 2, 3, 4], dtype=torch.long))
+
+        self.assertTrue(torch.equal(mask, torch.tensor([False, False, True, True])))
+
+    def test_reset_mask(self) -> None:
+        self.checker.update(torch.tensor([0, 1, 2], dtype=torch.long))
+
+        self.checker.reset_mask()
+        mask = self.checker.check_overlap(torch.tensor([0, 1, 2], dtype=torch.long))
+
+        self.assertTrue(torch.equal(mask, torch.tensor([False, False, False])))
+
+
+class SplitFeaturesTest(unittest.TestCase):
+    """Unit tests for the standalone split_features_by_values_mask function."""
+
+    def test_all_nonoverlapped(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f0", "f1"],
+            values=torch.tensor([10, 20, 30, 40]),
+            lengths=torch.tensor([2, 0, 1, 1]),
+        )
+        mask = torch.tensor([False, False, False, False])
+
+        ol, nol = split_features_by_values_mask(kjt, mask)
+
+        self.assertEqual(ol.values().numel(), 0)
+        self.assertTrue(torch.equal(nol.values(), torch.tensor([10, 20, 30, 40])))
+        self.assertTrue(torch.equal(nol.lengths(), torch.tensor([2, 0, 1, 1])))
+
+    def test_all_overlapped(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f0", "f1"],
+            values=torch.tensor([10, 20, 30, 40]),
+            lengths=torch.tensor([2, 0, 1, 1]),
+        )
+        mask = torch.tensor([True, True, True, True])
+
+        ol, nol = split_features_by_values_mask(kjt, mask)
+
+        self.assertTrue(torch.equal(ol.values(), torch.tensor([10, 20, 30, 40])))
+        self.assertTrue(torch.equal(ol.lengths(), torch.tensor([2, 0, 1, 1])))
+        self.assertEqual(nol.values().numel(), 0)
+        self.assertTrue(torch.equal(nol.lengths(), torch.tensor([0, 0, 0, 0])))
+
+    def test_partial_overlap(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f0", "f1"],
+            values=torch.tensor([10, 20, 30, 40, 50, 60]),
+            lengths=torch.tensor([2, 1, 1, 2]),
+        )
+        mask = torch.tensor([False, True, False, False, True, False])
+
+        ol, nol = split_features_by_values_mask(kjt, mask)
+
+        self.assertTrue(torch.equal(ol.values(), torch.tensor([20, 50])))
+        self.assertTrue(torch.equal(ol.lengths(), torch.tensor([1, 0, 0, 1])))
+        self.assertTrue(torch.equal(nol.values(), torch.tensor([10, 30, 40, 60])))
+        self.assertTrue(torch.equal(nol.lengths(), torch.tensor([1, 1, 1, 1])))
+
+    def test_with_weights(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["f0"],
+            values=torch.tensor([1, 2, 3]),
+            lengths=torch.tensor([3]),
+            weights=torch.tensor([0.1, 0.2, 0.3]),
+        )
+        mask = torch.tensor([False, True, False])
+
+        ol, nol = split_features_by_values_mask(kjt, mask)
+
+        self.assertTrue(torch.equal(ol.values(), torch.tensor([2])))
+        self.assertTrue(torch.allclose(ol.weights(), torch.tensor([0.2])))
+        self.assertTrue(torch.equal(nol.values(), torch.tensor([1, 3])))
+        self.assertTrue(torch.allclose(nol.weights(), torch.tensor([0.1, 0.3])))
+
+    def test_preserves_keys(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_a", "feature_b"],
+            values=torch.tensor([1, 2, 3, 4]),
+            lengths=torch.tensor([2, 2]),
+        )
+        mask = torch.tensor([True, False, False, True])
+
+        ol, nol = split_features_by_values_mask(kjt, mask)
+
+        self.assertEqual(ol.keys(), ["feature_a", "feature_b"])
+        self.assertEqual(nol.keys(), ["feature_a", "feature_b"])
+
+
+class RWCollisionHandlerTest(unittest.TestCase):
+    """Unit tests for RWCollisionHandler."""
+
+    def setUp(self) -> None:
+        self.tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+            EmbeddingConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+        ]
+        self.handler = self._create_handler(self.tables)
+
+    def _create_handler(
+        self,
+        tables: List[EmbeddingConfig],
+        local_rows: int = 8,
+    ) -> RWCollisionHandler:
+        return create_collision_handler(  # pyre-ignore[7]
+            sharding_type="row_wise",
+            device=torch.device("cpu"),
+            grouped_emb_configs=_make_grouped_configs(tables, local_rows),
+            table_name_to_config=_make_table_name_to_config(tables),
+            checker_type=OverlappingCheckerType.BOOLEAN,
+        )
+
+    def test_is_collision_handler_base(self) -> None:
+        self.assertIsInstance(self.handler, CollisionHandlerBase)
+
+    def test_feature_to_table_offset(self) -> None:
+        self.assertEqual(self.handler._feature_to_table_offset["feature_0"], 0)
+        self.assertEqual(self.handler._feature_to_table_offset["feature_1"], 8)
+
+    def test_remap_feature_values(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        remapped = self.handler._remap_feature_values(kjt)
+
+        self.assertTrue(torch.equal(remapped, torch.tensor([0, 1, 10, 11])))
+
+    def test_first_batch_no_overlap(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        result = self.handler.detect_collisions(kjt)
+
+        self.assertIsInstance(result, CollisionResult)
+        self.assertTrue(
+            torch.equal(result.forward_overlap_mask, torch.zeros(4, dtype=torch.bool))
+        )
+        self.assertIsNone(result.backward_overlap_mask)
+        self.assertEqual(result.remapped_feature_values.numel(), 4)
+
+    def test_second_batch_with_overlap(self) -> None:
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result1 = self.handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([1, 4, 3, 5]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        result2 = self.handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertTrue(
+            torch.equal(
+                result2.forward_overlap_mask,
+                torch.tensor([True, False, True, False]),
+            )
+        )
+        assert result2.backward_overlap_mask is not None
+        self.assertTrue(
+            torch.equal(
+                result2.backward_overlap_mask,
+                torch.tensor([False, True, False, True]),
+            )
+        )
+
+    def test_no_overlap_between_batches(self) -> None:
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result1 = self.handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([4, 5, 6, 7]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        result2 = self.handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertFalse(result2.forward_overlap_mask.any())
+        assert result2.backward_overlap_mask is not None
+        self.assertFalse(result2.backward_overlap_mask.any())
+
+    def test_full_overlap_between_batches(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result1 = self.handler.detect_collisions(kjt)
+
+        result2 = self.handler.detect_collisions(
+            kjt, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertTrue(result2.forward_overlap_mask.all())
+        assert result2.backward_overlap_mask is not None
+        self.assertTrue(result2.backward_overlap_mask.all())
+
+    def test_three_consecutive_batches(self) -> None:
+        """Only adjacent batches matter — checker resets on each update call."""
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result1 = self.handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([4, 5, 6, 7]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result2 = self.handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+        kjt3 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        result3 = self.handler.detect_collisions(
+            kjt3, prev_remapped_feature_values=result2.remapped_feature_values
+        )
+
+        self.assertFalse(result3.forward_overlap_mask.any())
+        assert result3.backward_overlap_mask is not None
+        self.assertFalse(result3.backward_overlap_mask.any())
+
+    def test_reset_clears_checker(self) -> None:
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        self.handler.detect_collisions(kjt)
+
+        self.handler.reset()
+
+        mask = self.handler._checker.check_overlap(
+            torch.tensor([0, 1, 2, 3], dtype=torch.long)
+        )
+        self.assertFalse(mask.any())
+
+    def test_variable_length_features(self) -> None:
+        """Features with different lengths per batch element."""
+        handler = self._create_handler(self.tables, local_rows=16)
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+            lengths=torch.tensor([3, 1, 1, 3]),
+        )
+        result1 = handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([2, 8, 5, 9]),
+            lengths=torch.tensor([2, 2]),
+        )
+
+        result2 = handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertTrue(
+            torch.equal(
+                result2.forward_overlap_mask,
+                torch.tensor([True, False, True, False]),
+            )
+        )
+
+    def test_empty_batch(self) -> None:
+        """Empty KJT (all lengths=0) should produce empty masks."""
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([], dtype=torch.long),
+            lengths=torch.tensor([0, 0]),
+        )
+
+        result = self.handler.detect_collisions(kjt)
+
+        self.assertEqual(result.forward_overlap_mask.numel(), 0)
+        self.assertIsNone(result.backward_overlap_mask)
+        self.assertEqual(result.remapped_feature_values.numel(), 0)
+
+    def test_single_table(self) -> None:
+        """Single table — offset is always 0."""
+        handler = self._create_handler([self.tables[0]])
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0"],
+            values=torch.tensor([0, 1, 2]),
+            lengths=torch.tensor([3]),
+        )
+        result1 = handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0"],
+            values=torch.tensor([1, 3]),
+            lengths=torch.tensor([2]),
+        )
+
+        result2 = handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertTrue(
+            torch.equal(result1.remapped_feature_values, torch.tensor([0, 1, 2]))
+        )
+        self.assertTrue(
+            torch.equal(result2.forward_overlap_mask, torch.tensor([True, False]))
+        )
+
+    def test_multiple_features_per_table(self) -> None:
+        """Two features sharing one table get the same offset."""
+        tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_a", "feature_b"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+        ]
+        handler = self._create_handler(tables)
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_a", "feature_b"],
+            values=torch.tensor([0, 1, 2, 3]),
+            lengths=torch.tensor([2, 2]),
+        )
+        result1 = handler.detect_collisions(kjt1)
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_a", "feature_b"],
+            values=torch.tensor([2, 5]),
+            lengths=torch.tensor([1, 1]),
+        )
+
+        result2 = handler.detect_collisions(
+            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
+        )
+
+        self.assertEqual(handler._feature_to_table_offset["feature_a"], 0)
+        self.assertEqual(handler._feature_to_table_offset["feature_b"], 0)
+        self.assertTrue(
+            torch.equal(result2.forward_overlap_mask, torch.tensor([True, False]))
+        )
+
+
+class CreateCollisionHandlerTest(unittest.TestCase):
+    """Unit tests for the create_collision_handler factory function."""
+
+    def test_row_wise_returns_rw_handler(self) -> None:
+        tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+        ]
+
+        handler = create_collision_handler(
+            sharding_type="row_wise",
+            device=torch.device("cpu"),
+            grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
+            table_name_to_config=_make_table_name_to_config(tables),
+            checker_type=OverlappingCheckerType.BOOLEAN,
+        )
+
+        self.assertIsInstance(handler, RWCollisionHandler)
+
+    def test_unsupported_sharding_type_raises(self) -> None:
+        tables = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=16,
+            ),
+        ]
+
+        with self.assertRaises(ValueError):
+            create_collision_handler(
+                sharding_type="column_wise",
+                device=torch.device("cpu"),
+                grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
+                table_name_to_config=_make_table_name_to_config(tables),
+                checker_type=OverlappingCheckerType.BOOLEAN,
+            )

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -10,6 +10,7 @@
 
 import copy
 import unittest
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import torch
@@ -119,6 +120,32 @@ class PECSparseArch(nn.Module):
         return loss, ec_out
 
 
+def _shard_pec(
+    tables: List[EmbeddingConfig],
+    ctx: MultiProcessContext,
+    sharder: ModuleSharder[nn.Module],
+    local_size: Optional[int] = None,
+) -> PECSparseArch:
+    sparse_arch = PECSparseArch(tables, torch.device("meta"))
+
+    module_sharding_plan = construct_module_sharding_plan(
+        sparse_arch._pec_ec,
+        per_param_sharding={table.name: row_wise() for table in tables},
+        local_size=local_size,
+        world_size=ctx.world_size,
+        device_type="cuda" if torch.cuda.is_available() else "cpu",
+        sharder=sharder,
+    )
+
+    return shard_modules(  # pyre-ignore[7]
+        module=copy.deepcopy(sparse_arch),
+        plan=ShardingPlan({"_pec_ec": module_sharding_plan}),
+        env=ShardingEnv.from_process_group(ctx.pg),
+        sharders=[sharder],
+        device=ctx.device,
+    )
+
+
 def _test_sharding(
     tables: List[EmbeddingConfig],
     rank: int,
@@ -129,25 +156,7 @@ def _test_sharding(
     local_size: Optional[int] = None,
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        kjt_input = kjt_input_per_rank[rank].to(ctx.device)
-        sparse_arch = PECSparseArch(tables, torch.device("meta"))
-
-        module_sharding_plan = construct_module_sharding_plan(
-            sparse_arch._pec_ec,
-            per_param_sharding={table.name: row_wise() for table in tables},
-            local_size=local_size,
-            world_size=world_size,
-            device_type="cuda" if torch.cuda.is_available() else "cpu",
-            sharder=sharder,
-        )
-
-        sharded_sparse_arch: PECSparseArch = shard_modules(  # pyre-ignore[9]
-            module=copy.deepcopy(sparse_arch),
-            plan=ShardingPlan({"_pec_ec": module_sharding_plan}),
-            env=ShardingEnv.from_process_group(ctx.pg),
-            sharders=[sharder],
-            device=ctx.device,
-        )
+        sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
 
         assert isinstance(sharded_sparse_arch._pec_ec, ShardedPECEmbeddingCollection)
         assert isinstance(
@@ -155,10 +164,65 @@ def _test_sharding(
             ShardedEmbeddingCollection,
         )
 
-        # Forward + backward, two iterations to exercise stateful components
+        kjt_input = kjt_input_per_rank[rank].to(ctx.device)
         for _ in range(2):
             loss, _ = sharded_sparse_arch(kjt_input)
             loss.backward()
+
+
+@dataclass
+class ExpectedCollisionResult:
+    remapped: List[int]
+    forward_mask: List[bool]
+    backward_mask: List[bool] | None
+
+
+def _test_detect_collisions(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[List[KeyedJaggedTensor]],
+    expected_per_rank: List[List[ExpectedCollisionResult]],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    local_size: Optional[int] = None,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        # Shard the model and get the ShardedPECEmbeddingCollection
+        sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
+        sharded_pec = sharded_sparse_arch._pec_ec
+        assert isinstance(sharded_pec, ShardedPECEmbeddingCollection)
+        assert len(sharded_pec._collision_handlers) > 0
+
+        batches = kjt_input_per_rank[rank]
+        expected_batches = expected_per_rank[rank]
+        prev_remapped = None
+
+        for batch_idx, kjt_input in enumerate(batches):
+            kjt_input = kjt_input.to(ctx.device)
+
+            # Simulate the pipeline: set prev batch's remapped values on ctx,
+            # run input_dist to redistribute features, then detect collisions.
+            pec_ctx = sharded_pec.create_context()
+            pec_ctx.prev_remapped_feature_values = prev_remapped
+            dist_input = sharded_pec.input_dist(pec_ctx, kjt_input).wait().wait()
+            results = sharded_pec.detect_collisions(pec_ctx, dist_input)
+
+            # Verify remapped values and overlap masks against expected results.
+            assert len(results) >= 1
+            result = results[0]
+            expected = expected_batches[batch_idx]
+
+            assert result.remapped_feature_values.tolist() == expected.remapped
+            assert result.forward_overlap_mask.tolist() == expected.forward_mask
+            if expected.backward_mask is None:
+                assert result.backward_overlap_mask is None
+            else:
+                assert result.backward_overlap_mask is not None
+                assert result.backward_overlap_mask.tolist() == expected.backward_mask
+
+            # Save remapped values for next batch's collision detection
+            prev_remapped = [r.remapped_feature_values for r in results]
 
 
 @skip_if_asan_class
@@ -190,6 +254,90 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=kjt_input_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_detect_collisions_two_batches(self) -> None:
+        """Two batches with partial overlap — verifies exact masks and remapped values."""
+        WORLD_SIZE = 2
+
+        kjt_input_per_rank = [
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([1, 3, 5, 7, 4, 6]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+            ],
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
+                    lengths=torch.LongTensor([1, 2, 2, 1]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([8, 10, 9, 11, 13, 15]),
+                    lengths=torch.LongTensor([1, 2, 2, 1]),
+                ),
+            ],
+        ]
+
+        # RW sharding with block_size=8: rank 0 owns IDs 0-7, rank 1 owns 8-15.
+        # After input_dist, values are remapped to local indices.
+        # Remapped = local_value + table_offset (table_0 offset=0, table_1 offset=8).
+        expected_per_rank = [
+            [
+                ExpectedCollisionResult(
+                    remapped=[0, 1, 2, 6, 7, 11, 12, 13],
+                    forward_mask=[False] * 8,
+                    backward_mask=None,
+                ),
+                ExpectedCollisionResult(
+                    remapped=[1, 3, 5, 15, 12, 14],
+                    forward_mask=[True, False, False, False, True, False],
+                    backward_mask=[
+                        False,
+                        True,
+                        False,
+                        False,
+                        False,
+                        False,
+                        True,
+                        False,
+                    ],
+                ),
+            ],
+            [
+                ExpectedCollisionResult(
+                    remapped=[0, 9, 10, 11],
+                    forward_mask=[False] * 4,
+                    backward_mask=None,
+                ),
+                ExpectedCollisionResult(
+                    remapped=[0, 2, 1, 11, 13, 15],
+                    forward_mask=[True, False, False, True, False, False],
+                    backward_mask=[True, False, False, True],
+                ),
+            ],
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_detect_collisions,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=kjt_input_per_rank,
+            expected_per_rank=expected_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )


### PR DESCRIPTION
Summary:
# Context

Adds collision detection for PEC — the mechanism that identifies overlapping embedding IDs between consecutive batches. Overlapping IDs are prioritized in the communication schedule (sent first), enabling the trainer to start computation earlier.

# New API

 **`ShardedPECEmbeddingCollection.detect_collisions`**: A new pipeline stage called after `input_dist` and before compute. The PEC pipeline calls `detect_collisions(ctx, dist_input)` to identify which post-dist features overlap with the previous batch, producing a `CollisionResult` per sharding group with forward/backward overlap masks and remapped feature values.

The pipeline should wire batches together by saving `result.remapped_feature_values` onto the next batch's `ctx.prev_remapped_feature_values`. On the first batch, `prev_remapped_feature_values` is None and the forward mask is all-False.


# How overlap detection works

Each table's embedding IDs are shifted by a cumulative per-table offset so that all tables share a single boolean mask without collisions between tables:

```
table_0 (8 local rows) → offset 0    table_1 (8 local rows) → offset 8

Batch N features (after input_dist):
  feature_0 values: [0, 1, 2]     → remapped: [0, 1, 2]
  feature_1 values: [3, 4, 5]     → remapped: [11, 12, 13]
```

The `BooleanMaskChecker` maintains a boolean tensor of size `sum(local_rows)`. On each batch:

```
1. check_overlap(cur_remapped)    → forward_overlap_mask
   Reads the mask: True where cur batch values were seen in prev batch.

2. update(cur_remapped)
   Resets mask, then marks cur batch positions as True.

3. check_overlap(prev_remapped)   → backward_overlap_mask
   Reads the updated mask: True where prev batch values appear in cur batch.
```

For the first batch, `prev_remapped` is None, so `forward_overlap_mask` is all-False and `backward_overlap_mask` is None.

## Example: two consecutive batches

```
Batch 0 remapped: [0, 1, 2, 6, 7, 11, 12, 13]
  → forward_mask:  all False (first batch, no prev)
  → mask updated:  positions {0,1,2,6,7,11,12,13} marked True

Batch 1 remapped: [1, 3, 5, 15, 12, 14]

Step 1 — check_overlap(batch_1_remapped) against mask from batch 0:
  1  → mask[1]=True   → True    (was in batch 0)
  3  → mask[3]=False  → False
  5  → mask[5]=False  → False
  15 → mask[15]=False → False
  12 → mask[12]=True  → True    (was in batch 0)
  14 → mask[14]=False → False
  forward_mask = [True, False, False, False, True, False]

Step 2 — update(batch_1_remapped):
  Reset mask, mark positions {1,3,5,15,12,14} True

Step 3 — check_overlap(batch_0_remapped) against updated mask:
  0  → False    1  → True     2  → False    6  → False
  7  → False    11 → False    12 → True     13 → False
  backward_mask = [False, True, False, False, False, False, True, False]
```

# Changes

**CollisionHandlerBase** (`pec_collision_handlers.py`) — minimal abstract interface with `detect_collisions` and `reset`. No shared implementation in the base — subclasses own all detection logic.

**RWCollisionHandler** — row-wise collision handler implementing the offset-based remapping and boolean mask checking described above.

**`create_collision_handler` factory** — dispatches handler creation by sharding type string. Currently supports `row_wise` only; raises `ValueError` for unsupported types. Called in `ShardedPECEmbeddingCollection.__init__` for each sharding group.

**`split_features_by_values_mask`** — utility to split a KJT into overlapped and non-overlapped partitions using a boolean mask, via fbgemm segment ops.

Differential Revision: D103428603


