### PR TITLE
torchrec/train_pipeline: switch PARAM_GRAD bwd hook to register_post_accumulate_grad_hook (FSDP2 support) (#4268)

### DIFF
--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -17,11 +17,12 @@ the backward all-to-all communication phase.
 
 Two hooking mechanisms are supported, selected via ``InjectionTargetType``:
 
-* **PARAM_GRAD** — uses ``torch.autograd.graph.register_multi_grad_hook`` on the
-  target module's trainable parameters.  This is **compile-safe**: unlike
-  forward hooks (which ``torch.compile`` can inline away), parameter
-  ``AccumulateGrad`` nodes survive compilation, so the hook fires reliably
-  under both eager and compiled (FMC) execution.
+* **PARAM_GRAD** — uses ``Tensor.register_post_accumulate_grad_hook`` on a
+  single trainable parameter under the target module. This works for both
+  plain leaf params (autograd's ``AccumulateGrad`` honors the hook dict) and
+  FSDP2 (``fully_shard``) DTensor params (FSDP2's ``foreach_reduce``
+  callback honors the same dict after writing the reduce-scattered grad).
+  Compile-safe: ``torch.compile`` does not strip these hooks.
 
 * **ACTIVATION** — uses a forward hook on the target module.  Each forward pass,
   the hook calls ``site.tensor_finder`` to locate an output tensor (e.g. the
@@ -76,6 +77,7 @@ from typing import (
 )
 
 import torch
+from pyre_extensions import none_throws
 from torch import nn
 from torchrec.distributed.comm_ops import Request
 from torchrec.distributed.embedding import EmbeddingCollectionAwaitable
@@ -102,9 +104,11 @@ class InjectionTargetType(Enum):
     """Selects the hooking mechanism used by ``register_backward_hook``.
 
     Attributes:
-        PARAM_GRAD: Compile-safe hook via ``register_multi_grad_hook`` on the
-            module's trainable parameters.  Suitable for dense sub-modules
-            whose parameters participate directly in the loss.
+        PARAM_GRAD: Hook via ``Tensor.register_post_accumulate_grad_hook`` on
+            a single trainable param under the target module. Works for plain
+            leaf params and FSDP2 DTensor params (both honor the
+            ``_post_accumulate_grad_hooks`` dict from their respective grad
+            writers — AccumulateGrad and FSDP2 ``foreach_reduce``). Compile-safe.
         ACTIVATION: Forward-hook + ``tensor_finder`` approach.  A forward hook
             calls ``site.tensor_finder`` each forward pass to locate the
             output tensor, then registers a per-tensor backward hook.
@@ -216,9 +220,11 @@ def register_backward_hook(
 
     The hooking mechanism is selected by ``site.target_type``:
 
-    * **PARAM_GRAD** — ``torch.autograd.graph.register_multi_grad_hook`` on the
-      module's trainable parameters.  Compile-safe (``AccumulateGrad``
-      nodes survive ``torch.compile``).  ``tensor_finder`` is ignored.
+    * **PARAM_GRAD** — ``Tensor.register_post_accumulate_grad_hook`` on a
+      single parameter under the target module. Works for both plain leaf
+      params and FSDP2 DTensor params (the dict is honored by AccumulateGrad
+      and FSDP2 ``foreach_reduce`` respectively). Compile-safe.
+      ``tensor_finder`` is ignored.
 
     * **ACTIVATION** — a forward hook that calls ``site.tensor_finder`` each
       forward pass, then registers ``hook_fn`` on the discovered tensor
@@ -259,36 +265,34 @@ def register_backward_hook(
 
 
 def will_hook_fire(p: torch.Tensor) -> bool:
-    """``param.register_hook`` only fires via ``AccumulateGrad``; sharded
-    embedding params (ShardedTensor / DTensor) bypass it via FBGEMM TBE
-    fused backward, so a hook landing on one will silently never fire."""
-    return (
-        p.is_leaf
-        and p.requires_grad
-        and type(p).__name__ not in ("ShardedTensor", "DTensor")
-    )
+    """A post-accumulate-grad hook fires only if the writer of ``param.grad``
+    iterates ``_post_accumulate_grad_hooks`` on the param. For plain leaves
+    that writer is autograd's ``AccumulateGrad``; for FSDP2 (``fully_shard``)
+    DTensor params it's FSDP2's ``foreach_reduce`` callback. ShardedTensor
+    params (sharded embeddings under FBGEMM TBE) are written from a fused
+    C++ backward that does not honor the dict, so a hook on them is silently
+    dropped — exclude them."""
+    return p.is_leaf and p.requires_grad and type(p).__name__ != "ShardedTensor"
 
 
 def _summarize_unhookable(
     named_params: list[tuple[str, nn.Parameter]],
 ) -> str:
     """Bucket every ``will_hook_fire``-failing param by the *first* reason it
-    fails (priority: no_requires_grad → ShardedTensor → DTensor → non_leaf).
+    fails (priority: no_requires_grad → ShardedTensor → non_leaf).
     Used in the no-hookable-param assert message so callers can see why."""
-    no_grad = sharded = dtensor = non_leaf = 0
+    no_grad = sharded = non_leaf = 0
     for _, p in named_params:
         t = type(p).__name__
         if not p.requires_grad:
             no_grad += 1
         elif t == "ShardedTensor":
             sharded += 1
-        elif t == "DTensor":
-            dtensor += 1
         elif not p.is_leaf:
             non_leaf += 1
     return (
         f"total={len(named_params)}, no_requires_grad={no_grad}, "
-        f"ShardedTensor={sharded}, DTensor={dtensor}, non_leaf={non_leaf}"
+        f"ShardedTensor={sharded}, non_leaf={non_leaf}"
     )
 
 
@@ -297,13 +301,34 @@ def _register_param_grad_hook(
     target: nn.Module,
     hook_fn: Callable[[torch.Tensor], None],
 ) -> torch.utils.hooks.RemovableHandle:
-    """Compile-safe hook on a single parameter selected by ``hook_position``.
+    """Register a post-accumulate-grad hook on a single parameter selected by
+    ``hook_position``.
+
+    Uses ``Tensor.register_post_accumulate_grad_hook`` (not
+    ``Tensor.register_hook``) so the hook fires regardless of who writes
+    ``param.grad``:
+
+    * For plain leaf params, autograd's ``AccumulateGrad`` node iterates
+      ``_post_accumulate_grad_hooks`` after final accumulation.
+    * For FSDP2 (``fully_shard``) DTensor params, FSDP2's ``foreach_reduce``
+      callback iterates the same dict after writing the reduce-scattered
+      sharded grad via Python attribute assignment.
+
+    ``register_hook`` would only fire via ``AccumulateGrad``, which is
+    bypassed in the FSDP2 case (the DTensor param is never on the live
+    autograd graph; FSDP2 routes grad through a custom backward function
+    against a temporary all-gathered tensor) — so this used to silently
+    drop, gated off via ``will_hook_fire``.
 
     The position picks an index across *all* named parameters (so the
     percentage is stable regardless of which params are hookable). If the
-    param at that index cannot fire a backward hook (sharded / non-leaf
-    / no grad), walk outward to the nearest hookable neighbor. Assert if
+    param at that index cannot fire a hook (ShardedTensor / non-leaf /
+    no grad), walk outward to the nearest hookable neighbor. Assert if
     no parameter under ``site.fqn`` is hookable at all.
+
+    ``hook_fn`` keeps its ``(grad: Tensor) -> None`` contract: the adapter
+    reads ``param.grad`` (post-accumulate fires only after grad is fully
+    written, so it's guaranteed non-None) and forwards it.
     """
     named_params = list(target.named_parameters())
     n = len(named_params)
@@ -318,7 +343,7 @@ def _register_param_grad_hook(
     assert chosen_idx is not None, (
         f"register_backward_hook: no hookable parameter in module "
         f"'{site.fqn}' ({_summarize_unhookable(named_params)}); "
-        f"need is_leaf + requires_grad + not ShardedTensor/DTensor."
+        f"need is_leaf + requires_grad + not ShardedTensor."
     )
 
     name, param = named_params[chosen_idx]
@@ -336,7 +361,11 @@ def _register_param_grad_hook(
         site.hook_position,
         site.fqn,
     )
-    return param.register_hook(hook_fn)
+
+    def _grad_adapter(p: torch.Tensor) -> None:
+        hook_fn(none_throws(p.grad))
+
+    return param.register_post_accumulate_grad_hook(_grad_adapter)
 
 
 def _walk_outward(start: int, n: int) -> Iterator[int]:

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -14,6 +14,8 @@ from typing import cast, List, Optional, Tuple
 import torch
 from hypothesis import given, settings, strategies as st
 from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import fully_shard
 from torchrec.distributed import DistributedModelParallel
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.test_utils.emb_sharder import TestEBCSharder
@@ -237,8 +239,9 @@ class InjectionSiteTest(unittest.TestCase):
 
     @staticmethod
     def _has_backward_hook(p: torch.Tensor) -> bool:
-        """True iff ``p`` currently has at least one backward hook registered."""
-        hooks = getattr(p, "_backward_hooks", None)
+        """True iff ``p`` currently has at least one post-accumulate-grad hook
+        registered (the dict that ``_register_param_grad_hook`` populates)."""
+        hooks = getattr(p, "_post_accumulate_grad_hooks", None)
         return hooks is not None and len(hooks) > 0
 
     @staticmethod
@@ -333,7 +336,6 @@ class InjectionSiteTest(unittest.TestCase):
         self.assertIn("total=3", msg)
         self.assertIn("no_requires_grad=3", msg)
         self.assertIn("ShardedTensor=0", msg)
-        self.assertIn("DTensor=0", msg)
         self.assertIn("non_leaf=0", msg)
 
     def test_register_hook_persists_and_removable(self) -> None:
@@ -641,4 +643,81 @@ class OutputDistTensorFinderTest(MultiProcessTestBase):
             data=data,
             sharding_type=ShardingType.TABLE_WISE.value,
             mismatched_sharding_type=ShardingType.COLUMN_WISE.value,
+        )
+
+
+def _run_fsdp2_dtensor_param_grad_hook_test(
+    rank: int,
+    world_size: int,
+    backend: str = "nccl",
+    local_size: Optional[int] = None,
+) -> None:
+    """PARAM_GRAD hook fires on DTensor params under FSDP2 (``fully_shard``).
+
+    Pre-fix, ``_register_param_grad_hook`` called ``param.register_hook``, which
+    dispatches only from ``AccumulateGrad``. FSDP2 bypasses ``AccumulateGrad``
+    for DTensor params (it writes ``param.grad`` from its ``foreach_reduce``
+    callback against a temporary all-gathered tensor), so the hook silently
+    never fired and ``will_hook_fire`` gated DTensor off with a fail-fast
+    assert. The fix switches to ``register_post_accumulate_grad_hook``, which
+    ``foreach_reduce`` honors after the reduce-scatter write.
+    """
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        parent = nn.Module()
+        child = nn.Sequential(
+            nn.Linear(8, 32, device=ctx.device),
+            nn.ReLU(),
+            nn.Linear(32, 8, device=ctx.device),
+        )
+        parent.add_module("child", child)
+
+        mesh = init_device_mesh(ctx.device.type, (world_size,))
+        fully_shard(child, mesh=mesh)
+
+        for _, p in child.named_parameters():
+            tc.assertEqual(
+                type(p).__name__,
+                "DTensor",
+                "fully_shard should convert child params to DTensor",
+            )
+
+        fire_count: List[int] = [0]
+        site = InjectionSite(
+            fqn="child",
+            tensor_finder=FirstGradTensorFinder(),
+            target_type=InjectionTargetType.PARAM_GRAD,
+        )
+        handle = register_backward_hook(
+            site,
+            parent,
+            lambda grad: fire_count.__setitem__(0, fire_count[0] + 1),
+        )
+
+        n_iters = 3
+        for _ in range(n_iters):
+            for p in child.parameters():
+                p.grad = None
+            child(torch.randn(2, 8, device=ctx.device)).sum().backward()
+
+        tc.assertEqual(
+            fire_count[0],
+            n_iters,
+            "PARAM_GRAD hook must fire once per backward on DTensor under FSDP2",
+        )
+        handle.remove()
+
+
+class FSDP2DTensorBackwardHookTest(MultiProcessTestBase):
+    """End-to-end test that the PARAM_GRAD hook fires on DTensor params under
+    FSDP2. Guards against regressing back to ``register_hook`` (which silently
+    no-ops on DTensor because FSDP2 bypasses ``AccumulateGrad``)."""
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Need at least 2 GPUs for FSDP2 test",
+    )
+    def test_param_grad_hook_fires_on_dtensor(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fsdp2_dtensor_param_grad_hook_test,
+            world_size=2,
         )


### PR DESCRIPTION
Summary:

## Why

Today `PARAM_GRAD`-mode backward-hook injection in `backward_injection.py` calls `param.register_hook(fn)`, which dispatches only from the autograd `AccumulateGrad` node. Under FSDP2 (`fully_shard`), the DTensor parameter is never on the live autograd graph for a given forward — FSDP2 all-gathers a fresh plain tensor for the matmul, and writes the reduce-scattered sharded grad back into `param.grad` via a plain attribute assignment from inside its custom backward Function. There is no `AccumulateGrad(param)` for autograd to dispatch from, so any `register_hook` on a DTensor param silently never fires. The existing `will_hook_fire` check correctly excluded DTensor with a fail-fast assertion (preferable to the silent miss), but that meant the SDD pipeline + FSDP2 dense combination was simply unsupported. Full diagnosis with experiments and ASCII flow diagrams: D105342967 and `users/ir/irobert/azhente/knowledge/efficiency_learning/sdd_dtensor_bwd_hook/`.

## What

`Tensor.register_post_accumulate_grad_hook` (PT 2.1+) writes into a separate dict — `tensor._post_accumulate_grad_hooks` — that is consumed not by the autograd engine itself but by whoever writes `param.grad`. For plain leaf params that's still `AccumulateGrad`; for FSDP2 DTensor params it's FSDP2's own `foreach_reduce` callback, which explicitly iterates this dict immediately after the reduce-scatter write (`torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:751-757`). Switching `_register_param_grad_hook` to this API therefore unlocks SDD + FSDP2 without breaking the existing plain-Parameter path.

Changes:

- `_register_param_grad_hook` now uses `Tensor.register_post_accumulate_grad_hook` with an inline adapter that reads `param.grad` (guaranteed non-None at post-accumulate time) and forwards it to `hook_fn`, preserving the existing `(grad: Tensor) -> None` contract callers depend on.
- `will_hook_fire` no longer excludes DTensor; ShardedTensor exclusion is kept (FBGEMM TBE writes sharded embedding grads from a fused C++ backward that does not honor either hook dict).
- `_summarize_unhookable` drops the DTensor bucket from its diagnostic output.
- Module-level docstring, `InjectionTargetType.PARAM_GRAD` docstring, and `register_backward_hook` docstring updated. The "compile-safe" property still holds: `register_post_accumulate_grad_hook` is not stripped by `torch.compile`.
- Test helper `_has_backward_hook` updated to check `_post_accumulate_grad_hooks`; `test_no_hookable_param_asserts` no longer asserts the `DTensor=0` substring (which no longer appears in the diagnostic).


## Why `register_post_accumulate_grad_hook` does fire under FSDP2

Both `register_hook` and `register_post_accumulate_grad_hook` work the same way at registration: they just insert `fn` into a dict-typed attribute on the tensor (`_backward_hooks` vs `_post_accumulate_grad_hooks`). The difference is **who iterates the dict**.

- `_backward_hooks` is iterated only by the autograd engine's AccumulateGrad node. No AccumulateGrad → no iteration → no fire.
- `_post_accumulate_grad_hooks` is iterated by *whoever writes* `.grad`. For plain leaf params that's also AccumulateGrad. **For FSDP2 DTensor params, FSDP2's `foreach_reduce` iterates it itself**, right after the reduce-scatter write.

From `torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py:751-757`:
```python
fsdp_param.sharded_param.grad = new_sharded_dtensor_grad      # write .grad
for hook in (
    getattr(fsdp_param.sharded_param, "_post_accumulate_grad_hooks", {})
    or {}
).values():
    hook(fsdp_param.sharded_param)                             # then call hooks
```

So under FSDP2 the lifecycle becomes:

```
REGISTRATION:

  dense.linear.weight  [DTensor]
        │
        └── _post_accumulate_grad_hooks  (dict on the tensor)
                  │
                  └── hook_id → fn   ←── register_post_accumulate_grad_hook(fn)
                                         just inserts here


FORWARD  (unchanged — DTensor still not on the graph):

  dense.linear.weight ──all-gather──> unsharded_w ──F.linear──> y


BACKWARD  (autograd + FSDP2 post-backward callback):

  loss ─→ … ─→ y.grad
                │
                └─→ aten.mm_backward → unsharded_w.grad ─→ AccumulateGrad(unsharded_w)
                                                                  │
                                                                  ↓
                                                        FSDP2 RegisterPostBackwardFunction
                                                                  │
                                                                  └─→ foreach_reduce(...)
                                                                        │
                                                                        ├─→ reduce_scatter_tensor
                                                                        │     → sharded_w_grad
                                                                        │
                                                                        ├─→ dense.linear.weight.grad =
                                                                        │       sharded_w_grad
                                                                        │
                                                                        └─→ for hook in
                                                                              dense.linear.weight
                                                                                ._post_accumulate_grad_hooks
                                                                                .values():
                                                                              hook(dense.linear.weight)   ←── FIRES
                                                                                       │
                                                                                       └── fn can now read
                                                                                            dense.linear.weight.grad
                                                                                            (already written above)
```

So the hook is *not* attached to an autograd node — it's attached to a Python attribute (dict) on the tensor itself. The autograd engine and FSDP2 both honor the same registration API, but they're independent consumers of that dict. FSDP2 chose to iterate `_post_accumulate_grad_hooks` (not `_backward_hooks`), which is why one fires and the other does not.

## API differences

|                    | `register_hook(fn)`                              | `register_post_accumulate_grad_hook(fn)`                          |
|--------------------|--------------------------------------------------|-------------------------------------------------------------------|
| Signature          | `fn(grad: Tensor) -> Optional[Tensor]`           | `fn(param: Tensor) -> None`                                       |
| Receives           | the grad tensor as it flows                      | the param (caller reads `param.grad`)                             |
| Can mutate grad?   | Yes — return value replaces grad in-flight       | No — return value ignored                                         |
| When fires         | During backward, at the AccumulateGrad node      | After `.grad` has been fully written                              |
| Storage            | `tensor._backward_hooks`                         | `tensor._post_accumulate_grad_hooks`                              |
| Who iterates       | Autograd engine (AccumulateGrad only)            | Whoever writes `.grad` (AccumulateGrad for leaves, FSDP2 for DTensor) |
| Available since    | always                                           | PyTorch 2.1+                                                      |

Reviewed By: spmex

Differential Revision: D105374617


