### PR TITLE
Add forward._name to _prefetch_embeddings record_function label

### DIFF
--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -742,7 +742,9 @@ def prefetch_embeddings(
         request = context.input_dist_tensors_requests.pop(forward._name)
         assert isinstance(request, Awaitable)
 
-        with record_function(f"## _prefetch_embeddings {context.index} ##"):
+        with record_function(
+            f"## _prefetch_embeddings {forward._name}: {context.index} ##"
+        ):
             # Finish waiting on the dist_stream,
             # in case some delayed stream scheduling happens during the wait() call.
             with stream_context(data_dist_stream):
@@ -792,7 +794,9 @@ def _prefetch_embeddings(
         assert forward._name in context.input_dist_tensors_requests
         request = context.input_dist_tensors_requests.pop(forward._name)
         assert isinstance(request, Awaitable)
-        with record_function(f"## _prefetch_embeddings {context.index} ##"):
+        with record_function(
+            f"## _prefetch_embeddings {forward._name}: {context.index} ##"
+        ):
             # Finish waiting on the dist_stream,
             # in case some delayed stream scheduling happens during the wait() call.
             with stream_context(data_dist_stream):


### PR DESCRIPTION
Summary: Add the sharded module name (`forward._name`) to the `record_function` label in `_prefetch_embeddings` so that trace events can be attributed to specific modules. Previously the label was `## _prefetch_embeddings {context.index} ##` which only showed the batch index — when multiple sharded modules exist (e.g. `sparse.ebc` and `sparse.weighted_ebc`), the trace events were indistinguishable. The new label follows the pattern `## _prefetch_embeddings {forward._name}: {context.index} ##`, consistent with other labels in the codebase that include extra disambiguation info (e.g. `{self.__class__.__name__} wait()`, `all2all_data:kjt {label}`, `backward_hook {site}`).

Differential Revision: D104261499


