### PR TITLE
Destroy gloo PG in tearDownModule (#4257)

### DIFF
--- a/torchrec/distributed/tests/test_pec_collision_handlers.py
+++ b/torchrec/distributed/tests/test_pec_collision_handlers.py
@@ -40,6 +40,14 @@ def _get_single_rank_pg() -> dist.ProcessGroup:
     return dist.group.WORLD  # pyre-ignore[7]
 
 
+def tearDownModule() -> None:
+    # The PG initialized by _get_single_rank_pg lives for the duration of
+    # this file's tests; destroy it so later test modules in the same
+    # pytest process can call init_process_group themselves.
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
 def _make_grouped_configs(
     tables: List[EmbeddingConfig],
     local_rows: int,


### PR DESCRIPTION
Summary:

`_get_single_rank_pg()` (added in D104562839) lazily calls `dist.init_process_group(backend="gloo", rank=0, world_size=1)` and never destroys it. Pytest collects `test_pec_collision_handlers.py` before `test_utils.py` alphabetically, so the leaked default PG makes any later test that calls `dist.init_process_group(...)` raise `ValueError: trying to initialize the default process group twice!`.

This is what's been failing OSS `unittest_ci_cpu` since 2026-05-11 (e.g. `torchrec/distributed/tests/test_utils.py::UtilsTest::test_get_unsharded_module_names`). The OSS bot blamed D102938675 by temporal correlation, but the regression actually started ~7h after D104562839 landed at 2026-05-10 22:24 PDT — last green run was 2026-05-10 13:34, first red was 2026-05-11 05:52, no `dist_data.py` / `test_dist_data.py` change in that window.

Add a module-level `tearDownModule` that destroys the PG once when this file's tests finish. `tearDownModule` is part of unittest and is also invoked by pytest, so the leak is contained to this file regardless of the test runner.

Closes T270888728.

Differential Revision: D105104474
