### PR TITLE
Fix KTRegroupAsDict _out_lengths None guard and FX/TorchScript compat

### DIFF
--- a/torchrec/modules/regroup.py
+++ b/torchrec/modules/regroup.py
@@ -7,9 +7,10 @@
 
 # pyre-strict
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import torch
+from torchrec.fx.tracer import is_fx_tracing
 from torchrec.modules.embedding_configs import data_type_to_dtype
 from torchrec.sparse.jagged_tensor import (
     _desugar_keyed_tensors,
@@ -124,17 +125,31 @@ class PermuteMultiEmbedding(torch.nn.Module):
             in_shapes = in_shapes.to(device, non_blocking=True)
             out_shapes = out_shapes.to(device, non_blocking=True)
 
+        out_lengths = self._out_lengths
+        if out_lengths is None:
+            return values
         return torch.ops.fbgemm.permute_multi_embedding(
             values,
             permutes,
             in_shapes,
             out_shapes,
-            self._out_lengths,
+            out_lengths,
         )
 
 
+@torch.fx.wrap
 def _to_tensor_dict(
-    keys: List[str], values: Union[List[torch.Tensor], Tuple[torch.Tensor, ...]]
+    keys: List[str], values: List[torch.Tensor]
+) -> Dict[str, torch.Tensor]:
+    return {key: values[i] for i, key in enumerate(keys)}
+
+
+# Separate FX-wrapped function for the torch.split path. FX wrapping is
+# per-function identity in _wrapped_fns_to_patch, so the split call site
+# needs its own wrapper to be treated as opaque by the tracer.
+@torch.fx.wrap
+def _split_to_tensor_dict(
+    keys: List[str], values: List[torch.Tensor]
 ) -> Dict[str, torch.Tensor]:
     return {key: values[i] for i, key in enumerate(keys)}
 
@@ -164,6 +179,9 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
 
     """
 
+    _splits: List[int]
+    _idx_key_pairs: List[Tuple[int, str]]
+
     def __init__(
         self,
         groups: List[List[str]],
@@ -188,8 +206,10 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
         # cached values populated on first forward call
         self._dim: int = 1
         self._use_fbgemm_regroup: bool = False
-        self._splits: List[int] = []
-        self._idx_key_pairs: List[Tuple[int, str]] = []
+        self._splits: List[int] = torch.jit.annotate(List[int], [])
+        self._idx_key_pairs: List[Tuple[int, str]] = torch.jit.annotate(
+            List[Tuple[int, str]], []
+        )
         self._permute_pooled_embs_impl = PermuteMultiEmbedding(groups, multi_device)
         self._emb_dtype = emb_dtype
 
@@ -251,8 +271,10 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
         Returns:
             Dict[str, torch.Tensor]: dictionary of tensors keyed by the keys.
         """
-        if not self._is_inited:
-            module_init(self, keyed_tensors)
+        if not torch.jit.is_scripting():
+            if not is_fx_tracing():
+                if not self._is_inited:
+                    module_init(self, keyed_tensors)
 
         if self._use_fbgemm_regroup:
             values = _get_kts_values(keyed_tensors)
@@ -265,7 +287,8 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
             )
             permuted_values = self.embedding_cast([permuted_values])[0]
             splitted_values = torch.split(permuted_values, self._splits, dim=self._dim)
-            return _to_tensor_dict(self._keys, splitted_values)
+            # pyre-ignore[6]: torch.split returns Tuple but _split_to_tensor_dict accepts List
+            return _split_to_tensor_dict(self._keys, splitted_values)
 
     def clear_cache(self) -> None:
         self._is_inited = False

--- a/torchrec/modules/tests/test_regroup.py
+++ b/torchrec/modules/tests/test_regroup.py
@@ -13,7 +13,12 @@ import torch
 import torch.fx
 from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.modules.embedding_configs import data_type_to_dtype
-from torchrec.modules.regroup import KTRegroupAsDict
+from torchrec.modules.regroup import (
+    _split_to_tensor_dict,
+    _to_tensor_dict,
+    KTRegroupAsDict,
+    PermuteMultiEmbedding,
+)
 from torchrec.sparse.jagged_tensor import _all_keys_used_once, KeyedTensor
 from torchrec.sparse.tests.utils import build_groups, build_kts
 from torchrec.types import DataType
@@ -215,3 +220,39 @@ class KTRegroupAsDictTest(unittest.TestCase):
         for key in eager_out.keys():
             self.assertEqual(cast_out[key].dtype, dtype)
             torch.allclose(cast_out[key], eager_out[key].to(dtype))
+
+    def test_permute_multi_embedding_none_out_lengths(self) -> None:
+        groups = [["f1", "f2"], ["f3"]]
+        permute = PermuteMultiEmbedding(groups)
+        values = [torch.randn(2, 4), torch.randn(2, 8)]
+        result = permute(values)
+        self.assertEqual(len(result), len(values))
+        for r, v in zip(result, values):
+            self.assertTrue(torch.equal(r, v))
+
+    def test_to_tensor_dict(self) -> None:
+        keys = ["a", "b", "c"]
+        values = [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])]
+        result = _to_tensor_dict(keys, values)
+        self.assertEqual(list(result.keys()), keys)
+        for k, v in zip(keys, values):
+            self.assertTrue(torch.equal(result[k], v))
+
+    def test_split_to_tensor_dict(self) -> None:
+        keys = ["x", "y"]
+        values = [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])]
+        result = _split_to_tensor_dict(keys, values)
+        self.assertEqual(list(result.keys()), keys)
+        for k, v in zip(keys, values):
+            self.assertTrue(torch.equal(result[k], v))
+
+    def test_fx_trace_with_none_out_lengths(self) -> None:
+        groups = build_groups(
+            kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False
+        )
+        regroup_module = KTRegroupAsDict(groups=groups, keys=self.keys)
+        eager_out = regroup_module(self.kts)
+        gm = torch.fx.symbolic_trace(regroup_module)
+        fx_out = gm(self.kts)
+        for key in eager_out.keys():
+            self.assertTrue(torch.equal(eager_out[key], fx_out[key]))


### PR DESCRIPTION
Summary:
KTRegroupAsDict had multiple issues preventing FX tracing and TorchScript compilation:

1. PermuteMultiEmbedding.forward passes _out_lengths (Optional[List[int]]) to fbgemm::permute_multi_embedding which expects List[int]. When None, TorchScript compilation fails. Fix: return input values unchanged when _out_lengths is None.

2. _to_tensor_dict uses Union[List, Tuple] unsupported by TorchScript. Fix: change to List[Tensor] with torch.fx.wrap.

3. _idx_key_pairs/_splits initialized as untyped empty lists that TorchScript cant infer. Fix: torch.jit.annotate + class-level type annotations.

4. module_init calls _init_fbgemm_regroup which TorchScript cant resolve. Fix: guard with is_scripting()/is_fx_tracing().

5. Non-fbgemm path uses list(torch.split(...)) which iterates a Proxy during FX tracing. Fix: add _split_to_tensor_dict torch.fx.wrap wrapper.

Reviewed By: Akshayaa1996

Differential Revision: D103428071


