### PR TITLE
value_dist_injection with Filter

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -65,7 +65,15 @@ Example usage:
 import logging
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Any, Callable, Optional, Protocol, runtime_checkable, TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    TYPE_CHECKING,
+)
 
 import torch
 from torch import nn
@@ -250,28 +258,100 @@ def register_backward_hook(
             )
 
 
+def will_hook_fire(p: torch.Tensor) -> bool:
+    """``param.register_hook`` only fires via ``AccumulateGrad``; sharded
+    embedding params (ShardedTensor / DTensor) bypass it via FBGEMM TBE
+    fused backward, so a hook landing on one will silently never fire."""
+    return (
+        p.is_leaf
+        and p.requires_grad
+        and type(p).__name__ not in ("ShardedTensor", "DTensor")
+    )
+
+
+def _summarize_unhookable(
+    named_params: list[tuple[str, torch.Tensor]],
+) -> str:
+    """Bucket every ``will_hook_fire``-failing param by the *first* reason it
+    fails (priority: no_requires_grad → ShardedTensor → DTensor → non_leaf).
+    Used in the no-hookable-param assert message so callers can see why."""
+    no_grad = sharded = dtensor = non_leaf = 0
+    for _, p in named_params:
+        t = type(p).__name__
+        if not p.requires_grad:
+            no_grad += 1
+        elif t == "ShardedTensor":
+            sharded += 1
+        elif t == "DTensor":
+            dtensor += 1
+        elif not p.is_leaf:
+            non_leaf += 1
+    return (
+        f"total={len(named_params)}, no_requires_grad={no_grad}, "
+        f"ShardedTensor={sharded}, DTensor={dtensor}, non_leaf={non_leaf}"
+    )
+
+
 def _register_param_grad_hook(
     site: InjectionSite,
     target: nn.Module,
     hook_fn: Callable[[torch.Tensor], None],
 ) -> torch.utils.hooks.RemovableHandle:
-    """Compile-safe hook on a single parameter selected by ``hook_position``."""
-    params = [p for p in target.parameters() if p.requires_grad]
-    if not params:
-        raise ValueError(
-            f"register_backward_hook: no trainable parameters in module '{site.fqn}'."
-        )
+    """Compile-safe hook on a single parameter selected by ``hook_position``.
 
-    idx = _position_to_index(site.hook_position, len(params))
-    param = params[idx]
+    The position picks an index across *all* named parameters (so the
+    percentage is stable regardless of which params are hookable). If the
+    param at that index cannot fire a backward hook (sharded / non-leaf
+    / no grad), walk outward to the nearest hookable neighbor. Assert if
+    no parameter under ``site.fqn`` is hookable at all.
+    """
+    named_params = list(target.named_parameters())
+    n = len(named_params)
+
+    target_idx = _position_to_index(site.hook_position, n) if n else 0
+
+    chosen_idx = next(
+        (i for i in _walk_outward(target_idx, n) if will_hook_fire(named_params[i][1])),
+        None,
+    )
+
+    assert chosen_idx is not None, (
+        f"register_backward_hook: no hookable parameter in module "
+        f"'{site.fqn}' ({_summarize_unhookable(named_params)}); "
+        f"need is_leaf + requires_grad + not ShardedTensor/DTensor."
+    )
+
+    name, param = named_params[chosen_idx]
+    print(
+        f"[hook target] requested_idx={target_idx} chosen_idx={chosen_idx}/{n} "
+        f"fqn={site.fqn}.{name} type={type(param).__name__} "
+        f"is_leaf={param.is_leaf}"
+    )
     logger.info(
-        "register_backward_hook: hooking param %d/%d (position=%.2f) in '%s'",
-        idx,
-        len(params),
+        "register_backward_hook: hooking param %d/%d "
+        "(requested=%d, position=%.2f) in '%s'",
+        chosen_idx,
+        n,
+        target_idx,
         site.hook_position,
         site.fqn,
     )
     return param.register_hook(hook_fn)
+
+
+def _walk_outward(start: int, n: int) -> Iterator[int]:
+    """Yield indices in ``[0, n)`` ordered by distance from ``start``, forward
+    direction first on ties: ``start, start+1, start-1, start+2, start-2, …``.
+    Out-of-range indices are skipped, so callers see at most ``n`` values."""
+    if 0 <= start < n:
+        yield start
+    for offset in range(1, n):
+        forward = start + offset
+        if forward < n:
+            yield forward
+        backward = start - offset
+        if 0 <= backward:
+            yield backward
 
 
 def _position_to_index(position: float, length: int) -> int:

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -223,7 +223,7 @@ class InjectionSiteTest(unittest.TestCase):
         handle.remove()
 
     def test_hook_position_no_trainable_params_raises(self) -> None:
-        """PARAM_GRAD on a module with no trainable params raises ValueError."""
+        """PARAM_GRAD on a module with no params asserts."""
         model = SimpleModel()
         # layer_b contains ReLU at index 1 which has no parameters
         site = InjectionSite(
@@ -232,8 +232,109 @@ class InjectionSiteTest(unittest.TestCase):
             target_type=InjectionTargetType.PARAM_GRAD,
             hook_position=0.5,
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AssertionError):
             register_backward_hook(site, model, lambda grad: None)
+
+    @staticmethod
+    def _has_backward_hook(p: torch.Tensor) -> bool:
+        """True iff ``p`` currently has at least one backward hook registered."""
+        hooks = getattr(p, "_backward_hooks", None)
+        return hooks is not None and len(hooks) > 0
+
+    @staticmethod
+    def _make_module_with_hookable_mask(
+        mask: List[bool],
+    ) -> Tuple[nn.Module, List[nn.Parameter]]:
+        """Build ``parent.child`` where ``child`` has ``len(mask)`` parameters;
+        ``mask[i]`` controls whether param ``i`` is hookable (requires_grad)."""
+        parent = nn.Module()
+        child = nn.Module()
+        parent.add_module("child", child)
+        params: List[nn.Parameter] = []
+        for i, hookable in enumerate(mask):
+            p = nn.Parameter(torch.randn(2), requires_grad=hookable)
+            child.register_parameter(f"p{i}", p)
+            params.append(p)
+        return parent, params
+
+    def test_fallback_walks_forward_to_nearest_hookable(self) -> None:
+        """target_idx points at an unhookable param; search walks forward."""
+        # 5 params; only indices 2 and 4 are hookable.
+        # hook_position=0.0 → target_idx=0 → walks 0,1,2 → picks 2.
+        parent, params = self._make_module_with_hookable_mask(
+            [False, False, True, False, True]
+        )
+        site = InjectionSite(
+            fqn="child",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=0.0,
+        )
+        handle = register_backward_hook(site, parent, lambda g: None)
+        self.assertTrue(self._has_backward_hook(params[2]))
+        for i in (0, 1, 3, 4):
+            self.assertFalse(self._has_backward_hook(params[i]))
+        handle.remove()
+
+    def test_fallback_walks_backward_to_nearest_hookable(self) -> None:
+        """target_idx at the end is unhookable; search walks backward."""
+        # 5 params; only index 1 is hookable.
+        # hook_position=1.0 → target_idx=4 → walks back through 3,2 → picks 1.
+        parent, params = self._make_module_with_hookable_mask(
+            [False, True, False, False, False]
+        )
+        site = InjectionSite(
+            fqn="child",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=1.0,
+        )
+        handle = register_backward_hook(site, parent, lambda g: None)
+        self.assertTrue(self._has_backward_hook(params[1]))
+        for i in (0, 2, 3, 4):
+            self.assertFalse(self._has_backward_hook(params[i]))
+        handle.remove()
+
+    def test_position_indexes_against_all_params(self) -> None:
+        """Percentage is computed over *all* params (not just hookable ones).
+
+        With 4 params where only indices 1 and 2 are hookable, hook_position=0.5
+        maps to target_idx = int(0.5*4) = 2 (hookable directly). If the index
+        were instead computed over the 2 hookable params, position 0.5 would
+        pick index 1 — this test guards against that regression.
+        """
+        parent, params = self._make_module_with_hookable_mask(
+            [False, True, True, False]
+        )
+        site = InjectionSite(
+            fqn="child",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=0.5,
+        )
+        handle = register_backward_hook(site, parent, lambda g: None)
+        self.assertTrue(self._has_backward_hook(params[2]))
+        self.assertFalse(self._has_backward_hook(params[1]))
+        handle.remove()
+
+    def test_no_hookable_param_asserts(self) -> None:
+        """If no param under the FQN is hookable, raise AssertionError with a
+        breakdown of how many params failed which check."""
+        parent, _ = self._make_module_with_hookable_mask([False, False, False])
+        site = InjectionSite(
+            fqn="child",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+            hook_position=0.5,
+        )
+        with self.assertRaises(AssertionError) as cm:
+            register_backward_hook(site, parent, lambda g: None)
+        msg = str(cm.exception)
+        self.assertIn("total=3", msg)
+        self.assertIn("no_requires_grad=3", msg)
+        self.assertIn("ShardedTensor=0", msg)
+        self.assertIn("DTensor=0", msg)
+        self.assertIn("non_leaf=0", msg)
 
     def test_register_hook_persists_and_removable(self) -> None:
         """Hook fires every iteration; removing it stops firing."""


### PR DESCRIPTION
Summary:
Make `_register_param_grad_hook` robust to sharded / unhookable params, and add a diagnostic print so we can see *which* param the hook actually landed on.

`param.register_hook` only fires through `AccumulateGrad`. Sharded embedding params (`ShardedTensor` / `DTensor`) bypass `AccumulateGrad` via FBGEMM TBE fused backward, so a hook attached to one silently never fires — the value-dist diagnostic prints nothing and the injection point looks broken.

## What changes

1. **Index over *all* named params, not just hookable ones.** `hook_position` now maps to a stable index regardless of how many params happen to be hookable (which depends on shard topology). Previously the same `hook_position=0.5` could land on different params across runs.
2. **Outward fallback.** If the param at the target index is unhookable, walk outward (forward first at each ring, then backward) to the nearest hookable neighbor.
3. **Assert** if no param under the FQN is hookable at all (was `ValueError` over filtered params; now covers the all-sharded case too).
4. **Diagnostic print** of `requested_idx`, `chosen_idx`, fqn, type, and `is_leaf` so it is obvious in logs which param the hook was attached to.

## How `hook_position` resolves to a param

```
named_parameters under site.fqn  (declaration order, n = 5)

  idx        0       1       2       3       4
  param    [emb]   [w_a]   [w_b]   [emb]   [bias]
  hookable   ✗       ✓       ✓       ✗       ✓
             │                       │
             └─ ShardedTensor ───────┘
                bypasses AccumulateGrad via FBGEMM TBE fused backward
                → register_hook silently never fires

position → target_idx = int(position * n)  → outward walk → chosen_idx

  0.00   →    0    →   0 ✗ → +1 ✓                       →   1
  0.30   →    1    →   1 ✓                              →   1
  0.50   →    2    →   2 ✓                              →   2
  0.60   →    3    →   3 ✗ → +1 ✓                       →   4
  1.00   →    4    →   4 ✓                              →   4
```

Outward walk at offset *k*: try `target+k` first, then `target-k`. So forward neighbors win at each ring, but the search expands symmetrically until it finds a hookable param or exhausts the module.

Differential Revision: D104766359


