### PR TITLE
Sync current stream on empty-offsets short-circuit in length_per_key (#4239)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -122,9 +122,6 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     if torch.jit.is_scripting() or not tensor.is_cuda:
         return tensor.tolist()
 
-    if tensor.numel() == 0:
-        return []
-
     # During torch.compile tracing, skip the JK check and _cuda_to_cpu_safe
     # and fall back to plain .tolist(). justknobs_check calls pyjk.check()
     # (a Cython function) which can raise SystemError in sandbox/RE
@@ -1326,6 +1323,26 @@ def _use_segment_sum_csr(stride_per_key: List[int]) -> bool:
     return len(stride_per_key) >= segment_threshold
 
 
+def _length_per_key_from_lengths(
+    lengths: torch.Tensor, len_keys: int, stride: int
+) -> List[int]:
+    """Compute per-key totals from a flat ``[len_keys * stride]`` lengths tensor.
+
+    Bundles the empty-lengths short-circuit with the GPU compute path so
+    callers don't have to. The empty branch syncs the current CUDA stream to
+    match the wait-set of the non-empty ``.tolist()`` path — without that,
+    ranks taking the empty short-circuit race ahead of ranks taking the
+    ``.tolist()`` path and deadlock the next collective.
+    """
+    if pt2_guard_size_oblivious(lengths.numel() == 0):
+        if not torch.jit.is_scripting() and lengths.is_cuda:
+            torch.cuda.current_stream(lengths.device).synchronize()
+        return [0] * len_keys
+    return _safe_tolist(
+        torch.sum(pt2_check_size_nonzero(lengths.view(len_keys, stride)), dim=1)
+    )
+
+
 def _length_per_key_from_stride_per_key(
     lengths: torch.Tensor, stride_per_key: List[int]
 ) -> List[int]:
@@ -1383,17 +1400,16 @@ def _maybe_compute_length_per_key(
         _length: List[int] = (
             _length_per_key_from_stride_per_key(lengths, stride_per_key)
             if variable_stride_per_key
-            else (
-                _safe_tolist(
-                    torch.sum(
-                        pt2_check_size_nonzero(lengths.view(len(keys), stride)), dim=1
-                    )
-                )
-                if pt2_guard_size_oblivious(lengths.numel() != 0)
-                else [0] * len(keys)
-            )
+            else _length_per_key_from_lengths(lengths, len(keys), stride)
         )
     elif len(keys) and offsets is not None and len(offsets) > 0:
+        # TODO: route this through _length_per_key_from_lengths once we
+        # confirm no caller depends on the empty-diff edge case returning [].
+        # Current behavior (returns [] when len(offsets) == 1) is inconsistent
+        # with the lengths-path empty case (returns [0] * len(keys)) and may
+        # have the same rank-divergence / cross-PG deadlock risk if it ever
+        # fires in collective code paths. Leaving as-is for now to scope this
+        # diff to the lengths-path only.
         _length: List[int] = (
             _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
             if variable_stride_per_key

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1403,18 +1403,24 @@ def _maybe_compute_length_per_key(
             else _length_per_key_from_lengths(lengths, len(keys), stride)
         )
     elif len(keys) and offsets is not None and len(offsets) > 0:
-        # TODO: route this through _length_per_key_from_lengths once we
-        # confirm no caller depends on the empty-diff edge case returning [].
-        # Current behavior (returns [] when len(offsets) == 1) is inconsistent
-        # with the lengths-path empty case (returns [0] * len(keys)) and may
-        # have the same rank-divergence / cross-PG deadlock risk if it ever
-        # fires in collective code paths. Leaving as-is for now to scope this
-        # diff to the lengths-path only.
-        _length: List[int] = (
-            _length_per_key_from_stride_per_key(torch.diff(offsets), stride_per_key)
-            if variable_stride_per_key
-            else _safe_tolist(torch.sum(torch.diff(offsets).view(-1, stride), dim=1))
-        )
+        if variable_stride_per_key:
+            if len(offsets) == 1:
+                # Sync the current CUDA stream even if torch.diff(offsets) is empty.
+                # This keeps the rank in sync with peers that get a non-empty diff.
+                # Return [0] * len(keys) to match the lengths-path empty contract.
+                if not torch.jit.is_scripting() and offsets.is_cuda:
+                    torch.cuda.current_stream(offsets.device).synchronize()
+                _length: List[int] = [0] * len(keys)
+            else:
+                _length: List[int] = _length_per_key_from_stride_per_key(
+                    torch.diff(offsets), stride_per_key
+                )
+        else:
+            # Delegate to _length_per_key_from_lengths, which syncs the stream
+            # on empty diffs and handles non-empty diffs via _safe_tolist.
+            _length: List[int] = _length_per_key_from_lengths(
+                torch.diff(offsets), len(keys), stride
+            )
     else:
         _length: List[int] = []
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -8,13 +8,17 @@
 # pyre-strict
 
 
+import contextlib
 import unittest
+from typing import Iterator
+from unittest import mock
 
 import torch
 import torch.utils._pytree as pytree
 from torch.testing import FileCheck
 from torchrec.fx import symbolic_trace
 from torchrec.sparse.jagged_tensor import (
+    _maybe_compute_length_per_key,
     _safe_tolist,
     ComputeJTDictToKJT,
     JaggedTensor,
@@ -23,6 +27,33 @@ from torchrec.sparse.jagged_tensor import (
 )
 
 torch.fx.wrap("len")
+
+
+@contextlib.contextmanager
+def _count_current_stream_syncs() -> Iterator[list[int]]:
+    """Patch ``torch.cuda.current_stream`` so the returned stream's
+    ``synchronize()`` calls are counted. Yields a single-element list whose
+    ``[0]`` is the call count when the context exits.
+    """
+    sync_count: list[int] = [0]
+    real_current_stream = torch.cuda.current_stream
+
+    class _Tracker:
+        def __init__(self, stream: torch.cuda.Stream) -> None:
+            self._stream = stream
+
+        def synchronize(self) -> None:
+            sync_count[0] += 1
+            self._stream.synchronize()
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._stream, name)
+
+    def _patched(device: object = None) -> object:
+        return _Tracker(real_current_stream(device))
+
+    with mock.patch("torch.cuda.current_stream", _patched):
+        yield sync_count
 
 
 class TestJaggedTensor(unittest.TestCase):
@@ -1417,3 +1448,55 @@ class TestJaggedTensorTracing(unittest.TestCase):
         tensor = torch.tensor([42], device="cuda")
         result = _safe_tolist(tensor)
         self.assertEqual(result, [42])
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_safe_tolist_empty_cuda_tensor_syncs_current_stream(self) -> None:
+        # _safe_tolist on an empty CUDA tensor must sync the current stream
+        # so callers don't race ahead of peer ranks taking the non-empty
+        # .tolist() path. Verified by patching torch.cuda.current_stream and
+        # counting synchronize() calls.
+        empty = torch.tensor([], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _safe_tolist(empty)
+
+        self.assertEqual(result, [])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_safe_tolist on empty CUDA tensor did not call "
+            "current_stream.synchronize()",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_maybe_compute_length_per_key_empty_lengths_cuda_syncs(self) -> None:
+        # When lengths.numel() == 0, _maybe_compute_length_per_key takes the
+        # [0] * len(keys) short-circuit. After the fix that branch must sync
+        # the current stream so ranks with empty lengths don't race ahead of
+        # ranks taking the .tolist() path.
+        keys = ["a", "b"]
+        empty_lengths = torch.tensor([], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _maybe_compute_length_per_key(
+                keys=keys,
+                stride=1,
+                stride_per_key=[1, 1],
+                variable_stride_per_key=False,
+                length_per_key=None,
+                lengths=empty_lengths,
+                offsets=None,
+                values=None,
+            )
+
+        self.assertEqual(result, [0, 0])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_maybe_compute_length_per_key empty-lengths branch did not call "
+            "current_stream.synchronize()",
+        )

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -49,7 +49,7 @@ def _count_current_stream_syncs() -> Iterator[list[int]]:
         def __getattr__(self, name: str) -> object:
             return getattr(self._stream, name)
 
-    def _patched(device: object = None) -> object:
+    def _patched(device: torch.device | int | str | None = None) -> object:
         return _Tracker(real_current_stream(device))
 
     with mock.patch("torch.cuda.current_stream", _patched):
@@ -1499,4 +1499,68 @@ class TestJaggedTensorTracing(unittest.TestCase):
             1,
             "_maybe_compute_length_per_key empty-lengths branch did not call "
             "current_stream.synchronize()",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_maybe_compute_length_per_key_empty_offsets_cuda_syncs(self) -> None:
+        # When offsets is provided (no lengths) and len(offsets) == 1,
+        # torch.diff(offsets) is empty. The fix routes this through a
+        # short-circuit that syncs the current stream and returns
+        # [0] * len(keys), matching the lengths-path empty case.
+        keys = ["a", "b"]
+        offsets = torch.tensor([0], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _maybe_compute_length_per_key(
+                keys=keys,
+                stride=1,
+                stride_per_key=[1, 1],
+                variable_stride_per_key=False,
+                length_per_key=None,
+                lengths=None,
+                offsets=offsets,
+                values=None,
+            )
+
+        self.assertEqual(result, [0, 0])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_maybe_compute_length_per_key empty-offsets branch did not call "
+            "current_stream.synchronize()",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 0,
+        "CUDA is not available",
+    )
+    def test_maybe_compute_length_per_key_empty_offsets_vspk_cuda_syncs(
+        self,
+    ) -> None:
+        # Variable-stride-per-key analogue of the above. Same input shape
+        # (len(offsets) == 1) hits the same short-circuit before delegating
+        # to _length_per_key_from_stride_per_key, which would otherwise
+        # return [] without any sync.
+        keys = ["a", "b"]
+        offsets = torch.tensor([0], dtype=torch.int64, device="cuda")
+        with _count_current_stream_syncs() as sync_count:
+            result = _maybe_compute_length_per_key(
+                keys=keys,
+                stride=1,
+                stride_per_key=[1, 1],
+                variable_stride_per_key=True,
+                length_per_key=None,
+                lengths=None,
+                offsets=offsets,
+                values=None,
+            )
+
+        self.assertEqual(result, [0, 0])
+        self.assertGreaterEqual(
+            sync_count[0],
+            1,
+            "_maybe_compute_length_per_key empty-offsets VSPK branch did not "
+            "call current_stream.synchronize()",
         )


### PR DESCRIPTION
Summary:

Follow-up to D103719817. Closes the same rank-divergence / cross-PG deadlock window in the offsets-only branch of `_maybe_compute_length_per_key`. When `len(offsets) == 1` the branch's `torch.diff(offsets)` is empty: previously it fell through to either `_length_per_key_from_stride_per_key` (which returns `[]` from its empty-segment short-circuit without syncing) or to `_safe_tolist(torch.sum(... .view(-1, stride), dim=1))` on an empty tensor. Both paths skip GPU synchronization while peer ranks taking the non-empty diff path implicitly sync inside `_safe_tolist`, leaving the empty-diff ranks free to race ahead into the next collective.

D103719817 explicitly flagged this with a TODO: routing through the lengths helper would change the return value from `[]` to `[0] * len(keys)`, and the lengths helper already syncs on the empty branch. Verified that no caller depends on the `[]` return — searched every consumer of `KeyedJaggedTensor.length_per_key()` and `_maybe_compute_length_per_key`, plus the test suite. `_maybe_compute_offset_per_key:1448-1469` still produces a mathematically consistent result (`[0]*(N+1)` offsets in both the `_cumsum` and the non-strict-export `asynchronous_complete_cumsum` paths) and several existing call sites — `dist_splits` at jagged_tensor.py:3202, `KeyedTensor` construction, `zip(keys, length_per_key)` patterns — silently assume the new shape and are currently latently broken with the `[]` return. `test_empty_to_dict` already documents `[0, 0]` as the contractually correct shape for the 2-key empty case.

Changes:
- `_maybe_compute_length_per_key` offsets-path: detect `len(offsets) == 1` before computing `torch.diff(offsets)`. On that path, sync the current CUDA stream when `offsets.is_cuda` and return `[0] * len(keys)`. Avoids allocating the empty diff tensor and matches the lengths-path empty-branch contract. TorchScript still bypasses the sync (script-mode divergence is pre-existing and out of scope, same as the lengths helper).
- Removes the TODO comment on the offsets branch.
- Tightens the type of `_count_current_stream_syncs._patched`'s `device` parameter from `object` to `torch.device | int | str | None` so it matches `torch.cuda.current_stream`'s signature (pyre fix; the helper was added in D103719817).

Differential Revision: D104351493


