### PR TITLE
Update CUDA unit test CI matrix to cu126 and cu130

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -65,7 +65,7 @@ def main():
             # Re-enable once fbgemm-gpu releases cu132 nightly builds
             continue
         if entry["python_version"] in ("3.9"):
-            # stop python3.9 support, and skipp python3.14 due to incompatibility with torch.compile
+            # stop python3.9 support
             # for python version: https://devguide.python.org/versions/
             continue
         new_matrix_entries.append(entry)

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda-tag: ["cu126", "cu128", "cu129", "cu130"]
+        cuda-tag: ["cu126", "cu130"]
         os:
           - linux.g5.12xlarge.nvidia.gpu
         python:
@@ -75,10 +75,6 @@ jobs:
           - is_pr: true
             cuda-tag: "cu130"
             python:
-              version: "3.10"
-          - is_pr: true
-            cuda-tag: "cu130"
-            python:
               version: "3.11"
           - is_pr: true
             cuda-tag: "cu130"
@@ -91,40 +87,19 @@ jobs:
           - is_main_push: true
             cuda-tag: "cu126"
             python:
-              version: "3.11"
-          - is_main_push: true
-            cuda-tag: "cu126"
-            python:
               version: "3.12"
           - is_main_push: true
             cuda-tag: "cu126"
             python:
               version: "3.13"
           - is_main_push: true
-            cuda-tag: "cu128"
+            cuda-tag: "cu130"
             python:
               version: "3.10"
           - is_main_push: true
-            cuda-tag: "cu128"
-            python:
-              version: "3.12"
-          - is_main_push: true
-            cuda-tag: "cu128"
-            python:
-              version: "3.14"
-          - is_main_push: true
-            cuda-tag: "cu129"
+            cuda-tag: "cu130"
             python:
               version: "3.11"
-          - is_main_push: true
-            cuda-tag: "cu129"
-            python:
-              version: "3.13"
-          - is_main_push: true
-            cuda-tag: "cu129"
-            python:
-              version: "3.14"
-              free_threaded: true
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Summary:
## 1. Context
The CUDA unit test CI matrix referenced stale CUDA versions (cu128, cu129) that are no longer supported. The supported versions are now cu126 (12.6) and cu130 (13.0), matching fbgemm-gpu nightly availability. cu132 is skipped for now as fbgemm-gpu does not yet publish cu132 nightly builds.

## 2. Approach
1. **Updated CUDA matrix**: Replaced `["cu126", "cu128", "cu129", "cu130"]` with `["cu126", "cu130"]`
2. **PR excludes**: Narrowed PR CI to 3 jobs for fast feedback — cu130 with py310, py314, and py314t
3. **Main push excludes**: 8 jobs covering every Python version at least once — cu126 gets py310/py311/py314/py314t, cu130 gets py312/py313/py314/py314t
4. **Kept cu132 skip in `filter.py`**: Re-enabled the cu132 skip since fbgemm-gpu nightly does not publish cu132 builds yet

### PR CI matrix (3 jobs)

| CUDA | Python |
|------|--------|
| cu130 | 3.10 |
| cu130 | 3.14 |
| cu130 | 3.14t |

### Main push CI matrix (8 jobs)

| CUDA | Python versions |
|------|----------------|
| cu126 | 3.10, 3.11, 3.14, 3.14t |
| cu130 | 3.12, 3.13, 3.14, 3.14t |

## 3. Changes
1. **`unittest_ci.yml`**: Updated `cuda-tag` matrix to `["cu126", "cu130"]`, rewrote `is_pr` and `is_main_push` exclude rules
2. **`filter.py`**: Re-enabled the cu132 skip with updated comment

Reviewed By: ahmed-shuaibi

Differential Revision: D105582178


