### PR TITLE
Add embedding pipeline func (#4261)

### DIFF
--- a/torchrec/modules/embedding_pipeline.py
+++ b/torchrec/modules/embedding_pipeline.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+def pipeline_forward(
+    named_modules_and_inputs: Dict[str, Tuple[torch.nn.Module, KeyedJaggedTensor]],
+) -> Dict[str, Any]:
+    """
+    Pipeline the forward pass of multiple embedding modules.
+
+    For local (non-sharded) embedding modules, the function calls forward
+    directly. For sharded embedding modules, it launches all ``input_dist``
+    calls first to overlap the all-to-all input distribution across modules,
+    then waits on the awaitables and runs ``compute_and_output_dist``.
+
+    Args:
+        named_modules_and_inputs: A mapping from a user-defined name to a
+            tuple of ``(module, kjt_input)``. ``module`` must be either a
+            local embedding module or a ``ShardedModule`` wrapping one;
+            ``kjt_input`` is the ``KeyedJaggedTensor`` to feed into that
+            module's forward pass.
+
+    Returns:
+        A dictionary mapping each name from ``named_modules_and_inputs`` to
+        the corresponding module's forward output.
+
+    Example:
+        >>> from torchrec.modules.embedding_pipeline import pipeline_forward
+        >>> # `ec_a` and `ebc_b` are EmbeddingCollection and EmbeddingBagCollection
+        >>> # instances respectively. When the model is sharded, they become sharded
+        >>> # modules. But the code below still works.
+        >>> # `kjt_a` and `kjt_b` are KeyedJaggedTensor inputs.
+        >>> outputs = pipeline_forward({
+        ...     "ec_a": (ec_a, kjt_a),
+        ...     "ebc_b": (ebc_b, kjt_b),
+        ... })
+        >>> pooled_a = outputs["ec_a"]
+        >>> pooled_b = outputs["ebc_b"]
+    """
+    from torchrec.distributed.types import ShardedModule
+
+    results: Dict[str, Any] = {}
+    sharded: List[Tuple[str, ShardedModule, KeyedJaggedTensor]] = []
+
+    for name, (module, kjt_input) in named_modules_and_inputs.items():
+        if isinstance(module, ShardedModule):
+            sharded.append((name, module, kjt_input))
+        else:
+            results[name] = module(kjt_input)
+
+    if sharded:
+        contexts = []
+        input_dist_awaitables = []
+        for _name, module, kjt_input in sharded:
+            ctx = module.create_context()
+            contexts.append(ctx)
+            input_dist_awaitables.append(module.input_dist(ctx, kjt_input))
+
+        dist_awaitables = [a.wait() for a in input_dist_awaitables]
+        dist_inputs = [a.wait() for a in dist_awaitables]
+
+        for i, (name, module, _kjt_input) in enumerate(sharded):
+            results[name] = module.compute_and_output_dist(contexts[i], dist_inputs[i])
+
+    return results

--- a/torchrec/modules/tests/test_embedding_pipeline.py
+++ b/torchrec/modules/tests/test_embedding_pipeline.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# pyre-strict
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import torch
+from torchrec.modules.embedding_pipeline import pipeline_forward
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class _MockAwaitable:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def wait(self) -> Any:
+        return self._value
+
+
+class _TrackedShardedModule(torch.nn.Module):
+    def __init__(self, name: str, output: Any, call_order: List[str]) -> None:
+        super().__init__()
+        self._name = name
+        self._output = output
+        self._call_order = call_order
+
+    def create_context(self) -> Any:
+        return MagicMock()
+
+    def input_dist(self, ctx: Any, *args: Any, **kwargs: Any) -> _MockAwaitable:
+        self._call_order.append(f"{self._name}.input_dist")
+        return _MockAwaitable(_MockAwaitable("dist_input"))
+
+    def compute_and_output_dist(self, ctx: Any, dist_input: Any) -> Any:
+        self._call_order.append(f"{self._name}.compute_and_output_dist")
+        return self._output
+
+
+class TestPipelineForward(unittest.TestCase):
+    def test_empty_input(self) -> None:
+        results = pipeline_forward({})
+        self.assertEqual(results, {})
+
+    def test_non_sharded_only(self) -> None:
+        module_a = MagicMock(spec=torch.nn.Module)
+        module_a.return_value = "output_a"
+        module_b = MagicMock(spec=torch.nn.Module)
+        module_b.return_value = "output_b"
+
+        kjt_a = MagicMock(spec=KeyedJaggedTensor)
+        kjt_b = MagicMock(spec=KeyedJaggedTensor)
+
+        results = pipeline_forward(
+            {
+                "a": (module_a, kjt_a),
+                "b": (module_b, kjt_b),
+            }
+        )
+
+        self.assertEqual(results["a"], "output_a")
+        self.assertEqual(results["b"], "output_b")
+        module_a.assert_called_once_with(kjt_a)
+        module_b.assert_called_once_with(kjt_b)
+
+    def test_sharded_pipeline_order(self) -> None:
+        from torchrec.distributed.types import ShardedModule
+
+        call_order: List[str] = []
+        mod_a = _TrackedShardedModule("a", "result_a", call_order)
+        mod_b = _TrackedShardedModule("b", "result_b", call_order)
+
+        ShardedModule.register(type(mod_a))
+
+        kjt = MagicMock(spec=KeyedJaggedTensor)
+
+        results = pipeline_forward(
+            {
+                "a": (mod_a, kjt),
+                "b": (mod_b, kjt),
+            }
+        )
+
+        self.assertEqual(results["a"], "result_a")
+        self.assertEqual(results["b"], "result_b")
+
+        input_dist_indices = [i for i, c in enumerate(call_order) if "input_dist" in c]
+        compute_indices = [
+            i for i, c in enumerate(call_order) if "compute_and_output_dist" in c
+        ]
+        self.assertTrue(
+            max(input_dist_indices) < min(compute_indices),
+            f"All input_dist should complete before any compute: {call_order}",
+        )
+
+    def test_mixed_sharded_and_non_sharded(self) -> None:
+        from torchrec.distributed.types import ShardedModule
+
+        call_order: List[str] = []
+        sharded_mod = _TrackedShardedModule("sharded", "sharded_result", call_order)
+        ShardedModule.register(type(sharded_mod))
+
+        non_sharded_mod = MagicMock(spec=torch.nn.Module)
+        non_sharded_mod.return_value = "direct_result"
+
+        kjt = MagicMock(spec=KeyedJaggedTensor)
+
+        results = pipeline_forward(
+            {
+                "non_sharded": (non_sharded_mod, kjt),
+                "sharded": (sharded_mod, kjt),
+            }
+        )
+
+        self.assertEqual(results["non_sharded"], "direct_result")
+        self.assertEqual(results["sharded"], "sharded_result")
+        non_sharded_mod.assert_called_once_with(kjt)
+
+    def test_result_keys_match_input_keys(self) -> None:
+        module = MagicMock(spec=torch.nn.Module)
+        module.return_value = "output"
+        kjt = MagicMock(spec=KeyedJaggedTensor)
+
+        results = pipeline_forward(
+            {
+                "foo": (module, kjt),
+                "bar": (module, kjt),
+            }
+        )
+
+        self.assertEqual(set(results.keys()), {"foo", "bar"})


### PR DESCRIPTION
Summary:

A new function pipeline_forward for embedding lookup is implemented. It takes a dictionary of (sharded) embedding modules as input and pipelines input_dist / compute / output_dist across all embedding modules, overlapping GPU communication with computation. This reduces the exposed communication latency and consequently improves throughput (QPS). Tests on product models show that pipeline_forward (with TrainPipelineBase) is on par with PEC embedding and TrainPipelineSparseDist, but saves peak GPU memory up to 5.6% (absolute value); it boosts the performance of TrainPipelineBase by 11.8% (relative value).


## Technical Details

Each sharded embedding module's forward is implemented in 3 phases:
* input_dist for transferring splits (i.e., lengths of IDs)
* wait for the splits and then start transferring IDs
* wait to receive the IDs, compute_and_output_dist for local embedding lookup and then transferring embedding vectors


It is common to see multiple sharded embedding modules (e.g., EmbeddingCollection, EmbeddingBagCollection and ManagedCollisionEmbeddingCollection) in a single recommendation model. By pipelining the three phases of all sharded embedding modules, we can overlap the GPU computation and communication as shown below.

* Top figure: the three embedding modules are executed sequentially without pipeline_forward. The transferring of splits, IDs and embedding vectors is exposed communication.
* Bottom figure: the three embedding modules are pipelined via pipeline_forward. The shaded area illustrates the overlapping of the computation and communication.


 {F1989840183} 


### Comparison to TrainPipelineSparseDist

TrainPipelineSparseDist also reduces exposed communication. It overlaps the embedding communication for the next batch with the computation of the current batch. TrainPipelineBase + pipeline_forward has the following pros and cons over TrainPipelineSparseDist.

Pros:
* Smaller peak GPU memory footprint. pipeline_forward only holds one batch of training data in each iteration. TrainPipelineSparseDist holds 3 batches of data.
* No need to make the model code fx traceable. TrainPipelineSparseDist applies fx trace for the model forward code to extract embedding modules and the preprocessing code for generating the input KJT to the embedding modules. Users have to refactor the non-traceable code with torch.fx.wrap.

Cons:

* It reduces exposed communication only when there are multiple embedding modules in the model. The amount of reduction depends on the overlap across the phases. TrainPipelineSparseDist works even when there is only a single embedding module in the model.
* It requires code refactoring to prepare the input for pipeline_forward and extract the embedding vectors from the output.

Differential Revision: D105112168


