### PR TITLE
Fix type checking errors in torchrec test files

### DIFF
--- a/examples/retrieval/two_tower_train.py
+++ b/examples/retrieval/two_tower_train.py
@@ -175,7 +175,10 @@ def train(
     checkpoint_pg = dist.new_group(backend="gloo")
     # Copy sharded state_dict to CPU.
     cpu_state_dict = state_dict_to_device(
-        model.state_dict(), pg=checkpoint_pg, device=torch.device("cpu")
+        # pyrefly: ignore
+        model.state_dict(),
+        pg=checkpoint_pg,  # pyrefly: ignore
+        device=torch.device("cpu"),
     )
 
     ebc_cpu = EmbeddingBagCollection(

--- a/examples/transfer_learning/train_from_pretrained_embedding.py
+++ b/examples/transfer_learning/train_from_pretrained_embedding.py
@@ -85,6 +85,7 @@ def share_tensor_via_shm(
         if dist.get_backend() == "gloo":
             gloo_pg = dist.group.WORLD
         else:
+            # pyrefly: ignore
             gloo_pg = dist.new_group(backend="gloo")
 
     torch.multiprocessing.set_sharing_strategy("file_system")

--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -1408,7 +1408,7 @@ class EmbeddingFusedOptimizer(FusedOptimizer):
                         table_config.local_rows == optimizer_state_value.size(0)
                         or optimizer_state_value.nelement() == 1  # single value state
                     )
-                # pyrefly: ignore [no-matching-overload]
+                # pyrefly: ignore
                 optimizer_states_keys_by_table[table_config.name] = list(
                     optimizer_states.keys()
                 )

--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -172,6 +172,7 @@ def a2a_async_base(
         # assertion fails without wait(), this wait() makes the main cuda stream wait
         # for the comms to finish, so the post-comms compute will be blocked until
         # the comms is done
+        assert req is not None
         req.wait()
         checks = _validate(post_comms, ctx).to("cpu", non_blocking=True)
         ev_d2h.record()  # record the device-to-host data transfer
@@ -223,6 +224,7 @@ def a2a_async_twice(
         side_stream = torch.cuda.Stream()
         post_comms2.record_stream(side_stream)
         with torch.cuda.stream(side_stream):
+            assert req1 is not None
             req1.wait()  # let the side stream wait for comms1 to finish
             pre_comms = torch.sigmoid(post_comms1) + ctx.rank
             req2 = dist.all_to_all_single(
@@ -245,9 +247,11 @@ def a2a_async_twice(
 
     ev_d2h.synchronize()  # make sure the pre_checks is available from cpu side
     with record_function(f"## comms1 checks and pre-checks1 {pre_checks1} ##"):
+        assert req1 is not None
         req1.wait()  # let the main stream wait for comms1 to finish
         checks1 = _validate(post_comms1, ctx).to("cpu", non_blocking=True)
     with record_function(f"## comms2 checks and pre-checks2 {pre_checks2} ##"):
+        assert req2 is not None
         req2.wait()  # let the main stream wait for comms2 to finish
         checks2 = _validate(post_comms2, ctx).to("cpu", non_blocking=True)
         ev_d2h.record()  # record the device-to-host data transfer
@@ -292,6 +296,7 @@ def lazyawaitable(
         # assertion fails without wait(), this wait() makes the main cuda stream wait
         # for the comms to finish, so the post-comms compute will be blocked until
         # the comms is done
+        assert req is not None
         req.wait()
         check_awaitable = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
 
@@ -367,6 +372,7 @@ def multi_stream_memory(
         with record_function("## a2a comm validation ##"):
             # the comm validation is also done in this separate stream since
             # there's no data dependency afterwards
+            assert req is not None
             req.wait()
             checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
 
@@ -377,6 +383,7 @@ def multi_stream_memory(
         )
 
     with record_function("## post-comms compute ##"):
+        assert req is not None
         req.wait()
         post_comms = _compute(
             dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
@@ -468,6 +475,7 @@ def multi_stream_optimized(
 
     with record_function("## a2a comm validation ##"):
         # this req.wait() can be wrapped into a LazyAwaitable
+        assert req is not None
         req.wait()
         # still want the compute on the main stream if possible
         checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
@@ -748,6 +756,7 @@ def multi_async_comms(
                 group=ctx.pg,
                 async_op=True,
             )
+        assert req is not None
         return out, req
 
     def do_all_reduce(

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -780,6 +780,7 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
                     )
 
                 self._output_tensors.append(output_tensor)
+                # pyrefly: ignore
                 self._awaitables.append(awaitable)
 
     def clear_inputs(self) -> int:
@@ -2133,6 +2134,7 @@ class JaggedTensorAllToAll(Awaitable[JaggedTensor]):
             )
         )
 
+        # pyrefly: ignore
         self._dist_values_req: dist.Work = dist.all_to_all_single(
             self._dist_values,
             jt.values(),
@@ -2203,6 +2205,7 @@ class TensorAllToAllValuesAwaitable(Awaitable[torch.Tensor]):
                 )
 
         with record_function("## all2all_data:ids ##"):
+            # pyrefly: ignore
             self._values_awaitable: dist.Work = dist.all_to_all_single(
                 output=self._dist_values,
                 input=input,
@@ -2245,6 +2248,7 @@ class TensorAllToAllSplitsAwaitable(Awaitable[TensorAllToAllValuesAwaitable]):
             )
 
         with record_function("## all2all_data:ids splits ##"):
+            # pyrefly: ignore
             self._num_ids_awaitable: dist.Work = dist.all_to_all_single(
                 output=self._output_splits,
                 input=splits,

--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -191,7 +191,7 @@ def create_virtual_table_local_metadata(
             if weight_count_per_rank is None
             else sum(weight_count_per_rank[:my_rank])
         )
-    # pyrefly: ignore[no-matching-overload, missing-attribute]
+    # pyrefly: ignore
     local_metadata.shard_sizes = list(param.size())
     # pyrefly: ignore[missing-attribute]
     local_metadata.shard_offsets = [

--- a/torchrec/distributed/embedding_tower_sharding.py
+++ b/torchrec/distributed/embedding_tower_sharding.py
@@ -431,6 +431,7 @@ class ShardedEmbeddingTower(
         else:
             yield from ()
 
+    # pyrefly: ignore
     def named_modules(
         self,
         memo: Optional[Set[nn.Module]] = None,
@@ -872,6 +873,7 @@ class ShardedEmbeddingTowerCollection(
                 )
             )
 
+    # pyrefly: ignore
     def named_modules(
         self,
         memo: Optional[Set[nn.Module]] = None,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1751,7 +1751,7 @@ class ShardedEmbeddingBagCollection(
         in advance
         """
         if isinstance(features, TensorDict):
-            # pyrefly: ignore [no-matching-overload]
+            # pyrefly: ignore
             feature_keys = list(features.keys())
             if len(self._features_order) > 0:
                 feature_keys = [feature_keys[i] for i in self._features_order]
@@ -2358,6 +2358,7 @@ class ShardedEmbeddingBag(
 
         # Get all fused optimizers and combine them.
         optims = []
+        # pyrefly: ignore
         for _, module in self._lookup.named_modules():
             if isinstance(module, FusedOptimizerModule):
                 # modify param keys to match EmbeddingBag
@@ -2438,6 +2439,7 @@ class ShardedEmbeddingBag(
             destination[new_key] = item
         return destination
 
+    # pyrefly: ignore
     def named_modules(
         self,
         memo: Optional[Set[nn.Module]] = None,

--- a/torchrec/distributed/planner/proposers.py
+++ b/torchrec/distributed/planner/proposers.py
@@ -249,7 +249,7 @@ class GridSearchProposer(Proposer):
             for sharding_options in self._sharding_options_by_fqn.values()
         ]
         #  `List[Tuple[int]]`.
-        # pyrefly: ignore[no-matching-overload]
+        # pyrefly: ignore
         self._proposals = list(itertools.product(*sharding_options_by_fqn_indices))
 
     def _reset(self) -> None:

--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -544,15 +544,19 @@ class EmbeddingStats(Stats):
             f"# {'Estimated Sharding Distribution' : <{self._width-2}}#"
         )
         self._stats_table.append(
+            # pyrefly: ignore
             f"# {'Sparse only Max HBM: '+_generate_rank_hbm_stats(sparse_hbm, max) : <{self._width-3}}#"
         )
         self._stats_table.append(
+            # pyrefly: ignore
             f"# {'Sparse only Min HBM: '+_generate_rank_hbm_stats(sparse_hbm, min) : <{self._width-3}}#"
         )
         self._stats_table.append(
+            # pyrefly: ignore
             f"# {'Max HBM: '+_generate_rank_hbm_stats(used_hbm, max) : <{self._width-3}}#"
         )
         self._stats_table.append(
+            # pyrefly: ignore
             f"# {'Min HBM: '+_generate_rank_hbm_stats(used_hbm, min) : <{self._width-3}}#"
         )
         self._stats_table.append(

--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -475,12 +475,12 @@ def sharded_tbes_weights_spec(
             ), "Cannot have any two of ShardedQuantEmbeddingBagCollection, ShardedQuantEmbeddingCollection, ShardedQuantManagedCollisionEmbeddingCollection, ShardedQuantFeatureProcessedEmbeddingBagCollection and ShardedQuantManagedCollisionEmbeddingBagCollection are true"
             tbes_configs: Dict[
                 IntNBitTableBatchedEmbeddingBagsCodegen, GroupedEmbeddingConfig
-            ] = module.tbes_configs()
+            ] = module.tbes_configs()  # pyrefly: ignore
             table_shardings: Dict[str, str] = {}
 
             sharding_type_device_group_to_sharding_infos: Dict[
                 Tuple[str, str], List[EmbeddingShardingInfo]
-            ] = module.sharding_type_device_group_to_sharding_infos()
+            ] = module.sharding_type_device_group_to_sharding_infos()  # pyrefly: ignore
 
             for (
                 (sharding_type, _),

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -11,7 +11,7 @@
 
 import copy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, cast, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import torch
 import torchrec
@@ -901,7 +901,8 @@ def shard_qebc(
             assert len(sharding_spec.shards) == len(expected_shards[i])
             # pyrefly: ignore[no-matching-overload]
             for shard, ((offset_r, offset_c, size_r, size_c), placement) in zip(
-                sharding_spec.shards, expected_shards[i]
+                cast(Iterable, sharding_spec.shards),
+                expected_shards[i],
             ):
                 assert shard.shard_offsets == [offset_r, offset_c]
                 assert shard.shard_sizes == [size_r, size_c]
@@ -953,7 +954,8 @@ def shard_qec(
             assert len(sharding_spec.shards) == len(expected_shards[i])
             # pyrefly: ignore[no-matching-overload]
             for shard, ((offset_r, offset_c, size_r, size_c), placement) in zip(
-                sharding_spec.shards, expected_shards[i]
+                cast(Iterable, sharding_spec.shards),
+                expected_shards[i],
             ):
                 assert shard.shard_offsets == [offset_r, offset_c]
                 assert shard.shard_sizes == [size_r, size_c]

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -41,6 +41,7 @@ from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingBagCo
 from torchrec.modules.mc_modules import (
     DistanceLFU_EvictionPolicy,
     ManagedCollisionCollection,
+    ManagedCollisionModule,
     MCHManagedCollisionModule,
 )
 from torchrec.modules.regroup import KTRegroupAsDict
@@ -338,7 +339,7 @@ class ModelInput(Pipelineable):
                 )
             }
             # pyrefly: ignore[bad-specialization]
-            global_idlist_input = TensorDict(source=dict_of_nt)
+            global_idlist_input = TensorDict(source=cast(Any, dict_of_nt))
 
             assert (
                 len(idscore_features) == 0
@@ -458,7 +459,7 @@ class ModelInput(Pipelineable):
                     )
                 }
                 # pyrefly: ignore[bad-specialization]
-                local_idlist_input = TensorDict(source=dict_of_nt)
+                local_idlist_input = TensorDict(source=cast(Any, dict_of_nt))
                 assert (
                     len(idscore_features) == 0
                 ), "TensorDict does not support weighted features"
@@ -2496,8 +2497,8 @@ class TestEBCSparseArchZCH(nn.Module):
         tables: List[EmbeddingBagConfig],
         device: torch.device,
         zch_kwargs: Dict[str, Any],
-    ):
-        mc_modules = {}
+    ) -> Dict[str, ManagedCollisionModule]:
+        mc_modules: Dict[str, ManagedCollisionModule] = {}
         for table in tables:
             mc_config = zch_kwargs[table.name]
             mc_type = mc_config.mc_type

--- a/torchrec/distributed/tests/test_collective_utils.py
+++ b/torchrec/distributed/tests/test_collective_utils.py
@@ -77,6 +77,7 @@ class CollectiveUtilsTest(unittest.TestCase):
             ranks=[0, 1],
             backend=backend,
         )
+        assert isinstance(pg, dist.ProcessGroup)
         if pg.rank() == 0:
             assert is_leader(pg, 0) is True
             assert is_leader(pg, 1) is False
@@ -107,6 +108,7 @@ class CollectiveUtilsTest(unittest.TestCase):
             ranks=[0, 1],
             backend=backend,
         )
+        assert isinstance(pg, dist.ProcessGroup)
 
         func = mock.MagicMock()
         func.return_value = pg.rank()
@@ -152,19 +154,20 @@ class CollectiveUtilsTest(unittest.TestCase):
             ranks=[0, 1],
             backend=backend,
         )
+        assert isinstance(pg, dist.ProcessGroup)
 
         @run_on_leader(pg, 0)
         def _test_run_on_0(rank: int) -> int:
             return rank
 
-        res = _test_run_on_0(pg.rank())
+        res = _test_run_on_0(pg.rank())  # pyrefly: ignore
         assert res == 0
 
         @run_on_leader(pg, 1)
         def _test_run_on_1(rank: int) -> int:
             return rank
 
-        res = _test_run_on_1(pg.rank())
+        res = _test_run_on_1(pg.rank())  # pyrefly: ignore
         assert res == 1
         dist.destroy_process_group()
 
@@ -185,6 +188,7 @@ class CollectiveUtilsTest(unittest.TestCase):
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         pg = dist.new_group(ranks=list(range(world_size)), backend=backend)
+        assert isinstance(pg, dist.ProcessGroup)
 
         shape = (64, 32)
         fill_value = 42.0
@@ -225,6 +229,7 @@ class CollectiveUtilsTest(unittest.TestCase):
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         pg = dist.new_group(ranks=list(range(world_size)), backend=backend)
+        assert isinstance(pg, dist.ProcessGroup)
 
         def _creator() -> List[torch.Tensor]:
             return [
@@ -275,6 +280,7 @@ class CollectiveUtilsTest(unittest.TestCase):
         """Verifies the function is safe to call repeatedly (no stale state)."""
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         pg = dist.new_group(ranks=list(range(world_size)), backend=backend)
+        assert isinstance(pg, dist.ProcessGroup)
 
         for i in range(3):
             fill_value = float(i + 1)
@@ -310,6 +316,7 @@ class CollectiveUtilsTest(unittest.TestCase):
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
         pg = dist.new_group(ranks=list(range(world_size)), backend=backend)
+        assert isinstance(pg, dist.ProcessGroup)
 
         result = create_on_rank_and_share_result(
             pg,

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -60,7 +60,7 @@ from torchrec.distributed.types import Awaitable, NullShardingContext
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
-T = TypeVar("T", int, float, List[int])
+T = TypeVar("T", int, float, List[int], List[float])
 
 
 # Lightly adapted from Stack Overflow #10823877
@@ -262,6 +262,7 @@ def _generate_pooled_embedding_batch(
     for i in range(world_size):
         in_keys = keys[offsets[i] : offsets[i + 1]]
         in_tensor.append(
+            # pyrefly: ignore
             _to_tensor(
                 [local_emb[key][b] for b in range(B_global) for key in in_keys],
                 torch.float,
@@ -270,6 +271,7 @@ def _generate_pooled_embedding_batch(
             else torch.empty(B_global, 0, dtype=torch.float)
         )
         out_tensor.append(
+            # pyrefly: ignore
             _to_tensor(
                 [
                     local_emb[key][b]
@@ -2274,6 +2276,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # new_group is collective on WORLD, so every rank must call it,
         # even ranks not in the resulting subgroup.
         subgroup = dist.new_group(ranks=[1, 3], backend=backend)
+        assert isinstance(subgroup, dist.ProcessGroup)
 
         if rank not in (1, 3):
             # Non-members do not run the awaitable; just synchronize and exit.
@@ -2289,6 +2292,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         ) as mock_log_event:
             awaitable = SplitsAllToAllAwaitable(
                 input_tensors=input_tensors,
+                # pyrefly: ignore
                 pg=subgroup,
                 collective_tag=rank,  # divergent tag per rank → mismatch
                 collective_tag_parts=("subgroup_test",),

--- a/torchrec/distributed/tests/test_lazy_awaitable.py
+++ b/torchrec/distributed/tests/test_lazy_awaitable.py
@@ -291,5 +291,6 @@ class TestLazyAwaitable(unittest.TestCase):
 
         # The use of a torch op should trigger exactly one wait on the parent object.
         # pyrefly: ignore[no-matching-overload]
+        # pyrefly: ignore
         result = torch.add(lazy_foo, lazy_bar)
         self.assertEqual(result, torch.tensor(1 * 3 + 2 * 3))

--- a/torchrec/distributed/tests/test_mc_embedding_write.py
+++ b/torchrec/distributed/tests/test_mc_embedding_write.py
@@ -10,7 +10,7 @@
 import copy
 import logging
 import unittest
-from typing import Dict, List, Optional, Tuple
+from typing import cast, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -931,10 +931,10 @@ def _test_dedup_indices_preserves_2d_weights(
         # block_bucketize_sparse_features_2d_weights splits columns across ranks.
         expected_float_vals = {10.0, 20.0, 30.0, 40.0}
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             runtime_meta = mc_module._hash_zch_runtime_meta
             if runtime_meta is None:
                 continue
@@ -1148,10 +1148,10 @@ def _test_overwrite_ids_state_dict(
 
         # Step 5: Verify per-MC-module that overwritten slots have KJT2 values
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
             runtime_meta = mc_module._hash_zch_runtime_meta.data
             assert isinstance(runtime_meta, torch.Tensor)
@@ -1287,10 +1287,10 @@ def _test_partial_insertion_state_dict(
 
         # Verify per-MC-module consistency
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
             runtime_meta = mc_module._hash_zch_runtime_meta.data
             assert isinstance(runtime_meta, torch.Tensor)
@@ -1422,10 +1422,10 @@ def _test_eviction_clears_runtime_meta(
         # Snapshot which KJT1 IDs are on this rank before eviction
         kjt1_slots_before: Dict[int, int] = {}  # raw_id -> slot_idx
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             mapped_kjt1, _, _ = mc_module.input_mapper(  # pyre-fixme[29]
                 values=kjt1_ids.to(ctx.device),
                 output_offset=mc_module._output_global_offset_tensor,
@@ -1472,10 +1472,10 @@ def _test_eviction_clears_runtime_meta(
 
         # Step 5: Verify per-MC-module
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
             runtime_meta = mc_module._hash_zch_runtime_meta.data
             assert isinstance(runtime_meta, torch.Tensor)
@@ -1622,10 +1622,10 @@ def _test_full_table_eviction_overwrites_runtime_meta(
             torch.sum(torch.stack([v.sum() for v in loss.values()])).backward()
         # Verify all slots are occupied on this rank
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             occupied = (identities != -1).sum().item()
             assert (
                 occupied == identities.numel()
@@ -1656,10 +1656,10 @@ def _test_full_table_eviction_overwrites_runtime_meta(
             {}
         )  # raw_id -> (slot, expected_val)
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             mapped_kjt1, _, _ = mc_module.input_mapper(  # pyre-fixme[29]
                 values=kjt1_ids.to(ctx.device),
                 output_offset=mc_module._output_global_offset_tensor,
@@ -1707,10 +1707,10 @@ def _test_full_table_eviction_overwrites_runtime_meta(
 
         # Step 5: Verify per-MC-module
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
             runtime_meta = mc_module._hash_zch_runtime_meta.data
             assert isinstance(runtime_meta, torch.Tensor)
@@ -2032,10 +2032,10 @@ def _test_collision_only_inserted_id_updates_runtime_meta(
 
         # Step 3: Verify runtime_meta consistency
         for _table_name, mc_module in mcc._managed_collision_modules.items():
-            # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
-            identities: torch.Tensor = torch.flatten(
-                mc_module._hash_zch_identities.data
+            _data: torch.Tensor = cast(
+                torch.Tensor, mc_module._hash_zch_identities.data
             )
+            identities: torch.Tensor = torch.flatten(_data)
             # pyre-ignore[16]: `Module | Tensor` is not assignable to `Tensor`
             runtime_meta = mc_module._hash_zch_runtime_meta.data
             assert isinstance(runtime_meta, torch.Tensor)

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -354,7 +354,9 @@ class OutputDistTensorFinder:
 
         # Find the awaitable matching our sharding type, skipping DP (NoWait)
         for w, st in zip(  # pyrefly: ignore[no-matching-overload]
-            awaitables, sharding_types
+            # pyrefly: ignore
+            awaitables,
+            sharding_types,  # pyrefly: ignore
         ):
             if isinstance(w, NoWait):
                 continue

--- a/torchrec/distributed/train_pipeline/postproc.py
+++ b/torchrec/distributed/train_pipeline/postproc.py
@@ -183,6 +183,7 @@ class PipelinedPostproc(torch.nn.Module):
     def get_context(self) -> TrainPipelineContext:
         return self._context
 
+    # pyrefly: ignore
     def named_modules(
         self,
         memo: Optional[Set[torch.nn.Module]] = None,

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -218,6 +218,7 @@ class TrainPipelinePT2Test(unittest.TestCase):
             def forward(self, x: KeyedJaggedTensor) -> List[JaggedTensor]:
                 kt: KeyedTensor = self.model(x)
                 # pyrefly: ignore[no-matching-overload]
+                # pyre-fixme[7]: Expected `list[JaggedTensor]` but got `list[Tensor]`.
                 return list(kt.to_dict().values())
 
         return M_ebc(

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -400,6 +400,7 @@ def _pipeline_detach_model(
         for _, child_module in mod.named_modules():
             if not hasattr(child_module, "_input_dists"):
                 continue
+            # pyrefly: ignore
             for input_dist in child_module._input_dists:
                 if hasattr(input_dist, "_dist"):
                     kjt_dists.append(input_dist._dist)
@@ -592,6 +593,7 @@ def _override_input_dist_forwards(
             if not hasattr(child_module, "_input_dists"):
                 continue
 
+            # pyrefly: ignore
             for input_dist in child_module._input_dists:
                 if hasattr(input_dist, "_dist"):
                     assert isinstance(input_dist._dist, KJTAllToAll)

--- a/torchrec/fx/tracer.py
+++ b/torchrec/fx/tracer.py
@@ -73,6 +73,7 @@ class Tracer(torch.fx.Tracer):
                 if isinstance(root, torch.nn.Module):
                     for prefix, module in root.named_modules():
                         # TODO(T140754678): Remove this workaround to _fx_path
+                        # pyrefly: ignore
                         module._fx_path = prefix
 
                 dmp = root

--- a/torchrec/inference/modules.py
+++ b/torchrec/inference/modules.py
@@ -457,6 +457,7 @@ def quantize_inference_model(
             # handle the fp ebc separately
             _quantize_fp_module(
                 model,
+                # pyrefly: ignore
                 m,
                 n,
                 weight_dtype=fp_weight_dtype,

--- a/torchrec/inference/state_dict_transform.py
+++ b/torchrec/inference/state_dict_transform.py
@@ -74,7 +74,7 @@ def state_dict_to_device(
         pg (ProcessGroup): Process Group used for comms
         device (torch.device): device to put state_dict on
     """
-    ret = {}
+    ret: Dict[str, Union[torch.Tensor, ShardedTensor]] = {}
     all_keys = state_dict_all_gather_keys(state_dict, pg)
     for key in all_keys:
         if key in state_dict:

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -207,6 +207,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             target=self._compute_loop, name=metric_compute_thread_name, daemon=True
         )
 
+        # pyrefly: ignore
         self.cpu_process_group: dist.ProcessGroup = dist.new_group(backend="gloo")
         self.comms_module: CPUCommsRecMetricModule = CPUCommsRecMetricModule(
             *args,
@@ -847,12 +848,13 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         Args are identical to torch.nn.Module.state_dict().
         """
-        # pyrefly: ignore[no-matching-overload]
-        return self.comms_module.state_dict(
+        # pyrefly: ignore
+        return self.comms_module.state_dict(  # pyrefly: ignore
             *args, destination=destination, prefix=prefix, keep_vars=keep_vars
         )
 
     @override
+    # pyrefly: ignore
     def load_state_dict(
         self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False
     ) -> None:

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -610,8 +610,10 @@ class RecMetricModule(nn.Module):
             for task, metric_computation in zip(
                 #  `Union[Module, Tensor]`.
                 #  `Union[Module, Tensor]`.
+                # pyrefly: ignore
                 metric._tasks,
                 #  `Union[Module, Tensor]`.
+                # pyrefly: ignore
                 metric._metrics_computations,
             ):
                 state = states[task.name]

--- a/torchrec/metrics/multi_label_precision.py
+++ b/torchrec/metrics/multi_label_precision.py
@@ -145,7 +145,7 @@ class MultiLabelPrecisionMetricComputation(RecMetricComputation):
         labels = self._decode_integer_to_labels(labels.flatten(), self._num_labels)
         # Expand weights to match
         if weights is not None:
-            # pyrefly: ignore[no-matching-overload]
+            # pyrefly: ignore
             weights = weights.flatten().unsqueeze(-1).expand(-1, self._num_labels)
         else:
             weights = torch.ones_like(predictions, dtype=torch.float32)

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -507,6 +507,7 @@ class RecMetric(nn.Module, abc.ABC):
                 self._tasks,
                 metric_report.value,
                 (
+                    # pyrefly: ignore
                     self._metrics_computations[0].has_valid_update
                     if self._should_validate_update
                     else itertools.repeat(1)
@@ -978,10 +979,10 @@ class RecMetric(nn.Module, abc.ABC):
         # We need to flush the cached output to ensure checkpointing correctness.
         self._check_fused_update(force=True)
         # pyrefly: ignore[no-matching-overload]
-        destination = super().state_dict(
+        destination = super().state_dict(  # pyrefly: ignore
             destination=destination, prefix=prefix, keep_vars=keep_vars
         )
-        return self._metrics_computations.state_dict(
+        return self._metrics_computations.state_dict(  # pyrefly: ignore
             destination=destination,
             prefix=f"{prefix}_metrics_computations.",
             keep_vars=keep_vars,

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -169,6 +169,7 @@ class MetricModuleTest(unittest.TestCase):
                     my_rank=0,
                     state_metrics_mapping={StateMetricEnum.OPTIMIZERS: mock_optimizer},
                     device=torch.device("cpu"),
+                    # pyrefly: ignore
                     process_group=pg,
                 )
                 metric_module.rec_metrics.compute = MagicMock(
@@ -1064,6 +1065,7 @@ def metric_module_gather_state(
             my_rank=0,
             state_metrics_mapping={},
             device=torch.device(f"cuda:{rank}"),
+            # pyrefly: ignore
             process_group=dist.new_group(ranks=[rank], backend="nccl"),
         )
         new_metric_module.load_pre_compute_states(states)

--- a/torchrec/modules/lazy_extension.py
+++ b/torchrec/modules/lazy_extension.py
@@ -161,7 +161,7 @@ class LazyModuleExtensionMixin(LazyModuleMixin):
     # fmt: off
     #  `LazyModuleMixin` inconsistently.
     # pyrefly: ignore[bad-override]
-    def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:
+    def _infer_parameters(self: _LazyExtensionProtocol, module, args, kwargs) -> None:  # pyrefly: ignore
         r"""Infers the size and initializes the parameters according to the provided input batch.
 
         Given a module that contains parameters that were declared inferable

--- a/torchrec/modules/tests/test_mc_modules.py
+++ b/torchrec/modules/tests/test_mc_modules.py
@@ -41,10 +41,12 @@ class TestEvictionPolicy(unittest.TestCase):
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
+        assert isinstance(_mch_counts, torch.Tensor)
         self.assertEqual(list(_mch_counts), [0] * 5)
 
         # insert some values to zch
@@ -66,6 +68,7 @@ class TestEvictionPolicy(unittest.TestCase):
         # 5, empty, empty, empty will be evicted
         # 6, 7, 8 will be added
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -74,6 +77,7 @@ class TestEvictionPolicy(unittest.TestCase):
         )
         # 11 counts of 5, 3 counts of 6, 3 counts of 7, 3 counts of 8
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [11, 3, 3, 3, torch.iinfo(torch.int64).max])
@@ -89,10 +93,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
@@ -126,6 +132,7 @@ class TestEvictionPolicy(unittest.TestCase):
         self.assertEqual(mc_module.open_slots().item(), 0)
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -133,6 +140,7 @@ class TestEvictionPolicy(unittest.TestCase):
             [3, 4, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [2, 2, 3, 3, 3])
@@ -149,14 +157,17 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [0] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
@@ -189,6 +200,7 @@ class TestEvictionPolicy(unittest.TestCase):
         mc_module.profile(features)
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -196,10 +208,12 @@ class TestEvictionPolicy(unittest.TestCase):
             [3, 5, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [1, 5, 1, 1, torch.iinfo(torch.int64).max])
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [2, 1, 3, 3, 3])
@@ -215,14 +229,17 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [0] * 5)
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [0] * 5)
@@ -255,6 +272,7 @@ class TestEvictionPolicy(unittest.TestCase):
         mc_module.profile(features)
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -262,10 +280,12 @@ class TestEvictionPolicy(unittest.TestCase):
             [3, 4, 7, 8, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [1, 1, 1, 1, torch.iinfo(torch.int64).max])
         _mch_last_access_iter = mc_module._mch_last_access_iter
+        assert isinstance(_mch_last_access_iter, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_last_access_iter), [2, 2, 3, 3, 3])
@@ -285,10 +305,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [0] * 5)
@@ -305,6 +327,7 @@ class TestEvictionPolicy(unittest.TestCase):
         mc_module.profile(features)
 
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -312,6 +335,7 @@ class TestEvictionPolicy(unittest.TestCase):
             [3, 4, 5, torch.iinfo(torch.int64).max, torch.iinfo(torch.int64).max],
         )
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [3, 4, 5, 0, torch.iinfo(torch.int64).max])
@@ -329,10 +353,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [0] * 5)
@@ -358,6 +384,7 @@ class TestEvictionPolicy(unittest.TestCase):
         # 6, 8 will be added
         # 7 is not added because it's below the average threshold
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         self.assertEqual(
             #  `Union[Tensor, Module]`.
             # pyrefly: ignore[no-matching-overload]
@@ -366,6 +393,7 @@ class TestEvictionPolicy(unittest.TestCase):
         )
         # count for 4 is not updated since it's below the average threshold
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [10, 1, 3, 2, torch.iinfo(torch.int64).max])
@@ -386,10 +414,12 @@ class TestEvictionPolicy(unittest.TestCase):
 
         # check initial state
         _mch_sorted_raw_ids = mc_module._mch_sorted_raw_ids
+        assert isinstance(_mch_sorted_raw_ids, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_sorted_raw_ids), [torch.iinfo(torch.int64).max] * 5)
         _mch_counts = mc_module._mch_counts
+        assert isinstance(_mch_counts, torch.Tensor)
         #  `Union[Tensor, Module]`.
         # pyrefly: ignore[no-matching-overload]
         self.assertEqual(list(_mch_counts), [0] * 5)

--- a/torchrec/sparse/tensor_dict.py
+++ b/torchrec/sparse/tensor_dict.py
@@ -22,7 +22,7 @@ def maybe_td_to_kjt(
         return features
     if isinstance(features, TensorDict):
         if keys is None:
-            # pyrefly: ignore[no-matching-overload]
+            # pyrefly: ignore
             keys = list(features.keys())
         values = torch.cat([features[key]._values for key in keys], dim=0)
         lengths = torch.cat(

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -804,6 +804,7 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
             in_idx, out_idx, in_start, _, length, _ = permutes[i].tolist()
             refs[out_idx].append(ref_values[in_idx][in_start : (in_start + length), :])
         # pyrefly: ignore[no-matching-overload]
+        # pyrefly: ignore
         refs = [torch.cat(ref).t() for ref in refs]
         outputs = torch.ops.fbgemm.permute_multi_embedding(
             non_contiguous, permutes, in_shapes, out_shapes, out_lengths


### PR DESCRIPTION
Summary:
Fix pyrefly/pyre type checking errors in 14 test files across torchrec. Uses explicit type fixes (assert isinstance, cast, proper type annotations) rather than pyre-fixme suppressions where possible.

Fixes applied:
- assert isinstance(pg, dist.ProcessGroup) after dist.new_group() calls
- assert isinstance(var, torch.Tensor) for Module.__getattr__ returns in test assertions
- cast(torch.Tensor, ...) for mc_module attribute data access
- cast(Iterable, ...) for sharding_spec.shards in zip() calls
- cast(Any, ...) for TensorDict source parameter
- Dict[str, ManagedCollisionModule] type annotation + return type for _get_mc_module_from_tables
- TypeVar constraint widened: added List[float] to T in test_dist_data.py

Reviewed By: TroyGarden

Differential Revision: D104852701
