### PR TITLE
Add cuda_device_count() utility and fix flaky GPU skip guards

### DIFF
--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -45,7 +45,10 @@ from torchrec.modules.embedding_configs import (
     PoolingType,
 )
 from torchrec.modules.embedding_modules import EmbeddingCollection
-from torchrec.test_utils import skip_if_asan_class
+from torchrec.test_utils import cuda_device_count, skip_if_asan_class
+
+
+CUDA_DEVICE_COUNT: int = cuda_device_count()
 
 
 @skip_if_asan_class
@@ -61,7 +64,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         super().setUp(backend=backend)
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -157,7 +160,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -254,7 +257,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -373,7 +376,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -466,7 +469,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -614,7 +617,7 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         }
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -681,7 +684,7 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -752,7 +755,7 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -904,7 +907,7 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         }
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -991,7 +994,7 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -1081,7 +1084,7 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -1224,7 +1227,7 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         super().setUp(backend=backend)
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -1321,7 +1324,7 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -1418,7 +1421,7 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -1516,7 +1519,7 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     @given(
@@ -1614,7 +1617,7 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 5,
+        CUDA_DEVICE_COUNT <= 5,
         "Not enough GPUs, this test requires at least six GPUs",
     )
     @given(
@@ -1757,7 +1760,7 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         }
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -1830,7 +1833,7 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -1903,7 +1906,7 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        CUDA_DEVICE_COUNT <= 7,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     @given(
@@ -1976,7 +1979,7 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 5,
+        CUDA_DEVICE_COUNT <= 5,
         "Not enough GPUs, this test requires at least six GPUs",
     )
     @given(

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -31,7 +31,10 @@ from torchrec.distributed.test_utils.test_model import (
 from torchrec.distributed.types import ShardedModule, ShardingEnv, ShardingType
 from torchrec.distributed.utils import copy_to_device
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.test_utils import cuda_device_count
 from torchrec.types import CopyMixIn
+
+CUDA_DEVICE_COUNT: int = cuda_device_count()
 
 
 class CopyModule(nn.Module, CopyMixIn):
@@ -139,7 +142,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
                 self._recursive_device_check(child, child_copy, device, device_copy)
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        CUDA_DEVICE_COUNT <= 1,
         "Not enough GPUs available",
     )
     @given(
@@ -201,7 +204,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         self._recursive_device_check(dmp.module, dmp_1.module, device, device_1)
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        CUDA_DEVICE_COUNT <= 1,
         "Not enough GPUs available",
     )
     @given(
@@ -294,7 +297,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        CUDA_DEVICE_COUNT <= 1,
         "Not enough GPUs available",
     )
     def test_quant_pred_state_dict_cw_list_copy(self) -> None:
@@ -368,7 +371,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        CUDA_DEVICE_COUNT <= 1,
         "Not enough GPUs available",
     )
     @given(
@@ -449,7 +452,7 @@ class QuantModelParallelModelCopyTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        CUDA_DEVICE_COUNT <= 1,
         "Not enough GPUs available",
     )
     def test_copy_mixin(self) -> None:
@@ -513,7 +516,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         ]
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 0,
+        CUDA_DEVICE_COUNT <= 0,
         "Not enough GPUs available",
     )
     @given(
@@ -620,7 +623,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 0,
+        CUDA_DEVICE_COUNT <= 0,
         "Not enough GPUs available",
     )
     @given(
@@ -706,7 +709,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 0,
+        CUDA_DEVICE_COUNT <= 0,
         "Not enough GPUs available",
     )
     @given(
@@ -796,7 +799,7 @@ class QuantModelParallelModelSharderTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 0,
+        CUDA_DEVICE_COUNT <= 0,
         "Not enough GPUs available",
     )
     @given(

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -109,6 +109,18 @@ def skip_if_asan_class(cls: TReturn) -> Optional[TReturn]:
     return cls
 
 
+def cuda_device_count() -> int:
+    """More robust CUDA device count that falls back to CUDA_VISIBLE_DEVICES
+    when NVML fails to initialize."""
+    count = torch.cuda.device_count()
+    if count > 0:
+        return count
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible is not None and cuda_visible.strip():
+        return len(cuda_visible.split(","))
+    return 0
+
+
 def init_distributed_single_host(
     rank: int, world_size: int, backend: str, local_size: Optional[int] = None
 ) -> dist.ProcessGroup:


### PR DESCRIPTION
Summary:
Multiple test files use `torch.cuda.device_count()` in `unittest.skipIf` guards. This returns 0 when NVML cannot initialize, causing false skips on GPU RE machines and `bad_quality` TestX states.

Fix: Add `cuda_device_count()` to `torchrec/test_utils/__init__.py` as a shared utility that falls back to `CUDA_VISIBLE_DEVICES` when NVML fails. Update all affected test files to import and use it:
- `test_2d_sharding.py` — 20 skip guards
- `test_quant_model_parallel.py` — 9 skip guards
- `test_roo_model_utils.py` — 1 skip guard (via HAS_GPU)

All BUCK targets already use `gpu-remote-execution`, so GPUs are guaranteed in CI.

Reviewed By: isururanawaka

Differential Revision: D103750127


