### PR TITLE
Move split logic into collision handler via split_dist

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -15,7 +15,10 @@ from typing import Dict, List, Tuple
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
+from torchrec.distributed.dist_data import (
+    SplitsAllToAllAwaitable,
+    TensorAllToAllValuesAwaitable,
+)
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import Awaitable
@@ -81,7 +84,7 @@ class BooleanMaskChecker:
         self._seen_values.zero_()
 
     def update(self, remapped_feature_values: torch.Tensor) -> None:
-        """Mark values as seen. Resets first (only current batch matters)."""
+        """Marks values as seen. Resets first (only current batch matters)."""
         self.reset_mask()
         self._seen_values[remapped_feature_values] = True
 
@@ -89,7 +92,7 @@ class BooleanMaskChecker:
         self,
         remapped_feature_values: torch.Tensor,
     ) -> torch.Tensor:
-        """Return bool mask: True where values overlap with previously-seen values."""
+        """Returns bool mask: True where values overlap with previously-seen values."""
         return self._seen_values[remapped_feature_values]
 
 
@@ -97,7 +100,7 @@ def split_features_by_values_mask(
     features: KeyedJaggedTensor,
     overlap_mask: torch.Tensor,
 ) -> Tuple[KeyedJaggedTensor, KeyedJaggedTensor]:
-    """Split KJT into overlapped and nonoverlapped partitions by bool mask.
+    """Splits KJT into overlapped and nonoverlapped partitions by bool mask.
 
     Uses fbgemm.asynchronous_complete_cumsum + fbgemm.segment_sum_csr to
     compute per-segment lengths for each partition efficiently.
@@ -148,7 +151,7 @@ def split_features_by_values_mask(
 
 
 class ForwardPermuteAwaitable(Awaitable[torch.Tensor]):
-    """RW-specific awaitable that computes forward_permute from a received mask.
+    """RW-specific awaitable that produces forward_permute from a received mask.
 
     On wait(), receives the mask via AllToAll, then builds forward_permute:
     a tensor for reordering merged [ol_embs, nol_embs] back to original
@@ -186,6 +189,54 @@ class ForwardPermuteAwaitable(Awaitable[torch.Tensor]):
         return bucket_to_merged[upt]
 
 
+@dataclass
+class CollisionSplits:
+    """Per-rank split sizes for overlapped/nonoverlapped partitions.
+
+    input_splits: [ol_per_rank, nol_per_rank] — how many values this rank
+        sends to each other rank per partition.
+    output_splits: [ol_received, nol_received] — how many values this rank
+        receives from each other rank per partition.
+    """
+
+    input_splits: List[List[int]]
+    output_splits: List[List[int]]
+
+
+class CollisionSplitsAwaitable(Awaitable[CollisionSplits]):
+    """Resolves to CollisionSplits for a single sharding group.
+
+    Wraps a SplitsAllToAllAwaitable that exchanges nonoverlapped per-rank
+    counts. On wait(), derives overlapped received splits from
+    total - nol_received, then assembles CollisionSplits.
+    """
+
+    def __init__(
+        self,
+        ol_input_splits: List[int],
+        nol_input_splits: List[int],
+        splits_awaitable: SplitsAllToAllAwaitable,
+        total_input_splits: List[int],
+    ) -> None:
+        super().__init__()
+        self._ol_input_splits = ol_input_splits
+        self._nol_input_splits = nol_input_splits
+        self._splits_awaitable = splits_awaitable
+        self._total_input_splits = total_input_splits
+
+    def _wait_impl(self) -> CollisionSplits:
+        result = self._splits_awaitable.wait()
+        nol_received = result[0]
+        ol_received = [
+            self._total_input_splits[r] - nol_received[r]
+            for r in range(len(nol_received))
+        ]
+        return CollisionSplits(
+            input_splits=[self._ol_input_splits, self._nol_input_splits],
+            output_splits=[ol_received, nol_received],
+        )
+
+
 class CollisionHandlerBase(abc.ABC):
     """Interface for PEC collision detection handlers.
 
@@ -198,7 +249,7 @@ class CollisionHandlerBase(abc.ABC):
         features: KeyedJaggedTensor,
         prev_remapped_feature_values: torch.Tensor | None = None,
     ) -> CollisionResult:
-        """Detect overlapping IDs between current and previous batch.
+        """Detects overlapping IDs between current and previous batch.
 
         Args:
             features: current batch features (after input dist)
@@ -211,7 +262,7 @@ class CollisionHandlerBase(abc.ABC):
 
     @abc.abstractmethod
     def reset(self) -> None:
-        """Reset internal state (e.g. at epoch boundary)."""
+        """Resets internal state (e.g. at epoch boundary)."""
         ...
 
     @abc.abstractmethod
@@ -221,7 +272,7 @@ class CollisionHandlerBase(abc.ABC):
         forward_overlap_mask: torch.Tensor,
         sharding_ctx: SequenceShardingContext,
     ) -> Awaitable[torch.Tensor]:
-        """Distribute the collision partition permutation via AllToAll.
+        """Distributes the collision partition permutation via AllToAll.
 
         Sends overlap information from sharding ranks back to the original
         rank and computes forward_permute — a tensor for reordering merged
@@ -233,23 +284,24 @@ class CollisionHandlerBase(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def compute_nonoverlapped_per_rank(
+    def split_dist(
         self,
         nonoverlapped_features: KeyedJaggedTensor,
-        batch_size_per_rank: List[int],
-    ) -> torch.Tensor:
-        """Computes per-rank nonoverlapped value counts.
+        sharding_ctx: SequenceShardingContext,
+    ) -> Awaitable[CollisionSplits]:
+        """Exchanges per-rank overlapped/nonoverlapped split sizes via AllToAll.
 
-        Used by collision_split_dist to compute per-rank split sizes for
-        the nonoverlapped partition. The overlapped splits are derived from
-        the total (output_splits - nonoverlapped).
+        Computes how many nonoverlapped values this rank sends to each peer
+        rank, derives the overlapped counts from the total, and starts a
+        SplitsAllToAll. Returns an awaitable that resolves to CollisionSplits.
 
         Args:
             nonoverlapped_features: nonoverlapped partition KJT
-            batch_size_per_rank: number of batch elements from each rank
+            sharding_ctx: sharding context from input_dist
 
         Returns:
-            Tensor of shape [world_size] with per-rank nonoverlapped value counts
+            Awaitable resolving to CollisionSplits with per-rank send/receive
+            counts for each partition.
         """
         ...
 
@@ -341,7 +393,7 @@ class RWCollisionHandler(CollisionHandlerBase):
     def reset(self) -> None:
         self._checker.reset_mask()
 
-    def compute_nonoverlapped_per_rank(
+    def _compute_nonoverlapped_per_rank(
         self,
         nonoverlapped_features: KeyedJaggedTensor,
         batch_size_per_rank: List[int],
@@ -368,13 +420,41 @@ class RWCollisionHandler(CollisionHandlerBase):
             num_features, batch_size_cumsum, lengths_batch_major
         )
 
+    def split_dist(
+        self,
+        nonoverlapped_features: KeyedJaggedTensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> CollisionSplitsAwaitable:
+        """Computes per-rank ol/nol split sizes and exchanges via AllToAll."""
+        assert sharding_ctx.batch_size_per_rank is not None
+        nol = self._compute_nonoverlapped_per_rank(
+            nonoverlapped_features, sharding_ctx.batch_size_per_rank
+        )
+        ol = (
+            torch.tensor(
+                sharding_ctx.output_splits,
+                device=nol.device,
+                dtype=nol.dtype,
+            )
+            - nol
+        )
+
+        splits_awaitable = SplitsAllToAllAwaitable([nol], self._pg)
+
+        return CollisionSplitsAwaitable(
+            ol_input_splits=ol.tolist(),
+            nol_input_splits=nol.tolist(),
+            splits_awaitable=splits_awaitable,
+            total_input_splits=sharding_ctx.input_splits,
+        )
+
     def permute_dist(
         self,
         features: KeyedJaggedTensor,
         forward_overlap_mask: torch.Tensor,
         sharding_ctx: SequenceShardingContext,
     ) -> ForwardPermuteAwaitable:
-        """Reorder mask to rank-major, AllToAll to original rank, compute forward_permute."""
+        """Reorders mask to rank-major, AllToAll to original rank, computes forward_permute."""
         assert sharding_ctx.sparse_features_recat is not None
         assert sharding_ctx.unbucketize_permute_tensor is not None
 
@@ -417,7 +497,7 @@ def create_collision_handler(
     process_group: dist.ProcessGroup,
     checker_type: OverlappingCheckerType,
 ) -> CollisionHandlerBase:
-    """Factory function to create a collision handler for a given sharding type."""
+    """Creates a collision handler for the given sharding type."""
     if sharding_type == "row_wise":
         return RWCollisionHandler(
             device=device,

--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -14,7 +14,11 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 import torch
+import torch.distributed as dist
+from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
+from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
+from torchrec.distributed.types import Awaitable
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
@@ -99,7 +103,7 @@ def split_features_by_values_mask(
     compute per-segment lengths for each partition efficiently.
 
     Args:
-        features: input KJT (after input dist, on sharder side)
+        features: input KJT (after input dist)
         overlap_mask: bool tensor of shape [num_values], True = overlapped
 
     Returns:
@@ -143,12 +147,49 @@ def split_features_by_values_mask(
     return overlapped_kjt, nonoverlapped_kjt
 
 
+class ForwardPermuteAwaitable(Awaitable[torch.Tensor]):
+    """RW-specific awaitable that computes forward_permute from a received mask.
+
+    On wait(), receives the mask via AllToAll, then builds forward_permute:
+    a tensor for reordering merged [ol_embs, nol_embs] back to original
+    order via index_select.
+
+    The received mask is in bucketized order (values sent to shard 0 first,
+    then shard 1, etc.). unbucketize_permute_tensor maps original position i
+    to bucket position upt[i]. We compose these to build forward_permute[i] =
+    position in merged [ol_embs, nol_embs] for original position i.
+    """
+
+    def __init__(
+        self,
+        values_awaitable: TensorAllToAllValuesAwaitable,
+        unbucketize_permute_tensor: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._values_awaitable = values_awaitable
+        self._unbucketize_permute_tensor = unbucketize_permute_tensor
+
+    def _wait_impl(self) -> torch.Tensor:
+        received_mask = self._values_awaitable.wait()
+        bool_mask = received_mask.bool()
+        upt = self._unbucketize_permute_tensor
+        num_ol = bool_mask.sum()
+
+        # Example: bool_mask = [T, F, T, T, F, F]
+        #   ol_rank  = cumsum([1,0,1,1,0,0]) - 1 = [0, 0, 1, 2, 2, 2]
+        #   nol_rank = cumsum([0,1,0,0,1,1]) - 1 + 3 = [2, 3, 3, 3, 4, 5]
+        #   bucket_to_merged = where(mask, ol_rank, nol_rank) = [0, 3, 1, 2, 4, 5]
+        ol_rank = bool_mask.long().cumsum(0) - 1
+        nol_rank = (~bool_mask).long().cumsum(0) - 1 + num_ol
+        bucket_to_merged = torch.where(bool_mask, ol_rank, nol_rank)
+
+        return bucket_to_merged[upt]
+
+
 class CollisionHandlerBase(abc.ABC):
     """Interface for PEC collision detection handlers.
 
     Subclasses implement sharding-specific overlap detection logic.
-    The pipeline passes prev_remapped_feature_values as an argument to detect_collisions
-    rather than storing cross-batch state internally.
     """
 
     @abc.abstractmethod
@@ -171,6 +212,24 @@ class CollisionHandlerBase(abc.ABC):
     @abc.abstractmethod
     def reset(self) -> None:
         """Reset internal state (e.g. at epoch boundary)."""
+        ...
+
+    @abc.abstractmethod
+    def permute_dist(
+        self,
+        features: KeyedJaggedTensor,
+        forward_overlap_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> Awaitable[torch.Tensor]:
+        """Distribute the collision partition permutation via AllToAll.
+
+        Sends overlap information from sharding ranks back to the original
+        rank and computes forward_permute — a tensor for reordering merged
+        [ol, nol] embeddings back to original order via index_select.
+
+        Returns:
+            Awaitable resolving to forward_permute tensor of shape [N].
+        """
         ...
 
     @abc.abstractmethod
@@ -208,12 +267,14 @@ class RWCollisionHandler(CollisionHandlerBase):
         device: torch.device,
         grouped_emb_configs: List[GroupedEmbeddingConfig],
         table_name_to_config: Dict[str, EmbeddingConfig],
+        process_group: dist.ProcessGroup,
         checker_type: OverlappingCheckerType = OverlappingCheckerType.BOOLEAN,
     ) -> None:
         assert (
             checker_type == OverlappingCheckerType.BOOLEAN
         ), f"Only BOOLEAN checker is supported, got {checker_type}"
         self._device = device
+        self._pg = process_group
         self._feature_to_table_offset: Dict[str, int] = {}
         self._input_features_offset: torch.Tensor = torch.empty(
             0,
@@ -307,12 +368,53 @@ class RWCollisionHandler(CollisionHandlerBase):
             num_features, batch_size_cumsum, lengths_batch_major
         )
 
+    def permute_dist(
+        self,
+        features: KeyedJaggedTensor,
+        forward_overlap_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> ForwardPermuteAwaitable:
+        """Reorder mask to rank-major, AllToAll to original rank, compute forward_permute."""
+        assert sharding_ctx.sparse_features_recat is not None
+        assert sharding_ctx.unbucketize_permute_tensor is not None
+
+        recat = torch.ops.fbgemm.invert_permute(sharding_ctx.sparse_features_recat)
+        mask_int = forward_overlap_mask.to(torch.int32)
+
+        _, permuted_mask, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+            recat,
+            features.lengths().view(recat.shape[0], -1),
+            mask_int,
+            None,
+            mask_int.numel(),
+        )
+
+        values_awaitable = TensorAllToAllValuesAwaitable(
+            self._pg,
+            permuted_mask,
+            input_splits=torch.tensor(
+                sharding_ctx.output_splits,
+                dtype=torch.int32,
+            ),
+            output_splits=torch.tensor(
+                sharding_ctx.input_splits,
+                dtype=torch.int32,
+            ),
+            device=permuted_mask.device,
+        )
+
+        return ForwardPermuteAwaitable(
+            values_awaitable=values_awaitable,
+            unbucketize_permute_tensor=sharding_ctx.unbucketize_permute_tensor,
+        )
+
 
 def create_collision_handler(
     sharding_type: str,
     device: torch.device,
     grouped_emb_configs: List[GroupedEmbeddingConfig],
     table_name_to_config: Dict[str, EmbeddingConfig],
+    process_group: dist.ProcessGroup,
     checker_type: OverlappingCheckerType,
 ) -> CollisionHandlerBase:
     """Factory function to create a collision handler for a given sharding type."""
@@ -321,6 +423,7 @@ def create_collision_handler(
             device=device,
             grouped_emb_configs=grouped_emb_configs,
             table_name_to_config=table_name_to_config,
+            process_group=process_group,
             checker_type=checker_type,
         )
     raise ValueError(

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Type
 
 import torch
 import torch.nn as nn
-from torchrec.distributed.dist_data import SplitsAllToAllAwaitable
 from torchrec.distributed.embedding import (
     EmbeddingCollectionContext,
     EmbeddingCollectionSharder,
@@ -29,6 +28,7 @@ from torchrec.distributed.embedding_types import (
 from torchrec.distributed.pec_collision_handlers import (
     CollisionHandlerBase,
     CollisionResult,
+    CollisionSplits,
     create_collision_handler,
 )
 from torchrec.distributed.types import (
@@ -52,67 +52,6 @@ class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
     """
 
     prev_remapped_feature_values: List[torch.Tensor] | None = None
-
-
-@dataclass
-class CollisionSplits:
-    """Result of waiting on CollisionSplitsAwaitable.
-
-    input_splits: [ol_per_rank, nol_per_rank] — how many values this rank
-        sends to each other rank per partition.
-    output_splits: [ol_received, nol_received] — how many values this rank
-        receives from each other rank per partition.
-    """
-
-    input_splits: List[List[int]]
-    output_splits: List[List[int]]
-
-
-class CollisionSplitsAwaitable(Awaitable[List[CollisionSplits]]):
-    """Awaitable for PEC collision split sizes, one per sharding group.
-
-    Wraps a SplitsAllToAllAwaitable that exchanges nonoverlapped per-rank
-    counts. On wait(), derives overlapped received splits from
-    total - nol_received, then assembles per-group CollisionSplits.
-
-    Args:
-        ol_input_splits: per-group overlapped send counts, each [world_size].
-        nol_input_splits: per-group nonoverlapped send counts, each [world_size].
-        splits_awaitable: SplitsAllToAll that exchanges nol counts across ranks.
-        total_input_splits: per-group total receive counts from input_dist,
-            each [world_size]. Used to derive ol_received = total - nol_received.
-    """
-
-    def __init__(
-        self,
-        ol_input_splits: List[List[int]],
-        nol_input_splits: List[List[int]],
-        splits_awaitable: SplitsAllToAllAwaitable,
-        total_input_splits: List[List[int]],
-    ) -> None:
-        super().__init__()
-        self._ol_input_splits = ol_input_splits
-        self._nol_input_splits = nol_input_splits
-        self._splits_awaitable = splits_awaitable
-        self._total_input_splits = total_input_splits
-
-    def _wait_impl(self) -> List[CollisionSplits]:
-        result = self._splits_awaitable.wait()
-        splits: List[CollisionSplits] = []
-        for nol_received, ol_input, nol_input, total in zip(
-            result,
-            self._ol_input_splits,
-            self._nol_input_splits,
-            self._total_input_splits,
-        ):
-            ol_received = [total[r] - nol_received[r] for r in range(len(nol_received))]
-            splits.append(
-                CollisionSplits(
-                    input_splits=[ol_input, nol_input],
-                    output_splits=[ol_received, nol_received],
-                )
-            )
-        return splits
 
 
 class ShardedPECEmbeddingCollection(
@@ -197,7 +136,7 @@ class ShardedPECEmbeddingCollection(
         ctx: PECEmbeddingCollectionContext,
         dist_input: KJTList,
     ) -> List[CollisionResult]:
-        """Detect collisions for each sharding group's features.
+        """Detects collisions for each sharding group's features.
 
         Reads ctx.prev_remapped_feature_values (set by the pipeline from the
         previous batch's CollisionResult). Returns masks only — KJT splitting
@@ -225,74 +164,33 @@ class ShardedPECEmbeddingCollection(
         self,
         ctx: PECEmbeddingCollectionContext,
         nonoverlapped_features: List[KeyedJaggedTensor],
-    ) -> CollisionSplitsAwaitable:
-        """Starts AllToAll to exchange per-rank nonoverlapped/overlapped split
-        sizes.
+    ) -> List[Awaitable[CollisionSplits]]:
+        """Exchanges per-rank overlapped/nonoverlapped split sizes via AllToAll.
 
-        For each sharding group, computes how many nonoverlapped values this
-        rank sends to each other rank (nol_per_rank), derives the overlapped
-        counts (ol_per_rank = total - nol), and bundles all groups into a
-        single SplitsAllToAll. On wait, the received nol counts are used to
-        derive the received ol counts.
+        Delegates to each handler's split_dist. Each awaitable resolves
+        to CollisionSplits with per-rank send/receive counts for
+        overlapped and nonoverlapped partitions.
 
         Args:
             ctx: PEC context (sharding_contexts must be set from input_dist)
             nonoverlapped_features: one nonoverlapped KJT per
                 sharding group, from split_features_by_values_mask()
+                # TODO: test with multiple sharding groups
 
         Returns:
-            CollisionSplitsAwaitable that resolves to CollisionSplits.
-            # TODO: test with multiple sharding groups
+            List of Awaitable[CollisionSplits], one per sharding group.
         """
-        # Per-group value counts for the overlapped partition. Derived from
-        # output splits form input dist, and will be used in output dist.
-        ol_input_splits: List[List[int]] = []
-
-        # Per-group value counts for non-overlapped partition. Derived from
-        # output splits from input dist, and will be used in output dist.
-        nol_input_splits: List[List[int]] = []
-
-        # Per-group split tensors for the nonoverlapped partition. Exchanged
-        # via SplitsAllToAll.
-        nol_splits: List[torch.Tensor] = []
-
-        # Per-group total receive counts from input_dist, used by the
-        # awaitable to derive ol_received = total - nol_received.
-        total_input_splits: List[List[int]] = []
-
-        for handler, nol_features, sharding_ctx in zip(
-            self._collision_handlers,
-            nonoverlapped_features,
-            ctx.sharding_contexts,
-        ):
-            assert sharding_ctx.batch_size_per_rank is not None
-            nol = handler.compute_nonoverlapped_per_rank(
-                nol_features, sharding_ctx.batch_size_per_rank
+        return [
+            handler.split_dist(
+                nol_features,
+                sharding_ctx,
             )
-            ol = (
-                torch.tensor(
-                    sharding_ctx.output_splits,
-                    device=nol.device,
-                    dtype=nol.dtype,
-                )
-                - nol
+            for handler, nol_features, sharding_ctx in zip(
+                self._collision_handlers,
+                nonoverlapped_features,
+                ctx.sharding_contexts,
             )
-
-            nol_splits.append(nol)
-
-            ol_input_splits.append(ol.tolist())
-            nol_input_splits.append(nol.tolist())
-            total_input_splits.append(sharding_ctx.input_splits)
-
-        assert self._env.process_group is not None
-        splits_awaitable = SplitsAllToAllAwaitable(nol_splits, self._env.process_group)
-
-        return CollisionSplitsAwaitable(
-            ol_input_splits=ol_input_splits,
-            nol_input_splits=nol_input_splits,
-            splits_awaitable=splits_awaitable,
-            total_input_splits=total_input_splits,
-        )
+        ]
 
     def permute_dist(
         self,

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -144,6 +144,7 @@ class ShardedPECEmbeddingCollection(
         )
         self._env: ShardingEnv = env
 
+        assert env.process_group is not None
         self._collision_handlers: List[CollisionHandlerBase] = []
         for (
             sharding_type,
@@ -155,6 +156,7 @@ class ShardedPECEmbeddingCollection(
                     device=device,
                     grouped_emb_configs=sharding._grouped_embedding_configs,  # pyre-ignore[16]
                     table_name_to_config=self._embedding_collection._table_name_to_config,
+                    process_group=env.process_group,
                     checker_type=module._checker_type,
                 )
             )
@@ -291,6 +293,41 @@ class ShardedPECEmbeddingCollection(
             splits_awaitable=splits_awaitable,
             total_input_splits=total_input_splits,
         )
+
+    def permute_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        features_per_group: List[KeyedJaggedTensor],
+        forward_overlap_masks: List[torch.Tensor],
+    ) -> List[Awaitable[torch.Tensor]]:
+        """Distributes collision partition permutations via AllToAll.
+
+        Delegates to each handler's permute_dist. Each awaitable resolves
+        to a forward_permute tensor for reordering merged [ol, nol]
+        embeddings back to original order.
+
+        Args:
+            ctx: PEC context (sharding_contexts must be set from input_dist)
+            features_per_group: per-group features after input_dist (for lengths)
+            forward_overlap_masks: per-group bool masks for overlapped values
+
+        Returns:
+            List of Awaitable[torch.Tensor], one per sharding group, each
+            resolving to a forward_permute tensor.
+        """
+        return [
+            handler.permute_dist(
+                features,
+                mask,
+                sharding_ctx,
+            )
+            for handler, features, mask, sharding_ctx in zip(
+                self._collision_handlers,
+                features_per_group,
+                forward_overlap_masks,
+                ctx.sharding_contexts,
+            )
+        ]
 
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):

--- a/torchrec/distributed/tests/test_pec_collision_handlers.py
+++ b/torchrec/distributed/tests/test_pec_collision_handlers.py
@@ -7,10 +7,12 @@
 
 # pyre-strict
 
+import os
 import unittest
 from typing import List
 
 import torch
+import torch.distributed as dist
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -27,6 +29,15 @@ from torchrec.distributed.pec_collision_handlers import (
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import get_free_port
+
+
+def _get_single_rank_pg() -> dist.ProcessGroup:
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ.setdefault("MASTER_PORT", str(get_free_port()))
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    return dist.group.WORLD  # pyre-ignore[7]
 
 
 def _make_grouped_configs(
@@ -214,6 +225,7 @@ class RWCollisionHandlerTest(unittest.TestCase):
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows),
             table_name_to_config=_make_table_name_to_config(tables),
+            process_group=_get_single_rank_pg(),
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
@@ -482,6 +494,7 @@ class CreateCollisionHandlerTest(unittest.TestCase):
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
             table_name_to_config=_make_table_name_to_config(tables),
+            process_group=_get_single_rank_pg(),
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
@@ -503,5 +516,6 @@ class CreateCollisionHandlerTest(unittest.TestCase):
                 device=torch.device("cpu"),
                 grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
                 table_name_to_config=_make_table_name_to_config(tables),
+                process_group=_get_single_rank_pg(),
                 checker_type=OverlappingCheckerType.BOOLEAN,
             )

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -18,10 +18,10 @@ import torch.nn as nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.pec_collision_handlers import (
     CollisionResult,
+    CollisionSplits,
     split_features_by_values_mask,
 )
 from torchrec.distributed.pec_embedding import (
-    CollisionSplits,
     PECEmbeddingCollectionSharder,
     ShardedPECEmbeddingCollection,
 )
@@ -269,10 +269,11 @@ def _test_pec_forward_stages(
                 )
                 nol_features.append(nol)
 
-            all_splits = sharded_pec.collision_split_dist(
+            split_awaitables = sharded_pec.collision_split_dist(
                 pec_ctx,
                 nol_features,
-            ).wait()
+            )
+            all_splits = [aw.wait() for aw in split_awaitables]
 
             if expected_splits_per_rank is not None:
                 _verify_collision_splits(

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -188,6 +188,13 @@ class ExpectedSplits:
     output_splits: List[List[int]]
 
 
+def _verify_forward_permute(
+    forward_permute: torch.Tensor,
+    expected: List[int],
+) -> None:
+    assert forward_permute.tolist() == expected
+
+
 def _verify_collision_result(
     result: CollisionResult,
     expected: ExpectedCollisionResult,
@@ -220,11 +227,13 @@ def _test_pec_forward_stages(
     backend: str,
     expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
     expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
+    expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
     local_size: Optional[int] = None,
 ) -> None:
     """Run PEC forward pipeline stages and verify against expected results.
 
-    Always runs: input_dist → detect_collisions → split → collision_split_dist.
+    Always runs: input_dist → detect_collisions → split →
+        collision_split_dist → permute_dist.
     Verification for each stage is enabled by providing its expected-output parameter.
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
@@ -269,6 +278,22 @@ def _test_pec_forward_stages(
                 _verify_collision_splits(
                     all_splits,
                     expected_splits_per_rank[rank][batch_idx],
+                )
+
+            # Stage 3: permute_dist
+            features_list = list(dist_input)
+            masks = [r.forward_overlap_mask for r in results]
+            permute_awaitables = sharded_pec.permute_dist(
+                pec_ctx,
+                features_list,
+                masks,
+            )
+            forward_permutes = [aw.wait() for aw in permute_awaitables]
+
+            if expected_forward_permutes_per_rank is not None:
+                _verify_forward_permute(
+                    forward_permutes[0],
+                    expected_forward_permutes_per_rank[rank][batch_idx],
                 )
 
             prev_remapped = [r.remapped_feature_values for r in results]
@@ -428,6 +453,65 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
             expected_splits_per_rank=expected_splits_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_permute_dist(self) -> None:
+        """Verifies exact forward_permute values with cross-shard partial overlap."""
+        WORLD_SIZE = 2
+
+        # Cross-shard data: each rank has values in both shard 0 (0-7) and shard 1 (8-15)
+        kjt_input_per_rank = [
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([0, 8, 2, 10, 4, 12]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([0, 8, 3, 11, 4, 13]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+            ],
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([1, 9, 5, 11, 6, 13]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([1, 9, 7, 14, 6, 15]),
+                    lengths=torch.LongTensor([2, 1, 1, 2]),
+                ),
+            ],
+        ]
+
+        # Batch 0: no overlap → forward_permute = upt = [0,3,1,4,2,5]
+        # Batch 1: partial overlap → forward_permute derived from received mask + upt
+        expected_forward_permutes_per_rank = [
+            [
+                [0, 3, 1, 4, 2, 5],
+                [0, 2, 5, 3, 1, 4],
+            ],
+            [
+                [0, 3, 1, 4, 2, 5],
+                [0, 2, 3, 4, 1, 5],
+            ],
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=kjt_input_per_rank,
+            expected_forward_permutes_per_rank=expected_forward_permutes_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )


### PR DESCRIPTION
Summary:
# Context

PEC adds two fundamental operations on top of standard EC: **partition** and **permutation**. `split_dist` handles partition — exchanging per-rank partition sizes so each rank knows how many overlapped/nonoverlapped values to send and receive. `permute_dist` handles permutation — distributing the reorder tensor that merges [ol, nol] embeddings back to original order.

Previously, `compute_nonoverlapped_per_rank` only computed per-rank nol counts, and the sharded module was responsible for deriving ol counts, creating the SplitsAllToAll, and assembling the awaitable. This split sharding-specific logic across two layers.

This refactor moves the full split computation + AllToAll into the handler via `split_dist`, matching the pattern established by `permute_dist`. The sharded module's `collision_split_dist` now just iterates over handlers and delegates.

Note: the actual KJT splitting (`split_features_by_values_mask`) remains a standalone utility outside the handler. It is sharding-agnostic (mask-based indexing) and produces split KJTs that the pipeline uses in multiple downstream stages (nol → `split_dist`, ol/nol → `compute_and_output_dist_in_partition`). The handler's `split_dist` takes the already-split nol KJT as input.

The pipeline flow remains:
```
input_dist → detect_collisions → split_features_by_values_mask → split_dist → permute_dist
```

Differential Revision: D104564583


