### PR TITLE
Add permute_dist for distributing forward permutation (#4241)

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -14,7 +14,11 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 import torch
+import torch.distributed as dist
+from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
+from torchrec.distributed.types import Awaitable
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -99,7 +103,7 @@ def split_features_by_values_mask(
     compute per-segment lengths for each partition efficiently.
 
     Args:
-        features: input KJT (after input dist, on sharder side)
+        features: input KJT (after input dist)
         overlap_mask: bool tensor of shape [num_values], True = overlapped
 
     Returns:
@@ -143,12 +147,49 @@ def split_features_by_values_mask(
     return overlapped_kjt, nonoverlapped_kjt
 
 
+class ForwardPermuteAwaitable(Awaitable[torch.Tensor]):
+    """RW-specific awaitable that computes forward_permute from a received mask.
+
+    On wait(), receives the mask via AllToAll, then builds forward_permute:
+    a tensor for reordering merged [ol_embs, nol_embs] back to original
+    order via index_select.
+
+    The received mask is in bucketized order (values sent to shard 0 first,
+    then shard 1, etc.). unbucketize_permute_tensor maps original position i
+    to bucket position upt[i]. We compose these to build forward_permute[i] =
+    position in merged [ol_embs, nol_embs] for original position i.
+    """
+
+    def __init__(
+        self,
+        values_awaitable: TensorAllToAllValuesAwaitable,
+        unbucketize_permute_tensor: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._values_awaitable = values_awaitable
+        self._unbucketize_permute_tensor = unbucketize_permute_tensor
+
+    def _wait_impl(self) -> torch.Tensor:
+        received_mask = self._values_awaitable.wait()
+        bool_mask = received_mask.bool()
+        upt = self._unbucketize_permute_tensor
+        num_ol = bool_mask.sum()
+
+        # Example: bool_mask = [T, F, T, T, F, F]
+        #   ol_rank  = cumsum([1,0,1,1,0,0]) - 1 = [0, 0, 1, 2, 2, 2]
+        #   nol_rank = cumsum([0,1,0,0,1,1]) - 1 + 3 = [2, 3, 3, 3, 4, 5]
+        #   bucket_to_merged = where(mask, ol_rank, nol_rank) = [0, 3, 1, 2, 4, 5]
+        ol_rank = bool_mask.long().cumsum(0) - 1
+        nol_rank = (~bool_mask).long().cumsum(0) - 1 + num_ol
+        bucket_to_merged = torch.where(bool_mask, ol_rank, nol_rank)
+
+        return bucket_to_merged[upt]
+
+
 class CollisionHandlerBase(abc.ABC):
     """Interface for PEC collision detection handlers.
 
     Subclasses implement sharding-specific overlap detection logic.
-    The pipeline passes prev_remapped_feature_values as an argument to detect_collisions
-    rather than storing cross-batch state internally.
     """
 
     @abc.abstractmethod
@@ -171,6 +212,24 @@ class CollisionHandlerBase(abc.ABC):
     @abc.abstractmethod
     def reset(self) -> None:
         """Reset internal state (e.g. at epoch boundary)."""
+        ...
+
+    @abc.abstractmethod
+    def permute_dist(
+        self,
+        features: KeyedJaggedTensor,
+        forward_overlap_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> Awaitable[torch.Tensor]:
+        """Distribute the collision partition permutation via AllToAll.
+
+        Sends overlap information from sharding ranks back to the original
+        rank and computes forward_permute — a tensor for reordering merged
+        [ol, nol] embeddings back to original order via index_select.
+
+        Returns:
+            Awaitable resolving to forward_permute tensor of shape [N].
+        """
         ...
 
     @abc.abstractmethod
@@ -208,12 +267,14 @@ class RWCollisionHandler(CollisionHandlerBase):
         device: torch.device,
         grouped_emb_configs: List[GroupedEmbeddingConfig],
         table_name_to_config: Dict[str, EmbeddingConfig],
+        process_group: dist.ProcessGroup,
         checker_type: OverlappingCheckerType = OverlappingCheckerType.BOOLEAN,
     ) -> None:
         assert (
             checker_type == OverlappingCheckerType.BOOLEAN
         ), f"Only BOOLEAN checker is supported, got {checker_type}"
         self._device = device
+        self._pg = process_group
         self._feature_to_table_offset: Dict[str, int] = {}
         self._input_features_offset: torch.Tensor = torch.empty(
             0,
@@ -307,12 +368,53 @@ class RWCollisionHandler(CollisionHandlerBase):
             num_features, batch_size_cumsum, lengths_batch_major
         )
 
+    def permute_dist(
+        self,
+        features: KeyedJaggedTensor,
+        forward_overlap_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> ForwardPermuteAwaitable:
+        """Reorder mask to rank-major, AllToAll to original rank, compute forward_permute."""
+        assert sharding_ctx.sparse_features_recat is not None
+        assert sharding_ctx.unbucketize_permute_tensor is not None
+
+        recat = torch.ops.fbgemm.invert_permute(sharding_ctx.sparse_features_recat)
+        mask_int = forward_overlap_mask.to(torch.int32)
+
+        _, permuted_mask, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+            recat,
+            features.lengths().view(recat.shape[0], -1),
+            mask_int,
+            None,
+            mask_int.numel(),
+        )
+
+        values_awaitable = TensorAllToAllValuesAwaitable(
+            self._pg,
+            permuted_mask,
+            input_splits=torch.tensor(
+                sharding_ctx.output_splits,
+                dtype=torch.int32,
+            ),
+            output_splits=torch.tensor(
+                sharding_ctx.input_splits,
+                dtype=torch.int32,
+            ),
+            device=permuted_mask.device,
+        )
+
+        return ForwardPermuteAwaitable(
+            values_awaitable=values_awaitable,
+            unbucketize_permute_tensor=sharding_ctx.unbucketize_permute_tensor,
+        )
+
 
 def create_collision_handler(
     sharding_type: str,
     device: torch.device,
     grouped_emb_configs: List[GroupedEmbeddingConfig],
     table_name_to_config: Dict[str, EmbeddingConfig],
+    process_group: dist.ProcessGroup,
     checker_type: OverlappingCheckerType,
 ) -> CollisionHandlerBase:
     """Factory function to create a collision handler for a given sharding type."""
@@ -321,6 +423,7 @@ def create_collision_handler(
             device=device,
             grouped_emb_configs=grouped_emb_configs,
             table_name_to_config=table_name_to_config,
+            process_group=process_group,
             checker_type=checker_type,
         )
     raise ValueError(

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -144,6 +144,7 @@ class ShardedPECEmbeddingCollection(
         )
         self._env: ShardingEnv = env
 
+        assert env.process_group is not None
         self._collision_handlers: List[CollisionHandlerBase] = []
         for (
             sharding_type,
@@ -155,6 +156,7 @@ class ShardedPECEmbeddingCollection(
                     device=device,
                     grouped_emb_configs=sharding._grouped_embedding_configs,  # pyre-ignore[16]
                     table_name_to_config=self._embedding_collection._table_name_to_config,
+                    process_group=env.process_group,
                     checker_type=module._checker_type,
                 )
             )
@@ -291,6 +293,41 @@ class ShardedPECEmbeddingCollection(
             splits_awaitable=splits_awaitable,
             total_input_splits=total_input_splits,
         )
+
+    def permute_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        features_per_group: List[KeyedJaggedTensor],
+        forward_overlap_masks: List[torch.Tensor],
+    ) -> List[Awaitable[torch.Tensor]]:
+        """Distributes collision partition permutations via AllToAll.
+
+        Delegates to each handler's permute_dist. Each awaitable resolves
+        to a forward_permute tensor for reordering merged [ol, nol]
+        embeddings back to original order.
+
+        Args:
+            ctx: PEC context (sharding_contexts must be set from input_dist)
+            features_per_group: per-group features after input_dist (for lengths)
+            forward_overlap_masks: per-group bool masks for overlapped values
+
+        Returns:
+            List of Awaitable[torch.Tensor], one per sharding group, each
+            resolving to a forward_permute tensor.
+        """
+        return [
+            handler.permute_dist(
+                features,
+                mask,
+                sharding_ctx,
+            )
+            for handler, features, mask, sharding_ctx in zip(
+                self._collision_handlers,
+                features_per_group,
+                forward_overlap_masks,
+                ctx.sharding_contexts,
+            )
+        ]
 
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):

--- a/torchrec/distributed/tests/test_pec_collision_handlers.py
+++ b/torchrec/distributed/tests/test_pec_collision_handlers.py
@@ -7,10 +7,12 @@
 
 # pyre-strict
 
+import os
 import unittest
 from typing import List
 
 import torch
+import torch.distributed as dist
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -27,6 +29,15 @@ from torchrec.distributed.pec_collision_handlers import (
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import get_free_port
+
+
+def _get_single_rank_pg() -> dist.ProcessGroup:
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ.setdefault("MASTER_PORT", str(get_free_port()))
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    return dist.group.WORLD  # pyre-ignore[7]
 
 
 def _make_grouped_configs(
@@ -214,6 +225,7 @@ class RWCollisionHandlerTest(unittest.TestCase):
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows),
             table_name_to_config=_make_table_name_to_config(tables),
+            process_group=_get_single_rank_pg(),
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
@@ -482,6 +494,7 @@ class CreateCollisionHandlerTest(unittest.TestCase):
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
             table_name_to_config=_make_table_name_to_config(tables),
+            process_group=_get_single_rank_pg(),
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
@@ -503,5 +516,6 @@ class CreateCollisionHandlerTest(unittest.TestCase):
                 device=torch.device("cpu"),
                 grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
                 table_name_to_config=_make_table_name_to_config(tables),
+                process_group=_get_single_rank_pg(),
                 checker_type=OverlappingCheckerType.BOOLEAN,
             )

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -188,6 +188,13 @@ class ExpectedSplits:
     output_splits: List[List[int]]
 
 
+def _verify_forward_permute(
+    forward_permute: torch.Tensor,
+    expected: List[int],
+) -> None:
+    assert forward_permute.tolist() == expected
+
+
 def _verify_collision_result(
     result: CollisionResult,
     expected: ExpectedCollisionResult,
@@ -220,11 +227,13 @@ def _test_pec_forward_stages(
     backend: str,
     expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
     expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
+    expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
     local_size: Optional[int] = None,
 ) -> None:
     """Run PEC forward pipeline stages and verify against expected results.
 
-    Always runs: input_dist → detect_collisions → split → collision_split_dist.
+    Always runs: input_dist → detect_collisions → split →
+        collision_split_dist → permute_dist.
     Verification for each stage is enabled by providing its expected-output parameter.
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
@@ -269,6 +278,22 @@ def _test_pec_forward_stages(
                 _verify_collision_splits(
                     all_splits,
                     expected_splits_per_rank[rank][batch_idx],
+                )
+
+            # Stage 3: permute_dist
+            features_list = list(dist_input)
+            masks = [r.forward_overlap_mask for r in results]
+            permute_awaitables = sharded_pec.permute_dist(
+                pec_ctx,
+                features_list,
+                masks,
+            )
+            forward_permutes = [aw.wait() for aw in permute_awaitables]
+
+            if expected_forward_permutes_per_rank is not None:
+                _verify_forward_permute(
+                    forward_permutes[0],
+                    expected_forward_permutes_per_rank[rank][batch_idx],
                 )
 
             prev_remapped = [r.remapped_feature_values for r in results]
@@ -428,6 +453,65 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
             expected_splits_per_rank=expected_splits_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_permute_dist(self) -> None:
+        """Verifies exact forward_permute values with cross-shard partial overlap."""
+        WORLD_SIZE = 2
+
+        # Cross-shard data: each rank has values in both shard 0 (0-7) and shard 1 (8-15)
+        kjt_input_per_rank = [
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([0, 8, 2, 10, 4, 12]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([0, 8, 3, 11, 4, 13]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+            ],
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([1, 9, 5, 11, 6, 13]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([1, 9, 7, 14, 6, 15]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+            ],
+        ]
+
+        # Batch 0: no overlap → forward_permute = upt = [0,3,1,4,2,5]
+        # Batch 1: partial overlap → forward_permute derived from received mask + upt
+        expected_forward_permutes_per_rank = [
+            [
+                [0, 3, 1, 4, 2, 5],
+                [0, 2, 5, 3, 1, 4],
+            ],
+            [
+                [0, 3, 1, 4, 2, 5],
+                [0, 2, 3, 4, 1, 5],
+            ],
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=kjt_input_per_rank,
+            expected_forward_permutes_per_rank=expected_forward_permutes_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )


### PR DESCRIPTION
Summary:

# Context

After collision detection splits features into overlapped (ol) and non-overlapped (nol) partitions, the sharded module will compute embeddings separately for each partition. The results need to be merged back into the original feature order. `permute_dist` computes the permutation tensor (`forward_permute`) that performs this reordering.

Collision detection runs on the local embeddings of each rank, but the merged embeddings are consumed on the original order (after output_dist). `permute_dist` uses AllToAll to send the overlap mask back to the original rank, where it is composed with `unbucketize_permute_tensor` to produce `forward_permute`.

# New API

**`ShardedPECEmbeddingCollection.permute_dist`**: Called after `collision_split_dist`. For each sharding group, delegates to the handler's `permute_dist`. For RW sharding specificly:

1. Reorders the overlap mask from feature-major to rank-major order using `invert_permute(sparse_features_recat)`
2. AllToAll's the mask back to the original rank (reverse direction of input_dist)
3. Returns a `ForwardPermuteAwaitable` that, on wait, computes `forward_permute`

The pipeline flow so far:

```
input_dist → detect_collisions → split_features_by_values_mask → collision_split_dist → permute_dist
```

# Changes

**`ForwardPermuteAwaitable`** — RW-specific awaitable. On wait, receives the overlap mask via AllToAll, builds a `bucket_to_merged` mapping via cumsum + `torch.where`, then composes with `unbucketize_permute_tensor` to produce `forward_permute`. Usage: `index_select(cat([ol_embs, nol_embs]), 0, forward_permute)` restores original order.

**`permute_dist`** on `CollisionHandlerBase` / `RWCollisionHandler` — abstract method and RW implementation. The RW implementation permutes the mask using `permute_2D_sparse_data`, starts the AllToAll, and returns `ForwardPermuteAwaitable`.

**`permute_dist`** on `ShardedPECEmbeddingCollection` — iterates over sharding groups, delegates to each handler, returns `List[Awaitable[torch.Tensor]]`.
# TODO: test with multiple sharding groups.

Reviewed By: TroyGarden

Differential Revision: D104562839


