### PR TITLE
Add fbgemm_gpu.tbe.ssd import fallback for D103493980

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -47,12 +47,23 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SparseType,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.tbe.ssd import (
-    ASSOC,
-    EvictionPolicy,
-    KVZCHParams,
-    SSDTableBatchedEmbeddingBags,
-)
+from fbgemm_gpu.tbe.ssd import ASSOC, SSDTableBatchedEmbeddingBags
+
+try:
+    from fbgemm_gpu.tbe.ssd import EvictionPolicy, KVZCHParams
+except ImportError:
+    # Track via _log_api_usage_once so we can quantify the callers still on
+    # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
+    # layers roll forward.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.batched_embedding_kernel.import_failure.tbe_ssd_kvzch_types"
+    )
+    # Fallback for fbgemm_gpu < D103282820 (EvictionPolicy, KVZCHParams
+    # moved from split_table_batched_embeddings_ops_common to tbe/ssd).
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        EvictionPolicy,
+        KVZCHParams,
+    )
 from fbgemm_gpu.tbe.ssd.utils.partially_materialized_tensor import (
     PartiallyMaterializedTensor,
 )
@@ -549,6 +560,7 @@ def _populate_zero_collision_tbe_params(
         bucket_sizes=bucket_sizes,
         enable_optimizer_offloading=True,
         backend_return_whole_row=(backend_type == BackendType.DRAM),
+        # pyrefly: ignore[bad-argument-type]
         eviction_policy=eviction_policy,
         embedding_cache_mode=embedding_cache_mode_,
         load_ckpt_without_opt=load_ckpt_without_opt,
@@ -2168,6 +2180,7 @@ class ZeroCollisionKeyValueEmbedding(
             feature_table_map=self._feature_table_map,
             ssd_cache_location=embedding_location,
             pooling_mode=PoolingMode.NONE,
+            # pyrefly: ignore[bad-argument-type]
             backend_type=backend_type,
             pg=pg,
             **ssd_tbe_params,
@@ -3365,6 +3378,7 @@ class ZeroCollisionKeyValueEmbeddingBag(
             feature_table_map=self._feature_table_map,
             ssd_cache_location=embedding_location,
             pooling_mode=self._pooling,
+            # pyrefly: ignore[bad-argument-type]
             backend_type=backend_type,
             pg=pg,
             **ssd_tbe_params,

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -20,7 +20,19 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     SplitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.tbe.ssd import BackendType
+
+try:
+    from fbgemm_gpu.tbe.ssd import BackendType
+except ImportError:
+    # Track via _log_api_usage_once so we can quantify the callers still on
+    # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
+    # layers roll forward.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.embedding_lookup.import_failure.BackendType"
+    )
+    # Fallback for fbgemm_gpu < D103282820 (BackendType moved from
+    # split_table_batched_embeddings_ops_common to tbe/ssd).
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
 from fbgemm_gpu.tbe.ssd.training import SSDTableBatchedEmbeddingBags
 from fbgemm_gpu.tbe.ssd.utils.partially_materialized_tensor import (
     PartiallyMaterializedTensor,

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -14,7 +14,19 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
+
+try:
+    from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
+except ImportError:
+    # Track via _log_api_usage_once so we can quantify the callers still on
+    # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
+    # layers roll forward.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.test_utils.sharding_config.import_failure.KVZCHTBEConfig"
+    )
+    # Fallback for fbgemm_gpu < D103282820 (KVZCHTBEConfig moved from
+    # split_table_batched_embeddings_ops_common to tbe/ssd).
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import KVZCHTBEConfig
 from torch import nn, optim
 from torch.optim import Optimizer
 from torchrec.distributed import DistributedModelParallel

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -15,7 +15,24 @@ from unittest.mock import MagicMock, patch
 
 import hypothesis.strategies as st
 import torch
-from fbgemm_gpu.tbe.ssd import BackendType, EnrichmentPolicy, EnrichmentType
+
+try:
+    from fbgemm_gpu.tbe.ssd import BackendType, EnrichmentPolicy, EnrichmentType
+except ImportError:
+    # Track via _log_api_usage_once so we can quantify the callers still on
+    # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
+    # layers roll forward.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.tests.test_embedding_sharding.import_failure.tbe_ssd_enrichment_types"
+    )
+    # Fallback for fbgemm_gpu < D103282820 (BackendType, EnrichmentPolicy,
+    # EnrichmentType moved from split_table_batched_embeddings_ops_common
+    # to tbe/ssd).
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        BackendType,
+        EnrichmentPolicy,
+        EnrichmentType,
+    )
 from hypothesis import given, settings
 from torchrec.distributed.batched_embedding_kernel import ZeroCollisionKeyValueEmbedding
 from torchrec.distributed.embedding import EmbeddingCollectionContext
@@ -683,6 +700,7 @@ class TestCreateEmbeddingKernelEnrichment(unittest.TestCase):
         """When enrichment_policy with truthy enrichment_type is set,
         should route to ZeroCollisionEmbeddingEnrichmentCache."""
         enrichment_policy = EnrichmentPolicy(
+            # pyrefly: ignore[bad-argument-type]
             enrichment_type=EnrichmentType.IGR_LASER_SID,
         )
         kvzch_tbe_config = MagicMock()
@@ -802,6 +820,7 @@ class TestCreateEmbeddingKernelEnrichment(unittest.TestCase):
             mock_zc_enrichment_cls.reset_mock()
 
             enrichment_policy = EnrichmentPolicy(
+                # pyrefly: ignore[bad-argument-type]
                 enrichment_type=enrichment_type,
             )
             kvzch_tbe_config = MagicMock()

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -35,7 +35,24 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
     MultiPassPrefetchConfig,
 )
 from fbgemm_gpu.tbe.monitoring import TBEStatsReporterConfig
-from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
+
+try:
+    from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig
+except ImportError:
+    # `import torch` happens further down in this module; do a local import
+    # so the _log_api_usage_once call is self-contained. Subsequent
+    # `import torch` statements are no-ops thanks to module caching.
+    import torch
+
+    # Track via _log_api_usage_once so we can quantify the callers still on
+    # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
+    # layers roll forward.
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.types.import_failure.KVZCHTBEConfig"
+    )
+    # Fallback for fbgemm_gpu < D103282820 (KVZCHTBEConfig moved
+    # from split_table_batched_embeddings_ops_common to tbe/ssd).
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import KVZCHTBEConfig
 from torch.autograd.profiler import record_function
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.distributed_c10d import _get_object_coll_device


### PR DESCRIPTION
Summary:
Follow-up to D103493980 (`[torchrec] Migrate SSD type imports to canonical
location`). D103493980 hard-cuts torchrec over to importing
`KVZCHTBEConfig`, `BackendType`, `EvictionPolicy`, `KVZCHParams`,
`EnrichmentPolicy`, `EnrichmentType` from `fbgemm_gpu.tbe.ssd`. Those
symbols were only added to that module by D103282820 (landed
2026-05-12 00:19 PT, commit `e143fc22bf66`).

Several base-layer fbpkgs trainers depend on (e.g.
`light_cli_vllm:234`, cut from rev `42cb7e65e02d` on 2026-05-10 — i.e.
predates D103282820) ship a torchrec from a fresher overlay layer
(e.g. `fire-app:c04b5e8`) on top of an older `fbgemm_gpu` from the
base layer. The mismatch crashes the trainer at module-import time:

    ImportError: cannot import name 'KVZCHTBEConfig' from 'fbgemm_gpu.tbe.ssd'
      File ".../torchrec/distributed/types.py", line 38, in <module>
        from fbgemm_gpu.tbe.ssd import KVZCHTBEConfig

Concrete repro: MAST job `fire-chenzhou-new_stage5-2026-05-14_15_15`
(`base_layer_pkg=light_cli_vllm:234`, `app_layer_pkg=fire-app:c04b5e8`).

Until every `fbgemm_gpu`-bundling base layer rolls forward past
D103282820, accept the symbols from either path. Wraps the new-path
imports D103493980 introduced in `try / except ImportError` blocks
that fall back to `fbgemm_gpu.split_table_batched_embeddings_ops_common`,
and re-adds the `:split_table_batched_embeddings_ops_common` BUCK deps
that D103493980 dropped (kept alongside the new
`:ssd_split_table_batched_embeddings_ops` deps so strict-deps resolves
whichever branch fires).

Symbols already present in `fbgemm_gpu.tbe.ssd` long before D103282820
(`ASSOC`, `SSDTableBatchedEmbeddingBags`) stay outside the try block —
no legacy alternative exists for them.

When the base-layer rollforward finishes, the `except ImportError`
branches become dead code and can be deleted in a cleanup followup.

Reviewed By: kausv

Differential Revision: D105254047


