### PR TITLE
Add 2D sharding logging to TrainingOptimizationLogger (#4225)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -45,6 +45,7 @@ class TorchrecComponent(Enum):
     LOOKUP = "lookup"
     REC_METRICS = "rec_metrics"
     ITEP = "itep"
+    DISTRIBUTED_MODEL_PARALLEL = "distributed_model_parallel"
 
 
 class EventLoggingHandler(EventLoggingHandlerBase):
@@ -363,6 +364,14 @@ def log_itep_ien_pruning_decision(
 def log_itep_itp_info(
     metadata: Optional[Dict[str, str]] = None,
     technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_two_dim_sharding_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.TWO_DIM_SHARDING,
 ) -> None:
     """No-op OSS stub."""
     pass

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -42,6 +42,7 @@ class OptimizationTechnique(Enum):
     ITEP = "itep"
     ALBT = "albt"
     SSD_OFFLOADING = "ssd_offloading"
+    TWO_DIM_SHARDING = "two_dim_sharding"
 
 
 @unique

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -32,6 +32,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.collective_utils import create_on_rank_and_share_result
 from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.logging_handlers import log_two_dim_sharding_config
 from torchrec.distributed.mc_embedding_modules import (
     BaseShardedManagedCollisionEmbeddingCollection,
 )
@@ -1197,6 +1198,20 @@ class DMPCollection(DistributedModelParallel):
         logger.info(
             "[TorchRec 2D Parallel] Consolidated sharding plan:\n%s", consolidated_plan
         )
+
+        # Log once per job; all ranks share the same config.
+        if self._global_rank == 0:
+            log_two_dim_sharding_config(
+                {
+                    "world_size": str(world_size),
+                    "sharding_group_size": str(sharding_group_size),
+                    "node_group_size": str(node_group_size),
+                    "sharding_strategy": sharding_strategy.name,
+                    "use_inter_host_allreduce": str(use_inter_host_allreduce),
+                    "has_submodule_configs": str(bool(submodule_configs)),
+                    "num_parallel_worlds": str(world_size // sharding_group_size),
+                }
+            )
 
         default_env = ShardingEnv2D(
             global_pg=self._pg,


### PR DESCRIPTION
Summary:

This diff extends the TrainingOptimizationLogger to capture 2D sharding configuration and activation by:

- Adding TWO_DIM_SHARDING to the OptimizationTechnique enum
- Adding DMP to the TorchrecComponent enum
- Adding log_two_dim_sharding_config() helper (OSS no-op stub + internal Scuba implementation)
- Instrumenting DMPCollection.__init__() in torchrec to emit a structured event with config fields: world_size, sharding_group_size, node_group_size, sharding_strategy, use_inter_host_allreduce, has_submodule_configs, num_parallel_worlds
- Extracting _TrainingOptimizationLoggerResetMixin for shared setUp/tearDown in test classes

Differential Revision: D103629272


