### PR TITLE
Add try/except import guard for logging_handlers in metric_module.py and cpu_offloaded_metric_module.py (#4234)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -19,7 +19,47 @@ from typing import Any, Dict, Mapping, Optional, Union
 import torch
 from torch import distributed as dist
 from torch.profiler import record_function
-from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+
+try:
+    # This is a safety measure against torch package issues for when
+    # Torchrec is included in the inference side model code. We should
+    # remove this once we are sure all model side packages have the required
+    # dependencies
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.metrics.cpu_offloaded_metric_module.import_failure.logging_handlers"
+    )
+
+    from enum import Enum as _Enum
+    from typing import Callable, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            REC_METRICS = "rec_metrics"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def event_logger(*args: object, **kwargs: object) -> Callable:
+                def decorator(func: Callable) -> Callable:
+                    return func
+
+                return decorator
+
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
+
+
 from torchrec.distributed.logging_utils import EventType
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.deferrable_metrics import (

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -21,7 +21,47 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import DeviceMesh
 from torch.profiler import record_function
-from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+
+try:
+    # This is a safety measure against torch package issues for when
+    # Torchrec is included in the inference side model code. We should
+    # remove this once we are sure all model side packages have the required
+    # dependencies
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.metrics.metric_module.import_failure.logging_handlers"
+    )
+
+    from enum import Enum as _Enum
+    from typing import Callable, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            REC_METRICS = "rec_metrics"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def event_logger(*args: object, **kwargs: object) -> Callable:
+                def decorator(func: Callable) -> Callable:
+                    return func
+
+                return decorator
+
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
+
+
 from torchrec.metrics.accuracy import AccuracyMetric
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.auprc import AUPRCMetric

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -37,7 +37,26 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.profiler import record_function
 from torchmetrics import Metric
-from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+
+try:
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.metrics.rec_metric.import_failure.logging_handlers"
+    )
+
+    class TorchrecComponent(Enum):  # pyre-ignore[11]
+        REC_METRICS = "rec_metrics"
+
+    class EventLoggingHandler:  # pyre-ignore[11]
+        @staticmethod
+        def n_batch_log_event(*args: object, **kwargs: object) -> None:
+            pass
+
+
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.types import get_tensor_size_bytes
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -976,8 +976,10 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         cpu_module = self._make_module(update_queue_size=1)
 
         block_event = threading.Event()
+        processing_started = threading.Event()
 
         def controlled_process_job(_: MetricUpdateJob) -> None:
+            processing_started.set()
             block_event.wait()
 
         model_out = {
@@ -991,6 +993,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         ), patch.object(cpu_module, "_log_event") as mock_log_event:
             # Fill the queue: 1 item being processed + 1 in queue = full
             cpu_module._update_rec_metrics(model_out)
+            # Wait for the update thread to pick up the first item before
+            # enqueueing the second, otherwise put_nowait races with get.
+            processing_started.wait(timeout=5.0)
             cpu_module._update_rec_metrics(model_out)
 
             with self.assertRaises(RecMetricException):


### PR DESCRIPTION
Summary:

Add try/except import guards for EventLoggingHandler and TorchrecComponent in metric_module.py and cpu_offloaded_metric_module.py. These files were missed by D101259013 and D101693348 (SEV S650452 mitigation).

## Problem

GMPP model publish for model dpa_product_retrieval_ctr_model (model entity 1051146232, MAST job f1078079559-lego_flow_mast-2108c06b-cabc) fails with:

```
ImportError: cannot import name 'EventLoggingHandler' from '<torch_package_1>.torchrec.distributed.logging_handlers'
```

## Root Cause

During torch package deserialization, pickle triggers a transitive module import chain:

```
grouped_embedding_bag.py:18
  -> pytorch_serialization_utils.py:68 (from torchrec.fb.metrics.meta_metrics import get_required_inputs)
    -> meta_metrics.py:79 (from torchrec.metrics.cpu_offloaded_metric_module import ...)
      -> cpu_offloaded_metric_module.py:21 (from torchrec.distributed.logging_handlers import EventLoggingHandler)  <-- CRASHES HERE
      -> metric_module.py:24 (from torchrec.distributed.logging_handlers import EventLoggingHandler)  <-- ALSO CRASHES
        -> rec_metric.py:40 (fixed in parent diff D104247627)
```

The torch package has an interned (frozen) copy of logging_handlers.py that either predates EventLoggingHandler or fails to load it due to missing dependencies (logging_utils.py). The import crashes before rec_metric.py is even reached.

## Why Prior Fixes Don't Help

- D101259013: Wraps imports in planners.py, lp_planner.py, sparsenn_configs.py, itep_modules.py — none in the failing chain
- D101693348: Wraps imports in train_pipeline/*.py — not in the failing chain
- D104247627 (parent): Wraps import in rec_metric.py — but cpu_offloaded_metric_module.py (line 21) crashes FIRST in the import order
- lego_flow:582, checkpoint_agent:370: Both contain fixes but the error is inside the frozen torch package, not the runtime

## Fix

Wrap the EventLoggingHandler/TorchrecComponent imports in cpu_offloaded_metric_module.py and metric_module.py with try/except, providing no-op stub fallbacks. Together with the parent diff (rec_metric.py), this covers the full transitive import chain.

## Investigation Timeline

1. Retrieved MAST job error -> identified EventLoggingHandler ImportError inside torch package
2. Confirmed lego_flow:582 and checkpoint_agent:370 both post-date the EventLoggingHandler addition (2026-03-26, commit 89c597ccb0c0)
3. Found training_platform.worker:298 (built 2026-04-26) also contains the fixes
4. Concluded the error is in the torch package's frozen code, not the runtime packages
5. Traced the full transitive import chain: grouped_embedding_bag -> pytorch_serialization_utils -> meta_metrics -> cpu_offloaded_metric_module/metric_module -> logging_handlers
6. Identified that cpu_offloaded_metric_module.py and metric_module.py are the uncovered files in this chain

Related: SEV S650452, D101259013, D101693348, D104247627

Reviewed By: nipung90

Differential Revision: D104250522


