### PR TITLE
Process-global uncaught-exception safety net

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -48,6 +48,7 @@ from torchrec.distributed.model_tracker.types import (
     Trackers,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.safety_net import install_torchrec_global_safety_net
 from torchrec.distributed.sharding_plan import get_default_sharders
 from torchrec.distributed.types import (
     DMPCollectionConfig,
@@ -292,6 +293,9 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         model_tracker_configs: Optional[ModelTrackerConfigs] = None,
     ) -> None:
         super().__init__()
+        # JK-gated, idempotent. Installs sys.excepthook / threading.excepthook
+        # wrappers that route uncaught exceptions to torchrec_event_logging.
+        install_torchrec_global_safety_net()
         torch._C._log_api_usage_once(f"torchrec.distributed.{self.__class__.__name__}")
 
         self.init_parameters = init_parameters

--- a/torchrec/distributed/safety_net.py
+++ b/torchrec/distributed/safety_net.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Process-global uncaught-exception safety net for torchrec.
+
+Installs ``sys.excepthook`` and ``threading.excepthook`` wrappers that
+emit a FAILURE event to ``torchrec_event_logging`` for torchrec-attributable
+uncaught exceptions, then chain to the previously-installed hooks so
+PyTorch's rank-prefixed stderr behavior is preserved.
+
+JK-gated (``pytorch/torchrec:enable_torchrec_global_safety_net``,
+default off). Off-path is "do not install" — byte-exact.
+
+Known limitations:
+- Pre-DMP exceptions (planner helpers without ``@event_logger``) miss.
+- No SIGTERM/SIGINT/faulthandler coverage — owned by APFShutdownHandler
+  and torchelastic ErrorHandler.
+- Wrapper helper sitting between torchrec and a dep raise (frame in
+  neither ``/torchrec/`` nor ``_TORCHREC_DEPENDENCY_MARKERS``) looks
+  like user code and is skipped.
+"""
+
+import logging
+import os
+import sys
+import threading
+import traceback
+from types import TracebackType
+from typing import Callable, Optional, Type
+
+import torch
+
+try:
+    # Defensive: torch-package / inference builds may strip the shim.
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.safety_net.import_failure.event_logging_handler"
+    )
+
+    from enum import Enum as _Enum
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            TRAIN_PIPELINE = "train_pipeline"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
+
+
+from torchrec.distributed.logging_utils import EventType
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SAFETY_NET_JK: str = "pytorch/torchrec:enable_torchrec_global_safety_net"
+_UNCAUGHT_EVENT_NAME: str = "torchrec_uncaught_exception"
+
+# Bound payload sizes so a pathological exception can't blow up the Scuba sample.
+_ERROR_MESSAGE_MAX_LEN: int = 4096
+_STACK_TRACE_MAX_LEN: int = 8192
+_TRUNCATION_MARKER: str = "...[truncated]"
+
+_TORCHREC_PATH_MARKER: str = "/torchrec/"
+
+# Frames in these libs count as "torchrec called a dep that raised";
+# anything else between the deepest torchrec frame and the leaf is user code.
+_TORCHREC_DEPENDENCY_MARKERS: tuple = (
+    "/torch/",
+    "/fbgemm/",
+    "/deeplearning/fbgemm/",
+)
+
+_installed: bool = False
+# Without the lock, two concurrent DMP constructions can each capture
+# sys.excepthook (one capturing the other's wrapper) and double-chain.
+_install_lock: threading.Lock = threading.Lock()
+_in_hook: threading.local = threading.local()
+_old_sys_excepthook: Callable[
+    [Type[BaseException], BaseException, Optional[TracebackType]], None
+] = sys.excepthook
+_old_threading_excepthook: Callable[["threading.ExceptHookArgs"], object] = (
+    threading.excepthook
+)
+_component: str = TorchrecComponent.TRAIN_PIPELINE.value
+
+
+# @dep=//aiplatform/runtime_environment:runtime_environment_pybind
+# @dep=//aiplatform/runtime_environment:runtime_environment_pybind_types
+# Annotations force autodeps to bundle the pybind module; without them
+# the function-scope import silently fails in Buck binaries and per-job
+# JK switchval targeting degrades to fleet-wide enablement.
+def _get_mast_job_name() -> str:
+    """Best-effort MAST job name for JK switchval. ``""`` when not on
+    MAST or when the fb-internal binding is unavailable (OSS, torch-package)."""
+    try:
+        from aiplatform.runtime_environment.runtime_environment_pybind import (  # @manual
+            RuntimeEnvironment,
+        )
+
+        return RuntimeEnvironment().get_mast_job_name() or ""
+    except Exception:
+        return ""
+
+
+def _safe_get_rank() -> int:
+    """Rank with fallback to torchelastic's RANK env var, then -1.
+    The hook can fire before ``dist.init_process_group()``."""
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank()
+    except Exception:
+        pass
+    rank_env = os.environ.get("RANK") or os.environ.get("LOCAL_RANK")
+    if rank_env is not None:
+        try:
+            return int(rank_env)
+        except ValueError:
+            pass
+    return -1
+
+
+def _should_log(exc_type: Type[BaseException], exc_value: BaseException) -> bool:
+    """Skip KeyboardInterrupt and SystemExit(None|0); log SystemExit(nonzero)."""
+    if issubclass(exc_type, KeyboardInterrupt):
+        return False
+    if issubclass(exc_type, SystemExit):
+        code = getattr(exc_value, "code", None)
+        if code is None or code == 0:
+            return False
+    return True
+
+
+def _is_torchrec_dependency(filename: str) -> bool:
+    return any(marker in filename for marker in _TORCHREC_DEPENDENCY_MARKERS)
+
+
+def _torchrec_frame_in_traceback(
+    exc_tb: Optional[TracebackType],
+) -> Optional[str]:
+    """Deepest torchrec ``"filename:lineno"`` if the failure is
+    torchrec-attributable, else ``None``. Attributable iff every frame
+    below the deepest torchrec frame is torchrec or a known dep — any
+    other frame means the chain handed off to user code (skip)."""
+    tb = exc_tb
+    deepest_torchrec_tb: Optional[TracebackType] = None
+    deepest_torchrec_frame: Optional[str] = None
+    while tb is not None:
+        try:
+            filename = tb.tb_frame.f_code.co_filename
+        except Exception:
+            filename = ""
+        if _TORCHREC_PATH_MARKER in filename:
+            deepest_torchrec_tb = tb
+            deepest_torchrec_frame = f"{filename}:{tb.tb_lineno}"
+        tb = tb.tb_next
+
+    if deepest_torchrec_tb is None:
+        return None
+
+    walker = deepest_torchrec_tb.tb_next
+    while walker is not None:
+        try:
+            fn = walker.tb_frame.f_code.co_filename
+        except Exception:
+            fn = ""
+        if _TORCHREC_PATH_MARKER not in fn and not _is_torchrec_dependency(fn):
+            return None
+        walker = walker.tb_next
+
+    return deepest_torchrec_frame
+
+
+def _truncate(s: str, max_len: int) -> str:
+    if len(s) <= max_len:
+        return s
+    keep = max(0, max_len - len(_TRUNCATION_MARKER))
+    return s[:keep] + _TRUNCATION_MARKER
+
+
+def _emit_failure_event(
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_tb: Optional[TracebackType],
+    thread_name: str,
+) -> None:
+    """Emit one FAILURE row for torchrec-attributable exceptions. May raise;
+    caller owns the outer try/except."""
+    torchrec_frame = _torchrec_frame_in_traceback(exc_tb)
+    if torchrec_frame is None:
+        return
+    EventLoggingHandler.log_event(
+        component=_component,
+        event_name=_UNCAUGHT_EVENT_NAME,
+        event_type=EventType.FAILURE,
+        metadata={
+            "exception_type": exc_type.__name__,
+            "thread_name": thread_name,
+            "rank": str(_safe_get_rank()),
+            "torchrec_frame": torchrec_frame,
+        },
+        error_message=_truncate(str(exc_value), _ERROR_MESSAGE_MAX_LEN),
+        stack_trace=_truncate(
+            "".join(traceback.format_exception(exc_type, exc_value, exc_tb)),
+            _STACK_TRACE_MAX_LEN,
+        ),
+    )
+
+
+def _jk_still_enabled() -> bool:
+    """Per-fire JK recheck so flipping the JK off acts as a runtime kill
+    switch on already-installed wrappers. Fail safe-off."""
+    try:
+        return torch._utils_internal.justknobs_check(
+            _SAFETY_NET_JK, default=False, switchval=_get_mast_job_name()
+        )
+    except Exception:
+        return False
+
+
+def _safe_diag_log(msg: str) -> None:
+    # logger.exception() can itself raise during interpreter teardown;
+    # never let it skip the chain.
+    try:
+        logger.exception(msg)
+    except BaseException:  # noqa: B036
+        pass
+
+
+def _safe_chain_sys(
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_tb: Optional[TracebackType],
+) -> None:
+    try:
+        _old_sys_excepthook(exc_type, exc_value, exc_tb)
+    except BaseException:  # noqa: B036
+        _safe_diag_log("safety_net: chain failed")
+
+
+def _safe_chain_threading(args: "threading.ExceptHookArgs") -> None:
+    try:
+        _old_threading_excepthook(args)
+    except BaseException:  # noqa: B036
+        _safe_diag_log("safety_net: chain failed")
+
+
+def _run_telemetry_sys(
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_tb: Optional[TracebackType],
+) -> None:
+    # Telemetry must never skip the chain in the caller — wrap broadly.
+    try:
+        if _jk_still_enabled() and _should_log(exc_type, exc_value):
+            try:
+                _emit_failure_event(
+                    exc_type,
+                    exc_value,
+                    exc_tb,
+                    threading.current_thread().name,
+                )
+            except Exception:
+                _safe_diag_log("safety_net: log_event failed")
+    except BaseException:  # noqa: B036
+        _safe_diag_log("safety_net: telemetry path raised")
+
+
+def _run_telemetry_threading(args: "threading.ExceptHookArgs") -> None:
+    try:
+        exc_type = args.exc_type
+        exc_value = args.exc_value
+        exc_tb = args.exc_traceback
+        thread = args.thread
+        thread_name = thread.name if thread is not None else "<unknown>"
+        # exc_value may be None per the threading.excepthook contract.
+        if exc_value is not None and exc_type is not None:
+            if _jk_still_enabled() and _should_log(exc_type, exc_value):
+                try:
+                    _emit_failure_event(exc_type, exc_value, exc_tb, thread_name)
+                except Exception:
+                    _safe_diag_log("safety_net: log_event failed")
+    except BaseException:  # noqa: B036
+        _safe_diag_log("safety_net: telemetry path raised")
+
+
+def _sys_excepthook_wrapper(
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_tb: Optional[TracebackType],
+) -> None:
+    # Must never escape — corrupting process exit would hide the original.
+    try:
+        if getattr(_in_hook, "active", False):
+            _safe_chain_sys(exc_type, exc_value, exc_tb)
+            return
+        _in_hook.active = True
+        try:
+            _run_telemetry_sys(exc_type, exc_value, exc_tb)
+            _safe_chain_sys(exc_type, exc_value, exc_tb)
+        finally:
+            _in_hook.active = False
+    except BaseException:  # noqa: B036
+        pass
+
+
+def _threading_excepthook_wrapper(args: "threading.ExceptHookArgs") -> None:
+    try:
+        if getattr(_in_hook, "active", False):
+            _safe_chain_threading(args)
+            return
+        _in_hook.active = True
+        try:
+            _run_telemetry_threading(args)
+            _safe_chain_threading(args)
+        finally:
+            _in_hook.active = False
+    except BaseException:  # noqa: B036
+        pass
+
+
+def install_torchrec_global_safety_net(
+    component: str = TorchrecComponent.TRAIN_PIPELINE.value,
+) -> None:
+    """Install the process-global excepthook safety net. Idempotent and
+    JK-gated. Call from ``DistributedModelParallel.__init__`` so install
+    runs after ``dist.init_process_group()`` and chains PyTorch's
+    rank-prefixing ``_distributed_excepthook``.
+
+    JK-off path is byte-exact (hooks unchanged) per the killswitch-fallback
+    rule. Trade-off: flipping JK on after a job starts does not retroactively
+    install on running processes — only DMP constructions that see JK=true
+    install. ``_jk_still_enabled()`` recheck makes flipping JK off a
+    runtime kill switch.
+    """
+    global _installed, _old_sys_excepthook, _old_threading_excepthook
+    global _component
+    # Double-checked locking — fast path avoids the lock once installed.
+    if _installed:
+        return
+    try:
+        # switchval=mast_job_name enables per-job admin-UI overrides.
+        if not torch._utils_internal.justknobs_check(
+            _SAFETY_NET_JK,
+            default=False,
+            switchval=_get_mast_job_name(),
+        ):
+            return
+    except Exception:
+        return
+
+    with _install_lock:
+        if _installed:
+            return
+        _component = component
+        _old_sys_excepthook = sys.excepthook
+        _old_threading_excepthook = threading.excepthook
+        sys.excepthook = _sys_excepthook_wrapper
+        threading.excepthook = _threading_excepthook_wrapper
+        _installed = True
+    logger.info(
+        "torchrec safety net installed: sys.excepthook + "
+        "threading.excepthook now route uncaught exceptions to "
+        f"{_UNCAUGHT_EVENT_NAME} in torchrec_event_logging"
+    )

--- a/torchrec/distributed/tests/test_safety_net.py
+++ b/torchrec/distributed/tests/test_safety_net.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import sys
+import threading
+import unittest
+from types import TracebackType
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import torchrec.distributed.safety_net as safety_net
+from torchrec.distributed.logging_utils import EventType
+from torchrec.distributed.safety_net import (
+    _safe_get_rank,
+    _should_log,
+    install_torchrec_global_safety_net,
+)
+
+
+class _SafetyNetTestBase(unittest.TestCase):
+    """Resets module-level state and restores excepthooks between tests."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved_sys_excepthook = sys.excepthook
+        self._saved_threading_excepthook = threading.excepthook
+        safety_net._installed = False
+        safety_net._old_sys_excepthook = sys.excepthook
+        safety_net._old_threading_excepthook = threading.excepthook
+        safety_net._in_hook = threading.local()
+
+    def tearDown(self) -> None:
+        sys.excepthook = self._saved_sys_excepthook
+        threading.excepthook = self._saved_threading_excepthook
+        safety_net._installed = False
+        safety_net._old_sys_excepthook = sys.excepthook
+        safety_net._old_threading_excepthook = threading.excepthook
+        safety_net._in_hook = threading.local()
+        super().tearDown()
+
+
+class InstallTest(_SafetyNetTestBase):
+    def test_install_idempotent(self) -> None:
+        original = sys.excepthook
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+            after_first = sys.excepthook
+            install_torchrec_global_safety_net()
+            after_second = sys.excepthook
+
+        self.assertIsNot(after_first, original)
+        self.assertIs(after_first, after_second)
+
+    def test_install_noop_when_jk_off(self) -> None:
+        """Byte-exact off-path: sys.excepthook unchanged when JK is off."""
+        original = sys.excepthook
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ):
+            install_torchrec_global_safety_net()
+        self.assertIs(sys.excepthook, original)
+        self.assertFalse(safety_net._installed)
+
+    def test_install_passes_jk_default_false_and_switchval(self) -> None:
+        # default=False keeps off-path on missing JK; switchval enables per-job override.
+        with patch(
+            "torchrec.distributed.safety_net._get_mast_job_name",
+            return_value="aps-mygap4canary-20260516-abc123",
+        ):
+            with patch(
+                "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+                return_value=False,
+            ) as mock_jk:
+                install_torchrec_global_safety_net()
+        mock_jk.assert_called_once_with(
+            "pytorch/torchrec:enable_torchrec_global_safety_net",
+            default=False,
+            switchval="aps-mygap4canary-20260516-abc123",
+        )
+
+    def test_install_safe_when_jk_check_itself_raises(self) -> None:
+        original = sys.excepthook
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            side_effect=RuntimeError("JK unreachable"),
+        ):
+            install_torchrec_global_safety_net()
+        self.assertIs(sys.excepthook, original)
+        self.assertFalse(safety_net._installed)
+
+    def test_install_serialized_across_concurrent_callers(self) -> None:
+        """Two concurrent installs must produce one wrapper; smoking-gun
+        is log_event call count == 1 (would be 2 if both chained)."""
+        original_sys = sys.excepthook
+        barrier = threading.Barrier(2)
+
+        def _worker() -> None:
+            with patch(
+                "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+                return_value=True,
+            ):
+                barrier.wait(timeout=5.0)
+                install_torchrec_global_safety_net()
+
+        t1 = threading.Thread(target=_worker)
+        t2 = threading.Thread(target=_worker)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        self.assertIsNot(sys.excepthook, original_sys)
+        self.assertIs(safety_net._old_sys_excepthook, original_sys)
+
+        # JK patch must stay active at fire time (wrappers re-check JK).
+        exc_type: Optional[type] = None
+        exc_value: Optional[BaseException] = None
+        exc_tb: Optional[TracebackType] = None
+        try:
+            raise RuntimeError("synthetic")
+        except RuntimeError:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+        assert exc_type is not None and exc_value is not None
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                sys.excepthook(exc_type, exc_value, exc_tb)
+        self.assertEqual(mock_log_event.call_count, 1)
+
+    def test_install_wraps_threading_excepthook_idempotently(self) -> None:
+        original = threading.excepthook
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+            after_first = threading.excepthook
+            install_torchrec_global_safety_net()
+            after_second = threading.excepthook
+
+        self.assertIsNot(after_first, original)
+        self.assertIs(after_first, after_second)
+
+
+class ExcepthookFireTest(_SafetyNetTestBase):
+    def _install_with_jk_on(self) -> None:
+        # Persistent patcher — wrappers re-check JK on every fire.
+        jk_patcher = patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        )
+        jk_patcher.start()
+        self.addCleanup(jk_patcher.stop)
+        install_torchrec_global_safety_net()
+
+    def _make_exc(self) -> tuple:
+        try:
+            raise RuntimeError("synthetic")
+        except RuntimeError:
+            return sys.exc_info()
+
+    def test_uncaught_main_thread_exception_fires_failure_event(self) -> None:
+        self._install_with_jk_on()
+        exc_type, exc_value, exc_tb = self._make_exc()
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(exc_type, exc_value, exc_tb)
+
+        mock_log_event.assert_called_once()
+        kwargs = mock_log_event.call_args.kwargs
+        self.assertEqual(kwargs["event_type"], EventType.FAILURE)
+        self.assertEqual(kwargs["event_name"], "torchrec_uncaught_exception")
+        self.assertEqual(kwargs["metadata"]["exception_type"], "RuntimeError")
+        self.assertEqual(kwargs["error_message"], "synthetic")
+        self.assertTrue(kwargs["stack_trace"])
+        self.assertIn("thread_name", kwargs["metadata"])
+        self.assertIn("rank", kwargs["metadata"])
+
+    def test_uncaught_thread_exception_fires_failure_event(self) -> None:
+        self._install_with_jk_on()
+        exc_type, exc_value, exc_tb = self._make_exc()
+        fake_thread = MagicMock()
+        fake_thread.name = "TestWorker"
+        args = threading.ExceptHookArgs([exc_type, exc_value, exc_tb, fake_thread])
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            threading.excepthook(args)
+
+        mock_log_event.assert_called_once()
+        kwargs = mock_log_event.call_args.kwargs
+        self.assertEqual(kwargs["event_type"], EventType.FAILURE)
+        self.assertEqual(kwargs["metadata"]["thread_name"], "TestWorker")
+
+    def test_thread_excepthook_handles_none_thread(self) -> None:
+        """thread=None per Python docs => thread_name='<unknown>', no crash."""
+        self._install_with_jk_on()
+        exc_type, exc_value, exc_tb = self._make_exc()
+        args = threading.ExceptHookArgs([exc_type, exc_value, exc_tb, None])
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            threading.excepthook(args)
+
+        mock_log_event.assert_called_once()
+        self.assertEqual(
+            mock_log_event.call_args.kwargs["metadata"]["thread_name"],
+            "<unknown>",
+        )
+
+    def test_systemexit_zero_chained_but_not_logged(self) -> None:
+        self._install_with_jk_on()
+        exc = SystemExit(0)
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(SystemExit, exc, None)
+        mock_log_event.assert_not_called()
+
+    def test_systemexit_none_chained_but_not_logged(self) -> None:
+        self._install_with_jk_on()
+        exc = SystemExit()
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(SystemExit, exc, None)
+        mock_log_event.assert_not_called()
+
+    def test_systemexit_nonzero_is_logged(self) -> None:
+        self._install_with_jk_on()
+        try:
+            raise SystemExit(1)
+        except SystemExit:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+        assert exc_type is not None and exc_value is not None
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(exc_type, exc_value, exc_tb)
+        mock_log_event.assert_called_once()
+        self.assertEqual(
+            mock_log_event.call_args.kwargs["metadata"]["exception_type"],
+            "SystemExit",
+        )
+
+    def test_keyboardinterrupt_chained_but_not_logged(self) -> None:
+        self._install_with_jk_on()
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(KeyboardInterrupt, KeyboardInterrupt(), None)
+        mock_log_event.assert_not_called()
+
+    def test_skips_non_torchrec_exception(self) -> None:
+        """No torchrec frame => trainer harness owns reporting; skip emit."""
+        self._install_with_jk_on()
+        with patch(
+            "torchrec.distributed.safety_net._torchrec_frame_in_traceback",
+            return_value=None,
+        ):
+            with patch(
+                "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                sys.excepthook(RuntimeError, RuntimeError("user code"), None)
+        mock_log_event.assert_not_called()
+
+    def test_emits_torchrec_frame_in_metadata(self) -> None:
+        self._install_with_jk_on()
+        exc_type, exc_value, exc_tb = self._make_exc()
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(exc_type, exc_value, exc_tb)
+        mock_log_event.assert_called_once()
+        metadata = mock_log_event.call_args.kwargs["metadata"]
+        self.assertIn("torchrec_frame", metadata)
+        self.assertIn("/torchrec/", metadata["torchrec_frame"])
+
+    def test_error_message_truncated(self) -> None:
+        self._install_with_jk_on()
+        exc_type: Optional[type] = None
+        exc_value: Optional[BaseException] = None
+        exc_tb: Optional[TracebackType] = None
+        try:
+            raise RuntimeError("x" * 10_000)
+        except RuntimeError:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+        assert exc_type is not None and exc_value is not None
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+        ) as mock_log_event:
+            sys.excepthook(exc_type, exc_value, exc_tb)
+        error_message = mock_log_event.call_args.kwargs["error_message"]
+        self.assertLessEqual(len(error_message), 4096)
+        self.assertTrue(error_message.endswith("...[truncated]"))
+
+    def test_stack_trace_truncated(self) -> None:
+        # Mock format_exception to avoid depending on Python's frame compression.
+        self._install_with_jk_on()
+        exc_type, exc_value, exc_tb = self._make_exc()
+        with patch(
+            "torchrec.distributed.safety_net.traceback.format_exception",
+            return_value=["x"] * 20_000,
+        ):
+            with patch(
+                "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                sys.excepthook(exc_type, exc_value, exc_tb)
+        stack_trace = mock_log_event.call_args.kwargs["stack_trace"]
+        self.assertLessEqual(len(stack_trace), 8192)
+        self.assertTrue(stack_trace.endswith("...[truncated]"))
+
+
+class ChainTest(_SafetyNetTestBase):
+    def test_chain_preserves_old_sys_excepthook(self) -> None:
+        old_hook_calls: list = []
+
+        def fake_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            old_hook_calls.append((t, v))
+
+        sys.excepthook = fake_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+
+        exc = RuntimeError("test")
+        with patch("torchrec.distributed.safety_net.EventLoggingHandler.log_event"):
+            sys.excepthook(RuntimeError, exc, None)
+
+        self.assertEqual(len(old_hook_calls), 1)
+        self.assertIs(old_hook_calls[0][1], exc)
+
+    def test_hook_never_raises_when_log_event_fails(self) -> None:
+        """log_event raise must not propagate AND chain must still fire."""
+        chain_called: list[bool] = [False]
+
+        def fake_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            chain_called[0] = True
+
+        sys.excepthook = fake_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event",
+            side_effect=RuntimeError("Scuba down"),
+        ):
+            sys.excepthook(RuntimeError, RuntimeError("real"), None)
+        self.assertTrue(
+            chain_called[0],
+            "chained excepthook must fire even when log_event raises",
+        )
+
+    def test_hook_never_raises_when_chain_fails(self) -> None:
+        """Chained hook raise must not propagate AND must have been attempted."""
+        chain_called: list[bool] = [False]
+
+        def bad_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            chain_called[0] = True
+            raise RuntimeError("chain explode")
+
+        sys.excepthook = bad_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+        with patch("torchrec.distributed.safety_net.EventLoggingHandler.log_event"):
+            sys.excepthook(RuntimeError, RuntimeError("real"), None)
+        self.assertTrue(
+            chain_called[0],
+            "chained excepthook must be attempted even when it raises",
+        )
+
+    def test_chain_fires_even_when_should_log_raises(self) -> None:
+        """Pre-chain helper raising must not skip the chain (rank stderr)."""
+        chain_called: list[bool] = [False]
+
+        def fake_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            chain_called[0] = True
+
+        sys.excepthook = fake_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+
+        with patch(
+            "torchrec.distributed.safety_net._should_log",
+            side_effect=RuntimeError("simulated malformed exc_type"),
+        ):
+            try:
+                raise RuntimeError("real")
+            except RuntimeError:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+            assert exc_type is not None and exc_value is not None
+            sys.excepthook(exc_type, exc_value, exc_tb)
+
+        self.assertTrue(
+            chain_called[0],
+            "chained excepthook must fire even when a pre-chain helper "
+            "(_should_log) raises — otherwise rank-prefixed stderr is lost",
+        )
+
+    def test_jk_flipped_off_after_install_acts_as_kill_switch(self) -> None:
+        """Flipping JK off mid-run stops emit but chain still fires."""
+        jk_state = {"on": True}
+
+        def jk_check_fn(name: str, default: bool = True, **kwargs: object) -> bool:
+            return jk_state["on"]
+
+        chain_called: list[bool] = [False]
+
+        def fake_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            chain_called[0] = True
+
+        sys.excepthook = fake_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            side_effect=jk_check_fn,
+        ):
+            install_torchrec_global_safety_net()
+            self.assertTrue(safety_net._installed)
+
+            jk_state["on"] = False
+
+            try:
+                raise RuntimeError("synthetic")
+            except RuntimeError:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+            assert exc_type is not None and exc_value is not None
+            with patch(
+                "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                sys.excepthook(exc_type, exc_value, exc_tb)
+
+            mock_log_event.assert_not_called()
+            self.assertTrue(
+                chain_called[0], "chain must fire even when JK is off mid-run"
+            )
+
+    def test_chain_fires_even_when_telemetry_and_logger_both_raise(self) -> None:
+        """log_event + logger.exception both raising must not suppress chain."""
+        chain_called: list[bool] = [False]
+
+        def fake_old(t: type, v: BaseException, tb: Optional[TracebackType]) -> None:
+            chain_called[0] = True
+
+        sys.excepthook = fake_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+
+        with patch(
+            "torchrec.distributed.safety_net.EventLoggingHandler.log_event",
+            side_effect=RuntimeError("scuba down"),
+        ):
+            with patch.object(
+                safety_net.logger,
+                "exception",
+                side_effect=RuntimeError("logging handler down"),
+            ):
+                try:
+                    raise RuntimeError("real")
+                except RuntimeError:
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                assert exc_type is not None and exc_value is not None
+                sys.excepthook(exc_type, exc_value, exc_tb)
+
+        self.assertTrue(
+            chain_called[0],
+            "chained excepthook must fire even when telemetry + logger "
+            "both raise — otherwise rank-prefixed stderr is lost",
+        )
+
+    def test_reentry_guard(self) -> None:
+        """Recursive sys.excepthook re-entry must not loop; log_event fires once."""
+
+        recursion_depth = {"value": 0}
+
+        def recursive_old(
+            t: type, v: BaseException, tb: Optional[TracebackType]
+        ) -> None:
+            recursion_depth["value"] += 1
+            if recursion_depth["value"] < 3:
+                sys.excepthook(t, v, tb)
+
+        sys.excepthook = recursive_old
+        with patch(
+            "torchrec.distributed.safety_net.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            install_torchrec_global_safety_net()
+            try:
+                raise RuntimeError("real")
+            except RuntimeError:
+                exc_type, exc_value, exc_tb = sys.exc_info()
+            assert exc_type is not None and exc_value is not None
+            with patch(
+                "torchrec.distributed.safety_net.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                sys.excepthook(exc_type, exc_value, exc_tb)
+
+        self.assertEqual(mock_log_event.call_count, 1)
+
+
+class HelperTest(_SafetyNetTestBase):
+    def test_safe_get_rank_fallback_to_env_var(self) -> None:
+        with patch.object(safety_net, "torch") as mock_torch:
+            mock_torch.distributed.is_available.return_value = True
+            mock_torch.distributed.is_initialized.return_value = False
+            with patch.dict(os.environ, {"RANK": "3"}, clear=True):
+                self.assertEqual(_safe_get_rank(), 3)
+
+    def test_safe_get_rank_fallback_to_local_rank_env_var(self) -> None:
+        with patch.object(safety_net, "torch") as mock_torch:
+            mock_torch.distributed.is_available.return_value = True
+            mock_torch.distributed.is_initialized.return_value = False
+            with patch.dict(os.environ, {"LOCAL_RANK": "5"}, clear=True):
+                self.assertEqual(_safe_get_rank(), 5)
+
+    def test_safe_get_rank_fallback_to_minus_one(self) -> None:
+        with patch.object(safety_net, "torch") as mock_torch:
+            mock_torch.distributed.is_available.return_value = True
+            mock_torch.distributed.is_initialized.return_value = False
+            with patch.dict(os.environ, {}, clear=True):
+                self.assertEqual(_safe_get_rank(), -1)
+
+    def test_torchrec_frame_in_traceback_detects_real_torchrec_path(
+        self,
+    ) -> None:
+        try:
+            raise RuntimeError("test")
+        except RuntimeError:
+            _, _, tb = sys.exc_info()
+        result = safety_net._torchrec_frame_in_traceback(tb)
+        self.assertIsNotNone(result)
+        # pyre-ignore[16]: result is not None per the assertion above
+        self.assertIn("/torchrec/", result)
+
+    def test_torchrec_frame_in_traceback_returns_none_for_non_torchrec(
+        self,
+    ) -> None:
+        fake_frame = MagicMock()
+        fake_frame.f_code.co_filename = "/usr/lib/python3.12/queue.py"
+        fake_tb = MagicMock()
+        fake_tb.tb_frame = fake_frame
+        fake_tb.tb_lineno = 42
+        fake_tb.tb_next = None
+        self.assertIsNone(safety_net._torchrec_frame_in_traceback(fake_tb))
+
+    def test_torchrec_frame_in_traceback_skips_user_code_passing_through_torchrec(
+        self,
+    ) -> None:
+        """DMP.forward => user model code raise must attribute to user, not torchrec."""
+        outer_frame = MagicMock()
+        outer_frame.f_code.co_filename = (
+            "/data/.../torchrec/distributed/model_parallel.py"
+        )
+        inner_frame = MagicMock()
+        inner_frame.f_code.co_filename = "/data/users/foo/my_app/model.py"
+
+        inner_tb = MagicMock()
+        inner_tb.tb_frame = inner_frame
+        inner_tb.tb_lineno = 99
+        inner_tb.tb_next = None
+
+        outer_tb = MagicMock()
+        outer_tb.tb_frame = outer_frame
+        outer_tb.tb_lineno = 300
+        outer_tb.tb_next = inner_tb
+
+        self.assertIsNone(safety_net._torchrec_frame_in_traceback(outer_tb))
+
+    def test_torchrec_frame_in_traceback_attributes_torchrec_to_dep(
+        self,
+    ) -> None:
+        """torchrec => dep raise (no user code in chain) attributes to torchrec."""
+        torchrec_frame = MagicMock()
+        torchrec_frame.f_code.co_filename = (
+            "/data/.../torchrec/distributed/embedding_lookup.py"
+        )
+        dep_frame = MagicMock()
+        dep_frame.f_code.co_filename = "/data/.../torch/nn/functional.py"
+
+        innermost_tb = MagicMock()
+        innermost_tb.tb_frame = dep_frame
+        innermost_tb.tb_lineno = 555
+        innermost_tb.tb_next = None
+
+        torchrec_tb = MagicMock()
+        torchrec_tb.tb_frame = torchrec_frame
+        torchrec_tb.tb_lineno = 200
+        torchrec_tb.tb_next = innermost_tb
+
+        result = safety_net._torchrec_frame_in_traceback(torchrec_tb)
+        self.assertIsNotNone(result)
+        self.assertIn("embedding_lookup.py", result or "")
+        self.assertIn("200", result or "")
+
+    def test_torchrec_frame_in_traceback_skips_when_user_code_below_torchrec(
+        self,
+    ) -> None:
+        """DMP.forward => user => torch.X: user frame in chain => skip."""
+        torchrec_frame = MagicMock()
+        torchrec_frame.f_code.co_filename = (
+            "/data/.../torchrec/distributed/model_parallel.py"
+        )
+        user_frame = MagicMock()
+        user_frame.f_code.co_filename = "/data/users/foo/my_app/model.py"
+        dep_frame = MagicMock()
+        dep_frame.f_code.co_filename = "/data/.../torch/nn/functional.py"
+
+        innermost_tb = MagicMock()
+        innermost_tb.tb_frame = dep_frame
+        innermost_tb.tb_lineno = 555
+        innermost_tb.tb_next = None
+
+        user_tb = MagicMock()
+        user_tb.tb_frame = user_frame
+        user_tb.tb_lineno = 42
+        user_tb.tb_next = innermost_tb
+
+        torchrec_tb = MagicMock()
+        torchrec_tb.tb_frame = torchrec_frame
+        torchrec_tb.tb_lineno = 300
+        torchrec_tb.tb_next = user_tb
+
+        self.assertIsNone(safety_net._torchrec_frame_in_traceback(torchrec_tb))
+
+    def test_is_torchrec_dependency(self) -> None:
+        self.assertTrue(
+            safety_net._is_torchrec_dependency("/data/.../torch/nn/functional.py")
+        )
+        self.assertTrue(
+            safety_net._is_torchrec_dependency("/data/.../fbgemm/something.py")
+        )
+        self.assertTrue(
+            safety_net._is_torchrec_dependency(
+                "/data/.../deeplearning/fbgemm/embeddings.py"
+            )
+        )
+        self.assertFalse(
+            safety_net._is_torchrec_dependency("/data/users/foo/my_app/model.py")
+        )
+        self.assertFalse(
+            safety_net._is_torchrec_dependency("/usr/lib/python3.12/queue.py")
+        )
+
+    def test_torchrec_frame_in_traceback_attributes_when_innermost_is_torchrec(
+        self,
+    ) -> None:
+        """user => torchrec raise: innermost is torchrec, attribute to torchrec."""
+        outer_frame = MagicMock()
+        outer_frame.f_code.co_filename = "/data/users/foo/my_app/main.py"
+        inner_frame = MagicMock()
+        inner_frame.f_code.co_filename = (
+            "/data/.../torchrec/distributed/embedding_lookup.py"
+        )
+
+        inner_tb = MagicMock()
+        inner_tb.tb_frame = inner_frame
+        inner_tb.tb_lineno = 123
+        inner_tb.tb_next = None
+
+        outer_tb = MagicMock()
+        outer_tb.tb_frame = outer_frame
+        outer_tb.tb_lineno = 50
+        outer_tb.tb_next = inner_tb
+
+        result = safety_net._torchrec_frame_in_traceback(outer_tb)
+        self.assertIsNotNone(result)
+        self.assertIn("embedding_lookup.py", result or "")
+        self.assertIn("123", result or "")
+
+    def test_truncate_under_limit_unchanged(self) -> None:
+        s = "x" * 100
+        self.assertEqual(safety_net._truncate(s, 4096), s)
+
+    def test_truncate_over_limit_marked(self) -> None:
+        s = "x" * 10_000
+        out = safety_net._truncate(s, 4096)
+        self.assertLessEqual(len(out), 4096)
+        self.assertTrue(out.endswith("...[truncated]"))
+
+    def test_get_mast_job_name_returns_empty_when_runtime_env_unavailable(
+        self,
+    ) -> None:
+        """OSS / torch-package: fb-internal binding unavailable => ''."""
+        with patch.dict(sys.modules, {}, clear=False):
+            sys.modules.pop(
+                "aiplatform.runtime_environment.runtime_environment_pybind", None
+            )
+            with patch(
+                "builtins.__import__",
+                side_effect=ImportError("fb-internal not available"),
+            ):
+                self.assertEqual(safety_net._get_mast_job_name(), "")
+
+    def test_get_mast_job_name_returns_empty_when_lookup_raises(self) -> None:
+        """Binding exists but lookup raises => still degrades to ''."""
+        fake_re = MagicMock()
+        fake_re.return_value.get_mast_job_name.side_effect = RuntimeError(
+            "service down"
+        )
+        fake_module = MagicMock()
+        fake_module.RuntimeEnvironment = fake_re
+        with patch.dict(
+            sys.modules,
+            {"aiplatform.runtime_environment.runtime_environment_pybind": fake_module},
+        ):
+            self.assertEqual(safety_net._get_mast_job_name(), "")
+
+    def test_should_log_filter(self) -> None:
+        self.assertFalse(_should_log(KeyboardInterrupt, KeyboardInterrupt()))
+        self.assertFalse(_should_log(SystemExit, SystemExit()))
+        self.assertFalse(_should_log(SystemExit, SystemExit(0)))
+        self.assertTrue(_should_log(SystemExit, SystemExit(1)))
+        self.assertTrue(_should_log(SystemExit, SystemExit("error")))
+        self.assertTrue(_should_log(RuntimeError, RuntimeError("x")))
+        self.assertTrue(_should_log(ValueError, ValueError("x")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -30,6 +30,7 @@ from torchrec.distributed.fp_embeddingbag import (
     FeatureProcessedEmbeddingBagCollectionSharder,
     ShardedFeatureProcessedEmbeddingBagCollection,
 )
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.model_parallel import DMPCollection
 from torchrec.distributed.sharding_plan import (
     construct_module_sharding_plan,
@@ -1843,6 +1844,19 @@ class TrainPipelineSparseDistLiteTest(TrainPipelineSparseDistTestBase):
             torch.testing.assert_close(pred, pred_pipeline)
 
 
+class _RaisingIter:
+    """Iterator whose __next__ always raises — simulates a failed dataloader."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __iter__(self) -> "_RaisingIter":
+        return self
+
+    def __next__(self) -> object:
+        raise self._exc
+
+
 class DataLoadingThreadTest(unittest.TestCase):
     def test_fetch_data(self) -> None:
         data = []
@@ -1861,6 +1875,179 @@ class DataLoadingThreadTest(unittest.TestCase):
         with self.assertRaises(StopIteration):
             data_loader.get_next_batch(True)
         data_loader.stop()
+
+    def test_fetch_failure_captured_on_iterator_exception_when_jk_on(self) -> None:
+        """JK on + iterator raises => get_next_batch re-raises promptly, no hang."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "OOM"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_re_raised_on_subsequent_calls(self) -> None:
+        """Captured exception is terminal: every call re-raises until pipeline.reset()."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            for _ in range(3):
+                with self.assertRaisesRegex(RuntimeError, "OOM"):
+                    data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_captured_on_copy_exception_when_jk_on(self) -> None:
+        """JK on + batch.to(device) raises => get_next_batch surfaces it."""
+        bad_batch = MagicMock()
+        bad_batch.to.side_effect = RuntimeError("CUDA OOM in copy")
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), iter([bad_batch]), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "CUDA OOM in copy"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_silent_when_jk_off(self) -> None:
+        """Off-path byte-exact: BG dies silently, no event fires, no capture."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            self.assertFalse(data_loader._buffer_filled_event.wait(timeout=0.5))
+            self.assertIsNone(data_loader._captured_exception)
+        finally:
+            # Force-stop the orphaned daemon (run() already returned).
+            data_loader._stop = True
+            data_loader._buffer_filled_event.set()
+            data_loader._buffer_empty_event.set()
+
+    def test_fetch_failure_emits_failure_telemetry(self) -> None:
+        """FAILURE Scuba sample has stage, exception_type, error_message, stack_trace."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaises(RuntimeError):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
+
+        self.assertEqual(mock_log_event.call_count, 1)
+        kwargs = mock_log_event.call_args.kwargs
+        self.assertEqual(kwargs["event_type"], EventType.FAILURE)
+        self.assertEqual(kwargs["event_name"], "DataLoadingThread.fetch_failure")
+        self.assertEqual(kwargs["metadata"]["stage"], "next_iterator")
+        self.assertEqual(kwargs["metadata"]["exception_type"], "RuntimeError")
+        self.assertEqual(kwargs["error_message"], "OOM")
+        self.assertTrue(kwargs["stack_trace"])
+
+    def test_fetch_failure_passes_jk_default_false_explicitly(self) -> None:
+        """Pins default=False; torch's justknobs_check defaults to True (fail-open)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ) as mock_jk:
+            # pyrefly: ignore[bad-specialization]
+            DataLoadingThread(torch.device("cpu"), iter([]), True)
+
+        capture_calls = [
+            c
+            for c in mock_jk.call_args_list
+            if c.args
+            and c.args[0]
+            == "pytorch/torchrec:enable_data_loading_thread_failure_capture"
+        ]
+        self.assertEqual(len(capture_calls), 1)
+        self.assertEqual(capture_calls[0].kwargs.get("default"), False)
+
+    def test_stopiteration_not_logged_as_failure_when_jk_on(self) -> None:
+        """End-of-epoch must NOT emit FAILURE on the safe branch."""
+        data = [torch.tensor([i]) for i in range(3)]
+        data_iter = iter(data)
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(torch.device("cpu"), data_iter, True)
+                data_loader.start()
+                try:
+                    for i in range(3):
+                        item = data_loader.get_next_batch()
+                        # pyrefly: ignore[missing-attribute]
+                        self.assertEqual(item.item(), i)
+                    self.assertIsNone(data_loader.get_next_batch(False))
+                finally:
+                    data_loader.stop()
+
+        failure_calls = [
+            c
+            for c in mock_log_event.call_args_list
+            if c.kwargs.get("event_type") == EventType.FAILURE
+        ]
+        self.assertEqual(len(failure_calls), 0)
+
+    def test_consumer_woken_even_when_telemetry_raises(self) -> None:
+        """log_event raising must not skip the consumer wake (no regression to hang)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event",
+                side_effect=RuntimeError("scuba down"),
+            ):
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaisesRegex(RuntimeError, "OOM"):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
 
 
 class EvalPipelineSparseDistTest(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -10,6 +10,7 @@ import contextlib
 import copy
 import dataclasses
 import logging
+import traceback
 from collections import defaultdict, deque
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
@@ -39,6 +40,7 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
+from torchrec.distributed.logging_utils import EventType
 
 try:
     from torchrec.distributed.logging_handlers import log_pipeline_module_info
@@ -49,6 +51,36 @@ except Exception:
 
     def log_pipeline_module_info(*args: Any, **kwargs: Any) -> None:
         pass
+
+
+try:
+    # Defensive: torch-package / inference builds may strip the shim.
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.utils.import_failure.event_logging_handler"
+    )
+
+    from enum import Enum as _Enum
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            TRAIN_PIPELINE = "train_pipeline"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
 
 
 try:
@@ -658,6 +690,14 @@ class DataLoadingThread(Thread, Generic[In]):
         self._to_device_non_blocking = to_device_non_blocking
         self._buffered: Optional[In] = None
         self._buffer_empty_event.set()
+        # JK-gated capture of non-StopIteration exceptions. Off-path
+        # preserves the original silent-death behavior bit-exact.
+        self._capture_failures_enabled: bool = torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:enable_data_loading_thread_failure_capture",
+            default=False,
+        )
+        self._captured_exception: Optional[BaseException] = None
+        self._captured_exception_event: Event = Event()
         one_time_rank0_logger.info(
             f"{self.__class__.__name__} created with device={device}, "
             f"to_device_non_blocking={to_device_non_blocking}, "
@@ -679,23 +719,80 @@ class DataLoadingThread(Thread, Generic[In]):
             if self._stop:
                 self._buffer_filled_event.set()
                 return
-            with record_function("## load_batch ##"):
-                try:
-                    batch = next(self._dataloader_iter)
-                except StopIteration:
-                    self._stop = True
+            if not self._capture_failures_enabled:
+                # Original off-path: byte-exact preservation. Non-StopIteration
+                # exceptions kill the daemon silently — consumer hangs.
+                with record_function("## load_batch ##"):
+                    try:
+                        batch = next(self._dataloader_iter)
+                    except StopIteration:
+                        self._stop = True
+                        self._buffer_filled_event.set()
+                        return
+                with record_function("## copy_batch_to_gpu ##"):
+                    with torch.get_device_module(self._device).stream(
+                        self._memcpy_stream
+                    ):
+                        self._buffered = cast(
+                            In,
+                            batch.to(
+                                self._device,
+                                non_blocking=self._to_device_non_blocking,
+                            ),
+                        )
+                    self._buffer_empty_event.clear()
                     self._buffer_filled_event.set()
-                    return
-            with record_function("## copy_batch_to_gpu ##"):
-                with torch.get_device_module(self._device).stream(self._memcpy_stream):
-                    self._buffered = cast(
-                        In,
-                        batch.to(
-                            self._device, non_blocking=self._to_device_non_blocking
-                        ),
+                continue
+
+            # Safe path: capture, emit FAILURE event, wake the consumer.
+            stage = "next_iterator"
+            try:
+                with record_function("## load_batch ##"):
+                    try:
+                        batch = next(self._dataloader_iter)
+                    except StopIteration:
+                        self._stop = True
+                        self._buffer_filled_event.set()
+                        return
+                stage = "copy_to_device"
+                with record_function("## copy_batch_to_gpu ##"):
+                    with torch.get_device_module(self._device).stream(
+                        self._memcpy_stream
+                    ):
+                        self._buffered = cast(
+                            In,
+                            batch.to(
+                                self._device,
+                                non_blocking=self._to_device_non_blocking,
+                            ),
+                        )
+                    self._buffer_empty_event.clear()
+                    self._buffer_filled_event.set()
+            except Exception as e:
+                # Telemetry wrapped so a logger/Scuba raise can never skip
+                # the consumer-wake below.
+                try:
+                    logger.exception(
+                        f"{self.__class__.__name__}: exception in {stage}: {e}"
                     )
-                self._buffer_empty_event.clear()
+                    EventLoggingHandler.log_event(
+                        component=TorchrecComponent.TRAIN_PIPELINE.value,
+                        event_name="DataLoadingThread.fetch_failure",
+                        event_type=EventType.FAILURE,
+                        metadata={
+                            "stage": stage,
+                            "exception_type": type(e).__name__,
+                            "device": str(self._device),
+                        },
+                        error_message=str(e),
+                        stack_trace=traceback.format_exc(),
+                    )
+                except BaseException:  # noqa: B036
+                    pass
+                self._captured_exception = e
+                self._captured_exception_event.set()
                 self._buffer_filled_event.set()
+                return
 
     def stop(self) -> None:
         logger.info(f"{self.__class__.__name__}: Stopping data loading thread...")
@@ -714,6 +811,16 @@ class DataLoadingThread(Thread, Generic[In]):
         the main thread in the training loop.
         """
         self._buffer_filled_event.wait()
+        if self._capture_failures_enabled and self._captured_exception_event.is_set():
+            # Terminal — pipeline.reset() rebuilds the thread to recover.
+            # Explicit None check (not assert) so python -O still raises
+            # the captured exception instead of TypeError.
+            captured = self._captured_exception
+            if captured is None:
+                raise RuntimeError(
+                    "DataLoadingThread: capture event set without captured exception"
+                )
+            raise captured
         batch = self._buffered
         if batch is None:
             if none_throws:


### PR DESCRIPTION
Summary:
Behind JK `pytorch/torchrec:enable_torchrec_global_safety_net` (default off). Installs `sys.excepthook` and `threading.excepthook` wrappers from `DistributedModelParallel.__init__` that emit a `FAILURE` row to `torchrec_event_logging` for any uncaught Python exception (in any thread) before the trainer process dies. Chains correctly over PyTorch's `_distributed_excepthook` so rank-prefixed stderr is preserved.

This adds a structural backstop for trainer-process exception observability. Without it, coverage requires every error-site author to remember the right `event_logger` decorator — one missed site and the failure escapes to stderr with no Scuba row, surfacing in MAST as a generic stuck-job kill rather than the actual exception type. Stacked with related per-site fixes (D105399948, D105462584) that close individual decorator gaps; this safety net catches everything else.

What was missing before this diff:
- Zero production installs of `sys.excepthook` in torchrec, aiplatform, apf, pyper, torchx. PyTorch's own `_distributed_excepthook` in `caffe2/torch/distributed/distributed_c10d.py:1919-1936` only prefixes stderr with `[rank{r}]` — never publishes to Scuba.
- Zero production installs of `threading.excepthook` anywhere in the trainer stack. Uncaught exceptions in worker threads are completely uncovered today.
- `record` on `apf/launcher/launcher.py:hydra_app` writes a MAST reply file but never publishes to any Scuba events table.
- `PyperShutdownHandler` / `APFShutdownHandler` flush their own Scuba tables on SIGTERM only, never on uncaught exceptions, and never to `torchrec_event_logging`.

Design (single OSS-public file `torchrec/distributed/safety_net.py`):
- `install_torchrec_global_safety_net(component=...)` is idempotent (module-level `_installed` flag), JK-gated (`default=False` pinned per the wrapper-default-True trap from D105399948), and safe to call from anywhere. Recommended call site is `DistributedModelParallel.__init__` so the install happens after `dist.init_process_group()` and the chain captures PyTorch's `_distributed_excepthook` correctly.
- `sys.excepthook` wrapper: re-entry-guarded via `threading.local`, 3-layer nested `try/except` for fail-closed semantics. Outer `except BaseException: pass` guarantees the hook never escapes (corrupting process exit would hide the original exception). Middle layers swallow log_event and chain failures independently. Filters `KeyboardInterrupt` and `SystemExit(0)/SystemExit(None)` (clean exits — chain only). `SystemExit(nonzero)` IS logged (programmatic failure).
- `threading.excepthook` wrapper: identical shape over `threading.ExceptHookArgs`, with thread name pulled from `args.thread.name`.
- `_safe_get_rank()` falls back to torchelastic's `RANK` / `LOCAL_RANK` env vars when `dist.is_initialized()` is False, then to `-1`. The hook can fire BEFORE `init_process_group()` (very-early init failure), so env-var fallback is critical.
- Component defaults to `TorchrecComponent.TRAIN_PIPELINE`; event name is `torchrec_uncaught_exception`; metadata carries `exception_type`, `thread_name`, `rank`.
- Defensive `EventLoggingHandler` / `TorchrecComponent` import block copies the template from `torchrec/metrics/cpu_offloaded_metric_module.py:23-60` — falls back to an in-file no-op when even the OSS shim is unavailable (torch-package contexts).

Off-path: when the JK is off, `install_torchrec_global_safety_net()` returns immediately and `sys.excepthook` / `threading.excepthook` are unchanged. Byte-exact preservation per the killswitch-fallback rule.

Known limitations (documented in `safety_net.py` docstring, deferred to follow-ups):
- Install at DMP construction time misses exceptions before DMP (e.g. planner-phase bare raises not covered by `event_logger`). v2 can move install to `apf/launcher/launcher.py:combo_launch` with install-order detection.
- No SIGTERM/SIGINT coverage — `APFShutdownHandler` (`aiplatform/observability/shutdown_handler.py`) already flushes `apf_training_events` on SIGTERM. Adding torchrec on top would duplicate or stomp.
- No `faulthandler` / C-crash coverage — `ErrorHandler.initialize()` already calls `faulthandler.enable(all_threads=True)` and `initFacebook` installs the C++ fatal-signal handlers.
- No `os.register_at_fork` reset — no torchrec `fork()` callers known today.

Differential Revision: D105463992


