### PR TITLE
Add PECAll2AllSeqWait autograd Function for backward gradient re-split (#4252)

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -161,18 +161,19 @@ class CollisionPermutation:
             backward). Overlapped values must wait for i-1's gradient update.
             Usage: index_select(cat([ol_embs, nol_embs]), 0, forward_permute)
 
-        backward_permute: For batch i-1 — reorders batch i-1's values to
-            [ol first, nol second] so gradients can be re-split. The ol
-            gradient update must complete before batch i's overlapped lookup.
-            None for the first batch.
+        backward_ol_permute: Original-order indices of batch i-1's
+            overlapped values, in rank-major order. Used to extract OL
+            gradients via index_select. The OL gradient update must
+            complete before batch i's ol lookup. None for the first batch.
 
-        backward_num_ol: Partition point in backward_permute.
-            backward_permute[:backward_num_ol] are overlapped indices.
+        backward_nol_permute: Original-order indices of batch i-1's
+            nonoverlapped values, in rank-major order. NOL gradient update
+            can be deferred into batch i. None for the first batch.
     """
 
     forward_permute: torch.Tensor
-    backward_permute: torch.Tensor | None = None
-    backward_num_ol: int = 0
+    backward_ol_permute: torch.Tensor | None = None
+    backward_nol_permute: torch.Tensor | None = None
 
 
 def _compute_permute_from_mask(
@@ -225,21 +226,28 @@ class CollisionPermuteAwaitable(Awaitable[CollisionPermutation]):
             fwd_mask, self._fwd_unbucketize_permute
         )
 
-        backward_permute = None
-        backward_num_ol = 0
+        backward_ol_permute = None
+        backward_nol_permute = None
 
         if self._bwd_awaitable is not None:
             assert self._bwd_unbucketize_permute is not None
             bwd_mask = self._bwd_awaitable.wait().bool()
-            backward_permute = _compute_permute_from_mask(
-                bwd_mask, self._bwd_unbucketize_permute
-            )
-            backward_num_ol = int(bwd_mask.sum().item())
+
+            # Pre-compose recat into indices so backward can index_select
+            # directly from original-order gradient without a separate
+            # recat step. The indices are in ascending bucketized order
+            # (rank-major), which aligns with AllToAll splits.
+            recat = torch.ops.fbgemm.invert_permute(self._bwd_unbucketize_permute)
+            (ol_bucket_indices,) = torch.where(bwd_mask)
+            (nol_bucket_indices,) = torch.where(~bwd_mask)
+
+            backward_ol_permute = recat[ol_bucket_indices]
+            backward_nol_permute = recat[nol_bucket_indices]
 
         return CollisionPermutation(
             forward_permute=forward_permute,
-            backward_permute=backward_permute,
-            backward_num_ol=backward_num_ol,
+            backward_ol_permute=backward_ol_permute,
+            backward_nol_permute=backward_nol_permute,
         )
 
 

--- a/torchrec/distributed/pec_comm_ops.py
+++ b/torchrec/distributed/pec_comm_ops.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.pec_collision_handlers import (
+    CollisionPermutation,
+    CollisionSplits,
+)
+
+
+@dataclass
+class PECAll2AllSeqInfo:
+    """Metadata for PEC backward gradient re-split and distribution.
+
+    Created by merge_partitioned_embeddings during forward. Read by
+    PECAll2AllSeqWait during backward to re-split and distribute gradients.
+
+    After backward, the pipeline reads the gradient outputs below and is
+    responsible for waiting on the OL AllToAll and applying both OL/NOL
+    gradients to TBE. A dedicated gradient manager class for wait + apply
+    will be added in a future diff.
+
+    Attributes:
+        permutation: CollisionPermutation containing forward_permute (used in
+            forward merge) and backward_ol_permute/backward_nol_permute
+            (pre-composed original-order indices for splitting gradients
+            in rank-major order — no separate recat needed).
+        backward_splits: Previous batch's forward CollisionSplits, reused as
+            the gradient AllToAll split sizes. None until set by pipeline.
+        pg: Process group for gradient AllToAll.
+
+    Gradient outputs (set by PECAll2AllSeqWait.backward):
+        ol_grad_work: Async work handle for OL gradient AllToAll.
+            Pipeline must wait before applying.
+        ol_grad_local: Output buffer for OL gradient AllToAll.
+        nol_grad: NOL gradient tensor. Pipeline starts its own deferred
+            AllToAll using backward_splits.[input|output]_splits[1].
+    """
+
+    permutation: CollisionPermutation
+    pg: dist.ProcessGroup | None = None
+    backward_splits: CollisionSplits | None = None
+
+    # Gradient outputs — set by PECAll2AllSeqWait.backward, read by pipeline.
+    # Pipeline is responsible for wait + apply (future: gradient manager class).
+    ol_grad_work: dist.Work | None = None
+    ol_grad_local: torch.Tensor | None = None
+    nol_grad: torch.Tensor | None = None
+
+
+def _grad_dist(
+    grad: torch.Tensor,
+    input_splits: List[int],
+    output_splits: List[int],
+    embedding_dim: int,
+    pg: dist.ProcessGroup,
+    async_op: bool = True,
+) -> Tuple[dist.Work, torch.Tensor]:
+    """Starts gradient reverse AllToAll. Shared by OL (autograd) and NOL (pipeline).
+
+    Args:
+        grad: gradient tensor to send.
+        input_splits: per-rank send counts (number of rows).
+        output_splits: per-rank receive counts (number of rows).
+        embedding_dim: embedding dimension.
+        pg: process group.
+        async_op: whether to run asynchronously.
+
+    Returns:
+        (work_handle, output_buffer) of shape [sum(output_splits) * embedding_dim].
+    """
+    output_split_sizes = [s * embedding_dim for s in output_splits]
+    input_split_sizes = [s * embedding_dim for s in input_splits]
+
+    output_buffer = torch.empty(
+        sum(output_split_sizes),
+        device=grad.device,
+        dtype=grad.dtype,
+    )
+
+    req = dist.all_to_all_single(
+        output_buffer,
+        grad.contiguous().view(-1),
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=pg,
+        async_op=async_op,
+    )
+    assert req is not None
+
+    return req, output_buffer
+
+
+class PECAll2AllSeqWait(torch.autograd.Function):
+    """PEC gradient intercept — merges embeddings in forward, re-splits gradients in backward.
+
+    Forward: merges OL/NOL embeddings using forward_permute from backward_ctx.permutation.
+
+    Backward: permutes gradient to bucketized order, splits by backward
+    overlap mask (using pre-computed ol/nol indices from backward_permute),
+    starts async OL gradient AllToAll (stored on backward_ctx for pipeline to wait),
+    saves NOL gradient on backward_ctx for deferred processing.
+
+    Gradient propagation stops here (returns None) — the pipeline applies
+    gradients to TBE separately.
+    """
+
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        ctx: torch.autograd.function.FunctionCtx,
+        backward_ctx: PECAll2AllSeqInfo,
+        ol_embs: torch.Tensor,
+        nol_embs: torch.Tensor,
+    ) -> torch.Tensor:
+        ctx.backward_ctx = backward_ctx  # pyre-ignore[16]
+
+        merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
+        return torch.index_select(
+            merged_embs, 0, backward_ctx.permutation.forward_permute
+        )
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        ctx: torch.autograd.function.FunctionCtx,
+        grad_output: torch.Tensor,
+    ) -> Tuple[None, None, None]:
+        backward_ctx: PECAll2AllSeqInfo = ctx.backward_ctx  # pyre-ignore[16]
+        perm = backward_ctx.permutation
+        splits = backward_ctx.backward_splits
+
+        assert perm.backward_ol_permute is not None
+        assert perm.backward_nol_permute is not None
+        assert splits is not None
+        assert backward_ctx.pg is not None
+
+        _, embedding_dim = grad_output.shape
+
+        # Split gradient into ol/nol. Permute indices are pre-composed
+        # with recat, so index_select produces rank-major order directly.
+        ol_grad = grad_output.index_select(0, perm.backward_ol_permute)
+        nol_grad = grad_output.index_select(0, perm.backward_nol_permute)
+
+        # 3. Start async reverse AllToAll for OL grad
+        ol_grad_work, ol_grad_local = _grad_dist(
+            ol_grad,
+            input_splits=splits.input_splits[0],
+            output_splits=splits.output_splits[0],
+            embedding_dim=embedding_dim,
+            pg=backward_ctx.pg,
+        )
+        backward_ctx.ol_grad_work = ol_grad_work
+        backward_ctx.ol_grad_local = ol_grad_local
+
+        # 4. Save NOL grad for pipeline (deferred AllToAll).
+        # Pipeline reads NOL splits from backward_ctx.backward_splits directly.
+        backward_ctx.nol_grad = nol_grad
+
+        return (None, None, None)

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -33,6 +33,7 @@ from torchrec.distributed.pec_collision_handlers import (
     CollisionSplits,
     create_collision_handler,
 )
+from torchrec.distributed.pec_comm_ops import PECAll2AllSeqInfo, PECAll2AllSeqWait
 from torchrec.distributed.types import (
     Awaitable,
     LazyAwaitable,
@@ -56,30 +57,34 @@ class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
 
     prev_remapped_feature_values: List[torch.Tensor] | None = None
 
+    # Set by merge_partitioned_embeddings, read by pipeline during backward.
+    # One per sharding group.
+    backward_ctxs: List[PECAll2AllSeqInfo] | None = None
+
 
 class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
     """Merges overlapped and nonoverlapped embedding partitions.
 
-    On wait, concatenates [ol, nol] embeddings per sharding group and applies
-    the corresponding forward_permute to restore original order, then constructs
-    Dict[str, JaggedTensor] output via construct_jagged_tensors.
+    On wait, passes OL/NOL embeddings through PECAll2AllSeqWait (which merges
+    via forward_permute and sets up the autograd graph for gradient re-split),
+    then constructs Dict[str, JaggedTensor] output via construct_jagged_tensors.
     """
 
     def __init__(
         self,
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
-        permutations: List[CollisionPermutation],
+        backward_ctxs: List[PECAll2AllSeqInfo],
         features_per_sharding: List[KeyedJaggedTensor],
         embedding_names_per_sharding: List[List[str]],
         need_indices: bool,
         features_to_permute_indices: Dict[str, List[int]],
     ) -> None:
         super().__init__()
-        # PEC-specific: partition awaitables and permutation results (per group)
+        # PEC-specific: partition awaitables and gradient intercept (per group)
         self._overlapped_awaitables = overlapped_awaitables
         self._nonoverlapped_awaitables = nonoverlapped_awaitables
-        self._permutations = permutations
+        self._backward_ctxs = backward_ctxs
 
         # From EC: used by construct_jagged_tensors to build output
         self._features_per_sharding = features_per_sharding
@@ -93,18 +98,17 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
     def _wait_impl(self) -> Dict[str, JaggedTensor]:
         jt_dict: Dict[str, JaggedTensor] = {}
 
-        for ol_aw, nol_aw, perm, features, embedding_names in zip(
+        for ol_aw, nol_aw, bwd_ctx, features, embedding_names in zip(
             self._overlapped_awaitables,
             self._nonoverlapped_awaitables,
-            self._permutations,
+            self._backward_ctxs,
             self._features_per_sharding,
             self._embedding_names_per_sharding,
         ):
             ol_embs = ol_aw.wait()
             nol_embs = nol_aw.wait()
 
-            merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
-            embeddings = torch.index_select(merged_embs, 0, perm.forward_permute)
+            embeddings = PECAll2AllSeqWait.apply(bwd_ctx, ol_embs, nol_embs)
 
             jt_dict.update(
                 construct_jagged_tensors(
@@ -395,9 +399,12 @@ class ShardedPECEmbeddingCollection(
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
         """Creates a LazyAwaitable that merges ol/nol embeddings on wait.
 
-        On wait: waits on both partition awaitables, concatenates [ol, nol],
-        applies forward_permute to restore original order, and constructs
-        the final Dict[str, JaggedTensor].
+        On wait: passes OL/NOL through PECAll2AllSeqWait (which merges via
+        forward_permute and sets up autograd for gradient re-split), then
+        constructs the final Dict[str, JaggedTensor].
+
+        Also creates one PECAll2AllSeqInfo per sharding group and stores
+        them on ctx.backward_ctxs for the pipeline to set backward_splits.
 
         Args:
             ctx: PEC context (sharding_contexts must be set from input_dist)
@@ -409,6 +416,16 @@ class ShardedPECEmbeddingCollection(
             LazyAwaitable resolving to Dict[str, JaggedTensor].
         """
         ec = self._embedding_collection
+
+        backward_ctxs = [
+            PECAll2AllSeqInfo(
+                permutation=perm,
+                pg=self._env.process_group,
+            )
+            for perm in permutations
+        ]
+        ctx.backward_ctxs = backward_ctxs
+
         features_per_sharding = [
             # pyre-ignore[6]
             sharding_ctx.features_before_input_dist
@@ -417,7 +434,7 @@ class ShardedPECEmbeddingCollection(
         return PECEmbeddingCollectionAwaitable(
             overlapped_awaitables=overlapped_awaitables,
             nonoverlapped_awaitables=nonoverlapped_awaitables,
-            permutations=permutations,
+            backward_ctxs=backward_ctxs,
             features_per_sharding=features_per_sharding,
             embedding_names_per_sharding=ec._embedding_names_per_sharding,
             need_indices=ec._need_indices,

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -199,15 +199,18 @@ def _verify_forward_permute(
 
 def _verify_backward_permute(
     permutation: "CollisionPermutation",
-    expected_permute: List[int] | None,
-    expected_num_ol: int,
+    expected_ol_permute: List[int] | None,
+    expected_nol_permute: List[int] | None,
 ) -> None:
-    if expected_permute is None:
-        assert permutation.backward_permute is None
+    if expected_ol_permute is None:
+        assert permutation.backward_ol_permute is None
+        assert permutation.backward_nol_permute is None
     else:
-        assert permutation.backward_permute is not None
-        assert permutation.backward_permute.tolist() == expected_permute
-    assert permutation.backward_num_ol == expected_num_ol
+        assert permutation.backward_ol_permute is not None
+        assert permutation.backward_nol_permute is not None
+        assert permutation.backward_ol_permute.tolist() == expected_ol_permute
+        assert expected_nol_permute is not None
+        assert permutation.backward_nol_permute.tolist() == expected_nol_permute
 
 
 def _verify_collision_result(
@@ -299,8 +302,8 @@ def _test_pec_forward_stages(
     expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
     expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
     expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
-    expected_backward_permutes_per_rank: List[List[List[int] | None]] | None = None,
-    expected_backward_num_ol_per_rank: List[List[int]] | None = None,
+    expected_backward_ol_permutes_per_rank: List[List[List[int] | None]] | None = None,
+    expected_backward_nol_permutes_per_rank: List[List[List[int] | None]] | None = None,
     ref_ec: EmbeddingCollection | None = None,
     expected_ol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
     expected_nol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
@@ -390,15 +393,12 @@ def _test_pec_forward_stages(
                     expected_forward_permutes_per_rank[rank][batch_idx],
                 )
 
-            if expected_backward_permutes_per_rank is not None:
+            if expected_backward_ol_permutes_per_rank is not None:
+                assert expected_backward_nol_permutes_per_rank is not None
                 _verify_backward_permute(
                     permutations[0],
-                    expected_backward_permutes_per_rank[rank][batch_idx],
-                    (
-                        expected_backward_num_ol_per_rank[rank][batch_idx]
-                        if expected_backward_num_ol_per_rank is not None
-                        else 0
-                    ),
+                    expected_backward_ol_permutes_per_rank[rank][batch_idx],
+                    expected_backward_nol_permutes_per_rank[rank][batch_idx],
                 )
 
             # Stage 4: compute_and_output_dist_in_partition
@@ -684,26 +684,27 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
 
         Batch 0: no backward (first batch) → backward_permute=None, num_ol=0.
         Batch 1: backward mask from batch 0's values overlapping with batch 1.
-          Rank 0 received bwd mask: [T,F,T, T,F,F] → 3 ol, 3 nol
-          Rank 1 received bwd mask: [T,F,T, T,T,T] → 5 ol, 1 nol
-          backward_permute = _compute_permute_from_mask(bwd_mask, batch0_upt)
+
+        Received bwd mask (bucketized): rank0=[T,F,T,T,F,F], rank1=[T,F,T,T,T,T]
+        recat = invert_permute(batch0_upt) = invert_permute([0,3,1,4,2,5]) = [0,2,4,1,3,5]
+        backward_permute = cat([recat[where(mask)], recat[where(~mask)]])
+
+        Rank 0: where(mask)=[0,2,3], recat[[0,2,3]]=[0,4,1]
+                where(~mask)=[1,4,5], recat[[1,4,5]]=[2,3,5]
+                backward_permute=[0,4,1, 2,3,5], num_ol=3
+        Rank 1: where(mask)=[0,2,3,4,5], recat[[0,2,3,4,5]]=[0,4,1,3,5]
+                where(~mask)=[1], recat[[1]]=[2]
+                backward_permute=[0,4,1,3,5, 2], num_ol=5
         """
         WORLD_SIZE = 2
 
-        # backward_permute = bucket_to_merged[upt]
-        # upt for batch 0 = [0,3,1,4,2,5] (no overlap, same as forward)
-        #
-        # Rank 0: mask=[T,F,T,T,F,F], bucket_to_merged=[0,3,1,2,4,5]
-        #   backward_permute = [0,2,3,4,1,5], num_ol=3
-        # Rank 1: mask=[T,F,T,T,T,T], bucket_to_merged=[0,5,1,2,3,4]
-        #   backward_permute = [0,2,5,3,1,4], num_ol=5
-        expected_backward_permutes_per_rank = [
-            [None, [0, 2, 3, 4, 1, 5]],
-            [None, [0, 2, 5, 3, 1, 4]],
+        expected_backward_ol_permutes_per_rank = [
+            [None, [0, 4, 1]],
+            [None, [0, 4, 1, 3, 5]],
         ]
-        expected_backward_num_ol_per_rank = [
-            [0, 3],
-            [0, 5],
+        expected_backward_nol_permutes_per_rank = [
+            [None, [2, 3, 5]],
+            [None, [2]],
         ]
 
         self._run_multi_process_test(
@@ -711,8 +712,8 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
-            expected_backward_permutes_per_rank=expected_backward_permutes_per_rank,
-            expected_backward_num_ol_per_rank=expected_backward_num_ol_per_rank,
+            expected_backward_ol_permutes_per_rank=expected_backward_ol_permutes_per_rank,
+            expected_backward_nol_permutes_per_rank=expected_backward_nol_permutes_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )


### PR DESCRIPTION
Summary:

# Context

During `loss.backward()`, gradients flow back through the merged embedding output. PEC needs to intercept these gradients, re-split them into OL/NOL partitions using the backward overlap mask, and distribute them back to the sharding ranks via AllToAll.

The OL gradient AllToAll runs first (blocking batch i's OL lookup), while the NOL gradient is deferred. Gradient wait + apply to TBE will be handled by a dedicated gradient manager class in the next diff.

# Changes to `CollisionPermutation.backward_permute`

`backward_permute` now contains **original-order indices pre-composed with recat**, so the backward pass can split gradients directly from the original-order gradient. The indices are ordered by bucketized position (rank-major), which aligns with AllToAll splits. 

# New file: `pec_comm_ops.py`

**`PECAll2AllSeqInfo`** — per-sharding-group metadata created by `merge_partitioned_embeddings`. Holds `CollisionPermutation` (forward/backward permute tensors) and gradient output fields (`ol_grad_work`, `ol_grad_local`, `nol_grad`) written by backward and read by pipeline.

**`_grad_dist`** — starts an async gradient AllToAll. Shared by OL (called from autograd backward) and NOL (called by pipeline).

**`PECAll2AllSeqWait`** — `torch.autograd.Function`:
- Forward: merges OL/NOL embeddings via `forward_permute`
- Backward: **intercepts the graident,** splits gradient into ol/nol via `index_select` using pre-composed `backward_permute` indices, starts async OL gradient AllToAll, saves NOL gradient for deferred processing
- Gradient propagation stops here — pipeline applies gradients to TBE separately

Reviewed By: TroyGarden

Differential Revision: D104781355


