### PR TITLE
Add try/except import guard for logging_handlers in rec_metric.py (#4233)

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -37,7 +37,26 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.profiler import record_function
 from torchmetrics import Metric
-from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+
+try:
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.metrics.rec_metric.import_failure.logging_handlers"
+    )
+
+    class TorchrecComponent(Enum):  # pyre-ignore[11]
+        REC_METRICS = "rec_metrics"
+
+    class EventLoggingHandler:  # pyre-ignore[11]
+        @staticmethod
+        def n_batch_log_event(*args: object, **kwargs: object) -> None:
+            pass
+
+
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.types import get_tensor_size_bytes
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo


### PR DESCRIPTION
Summary:

Add try/except import guard for `EventLoggingHandler` and `TorchrecComponent` from `torchrec.distributed.logging_handlers` in `rec_metric.py`. This is the same pattern applied in D101259013 and D101693348 (SEV S650452 mitigation), but `rec_metric.py` was missed.

When old torch packages (created before `EventLoggingHandler`/`TorchrecComponent` were added to `logging_handlers.py`) are deserialized during GMPP model publish, the `PackageImporter` resolves to the interned (old) copy which lacks these symbols, causing an `ImportError` that fails the entire publish pipeline.

The fix catches the `ImportError` and provides no-op stub fallbacks so deserialization can proceed. Logging becomes a no-op for these old packages, which is acceptable since the alternative is a hard crash.

Affected models: at least `f1051146232` (recurrent training) and others using `dpa_product_retrieval_ctr_model`.

Related:
- SEV S650452 (original torch package version skew incident)
- D101259013, D101693348 (prior import guard fixes that missed this file)
- T266590007 (long-term fix: extern logging_handlers in packaging config)

Reviewed By: nipung90

Differential Revision: D104247627


