### PR TITLE
Add I/O size estimate validation and logging (#4220)

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -9,7 +9,7 @@
 
 import logging
 import math
-from typing import cast, Dict, List, Optional, Tuple, Type
+from typing import cast, Dict, List, Optional, Sequence, Tuple, Type
 
 import torch
 import torchrec.optim as trec_optim
@@ -512,6 +512,35 @@ def get_num_poolings(
     return [NUM_POOLINGS] * len(so.input_lengths)
 
 
+def _validate_io_sizes(
+    input_sizes: Sequence[float],
+    output_sizes: Sequence[float],
+    sharding_type: str,
+) -> None:
+    for i, size in enumerate(input_sizes):
+        assert not math.isnan(size), (
+            f"[TorchRec Planner] NaN detected in input_sizes[{i}] "
+            f"for sharding_type={sharding_type}. "
+            f"input_sizes={input_sizes}, output_sizes={output_sizes}"
+        )
+        assert size >= 0, (
+            f"[TorchRec Planner] Negative value detected in input_sizes[{i}]={size} "
+            f"for sharding_type={sharding_type}. "
+            f"input_sizes={input_sizes}, output_sizes={output_sizes}"
+        )
+    for i, size in enumerate(output_sizes):
+        assert not math.isnan(size), (
+            f"[TorchRec Planner] NaN detected in output_sizes[{i}] "
+            f"for sharding_type={sharding_type}. "
+            f"input_sizes={input_sizes}, output_sizes={output_sizes}"
+        )
+        assert size >= 0, (
+            f"[TorchRec Planner] Negative value detected in output_sizes[{i}]={size} "
+            f"for sharding_type={sharding_type}. "
+            f"input_sizes={input_sizes}, output_sizes={output_sizes}"
+        )
+
+
 def _calculate_shard_io_sizes(
     sharding_type: str,
     batch_sizes: List[int],
@@ -526,7 +555,7 @@ def _calculate_shard_io_sizes(
     is_pooled: bool,
 ) -> Tuple[List[int], List[int]]:
     if sharding_type == ShardingType.DATA_PARALLEL.value:
-        return _calculate_dp_shard_io_sizes(
+        input_sizes, output_sizes = _calculate_dp_shard_io_sizes(
             batch_sizes=batch_sizes,
             input_lengths=input_lengths,
             emb_dim=emb_dim,
@@ -537,7 +566,7 @@ def _calculate_shard_io_sizes(
             is_pooled=is_pooled,
         )
     elif sharding_type == ShardingType.TABLE_WISE.value:
-        return _calculate_tw_shard_io_sizes(
+        input_sizes, output_sizes = _calculate_tw_shard_io_sizes(
             batch_sizes=batch_sizes,
             world_size=world_size,
             input_lengths=input_lengths,
@@ -551,7 +580,7 @@ def _calculate_shard_io_sizes(
         ShardingType.COLUMN_WISE.value,
         ShardingType.TABLE_COLUMN_WISE.value,
     }:
-        return _calculate_cw_shard_io_sizes(
+        input_sizes, output_sizes = _calculate_cw_shard_io_sizes(
             batch_sizes=batch_sizes,
             world_size=world_size,
             input_lengths=input_lengths,
@@ -562,7 +591,7 @@ def _calculate_shard_io_sizes(
             is_pooled=is_pooled,
         )
     elif sharding_type == ShardingType.ROW_WISE.value:
-        return _calculate_rw_shard_io_sizes(
+        input_sizes, output_sizes = _calculate_rw_shard_io_sizes(
             batch_sizes=batch_sizes,
             world_size=world_size,
             input_lengths=input_lengths,
@@ -576,7 +605,7 @@ def _calculate_shard_io_sizes(
         sharding_type == ShardingType.TABLE_ROW_WISE.value
         or sharding_type == ShardingType.GRID_SHARD.value  # same as table row wise
     ):
-        return _calculate_twrw_shard_io_sizes(
+        input_sizes, output_sizes = _calculate_twrw_shard_io_sizes(
             batch_sizes=batch_sizes,
             world_size=world_size,
             local_world_size=local_world_size,
@@ -591,6 +620,9 @@ def _calculate_shard_io_sizes(
         raise ValueError(
             f"Unrecognized or unsupported sharding type provided: {sharding_type}"
         )
+
+    _validate_io_sizes(input_sizes, output_sizes, sharding_type)
+    return input_sizes, output_sizes
 
 
 def _calculate_dp_shard_io_sizes(

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -31,7 +31,9 @@ from torchrec.distributed.planner.constants import (
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
 from torchrec.distributed.planner.shard_estimators import (
+    _calculate_shard_io_sizes,
     _calculate_storage_specific_sizes,
+    _validate_io_sizes,
     EmbeddingOffloadStats,
     EmbeddingStorageEstimator,
 )
@@ -1845,3 +1847,159 @@ class TestComputeStorageUsage(unittest.TestCase):
         )
         expected = get_tensor_size_bytes(tensor)
         self.assertEqual(result, {"hbm": expected})
+
+
+class TestValidateIoSizes(unittest.TestCase):
+    def test_valid_sizes_no_assertion(self) -> None:
+        result = _validate_io_sizes([100, 200], [300, 400], "table_wise")
+        self.assertIsNone(result)
+
+    def test_negative_input_size_asserts(self) -> None:
+        with self.assertRaises(AssertionError) as ctx:
+            _validate_io_sizes([-1, 100], [200, 300], "table_wise")
+        self.assertIn(
+            "Negative value detected in input_sizes[0]=-1", str(ctx.exception)
+        )
+
+    def test_negative_output_size_asserts(self) -> None:
+        with self.assertRaises(AssertionError) as ctx:
+            _validate_io_sizes([100, 200], [-5, 300], "row_wise")
+        self.assertIn(
+            "Negative value detected in output_sizes[0]=-5", str(ctx.exception)
+        )
+
+    def test_nan_input_size_asserts(self) -> None:
+        with self.assertRaises(AssertionError) as ctx:
+            _validate_io_sizes([float("nan"), 100], [200, 300], "column_wise")
+        self.assertIn("NaN detected in input_sizes[0]", str(ctx.exception))
+
+    def test_nan_output_size_asserts(self) -> None:
+        with self.assertRaises(AssertionError) as ctx:
+            _validate_io_sizes([100, 200], [300, float("nan")], "data_parallel")
+        self.assertIn("NaN detected in output_sizes[1]", str(ctx.exception))
+
+
+class TestCalculateShardIoSizesValidation(unittest.TestCase):
+    def test_valid_tw_sizes_are_non_negative(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="table_wise",
+            batch_sizes=[32],
+            world_size=2,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[100, 64]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        for size in input_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+        for size in output_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+
+    def test_valid_rw_sizes_are_non_negative(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="row_wise",
+            batch_sizes=[32],
+            world_size=2,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[50, 64], [50, 64]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        for size in input_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+        for size in output_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+
+    def test_valid_cw_sizes_are_non_negative(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="column_wise",
+            batch_sizes=[32],
+            world_size=2,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[100, 32], [100, 32]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        for size in input_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+        for size in output_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+
+    def test_valid_dp_sizes_are_non_negative(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="data_parallel",
+            batch_sizes=[32],
+            world_size=2,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[100, 64], [100, 64]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        for size in input_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+        for size in output_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+
+    def test_valid_twrw_sizes_are_non_negative(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="table_row_wise",
+            batch_sizes=[32],
+            world_size=4,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[50, 64], [50, 64]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        for size in input_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+        for size in output_sizes:
+            self.assertGreaterEqual(size, 0)
+            self.assertFalse(math.isnan(size))
+
+    def test_zero_shard_sizes_produce_zero_io(self) -> None:
+        input_sizes, output_sizes = _calculate_shard_io_sizes(
+            sharding_type="row_wise",
+            batch_sizes=[32],
+            world_size=2,
+            local_world_size=2,
+            input_lengths=[10.0],
+            emb_dim=64,
+            shard_sizes=[[0, 0], [100, 64]],
+            input_data_type_size=4.0,
+            output_data_type_size=4.0,
+            num_poolings=[1.0],
+            is_pooled=True,
+        )
+        self.assertEqual(input_sizes[0], 0)
+        self.assertEqual(output_sizes[0], 0)
+        self.assertGreater(input_sizes[1], 0)
+        self.assertGreater(output_sizes[1], 0)


### PR DESCRIPTION
Summary:

Adds validation to ensure that I/O size estimates produced by `_calculate_shard_io_sizes` are non-negative and not-NaN. When a violation is detected, an AssertionError is raised with full context (sharding type, index, and all sizes) so estimation bugs are caught immediately.

The validation is placed inside `_calculate_shard_io_sizes` which is the single entry point for all sharding-type-specific I/O calculations (DP, TW, CW, RW, TWRW, grid). This covers all 3 call sites: `calculate_shard_storages` in shard_estimators.py, and stats reporting in both OSS and FB `stats.py`.

Also adds unit tests for:
- `_validate_io_sizes` directly (NaN and negative detection for both input and output)
- `_calculate_shard_io_sizes` for each sharding type (non-negative, not-NaN invariants)
- Zero shard sizes producing zero I/O (edge case for RW/TWRW)

Reviewed By: micrain

Differential Revision: D103718126


