### PR TITLE
construct_jagged_tensors index_select change (#4211)

### DIFF
--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -265,9 +265,7 @@ def construct_jagged_tensors(
                 )
                 embeddings = torch.gather(embeddings, 0, expanded_indices)
             else:
-                embeddings = torch.index_select(
-                    embeddings, 0, reverse_indices.to(torch.int32)
-                )
+                embeddings = torch.index_select(embeddings, 0, reverse_indices)
         ret: Dict[str, JaggedTensor] = {}
 
         if seq_vbe_ctx is not None:


### PR DESCRIPTION
Summary:

Avoid a type cast to i32 , which shows a bit mem saving

Reviewed By: yjhao

Differential Revision: D103429512


