### PR TITLE
Add compute kernel validation to sharding planners (#4242)

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -20,6 +20,7 @@ import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.planner.constants import BATCH_SIZE, MAX_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
@@ -343,6 +344,80 @@ def validate_rank_assignment(sharding_plan: ShardingPlan, topology: Topology) ->
             else:
                 msg = f"Sharding spec not found for {module_name}.{param_name}"
                 logging.warning(msg)
+
+
+_VALID_COMPUTE_KERNELS: set[str] = {k.value for k in EmbeddingComputeKernel}
+
+_CACHING_KERNELS: set[str] = {
+    EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+    EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
+}
+
+
+def validate_compute_kernels(
+    best_plan: List[ShardingOption],
+) -> None:
+    """
+    Validates that compute kernel selections in the sharding plan are valid and
+    consistent with other sharding option attributes.
+
+    Args:
+        best_plan: The selected sharding options comprising the plan.
+
+    Raises:
+        PlannerError: If any sharding option has an invalid or inconsistent
+            compute kernel configuration.
+    """
+    violations: List[str] = []
+
+    for so in best_plan:
+        fqn = so.fqn
+        kernel = so.compute_kernel
+
+        if kernel not in _VALID_COMPUTE_KERNELS:
+            violations.append(f"{fqn}: unknown compute kernel '{kernel}'")
+            continue
+
+        if (
+            kernel == EmbeddingComputeKernel.DENSE.value
+            and so.sharding_type != ShardingType.DATA_PARALLEL.value
+        ):
+            violations.append(
+                f"{fqn}: DENSE kernel requires DATA_PARALLEL sharding, "
+                f"got '{so.sharding_type}'"
+            )
+
+        if kernel in _CACHING_KERNELS:
+            clf = so.cache_load_factor
+            if clf is not None and (clf <= 0 or clf >= 1):
+                violations.append(
+                    f"{fqn}: {kernel} requires cache_load_factor strictly "
+                    f"between 0 and 1, got {clf}"
+                )
+
+        # Validate storage for all kernels (negative storage is invalid for any kernel)
+        storage = so.total_storage
+        if storage.hbm < 0:
+            violations.append(
+                f"{fqn}: {kernel} has negative HBM storage ({storage.hbm})"
+            )
+        if storage.ddr < 0:
+            violations.append(
+                f"{fqn}: {kernel} has negative DDR storage ({storage.ddr})"
+            )
+
+    if violations:
+        for v in violations:
+            logging.warning(f"Compute kernel validation: {v}")
+        msg = (
+            "Compute kernel validation failed with "
+            f"{len(violations)} violation(s):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+        raise PlannerError(
+            error_type=PlannerErrorType.INVALID_COMPUTE_KERNEL,
+            message=msg,
+        )
 
 
 def extract_plan(
@@ -920,6 +995,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
 
             validate_modules_inclusion_in_sharding_plan(sharding_plan, module, sharders)
             validate_rank_assignment(sharding_plan, self._topology)
+            validate_compute_kernels(best_plan)
 
             log_planning_result(
                 planner_type=self.__class__.__name__,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -10,6 +10,7 @@
 import copy
 import logging
 import time
+from collections import deque
 from functools import reduce
 from time import perf_counter
 from typing import Callable, cast, Dict, List, Optional, Tuple, Union
@@ -54,6 +55,7 @@ from torchrec.distributed.planner.types import (
 from torchrec.distributed.planner.utils import (
     bytes_to_gb,
     reset_shard_rank,
+    sharder_name,
     storage_repr_in_gb,
 )
 from torchrec.distributed.sharding_plan import get_default_sharders, placement
@@ -186,6 +188,122 @@ def to_sharding_plan(
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]
     return ShardingPlan(plan)
+
+
+def _module_in_device_group(
+    shardable_params: Dict[str, nn.Parameter],
+    constraints: Dict[str, ParameterConstraints],
+    device_group: str,
+) -> bool:
+    # Check if any parameter that will actually be sharded belongs to the device group.
+    # We iterate over shardable_params (params that will be sharded) and check if
+    # they have constraints matching the target device_group.
+    for param_name in shardable_params:
+        if (
+            param_name in constraints
+            and constraints[param_name].device_group == device_group
+        ):
+            return True
+    return False
+
+
+def validate_modules_inclusion_in_sharding_plan(
+    sharding_plan: ShardingPlan,
+    module: nn.Module,
+    sharders: List[ModuleSharder[nn.Module]],
+    constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    device_group: Optional[str] = None,
+) -> None:
+    """
+    Validates that all shardable modules in the model are included in the sharding plan.
+
+    This function traverses through the module hierarchy to identify all shardable
+    modules (modules that have a corresponding sharder AND have shardable parameters)
+    and validates that each one is present in the final sharding plan.
+
+    A module is only expected to be in the sharding plan if:
+    1. It has a corresponding sharder (by module type)
+    2. The sharder's shardable_parameters() returns at least one parameter for it
+    3. If device_group is specified, the module's constraint must match the device_group
+
+    This handles cases where a sharder is configured to only shard specific tables
+    (e.g., via shardable_params filter), leaving some modules with no parameters
+    to shard. It also supports group-based validation for HeteroEmbeddingShardingPlanner
+    where modules are partitioned across different device groups.
+
+    Args:
+        sharding_plan (ShardingPlan): The final sharding plan to validate.
+        module (nn.Module): The root module to traverse and validate.
+        sharders (List[ModuleSharder[nn.Module]]): The list of sharders used for
+            sharding. These define which module types are considered shardable.
+        constraints (Optional[Dict[str, ParameterConstraints]]): Per-table constraints
+            for sharding. Required when device_group is specified.
+        device_group (Optional[str]): If specified, only validate modules that belong
+            to this device group. This is used by HeteroEmbeddingShardingPlanner to
+            validate per-group sharding plans.
+
+    Raises:
+        PlannerError: If any shardable module with shardable parameters
+            is not found in the sharding plan.
+    """
+    if device_group is not None and constraints is None:
+        raise ValueError(
+            "device_group is set but constraints is None; "
+            "device_group filtering requires constraints to be provided"
+        )
+
+    sharder_map = {sharder_name(sharder.module_type): sharder for sharder in sharders}
+    expected_modules: set[str] = set()
+
+    named_modules_queue = deque([("", module)])
+    while named_modules_queue:
+        child_path, child_module = named_modules_queue.popleft()
+        sharder_key = sharder_name(type(child_module))
+        sharder = sharder_map.get(sharder_key, None)
+
+        if not sharder:
+            for n, m in child_module.named_children():
+                if child_path != "":
+                    named_modules_queue.append((child_path + "." + n, m))
+                else:
+                    named_modules_queue.append((n, m))
+            continue
+
+        shardable_params = sharder.shardable_parameters(child_module)
+        if shardable_params:
+            if device_group is not None and constraints is not None:
+                if _module_in_device_group(shardable_params, constraints, device_group):
+                    expected_modules.add(child_path)
+            else:
+                expected_modules.add(child_path)
+            # Skip traversing children of a module that will be sharded.
+            # The children are internal implementation details (e.g., _embedding_module
+            # inside ManagedCollisionEmbeddingCollection) and should not be separately
+            # validated or included in the sharding plan.
+            continue
+
+        # Continue traversing children only if this module doesn't have a sharder
+        # or has no shardable parameters
+        for n, m in child_module.named_children():
+            if child_path != "":
+                named_modules_queue.append((child_path + "." + n, m))
+            else:
+                named_modules_queue.append((n, m))
+
+    plan_modules = set(sharding_plan.plan.keys())
+    missing_modules = sorted(expected_modules - plan_modules)
+
+    if missing_modules:
+        group_info = f" for device group '{device_group}'" if device_group else ""
+        msg = (
+            f"The following shardable modules are not present in the "
+            f"sharding plan{group_info}: {missing_modules}."
+        )
+        logging.error(msg)
+        raise PlannerError(
+            error_type=PlannerErrorType.MISSING_MODULE_IN_PLAN,
+            message=msg,
+        )
 
 
 def validate_rank_assignment(sharding_plan: ShardingPlan, topology: Topology) -> None:
@@ -800,6 +918,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                     ),
                 )
 
+            validate_modules_inclusion_in_sharding_plan(sharding_plan, module, sharders)
             validate_rank_assignment(sharding_plan, self._topology)
 
             log_planning_result(

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -11,6 +11,7 @@ import unittest
 from typing import cast, Dict, List, Optional
 
 import torch
+from torch import nn
 from torchrec import EmbeddingBagCollection, EmbeddingConfig
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -18,7 +19,11 @@ from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.perf_models import NoopPerfModel
-from torchrec.distributed.planner.planners import EmbeddingShardingPlanner, extract_plan
+from torchrec.distributed.planner.planners import (
+    EmbeddingShardingPlanner,
+    extract_plan,
+    validate_modules_inclusion_in_sharding_plan,
+)
 from torchrec.distributed.planner.proposers import EmbeddingOffloadScaleupProposer
 from torchrec.distributed.planner.shard_estimators import EmbeddingStorageEstimator
 from torchrec.distributed.planner.stats import EmbeddingStats
@@ -1687,3 +1692,171 @@ class TestStorageEstimation(unittest.TestCase):
                             f"{so_default.name} ({so_default.compute_kernel}, "
                             f"{so_default.sharding_type})",
                         )
+
+
+class TestValidateModulesInclusionInShardingPlan(unittest.TestCase):
+    """Test cases for validate_modules_inclusion_in_sharding_plan function."""
+
+    def setUp(self) -> None:
+        compute_device = "cuda"
+        self.topology = Topology(
+            world_size=2, hbm_cap=1024 * 1024 * 2, compute_device=compute_device
+        )
+        self.tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(4)
+        ]
+        self.model = TestSparseNN(
+            tables=self.tables, sparse_device=torch.device("meta")
+        )
+        self.planner = EmbeddingShardingPlanner(topology=self.topology)
+
+    def test_validate_modules_inclusion_success(self) -> None:
+        """Test that validation passes when all shardable modules are in the plan."""
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], TWvsRWSharder())
+        ]
+        sharding_plan = self.planner.plan(module=self.model, sharders=sharders)
+
+        # Should not raise any exception
+        validate_modules_inclusion_in_sharding_plan(sharding_plan, self.model, sharders)
+
+    def test_validate_modules_inclusion_missing_module(self) -> None:
+        """Test that validation fails when a shardable module is missing from the plan."""
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], TWvsRWSharder())
+        ]
+        sharding_plan = self.planner.plan(module=self.model, sharders=sharders)
+
+        # Remove a module from the plan to simulate missing module
+        if "sparse.ebc" in sharding_plan.plan:
+            del sharding_plan.plan["sparse.ebc"]
+
+        with self.assertRaises(PlannerError) as context:
+            validate_modules_inclusion_in_sharding_plan(
+                sharding_plan, self.model, sharders
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.MISSING_MODULE_IN_PLAN
+        )
+        self.assertIn("not present in the sharding plan", str(context.exception))
+
+    def test_validate_modules_inclusion_empty_plan(self) -> None:
+        """Test that validation fails with empty sharding plan when model has shardable modules."""
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], TWvsRWSharder())
+        ]
+        empty_plan = ShardingPlan({})
+
+        with self.assertRaises(PlannerError) as context:
+            validate_modules_inclusion_in_sharding_plan(
+                empty_plan, self.model, sharders
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.MISSING_MODULE_IN_PLAN
+        )
+
+    def test_validate_modules_inclusion_no_shardable_modules(self) -> None:
+        """Test that validation passes when model has no shardable modules."""
+        # Use a simple model with no embedding tables
+        simple_model = nn.Linear(10, 10)
+        empty_plan = ShardingPlan({})
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], TWvsRWSharder())
+        ]
+
+        # Should not raise any exception since there are no shardable modules
+        validate_modules_inclusion_in_sharding_plan(empty_plan, simple_model, sharders)
+
+    def test_validate_modules_inclusion_no_sharders(self) -> None:
+        """Test that validation passes when no sharders are provided."""
+        empty_plan = ShardingPlan({})
+
+        # Should not raise any exception since no sharders means no modules are considered shardable
+        validate_modules_inclusion_in_sharding_plan(empty_plan, self.model, [])
+
+    def test_validate_modules_inclusion_partial_shardable_params(self) -> None:
+        """Test that validation passes when sharder filters out some modules via shardable_params.
+
+        When a sharder is configured with shardable_params to only shard specific tables,
+        modules that exist but have no shardable parameters (due to the filter) should
+        NOT be flagged as missing from the sharding plan.
+        """
+        # Create a model with multiple EBC modules (weighted and non-weighted)
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        weighted_tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=32,
+                name="weighted_table_" + str(i),
+                feature_names=["weighted_feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        model = TestSparseNN(
+            tables=tables,
+            weighted_tables=weighted_tables,
+            sparse_device=torch.device("meta"),
+        )
+
+        # Create a sharder that only shards the non-weighted tables
+        # This simulates the scenario where weighted_ebc module has a matching sharder type
+        # but the sharder filters out all its parameters via shardable_params
+        class PartialEBCSharder(EmbeddingBagCollectionSharder):
+            def __init__(self, shardable_params: List[str]) -> None:
+                super().__init__()
+                self._shardable_params = shardable_params
+
+            def sharding_types(self, compute_device_type: str) -> List[str]:
+                return [ShardingType.TABLE_WISE.value]
+
+            def compute_kernels(
+                self, sharding_type: str, compute_device_type: str
+            ) -> List[str]:
+                return [EmbeddingComputeKernel.FUSED.value]
+
+            def shardable_parameters(
+                self, module: nn.Module
+            ) -> Dict[str, nn.Parameter]:
+                # Filter to only include parameters that are in shardable_params
+                all_params = super().shardable_parameters(
+                    cast(EmbeddingBagCollection, module)
+                )
+                return {
+                    name: param
+                    for name, param in all_params.items()
+                    if name in self._shardable_params
+                }
+
+        # Only include non-weighted table names in shardable_params
+        sharder = PartialEBCSharder(shardable_params=[table.name for table in tables])
+        sharders = [cast(ModuleSharder[nn.Module], sharder)]
+
+        # Plan with the partial sharder - this should only plan for non-weighted tables
+        planner = EmbeddingShardingPlanner(topology=self.topology)
+        sharding_plan = planner.plan(module=model, sharders=sharders)
+
+        # The validation should pass because weighted_ebc has no shardable parameters
+        # (they were filtered out by shardable_params), so it shouldn't be expected
+        # in the sharding plan
+        validate_modules_inclusion_in_sharding_plan(sharding_plan, model, sharders)
+
+        # Verify that only non-weighted ebc is in the plan
+        self.assertIn("sparse.ebc", sharding_plan.plan)
+        # weighted_ebc should not be in the plan since it has no shardable params
+        self.assertNotIn("sparse.weighted_ebc", sharding_plan.plan)

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -22,6 +22,7 @@ from torchrec.distributed.planner.perf_models import NoopPerfModel
 from torchrec.distributed.planner.planners import (
     EmbeddingShardingPlanner,
     extract_plan,
+    validate_compute_kernels,
     validate_modules_inclusion_in_sharding_plan,
 )
 from torchrec.distributed.planner.proposers import EmbeddingOffloadScaleupProposer
@@ -37,6 +38,7 @@ from torchrec.distributed.planner.types import (
     PlannerErrorType,
     Shard,
     ShardingOption,
+    Storage,
     Topology,
 )
 from torchrec.distributed.sharding_plan import get_default_sharders
@@ -1860,3 +1862,254 @@ class TestValidateModulesInclusionInShardingPlan(unittest.TestCase):
         self.assertIn("sparse.ebc", sharding_plan.plan)
         # weighted_ebc should not be in the plan since it has no shardable params
         self.assertNotIn("sparse.weighted_ebc", sharding_plan.plan)
+
+    def test_validate_modules_inclusion_device_group_without_constraints(self) -> None:
+        """Test that validation raises ValueError when device_group is set but constraints is None."""
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], TWvsRWSharder())
+        ]
+
+        # Should raise ValueError when device_group is set but constraints is None
+        empty_plan = ShardingPlan({})
+        with self.assertRaises(ValueError) as context:
+            validate_modules_inclusion_in_sharding_plan(
+                empty_plan,
+                self.model,
+                sharders,
+                constraints=None,
+                device_group="test_group",
+            )
+        self.assertIn(
+            "device_group is set but constraints is None", str(context.exception)
+        )
+
+
+class TestValidateComputeKernels(unittest.TestCase):
+
+    def _make_sharding_option(
+        self,
+        name: str = "table_0",
+        module_path: str = "sparse.ebc",
+        compute_kernel: str = EmbeddingComputeKernel.FUSED.value,
+        sharding_type: str = ShardingType.TABLE_WISE.value,
+        cache_params: Optional[CacheParams] = None,
+        key_value_params: Optional[KeyValueParams] = None,
+        storage: Optional[Storage] = None,
+    ) -> ShardingOption:
+        shard_storage = storage if storage is not None else Storage(hbm=1000, ddr=0)
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=64,
+                    name=name,
+                    feature_names=[f"feature_{name}"],
+                )
+            ],
+            device=torch.device("meta"),
+        )
+        return ShardingOption(
+            name=name,
+            tensor=torch.zeros(100, 64, device="meta"),
+            module=(module_path, ebc),
+            input_lengths=[1.0],
+            batch_size=128,
+            sharding_type=sharding_type,
+            partition_by="device",
+            compute_kernel=compute_kernel,
+            shards=[
+                Shard(
+                    size=[100, 64],
+                    offset=[0, 0],
+                    storage=shard_storage,
+                    rank=0,
+                ),
+            ],
+            cache_params=cache_params,
+            key_value_params=key_value_params,
+        )
+
+    def test_valid_fused_kernel(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            storage=Storage(hbm=1000, ddr=0),
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_valid_dense_kernel(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.DENSE.value,
+            sharding_type=ShardingType.DATA_PARALLEL.value,
+            storage=Storage(hbm=1000, ddr=0),
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_valid_fused_uvm_caching_kernel(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=0.5),
+            storage=Storage(hbm=500, ddr=1000),
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_valid_quant_uvm_caching_kernel(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.QUANT_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=0.2),
+            storage=Storage(hbm=200, ddr=1000),
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_valid_key_value_kernel(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.KEY_VALUE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            key_value_params=KeyValueParams(),
+            storage=Storage(hbm=500, ddr=0),
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_unknown_compute_kernel(self) -> None:
+        so = self._make_sharding_option(compute_kernel="invalid_kernel")
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertEqual(
+            ctx.exception.error_type, PlannerErrorType.INVALID_COMPUTE_KERNEL
+        )
+        self.assertIn("unknown compute kernel", str(ctx.exception))
+
+    def test_dense_kernel_wrong_sharding_type(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.DENSE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertEqual(
+            ctx.exception.error_type, PlannerErrorType.INVALID_COMPUTE_KERNEL
+        )
+        self.assertIn("DENSE kernel requires DATA_PARALLEL", str(ctx.exception))
+
+    def test_fused_uvm_caching_missing_cache_load_factor(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            storage=Storage(hbm=500, ddr=1000),
+        )
+        # cache_load_factor=None is allowed because the OSS planner UVM path
+        # stores cache_load_factor in sharder.fused_params and computes the
+        # precise value post-planning via calc_cache_load_factor.
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_fused_uvm_caching_invalid_cache_load_factor(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=1.0),
+            storage=Storage(hbm=500, ddr=1000),
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertIn("cache_load_factor", str(ctx.exception))
+
+    def test_key_value_kernel_without_params(self) -> None:
+        # key_value_params is optional - estimator creates defaults if needed
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.KEY_VALUE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_fused_uvm_caching_negative_hbm(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=0.5),
+            storage=Storage(hbm=-100, ddr=1000),
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertIn("negative HBM", str(ctx.exception))
+
+    def test_fused_uvm_caching_negative_ddr(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=0.5),
+            storage=Storage(hbm=500, ddr=-100),
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertIn("negative DDR", str(ctx.exception))
+
+    def test_ssd_virtual_table_without_params(self) -> None:
+        # key_value_params is optional - estimator creates defaults if needed
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_multiple_violations(self) -> None:
+        so1 = self._make_sharding_option(
+            name="table_0",
+            compute_kernel=EmbeddingComputeKernel.DENSE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        so2 = self._make_sharding_option(
+            name="table_1",
+            compute_kernel="invalid_kernel",
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so1, so2])
+        self.assertIn("2 violation(s)", str(ctx.exception))
+
+    def test_empty_plan(self) -> None:
+        # Should not raise
+        validate_compute_kernels([])
+
+    def test_fused_uvm_caching_zero_cache_load_factor(self) -> None:
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            cache_params=CacheParams(load_factor=0.0),
+            storage=Storage(hbm=500, ddr=1000),
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertIn("cache_load_factor", str(ctx.exception))
+
+    def test_dram_virtual_table_without_params(self) -> None:
+        # key_value_params is optional - estimator creates defaults if needed
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+        )
+        # Should not raise
+        validate_compute_kernels([so])
+
+    def test_valid_with_negative_storage(self) -> None:
+        # Negative storage should fail validation for caching kernels
+        # Production data shows this never occurs (0 in 6.6M+ plans), so validation is safe
+        so = self._make_sharding_option(
+            compute_kernel=EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            storage=Storage(hbm=-100, ddr=-200),
+        )
+        with self.assertRaises(PlannerError) as ctx:
+            validate_compute_kernels([so])
+        self.assertIn("negative HBM", str(ctx.exception))
+        self.assertIn("negative DDR", str(ctx.exception))
+        self.assertIn("2 violation(s)", str(ctx.exception))

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1447,6 +1447,7 @@ class PlannerErrorType(Enum):
     INVALID_RANK_ASSIGNMENT = "invalid_rank_assignment"
     INPUT_VALIDATION = "input_validation"
     MISSING_MODULE_IN_PLAN = "missing_module_in_plan"
+    INVALID_COMPUTE_KERNEL = "invalid_compute_kernel"
 
 
 class PlannerError(Exception):

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1446,6 +1446,7 @@ class PlannerErrorType(Enum):
     PLAN_LOADING_FAILED = "plan_loading_failed"
     INVALID_RANK_ASSIGNMENT = "invalid_rank_assignment"
     INPUT_VALIDATION = "input_validation"
+    MISSING_MODULE_IN_PLAN = "missing_module_in_plan"
 
 
 class PlannerError(Exception):


### PR DESCRIPTION
Summary:

Adds a `validate_compute_kernels()` function that validates compute kernel selections in sharding plans are valid and consistent with other sharding option attributes. This is called post-planning in all three planners (EmbeddingShardingPlanner, LinearProgrammingPlanner, ManifoldPlanner) alongside the existing `validate_rank_assignment` and `validate_modules_inclusion_in_sharding_plan` checks.

Validations performed per `ShardingOption`:
- Compute kernel must be a valid `EmbeddingComputeKernel` value
- `DENSE` kernel must use `DATA_PARALLEL` sharding type
- Caching kernels (`FUSED_UVM_CACHING`, `QUANT_UVM_CACHING`) require `cache_load_factor` strictly between 0 and 1, and non-negative HBM/DDR storage

Each violation is logged via `logging.warning()` for oncall monitoring, and all violations are collected and raised as a single `PlannerError` with the new `INVALID_COMPUTE_KERNEL` error type.

Note: The KV kernels (`KEY_VALUE`, `SSD_VIRTUAL_TABLE`, `DRAM_VIRTUAL_TABLE`) key_value_params check was removed because the estimator automatically creates defaults when needed.

Reviewed By: mserturk

Differential Revision: D104314794


