### PR TITLE
Fix PermuteMultiEmbedding early-return during FX tracing

### DIFF
--- a/torchrec/modules/regroup.py
+++ b/torchrec/modules/regroup.py
@@ -109,7 +109,12 @@ class PermuteMultiEmbedding(torch.nn.Module):
 
         out_lengths = self._out_lengths
         if out_lengths is None:
-            return values
+            if torch.jit.is_scripting():
+                out_lengths = torch.jit.annotate(List[int], [])
+            else:
+                if not is_fx_tracing():
+                    return values
+                out_lengths = torch.jit.annotate(List[int], [])
         return torch.ops.fbgemm.permute_multi_embedding(
             values,
             permutes,


### PR DESCRIPTION
Summary:
D103428071 added an early-return in PermuteMultiEmbedding.forward when
_out_lengths is None. This broke PNI structure-based model split because
during FX tracing module_init is skipped, _out_lengths stays None, and the
traced graph captures a no-op instead of permute_multi_embedding.

Fix: only early-return at normal runtime. During TorchScript compilation,
use a placeholder empty list (dead-code-eliminates the else branch).
During FX tracing, fall through to permute_multi_embedding so the op is
captured in the graph.

UJO is unaffected because its FX trace takes the non-fbgemm branch
(_use_fbgemm_regroup stays False when module_init is skipped).

Reviewed By: Akshayaa1996

Differential Revision: D104270499


