### PR TITLE
Sync current stream on empty-lengths short-circuit in length_per_key (#4219)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -122,9 +122,6 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     if torch.jit.is_scripting() or not tensor.is_cuda:
         return tensor.tolist()
 
-    if tensor.numel() == 0:
-        return []
-
     # During torch.compile tracing, skip the JK check and _cuda_to_cpu_safe
     # and fall back to plain .tolist(). justknobs_check calls pyjk.check()
     # (a Cython function) which can raise SystemError in sandbox/RE
@@ -1326,6 +1323,26 @@ def _use_segment_sum_csr(stride_per_key: List[int]) -> bool:
     return len(stride_per_key) >= segment_threshold
 
 
+def _length_per_key_from_lengths(
+    lengths: torch.Tensor, len_keys: int, stride: int
+) -> List[int]:
+    """Compute per-key totals from a flat ``[len_keys * stride]`` lengths tensor.
+
+    Bundles the empty-lengths short-circuit with the GPU compute path so
+    callers don't have to. The empty branch syncs the current CUDA stream to
+    match the wait-set of the non-empty ``.tolist()`` path — without that,
+    ranks taking the empty short-circuit race ahead of ranks taking the
+    ``.tolist()`` path and deadlock the next collective.
+    """
+    if pt2_guard_size_oblivious(lengths.numel() == 0):
+        if not torch.jit.is_scripting() and lengths.is_cuda:
+            torch.cuda.current_stream(lengths.device).synchronize()
+        return [0] * len_keys
+    return _safe_tolist(
+        torch.sum(pt2_check_size_nonzero(lengths.view(len_keys, stride)), dim=1)
+    )
+
+
 def _length_per_key_from_stride_per_key(
     lengths: torch.Tensor, stride_per_key: List[int]
 ) -> List[int]:
@@ -1383,17 +1400,16 @@ def _maybe_compute_length_per_key(
         _length: List[int] = (
             _length_per_key_from_stride_per_key(lengths, stride_per_key)
             if variable_stride_per_key
-            else (
-                _safe_tolist(
-                    torch.sum(
-                        pt2_check_size_nonzero(lengths.view(len(keys), stride)), dim=1
-                    )
-                )
-                if pt2_guard_size_oblivious(lengths.numel() != 0)
-                else [0] * len(keys)
-            )
+            else _length_per_key_from_lengths(lengths, len(keys), stride)
         )
     elif len(keys) and offsets is not None and len(offsets) > 0:
+        # TODO: route this through _length_per_key_from_lengths once we
+        # confirm no caller depends on the empty-diff edge case returning [].
+        # Current behavior (returns [] when len(offsets) == 1) is inconsistent
+        # with the lengths-path empty case (returns [0] * len(keys)) and may
+        # have the same rank-divergence / cross-PG deadlock risk if it ever
+        # fires in collective code paths. Leaving as-is for now to scope this
+        # diff to the lengths-path only.
         _length: List[int] = (
             _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
             if variable_stride_per_key

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -8,13 +8,17 @@
 # pyre-strict
 
 
+import contextlib
 import unittest
+from typing import Iterator
+from unittest import mock
 
 import torch
 import torch.utils._pytree as pytree
 from torch.testing import FileCheck
 from torchrec.fx import symbolic_trace
 from torchrec.sparse.jagged_tensor import (
+    _maybe_compute_length_per_key,
     _safe_tolist,
     ComputeJTDictToKJT,
     JaggedTensor,
@@ -23,6 +27,33 @@ from torchrec.sparse.jagged_tensor import (
 )
 
 torch.fx.wrap("len")
+
+
+@contextlib.contextmanager
+def _count_current_stream_syncs() -> Iterator[list[int]]:
+    """Patch ``torch.cuda.current_stream`` so the returned stream's
+    ``synchronize()`` calls are counted. Yields a single-element list whose
+    ``[0]`` is the call count when the context exits.
+    """
+    sync_count: list[int] = [0]
+    real_current_stream = torch.cuda.current_stream
+
+    class _Tracker:
+        def __init__(self, stream: torch.cuda.Stream) -> None:
+            self._stream = stream
+
+        def synchronize(self) -> None:
+            sync_count[0] += 1
+            self._stream.synchronize()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._stream, name)
+
+    def _patched(device: object = None) -> object:
+        return _Tracker(real_current_stream(device))
+
+    with mock.patch("torch.cuda.current_stream", _patched):
+        yield sync_count
 
 
 class TestJaggedTensor(unittest.TestCase):
@@ -1417,3 +1448,55 @@ class TestJaggedTensorTracing(unittest.TestCase):
         tensor = torch.tensor([42], device="cuda")
         result = _safe_tolist(tensor)
         self.assertEqual(result, [42])
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_safe_tolist_empty_cuda_tensor_syncs_current_stream(self) -> None:
+        # _safe_tolist on an empty CUDA tensor must sync the current stream
+        # so callers don't race ahead of peer ranks taking the non-empty
+        # .tolist() path. Verified by patching torch.cuda.current_stream and
+        # counting synchronize() calls.
+        empty = torch.tensor([], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _safe_tolist(empty)
+
+        self.assertEqual(result, [])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_safe_tolist on empty CUDA tensor did not call "
+            "current_stream.synchronize()",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_maybe_compute_length_per_key_empty_lengths_cuda_syncs(self) -> None:
+        # When lengths.numel() == 0, _maybe_compute_length_per_key takes the
+        # [0] * len(keys) short-circuit. After the fix that branch must sync
+        # the current stream so ranks with empty lengths don't race ahead of
+        # ranks taking the .tolist() path.
+        keys = ["a", "b"]
+        empty_lengths = torch.tensor([], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _maybe_compute_length_per_key(
+                keys=keys,
+                stride=1,
+                stride_per_key=[1, 1],
+                variable_stride_per_key=False,
+                length_per_key=None,
+                lengths=empty_lengths,
+                offsets=None,
+                values=None,
+            )
+
+        self.assertEqual(result, [0, 0])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_maybe_compute_length_per_key empty-lengths branch did not call "
+            "current_stream.synchronize()",
+        )


### PR DESCRIPTION
Summary:

The `[0] * len(keys)` early-return branch in `_maybe_compute_length_per_key` skipped GPU synchronization entirely, while the sibling `.tolist()` path (taken when `lengths.numel() != 0`) implicitly synced the current CUDA stream as part of materializing the result. Ranks taking the empty short-circuit therefore raced ahead of ranks taking the `.tolist()` path, leaving the next collective waiting on a rank that had already moved on. This is one possible upstream trigger for the cross-PG deadlocks observed in `mvai-training-online-2130305043` (rank 7 stuck inside `KJTAllToAllTensorsAwaitable.__init__` calling `dist.all_to_all_single` at `torchrec/distributed/dist_data.py:407`, while ranks 0–6 stuck in `_maybe_compute_length_per_key`'s `.tolist()` at `torchrec/sparse/jagged_tensor.py:1305`).

Same divergence exists at the `_safe_tolist` `numel() == 0` short-circuit added by D101235037 — the plain `.tolist()` it replaced still synced even on an empty CUDA tensor (going through `tensor.cpu()` to materialize), but the new short-circuit returned `[]` immediately with no sync.

Changes:
- New `_length_per_key_from_lengths(lengths, len_keys, stride)` helper in `torchrec/sparse/jagged_tensor.py`. Bundles the empty-lengths early-out with the GPU compute path. Empty branch (`numel == 0`) syncs the current CUDA stream then returns `[0] * len_keys`. Non-empty branch is the existing `view → sum → _safe_tolist` pipeline. TorchScript bypasses the sync (script-mode divergence is pre-existing and out of scope).
- `_maybe_compute_length_per_key`'s lengths-path (the case from the production trace) is collapsed to a single ternary that calls the new helper.
- `_safe_tolist`: removes the `if tensor.numel() == 0: return []` short-circuit. Empty CUDA tensors now fall through to `_cuda_to_cpu_safe(tensor).tolist()` — the empty CPU buffer returns `[]`, but the path now syncs the current stream first. Behavior is unchanged on the return value, but the wait-set now matches the non-empty path.
- TODO added on the `_maybe_compute_length_per_key` offsets-path: it has the same shape of latent divergence (`torch.diff(offsets)` can be empty when `len(offsets) == 1`), but routing it through the helper would change its return value from `[]` to `[0] * len(keys)` for that edge case. Out of scope for this diff; flagged for follow-up once we audit consumers.

Reviewed By: isururanawaka, TroyGarden

Differential Revision: D103719817


