### PR TITLE
Add merge_partitioned_embeddings building block

### DIFF
--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -41,6 +41,7 @@ from torchrec.distributed.types import (
     ShardingType,
 )
 from torchrec.modules.pec_embedding_modules import PECEmbeddingCollection
+from torchrec.modules.utils import construct_jagged_tensors
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
@@ -53,6 +54,68 @@ class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
     """
 
     prev_remapped_feature_values: List[torch.Tensor] | None = None
+
+
+class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
+    """Merges overlapped and nonoverlapped embedding partitions.
+
+    On wait, concatenates [ol, nol] embeddings per sharding group and applies
+    the corresponding forward_permute to restore original order, then constructs
+    Dict[str, JaggedTensor] output via construct_jagged_tensors.
+    """
+
+    def __init__(
+        self,
+        overlapped_awaitables: List[Awaitable[torch.Tensor]],
+        nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
+        forward_permutes: List[torch.Tensor],
+        features_per_sharding: List[KeyedJaggedTensor],
+        embedding_names_per_sharding: List[List[str]],
+        need_indices: bool,
+        features_to_permute_indices: Dict[str, List[int]],
+    ) -> None:
+        super().__init__()
+        # PEC-specific: partition awaitables and merge permutation (per group)
+        self._overlapped_awaitables = overlapped_awaitables
+        self._nonoverlapped_awaitables = nonoverlapped_awaitables
+        self._forward_permutes = forward_permutes
+
+        # From EC: used by construct_jagged_tensors to build output
+        self._features_per_sharding = features_per_sharding
+        self._embedding_names_per_sharding = embedding_names_per_sharding
+        self._need_indices = need_indices
+
+        # CW-only: reorders column shards from rank-grouped to original order.
+        # Empty dict for RW sharding (PEC currently only supports RW).
+        self._features_to_permute_indices = features_to_permute_indices
+
+    def _wait_impl(self) -> Dict[str, JaggedTensor]:
+        jt_dict: Dict[str, JaggedTensor] = {}
+
+        for ol_aw, nol_aw, fwd_perm, features, embedding_names in zip(
+            self._overlapped_awaitables,
+            self._nonoverlapped_awaitables,
+            self._forward_permutes,
+            self._features_per_sharding,
+            self._embedding_names_per_sharding,
+        ):
+            ol_embs = ol_aw.wait()
+            nol_embs = nol_aw.wait()
+
+            merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
+            embeddings = torch.index_select(merged_embs, 0, fwd_perm)
+
+            jt_dict.update(
+                construct_jagged_tensors(
+                    embeddings=embeddings,
+                    features=features,
+                    embedding_names=embedding_names,
+                    need_indices=self._need_indices,
+                    features_to_permute_indices=self._features_to_permute_indices,
+                )
+            )
+
+        return jt_dict
 
 
 class ShardedPECEmbeddingCollection(
@@ -235,58 +298,91 @@ class ShardedPECEmbeddingCollection(
         collision_splits: CollisionSplits,
         is_overlapped: bool,
     ) -> List[Awaitable[torch.Tensor]]:
-        """Embedding lookup + output dist for one partition (overlapped or nonoverlapped).
+        """Performs embedding lookup and output AllToAll for one partition.
 
-        Performs lookup on the partition's features using the inner EC's lookup
-        module, then AllToAll's the embeddings back to trainer using the
-        collision-specific splits. The embedding AllToAll goes in the reverse
-        direction of the features AllToAll, so collision output_splits become
-        embedding input_splits and vice versa.
+        Looks up embeddings for the partition's features using the inner EC's
+        lookup module, then AllToAll's the results back using partition-specific
+        splits. The embedding AllToAll reverses the direction of the features
+        AllToAll, so collision output_splits become embedding input_splits.
 
         Args:
             ctx: PEC context (sharding_contexts must be set from input_dist)
-            features: partition features (ol or nol KJT from split_features)
-            collision_splits: splits from collision_split_dist().wait()
+            features: partition features (ol or nol KJT)
+            collision_splits: splits from split_dist
             is_overlapped: True for overlapped partition, False for nonoverlapped
 
         Returns:
             List of Awaitable[torch.Tensor], one per sharding group.
         """
         partition_idx = 0 if is_overlapped else 1
+        ec = self._embedding_collection
         awaitables: List[Awaitable[torch.Tensor]] = []
 
         for lookup, odist, sharding_ctx, sharding_type in zip(
-            self._embedding_collection._lookups,
-            self._embedding_collection._output_dists,
+            ec._lookups,
+            ec._output_dists,
             ctx.sharding_contexts,
-            self._embedding_collection._sharding_type_to_sharding,
+            ec._sharding_type_to_sharding,
         ):
-            # Shallow copy to avoid mutating the original sharding context
             partition_ctx = copy(sharding_ctx)
 
-            # The original lengths_after_input_dist reflects the full batch.
-            # Replace with this partition's lengths so the embedding AllToAll
-            # knows the correct per-feature sequence lengths for recat.
+            # Replace full-batch lengths with this partition's lengths.
             partition_ctx.lengths_after_input_dist = features.lengths().view(
                 -1, features.stride()
             )
-            # Embedding AllToAll reverses the direction of features AllToAll:
+
+            # Reverse direction: collision output → embedding input.
             partition_ctx.input_splits = collision_splits.output_splits[partition_idx]
             partition_ctx.output_splits = collision_splits.input_splits[partition_idx]
 
-            # upt maps positions in the full (pre-split) batch. Each partition
-            # only has a subset of values, so the full upt would have wrong size
-            # and wrong index mappings. PEC handles reordering after merging both
-            # partitions via forward_permute from permute_dist.
+            # upt maps positions in the full (pre-split) batch — wrong size for
+            # a partition. Reordering is handled by forward_permute after merge.
             partition_ctx.unbucketize_permute_tensor = None
 
-            embedding_dim = self._embedding_collection._embedding_dim_for_sharding_type(
-                sharding_type
-            )
+            embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
             embs = lookup(features)
             awaitables.append(odist(embs.view(-1, embedding_dim), partition_ctx))
 
         return awaitables
+
+    def merge_partitioned_embeddings(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        overlapped_awaitables: List[Awaitable[torch.Tensor]],
+        nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
+        forward_permutes: List[torch.Tensor],
+    ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
+        """Creates a LazyAwaitable that merges ol/nol embeddings on wait.
+
+        On wait: waits on both partition awaitables, concatenates [ol, nol],
+        applies forward_permute to restore original order, and constructs
+        the final Dict[str, JaggedTensor].
+
+        Args:
+            ctx: PEC context (sharding_contexts must be set from input_dist)
+            overlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=True)
+            nonoverlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=False)
+            forward_permutes: from permute_dist, one per sharding group,
+                reorders merged [ol, nol] back to original order
+
+        Returns:
+            LazyAwaitable resolving to Dict[str, JaggedTensor].
+        """
+        ec = self._embedding_collection
+        features_per_sharding = [
+            # pyre-ignore[6]
+            sharding_ctx.features_before_input_dist
+            for sharding_ctx in ctx.sharding_contexts
+        ]
+        return PECEmbeddingCollectionAwaitable(
+            overlapped_awaitables=overlapped_awaitables,
+            nonoverlapped_awaitables=nonoverlapped_awaitables,
+            forward_permutes=forward_permutes,
+            features_per_sharding=features_per_sharding,
+            embedding_names_per_sharding=ec._embedding_names_per_sharding,
+            need_indices=ec._need_indices,
+            features_to_permute_indices=ec._features_to_permute_indices,
+        )
 
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -237,6 +237,44 @@ def _verify_partition_embeddings(
         torch.testing.assert_close(embs, expected_tensor)
 
 
+def _verify_merged_output(
+    jt_dict: Dict[str, JaggedTensor],
+    kjt_input: KeyedJaggedTensor,
+    original_values: torch.Tensor,
+    original_lengths: torch.Tensor,
+    tables: List[EmbeddingConfig],
+    ref_ec: EmbeddingCollection,
+    device: torch.device,
+) -> None:
+    feature_to_table = {}
+    for table in tables:
+        for fname in table.feature_names:
+            feature_to_table[fname] = table.name
+
+    assert set(jt_dict.keys()) == set(feature_to_table.keys())
+
+    stride = kjt_input.stride()
+    offset = 0
+    for feat_idx, fname in enumerate(kjt_input.keys()):
+        tname = feature_to_table[fname]
+        feat_lengths = original_lengths[feat_idx * stride : (feat_idx + 1) * stride]
+        num_values = feat_lengths.sum().item()
+        feat_ids = original_values[offset : offset + num_values]
+
+        actual_jt = jt_dict[fname]
+        torch.testing.assert_close(actual_jt.lengths().cpu(), feat_lengths)
+        if num_values > 0:
+            expected_embs = torch.stack(
+                [
+                    # pyre-ignore[16]: embeddings[tname] is nn.Embedding
+                    ref_ec.embeddings[tname].weight[vid.item()]
+                    for vid in feat_ids
+                ]
+            ).to(device)
+            torch.testing.assert_close(actual_jt.values(), expected_embs)
+        offset += num_values
+
+
 def _test_pec_forward_stages(
     tables: List[EmbeddingConfig],
     rank: int,
@@ -250,14 +288,17 @@ def _test_pec_forward_stages(
     ref_ec: EmbeddingCollection | None = None,
     expected_ol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
     expected_nol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
+    verify_merge: bool = False,
     local_size: Optional[int] = None,
 ) -> None:
     """Runs PEC forward pipeline stages and verifies against expected results.
 
     Always runs: input_dist → detect_collisions → split →
-        collision_split_dist → permute_dist.
-    Optionally runs: compute_and_output_dist_in_partition (when ref_ec is provided).
+        collision_split_dist → permute_dist →
+        compute_and_output_dist_in_partition (OL + NOL).
+    Optionally runs: merge_partitioned_embeddings (when verify_merge=True).
     Verification for each stage is enabled by providing its expected-output parameter.
+    Partition and merge verification require ref_ec for weight comparison.
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
@@ -275,6 +316,8 @@ def _test_pec_forward_stages(
         prev_remapped = None
 
         for batch_idx, kjt_input in enumerate(batches):
+            original_values = kjt_input.values()
+            original_lengths = kjt_input.lengths()
             kjt_input = kjt_input.to(ctx.device)
 
             # Stage 1: input_dist → detect_collisions
@@ -336,7 +379,6 @@ def _test_pec_forward_stages(
                 is_overlapped=True,
             )
             assert len(ol_awaitables) == 1
-            ol_embs = ol_awaitables[0].wait()
 
             nol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
                 pec_ctx,
@@ -345,23 +387,41 @@ def _test_pec_forward_stages(
                 is_overlapped=False,
             )
             assert len(nol_awaitables) == 1
-            nol_embs = nol_awaitables[0].wait()
 
-            if ref_ec is not None:
-                if expected_ol_per_rank is not None:
-                    _verify_partition_embeddings(
-                        ol_embs,
-                        expected_ol_per_rank[rank][batch_idx],
-                        ref_ec,
-                        ctx.device,
-                    )
-                if expected_nol_per_rank is not None:
-                    _verify_partition_embeddings(
-                        nol_embs,
-                        expected_nol_per_rank[rank][batch_idx],
-                        ref_ec,
-                        ctx.device,
-                    )
+            if ref_ec is not None and expected_ol_per_rank is not None:
+                _verify_partition_embeddings(
+                    ol_awaitables[0].wait(),
+                    expected_ol_per_rank[rank][batch_idx],
+                    ref_ec,
+                    ctx.device,
+                )
+            if ref_ec is not None and expected_nol_per_rank is not None:
+                _verify_partition_embeddings(
+                    nol_awaitables[0].wait(),
+                    expected_nol_per_rank[rank][batch_idx],
+                    ref_ec,
+                    ctx.device,
+                )
+
+            # Stage 5: merge_partitioned_embeddings
+            if verify_merge:
+                assert ref_ec is not None
+                lazy_result = sharded_pec.merge_partitioned_embeddings(
+                    pec_ctx,
+                    ol_awaitables,
+                    nol_awaitables,
+                    forward_permutes,
+                )
+                jt_dict = lazy_result.wait()
+                _verify_merged_output(
+                    jt_dict,
+                    kjt_input,
+                    original_values,
+                    original_lengths,
+                    tables,
+                    ref_ec,
+                    ctx.device,
+                )
 
             prev_remapped = [r.remapped_feature_values for r in results]
 
@@ -655,4 +715,28 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             ref_ec=ref_ec,
             expected_ol_per_rank=expected_ol,
             expected_nol_per_rank=expected_nol,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_merge_partitioned_embeddings(self) -> None:
+        """Tests merged output matches expected embeddings from ref EC."""
+        WORLD_SIZE = 2
+
+        ref_ec = EmbeddingCollection(
+            tables=EMBEDDING_TABLES,
+            device=torch.device("cpu"),
+        )
+
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+            ref_ec=ref_ec,
+            verify_merge=True,
         )


### PR DESCRIPTION
Summary:
# Context

After `compute_and_output_dist_in_partition` produces separate overlapped and nonoverlapped embedding tensors, the final step is merging them back into the original feature order and constructing the `Dict[str, JaggedTensor]` output that downstream modules expect.

The merge concatenates [ol, nol] embeddings and applies `forward_permute` (from `permute_dist`) to restore pre-input_dist order. The result is passed to `construct_jagged_tensors` (standard EC utility) to build per-feature JaggedTensors.

The complete PEC forward pipeline:
```
input_dist 
→ detect_collisions 
→ split_features_by_values_mask 
→ split_dist 
→ permute_dist 
→ compute_and_output_dist_in_partition (OL + NOL) 
→ merge_partitioned_embeddings
```

# New API

**`ShardedPECEmbeddingCollection.merge_partitioned_embeddings`**: Takes the OL/NOL embedding awaitables and `forward_permute`. Returns a `LazyAwaitable[Dict[str, JaggedTensor]]` — on wait, it merges partitions, applies the permutation, and constructs the final output via `construct_jagged_tensors`.

**`PECEmbeddingCollectionAwaitable`** — the LazyAwaitable returned by `merge_partitioned_embeddings`. Stores PEC-specific state (partition awaitables, forward_permute) alongside EC state passed through from the inner `ShardedEmbeddingCollection` (features_per_sharding, embedding_names, features_to_permute_indices)

Reviewed By: TroyGarden

Differential Revision: D104617526


