### PR TITLE
Worker-side micro-batching for ZORM update queue (#4228)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -8,6 +8,7 @@
 # pyre-strict
 import atexit
 import concurrent
+import contextlib
 import logging
 import queue
 import threading
@@ -43,6 +44,55 @@ metric_update_thread_name: str = "metric_update"
 metric_compute_thread_name: str = "metric_compute"
 
 
+def _safe_merge_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Concatenate tensors along the batch dim. Falls back to torch.stack
+    for 0-dim tensors since torch.cat cannot concatenate them."""
+    if tensors[0].dim() == 0:
+        return torch.stack(tensors, dim=0)
+    return torch.cat(tensors, dim=0)
+
+
+def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
+    """
+    Merge a list of MetricUpdateJobs into a single job by concatenating
+    per-key tensors in `model_out` and any tensor entries in
+    `kwargs['required_inputs']` along the batch dimension (dim=0).
+
+    Worker-side input batching: K mini-batches' worth of model outputs
+    are passed to rec_metrics.update as a single (concatenated) call,
+    cutting PyBind crossings on the worker thread by ~K× for sum-style
+    metrics. Semantically equivalent for sum-reduction metrics; for
+    raw-retention metrics (AUC family) the window-eviction math advances
+    by +1 instead of +K, which is negligible when window_size >> K.
+
+    All jobs must share the same model_out key set and required_inputs
+    key set; non-tensor kwargs are taken from the first job.
+    """
+    if len(jobs) == 1:
+        return jobs[0]
+
+    first = jobs[0]
+    merged_model_out: Dict[str, torch.Tensor] = {
+        key: _safe_merge_tensors([j.model_out[key] for j in jobs])
+        for key in first.model_out.keys()
+    }
+
+    merged_kwargs: Dict[str, Any] = dict(first.kwargs)
+    required_inputs_first = first.kwargs.get("required_inputs")
+    if isinstance(required_inputs_first, dict) and required_inputs_first:
+        merged_required: Dict[str, torch.Tensor] = {
+            key: _safe_merge_tensors([j.kwargs["required_inputs"][key] for j in jobs])
+            for key in required_inputs_first.keys()
+        }
+        merged_kwargs["required_inputs"] = merged_required
+
+    return MetricUpdateJob(
+        model_out=merged_model_out,
+        kwargs=merged_kwargs,
+        merged_count=sum(j.merged_count for j in jobs),
+    )
+
+
 class CPUOffloadedRecMetricModule(RecMetricModule):
     """
     RecMetricModule that offloads metric update() and compute() to CPU using background threads.
@@ -73,6 +123,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         model_out_device: torch.device,
         update_queue_size: int = 100,
         compute_queue_size: int = 100,
+        update_batch_size: int = 10,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -83,11 +134,19 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             model_out_device: the device where the model_out is located (used to determine whether to perform GPU to CPU transfers).
             update_queue_size: Maximum size of the update queue. Default is 100.
             compute_queue_size: Maximum size of the compute queue. Default is 100.
+            update_batch_size: Worker-side micro-batching K. The worker
+                drains up to K MetricUpdateJobs per cycle, merges their
+                tensors on GPU via torch.cat, and dispatches one
+                rec_metrics.update call — cutting PyBind crossings on the
+                worker by ~K× with no added trainer-thread work. Drain
+                stops at any SynchronizationMarker, which is processed
+                after the merged batch. Default is 10; set to 1 to disable.
             *args: Additional positional arguments passed to RecMetricModule.
             **kwargs: Additional keyword arguments passed to RecMetricModule.
         """
         super().__init__(*args, **kwargs)
         self._model_out_device = model_out_device
+        self._update_batch_size: int = max(1, update_batch_size)
         self._shutdown_event: threading.Event = threading.Event()
         self._compute_shutdown_event: threading.Event = threading.Event()
         self._shutdown_complete: bool = False
@@ -262,24 +321,20 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
 
             if self.throughput_metric:
-                self.throughput_metric.update()
+                for _ in range(metric_update_job.merged_count):
+                    self.throughput_metric.update()
 
             elapsed_ms = (time.time() - start_time) * 1000
             self.update_job_time_logger.add(elapsed_ms)
-            self._total_updates_processed += 1
+            self._total_updates_processed += metric_update_job.merged_count
 
     @override
     def shutdown(self) -> None:
-        """
-        Two-phase shutdown: stop the update thread first so its flush can
-        enqueue any final compute jobs, then stop the compute thread.
-        Idempotent — safe under explicit call + atexit.
-        """
+        """Two-phase shutdown: stop the update thread, then the compute thread.
+        Idempotent — safe under explicit call + atexit."""
 
         if self._shutdown_complete:
             return
-
-        shutdown_timeout = 300.0
 
         logger.info(
             f"Gracefully shutting down CPUOffloadedRecMetricModule... "
@@ -288,8 +343,15 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         )
 
         self._shutdown_event.set()
+        try:
+            # pyrefly: ignore[implicit-import]
+            self.update_queue.put_nowait(
+                SynchronizationMarker(concurrent.futures.Future())
+            )
+        except queue.Full:
+            pass
         if self.update_thread.is_alive():
-            self.update_thread.join(timeout=shutdown_timeout)
+            self.update_thread.join()
         logger.info(
             f"Update thread: alive={self.update_thread.is_alive()}, "
             f"update_queue_remaining={self.update_queue.qsize()}"
@@ -297,7 +359,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         self._compute_shutdown_event.set()
         if self.compute_thread.is_alive():
-            self.compute_thread.join(timeout=shutdown_timeout)
+            self.compute_thread.join()
         logger.info(
             f"Compute thread: alive={self.compute_thread.is_alive()}, "
             f"compute_queue_remaining={self.compute_queue.qsize()}"
@@ -431,6 +493,13 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             if not self.rec_metrics:
                 raise RecMetricException("No metrics to compute.")
 
+            if self._captured_exception_event.is_set():
+                synchronization_marker.future.set_exception(
+                    self._captured_exception
+                    or RecMetricException("compute thread is unavailable")
+                )
+                return
+
             metric_state_snapshot = MetricStateSnapshot.from_metrics(
                 self.rec_metrics,
                 self.throughput_metric,
@@ -498,7 +567,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         while not self._shutdown_event.is_set():
             try:
-                self._do_work(self.update_queue)
+                self._do_batched_update_work()
             except Exception as e:
                 self._update_errors += 1
                 logger.exception(f"Exception in update loop: {e}")
@@ -515,14 +584,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 self._captured_exception = e
                 self._captured_exception_event.set()
                 return
-
-        try:
-            # pyrefly: ignore[implicit-import]
-            self.update_queue.put_nowait(
-                SynchronizationMarker(concurrent.futures.Future())
-            )
-        except queue.Full:
-            logger.warning("Could not enqueue final SyncMarker: update queue full")
 
         remaining = self._flush_remaining_work(self.update_queue)
         logger.info(f"Flushed {remaining} remaining update items during shutdown.")
@@ -571,6 +632,67 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             if isinstance(job, MetricComputeJob) and not job.future.done():
                 job.future.set_exception(error)
             self.compute_queue.task_done()
+
+    def _drain_update_batch(
+        self, first: MetricUpdateJob
+    ) -> tuple[list[MetricUpdateJob], Optional[SynchronizationMarker], int]:
+        """Opportunistically drain up to update_batch_size jobs; stop at any
+        SynchronizationMarker."""
+        pending_jobs: list[MetricUpdateJob] = [first]
+        pending_marker: Optional[SynchronizationMarker] = None
+        items_pulled = 1
+        while len(pending_jobs) < self._update_batch_size:
+            try:
+                next_item = self.update_queue.get_nowait()
+            except queue.Empty:
+                break
+            items_pulled += 1
+            if isinstance(next_item, MetricUpdateJob):
+                pending_jobs.append(next_item)
+            else:
+                pending_marker = next_item
+                break
+        return pending_jobs, pending_marker, items_pulled
+
+    def _do_batched_update_work(self) -> None:
+        """Drain up to K MetricUpdateJobs, merge, and dispatch one
+        rec_metrics.update call. Held SynchronizationMarker (if any) is
+        processed after the merged batch."""
+        first = self.update_queue.get()
+        pending_jobs: list[MetricUpdateJob] = []
+        pending_marker: Optional[SynchronizationMarker] = None
+        items_pulled = 1
+
+        if isinstance(first, MetricUpdateJob):
+            pending_jobs, pending_marker, items_pulled = self._drain_update_batch(first)
+        elif isinstance(first, SynchronizationMarker):
+            pending_marker = first
+
+        try:
+            try:
+                if pending_jobs:
+                    self._process_metric_update_job(_merge_update_jobs(pending_jobs))
+            except Exception:
+                if pending_marker is not None and not pending_marker.future.done():
+                    # pyrefly: ignore[implicit-import]
+                    with contextlib.suppress(concurrent.futures.InvalidStateError):
+                        pending_marker.future.set_exception(
+                            RecMetricException(
+                                "MetricUpdateJob batch failed before SynchronizationMarker"
+                            )
+                        )
+                raise
+            if pending_marker is not None:
+                try:
+                    self._process_synchronization_marker(pending_marker)
+                except Exception as e:
+                    # pyrefly: ignore[implicit-import]
+                    with contextlib.suppress(concurrent.futures.InvalidStateError):
+                        pending_marker.future.set_exception(e)
+                    raise
+        finally:
+            for _ in range(items_pulled):
+                self.update_queue.task_done()
 
     def _do_work(
         self,
@@ -663,26 +785,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
     @override
     def sync(self) -> None:
-        """
-        Sync the metric states across ranks. This is required before checkpointing.
-        """
-
-        # Prepare for checkpointing by waiting for all queued work to complete.
-        # This ensures that the timing of the snapshot is consistent across all ranks.
-        self.wait_until_queue_is_empty(self.update_queue)
-        self.wait_until_queue_is_empty(self.compute_queue)
-        logger.info("Ready for checkpoint.")
-
-        snapshot = MetricStateSnapshot.from_metrics(
-            self.rec_metrics,
-            self.throughput_metric,
-        )
-        self.comms_module.load_local_metric_state_snapshot(snapshot)
-        aggregated_states = self.comms_module.get_pre_compute_states(
-            self.cpu_process_group
-        )
-        self.comms_module.load_pre_compute_states(aggregated_states)
-
+        """Sync the metric states across ranks. Required before checkpointing.
+        Reuses the compute path so the all-gather happens via the compute thread;
+        the metric values are not used here."""
+        self.async_compute().resolve()
         logger.info("CPUOffloadedRecMetricModule synced.")
 
     @override

--- a/torchrec/metrics/metric_job_types.py
+++ b/torchrec/metrics/metric_job_types.py
@@ -22,22 +22,27 @@ class MetricUpdateJob:
     to update each metric's state tensors.
     """
 
-    __slots__ = ["model_out", "kwargs"]
+    __slots__ = ["model_out", "kwargs", "merged_count"]
 
     def __init__(
         self,
         model_out: Dict[str, torch.Tensor],
         kwargs: Dict[str, Any],
+        merged_count: int = 1,
     ) -> None:
         """
         Args:
             model_out: intermediate model outputs (may be on GPU; DtoH
                 transfer is handled by the processing thread)
             kwargs: additional arguments from the trainer platform
+            merged_count: number of logical update() calls this job
+                represents (>1 when worker-side micro-batching merges
+                K calls into one job).
         """
 
         self.model_out: Dict[str, torch.Tensor] = model_out
         self.kwargs: Dict[str, Any] = kwargs
+        self.merged_count: int = merged_count
 
 
 class MetricComputeJob:

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -12,7 +12,7 @@ import queue
 import threading
 import time
 import unittest
-from typing import Callable, cast
+from typing import Callable, cast, Optional
 from unittest.mock import patch
 
 import torch
@@ -20,10 +20,12 @@ import torch.distributed as dist
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.metrics.cpu_offloaded_metric_module import (
+    _merge_update_jobs,
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
 )
 from torchrec.metrics.deferrable_metrics import transfer_tensors_to_cpu
+from torchrec.metrics.metric_job_types import SynchronizationMarker
 from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
 from torchrec.metrics.metrics_config import DefaultMetricsConfig
 from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
@@ -74,18 +76,26 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         self.rec_metrics = RecMetricList([self.mock_metric])
 
         dist.init_process_group("gloo")
-        self.cpu_module: CPUOffloadedRecMetricModule = CPUOffloadedRecMetricModule(
-            model_out_device=torch.device("cpu"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
-            rec_metrics=self.rec_metrics,
+        self.cpu_module: CPUOffloadedRecMetricModule = self._make_module(
             throughput_metric=ThroughputMetric(
                 world_size=self.world_size,
                 batch_size=self.batch_size,
                 window_seconds=1,
             ),
         )
+
+    def _make_module(self, **overrides: object) -> CPUOffloadedRecMetricModule:
+        """K=1 isolates per-call semantics; batching paths use dedicated tests."""
+        defaults: dict[str, object] = {
+            "model_out_device": torch.device("cpu"),
+            "batch_size": self.batch_size,
+            "world_size": self.world_size,
+            "rec_tasks": self.tasks,
+            "rec_metrics": self.rec_metrics,
+            "update_batch_size": 1,
+        }
+        # pyrefly: ignore[bad-argument-type]
+        return CPUOffloadedRecMetricModule(**{**defaults, **overrides})
 
     def tearDown(self) -> None:
         if dist.is_initialized():
@@ -155,12 +165,8 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         "Not enough GPUs, this test requires at least one GPU",
     )
     def test_update_rec_metrics_queue_full(self) -> None:
-        cpu_module = CPUOffloadedRecMetricModule(
+        cpu_module = self._make_module(
             model_out_device=torch.device("cuda"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
-            rec_metrics=self.rec_metrics,
             update_queue_size=1,  # Small queue size
         )
 
@@ -435,11 +441,8 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 "state_3": torch.tensor([3.0]),
             },
         )
-        offloaded_module = CPUOffloadedRecMetricModule(
+        offloaded_module = self._make_module(
             model_out_device=torch.device("cuda"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
             rec_metrics=RecMetricList([offloaded_metric]),
         )
 
@@ -500,11 +503,8 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 "state_3": torch.tensor([1.0]),
             },
         )
-        offloaded_module = CPUOffloadedRecMetricModule(
+        offloaded_module = self._make_module(
             model_out_device=torch.device("cuda"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
             rec_metrics=RecMetricList([offloaded_metric]),
         )
 
@@ -544,12 +544,8 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         since torch.device("cuda:1") != torch.device("cuda").
         """
         # Create module with indexed cuda device (cuda:1)
-        cpu_module_indexed = CPUOffloadedRecMetricModule(
+        cpu_module_indexed = self._make_module(
             model_out_device=torch.device("cuda:1"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
-            rec_metrics=self.rec_metrics,
         )
 
         # Create tensors on cuda:1
@@ -665,11 +661,8 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         )
 
         device = torch.device("cuda") if use_cuda else torch.device("cpu")
-        offloaded_module = CPUOffloadedRecMetricModule(
+        offloaded_module = self._make_module(
             model_out_device=device,
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
             rec_metrics=RecMetricList([offloaded_metric]),
         )
 
@@ -817,13 +810,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
     def test_log_event_called_on_init(self) -> None:
         """Verify _log_event is called with INFO during __init__."""
         with patch.object(CPUOffloadedRecMetricModule, "_log_event") as mock_log_event:
-            module = CPUOffloadedRecMetricModule(
-                model_out_device=torch.device("cpu"),
-                batch_size=self.batch_size,
-                world_size=self.world_size,
-                rec_tasks=self.tasks,
-                rec_metrics=self.rec_metrics,
-            )
+            module = self._make_module()
 
             mock_log_event.assert_called_once_with(
                 "init",
@@ -955,14 +942,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
     def test_enqueue_update_logs_failure_on_queue_full(self) -> None:
         """Verify FAILURE event is logged when update queue is full."""
-        cpu_module = CPUOffloadedRecMetricModule(
-            model_out_device=torch.device("cpu"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
-            rec_metrics=self.rec_metrics,
-            update_queue_size=1,
-        )
+        cpu_module = self._make_module(update_queue_size=1)
 
         block_event = threading.Event()
 
@@ -993,14 +973,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
 
     def test_enqueue_compute_logs_failure_on_queue_full(self) -> None:
         """Verify FAILURE event is logged when update queue is full during async_compute."""
-        cpu_module = CPUOffloadedRecMetricModule(
-            model_out_device=torch.device("cpu"),
-            batch_size=self.batch_size,
-            world_size=self.world_size,
-            rec_tasks=self.tasks,
-            rec_metrics=self.rec_metrics,
-            update_queue_size=1,
-        )
+        cpu_module = self._make_module(update_queue_size=1)
 
         block_event = threading.Event()
 
@@ -1086,6 +1059,21 @@ class CPUOffloadedMetricModuleDistributedTest(MultiProcessTestBase):
             compare_sync=False,
         )
 
+    def test_cpu_offloaded_vs_standard_at_default_k_compute_only(self) -> None:
+        world_size = 2
+        batch_size = 8
+        num_batches = 20
+
+        self._run_multi_process_test(
+            callable=_compare_metric_results_worker,
+            world_size=world_size,
+            batch_size=batch_size,
+            num_batches=num_batches,
+            compare_sync=False,
+            update_batch_size=10,
+            compare_per_call=False,
+        )
+
 
 def _compare_metric_results_worker(
     rank: int,
@@ -1093,6 +1081,8 @@ def _compare_metric_results_worker(
     batch_size: int,
     num_batches: int,
     compare_sync: bool,
+    update_batch_size: int = 1,
+    compare_per_call: bool = True,
 ) -> None:
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
@@ -1137,6 +1127,7 @@ def _compare_metric_results_worker(
         world_size=world_size,
         rec_tasks=tasks,
         rec_metrics=RecMetricList([offloaded_metric]),
+        update_batch_size=update_batch_size,
     ).to(device)
 
     # Generate same training data for both modules
@@ -1178,33 +1169,35 @@ def _compare_metric_results_worker(
 
     # Wait for async compute to finish. Compare the input to each update()
     offloaded_results = future.resolve()
-    for (
-        offloaded_predictions,
-        offloaded_labels,
-        offloaded_weights,
-        standard_predictions,
-        standard_labels,
-        standard_weights,
-    ) in zip(
-        offloaded_metric.predictions_update_calls,
-        offloaded_metric.labels_update_calls,
-        offloaded_metric.weights_update_calls,
-        standard_metric.predictions_update_calls,
-        standard_metric.labels_update_calls,
-        standard_metric.weights_update_calls,
-    ):
-        assert_tensor_dict_equals(
-            actual_states=offloaded_predictions,
-            expected_states=standard_predictions,
-        )
-        assert_tensor_dict_equals(
-            actual_states=offloaded_labels,
-            expected_states=standard_labels,
-        )
-        assert_tensor_dict_equals(
-            actual_states=offloaded_weights,
-            expected_states=standard_weights,
-        )
+
+    if compare_per_call:
+        for (
+            offloaded_predictions,
+            offloaded_labels,
+            offloaded_weights,
+            standard_predictions,
+            standard_labels,
+            standard_weights,
+        ) in zip(
+            offloaded_metric.predictions_update_calls,
+            offloaded_metric.labels_update_calls,
+            offloaded_metric.weights_update_calls,
+            standard_metric.predictions_update_calls,
+            standard_metric.labels_update_calls,
+            standard_metric.weights_update_calls,
+        ):
+            assert_tensor_dict_equals(
+                actual_states=offloaded_predictions,
+                expected_states=standard_predictions,
+            )
+            assert_tensor_dict_equals(
+                actual_states=offloaded_labels,
+                expected_states=standard_labels,
+            )
+            assert_tensor_dict_equals(
+                actual_states=offloaded_weights,
+                expected_states=standard_weights,
+            )
 
     # Compare the computed metric results from both modules
     assert_tensor_dict_equals(
@@ -1214,6 +1207,319 @@ def _compare_metric_results_worker(
 
     cpu_offloaded_module.shutdown()
     dist.destroy_process_group()
+
+
+@skip_if_asan_class
+class WorkerSideBatchingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.world_size = 1
+        self.batch_size = 1
+        self.tasks = gen_test_tasks(["task1"])
+        self.initial_states = create_tensor_states(["cross_entropy_sum"])
+
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["LOCAL_WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+
+        self.mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=0,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=self.initial_states,
+        )
+        self.rec_metrics = RecMetricList([self.mock_metric])
+
+        dist.init_process_group("gloo")
+
+    def tearDown(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        if hasattr(self, "cpu_module"):
+            try:
+                self.cpu_module.shutdown()
+            except Exception:
+                pass
+
+    def _make_module(self, update_batch_size: int) -> CPUOffloadedRecMetricModule:
+        self.cpu_module: CPUOffloadedRecMetricModule = CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"),
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+            update_batch_size=update_batch_size,
+        )
+        return self.cpu_module
+
+    def test_worker_drains_and_merges_into_one_call(self) -> None:
+        cpu_module = self._make_module(update_batch_size=4)
+
+        captured_jobs: list[MetricUpdateJob] = []
+        original_process = cpu_module._process_metric_update_job
+
+        def gated_process(job: MetricUpdateJob) -> None:
+            captured_jobs.append(job)
+            original_process(job)
+
+        with patch.object(
+            cpu_module,
+            "_process_metric_update_job",
+            side_effect=gated_process,
+        ):
+            for _ in range(4):
+                cpu_module._update_rec_metrics(
+                    {
+                        "task1-prediction": torch.tensor([0.5]),
+                        "task1-label": torch.tensor([0.5]),
+                        "task1-weight": torch.tensor([1.0]),
+                    }
+                )
+            wait_until_true(lambda: cpu_module._total_updates_processed == 4)
+
+        self.assertEqual(cpu_module._total_updates_processed, 4)
+        total_merged = sum(j.merged_count for j in captured_jobs)
+        self.assertEqual(total_merged, 4)
+        self.assertLessEqual(len(captured_jobs), 4)
+
+    def test_marker_mid_batch_flushes_pending_then_processes_marker(self) -> None:
+        cpu_module = self._make_module(update_batch_size=10)
+
+        gate = threading.Event()
+        original_get = cpu_module.update_queue.get
+
+        def blocked_get(block: bool = True, timeout: Optional[float] = None) -> object:
+            gate.wait()
+            return original_get(block, timeout)
+
+        process_order: list[str] = []
+        original_process_update = cpu_module._process_metric_update_job
+        original_process_marker = cpu_module._process_synchronization_marker
+
+        def tracking_update(job: MetricUpdateJob) -> None:
+            process_order.append(f"update(merged={job.merged_count})")
+            original_process_update(job)
+
+        def tracking_marker(marker: SynchronizationMarker) -> None:
+            process_order.append("marker")
+            original_process_marker(marker)
+
+        with patch.object(
+            cpu_module.update_queue, "get", side_effect=blocked_get
+        ), patch.object(
+            cpu_module,
+            "_process_metric_update_job",
+            side_effect=tracking_update,
+        ), patch.object(
+            cpu_module,
+            "_process_synchronization_marker",
+            side_effect=tracking_marker,
+        ):
+            for _ in range(3):
+                cpu_module._update_rec_metrics(
+                    {
+                        "task1-prediction": torch.tensor([0.5]),
+                        "task1-label": torch.tensor([0.5]),
+                        "task1-weight": torch.tensor([1.0]),
+                    }
+                )
+            cpu_module.async_compute()
+
+            gate.set()
+
+            wait_until_true(
+                lambda: cpu_module._total_updates_processed == 3
+                and cpu_module._total_computes_enqueued == 1
+            )
+
+        self.assertEqual(process_order[0], "update(merged=3)")
+        self.assertEqual(process_order[1], "marker")
+
+    def test_bare_marker_first_processed_alone(self) -> None:
+        cpu_module = self._make_module(update_batch_size=4)
+
+        future = cpu_module.async_compute()
+        future.resolve()
+
+        self.assertEqual(cpu_module._total_updates_processed, 0)
+        self.assertEqual(cpu_module._total_computes_enqueued, 1)
+
+    def test_batch_failure_fails_held_marker_future(self) -> None:
+        cpu_module = self._make_module(update_batch_size=10)
+
+        gate = threading.Event()
+        original_get = cpu_module.update_queue.get
+
+        def blocked_get(block: bool = True, timeout: Optional[float] = None) -> object:
+            gate.wait()
+            return original_get(block, timeout)
+
+        with patch.object(
+            cpu_module.update_queue, "get", side_effect=blocked_get
+        ), patch.object(
+            cpu_module,
+            "_process_metric_update_job",
+            side_effect=RuntimeError("merged batch failed"),
+        ):
+            cpu_module._update_rec_metrics(
+                {
+                    "task1-prediction": torch.tensor([0.5]),
+                    "task1-label": torch.tensor([0.5]),
+                    "task1-weight": torch.tensor([1.0]),
+                }
+            )
+            deferrable = cpu_module.async_compute()
+            gate.set()
+
+            with self.assertRaisesRegex(
+                RecMetricException,
+                "MetricUpdateJob batch failed before SynchronizationMarker",
+            ):
+                deferrable.resolve()
+
+    def test_sync_does_not_deadlock_with_partial_batch(self) -> None:
+        cpu_module = self._make_module(update_batch_size=10)
+
+        for _ in range(3):
+            cpu_module._update_rec_metrics(
+                {
+                    "task1-prediction": torch.tensor([0.5]),
+                    "task1-label": torch.tensor([0.5]),
+                    "task1-weight": torch.tensor([1.0]),
+                }
+            )
+
+        sync_completed = threading.Event()
+
+        def call_sync() -> None:
+            cpu_module.sync()
+            sync_completed.set()
+
+        threading.Thread(target=call_sync, daemon=True).start()
+        self.assertTrue(
+            sync_completed.wait(timeout=5.0),
+            "sync() deadlocked when called with a partial K-batch in flight",
+        )
+        self.assertEqual(cpu_module._total_updates_processed, 3)
+
+
+class MergeUpdateJobsTest(unittest.TestCase):
+    def test_single_job_returned_unchanged(self) -> None:
+        job = MetricUpdateJob(
+            model_out={"label": torch.tensor([[1.0, 2.0]])},
+            kwargs={},
+        )
+        merged = _merge_update_jobs([job])
+        self.assertIs(merged, job)
+
+    def test_concat_model_out_along_batch_dim(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={
+                    "label": torch.tensor([[1.0, 2.0]]),
+                    "prediction": torch.tensor([[0.1, 0.2]]),
+                },
+                kwargs={},
+            ),
+            MetricUpdateJob(
+                model_out={
+                    "label": torch.tensor([[3.0, 4.0]]),
+                    "prediction": torch.tensor([[0.3, 0.4]]),
+                },
+                kwargs={},
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        self.assertEqual(merged.model_out["label"].shape, (2, 2))
+        self.assertEqual(merged.model_out["prediction"].shape, (2, 2))
+        self.assertTrue(
+            torch.equal(
+                merged.model_out["label"],
+                torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                merged.model_out["prediction"],
+                torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
+            )
+        )
+
+    def test_concat_required_inputs(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([1.0])},
+                kwargs={
+                    "required_inputs": {"target_tensor": torch.tensor([5.0])},
+                    "scalar_kwarg": "preserve_me",
+                },
+            ),
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([2.0])},
+                kwargs={
+                    "required_inputs": {"target_tensor": torch.tensor([6.0])},
+                    "scalar_kwarg": "preserve_me",
+                },
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        self.assertEqual(merged.kwargs["scalar_kwarg"], "preserve_me")
+        self.assertTrue(
+            torch.equal(
+                merged.kwargs["required_inputs"]["target_tensor"],
+                torch.tensor([5.0, 6.0]),
+            )
+        )
+
+    def test_safe_merge_zero_dim_falls_back_to_stack(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"label": torch.tensor(1.0)},
+                kwargs={},
+            ),
+            MetricUpdateJob(
+                model_out={"label": torch.tensor(2.0)},
+                kwargs={},
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        self.assertEqual(merged.model_out["label"].shape, (2,))
+        self.assertTrue(
+            torch.equal(merged.model_out["label"], torch.tensor([1.0, 2.0]))
+        )
+
+    def test_merged_count_sums_input_counts(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([1.0])},
+                kwargs={},
+                merged_count=3,
+            ),
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([2.0])},
+                kwargs={},
+                merged_count=5,
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        self.assertEqual(merged.merged_count, 8)
+
+    def test_empty_required_inputs_passes_through(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([[1.0]])},
+                kwargs={"required_inputs": {}},
+            ),
+            MetricUpdateJob(
+                model_out={"label": torch.tensor([[2.0]])},
+                kwargs={"required_inputs": {}},
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        self.assertEqual(merged.kwargs.get("required_inputs"), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

Worker-side micro-batching for ZORM's metric_update worker. The worker drains up to K=10 `MetricUpdateJob`s per cycle, merges their `model_out` and `required_inputs` on GPU via `torch.cat`, and dispatches one `rec_metrics.update` call. PyBind crossings on the worker drop ~Kx, mitigating the GIL contention identified in the ZORM Bottleneck investigation.

Trainer cost is unchanged: one `put_nowait` per `update()`, no `torch.cat` work added.

## Design

- Worker uses blocking `update_queue.get()` for the first item (event-driven wake), then `get_nowait()` for items 2..K (a slow producer can't pin pending items). Drain stops at any `SynchronizationMarker`, processed after the merged batch.
- `_merge_update_jobs` cats per-key tensors along `dim=0`. Falls back to `torch.stack` for 0-dim scalars.
- `merged_count` on `MetricUpdateJob` keeps `_total_updates_processed` and `throughput_metric` aligned with `_total_updates_enqueued`.
- `sync()` reduces to `async_compute().resolve()`, reusing the existing compute path.
- `shutdown()` pushes a `SynchronizationMarker` (via `put_nowait`) to wake the worker for a final compute.

Differential Revision: D103443331


