### PR TITLE
Add collision_split_dist for exchanging per-rank overlap split sizes

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -173,6 +173,27 @@ class CollisionHandlerBase(abc.ABC):
         """Reset internal state (e.g. at epoch boundary)."""
         ...
 
+    @abc.abstractmethod
+    def compute_nonoverlapped_per_rank(
+        self,
+        nonoverlapped_features: KeyedJaggedTensor,
+        batch_size_per_rank: List[int],
+    ) -> torch.Tensor:
+        """Computes per-rank nonoverlapped value counts.
+
+        Used by collision_split_dist to compute per-rank split sizes for
+        the nonoverlapped partition. The overlapped splits are derived from
+        the total (output_splits - nonoverlapped).
+
+        Args:
+            nonoverlapped_features: nonoverlapped partition KJT
+            batch_size_per_rank: number of batch elements from each rank
+
+        Returns:
+            Tensor of shape [world_size] with per-rank nonoverlapped value counts
+        """
+        ...
+
 
 class RWCollisionHandler(CollisionHandlerBase):
     """Row-wise collision handler for PEC.
@@ -258,6 +279,33 @@ class RWCollisionHandler(CollisionHandlerBase):
 
     def reset(self) -> None:
         self._checker.reset_mask()
+
+    def compute_nonoverlapped_per_rank(
+        self,
+        nonoverlapped_features: KeyedJaggedTensor,
+        batch_size_per_rank: List[int],
+    ) -> torch.Tensor:
+        """Computes per-rank nonoverlapped value counts for RW sharding.
+
+        After RW input_dist, the KJT lengths are in feature-major order.
+        We transpose to batch-major, then use segment_sum_csr with
+        batch_size_per_rank as segment boundaries to sum lengths across
+        all features for each rank's batch elements.
+        """
+        batch_size_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor(
+                batch_size_per_rank,
+                device=self._device,
+                dtype=torch.int64,
+            )
+        )
+        num_features = len(nonoverlapped_features.keys())
+        lengths_batch_major = (
+            nonoverlapped_features.lengths().view(num_features, -1).t().flatten()
+        )
+        return torch.ops.fbgemm.segment_sum_csr(
+            num_features, batch_size_cumsum, lengths_batch_major
+        )
 
 
 def create_collision_handler(

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Type
 
 import torch
 import torch.nn as nn
+from torchrec.distributed.dist_data import SplitsAllToAllAwaitable
 from torchrec.distributed.embedding import (
     EmbeddingCollectionContext,
     EmbeddingCollectionSharder,
@@ -53,6 +54,67 @@ class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
     prev_remapped_feature_values: List[torch.Tensor] | None = None
 
 
+@dataclass
+class CollisionSplits:
+    """Result of waiting on CollisionSplitsAwaitable.
+
+    input_splits: [ol_per_rank, nol_per_rank] — how many values this rank
+        sends to each other rank per partition.
+    output_splits: [ol_received, nol_received] — how many values this rank
+        receives from each other rank per partition.
+    """
+
+    input_splits: List[List[int]]
+    output_splits: List[List[int]]
+
+
+class CollisionSplitsAwaitable(Awaitable[List[CollisionSplits]]):
+    """Awaitable for PEC collision split sizes, one per sharding group.
+
+    Wraps a SplitsAllToAllAwaitable that exchanges nonoverlapped per-rank
+    counts. On wait(), derives overlapped received splits from
+    total - nol_received, then assembles per-group CollisionSplits.
+
+    Args:
+        ol_input_splits: per-group overlapped send counts, each [world_size].
+        nol_input_splits: per-group nonoverlapped send counts, each [world_size].
+        splits_awaitable: SplitsAllToAll that exchanges nol counts across ranks.
+        total_input_splits: per-group total receive counts from input_dist,
+            each [world_size]. Used to derive ol_received = total - nol_received.
+    """
+
+    def __init__(
+        self,
+        ol_input_splits: List[List[int]],
+        nol_input_splits: List[List[int]],
+        splits_awaitable: SplitsAllToAllAwaitable,
+        total_input_splits: List[List[int]],
+    ) -> None:
+        super().__init__()
+        self._ol_input_splits = ol_input_splits
+        self._nol_input_splits = nol_input_splits
+        self._splits_awaitable = splits_awaitable
+        self._total_input_splits = total_input_splits
+
+    def _wait_impl(self) -> List[CollisionSplits]:
+        result = self._splits_awaitable.wait()
+        splits: List[CollisionSplits] = []
+        for nol_received, ol_input, nol_input, total in zip(
+            result,
+            self._ol_input_splits,
+            self._nol_input_splits,
+            self._total_input_splits,
+        ):
+            ol_received = [total[r] - nol_received[r] for r in range(len(nol_received))]
+            splits.append(
+                CollisionSplits(
+                    input_splits=[ol_input, nol_input],
+                    output_splits=[ol_received, nol_received],
+                )
+            )
+        return splits
+
+
 class ShardedPECEmbeddingCollection(
     ShardedEmbeddingModule[
         KJTList,  # CompIn
@@ -80,6 +142,7 @@ class ShardedPECEmbeddingCollection(
             env=env,
             device=device,
         )
+        self._env: ShardingEnv = env
 
         self._collision_handlers: List[CollisionHandlerBase] = []
         for (
@@ -155,6 +218,79 @@ class ShardedPECEmbeddingCollection(
             prev = prev_values[i] if prev_values is not None else None
             results.append(handler.detect_collisions(features, prev))
         return results
+
+    def collision_split_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        nonoverlapped_features: List[KeyedJaggedTensor],
+    ) -> CollisionSplitsAwaitable:
+        """Starts AllToAll to exchange per-rank nonoverlapped/overlapped split
+        sizes.
+
+        For each sharding group, computes how many nonoverlapped values this
+        rank sends to each other rank (nol_per_rank), derives the overlapped
+        counts (ol_per_rank = total - nol), and bundles all groups into a
+        single SplitsAllToAll. On wait, the received nol counts are used to
+        derive the received ol counts.
+
+        Args:
+            ctx: PEC context (sharding_contexts must be set from input_dist)
+            nonoverlapped_features: one nonoverlapped KJT per
+                sharding group, from split_features_by_values_mask()
+
+        Returns:
+            CollisionSplitsAwaitable that resolves to CollisionSplits.
+            # TODO: test with multiple sharding groups
+        """
+        # Per-group value counts for the overlapped partition. Derived from
+        # output splits form input dist, and will be used in output dist.
+        ol_input_splits: List[List[int]] = []
+
+        # Per-group value counts for non-overlapped partition. Derived from
+        # output splits from input dist, and will be used in output dist.
+        nol_input_splits: List[List[int]] = []
+
+        # Per-group split tensors for the nonoverlapped partition. Exchanged
+        # via SplitsAllToAll.
+        nol_splits: List[torch.Tensor] = []
+
+        # Per-group total receive counts from input_dist, used by the
+        # awaitable to derive ol_received = total - nol_received.
+        total_input_splits: List[List[int]] = []
+
+        for handler, nol_features, sharding_ctx in zip(
+            self._collision_handlers,
+            nonoverlapped_features,
+            ctx.sharding_contexts,
+        ):
+            assert sharding_ctx.batch_size_per_rank is not None
+            nol = handler.compute_nonoverlapped_per_rank(
+                nol_features, sharding_ctx.batch_size_per_rank
+            )
+            ol = (
+                torch.tensor(
+                    sharding_ctx.output_splits,
+                    device=nol.device,
+                    dtype=nol.dtype,
+                )
+                - nol
+            )
+
+            nol_splits.append(nol)
+
+            ol_input_splits.append(ol.tolist())
+            nol_input_splits.append(nol.tolist())
+            total_input_splits.append(sharding_ctx.input_splits)
+
+        assert self._env.process_group is not None
+        splits_awaitable = SplitsAllToAllAwaitable(nol_splits, self._env.process_group)
+
+        return CollisionSplitsAwaitable(
+            ol_input_splits=ol_input_splits,
+            nol_input_splits=nol_input_splits,
+            splits_awaitable=splits_awaitable,
+            total_input_splits=total_input_splits,
+        )
 
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -16,7 +16,12 @@ from typing import Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.pec_collision_handlers import (
+    CollisionResult,
+    split_features_by_values_mask,
+)
 from torchrec.distributed.pec_embedding import (
+    CollisionSplits,
     PECEmbeddingCollectionSharder,
     ShardedPECEmbeddingCollection,
 )
@@ -177,52 +182,124 @@ class ExpectedCollisionResult:
     backward_mask: List[bool] | None
 
 
-def _test_detect_collisions(
+@dataclass
+class ExpectedSplits:
+    input_splits: List[List[int]]
+    output_splits: List[List[int]]
+
+
+def _verify_collision_result(
+    result: CollisionResult,
+    expected: ExpectedCollisionResult,
+) -> None:
+    assert result.remapped_feature_values.tolist() == expected.remapped
+    assert result.forward_overlap_mask.tolist() == expected.forward_mask
+    if expected.backward_mask is None:
+        assert result.backward_overlap_mask is None
+    else:
+        assert result.backward_overlap_mask is not None
+        assert result.backward_overlap_mask.tolist() == expected.backward_mask
+
+
+def _verify_collision_splits(
+    all_splits: List[CollisionSplits],
+    expected: ExpectedSplits,
+) -> None:
+    assert len(all_splits) == 1
+    splits = all_splits[0]
+    assert splits.input_splits == expected.input_splits
+    assert splits.output_splits == expected.output_splits
+
+
+def _test_pec_forward_stages(
     tables: List[EmbeddingConfig],
     rank: int,
     world_size: int,
     kjt_input_per_rank: List[List[KeyedJaggedTensor]],
-    expected_per_rank: List[List[ExpectedCollisionResult]],
     sharder: ModuleSharder[nn.Module],
     backend: str,
+    expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
+    expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
     local_size: Optional[int] = None,
 ) -> None:
+    """Run PEC forward pipeline stages and verify against expected results.
+
+    Always runs: input_dist → detect_collisions → split → collision_split_dist.
+    Verification for each stage is enabled by providing its expected-output parameter.
+    """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        # Shard the model and get the ShardedPECEmbeddingCollection
         sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
         sharded_pec = sharded_sparse_arch._pec_ec
         assert isinstance(sharded_pec, ShardedPECEmbeddingCollection)
         assert len(sharded_pec._collision_handlers) > 0
 
         batches = kjt_input_per_rank[rank]
-        expected_batches = expected_per_rank[rank]
         prev_remapped = None
 
         for batch_idx, kjt_input in enumerate(batches):
             kjt_input = kjt_input.to(ctx.device)
 
-            # Simulate the pipeline: set prev batch's remapped values on ctx,
-            # run input_dist to redistribute features, then detect collisions.
+            # Stage 1: input_dist → detect_collisions
             pec_ctx = sharded_pec.create_context()
             pec_ctx.prev_remapped_feature_values = prev_remapped
             dist_input = sharded_pec.input_dist(pec_ctx, kjt_input).wait().wait()
             results = sharded_pec.detect_collisions(pec_ctx, dist_input)
 
-            # Verify remapped values and overlap masks against expected results.
-            assert len(results) >= 1
-            result = results[0]
-            expected = expected_batches[batch_idx]
+            if expected_collisions_per_rank is not None:
+                _verify_collision_result(
+                    results[0],
+                    expected_collisions_per_rank[rank][batch_idx],
+                )
 
-            assert result.remapped_feature_values.tolist() == expected.remapped
-            assert result.forward_overlap_mask.tolist() == expected.forward_mask
-            if expected.backward_mask is None:
-                assert result.backward_overlap_mask is None
-            else:
-                assert result.backward_overlap_mask is not None
-                assert result.backward_overlap_mask.tolist() == expected.backward_mask
+            # Stage 2: split features → collision_split_dist
+            nol_features = []
+            for result, features in zip(results, dist_input):
+                _, nol = split_features_by_values_mask(
+                    features,
+                    result.forward_overlap_mask,
+                )
+                nol_features.append(nol)
 
-            # Save remapped values for next batch's collision detection
+            all_splits = sharded_pec.collision_split_dist(
+                pec_ctx,
+                nol_features,
+            ).wait()
+
+            if expected_splits_per_rank is not None:
+                _verify_collision_splits(
+                    all_splits,
+                    expected_splits_per_rank[rank][batch_idx],
+                )
+
             prev_remapped = [r.remapped_feature_values for r in results]
+
+
+TWO_BATCH_KJT_INPUT_PER_RANK = [
+    [
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
+        ),
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([1, 3, 5, 7, 4, 6]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
+        ),
+    ],
+    [
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
+            lengths=torch.LongTensor([1, 2, 2, 1]),
+        ),
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([8, 10, 9, 11, 13, 15]),
+            lengths=torch.LongTensor([1, 2, 2, 1]),
+        ),
+    ],
+]
 
 
 @skip_if_asan_class
@@ -262,41 +339,13 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    def test_detect_collisions_two_batches(self) -> None:
-        """Two batches with partial overlap — verifies exact masks and remapped values."""
+    def test_detect_collisions(self) -> None:
+        """Verifies exact collision masks and remapped values."""
         WORLD_SIZE = 2
 
-        kjt_input_per_rank = [
-            [
-                KeyedJaggedTensor.from_lengths_sync(
-                    keys=["feature_0", "feature_1"],
-                    values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
-                    lengths=torch.LongTensor([2, 1, 1, 2]),
-                ),
-                KeyedJaggedTensor.from_lengths_sync(
-                    keys=["feature_0", "feature_1"],
-                    values=torch.LongTensor([1, 3, 5, 7, 4, 6]),
-                    lengths=torch.LongTensor([2, 1, 1, 2]),
-                ),
-            ],
-            [
-                KeyedJaggedTensor.from_lengths_sync(
-                    keys=["feature_0", "feature_1"],
-                    values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
-                    lengths=torch.LongTensor([1, 2, 2, 1]),
-                ),
-                KeyedJaggedTensor.from_lengths_sync(
-                    keys=["feature_0", "feature_1"],
-                    values=torch.LongTensor([8, 10, 9, 11, 13, 15]),
-                    lengths=torch.LongTensor([1, 2, 2, 1]),
-                ),
-            ],
-        ]
-
         # RW sharding with block_size=8: rank 0 owns IDs 0-7, rank 1 owns 8-15.
-        # After input_dist, values are remapped to local indices.
         # Remapped = local_value + table_offset (table_0 offset=0, table_1 offset=8).
-        expected_per_rank = [
+        expected_collisions_per_rank = [
             [
                 ExpectedCollisionResult(
                     remapped=[0, 1, 2, 6, 7, 11, 12, 13],
@@ -333,11 +382,52 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         ]
 
         self._run_multi_process_test(
-            callable=_test_detect_collisions,
+            callable=_test_pec_forward_stages,
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
-            kjt_input_per_rank=kjt_input_per_rank,
-            expected_per_rank=expected_per_rank,
+            kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
+            expected_collisions_per_rank=expected_collisions_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_collision_split_dist(self) -> None:
+        """Verifies exact collision split values per rank."""
+        WORLD_SIZE = 2
+
+        expected_splits_per_rank = [
+            [
+                ExpectedSplits(
+                    input_splits=[[0, 0], [6, 2]],
+                    output_splits=[[0, 0], [6, 0]],
+                ),
+                ExpectedSplits(
+                    input_splits=[[2, 0], [4, 0]],
+                    output_splits=[[2, 0], [4, 0]],
+                ),
+            ],
+            [
+                ExpectedSplits(
+                    input_splits=[[0, 0], [0, 4]],
+                    output_splits=[[0, 0], [2, 4]],
+                ),
+                ExpectedSplits(
+                    input_splits=[[0, 2], [0, 4]],
+                    output_splits=[[0, 2], [0, 4]],
+                ),
+            ],
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
+            expected_splits_per_rank=expected_splits_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )


### PR DESCRIPTION
Summary:
# Context

After collision detection identifies overlapping vs non-overlapping KJT values, the next step is exchanging per-rank split sizes so each rank knows how many overlapped and non-overlapped values it will send/receive in the partitioned embedding AllToAll.

# New API

**`ShardedPECEmbeddingCollection.collision_split_dist`**: Called after `detect_collisions` and `split_features_by_values_mask`. For each sharding group, computes how many non-overlapped values this rank sends to each peer rank, derives the overlapped counts from the total, then starts a single `SplitsAllToAll` to exchange the non-overlapped counts. Returns a `CollisionSplitsAwaitable` that, on wait, derives the overlapped received counts and assembles per-group `CollisionSplits`.

The forward stages flow so far:

```
input_dist → detect_collisions → split_features_by_values_mask → collision_split_dist
```

# Changes

**`CollisionSplits`** dataclass — holds `input_splits=[ol, nol]` and `output_splits=[ol, nol]` for one sharding group. `input_splits` are send-side counts, `output_splits` are receive-side counts.

**`CollisionSplitsAwaitable`** — wraps `SplitsAllToAllAwaitable`. Takes per-group ol/nol send counts and total receive counts. On wait, derives `ol_received = total - nol_received` and returns `List[CollisionSplits]`, one per sharding group.

**`compute_nonoverlapped_per_rank`** on `CollisionHandlerBase` / `RWCollisionHandler` — computes per-rank non-overlapped value counts from the non-overlapped KJT, using feature-major to batch-major transpose and `segment_sum_csr`.

Differential Revision: D103509258


