### PR TITLE
Fix type checking errors in `batched_embedding_kernel` and `backward_injection`

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -34,6 +34,7 @@ from typing import (
 import torch
 import torch.distributed as dist
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -48,7 +49,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
 )
 from fbgemm_gpu.tbe.ssd import (
     ASSOC,
-    BackendType,
     EvictionPolicy,
     KVZCHParams,
     SSDTableBatchedEmbeddingBags,

--- a/torchrec/distributed/train_pipeline/backward_injection.py
+++ b/torchrec/distributed/train_pipeline/backward_injection.py
@@ -270,7 +270,7 @@ def will_hook_fire(p: torch.Tensor) -> bool:
 
 
 def _summarize_unhookable(
-    named_params: list[tuple[str, torch.Tensor]],
+    named_params: list[tuple[str, nn.Parameter]],
 ) -> str:
     """Bucket every ``will_hook_fire``-failing param by the *first* reason it
     fails (priority: no_requires_grad → ShardedTensor → DTensor → non_leaf).


### PR DESCRIPTION
Summary:
Two type checking targets (`batched_embedding_kernel-type-checking` and `backward_injection-type-checking`) fail due to type mismatches between nearly-identical but distinct types.

In `batched_embedding_kernel.py`, `BackendType` is imported from `fbgemm_gpu.tbe.ssd`, which re-exports `fbgemm_gpu.tbe.ssd.ssd_config.BackendType`. However, `SSDTableBatchedEmbeddingBags.__init__` expects `fbgemm_gpu.split_table_batched_embeddings_ops_common.BackendType` — a separate enum class with the same members. These are distinct Python types that fail static type checking despite being runtime-compatible.

In `backward_injection.py`, `_summarize_unhookable` declares its parameter as `list[tuple[str, torch.Tensor]]`, but its only call site passes the result of `list(target.named_parameters())`, which is `list[tuple[str, nn.Parameter]]`. Because lists are invariant in their type parameter, `list[tuple[str, Parameter]]` is not assignable to `list[tuple[str, Tensor]]`.

**Approach:**
1. **`BackendType` import fix**: Import `BackendType` from `fbgemm_gpu.split_table_batched_embeddings_ops_common` (the canonical definition used by `SSDTableBatchedEmbeddingBags.__init__`) instead of from `fbgemm_gpu.tbe.ssd` (which re-exports the duplicate `ssd_config` copy).
2. **`_summarize_unhookable` signature fix**: Change the parameter type from `list[tuple[str, torch.Tensor]]` to `list[tuple[str, nn.Parameter]]` to match the actual call site.

Both fixes are type-annotation-only with no behavioral change.

Differential Revision: D105582303


