### PR TITLE
Add backward support to permute_dist via CollisionPermutation

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -150,43 +150,97 @@ def split_features_by_values_mask(
     return overlapped_kjt, nonoverlapped_kjt
 
 
-class ForwardPermuteAwaitable(Awaitable[torch.Tensor]):
-    """RW-specific awaitable that produces forward_permute from a received mask.
+@dataclass
+class CollisionPermutation:
+    """Result of permute_dist for a single sharding group.
 
-    On wait(), receives the mask via AllToAll, then builds forward_permute:
-    a tensor for reordering merged [ol_embs, nol_embs] back to original
-    order via index_select.
+    Attributes:
+        forward_permute: For batch i — merges [ol, nol] embeddings back to
+            original order. Nonoverlapped values don't conflict with batch
+            i-1, so their lookup can start early (overlapped with i-1's
+            backward). Overlapped values must wait for i-1's gradient update.
+            Usage: index_select(cat([ol_embs, nol_embs]), 0, forward_permute)
 
-    The received mask is in bucketized order (values sent to shard 0 first,
-    then shard 1, etc.). unbucketize_permute_tensor maps original position i
-    to bucket position upt[i]. We compose these to build forward_permute[i] =
-    position in merged [ol_embs, nol_embs] for original position i.
+        backward_permute: For batch i-1 — reorders batch i-1's values to
+            [ol first, nol second] so gradients can be re-split. The ol
+            gradient update must complete before batch i's overlapped lookup.
+            None for the first batch.
+
+        backward_num_ol: Partition point in backward_permute.
+            backward_permute[:backward_num_ol] are overlapped indices.
+    """
+
+    forward_permute: torch.Tensor
+    backward_permute: torch.Tensor | None = None
+    backward_num_ol: int = 0
+
+
+def _compute_permute_from_mask(
+    bool_mask: torch.Tensor,
+    unbucketize_permute_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Computes a permute tensor from a received overlap mask and upt.
+
+    The mask is in bucketized order (shard 0 values first, then shard 1, etc.).
+    Builds a mapping from original position to position in merged [ol, nol],
+    composed with unbucketize_permute_tensor.
+
+    Example: bool_mask = [T, F, T, T, F, F]
+      ol_rank  = cumsum([1,0,1,1,0,0]) - 1 = [0, 0, 1, 2, 2, 2]
+      nol_rank = cumsum([0,1,0,0,1,1]) - 1 + 3 = [2, 3, 3, 3, 4, 5]
+      bucket_to_merged = where(mask, ol_rank, nol_rank) = [0, 3, 1, 2, 4, 5]
+    """
+    num_ol = bool_mask.sum()
+
+    ol_rank = bool_mask.long().cumsum(0) - 1
+    nol_rank = (~bool_mask).long().cumsum(0) - 1 + num_ol
+    bucket_to_merged = torch.where(bool_mask, ol_rank, nol_rank)
+
+    return bucket_to_merged[unbucketize_permute_tensor]
+
+
+class CollisionPermuteAwaitable(Awaitable[CollisionPermutation]):
+    """RW-specific awaitable that produces CollisionPermutation from received masks.
+
+    On wait(), receives forward (and optionally backward) masks via AllToAll,
+    then builds permute tensors by composing with unbucketize_permute_tensor.
     """
 
     def __init__(
         self,
-        values_awaitable: TensorAllToAllValuesAwaitable,
-        unbucketize_permute_tensor: torch.Tensor,
+        fwd_awaitable: TensorAllToAllValuesAwaitable,
+        fwd_unbucketize_permute: torch.Tensor,
+        bwd_awaitable: TensorAllToAllValuesAwaitable | None = None,
+        bwd_unbucketize_permute: torch.Tensor | None = None,
     ) -> None:
         super().__init__()
-        self._values_awaitable = values_awaitable
-        self._unbucketize_permute_tensor = unbucketize_permute_tensor
+        self._fwd_awaitable = fwd_awaitable
+        self._fwd_unbucketize_permute = fwd_unbucketize_permute
+        self._bwd_awaitable = bwd_awaitable
+        self._bwd_unbucketize_permute = bwd_unbucketize_permute
 
-    def _wait_impl(self) -> torch.Tensor:
-        received_mask = self._values_awaitable.wait()
-        bool_mask = received_mask.bool()
-        upt = self._unbucketize_permute_tensor
-        num_ol = bool_mask.sum()
+    def _wait_impl(self) -> CollisionPermutation:
+        fwd_mask = self._fwd_awaitable.wait().bool()
+        forward_permute = _compute_permute_from_mask(
+            fwd_mask, self._fwd_unbucketize_permute
+        )
 
-        # Example: bool_mask = [T, F, T, T, F, F]
-        #   ol_rank  = cumsum([1,0,1,1,0,0]) - 1 = [0, 0, 1, 2, 2, 2]
-        #   nol_rank = cumsum([0,1,0,0,1,1]) - 1 + 3 = [2, 3, 3, 3, 4, 5]
-        #   bucket_to_merged = where(mask, ol_rank, nol_rank) = [0, 3, 1, 2, 4, 5]
-        ol_rank = bool_mask.long().cumsum(0) - 1
-        nol_rank = (~bool_mask).long().cumsum(0) - 1 + num_ol
-        bucket_to_merged = torch.where(bool_mask, ol_rank, nol_rank)
+        backward_permute = None
+        backward_num_ol = 0
 
-        return bucket_to_merged[upt]
+        if self._bwd_awaitable is not None:
+            assert self._bwd_unbucketize_permute is not None
+            bwd_mask = self._bwd_awaitable.wait().bool()
+            backward_permute = _compute_permute_from_mask(
+                bwd_mask, self._bwd_unbucketize_permute
+            )
+            backward_num_ol = int(bwd_mask.sum().item())
+
+        return CollisionPermutation(
+            forward_permute=forward_permute,
+            backward_permute=backward_permute,
+            backward_num_ol=backward_num_ol,
+        )
 
 
 @dataclass
@@ -268,18 +322,31 @@ class CollisionHandlerBase(abc.ABC):
     @abc.abstractmethod
     def permute_dist(
         self,
+        # Forward: current batch
         features: KeyedJaggedTensor,
-        forward_overlap_mask: torch.Tensor,
         sharding_ctx: SequenceShardingContext,
-    ) -> Awaitable[torch.Tensor]:
-        """Distributes the collision partition permutation via AllToAll.
+        forward_overlap_mask: torch.Tensor,
+        # Backward: previous batch (all None for first batch)
+        prev_features: KeyedJaggedTensor | None = None,
+        prev_sharding_ctx: SequenceShardingContext | None = None,
+        backward_overlap_mask: torch.Tensor | None = None,
+    ) -> Awaitable[CollisionPermutation]:
+        """Distributes forward and backward partition permutations via AllToAll.
 
-        Sends overlap information from sharding ranks back to the original
-        rank and computes forward_permute — a tensor for reordering merged
-        [ol, nol] embeddings back to original order via index_select.
+        Sends forward overlap mask (current batch) and optionally backward
+        overlap mask (previous batch) from sharding ranks back to the original
+        rank. Both AllToAlls are fired together for batching.
+
+        Args:
+            features: current batch features after input_dist
+            sharding_ctx: current batch's sharding context
+            forward_overlap_mask: current batch's overlap mask
+            prev_features: previous batch's features (None for first batch)
+            prev_sharding_ctx: previous batch's sharding context
+            backward_overlap_mask: previous batch's backward mask
 
         Returns:
-            Awaitable resolving to forward_permute tensor of shape [N].
+            Awaitable resolving to CollisionPermutation.
         """
         ...
 
@@ -448,18 +515,17 @@ class RWCollisionHandler(CollisionHandlerBase):
             total_input_splits=sharding_ctx.input_splits,
         )
 
-    def permute_dist(
+    def _mask_dist(
         self,
         features: KeyedJaggedTensor,
-        forward_overlap_mask: torch.Tensor,
         sharding_ctx: SequenceShardingContext,
-    ) -> ForwardPermuteAwaitable:
-        """Reorders mask to rank-major, AllToAll to original rank, computes forward_permute."""
+        overlap_mask: torch.Tensor,
+    ) -> TensorAllToAllValuesAwaitable:
+        """Permutes mask to rank-major order and starts reverse AllToAll."""
         assert sharding_ctx.sparse_features_recat is not None
-        assert sharding_ctx.unbucketize_permute_tensor is not None
 
         recat = torch.ops.fbgemm.invert_permute(sharding_ctx.sparse_features_recat)
-        mask_int = forward_overlap_mask.to(torch.int32)
+        mask_int = overlap_mask.to(torch.int32)
 
         _, permuted_mask, _ = torch.ops.fbgemm.permute_2D_sparse_data(
             recat,
@@ -469,7 +535,7 @@ class RWCollisionHandler(CollisionHandlerBase):
             mask_int.numel(),
         )
 
-        values_awaitable = TensorAllToAllValuesAwaitable(
+        return TensorAllToAllValuesAwaitable(
             self._pg,
             permuted_mask,
             input_splits=torch.tensor(
@@ -483,9 +549,44 @@ class RWCollisionHandler(CollisionHandlerBase):
             device=permuted_mask.device,
         )
 
-        return ForwardPermuteAwaitable(
-            values_awaitable=values_awaitable,
-            unbucketize_permute_tensor=sharding_ctx.unbucketize_permute_tensor,
+    def permute_dist(
+        self,
+        features: KeyedJaggedTensor,
+        sharding_ctx: SequenceShardingContext,
+        forward_overlap_mask: torch.Tensor,
+        prev_features: KeyedJaggedTensor | None = None,
+        prev_sharding_ctx: SequenceShardingContext | None = None,
+        backward_overlap_mask: torch.Tensor | None = None,
+    ) -> CollisionPermuteAwaitable:
+        """Fires forward (and optionally backward) mask AllToAlls together."""
+        assert sharding_ctx.unbucketize_permute_tensor is not None
+
+        fwd_awaitable = self._mask_dist(
+            features,
+            sharding_ctx,
+            forward_overlap_mask,
+        )
+
+        bwd_awaitable = None
+        bwd_unbucketize_permute = None
+
+        if backward_overlap_mask is not None:
+            assert prev_features is not None
+            assert prev_sharding_ctx is not None
+            assert prev_sharding_ctx.unbucketize_permute_tensor is not None
+
+            bwd_awaitable = self._mask_dist(
+                prev_features,
+                prev_sharding_ctx,
+                backward_overlap_mask,
+            )
+            bwd_unbucketize_permute = prev_sharding_ctx.unbucketize_permute_tensor
+
+        return CollisionPermuteAwaitable(
+            fwd_awaitable=fwd_awaitable,
+            fwd_unbucketize_permute=sharding_ctx.unbucketize_permute_tensor,
+            bwd_awaitable=bwd_awaitable,
+            bwd_unbucketize_permute=bwd_unbucketize_permute,
         )
 
 

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -28,6 +28,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.pec_collision_handlers import (
     CollisionHandlerBase,
+    CollisionPermutation,
     CollisionResult,
     CollisionSplits,
     create_collision_handler,
@@ -68,17 +69,17 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
         self,
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
-        forward_permutes: List[torch.Tensor],
+        permutations: List[CollisionPermutation],
         features_per_sharding: List[KeyedJaggedTensor],
         embedding_names_per_sharding: List[List[str]],
         need_indices: bool,
         features_to_permute_indices: Dict[str, List[int]],
     ) -> None:
         super().__init__()
-        # PEC-specific: partition awaitables and merge permutation (per group)
+        # PEC-specific: partition awaitables and permutation results (per group)
         self._overlapped_awaitables = overlapped_awaitables
         self._nonoverlapped_awaitables = nonoverlapped_awaitables
-        self._forward_permutes = forward_permutes
+        self._permutations = permutations
 
         # From EC: used by construct_jagged_tensors to build output
         self._features_per_sharding = features_per_sharding
@@ -92,10 +93,10 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
     def _wait_impl(self) -> Dict[str, JaggedTensor]:
         jt_dict: Dict[str, JaggedTensor] = {}
 
-        for ol_aw, nol_aw, fwd_perm, features, embedding_names in zip(
+        for ol_aw, nol_aw, perm, features, embedding_names in zip(
             self._overlapped_awaitables,
             self._nonoverlapped_awaitables,
-            self._forward_permutes,
+            self._permutations,
             self._features_per_sharding,
             self._embedding_names_per_sharding,
         ):
@@ -103,7 +104,7 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
             nol_embs = nol_aw.wait()
 
             merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
-            embeddings = torch.index_select(merged_embs, 0, fwd_perm)
+            embeddings = torch.index_select(merged_embs, 0, perm.forward_permute)
 
             jt_dict.update(
                 construct_jagged_tensors(
@@ -260,36 +261,76 @@ class ShardedPECEmbeddingCollection(
         self,
         ctx: PECEmbeddingCollectionContext,
         features_per_group: List[KeyedJaggedTensor],
-        forward_overlap_masks: List[torch.Tensor],
-    ) -> List[Awaitable[torch.Tensor]]:
-        """Distributes collision partition permutations via AllToAll.
+        overlap_results: List[CollisionResult],
+        prev_ctx: PECEmbeddingCollectionContext | None = None,
+        prev_features_per_group: List[KeyedJaggedTensor] | None = None,
+    ) -> List[Awaitable[CollisionPermutation]]:
+        """Distributes forward and backward partition permutations via AllToAll.
 
-        Delegates to each handler's permute_dist. Each awaitable resolves
-        to a forward_permute tensor for reordering merged [ol, nol]
-        embeddings back to original order.
+        PEC partitions each batch into overlapped (ol) and nonoverlapped (nol)
+        values relative to the previous batch. The nol partition's lookup can
+        start early in batch i - 1 since those values don't conflict. The ol
+        partition must wait for batch i-1's gradient update before lookup.
+
+        Forward mask (batch i): produces forward_permute for merging [ol, nol]
+        embeddings back to original order after both lookups complete.
+
+        Backward mask (batch i-1): produces backward_permute for re-splitting
+        batch i-1's gradients into ol/nol. The ol gradient update of batch i - 1
+        must finish before batch i's ol lookup can proceed. The nol gradient
+        update of batch i - 1 can be deferred further into batch i since those
+        values don't conflict.
+
+        Both AllToAlls are fired together per handler for batching. The
+        backward mask lives on the previous batch's sharding ranks, so its
+        AllToAll needs prev_features (for lengths) and prev_ctx (for splits
+        and unbucketize_permute). The pipeline saves these across batches.
 
         Args:
-            ctx: PEC context (sharding_contexts must be set from input_dist)
-            features_per_group: per-group features after input_dist (for lengths)
-            forward_overlap_masks: per-group bool masks for overlapped values
+            ctx: PEC context for current batch (sharding contexts as state)
+            features_per_group: current batch features after input_dist
+            overlap_results: from detect_collisions, contains both forward
+                and backward overlap masks
+            prev_ctx: previous batch's PEC context, needed for backward mask
+                AllToAll (None for first batch)
+            prev_features_per_group: previous batch's features after input_dist,
+                needed for backward mask AllToAll (None for first batch)
 
         Returns:
-            List of Awaitable[torch.Tensor], one per sharding group, each
-            resolving to a forward_permute tensor.
+            List of Awaitable[CollisionPermutation], one per sharding group.
         """
-        return [
-            handler.permute_dist(
-                features,
-                mask,
-                sharding_ctx,
-            )
-            for handler, features, mask, sharding_ctx in zip(
+        awaitables: List[Awaitable[CollisionPermutation]] = []
+
+        for i, (handler, features, result, sharding_ctx) in enumerate(
+            zip(
                 self._collision_handlers,
                 features_per_group,
-                forward_overlap_masks,
+                overlap_results,
                 ctx.sharding_contexts,
             )
-        ]
+        ):
+            bwd_mask = result.backward_overlap_mask
+            prev_features = None
+            prev_sharding_ctx = None
+
+            if bwd_mask is not None:
+                assert prev_ctx is not None
+                assert prev_features_per_group is not None
+                prev_features = prev_features_per_group[i]
+                prev_sharding_ctx = prev_ctx.sharding_contexts[i]
+
+            awaitables.append(
+                handler.permute_dist(
+                    features,
+                    sharding_ctx,
+                    result.forward_overlap_mask,
+                    prev_features=prev_features,
+                    prev_sharding_ctx=prev_sharding_ctx,
+                    backward_overlap_mask=bwd_mask,
+                )
+            )
+
+        return awaitables
 
     def compute_and_output_dist_in_partition(
         self,
@@ -350,7 +391,7 @@ class ShardedPECEmbeddingCollection(
         ctx: PECEmbeddingCollectionContext,
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
-        forward_permutes: List[torch.Tensor],
+        permutations: List[CollisionPermutation],
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
         """Creates a LazyAwaitable that merges ol/nol embeddings on wait.
 
@@ -362,8 +403,7 @@ class ShardedPECEmbeddingCollection(
             ctx: PEC context (sharding_contexts must be set from input_dist)
             overlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=True)
             nonoverlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=False)
-            forward_permutes: from permute_dist, one per sharding group,
-                reorders merged [ol, nol] back to original order
+            permutations: from permute_dist, one per sharding group
 
         Returns:
             LazyAwaitable resolving to Dict[str, JaggedTensor].
@@ -377,7 +417,7 @@ class ShardedPECEmbeddingCollection(
         return PECEmbeddingCollectionAwaitable(
             overlapped_awaitables=overlapped_awaitables,
             nonoverlapped_awaitables=nonoverlapped_awaitables,
-            forward_permutes=forward_permutes,
+            permutations=permutations,
             features_per_sharding=features_per_sharding,
             embedding_names_per_sharding=ec._embedding_names_per_sharding,
             need_indices=ec._need_indices,

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -17,6 +17,7 @@ import torch
 import torch.nn as nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.pec_collision_handlers import (
+    CollisionPermutation,
     CollisionResult,
     CollisionSplits,
     split_features_by_values_mask,
@@ -196,6 +197,19 @@ def _verify_forward_permute(
     assert forward_permute.tolist() == expected
 
 
+def _verify_backward_permute(
+    permutation: "CollisionPermutation",
+    expected_permute: List[int] | None,
+    expected_num_ol: int,
+) -> None:
+    if expected_permute is None:
+        assert permutation.backward_permute is None
+    else:
+        assert permutation.backward_permute is not None
+        assert permutation.backward_permute.tolist() == expected_permute
+    assert permutation.backward_num_ol == expected_num_ol
+
+
 def _verify_collision_result(
     result: CollisionResult,
     expected: ExpectedCollisionResult,
@@ -285,6 +299,8 @@ def _test_pec_forward_stages(
     expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
     expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
     expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
+    expected_backward_permutes_per_rank: List[List[List[int] | None]] | None = None,
+    expected_backward_num_ol_per_rank: List[List[int]] | None = None,
     ref_ec: EmbeddingCollection | None = None,
     expected_ol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
     expected_nol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
@@ -314,6 +330,8 @@ def _test_pec_forward_stages(
 
         batches = kjt_input_per_rank[rank]
         prev_remapped = None
+        prev_ctx = None
+        prev_features_list = None
 
         for batch_idx, kjt_input in enumerate(batches):
             original_values = kjt_input.values()
@@ -357,18 +375,30 @@ def _test_pec_forward_stages(
 
             # Stage 3: permute_dist
             features_list = list(dist_input)
-            masks = [r.forward_overlap_mask for r in results]
             permute_awaitables = sharded_pec.permute_dist(
                 pec_ctx,
                 features_list,
-                masks,
+                results,
+                prev_ctx=prev_ctx,
+                prev_features_per_group=prev_features_list,
             )
-            forward_permutes = [aw.wait() for aw in permute_awaitables]
+            permutations = [aw.wait() for aw in permute_awaitables]
 
             if expected_forward_permutes_per_rank is not None:
                 _verify_forward_permute(
-                    forward_permutes[0],
+                    permutations[0].forward_permute,
                     expected_forward_permutes_per_rank[rank][batch_idx],
+                )
+
+            if expected_backward_permutes_per_rank is not None:
+                _verify_backward_permute(
+                    permutations[0],
+                    expected_backward_permutes_per_rank[rank][batch_idx],
+                    (
+                        expected_backward_num_ol_per_rank[rank][batch_idx]
+                        if expected_backward_num_ol_per_rank is not None
+                        else 0
+                    ),
                 )
 
             # Stage 4: compute_and_output_dist_in_partition
@@ -410,7 +440,7 @@ def _test_pec_forward_stages(
                     pec_ctx,
                     ol_awaitables,
                     nol_awaitables,
-                    forward_permutes,
+                    permutations,
                 )
                 jt_dict = lazy_result.wait()
                 _verify_merged_output(
@@ -424,6 +454,8 @@ def _test_pec_forward_stages(
                 )
 
             prev_remapped = [r.remapped_feature_values for r in results]
+            prev_ctx = pec_ctx
+            prev_features_list = features_list
 
 
 # Cross-shard data: each rank has values in both shard 0 (0-7) and shard 1 (8-15)
@@ -647,8 +679,50 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
+    def test_backward_permute_dist(self) -> None:
+        """Verifies backward_permute and backward_num_ol with cross-shard overlap.
+
+        Batch 0: no backward (first batch) → backward_permute=None, num_ol=0.
+        Batch 1: backward mask from batch 0's values overlapping with batch 1.
+          Rank 0 received bwd mask: [T,F,T, T,F,F] → 3 ol, 3 nol
+          Rank 1 received bwd mask: [T,F,T, T,T,T] → 5 ol, 1 nol
+          backward_permute = _compute_permute_from_mask(bwd_mask, batch0_upt)
+        """
+        WORLD_SIZE = 2
+
+        # backward_permute = bucket_to_merged[upt]
+        # upt for batch 0 = [0,3,1,4,2,5] (no overlap, same as forward)
+        #
+        # Rank 0: mask=[T,F,T,T,F,F], bucket_to_merged=[0,3,1,2,4,5]
+        #   backward_permute = [0,2,3,4,1,5], num_ol=3
+        # Rank 1: mask=[T,F,T,T,T,T], bucket_to_merged=[0,5,1,2,3,4]
+        #   backward_permute = [0,2,5,3,1,4], num_ol=5
+        expected_backward_permutes_per_rank = [
+            [None, [0, 2, 3, 4, 1, 5]],
+            [None, [0, 2, 5, 3, 1, 4]],
+        ]
+        expected_backward_num_ol_per_rank = [
+            [0, 3],
+            [0, 5],
+        ]
+
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
+            expected_backward_permutes_per_rank=expected_backward_permutes_per_rank,
+            expected_backward_num_ol_per_rank=expected_backward_num_ol_per_rank,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
     def test_compute_and_output_dist_in_partition(self) -> None:
-        """Test OL/NOL embeddings match expected weight rows.
+        """Tests OL/NOL embeddings match expected weight rows.
 
         Uses cross-shard partial overlap data. num_embeddings=16, world_size=2,
         block_size=8. Shard 0 stores original rows 0-7, shard 1 stores 8-15.


### PR DESCRIPTION
Summary:
# Context

PEC partitions each batch into overlapped (ol) and nonoverlapped (nol) values relative to the previous batch. `permute_dist` distributes the permutation tensors that enable this partitioning on both the forward and backward paths:

- **Forward (batch i over batch i-1):** Identifies which batch i values overlap with batch i-1. 
  * **The nol partition's lookup can start early during batch i-1**, since those embedding rows are not being updated.
  * The ol partition must wait for batch i-1's ol gradient update to complete.
  * Forward Permute enables the embeddings to be correctly re-ordered *after merging* in batch i forward.

- **Backward (batch i-1 over batch i):** Identifies which batch i-1 values overlap with batch i.
  * Re-splits batch i-1's gradients so the ol gradient update runs first (unblocking batch i's ol lookup)
  * **The nol gradient update can be deferred into batch i**.
  * Backward Permute enables the embedding to be correctly re-ordered *after split* via overlapping mask.

# Changes to `ShardedPECEmbeddingCollection.permute_dist`

Takes optional `prev_ctx` and `prev_features_per_group` for the backward AllToAll: the backward re-split is done by splitting previous batch (i - 1) features.

Differential Revision: D104694073


