### PR TITLE
Make module_init opaque to TorchScript via @torch.jit.ignore

### DIFF
--- a/torchrec/modules/regroup.py
+++ b/torchrec/modules/regroup.py
@@ -34,24 +34,6 @@ def _permuted_values(
     return torch.cat(values, dim=dim)
 
 
-@torch.fx.wrap
-def module_init(module: "KTRegroupAsDict", keyed_tensors: List[KeyedTensor]) -> None:
-    assert len(keyed_tensors) > 0, "Empty list provided"
-    assert all(
-        kt.device() == keyed_tensors[0].device() for kt in keyed_tensors
-    ), "All inputs should be on the same device."
-    assert all(
-        kt.key_dim() == keyed_tensors[0].key_dim() for kt in keyed_tensors
-    ), "All inputs should have the same key_dim"
-    module._dim = keyed_tensors[0].key_dim()
-
-    if module._dim == 1:
-        module._init_fbgemm_regroup(keyed_tensors)
-    else:
-        module._init_regroup(keyed_tensors)
-    module._is_inited = True
-
-
 class PermuteMultiEmbedding(torch.nn.Module):
     """
     Module to handle cached tensors and running FBGEMM
@@ -181,6 +163,7 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
 
     _splits: List[int]
     _idx_key_pairs: List[Tuple[int, str]]
+    _is_inited: bool
 
     def __init__(
         self,
@@ -292,3 +275,27 @@ class KTRegroupAsDict(torch.nn.Module, CacheMixin):
 
     def clear_cache(self) -> None:
         self._is_inited = False
+
+
+# Defined after KTRegroupAsDict so the type annotation can use the unquoted
+# class name. TorchScript can't resolve string forward-references for
+# @torch.jit.ignore'd functions when scripting cross-compilation-unit FX
+# graphs (e.g. when the FX graph is built in one CU and the regroup module
+# is loaded as an nn.Module in another).
+@torch.jit.ignore
+@torch.fx.wrap
+def module_init(module: KTRegroupAsDict, keyed_tensors: List[KeyedTensor]) -> None:
+    assert len(keyed_tensors) > 0, "Empty list provided"
+    assert all(
+        kt.device() == keyed_tensors[0].device() for kt in keyed_tensors
+    ), "All inputs should be on the same device."
+    assert all(
+        kt.key_dim() == keyed_tensors[0].key_dim() for kt in keyed_tensors
+    ), "All inputs should have the same key_dim"
+    module._dim = keyed_tensors[0].key_dim()
+
+    if module._dim == 1:
+        module._init_fbgemm_regroup(keyed_tensors)
+    else:
+        module._init_regroup(keyed_tensors)
+    module._is_inited = True

--- a/torchrec/modules/tests/test_regroup.py
+++ b/torchrec/modules/tests/test_regroup.py
@@ -160,6 +160,52 @@ class KTRegroupAsDictTest(unittest.TestCase):
         for key in out.keys():
             torch.allclose(out[key], eager_out[key])
 
+    def test_fx_and_jit_regroup_captures_lazy_init(self) -> None:
+        """
+        Regression test: when KTRegroupAsDict is FX-traced as a submodule
+        of a parent module before its first forward call, the lazy-init
+        guard does not skip the module_init free function, so module_init
+        is captured into the resulting FX graph as a call_function node.
+        torch.jit.script must then succeed on that graph -- without
+        @torch.jit.ignore on module_init, TS would try to compile its
+        body and abort at script time with:
+
+          RuntimeError: 'KTRegroupAsDict' object has no attribute or
+          method '_init_fbgemm_regroup'. 'module_init' is being compiled
+          since it was called from 'GraphModule.forward'
+
+        This test only covers script-time success. Runtime dispatch of
+        the captured call requires the regroup module to be the original
+        Python instance (not a scripted submodule that strips its
+        non-TS methods); production achieves that via a cross-CU
+        torch.package setup that isn't reproducible in-process.
+        """
+        from torchrec.modules.regroup import module_init
+
+        class _Parent(torch.nn.Module):
+            def __init__(self, groups: list[list[str]], keys: list[str]) -> None:
+                super().__init__()
+                self.regroup = KTRegroupAsDict(groups=groups, keys=keys)
+
+            def forward(self, kts: list[KeyedTensor]) -> dict[str, torch.Tensor]:
+                return self.regroup(kts)
+
+        groups = build_groups(
+            kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False
+        )
+        parent = _Parent(groups=groups, keys=self.keys)
+        self.assertFalse(parent.regroup._is_inited)
+
+        # Trace BEFORE running forward, so module_init is captured into
+        # the resulting FX graph (rather than being skipped by the lazy-init guard).
+        gm = torch.fx.symbolic_trace(parent)
+        captured_targets = {n.target for n in gm.graph.nodes if n.op == "call_function"}
+        self.assertIn(module_init, captured_targets)
+
+        # Must not raise. Without @torch.jit.ignore on module_init this
+        # would fail with the RuntimeError above during compilation.
+        torch.jit.script(gm)
+
     def test_fx_and_jit_regroup_with_multi_device(self) -> None:
         groups = build_groups(
             kts=self.kts, num_groups=self.num_groups, skips=False, duplicates=False


### PR DESCRIPTION
Summary:
KTRegroupAsDict.forward() lazy-initializes via the module-level free
function module_init(), guarded by `is_fx_tracing()` from
torchrec.fx.tracer. That guard only knows about torchrec's own
torch.fx.Tracer subclass — when the model is traced by a different
FX tracer subclass, the guard returns False and module_init gets
captured into the FX graph as a single call_function node (it already
has torch.fx.wrap).

Downstream, when the resulting FX GraphModule is compiled with
TorchScript, TS attempts to compile module_init's body. It chokes
because the init helpers it calls (_init_fbgemm_regroup ->
_desugar_keyed_tensors with nested dict-comp, _init_regroup, etc.)
were never designed to be TorchScript-compatible:

  RuntimeError: 'KTRegroupAsDict' object has no attribute or method
  '_init_fbgemm_regroup'.
  'module_init' is being compiled since it was called from
  'GraphModule.forward'

This diff:

1. Adds torch.jit.ignore to module_init. TS no longer compiles its
   body — at runtime the call is dispatched to the Python interpreter
   (which can do arbitrary attribute access on the KTRegroupAsDict
   instance, no problem). torch.fx.wrap stays so the FX tracer keeps
   treating it as an opaque single node.

2. Moves the module_init definition to AFTER the KTRegroupAsDict
   class so its `module: KTRegroupAsDict` annotation can be unquoted.
   With the previous forward-reference string, TS's torch.jit.ignore
   signature resolution failed across compilation units (e.g. when
   the model is loaded from a torch.package archive in one CU while
   nn.Module is loaded from another):

     ValueError: Unknown type annotation: 'KTRegroupAsDict'

   And substituting torch.nn.Module didn't help because TS treats the
   torch.package'd KTRegroupAsDict and the separately-loaded
   nn.Module as distinct types in different compilation units.

The free-function form (vs. refactoring to a class method) is
preserved to keep torch.fx.wrap working — torch.fx.wrap doesn't
apply to instance methods.

Reviewed By: Akshayaa1996

Differential Revision: D103741307


