### PR TITLE
[detailed][memory] Add record_stream benchmark to reproduce NaN issue in EMS

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -794,6 +794,93 @@ def multi_async_comms(
         assert checks.item()
 
 
+def data_copy_record_stream(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    use_record_stream: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Reproduce the record_stream bug fixed by D102202725.
+
+    Without record_stream(), resize_(0) lets the caching allocator reuse
+    HBM while an async D2H copy on a side stream is still in flight,
+    corrupting the copied data (NaN / wrong values).
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        data_copy_stream = torch.cuda.Stream()
+
+        gpu_tensor = torch.full(
+            (num_concat * dim, dim),
+            fill_value=float(ctx.rank + 1),
+            device=ctx.device,
+        )
+        cpu_buffer = torch.empty_like(gpu_tensor, device="cpu").pin_memory()
+
+    with record_function("## async D2H copy on side stream ##"):
+        with torch.cuda.stream(data_copy_stream):
+            data_copy_stream.wait_stream(main_stream)
+            cpu_buffer.copy_(gpu_tensor, non_blocking=True)
+
+        if use_record_stream:
+            gpu_tensor.record_stream(data_copy_stream)
+
+    with record_function("## free source tensor ##"):
+        # untyped_storage().resize_(0) releases the underlying GPU memory
+        # back to the caching allocator. Without record_stream() above,
+        # the allocator may immediately reuse this memory for new
+        # allocations while the D2H copy is still reading from it.
+        gpu_tensor.untyped_storage().resize_(0)
+
+    with record_function("## new allocations that reuse freed HBM ##"):
+        _: list[torch.Tensor] = [
+            torch.full(
+                (num_concat * dim, dim),
+                fill_value=-1.0,
+                device=ctx.device,
+            )
+            for _ in range(num_mul)
+        ]
+
+    with record_function("## wait and validate ##"):
+        data_copy_stream.synchronize()
+        expected = float(ctx.rank + 1)
+        all_correct = bool(torch.all(cpu_buffer == expected).item())
+        has_nan = bool(torch.any(torch.isnan(cpu_buffer)).item())
+        logger.info(
+            f"[rank-{ctx.rank}] record_stream={use_record_stream}: "
+            f"correct={all_correct}, has_nan={has_nan}"
+        )
+
+    with record_function("## validation result ##"):
+        if has_nan:
+            logger.error(f"[rank-{ctx.rank}] NaN detected — missing record_stream()")
+        if not all_correct:
+            logger.error(f"[rank-{ctx.rank}] Data corruption — missing record_stream()")
+
+
+def data_copy_no_record_stream(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    return data_copy_record_stream(
+        _batch_inputs=_batch_inputs,
+        dim=dim,
+        num_mul=num_mul,
+        num_concat=num_concat,
+        ctx=ctx,
+        use_record_stream=False,
+    )
+
+
 # single-rank runner
 def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) -> None:
     if arg.backend == "nccl":
@@ -851,6 +938,10 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 multi_async_comms._ar_pg = dist.new_group(
                     ranks=list(range(ctx.world_size))
                 )
+            case "data_copy_record_stream":
+                func = data_copy_record_stream
+            case "data_copy_no_record_stream":
+                func = data_copy_no_record_stream
             case _:
                 raise ValueError(f"Unknown benchmark name: {arg.name}")
 

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -65,6 +65,7 @@ from torchrec.distributed.train_pipeline import (
     GradientAccumulationWrapper,
     TrainPipeline,
 )
+from torchrec.distributed.types import DeviceToHostTensorAwaitable
 from torchrec.metrics.metric_module import RecMetricModule
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
@@ -266,9 +267,19 @@ def runner(
                 )
             else:
                 dataloader = iter(bench_inputs)
+
+            not_nan_awaitable: Optional[DeviceToHostTensorAwaitable] = None
             while True:
                 try:
                     output = pipeline.progress(dataloader)
+                    if isinstance(output, torch.Tensor):
+                        not_nan_awaitable = DeviceToHostTensorAwaitable(
+                            ~torch.any(torch.isnan(output))
+                        )
+                    elif output is not None:
+                        logger.warning(
+                            f"Pipeline output is not a tensor: {type(output)}, skipping NaN check"
+                        )
 
                     if metric_module is not None and output is not None:
                         assert metric_model_out is not None
@@ -277,11 +288,18 @@ def runner(
                         if metric_module.should_compute():
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
+
                     if run_option.sync_fwd:
                         fwd_event.synchronize()
                     if run_option.sync_batch:
                         torch.cuda.synchronize()
+                    if (
+                        run_option.sync_fwd or run_option.sync_batch
+                    ) and not_nan_awaitable is not None:
+                        assert not_nan_awaitable.item(), "Pipeline output contains NaN"
                 except StopIteration:
+                    if not_nan_awaitable is not None:
+                        assert not_nan_awaitable.item(), "Pipeline output contains NaN"
                     break
 
         pipeline = pipeline_config.generate_pipeline(


### PR DESCRIPTION
Summary:
## 1. Context
D102202725 fixed a NaN corruption bug in `memory_stashing.py` caused by missing `record_stream()` calls. When async D2H copies run on a side stream and the source tensor's GPU memory is released back to the caching allocator (via `untyped_storage().resize_(0)`), the allocator can immediately reuse that memory for new allocations on the default stream — corrupting the in-flight copy. The fix was adding `tensor.record_stream(d2h_stream)` to tell the allocator to defer reuse until the side stream catches up.

This diff adds a benchmark that reproduces the exact bug pattern for educational and debugging purposes, with trace and memory snapshot output.

## 2. What does `record_stream` do?

[`torch.Tensor.record_stream(stream)`](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html) marks a tensor as having been used by a given stream. When the tensor is later deallocated, the CUDA caching allocator will not reuse its memory until all work queued on `stream` (at the time of deallocation) has completed.

<img width="2384" height="844" alt="image" src="https://github.com/user-attachments/assets/476f3292-18b8-415b-9991-cb5b4f63ddd2" />

The diagram shows two streams (main and side) and the caching allocator (CCA) memory snapshot above. Tensor A is allocated at `0x1000` on the main stream and used on the side stream via an async copy. After `A.record_stream(side_stream)`, when the main stream frees A, the CCA cannot reuse `0x1000` until `side_stream` finishes reading it — so tensor B gets a fresh block at `0x3000` instead. Without `record_stream`, B would have been placed at `0x1000`, corrupting A's in-flight read on the side stream.

Note the timing: deallocation (`free 0x1000`) happens on the **host side** (CCA), not on any CUDA stream. When the host attempts to free the block, CCA polls the side stream to check whether execution has reached the point that was recorded by `record_stream`. If the side stream hasn't caught up yet, CCA puts the block on a pending-free list and defers the actual free. Only once the side stream advances past the recorded position does CCA actually release `0x1000` back to the free pool — at that point the side stream is guaranteed to have finished reading from it.

### 2.1 Why it's needed

The caching allocator only tracks the stream where a tensor was **allocated** (the "creation stream"). It automatically manages the tensor's lifetime on that stream. But if a tensor is **used on a different stream** — e.g., a side stream performs an async D2H copy — the allocator has no visibility into that usage. When the tensor is freed on the creation stream, the allocator may immediately hand its memory to a new allocation, even though the side stream is still reading from it.

`record_stream` closes this gap: it tells the allocator "this tensor is also in use on `stream`, so defer reuse until `stream` catches up."

### 2.2 Tradeoff

`record_stream` trades some allocator predictability for safety. In the diagram, by the time the main stream launches `B = A * 2`, the side stream may have already finished reading `0x1000` on the GPU — so the GPU could safely reuse that memory. But the CCA operates on the host side: it polls the recorded stream event to check completion, and the host-side query lags behind actual GPU execution. From the CCA's perspective the side stream hasn't caught up yet, so it keeps `0x1000` on the pending-free list and allocates a fresh block at `0x3000` for B instead. This means memory that the GPU no longer needs stays reserved longer than strictly necessary, increasing peak memory usage.

The alternative is manual stream synchronization via `wait_stream` before deallocation, which gives precise control but is fragile to maintain. See the [PyTorch docs](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html) for the full discussion and code example.

This is the core tradeoff: `record_stream` may over-hold memory because the host can't observe GPU completion instantly, while the manual `wait_stream` approach gives precise control but is fragile to maintain. For cases like EMS where tensors are created on one stream and consumed on another deep in the pipeline, `record_stream` is the practical choice.

## 3. Approach

The benchmark `data_copy_record_stream` reproduces the bug in five steps. A convenience wrapper `data_copy_no_record_stream` calls it with `use_record_stream=False`.

### Step-by-step

1. **Setup**: Allocate a GPU tensor `gpu_tensor` filled with a known value (`rank + 1`), and a pinned CPU buffer of the same shape.

2. **Async D2H copy on side stream**: Switch to `data_copy_stream`, wait for the main stream, then `cpu_buffer.copy_(gpu_tensor, non_blocking=True)`. If `use_record_stream=True`, call `gpu_tensor.record_stream(data_copy_stream)`.

3. **Free source tensor**: On the main stream, call `gpu_tensor.untyped_storage().resize_(0)` to release the GPU memory back to the caching allocator.

4. **New allocations that reuse freed HBM**: Allocate `num_mul` tensors of the **same shape** filled with `-1.0`. Without `record_stream`, the allocator hands back `gpu_tensor`'s old block — overwriting the memory while the D2H copy on the side stream is still reading from it.

5. **Wait and validate**: `data_copy_stream.synchronize()` to ensure the D2H copy completes, then check `cpu_buffer` for correctness.

### Timeline

```
              1        2         3         4         5
             alloc   record_  resize_  alloc new  wait &
            gpu_tens stream?    (0)    tensors   validate
main         ┌──┐              ┌──┐    ┌──────┐
stream       │  │──────────────│  │────│ -1.0 │───
             └──┘              └──┘    └──────┘
                  ╲                       │
                   ╲                reuses 0x1000?
                    ╲
copy         ┌───────────────────────────────┐
stream       │ wait ──► copy_(gpu→cpu)       │───
             └───────────────────────────────┘
                                          │
                                     synchronize
                                          │
host                              check cpu_buffer

  with record_stream:    fresh block  → correct  ✓
  without record_stream: reused block → corrupt  ✗
```

## 4. Results

* repro commands
```bash
# With record_stream (passes)
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=data_copy_record_stream \
    --memory_snapshot=True --num_concat=1

# Without record_stream (corruption detected)
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=data_copy_no_record_stream \
    --memory_snapshot=True --num_concat=1
```
[artifacts.zip](https://github.com/user-attachments/files/27486266/artifacts.zip)

* expected error (without record_stream)
```
  File "benchmark_comms.py", line 871, in data_copy_no_record_stream
    return data_copy_record_stream(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "benchmark_comms.py", line 860, in data_copy_record_stream
    assert all_correct, "Data corruption — missing record_stream()"
           ^^^^^^^^^^^
AssertionError: Data corruption — missing record_stream()
```

* trace — without record_stream

<img width="3140" height="648" alt="image" src="https://github.com/user-attachments/assets/46128794-3b43-4aa4-8bc4-b6268af37a27" />

Without `record_stream`, the trace shows `MemCpy DtoH (Device → Pinned)` on stream 28 running concurrently with the "new allocations that reuse freed HBM" on stream 7 (main GPU stream). The new `aten::full` kernels on the main stream write `-1.0` to the reused block while the DMA engine is still reading from it — this is the corruption window.

* trace — with record_stream

<img width="2846" height="648" alt="image" src="https://github.com/user-attachments/assets/98df2926-7a2b-4517-ad98-737b0c1eeafb" />

With `record_stream`, the layout looks similar — the D2H copy on stream 28 still overlaps with the new allocations on the main stream. But the allocator does not reuse `gpu_tensor`'s block for the new tensors, so the `aten::full` kernels write to fresh memory and the DMA reads uncorrupted data.

* memory snapshot — without record_stream

<img width="3456" height="1122" alt="image" src="https://github.com/user-attachments/assets/18c633ec-799e-47ed-950a-586e0d373369" />

Without `record_stream`, the blue block (`gpu_tensor`, ~16MB) disappears early — `resize_(0)` returns it to the free pool immediately. The new allocations (orange, red, teal, green, yellow) each claim ~16MB and stack upward. The first new allocation (orange) starts at the same base address as the freed `gpu_tensor`, confirming the allocator reused the block while the D2H copy was still in flight.

* memory snapshot — with record_stream

<img width="3456" height="1122" alt="image" src="https://github.com/user-attachments/assets/f4bc48c8-2775-483b-b8c1-33b93865127b" />


With `record_stream`, the blue block (`gpu_tensor`) persists much longer — it stays allocated while the new tensors are being created, because the CCA defers its free until `data_copy_stream` catches up. The new allocations are placed at fresh addresses (stacking above the blue block), so the D2H copy reads from uncorrupted memory. The blue block only drops off after the side stream finishes.

## 5. Analysis
1. **Without `record_stream` — memory reuse causes corruption**: The memory snapshot shows `gpu_tensor`'s block is freed immediately after `resize_(0)`. The first new same-shaped allocation lands at the same base address, overwriting the source while the D2H copy on `data_copy_stream` is still reading from it. The result: `cpu_buffer` contains `-1.0` (from the overwriting `aten::full`) instead of the expected `rank + 1`.
2. **With `record_stream` — deferred free prevents corruption**: The CCA holds `gpu_tensor`'s block on the pending-free list until `data_copy_stream` catches up. New allocations are placed at fresh addresses (stacking above the blue block in the snapshot), so the DMA reads uncorrupted data.
3. **Trace confirms the overlap window**: Both traces show `MemCpy DtoH` on stream 28 running concurrently with the `aten::full` kernels on the main stream — the exact window where corruption occurs. The difference is invisible in the trace (same kernel timeline) and only observable in the memory snapshot (address reuse vs fresh allocation).

> **Note**: In the `record_stream` trace, the D2H copy finishes after the second allocation, but `gpu_tensor`'s memory is only reused starting from the third allocation. This is because the CCA polls stream completion on the host side — by the time the host observes the D2H copy is done and moves the block from the pending-free list back to the free pool, the third allocation has already been fired from the CPU. In practice, the deferred release from `record_stream` won't impact peak memory usage as long as the data copy doesn't overlap with the peak memory window.

## 6. Changes
1. **`benchmark_comms.py`**: Added `data_copy_record_stream` (with `use_record_stream` toggle) and `data_copy_no_record_stream` wrapper. Registered both in the `a2a_single_runner` match statement.

Differential Revision: D103795866


