### PR TITLE
Override optimizer to EXACT_ROWWISE_ADAGRAD for cache-mode KVZCH TBEs

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -530,6 +530,9 @@ def _populate_zero_collision_tbe_params(
         )
     )
 
+    if embedding_cache_mode_:
+        tbe_params["optimizer"] = OptimType.EXACT_ROWWISE_ADAGRAD
+
     optimizer_type_for_st: Optional[str] = None
     optimizer_state_dtypes_for_st: Optional[FrozenSet[Tuple[str, int]]] = None
     load_ckpt_without_opt = False


### PR DESCRIPTION
Summary:
Training is broken on trunk. Errors from sample train job (fire-xialuli-f1075647197)

```
AssertionError: only EXACT_ROWWISE_ADAGRAD supports embedding cache mode, but got partial_row_wise_adam
```

When `embedding_cache_mode` is True, `SSDTableBatchedEmbeddingBags` asserts that the optimizer must be `EXACT_ROWWISE_ADAGRAD`. Cache-mode TBEs (`ZeroCollisionEmbeddingCache`, `ZeroCollisionEmbeddingEnrichmentCache`) do not perform gradient training — `forward()` is wrapped in `torch.no_grad()` — so the optimizer is semantically irrelevant.

Models using other sparse optimizers (e.g. `PARTIAL_ROWWISE_ADAM`) fail at TBE construction when enrichment cache tables are created, because the model-level optimizer flows through `fused_params` into the cache TBE constructor unchanged.

This diff overrides the optimizer to `EXACT_ROWWISE_ADAGRAD` in `_populate_zero_collision_tbe_params` when `embedding_cache_mode` is True, before the params reach the SSD TBE constructor. This is the correct layer because:
- Cache TBEs do not train, so the optimizer value has no effect on model behavior
- It applies to all models using enrichment cache, not just a specific model config
- It avoids relaxing the safety assertion in fbgemm

Reviewed By: mengyuehang

Differential Revision: D103567516


