### PR TITLE
[detailed][distributed] Multiple Process Groups - Add competing_comms benchmark for multi-stream collective overlap

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -794,6 +794,96 @@ def multi_async_comms(
         assert checks.item()
 
 
+def competing_comms(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    wait_for_comm1: bool = False,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Two collectives (a2a on pg1, all_reduce on pg2) on separate streams
+    with independent NCCL communicators. When wait_for_comm1=False (default),
+    both comms compete freely. When wait_for_comm1=True, stream_b waits
+    for comm1 to finish before issuing comm2.
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        # pyrefly: ignore[missing-attribute]
+        ar_pg = competing_comms._ar_pg
+        dist.barrier(group=ar_pg)
+
+    with record_function("## pre-comms compute ##"):
+        input_a = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        input_b = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat * 2, ctx=ctx)
+
+    with record_function("## comm1: a2a on stream_a ##"):
+        out_a = torch.zeros_like(input_a)
+        out_a.record_stream(stream_a)
+        with torch.cuda.stream(stream_a):
+            stream_a.wait_stream(main_stream)
+            req_a = dist.all_to_all_single(
+                output=out_a,
+                input=input_a,
+                group=ctx.pg,
+                async_op=True,
+            )
+
+    with record_function("## comm2: all_reduce on stream_b ##"):
+        out_b = input_b.clone()
+        out_b.record_stream(stream_b)
+        with torch.cuda.stream(stream_b):
+            if wait_for_comm1:
+                req_a.wait()
+            stream_b.wait_stream(main_stream)
+            req_b = dist.all_reduce(
+                out_b,
+                op=dist.ReduceOp.SUM,
+                group=ar_pg,
+                async_op=True,
+            )
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        req_a.wait()
+        req_b.wait()
+        main_stream.wait_stream(stream_a)
+        main_stream.wait_stream(stream_b)
+        checks_a = _validate(out_a, ctx)
+        checks_b = torch.all(out_b.to(torch.int) >= 1)
+        checks = DeviceToHostTensorAwaitable(checks_a & checks_b)
+
+    with record_function("## post-comms compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=out_a[0])
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
+def competing_comms_with_req_wait(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    return competing_comms(
+        _batch_inputs=_batch_inputs,
+        dim=dim,
+        num_mul=num_mul,
+        num_concat=num_concat,
+        ctx=ctx,
+        wait_for_comm1=True,
+    )
+
+
 def data_copy_record_stream(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
@@ -936,6 +1026,18 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = multi_async_comms
                 # pyrefly: ignore[missing-attribute]
                 multi_async_comms._ar_pg = dist.new_group(
+                    ranks=list(range(ctx.world_size))
+                )
+            case "competing_comms":
+                func = competing_comms
+                # pyrefly: ignore[missing-attribute]
+                competing_comms._ar_pg = dist.new_group(
+                    ranks=list(range(ctx.world_size))
+                )
+            case "competing_comms_with_req_wait":
+                func = competing_comms_with_req_wait
+                # pyrefly: ignore[missing-attribute]
+                competing_comms._ar_pg = dist.new_group(
                     ranks=list(range(ctx.world_size))
                 )
             case "data_copy_record_stream":


### PR DESCRIPTION
Summary:
## 1. Context
Within a single process group, collectives like all_reduce, all_to_all, and all_gather share the same NCCL communicator and therefore run on the same internal NCCL stream. Even if the user issues these collectives from different CUDA streams, NCCL serializes them onto its own stream since they share the same underlying resource (NVLink). This means collectives within the same PG cannot truly overlap on the GPU.

However, collectives on *different* process groups have independent NCCL communicators and independent streams. When two PGs issue collectives concurrently, they genuinely compete for NVLink bandwidth. This is the pattern that occurs in real pipelined training -- for example, sparse-dist a2a on one PG overlapping with dense-grad all_reduce on another PG.

Overlapping (competing) comms makes all comms slower due to resource contention -- each collective gets a fraction of the available NVLink bandwidth instead of the full link. Ideally we would serialize them so each collective runs at full bandwidth, but the PG's internal NCCL stream is not publicly accessible, making it difficult for users to directly control the execution order of collectives across PGs.

In this benchmark we demonstrate an approach that leverages the `Work` request object returned by async collectives. By calling `req_a.wait()` on the side stream before issuing the second collective, we force the second comm to wait until the first has completed, effectively serializing cross-PG collectives without needing access to the internal NCCL streams. Crucially, neither the CPU nor the main CUDA stream is blocked -- only the side stream waits, so the main stream can continue running compute or other work in parallel.

## 2. Approach
1. **Separate CUDA streams per collective**: `competing_comms` creates `stream_a` for the a2a collective and `stream_b` for the all_reduce, each with its own NCCL communicator (via separate process groups). Both streams wait on the main stream before issuing their respective collectives, then the main stream waits on both before validation.
2. **Configurable serialization via `wait_for_comm1`**: When `False` (default), both collectives compete freely for bandwidth. When `True`, `stream_b` calls `req_a.wait()` before issuing the all_reduce, serializing the two collectives. This enables A/B comparison of overlapping vs serialized multi-stream collective behavior.
3. **`competing_comms_with_req_wait` wrapper**: A convenience function that delegates to `competing_comms(wait_for_comm1=True)`, following the existing pattern used by `single_stream_memory` and `blocking_copy`.

## 3. Results

### Competing comms (no wait)

<img width="4020" height="988" alt="image" src="https://github.com/user-attachments/assets/bc58f63a-c263-4e3b-84e2-bd27108f82e9" />

Both `nccl:all_to_all` (stream 32) and `nccl:all_reduce` (stream 28) run concurrently. The two NCCL kernels overlap on the GPU timeline, competing for NVLink bandwidth. Both collectives take longer than they would in isolation.

### With req_a.wait() serialization

<img width="3922" height="1032" alt="image" src="https://github.com/user-attachments/assets/b6dd89aa-93c5-456f-aac8-ca0490dad3d3" />

`stream_b` calls `req_a.wait()` before issuing the all_reduce. The all_reduce (stream 28) starts only after the a2a (stream 32) completes. Each collective gets the full NVLink bandwidth. The main stream and CPU remain unblocked -- irrelevant compute on the main stream runs in parallel with both comms.

## 4. Run Commands

OSS:
```
# competing (no wait)
python -m torchrec.distributed.benchmark.benchmark_comms \
  a2a_single --name=competing_comms

# with req wait
python -m torchrec.distributed.benchmark.benchmark_comms \
  a2a_single --name=competing_comms_with_req_wait
```

## 5. Analysis
1. **Collective patterns**: This benchmark explicitly exercises concurrent a2a + all_reduce on separate streams with separate NCCL communicators, which is the key pattern for understanding bandwidth contention in pipelined training.
2. **Backward compatibility**: Purely additive; no existing benchmarks or APIs are modified.
3. **Stream safety**: `record_stream()` is called on output tensors to prevent premature reuse by the caching allocator, and `main_stream.wait_stream()` ensures proper synchronization before validation.

## 6. Changes
1. **`benchmark_comms.py`**: Added `competing_comms()` function with dual-stream a2a + all_reduce benchmark, `competing_comms_with_req_wait()` wrapper, and two match-case entries in `a2a_single_runner` for CLI dispatch with `_ar_pg` process group creation.

Differential Revision: D104924091


