### PR TITLE
Add hook_position to InjectionSite for fine-grained backward hook placement

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -65,15 +65,7 @@ Example usage:
 import logging
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import (
-    Any,
-    Callable,
-    Optional,
-    Protocol,
-    runtime_checkable,
-    Sequence,
-    TYPE_CHECKING,
-)
+from typing import Any, Callable, Optional, Protocol, runtime_checkable, TYPE_CHECKING
 
 import torch
 from torch import nn
@@ -186,11 +178,16 @@ class InjectionSite:
         target_type: Selects the hooking mechanism.  Use ``PARAM_GRAD`` for
             compile-safe parameter-gradient hooks, ``ACTIVATION`` for
             forward-hook + ``tensor_finder`` hooks.
+        hook_position: Float in [0.0, 1.0] selecting which parameter to hook
+            within the target module (``PARAM_GRAD`` only).  0.0 picks the
+            first parameter (in ``module.parameters()`` order), 1.0 picks
+            the last.  Ignored for ``ACTIVATION``.
     """
 
     fqn: str
     tensor_finder: GradTensorFinder
     target_type: InjectionTargetType = InjectionTargetType.ACTIVATION
+    hook_position: float = 1.0
 
 
 def register_backward_hook(
@@ -250,34 +247,29 @@ def _register_param_grad_hook(
     target: nn.Module,
     hook_fn: Callable[[torch.Tensor], None],
 ) -> torch.utils.hooks.RemovableHandle:
-    """Compile-safe hook via ``register_multi_grad_hook`` on parameters."""
+    """Compile-safe hook on a single parameter selected by ``hook_position``."""
     params = [p for p in target.parameters() if p.requires_grad]
     if not params:
         raise ValueError(
             f"register_backward_hook: no trainable parameters in module '{site.fqn}'."
         )
 
-    def _multi_grad_callback(
-        grads: Sequence[torch.Tensor | None],
-    ) -> None:
-        """Invoke ``hook_fn`` with the first non-None gradient.
+    idx = _position_to_index(site.hook_position, len(params))
+    param = params[idx]
+    logger.info(
+        "register_backward_hook: hooking param %d/%d (position=%.2f) in '%s'",
+        idx,
+        len(params),
+        site.hook_position,
+        site.fqn,
+    )
+    return param.register_hook(hook_fn)
 
-        ``register_multi_grad_hook`` calls this once all tracked
-        parameters have accumulated their gradients.  We forward the
-        first available gradient tensor to the user-supplied
-        ``hook_fn``.
 
-        Raises:
-            RuntimeError: If every gradient in *grads* is ``None``.
-        """
-        grad = next((g for g in grads if g is not None), None)
-        if grad is None:
-            raise RuntimeError(
-                f"register_backward_hook: no non-None gradient found for module '{site.fqn}'."
-            )
-        hook_fn(grad)
-
-    return torch.autograd.graph.register_multi_grad_hook(params, _multi_grad_callback)
+def _position_to_index(position: float, length: int) -> int:
+    """Convert a [0.0, 1.0] position to an index in a list of ``length``."""
+    clamped = max(0.0, min(1.0, position))
+    return min(int(clamped * length), length - 1)
 
 
 def _register_activation_hook(

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -23,6 +23,7 @@ from torchrec.distributed.test_utils.multi_process import (
 )
 from torchrec.distributed.test_utils.test_model import ModelInput, TestSparseNN
 from torchrec.distributed.train_pipeline.backward_injection import (
+    _position_to_index,
     FirstGradTensorFinder,
     InjectionSite,
     InjectionTargetType,
@@ -122,6 +123,66 @@ class InjectionSiteTest(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             register_backward_hook(site, SimpleModel(), lambda grad: None)
+
+    def test_position_to_index(self) -> None:
+        self.assertEqual(_position_to_index(0.0, 5), 0)
+        self.assertEqual(_position_to_index(1.0, 5), 4)
+        self.assertEqual(_position_to_index(0.5, 4), 2)
+        self.assertEqual(_position_to_index(0.0, 1), 0)
+        self.assertEqual(_position_to_index(1.0, 1), 0)
+        # out-of-range values are clamped
+        self.assertEqual(_position_to_index(-0.5, 5), 0)
+        self.assertEqual(_position_to_index(1.5, 5), 4)
+
+    def test_hook_position_selects_parameter(self) -> None:
+        """hook_position=0.0 hooks weight, hook_position=1.0 hooks bias."""
+        model = SimpleModel()
+        grad_shapes: List[torch.Size] = []
+
+        # layer_a is nn.Linear(4, 4): params are [weight(4,4), bias(4)]
+        site_first = InjectionSite(
+            fqn="layer_a",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=0.0,
+        )
+        handle = register_backward_hook(
+            site_first,
+            model,
+            lambda grad: grad_shapes.append(grad.shape),
+        )
+        model(torch.randn(2, 4)).sum().backward()
+        self.assertEqual(grad_shapes[-1], torch.Size([4, 4]))
+        handle.remove()
+
+        site_last = InjectionSite(
+            fqn="layer_a",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=1.0,
+        )
+        handle = register_backward_hook(
+            site_last,
+            model,
+            lambda grad: grad_shapes.append(grad.shape),
+        )
+        model.zero_grad()
+        model(torch.randn(2, 4)).sum().backward()
+        self.assertEqual(grad_shapes[-1], torch.Size([4]))
+        handle.remove()
+
+    def test_hook_position_no_trainable_params_raises(self) -> None:
+        """PARAM_GRAD on a module with no trainable params raises ValueError."""
+        model = SimpleModel()
+        # layer_b contains ReLU at index 1 which has no parameters
+        site = InjectionSite(
+            fqn="layer_b.1",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=0.5,
+        )
+        with self.assertRaises(ValueError):
+            register_backward_hook(site, model, lambda grad: None)
 
     def test_register_hook_persists_and_removable(self) -> None:
         """Hook fires every iteration; removing it stops firing."""


### PR DESCRIPTION
Summary:
Adds a `hook_position: float` field (0.0-1.0) to `InjectionSite` that controls which parameter within the target module receives the backward hook in `PARAM_GRAD` mode.

Previously, `register_multi_grad_hook` was used on all trainable parameters, firing only after every gradient was computed. This change replaces it with `param.register_hook` on a single parameter selected by `hook_position`, giving precise control over when the hook fires during backward:
- `0.0` selects the first parameter (in `module.parameters()` order)
- `1.0` selects the last parameter (default, backward-compatible)

Changes:
- `backward_injection.py`: Add `hook_position` to `InjectionSite`, replace `register_multi_grad_hook` with position-based single-param `register_hook`, add `_position_to_index` helper
- `app_config.py`: Add `value_dist_injection_hook_position` to `AdsSparseDistPipelineConfig`
- `train_pipeline.py`: Pass config value through to `InjectionSite`
- `test_backward_injection.py`: Add tests for `_position_to_index`, hook position parameter selection, and no-trainable-params error

Differential Revision: D103504751


