### PR TITLE
Add NaN validation to train pipeline benchmark

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -65,6 +65,7 @@ from torchrec.distributed.train_pipeline import (
     GradientAccumulationWrapper,
     TrainPipeline,
 )
+from torchrec.distributed.types import DeviceToHostTensorAwaitable
 from torchrec.metrics.metric_module import RecMetricModule
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
@@ -266,9 +267,19 @@ def runner(
                 )
             else:
                 dataloader = iter(bench_inputs)
+
+            not_nan_awaitable: Optional[DeviceToHostTensorAwaitable] = None
             while True:
                 try:
                     output = pipeline.progress(dataloader)
+                    if isinstance(output, torch.Tensor):
+                        not_nan_awaitable = DeviceToHostTensorAwaitable(
+                            ~torch.any(torch.isnan(output))
+                        )
+                    elif output is not None:
+                        logger.warning(
+                            f"Pipeline output is not a tensor: {type(output)}, skipping NaN check"
+                        )
 
                     if metric_module is not None and output is not None:
                         assert metric_model_out is not None
@@ -277,11 +288,18 @@ def runner(
                         if metric_module.should_compute():
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
+
                     if run_option.sync_fwd:
                         fwd_event.synchronize()
                     if run_option.sync_batch:
                         torch.cuda.synchronize()
+                    if (
+                        run_option.sync_fwd or run_option.sync_batch
+                    ) and not_nan_awaitable is not None:
+                        assert not_nan_awaitable.item(), "Pipeline output contains NaN"
                 except StopIteration:
+                    if not_nan_awaitable is not None:
+                        assert not_nan_awaitable.item(), "Pipeline output contains NaN"
                     break
 
         pipeline = pipeline_config.generate_pipeline(


### PR DESCRIPTION
Summary:
## 1. Context
The train pipeline benchmark (`benchmark_train_pipeline.py`) runs `pipeline.progress()` in a loop but never validates the output. If the model produces NaN values (e.g., due to numerical instability from learning rate, fused optimizer issues, or pipeline bugs), the benchmark silently reports timing results that are meaningless. The comms benchmark (`benchmark_comms.py`) already validates results using `DeviceToHostTensorAwaitable` from D85211205.

## 2. Approach
1. **Non-blocking NaN check via `DeviceToHostTensorAwaitable`**: After each `pipeline.progress()` call, wrap `~torch.any(torch.isnan(output))` in a `DeviceToHostTensorAwaitable`. This starts a non-blocking device-to-host copy immediately, allowing metric updates and other GPU work to overlap with the D2H transfer.
2. **Merged with existing sync points**: The NaN assertion is guarded by `sync_fwd or sync_batch`, so the check only runs when the benchmark is already synchronizing — no additional overhead in fully async mode.
3. **Non-tensor output warning**: If the pipeline output is not a `torch.Tensor` (unexpected for current benchmark models), a warning is logged so the user knows the NaN check was skipped.

## 3. Changes
1. **`benchmark_train_pipeline.py`**: Added `DeviceToHostTensorAwaitable` import and NaN validation logic inside `_func_to_benchmark`. The check is created after `pipeline.progress()`, overlaps with metric computation, and asserts at the existing sync points. Also asserts on `StopIteration` to catch NaN on the final batch.
2. **`BUCK`**: Added `//torchrec/distributed:types` dependency for `DeviceToHostTensorAwaitable`.

Differential Revision: D104073300


