### PR TITLE
Migrate SSD type imports to canonical location

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -34,11 +34,6 @@ from typing import (
 import torch
 import torch.distributed as dist
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    EvictionPolicy,
-    KVZCHParams,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -51,7 +46,13 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SparseType,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.tbe.ssd import ASSOC, SSDTableBatchedEmbeddingBags
+from fbgemm_gpu.tbe.ssd import (
+    ASSOC,
+    BackendType,
+    EvictionPolicy,
+    KVZCHParams,
+    SSDTableBatchedEmbeddingBags,
+)
 from fbgemm_gpu.tbe.ssd.utils.partially_materialized_tensor import (
     PartiallyMaterializedTensor,
 )

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -14,13 +14,13 @@ from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, U
 
 import torch
 import torch.distributed as dist
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+from fbgemm_gpu.tbe.ssd import BackendType
 from fbgemm_gpu.tbe.ssd.training import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.ssd.utils.partially_materialized_tensor import (
     PartiallyMaterializedTensor,

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -14,7 +14,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import KVZCHTBEConfig
+from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
 from torch import nn, optim
 from torch.optim import Optimizer
 from torchrec.distributed import DistributedModelParallel

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -15,11 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import hypothesis.strategies as st
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BackendType,
-    EnrichmentPolicy,
-    EnrichmentType,
-)
+from fbgemm_gpu.tbe.ssd import BackendType, EnrichmentPolicy, EnrichmentType
 from hypothesis import given, settings
 from torchrec.distributed.batched_embedding_kernel import ZeroCollisionKeyValueEmbedding
 from torchrec.distributed.embedding import EmbeddingCollectionContext

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -32,10 +32,10 @@ from typing import (
 from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     BoundsCheckMode,
     CacheAlgorithm,
-    KVZCHTBEConfig,
     MultiPassPrefetchConfig,
 )
 from fbgemm_gpu.tbe.monitoring import TBEStatsReporterConfig
+from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
 from torch.autograd.profiler import record_function
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.distributed_c10d import _get_object_coll_device


### PR DESCRIPTION
Summary:
Migrate torchrec imports of SSD/KVZCH types from
`fbgemm_gpu.split_table_batched_embeddings_ops_common` to the new canonical
`fbgemm_gpu.tbe.ssd` package.

This is a pure import-path migration — no logic changes. The old import paths
continue to work via backward-compat re-exports in ops_common.py.

## Detailed Changes

### `torchrec/distributed/batched_embedding_kernel.py`
- Drop `from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType, EvictionPolicy, KVZCHParams`
- Consolidate `BackendType`, `EvictionPolicy`, `KVZCHParams` into the existing
  `from fbgemm_gpu.tbe.ssd import ...` block alongside `ASSOC`, `SSDTableBatchedEmbeddingBags`.

### `torchrec/distributed/embedding_lookup.py`
- Replace `from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType`
  with `from fbgemm_gpu.tbe.ssd import BackendType`.

### `torchrec/distributed/types.py`
- Remove `KVZCHTBEConfig` from the `split_table_batched_embeddings_ops_common` import.
- Add `from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig`.

### `torchrec/distributed/test_utils/sharding_config.py`
- Replace `from fbgemm_gpu.split_table_batched_embeddings_ops_common import KVZCHTBEConfig`
  with `from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig`.

### `torchrec/distributed/tests/test_embedding_sharding.py`
- Replace `from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType, EnrichmentPolicy, EnrichmentType`
  with `from fbgemm_gpu.tbe.ssd import BackendType, EnrichmentPolicy, EnrichmentType`.

### `torchrec/distributed/BUCK`
- Drop `:split_table_batched_embeddings_ops_common` dep from `batched_embedding_kernel`
  and `embedding_lookup` targets (types now come via `:ssd_split_table_batched_embeddings_ops`).
- Add `:ssd_split_table_batched_embeddings_ops` to the `types` target (required for `KVZCHTBEConfig`).

### `torchrec/distributed/test_utils/BUCK`
- Swap `:split_table_batched_embeddings_ops_common` → `:ssd_split_table_batched_embeddings_ops`
  on the `sharding_config` target.

### `torchrec/distributed/tests/BUCK`
- Swap `:split_table_batched_embeddings_ops_common` → `:ssd_split_table_batched_embeddings_ops`
  on the `test_embedding_sharding` target.

Reviewed By: henrylhtsang

Differential Revision: D103493980


