### PR TITLE
Refactor handler API and overlap_dist

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -15,10 +15,7 @@ from typing import Dict, List, Tuple
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import (
-    SplitsAllToAllAwaitable,
-    TensorAllToAllValuesAwaitable,
-)
+from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import Awaitable
@@ -28,82 +25,75 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 @dataclass
-class CollisionResult:
-    """Output of detect_collisions for a single sharding group.
+class OverlapMasks:
+    """Overlap masks from detect_overlap for a single sharding group.
 
-    Contains overlap masks and remapped feature values. Remapped feature
-    values are KJT values shifted by per-table cumulative offsets so that
-    values from different tables occupy non-overlapping ranges, allowing a
-    single boolean mask to track overlap across all tables.
-
-    Example with two tables (table_0: 8 local rows, table_1: 8 local rows)::
-
-        table_0 offset = 0,  table_1 offset = 8
-        Raw values:      [3, 5]  (table_0)    [2, 7]  (table_1)
-        Remapped values: [3, 5]                [10, 15]
-
-    The pipeline saves `remapped_feature_values` from each batch and sets it
-    on the next batch's context as `prev_remapped_feature_values`.
+    These masks are calculated after input dist and serve as input to mask_dist,
+    which permutes and AllToAll's them to produce post-dist masks.
 
     Attributes:
         forward_overlap_mask: Bool tensor, shape [num_values]. True at
             position i means the i-th value in the current batch was also
-            present in the previous batch. Used to split the current batch
-            into overlapped (prioritized) and non-overlapped partitions.
-            All False for the first batch.
+            present in the previous batch. None when there is no current
+            batch (last-batch finalization).
         backward_overlap_mask: Bool tensor, shape [num_prev_values]. True
             at position i means the i-th value from the previous batch is
-            also present in the current batch. Used to re-split the previous
-            batch's gradients during backward. None for the first batch.
-        remapped_feature_values: Tensor, shape [num_values]. Current batch's
-            feature values shifted by per-table cumulative offsets.
+            also present in the current batch. None when there is no
+            previous batch (first batch).
     """
 
-    forward_overlap_mask: torch.Tensor
+    forward_overlap_mask: torch.Tensor | None
     backward_overlap_mask: torch.Tensor | None
-    remapped_feature_values: torch.Tensor
 
 
-class BooleanMaskChecker:
-    """Boolean mask checker for overlap detection.
+class OverlapChecker(abc.ABC):
+    """Interface for overlap detection between consecutive batches."""
 
-    Maintains a boolean tensor of size `mask_size` (total local rows across
-    all tables). Each position corresponds to a remapped feature value.
-    `update` marks positions as seen; `check_overlap` checks them.
+    @abc.abstractmethod
+    def check(
+        self,
+        current_remapped: torch.Tensor,
+        prev_remapped: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Returns (forward_mask, backward_mask)."""
+        ...
+
+
+class BooleanOverlapChecker(OverlapChecker):
+    """Boolean mask checker with reusable scratch buffer.
+
+    Semantically stateless — buffer is zeroed before every use.
     """
 
     def __init__(self, device: torch.device, mask_size: int) -> None:
-        self._device = device
-        self._seen_values = torch.zeros(
+        self._seen_buffer = torch.zeros(
             mask_size,
             dtype=torch.bool,
             device=device,
         )
 
-    def reset_mask(self) -> None:
-        self._seen_values.zero_()
-
-    def update(self, remapped_feature_values: torch.Tensor) -> None:
-        """Marks values as seen. Resets first (only current batch matters)."""
-        self.reset_mask()
-        self._seen_values[remapped_feature_values] = True
-
-    def check_overlap(
+    def check(
         self,
-        remapped_feature_values: torch.Tensor,
-    ) -> torch.Tensor:
-        """Returns bool mask: True where values overlap with previously-seen values."""
-        return self._seen_values[remapped_feature_values]
+        current_remapped: torch.Tensor,
+        prev_remapped: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self._seen_buffer.zero_()
+        self._seen_buffer[prev_remapped] = True
+        forward_mask = self._seen_buffer[current_remapped].clone()
+
+        self._seen_buffer.zero_()
+        self._seen_buffer[current_remapped] = True
+        backward_mask = self._seen_buffer[prev_remapped].clone()
+
+        return forward_mask, backward_mask
 
 
-def split_features_by_values_mask(
+def split_kjt_by_values_mask(
     features: KeyedJaggedTensor,
     overlap_mask: torch.Tensor,
 ) -> Tuple[KeyedJaggedTensor, KeyedJaggedTensor]:
-    """Splits KJT into overlapped and nonoverlapped partitions by bool mask.
-
-    Uses fbgemm.asynchronous_complete_cumsum + fbgemm.segment_sum_csr to
-    compute per-segment lengths for each partition efficiently.
+    """Splits KJT into overlapped and nonoverlapped partitions by bool mask over
+    KJT values tensor.
 
     Args:
         features: input KJT (after input dist)
@@ -116,10 +106,8 @@ def split_features_by_values_mask(
     values = features.values()
     weights = features.weights_or_none()
 
-    # Compute per-segment nonoverlapped counts via segment_sum_csr
     lengths_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
 
-    # 1 = nonoverlapped, 0 = overlapped
     nol_indicator = (~overlap_mask).to(lengths.dtype)
     nol_lengths = torch.ops.fbgemm.segment_sum_csr(
         1,
@@ -127,7 +115,6 @@ def split_features_by_values_mask(
         nol_indicator,
     )
 
-    # Split weights if present
     ol_weights = None
     nol_weights = None
 
@@ -151,243 +138,125 @@ def split_features_by_values_mask(
 
 
 @dataclass
-class CollisionPermutation:
-    """Result of permute_dist for a single sharding group.
-
-    Attributes:
-        forward_permute: For batch i — merges [ol, nol] embeddings back to
-            original order. Nonoverlapped values don't conflict with batch
-            i-1, so their lookup can start early (overlapped with i-1's
-            backward). Overlapped values must wait for i-1's gradient update.
-            Usage: index_select(cat([ol_embs, nol_embs]), 0, forward_permute)
-
-        backward_ol_permute: Original-order indices of batch i-1's
-            overlapped values, in rank-major order. Used to extract OL
-            gradients via index_select. The OL gradient update must
-            complete before batch i's ol lookup. None for the first batch.
-
-        backward_nol_permute: Original-order indices of batch i-1's
-            nonoverlapped values, in rank-major order. NOL gradient update
-            can be deferred into batch i. None for the first batch.
-    """
-
-    forward_permute: torch.Tensor
-    backward_ol_permute: torch.Tensor | None = None
-    backward_nol_permute: torch.Tensor | None = None
-
-
-def _compute_permute_from_mask(
-    bool_mask: torch.Tensor,
-    unbucketize_permute_tensor: torch.Tensor,
-) -> torch.Tensor:
-    """Computes a permute tensor from a received overlap mask and upt.
-
-    The mask is in bucketized order (shard 0 values first, then shard 1, etc.).
-    Builds a mapping from original position to position in merged [ol, nol],
-    composed with unbucketize_permute_tensor.
-
-    Example: bool_mask = [T, F, T, T, F, F]
-      ol_rank  = cumsum([1,0,1,1,0,0]) - 1 = [0, 0, 1, 2, 2, 2]
-      nol_rank = cumsum([0,1,0,0,1,1]) - 1 + 3 = [2, 3, 3, 3, 4, 5]
-      bucket_to_merged = where(mask, ol_rank, nol_rank) = [0, 3, 1, 2, 4, 5]
-    """
-    num_ol = bool_mask.sum()
-
-    ol_rank = bool_mask.long().cumsum(0) - 1
-    nol_rank = (~bool_mask).long().cumsum(0) - 1 + num_ol
-    bucket_to_merged = torch.where(bool_mask, ol_rank, nol_rank)
-
-    return bucket_to_merged[unbucketize_permute_tensor]
-
-
-class CollisionPermuteAwaitable(Awaitable[CollisionPermutation]):
-    """RW-specific awaitable that produces CollisionPermutation from received masks.
-
-    On wait(), receives forward (and optionally backward) masks via AllToAll,
-    then builds permute tensors by composing with unbucketize_permute_tensor.
-    """
-
-    def __init__(
-        self,
-        fwd_awaitable: TensorAllToAllValuesAwaitable,
-        fwd_unbucketize_permute: torch.Tensor,
-        bwd_awaitable: TensorAllToAllValuesAwaitable | None = None,
-        bwd_unbucketize_permute: torch.Tensor | None = None,
-    ) -> None:
-        super().__init__()
-        self._fwd_awaitable = fwd_awaitable
-        self._fwd_unbucketize_permute = fwd_unbucketize_permute
-        self._bwd_awaitable = bwd_awaitable
-        self._bwd_unbucketize_permute = bwd_unbucketize_permute
-
-    def _wait_impl(self) -> CollisionPermutation:
-        fwd_mask = self._fwd_awaitable.wait().bool()
-        forward_permute = _compute_permute_from_mask(
-            fwd_mask, self._fwd_unbucketize_permute
-        )
-
-        backward_ol_permute = None
-        backward_nol_permute = None
-
-        if self._bwd_awaitable is not None:
-            assert self._bwd_unbucketize_permute is not None
-            bwd_mask = self._bwd_awaitable.wait().bool()
-
-            # Pre-compose recat into indices so backward can index_select
-            # directly from original-order gradient without a separate
-            # recat step. The indices are in ascending bucketized order
-            # (rank-major), which aligns with AllToAll splits.
-            recat = torch.ops.fbgemm.invert_permute(self._bwd_unbucketize_permute)
-            (ol_bucket_indices,) = torch.where(bwd_mask)
-            (nol_bucket_indices,) = torch.where(~bwd_mask)
-
-            backward_ol_permute = recat[ol_bucket_indices]
-            backward_nol_permute = recat[nol_bucket_indices]
-
-        return CollisionPermutation(
-            forward_permute=forward_permute,
-            backward_ol_permute=backward_ol_permute,
-            backward_nol_permute=backward_nol_permute,
-        )
-
-
-@dataclass
-class CollisionSplits:
+class OverlapSplits:
     """Per-rank split sizes for overlapped/nonoverlapped partitions.
 
-    input_splits: [ol_per_rank, nol_per_rank] — how many values this rank
+    input_splits: (ol_per_rank, nol_per_rank) — how many values this rank
         sends to each other rank per partition.
-    output_splits: [ol_received, nol_received] — how many values this rank
+    output_splits: (ol_received, nol_received) — how many values this rank
         receives from each other rank per partition.
     """
 
-    input_splits: List[List[int]]
-    output_splits: List[List[int]]
+    input_splits: Tuple[List[int], List[int]]
+    output_splits: Tuple[List[int], List[int]]
 
 
-class CollisionSplitsAwaitable(Awaitable[CollisionSplits]):
-    """Resolves to CollisionSplits for a single sharding group.
+class OverlapHandler(abc.ABC):
+    """Interface for PEC overlap detection and distribution handlers.
 
-    Wraps a SplitsAllToAllAwaitable that exchanges nonoverlapped per-rank
-    counts. On wait(), derives overlapped received splits from
-    total - nol_received, then assembles CollisionSplits.
+    Subclasses implement sharding-specific logic. The sharded module
+    calls these methods in a sharding-agnostic orchestration.
+    """
+
+    @abc.abstractmethod
+    def remap_kjt_values(
+        self,
+        features: KeyedJaggedTensor,
+    ) -> torch.Tensor:
+        """Remaps KJT values to globally-unique keys across tables.
+
+        Sharding-specific: offset computation depends on how rows
+        are distributed across shards.
+        """
+        ...
+
+    @abc.abstractmethod
+    def detect_overlap(
+        self,
+        current_remapped: torch.Tensor | None,
+        prev_remapped: torch.Tensor | None,
+    ) -> OverlapMasks:
+        """Detects overlap between current and previous remapped values."""
+        ...
+
+    @abc.abstractmethod
+    def mask_dist(
+        self,
+        features: KeyedJaggedTensor,
+        sharding_ctx: SequenceShardingContext,
+        overlap_mask: torch.Tensor,
+    ) -> MaskDistAwaitable:
+        """Distributes overlap mask via AllToAll.
+
+        Sends the overlap mask using same splits from input_dist (reuses
+        sharding_ctx splits). Returns MaskDistAwaitable which holds both the
+        AllToAll awaitable and the pre-AllToAll permuted mask (needed by
+        compute_splits).
+        """
+        ...
+
+    @abc.abstractmethod
+    def compute_splits(
+        self,
+        post_dist_mask: torch.Tensor,
+        pre_dist_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> OverlapSplits:
+        """Computes per-rank OL/NOL splits from masks.
+
+        Args:
+            post_dist_mask: mask after mask_dist AllToAll
+            pre_dist_mask: mask before mask_dist AllToAll
+            sharding_ctx: provides total per-rank splits as segment boundaries
+        """
+        ...
+
+    @abc.abstractmethod
+    def compute_forward_permute(
+        self,
+        post_dist_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> torch.Tensor:
+        """Computes forward permute for merging [ol, nol] → original order."""
+        ...
+
+    @abc.abstractmethod
+    def compute_backward_permutes(
+        self,
+        post_dist_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Computes (ol_permute, nol_permute) to partition backward gradient.
+
+        Returns original-order indices pre-composed with recat,
+        in rank-major order for AllToAll alignment.
+        """
+        ...
+
+
+class MaskDistAwaitable(Awaitable[Tuple[torch.Tensor, torch.Tensor]]):
+    """Wraps TensorAllToAllValuesAwaitable for mask AllToAll.
+
+    On wait, returns (post_dist_mask, pre_dist_mask):
+    - post_dist_mask: bool mask after AllToAll
+    - pre_dist_mask: bool mask before AllToAll (needed by compute_splits)
     """
 
     def __init__(
         self,
-        ol_input_splits: List[int],
-        nol_input_splits: List[int],
-        splits_awaitable: SplitsAllToAllAwaitable,
-        total_input_splits: List[int],
+        awaitable: TensorAllToAllValuesAwaitable,
+        pre_dist_mask: torch.Tensor,
     ) -> None:
         super().__init__()
-        self._ol_input_splits = ol_input_splits
-        self._nol_input_splits = nol_input_splits
-        self._splits_awaitable = splits_awaitable
-        self._total_input_splits = total_input_splits
+        self._awaitable = awaitable
+        self._pre_dist_mask = pre_dist_mask
 
-    def _wait_impl(self) -> CollisionSplits:
-        result = self._splits_awaitable.wait()
-        nol_received = result[0]
-        ol_received = [
-            self._total_input_splits[r] - nol_received[r]
-            for r in range(len(nol_received))
-        ]
-        return CollisionSplits(
-            input_splits=[self._ol_input_splits, self._nol_input_splits],
-            output_splits=[ol_received, nol_received],
-        )
+    def _wait_impl(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self._awaitable.wait().bool(), self._pre_dist_mask
 
 
-class CollisionHandlerBase(abc.ABC):
-    """Interface for PEC collision detection handlers.
-
-    Subclasses implement sharding-specific overlap detection logic.
-    """
-
-    @abc.abstractmethod
-    def detect_collisions(
-        self,
-        features: KeyedJaggedTensor,
-        prev_remapped_feature_values: torch.Tensor | None = None,
-    ) -> CollisionResult:
-        """Detects overlapping IDs between current and previous batch.
-
-        Args:
-            features: current batch features (after input dist)
-            prev_remapped_feature_values: previous batch's remapped_feature_values, None for first batch
-
-        Returns:
-            CollisionResult with forward/backward masks and remapped_feature_values
-        """
-        ...
-
-    @abc.abstractmethod
-    def reset(self) -> None:
-        """Resets internal state (e.g. at epoch boundary)."""
-        ...
-
-    @abc.abstractmethod
-    def permute_dist(
-        self,
-        # Forward: current batch
-        features: KeyedJaggedTensor,
-        sharding_ctx: SequenceShardingContext,
-        forward_overlap_mask: torch.Tensor,
-        # Backward: previous batch (all None for first batch)
-        prev_features: KeyedJaggedTensor | None = None,
-        prev_sharding_ctx: SequenceShardingContext | None = None,
-        backward_overlap_mask: torch.Tensor | None = None,
-    ) -> Awaitable[CollisionPermutation]:
-        """Distributes forward and backward partition permutations via AllToAll.
-
-        Sends forward overlap mask (current batch) and optionally backward
-        overlap mask (previous batch) from sharding ranks back to the original
-        rank. Both AllToAlls are fired together for batching.
-
-        Args:
-            features: current batch features after input_dist
-            sharding_ctx: current batch's sharding context
-            forward_overlap_mask: current batch's overlap mask
-            prev_features: previous batch's features (None for first batch)
-            prev_sharding_ctx: previous batch's sharding context
-            backward_overlap_mask: previous batch's backward mask
-
-        Returns:
-            Awaitable resolving to CollisionPermutation.
-        """
-        ...
-
-    @abc.abstractmethod
-    def split_dist(
-        self,
-        nonoverlapped_features: KeyedJaggedTensor,
-        sharding_ctx: SequenceShardingContext,
-    ) -> Awaitable[CollisionSplits]:
-        """Exchanges per-rank overlapped/nonoverlapped split sizes via AllToAll.
-
-        Computes how many nonoverlapped values this rank sends to each peer
-        rank, derives the overlapped counts from the total, and starts a
-        SplitsAllToAll. Returns an awaitable that resolves to CollisionSplits.
-
-        Args:
-            nonoverlapped_features: nonoverlapped partition KJT
-            sharding_ctx: sharding context from input_dist
-
-        Returns:
-            Awaitable resolving to CollisionSplits with per-rank send/receive
-            counts for each partition.
-        """
-        ...
-
-
-class RWCollisionHandler(CollisionHandlerBase):
-    """Row-wise collision handler for PEC.
-
-    Uses cumulative local_rows across all tables as the offset space for
-    BooleanMaskChecker. Each feature's IDs are offset by their table's
-    cumulative row position so that IDs from different tables don't collide.
-    """
+class RWOverlapHandler(OverlapHandler):
+    """Row-wise overlap handler for PEC."""
 
     def __init__(
         self,
@@ -400,6 +269,7 @@ class RWCollisionHandler(CollisionHandlerBase):
         assert (
             checker_type == OverlappingCheckerType.BOOLEAN
         ), f"Only BOOLEAN checker is supported, got {checker_type}"
+
         self._device = device
         self._pg = process_group
         self._feature_to_table_offset: Dict[str, int] = {}
@@ -416,9 +286,24 @@ class RWCollisionHandler(CollisionHandlerBase):
                     self._feature_to_table_offset[fname] = mask_size
                 mask_size += emb_table.local_rows
 
-        self._checker = BooleanMaskChecker(device, mask_size)
+        self._checker = BooleanOverlapChecker(device, mask_size)
 
-    def _remap_feature_values(self, features: KeyedJaggedTensor) -> torch.Tensor:
+    def remap_kjt_values(self, features: KeyedJaggedTensor) -> torch.Tensor:
+        """Adds per-table row offsets to make values unique within the shard.
+
+        In RW sharding, values from different tables may collide (e.g.,
+        table_0 row 3 and table_1 row 3 are both value 3). This adds
+        cumulative local_rows offsets per table so each value maps to a
+        unique position in the checker's boolean buffer.
+
+        Example: 2 tables with local_rows=8 each, features=[f0, f1].
+          table_0 offset = 0, table_1 offset = 8.
+          values = [0, 1, 2, 3] with keys=[f0, f1], lengths=[2, 2]
+          → remapped = [0+0, 1+0, 2+8, 3+8] = [0, 1, 10, 11]
+
+        The offset tensor is lazily initialized on the first call and
+        reused for subsequent batches.
+        """
         if self._input_features_offset.numel() == 0:
             offset_list = [
                 self._feature_to_table_offset[fname] for fname in features.keys()
@@ -437,105 +322,70 @@ class RWCollisionHandler(CollisionHandlerBase):
         )
         return features.values() + offsets.view(-1)
 
-    def detect_collisions(
+    def detect_overlap(
         self,
-        features: KeyedJaggedTensor,
-        prev_remapped_feature_values: torch.Tensor | None = None,
-    ) -> CollisionResult:
-        remapped_feature_values = self._remap_feature_values(features)
+        current_remapped: torch.Tensor | None,
+        prev_remapped: torch.Tensor | None,
+    ) -> OverlapMasks:
+        """Detects value overlap between current and previous batches.
 
-        if prev_remapped_feature_values is not None:
-            forward_overlap_mask = self._checker.check_overlap(remapped_feature_values)
-            self._checker.update(remapped_feature_values)
-            backward_overlap_mask = self._checker.check_overlap(
-                prev_remapped_feature_values
-            )
-        else:
-            forward_overlap_mask = torch.zeros(
-                features.values().numel(),
-                dtype=torch.bool,
-                device=self._device,
-            )
-            backward_overlap_mask = None
-            self._checker.update(remapped_feature_values)
+        First batch (prev None): no overlap possible, returns all-False
+        forward mask so all values go to the NOL partition.
 
-        return CollisionResult(
-            forward_overlap_mask=forward_overlap_mask,
-            backward_overlap_mask=backward_overlap_mask,
-            remapped_feature_values=remapped_feature_values,
-        )
+        Last batch (current None): no next batch to overlap with, returns
+        all-True backward mask so all previous values go through the OL
+        gradient path.
 
-    def reset(self) -> None:
-        self._checker.reset_mask()
-
-    def _compute_nonoverlapped_per_rank(
-        self,
-        nonoverlapped_features: KeyedJaggedTensor,
-        batch_size_per_rank: List[int],
-    ) -> torch.Tensor:
-        """Computes per-rank nonoverlapped value counts for RW sharding.
-
-        After RW input_dist, the KJT lengths are in feature-major order.
-        We transpose to batch-major, then use segment_sum_csr with
-        batch_size_per_rank as segment boundaries to sum lengths across
-        all features for each rank's batch elements.
+        Normal batch: runs the checker to produce per-value forward and
+        backward masks.
         """
-        batch_size_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(
-            torch.tensor(
-                batch_size_per_rank,
-                device=self._device,
-                dtype=torch.int64,
+        if prev_remapped is None:
+            assert current_remapped is not None
+            return OverlapMasks(
+                forward_overlap_mask=torch.zeros(
+                    current_remapped.numel(),
+                    dtype=torch.bool,
+                    device=self._device,
+                ),
+                backward_overlap_mask=None,
             )
-        )
-        num_features = len(nonoverlapped_features.keys())
-        lengths_batch_major = (
-            nonoverlapped_features.lengths().view(num_features, -1).t().flatten()
-        )
-        return torch.ops.fbgemm.segment_sum_csr(
-            num_features, batch_size_cumsum, lengths_batch_major
-        )
 
-    def split_dist(
-        self,
-        nonoverlapped_features: KeyedJaggedTensor,
-        sharding_ctx: SequenceShardingContext,
-    ) -> CollisionSplitsAwaitable:
-        """Computes per-rank ol/nol split sizes and exchanges via AllToAll."""
-        assert sharding_ctx.batch_size_per_rank is not None
-        nol = self._compute_nonoverlapped_per_rank(
-            nonoverlapped_features, sharding_ctx.batch_size_per_rank
-        )
-        ol = (
-            torch.tensor(
-                sharding_ctx.output_splits,
-                device=nol.device,
-                dtype=nol.dtype,
+        if current_remapped is None:
+            return OverlapMasks(
+                forward_overlap_mask=None,
+                backward_overlap_mask=torch.ones(
+                    prev_remapped.numel(),
+                    dtype=torch.bool,
+                    device=self._device,
+                ),
             )
-            - nol
+
+        fwd_mask, bwd_mask = self._checker.check(current_remapped, prev_remapped)
+        return OverlapMasks(
+            forward_overlap_mask=fwd_mask,
+            backward_overlap_mask=bwd_mask,
         )
 
-        splits_awaitable = SplitsAllToAllAwaitable([nol], self._pg)
-
-        return CollisionSplitsAwaitable(
-            ol_input_splits=ol.tolist(),
-            nol_input_splits=nol.tolist(),
-            splits_awaitable=splits_awaitable,
-            total_input_splits=sharding_ctx.input_splits,
-        )
-
-    def _mask_dist(
+    def mask_dist(
         self,
         features: KeyedJaggedTensor,
         sharding_ctx: SequenceShardingContext,
         overlap_mask: torch.Tensor,
-    ) -> TensorAllToAllValuesAwaitable:
-        """Permutes mask to rank-major order and starts reverse AllToAll."""
+    ) -> MaskDistAwaitable:
+        """Permutes mask from feature-major to rank-major order via recat, then
+        AllToAll.
+
+        In RW sharding, input_dist recats features from [f0_r0, f0_r1,
+        f1_r0, f1_r1] (feature-major) to [f0_r0, f1_r0, f0_r1, f1_r1]
+        (rank-major). The mask must follow the same recat before AllToAll
+        so it aligns with the per-rank splits in sharding_ctx.
+        """
         assert sharding_ctx.sparse_features_recat is not None
 
         recat = torch.ops.fbgemm.invert_permute(sharding_ctx.sparse_features_recat)
         mask_int = overlap_mask.to(torch.int32)
 
-        _, permuted_mask, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+        _, pre_dist_mask, _ = torch.ops.fbgemm.permute_2D_sparse_data(
             recat,
             features.lengths().view(recat.shape[0], -1),
             mask_int,
@@ -543,9 +393,9 @@ class RWCollisionHandler(CollisionHandlerBase):
             mask_int.numel(),
         )
 
-        return TensorAllToAllValuesAwaitable(
+        values_awaitable = TensorAllToAllValuesAwaitable(
             self._pg,
-            permuted_mask,
+            pre_dist_mask,
             input_splits=torch.tensor(
                 sharding_ctx.output_splits,
                 dtype=torch.int32,
@@ -554,61 +404,165 @@ class RWCollisionHandler(CollisionHandlerBase):
                 sharding_ctx.input_splits,
                 dtype=torch.int32,
             ),
-            device=permuted_mask.device,
+            device=pre_dist_mask.device,
         )
 
-    def permute_dist(
+        return MaskDistAwaitable(values_awaitable, pre_dist_mask)
+
+    def compute_splits(
         self,
-        features: KeyedJaggedTensor,
+        post_dist_mask: torch.Tensor,
+        pre_dist_mask: torch.Tensor,
         sharding_ctx: SequenceShardingContext,
-        forward_overlap_mask: torch.Tensor,
-        prev_features: KeyedJaggedTensor | None = None,
-        prev_sharding_ctx: SequenceShardingContext | None = None,
-        backward_overlap_mask: torch.Tensor | None = None,
-    ) -> CollisionPermuteAwaitable:
-        """Fires forward (and optionally backward) mask AllToAlls together."""
+    ) -> OverlapSplits:
+        """Segments the mask by per-rank splits to get OL/NOL counts.
+
+        Uses sharding_ctx.input_splits as segment boundaries for
+        post_dist_mask, and sharding_ctx.output_splits as segment
+        boundaries for pre_dist_mask. segment_sum_csr counts True
+        values per segment to produce OL counts; NOL = total - OL.
+
+        Example: world_size=2, post_dist_mask = [T, F, T, T, F, F]
+          input_splits = [3, 3] → segments [T,F,T] and [T,F,F]
+          ol_input = [2, 1], nol_input = [1, 2]
+          → input_splits = ([2, 1], [1, 2])
+        """
+        device = post_dist_mask.device
+
+        # Input splits (what this rank sends): from post-dist mask
+        input_total = torch.tensor(
+            sharding_ctx.input_splits,
+            device=device,
+            dtype=torch.int64,
+        )
+        input_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(input_total)
+        ol_input = torch.ops.fbgemm.segment_sum_csr(
+            1,
+            input_cumsum,
+            post_dist_mask.long(),
+        )
+        nol_input = input_total - ol_input
+
+        # Output splits (what this rank receives): from pre-dist mask
+        output_total = torch.tensor(
+            sharding_ctx.output_splits,
+            device=device,
+            dtype=torch.int64,
+        )
+        output_cumsum = torch.ops.fbgemm.asynchronous_complete_cumsum(output_total)
+        ol_output = torch.ops.fbgemm.segment_sum_csr(
+            1,
+            output_cumsum,
+            pre_dist_mask.long(),
+        )
+        nol_output = output_total - ol_output
+
+        return OverlapSplits(
+            input_splits=(ol_input.tolist(), nol_input.tolist()),
+            output_splits=(ol_output.tolist(), nol_output.tolist()),
+        )
+
+    def compute_forward_permute(
+        self,
+        post_dist_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> torch.Tensor:
+        """Builds a permutation that merges [OL, NOL] back to original order.
+
+        After OL and NOL embeddings are AllToAll'd back separately, they
+        arrive as [ol_embs, nol_embs]. This computes a permutation that
+        maps each position to its slot in [ol, nol] order, composed with
+        unbucketize_permute_tensor to undo input_dist bucketization.
+
+        Example:
+          Assume world_size = 2, hash_size = 6
+          - KJT values: [5, 3, 0, 1, 2, 4]
+          - bucketized: [0, 1, 2, 5, 3, 4]
+          - upt: [3, 4, 0, 1, 2, 5]
+
+          Assume overlaps:
+          - rank 0: [0, 1, 2] -> [F, T, T]
+          - rank 1: [5, 3, 4] -> [T, F, F]
+
+          post_dist_mask = [F, T, T, T, F, F] in bucketized order
+          ol_rank  = cumsum([0,1,1,1,0,0]) - 1 = [-1, 0, 1, 2, 2, 2]
+          nol_rank = cumsum([1,0,0,0,1,1]) - 1 + 3 = [3, 3, 3, 3, 4, 5]
+          bucket_to_merged = [3 (nol), 0(ol), 1(ol), 2(ol), 4(nol), 5(nol)]
+          merged_order = [1, 2, 5] (ol) + [0, 3, 4] (nol)
+
+          bucket_to_merged will map merged_order back to bucketized order above:
+            [1, 2, 5, 0, 3, 4] -> [0, 1, 2, 5, 3, 4]
+          And then upt can unbucketize to the original order.
+
+        """
+        assert sharding_ctx.unbucketize_permute_tensor is not None
+        upt = sharding_ctx.unbucketize_permute_tensor
+
+        num_ol = post_dist_mask.sum()
+        ol_rank = post_dist_mask.long().cumsum(0) - 1
+        nol_rank = (~post_dist_mask).long().cumsum(0) - 1 + num_ol
+        bucket_to_merged = torch.where(post_dist_mask, ol_rank, nol_rank)
+
+        return bucket_to_merged[upt]
+
+    def compute_backward_permutes(
+        self,
+        post_dist_mask: torch.Tensor,
+        sharding_ctx: SequenceShardingContext,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Computes indices to split the backward gradient into OL and NOL.
+
+        During backward, gradients arrive in original (pre-input-dist)
+        order. We need to select OL and NOL gradients separately for
+        their respective AllToAlls. The selected indices must be in
+        rank-major (bucketized) order to align with AllToAll splits.
+
+        recat = invert_permute(upt) maps original_pos → bucket_pos.
+        We find which bucket positions are OL vs NOL from the mask,
+        then index into recat so index_select produces gradients in
+        rank-major order directly.
+
+        Example:
+          Same setup as compute_forward_permute:
+          - KJT values: [5, 3, 0, 1, 2, 4]
+          - bucketized: [0, 1, 2, 5, 3, 4]
+          - upt: [3, 4, 0, 1, 2, 5]
+          - post_dist_mask = [F, T, T, T, F, F] in bucketized order
+
+          recat = invert_permute(upt) = [2, 3, 4, 0, 1, 5]
+          ol_bucket_indices  = where(mask)  = [1, 2, 3]
+          nol_bucket_indices = where(~mask) = [0, 4, 5]
+          ol_permute  = recat[[1, 2, 3]] = [3, 4, 0]
+          nol_permute = recat[[0, 4, 5]] = [2, 1, 5]
+
+          Usage: grad_output is in original order [5, 3, 0, 1, 2, 4].
+            ol_grad  = grad_output.index_select(0, ol_permute)
+                     = grad_output[[3, 4, 0]] -> grads for [1, 2, 5]
+            nol_grad = grad_output.index_select(0, nol_permute)
+                     = grad_output[[2, 1, 5]] -> grads for [0, 3, 4]
+          Both are in rank-major order, ready for gradient AllToAll.
+
+        """
         assert sharding_ctx.unbucketize_permute_tensor is not None
 
-        fwd_awaitable = self._mask_dist(
-            features,
-            sharding_ctx,
-            forward_overlap_mask,
-        )
+        recat = torch.ops.fbgemm.invert_permute(sharding_ctx.unbucketize_permute_tensor)
+        (ol_bucket_indices,) = torch.where(post_dist_mask)
+        (nol_bucket_indices,) = torch.where(~post_dist_mask)
 
-        bwd_awaitable = None
-        bwd_unbucketize_permute = None
-
-        if backward_overlap_mask is not None:
-            assert prev_features is not None
-            assert prev_sharding_ctx is not None
-            assert prev_sharding_ctx.unbucketize_permute_tensor is not None
-
-            bwd_awaitable = self._mask_dist(
-                prev_features,
-                prev_sharding_ctx,
-                backward_overlap_mask,
-            )
-            bwd_unbucketize_permute = prev_sharding_ctx.unbucketize_permute_tensor
-
-        return CollisionPermuteAwaitable(
-            fwd_awaitable=fwd_awaitable,
-            fwd_unbucketize_permute=sharding_ctx.unbucketize_permute_tensor,
-            bwd_awaitable=bwd_awaitable,
-            bwd_unbucketize_permute=bwd_unbucketize_permute,
-        )
+        return recat[ol_bucket_indices], recat[nol_bucket_indices]
 
 
-def create_collision_handler(
+def create_overlap_handler(
     sharding_type: str,
     device: torch.device,
     grouped_emb_configs: List[GroupedEmbeddingConfig],
     table_name_to_config: Dict[str, EmbeddingConfig],
     process_group: dist.ProcessGroup,
     checker_type: OverlappingCheckerType,
-) -> CollisionHandlerBase:
-    """Creates a collision handler for the given sharding type."""
+) -> OverlapHandler:
+    """Creates an overlap handler for the given sharding type."""
     if sharding_type == "row_wise":
-        return RWCollisionHandler(
+        return RWOverlapHandler(
             device=device,
             grouped_emb_configs=grouped_emb_configs,
             table_name_to_config=table_name_to_config,
@@ -616,5 +570,5 @@ def create_collision_handler(
             checker_type=checker_type,
         )
     raise ValueError(
-        f"PEC collision detection does not support sharding type: {sharding_type}"
+        f"PEC overlap detection does not support sharding type: {sharding_type}"
     )

--- a/torchrec/distributed/pec_comm_ops.py
+++ b/torchrec/distributed/pec_comm_ops.py
@@ -14,10 +14,7 @@ from typing import List, Tuple
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.pec_collision_handlers import (
-    CollisionPermutation,
-    CollisionSplits,
-)
+from torchrec.distributed.pec_collision_handlers import OverlapSplits
 
 
 @dataclass
@@ -33,28 +30,25 @@ class PECAll2AllSeqInfo:
     will be added in a future diff.
 
     Attributes:
-        permutation: CollisionPermutation containing forward_permute (used in
-            forward merge) and backward_ol_permute/backward_nol_permute
-            (pre-composed original-order indices for splitting gradients
-            in rank-major order — no separate recat needed).
-        backward_splits: Previous batch's forward CollisionSplits, reused as
-            the gradient AllToAll split sizes. None until set by pipeline.
+        forward_permute: Permute tensor for merging [ol, nol] → original order.
+        backward_ol_permute: Original-order indices for OL gradient split.
+        backward_nol_permute: Original-order indices for NOL gradient split.
+        backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
         pg: Process group for gradient AllToAll.
 
     Gradient outputs (set by PECAll2AllSeqWait.backward):
         ol_grad_work: Async work handle for OL gradient AllToAll.
-            Pipeline must wait before applying.
         ol_grad_local: Output buffer for OL gradient AllToAll.
-        nol_grad: NOL gradient tensor. Pipeline starts its own deferred
-            AllToAll using backward_splits.[input|output]_splits[1].
+        nol_grad: NOL gradient tensor for deferred AllToAll.
     """
 
-    permutation: CollisionPermutation
+    forward_permute: torch.Tensor
+    backward_ol_permute: torch.Tensor | None = None
+    backward_nol_permute: torch.Tensor | None = None
+    backward_splits: OverlapSplits | None = None
     pg: dist.ProcessGroup | None = None
-    backward_splits: CollisionSplits | None = None
 
-    # Gradient outputs — set by PECAll2AllSeqWait.backward, read by pipeline.
-    # Pipeline is responsible for wait + apply (future: gradient manager class).
+    # Gradient outputs — set by PECAll2AllSeqWait.backward
     ol_grad_work: dist.Work | None = None
     ol_grad_local: torch.Tensor | None = None
     nol_grad: torch.Tensor | None = None
@@ -128,9 +122,7 @@ class PECAll2AllSeqWait(torch.autograd.Function):
         ctx.backward_ctx = backward_ctx  # pyre-ignore[16]
 
         merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
-        return torch.index_select(
-            merged_embs, 0, backward_ctx.permutation.forward_permute
-        )
+        return torch.index_select(merged_embs, 0, backward_ctx.forward_permute)
 
     @staticmethod
     # pyre-ignore[14]
@@ -139,11 +131,10 @@ class PECAll2AllSeqWait(torch.autograd.Function):
         grad_output: torch.Tensor,
     ) -> Tuple[None, None, None]:
         backward_ctx: PECAll2AllSeqInfo = ctx.backward_ctx  # pyre-ignore[16]
-        perm = backward_ctx.permutation
         splits = backward_ctx.backward_splits
 
-        assert perm.backward_ol_permute is not None
-        assert perm.backward_nol_permute is not None
+        assert backward_ctx.backward_ol_permute is not None
+        assert backward_ctx.backward_nol_permute is not None
         assert splits is not None
         assert backward_ctx.pg is not None
 
@@ -151,8 +142,8 @@ class PECAll2AllSeqWait(torch.autograd.Function):
 
         # Split gradient into ol/nol. Permute indices are pre-composed
         # with recat, so index_select produces rank-major order directly.
-        ol_grad = grad_output.index_select(0, perm.backward_ol_permute)
-        nol_grad = grad_output.index_select(0, perm.backward_nol_permute)
+        ol_grad = grad_output.index_select(0, backward_ctx.backward_ol_permute)
+        nol_grad = grad_output.index_select(0, backward_ctx.backward_nol_permute)
 
         # 3. Start async reverse AllToAll for OL grad
         ol_grad_work, ol_grad_local = _grad_dist(

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Tuple, Type
 
 import torch
 import torch.nn as nn
@@ -27,13 +27,15 @@ from torchrec.distributed.embedding_types import (
     ShardedEmbeddingModule,
 )
 from torchrec.distributed.pec_collision_handlers import (
-    CollisionHandlerBase,
-    CollisionPermutation,
-    CollisionResult,
-    CollisionSplits,
-    create_collision_handler,
+    create_overlap_handler,
+    MaskDistAwaitable,
+    OverlapHandler,
+    OverlapMasks,
+    OverlapSplits,
+    split_kjt_by_values_mask,
 )
 from torchrec.distributed.pec_comm_ops import PECAll2AllSeqInfo, PECAll2AllSeqWait
+from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import (
     Awaitable,
     LazyAwaitable,
@@ -47,19 +49,248 @@ from torchrec.modules.utils import construct_jagged_tensors
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
-@dataclass
-class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
-    """Per-module context for ShardedPECEmbeddingCollection.
+def _mask_dist(
+    handler: OverlapHandler,
+    features: KeyedJaggedTensor | None,
+    sharding_ctx: SequenceShardingContext | None,
+    prev_features: KeyedJaggedTensor | None,
+    prev_sharding_ctx: SequenceShardingContext | None,
+    masks: OverlapMasks,
+) -> Tuple[MaskDistAwaitable | None, MaskDistAwaitable | None]:
+    """Starts forward and backward mask AllToAlls for one sharding group.
 
-    Inherits from EmbeddingCollectionContext so it can be passed directly
-    to the inner ShardedEmbeddingCollection's compute/output_dist methods.
+    Kicks off both AllToAlls (non-blocking) before any local work, so
+    they overlap with the subsequent _split_kjt computation. Returns
+    None for a direction whose mask is None (first/last batch).
+
+    Args:
+        handler: sharding-specific overlap handler.
+        features: current batch features after input_dist. None for last batch.
+        sharding_ctx: current batch sharding context. None for last batch.
+        prev_features: previous batch features after input_dist. None for first batch.
+        prev_sharding_ctx: previous batch sharding context. None for first batch.
+        masks: overlap masks from detect_overlap.
+
+    Returns:
+        (forward_mask_awaitable, backward_mask_awaitable). Either may be None.
+    """
+    fwd_aw = None
+    if masks.forward_overlap_mask is not None:
+        assert features is not None and sharding_ctx is not None
+        fwd_aw = handler.mask_dist(
+            features,
+            sharding_ctx,
+            masks.forward_overlap_mask,
+        )
+
+    bwd_aw = None
+    if masks.backward_overlap_mask is not None:
+        assert prev_features is not None and prev_sharding_ctx is not None
+        bwd_aw = handler.mask_dist(
+            prev_features,
+            prev_sharding_ctx,
+            masks.backward_overlap_mask,
+        )
+
+    return fwd_aw, bwd_aw
+
+
+def _split_kjt(
+    features: KeyedJaggedTensor | None,
+    prev_features: KeyedJaggedTensor | None,
+    masks: OverlapMasks,
+) -> Tuple[
+    KeyedJaggedTensor | None,
+    KeyedJaggedTensor | None,
+    KeyedJaggedTensor | None,
+    KeyedJaggedTensor | None,
+]:
+    """Splits current and prev features into OL/NOL partitions for one group.
+
+    Args:
+        features: current batch features. None for last batch.
+        prev_features: previous batch features. None for first batch.
+        masks: overlap masks from detect_overlap.
+
+    Returns:
+        (ol_kjt, nol_kjt, bwd_ol_kjt, bwd_nol_kjt). Any pair may be
+        (None, None) if the corresponding mask is None.
+    """
+    ol_kjt, nol_kjt = None, None
+    if masks.forward_overlap_mask is not None:
+        assert features is not None
+        ol_kjt, nol_kjt = split_kjt_by_values_mask(
+            features,
+            masks.forward_overlap_mask,
+        )
+
+    bwd_ol_kjt, bwd_nol_kjt = None, None
+    if masks.backward_overlap_mask is not None:
+        assert prev_features is not None
+        bwd_ol_kjt, bwd_nol_kjt = split_kjt_by_values_mask(
+            prev_features,
+            masks.backward_overlap_mask,
+        )
+
+    return ol_kjt, nol_kjt, bwd_ol_kjt, bwd_nol_kjt
+
+
+@dataclass
+class ForwardPartitionContext:
+    """Forward partition result for one sharding group, produced by
+    OverlapDistAwaitable on wait.
+
+    Attributes:
+        splits: per-rank OL/NOL split sizes for the embedding AllToAll.
+        permute: permutation tensor that merges [ol, nol] embeddings
+            back to the original (pre-split) order.
+        ol_features: overlapped partition KJT (values present in prev batch).
+        nol_features: nonoverlapped partition KJT (values not in prev batch).
     """
 
-    prev_remapped_feature_values: List[torch.Tensor] | None = None
+    splits: OverlapSplits
+    permute: torch.Tensor
+    ol_features: KeyedJaggedTensor
+    nol_features: KeyedJaggedTensor
 
-    # Set by merge_partitioned_embeddings, read by pipeline during backward.
-    # One per sharding group.
-    backward_ctxs: List[PECAll2AllSeqInfo] | None = None
+
+@dataclass
+class BackwardPartitionContext:
+    """Backward partition result for one sharding group.
+
+    Produced by OverlapDistAwaitable on wait. Contains the previous
+    batch's features re-split by overlap with the current batch, for
+    gradient re-routing during backward. The pipeline sets these on
+    PECAll2AllSeqInfo before calling loss.backward().
+
+    Attributes:
+        splits: per-rank OL/NOL split sizes for gradient AllToAll.
+        ol_permute: indices into the gradient tensor for OL values,
+            pre-composed with recat for rank-major AllToAll alignment.
+        nol_permute: indices into the gradient tensor for NOL values,
+            pre-composed with recat for rank-major AllToAll alignment.
+        ol_features: overlapped partition KJT of the previous batch.
+        nol_features: nonoverlapped partition KJT of the previous batch.
+            Empty (zero values) when backward mask is all-True (last batch).
+    """
+
+    splits: OverlapSplits
+    ol_permute: torch.Tensor
+    nol_permute: torch.Tensor
+    ol_features: KeyedJaggedTensor
+    nol_features: KeyedJaggedTensor
+
+
+OverlapDistOutput = Tuple[
+    ForwardPartitionContext | None, BackwardPartitionContext | None
+]
+
+
+class OverlapDistAwaitable(LazyAwaitable[OverlapDistOutput]):
+    """Awaitable that resolves mask AllToAlls and produces partition contexts.
+
+    Created by overlap_dist with in-flight mask AllToAlls. On wait,
+    completes the AllToAlls and computes splits + permutations from the
+    received masks, returning (ForwardPartitionContext, BackwardPartitionContext).
+    Either may be None: forward is None for last-batch finalization,
+    backward is None for the first batch.
+    """
+
+    def __init__(
+        self,
+        handler: OverlapHandler,
+        ol_features: KeyedJaggedTensor | None,
+        nol_features: KeyedJaggedTensor | None,
+        forward_mask_dist: MaskDistAwaitable | None,
+        forward_sharding_ctx: SequenceShardingContext | None,
+        backward_mask_dist: MaskDistAwaitable | None,
+        backward_sharding_ctx: SequenceShardingContext | None,
+        bwd_ol_features: KeyedJaggedTensor | None,
+        bwd_nol_features: KeyedJaggedTensor | None,
+    ) -> None:
+        super().__init__()
+        self._handler = handler
+
+        # Forward fields (None for last-batch finalization)
+        self._ol_features = ol_features
+        self._nol_features = nol_features
+        self._forward_mask_dist = forward_mask_dist
+        self._forward_sharding_ctx = forward_sharding_ctx
+
+        # Backward fields (None for first batch)
+        self._backward_mask_dist = backward_mask_dist
+        self._backward_sharding_ctx = backward_sharding_ctx
+        self._bwd_ol_features = bwd_ol_features
+        self._bwd_nol_features = bwd_nol_features
+
+    def _wait_impl(self) -> OverlapDistOutput:
+        forward_ctx = None
+        backward_ctx = None
+
+        if self._forward_mask_dist is not None:
+            assert self._forward_sharding_ctx is not None
+            assert self._ol_features is not None
+            assert self._nol_features is not None
+
+            fwd_post_dist_mask, fwd_pre_dist_mask = self._forward_mask_dist.wait()
+            forward_ctx = ForwardPartitionContext(
+                ol_features=self._ol_features,
+                nol_features=self._nol_features,
+                splits=self._handler.compute_splits(
+                    fwd_post_dist_mask,
+                    fwd_pre_dist_mask,
+                    self._forward_sharding_ctx,
+                ),
+                permute=self._handler.compute_forward_permute(
+                    fwd_post_dist_mask,
+                    self._forward_sharding_ctx,
+                ),
+            )
+
+        if self._backward_mask_dist is not None:
+            assert self._backward_sharding_ctx is not None
+            assert self._bwd_ol_features is not None
+            assert self._bwd_nol_features is not None
+
+            bwd_post_dist_mask, bwd_pre_dist_mask = self._backward_mask_dist.wait()
+            bwd_ol_permute, bwd_nol_permute = self._handler.compute_backward_permutes(
+                bwd_post_dist_mask,
+                self._backward_sharding_ctx,
+            )
+            backward_ctx = BackwardPartitionContext(
+                splits=self._handler.compute_splits(
+                    bwd_post_dist_mask,
+                    bwd_pre_dist_mask,
+                    self._backward_sharding_ctx,
+                ),
+                ol_permute=bwd_ol_permute,
+                nol_permute=bwd_nol_permute,
+                ol_features=self._bwd_ol_features,
+                nol_features=self._bwd_nol_features,
+            )
+
+        return forward_ctx, backward_ctx
+
+
+@dataclass
+class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
+    """Per-batch context for ShardedPECEmbeddingCollection.
+
+    Extends EmbeddingCollectionContext with PEC-specific state. Passed
+    to all pipeline stages for a single batch.
+
+    Attributes:
+        remapped_kjt_values: Cached remapped values per sharding group,
+            set by overlap_dist. Used by the next batch's overlap_dist
+            to detect overlap without re-remapping.
+        backward_ctx_per_group: PECAll2AllSeqInfo per sharding group,
+            set by merge_partitioned_embeddings. The pipeline sets
+            backward fields from the next batch's overlap_dist, then
+            read by PECAll2AllSeqWait during loss.backward().
+    """
+
+    remapped_kjt_values: List[torch.Tensor] | None = None
+    backward_ctx_per_group: List[PECAll2AllSeqInfo] | None = None
 
 
 class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
@@ -153,13 +384,13 @@ class ShardedPECEmbeddingCollection(
         self._env: ShardingEnv = env
 
         assert env.process_group is not None
-        self._collision_handlers: List[CollisionHandlerBase] = []
+        self._overlap_handlers: List[OverlapHandler] = []
         for (
             sharding_type,
             sharding,
         ) in self._embedding_collection._sharding_type_to_sharding.items():
-            self._collision_handlers.append(
-                create_collision_handler(
+            self._overlap_handlers.append(
+                create_overlap_handler(
                     sharding_type=sharding_type,
                     device=device,
                     grouped_emb_configs=sharding._grouped_embedding_configs,  # pyre-ignore[16]
@@ -200,139 +431,100 @@ class ShardedPECEmbeddingCollection(
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
         return self._embedding_collection.compute_and_output_dist(ctx, input)
 
-    def detect_collisions(
+    def overlap_dist(
         self,
-        ctx: PECEmbeddingCollectionContext,
-        dist_input: KJTList,
-    ) -> List[CollisionResult]:
-        """Detects collisions for each sharding group's features.
-
-        Reads ctx.prev_remapped_feature_values (set by the pipeline from the
-        previous batch's CollisionResult). Returns masks only — KJT splitting
-        is done externally via split_features_by_values_mask().
-
-        Args:
-            ctx: PEC context for this batch. Pipeline sets
-                ctx.prev_remapped_feature_values from the previous batch's
-                CollisionResult.remapped_feature_values (None for first batch).
-            dist_input: KJTList from input_dist (one KJT per sharding group)
-
-        Returns:
-            List of CollisionResult (one per sharding group, typically just one for RW)
-        """
-        prev_values = ctx.prev_remapped_feature_values
-        results: List[CollisionResult] = []
-        for i, (handler, features) in enumerate(
-            zip(self._collision_handlers, dist_input)
-        ):
-            prev = prev_values[i] if prev_values is not None else None
-            results.append(handler.detect_collisions(features, prev))
-        return results
-
-    def collision_split_dist(
-        self,
-        ctx: PECEmbeddingCollectionContext,
-        nonoverlapped_features: List[KeyedJaggedTensor],
-    ) -> List[Awaitable[CollisionSplits]]:
-        """Exchanges per-rank overlapped/nonoverlapped split sizes via AllToAll.
-
-        Delegates to each handler's split_dist. Each awaitable resolves
-        to CollisionSplits with per-rank send/receive counts for
-        overlapped and nonoverlapped partitions.
-
-        Args:
-            ctx: PEC context (sharding_contexts must be set from input_dist)
-            nonoverlapped_features: one nonoverlapped KJT per
-                sharding group, from split_features_by_values_mask()
-                # TODO: test with multiple sharding groups
-
-        Returns:
-            List of Awaitable[CollisionSplits], one per sharding group.
-        """
-        return [
-            handler.split_dist(
-                nol_features,
-                sharding_ctx,
-            )
-            for handler, nol_features, sharding_ctx in zip(
-                self._collision_handlers,
-                nonoverlapped_features,
-                ctx.sharding_contexts,
-            )
-        ]
-
-    def permute_dist(
-        self,
-        ctx: PECEmbeddingCollectionContext,
-        features_per_group: List[KeyedJaggedTensor],
-        overlap_results: List[CollisionResult],
+        ctx: PECEmbeddingCollectionContext | None = None,
+        dist_input: KJTList | None = None,
         prev_ctx: PECEmbeddingCollectionContext | None = None,
-        prev_features_per_group: List[KeyedJaggedTensor] | None = None,
-    ) -> List[Awaitable[CollisionPermutation]]:
-        """Distributes forward and backward partition permutations via AllToAll.
+        prev_dist_input: KJTList | None = None,
+    ) -> List[LazyAwaitable[OverlapDistOutput]]:
+        """Detects and distributes overlap between batches.
 
-        PEC partitions each batch into overlapped (ol) and nonoverlapped (nol)
-        values relative to the previous batch. The nol partition's lookup can
-        start early in batch i - 1 since those values don't conflict. The ol
-        partition must wait for batch i-1's gradient update before lookup.
+        For each sharding group: remaps current values, detects overlap
+        with the previous batch, starts mask AllToAlls (non-blocking),
+        and splits features into OL/NOL partitions while AllToAlls are
+        in flight. Returns LazyAwaitables that compute splits and
+        permutations from the received masks on wait.
 
-        Forward mask (batch i): produces forward_permute for merging [ol, nol]
-        embeddings back to original order after both lookups complete.
+        Handles three batch positions based on which args are None:
+        - First batch (ctx set, prev_ctx None): forward only, no backward
+        - Normal batch (both set): forward + backward
+        - Last batch finalization (ctx None, prev_ctx set): backward only
 
-        Backward mask (batch i-1): produces backward_permute for re-splitting
-        batch i-1's gradients into ol/nol. The ol gradient update of batch i - 1
-        must finish before batch i's ol lookup can proceed. The nol gradient
-        update of batch i - 1 can be deferred further into batch i since those
-        values don't conflict.
-
-        Both AllToAlls are fired together per handler for batching. The
-        backward mask lives on the previous batch's sharding ranks, so its
-        AllToAll needs prev_features (for lengths) and prev_ctx (for splits
-        and unbucketize_permute). The pipeline saves these across batches.
+        The pipeline calls this during prefetch, then unpacks
+        ForwardPartitionContext for compute_and_output_dist_in_partition
+        and BackwardPartitionContext for gradient re-routing.
 
         Args:
-            ctx: PEC context for current batch (sharding contexts as state)
-            features_per_group: current batch features after input_dist
-            overlap_results: from detect_collisions, contains both forward
-                and backward overlap masks
-            prev_ctx: previous batch's PEC context, needed for backward mask
-                AllToAll (None for first batch)
-            prev_features_per_group: previous batch's features after input_dist,
-                needed for backward mask AllToAll (None for first batch)
+            ctx: PEC context for current batch. None for last-batch
+                finalization.
+            dist_input: KJTList from input_dist (one KJT per sharding
+                group). None for last-batch finalization.
+            prev_ctx: Previous batch's PEC context (has remapped_kjt_values
+                and sharding_contexts). None for first batch.
+            prev_dist_input: Previous batch's features after input_dist.
+                None for first batch.
 
         Returns:
-            List of Awaitable[CollisionPermutation], one per sharding group.
+            List of LazyAwaitable[OverlapDistOutput], one per sharding
+            group. Each resolves to (ForwardPartitionContext | None,
+            BackwardPartitionContext | None).
         """
-        awaitables: List[Awaitable[CollisionPermutation]] = []
+        assert ctx is not None or prev_ctx is not None
 
-        for i, (handler, features, result, sharding_ctx) in enumerate(
-            zip(
-                self._collision_handlers,
-                features_per_group,
-                overlap_results,
-                ctx.sharding_contexts,
-            )
-        ):
-            bwd_mask = result.backward_overlap_mask
-            prev_features = None
-            prev_sharding_ctx = None
+        remapped_values = []
+        awaitables: List[LazyAwaitable[OverlapDistOutput]] = []
 
-            if bwd_mask is not None:
-                assert prev_ctx is not None
-                assert prev_features_per_group is not None
-                prev_features = prev_features_per_group[i]
+        for i, handler in enumerate(self._overlap_handlers):
+            current_remapped, sharding_ctx, features = None, None, None
+            if ctx is not None:
+                assert dist_input is not None
+                current_remapped = handler.remap_kjt_values(dist_input[i])
+                sharding_ctx = ctx.sharding_contexts[i]
+                features = dist_input[i]
+                remapped_values.append(current_remapped)
+
+            prev_remapped, prev_sharding_ctx, prev_features = None, None, None
+            if prev_ctx is not None:
+                assert prev_ctx.remapped_kjt_values is not None
+                assert prev_dist_input is not None
+                prev_remapped = prev_ctx.remapped_kjt_values[i]
                 prev_sharding_ctx = prev_ctx.sharding_contexts[i]
+                prev_features = prev_dist_input[i]
+
+            masks = handler.detect_overlap(current_remapped, prev_remapped)
+
+            fwd_aw, bwd_aw = _mask_dist(
+                handler=handler,
+                features=features,
+                sharding_ctx=sharding_ctx,
+                prev_features=prev_features,
+                prev_sharding_ctx=prev_sharding_ctx,
+                masks=masks,
+            )
+
+            ol_kjt, nol_kjt, bwd_ol_kjt, bwd_nol_kjt = _split_kjt(
+                features=features,
+                prev_features=prev_features,
+                masks=masks,
+            )
 
             awaitables.append(
-                handler.permute_dist(
-                    features,
-                    sharding_ctx,
-                    result.forward_overlap_mask,
-                    prev_features=prev_features,
-                    prev_sharding_ctx=prev_sharding_ctx,
-                    backward_overlap_mask=bwd_mask,
+                OverlapDistAwaitable(
+                    handler=handler,
+                    ol_features=ol_kjt,
+                    nol_features=nol_kjt,
+                    forward_mask_dist=fwd_aw,
+                    forward_sharding_ctx=sharding_ctx,
+                    backward_mask_dist=bwd_aw,
+                    backward_sharding_ctx=prev_sharding_ctx,
+                    bwd_ol_features=bwd_ol_kjt,
+                    bwd_nol_features=bwd_nol_kjt,
                 )
             )
+
+        if ctx is not None:
+            ctx.remapped_kjt_values = remapped_values
 
         return awaitables
 
@@ -340,21 +532,29 @@ class ShardedPECEmbeddingCollection(
         self,
         ctx: PECEmbeddingCollectionContext,
         features: KeyedJaggedTensor,
-        collision_splits: CollisionSplits,
+        overlap_splits: OverlapSplits,
         is_overlapped: bool,
     ) -> List[Awaitable[torch.Tensor]]:
         """Performs embedding lookup and output AllToAll for one partition.
 
-        Looks up embeddings for the partition's features using the inner EC's
-        lookup module, then AllToAll's the results back using partition-specific
-        splits. The embedding AllToAll reverses the direction of the features
-        AllToAll, so collision output_splits become embedding input_splits.
+        Looks up embeddings for the partition's features using the inner
+        EC's lookup module, then AllToAll's the results back using
+        partition-specific splits from ForwardPartitionContext.splits.
+
+        Called twice per batch: once for OL (is_overlapped=True) and
+        once for NOL (is_overlapped=False). The partition may be empty
+        (e.g., first batch OL when no overlap exists) — empty lookups
+        and zero-length AllToAll segments are handled correctly.
 
         Args:
-            ctx: PEC context (sharding_contexts must be set from input_dist)
-            features: partition features (ol or nol KJT)
-            collision_splits: splits from split_dist
-            is_overlapped: True for overlapped partition, False for nonoverlapped
+            ctx: PEC context (sharding_contexts must be set from
+                input_dist).
+            features: partition features (OL or NOL KJT from
+                ForwardPartitionContext).
+            overlap_splits: per-rank OL/NOL split sizes from
+                ForwardPartitionContext.splits.
+            is_overlapped: True for overlapped partition (index 0 in
+                splits), False for nonoverlapped (index 1).
 
         Returns:
             List of Awaitable[torch.Tensor], one per sharding group.
@@ -376,12 +576,13 @@ class ShardedPECEmbeddingCollection(
                 -1, features.stride()
             )
 
-            # Reverse direction: collision output → embedding input.
-            partition_ctx.input_splits = collision_splits.output_splits[partition_idx]
-            partition_ctx.output_splits = collision_splits.input_splits[partition_idx]
+            # Map overlap splits to embedding AllToAll context
+            partition_ctx.input_splits = overlap_splits.input_splits[partition_idx]
+            partition_ctx.output_splits = overlap_splits.output_splits[partition_idx]
 
-            # upt maps positions in the full (pre-split) batch — wrong size for
-            # a partition. Reordering is handled by forward_permute after merge.
+            # In RW sharding, upt maps positions in the full (pre-split) batch —
+            # wrong size for a partition. Reordering is handled by RW handler
+            # if needed.
             partition_ctx.unbucketize_permute_tensor = None
 
             embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
@@ -395,22 +596,30 @@ class ShardedPECEmbeddingCollection(
         ctx: PECEmbeddingCollectionContext,
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
-        permutations: List[CollisionPermutation],
+        forward_ctxs: List[ForwardPartitionContext],
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
-        """Creates a LazyAwaitable that merges ol/nol embeddings on wait.
+        """Creates a LazyAwaitable that merges OL/NOL embeddings on wait.
 
-        On wait: passes OL/NOL through PECAll2AllSeqWait (which merges via
-        forward_permute and sets up autograd for gradient re-split), then
-        constructs the final Dict[str, JaggedTensor].
+        On wait: passes OL/NOL embedding awaitables through
+        PECAll2AllSeqWait (which merges via ForwardPartitionContext.permute
+        and sets up the autograd graph for gradient re-split in backward),
+        then constructs the final Dict[str, JaggedTensor] output.
 
-        Also creates one PECAll2AllSeqInfo per sharding group and stores
-        them on ctx.backward_ctxs for the pipeline to set backward_splits.
+        Also creates one PECAll2AllSeqInfo per sharding group (with only
+        forward_permute set) and stores them on PEC context. The
+        pipeline is responsible for setting backward fields (splits,
+        permutes) from the next batch's overlap_dist result before
+        calling loss.backward().
 
         Args:
-            ctx: PEC context (sharding_contexts must be set from input_dist)
-            overlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=True)
-            nonoverlapped_awaitables: from compute_and_output_dist_in_partition(is_overlapped=False)
-            permutations: from permute_dist, one per sharding group
+            ctx: PEC context (sharding_contexts must be set from
+                input_dist).
+            overlapped_awaitables: from
+                compute_and_output_dist_in_partition(is_overlapped=True).
+            nonoverlapped_awaitables: from
+                compute_and_output_dist_in_partition(is_overlapped=False).
+            forward_ctxs: ForwardPartitionContexts from overlap_dist,
+                one per sharding group.
 
         Returns:
             LazyAwaitable resolving to Dict[str, JaggedTensor].
@@ -419,15 +628,14 @@ class ShardedPECEmbeddingCollection(
 
         backward_ctxs = [
             PECAll2AllSeqInfo(
-                permutation=perm,
+                forward_permute=fc.permute,
                 pg=self._env.process_group,
             )
-            for perm in permutations
+            for fc in forward_ctxs
         ]
-        ctx.backward_ctxs = backward_ctxs
+        ctx.backward_ctx_per_group = backward_ctxs
 
         features_per_sharding = [
-            # pyre-ignore[6]
             sharding_ctx.features_before_input_dist
             for sharding_ctx in ctx.sharding_contexts
         ]

--- a/torchrec/distributed/tests/test_pec_collision_handlers.py
+++ b/torchrec/distributed/tests/test_pec_collision_handlers.py
@@ -19,12 +19,11 @@ from torchrec.distributed.embedding_types import (
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.pec_collision_handlers import (
-    BooleanMaskChecker,
-    CollisionHandlerBase,
-    CollisionResult,
-    create_collision_handler,
-    RWCollisionHandler,
-    split_features_by_values_mask,
+    BooleanOverlapChecker,
+    create_overlap_handler,
+    OverlapMasks,
+    RWOverlapHandler,
+    split_kjt_by_values_mask,
 )
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
@@ -41,9 +40,6 @@ def _get_single_rank_pg() -> dist.ProcessGroup:
 
 
 def tearDownModule() -> None:
-    # The PG initialized by _get_single_rank_pg lives for the duration of
-    # this file's tests; destroy it so later test modules in the same
-    # pytest process can call init_process_group themselves.
     if dist.is_initialized():
         dist.destroy_process_group()
 
@@ -89,45 +85,53 @@ def _make_table_name_to_config(
     return {t.name: t for t in tables}
 
 
-class BooleanMaskCheckerTest(unittest.TestCase):
-    """Unit tests for BooleanMaskChecker."""
+class BooleanOverlapCheckerTest(unittest.TestCase):
+    """Unit tests for BooleanOverlapChecker."""
 
     def setUp(self) -> None:
-        self.checker = BooleanMaskChecker(torch.device("cpu"), mask_size=10)
+        self.checker = BooleanOverlapChecker(torch.device("cpu"), mask_size=10)
 
-    def test_empty_mask(self) -> None:
-        values = torch.tensor([0, 3, 5], dtype=torch.long)
+    def test_no_overlap(self) -> None:
+        prev = torch.tensor([0, 1, 2], dtype=torch.long)
+        current = torch.tensor([3, 4, 5], dtype=torch.long)
 
-        mask = self.checker.check_overlap(values)
+        fwd_mask, bwd_mask = self.checker.check(current, prev)
 
-        self.assertTrue(torch.equal(mask, torch.tensor([False, False, False])))
+        self.assertTrue(torch.equal(fwd_mask, torch.tensor([False, False, False])))
+        self.assertTrue(torch.equal(bwd_mask, torch.tensor([False, False, False])))
 
-    def test_update_and_check(self) -> None:
-        self.checker.update(torch.tensor([1, 3, 5], dtype=torch.long))
+    def test_full_overlap(self) -> None:
+        prev = torch.tensor([1, 3, 5], dtype=torch.long)
+        current = torch.tensor([1, 3, 5], dtype=torch.long)
 
-        mask = self.checker.check_overlap(torch.tensor([1, 3, 7], dtype=torch.long))
+        fwd_mask, bwd_mask = self.checker.check(current, prev)
 
-        self.assertTrue(torch.equal(mask, torch.tensor([True, True, False])))
+        self.assertTrue(torch.equal(fwd_mask, torch.tensor([True, True, True])))
+        self.assertTrue(torch.equal(bwd_mask, torch.tensor([True, True, True])))
 
-    def test_update_resets_previous(self) -> None:
-        self.checker.update(torch.tensor([1, 2], dtype=torch.long))
-        self.checker.update(torch.tensor([3, 4], dtype=torch.long))
+    def test_partial_overlap(self) -> None:
+        prev = torch.tensor([1, 3, 5], dtype=torch.long)
+        current = torch.tensor([1, 3, 7], dtype=torch.long)
 
-        mask = self.checker.check_overlap(torch.tensor([1, 2, 3, 4], dtype=torch.long))
+        fwd_mask, bwd_mask = self.checker.check(current, prev)
 
-        self.assertTrue(torch.equal(mask, torch.tensor([False, False, True, True])))
+        self.assertTrue(torch.equal(fwd_mask, torch.tensor([True, True, False])))
+        self.assertTrue(torch.equal(bwd_mask, torch.tensor([True, True, False])))
 
-    def test_reset_mask(self) -> None:
-        self.checker.update(torch.tensor([0, 1, 2], dtype=torch.long))
+    def test_asymmetric_overlap(self) -> None:
+        prev = torch.tensor([0, 1, 2, 3], dtype=torch.long)
+        current = torch.tensor([1, 4], dtype=torch.long)
 
-        self.checker.reset_mask()
-        mask = self.checker.check_overlap(torch.tensor([0, 1, 2], dtype=torch.long))
+        fwd_mask, bwd_mask = self.checker.check(current, prev)
 
-        self.assertTrue(torch.equal(mask, torch.tensor([False, False, False])))
+        self.assertTrue(torch.equal(fwd_mask, torch.tensor([True, False])))
+        self.assertTrue(
+            torch.equal(bwd_mask, torch.tensor([False, True, False, False]))
+        )
 
 
 class SplitFeaturesTest(unittest.TestCase):
-    """Unit tests for the standalone split_features_by_values_mask function."""
+    """Unit tests for the standalone split_kjt_by_values_mask function."""
 
     def test_all_nonoverlapped(self) -> None:
         kjt = KeyedJaggedTensor.from_lengths_sync(
@@ -137,9 +141,11 @@ class SplitFeaturesTest(unittest.TestCase):
         )
         mask = torch.tensor([False, False, False, False])
 
-        ol, nol = split_features_by_values_mask(kjt, mask)
+        ol, nol = split_kjt_by_values_mask(kjt, mask)
 
         self.assertEqual(ol.values().numel(), 0)
+        self.assertTrue(torch.equal(ol.lengths(), torch.tensor([0, 0, 0, 0])))
+        self.assertEqual(ol.keys(), ["f0", "f1"])
         self.assertTrue(torch.equal(nol.values(), torch.tensor([10, 20, 30, 40])))
         self.assertTrue(torch.equal(nol.lengths(), torch.tensor([2, 0, 1, 1])))
 
@@ -151,12 +157,13 @@ class SplitFeaturesTest(unittest.TestCase):
         )
         mask = torch.tensor([True, True, True, True])
 
-        ol, nol = split_features_by_values_mask(kjt, mask)
+        ol, nol = split_kjt_by_values_mask(kjt, mask)
 
         self.assertTrue(torch.equal(ol.values(), torch.tensor([10, 20, 30, 40])))
         self.assertTrue(torch.equal(ol.lengths(), torch.tensor([2, 0, 1, 1])))
         self.assertEqual(nol.values().numel(), 0)
         self.assertTrue(torch.equal(nol.lengths(), torch.tensor([0, 0, 0, 0])))
+        self.assertEqual(nol.keys(), ["f0", "f1"])
 
     def test_partial_overlap(self) -> None:
         kjt = KeyedJaggedTensor.from_lengths_sync(
@@ -166,7 +173,7 @@ class SplitFeaturesTest(unittest.TestCase):
         )
         mask = torch.tensor([False, True, False, False, True, False])
 
-        ol, nol = split_features_by_values_mask(kjt, mask)
+        ol, nol = split_kjt_by_values_mask(kjt, mask)
 
         self.assertTrue(torch.equal(ol.values(), torch.tensor([20, 50])))
         self.assertTrue(torch.equal(ol.lengths(), torch.tensor([1, 0, 0, 1])))
@@ -182,7 +189,7 @@ class SplitFeaturesTest(unittest.TestCase):
         )
         mask = torch.tensor([False, True, False])
 
-        ol, nol = split_features_by_values_mask(kjt, mask)
+        ol, nol = split_kjt_by_values_mask(kjt, mask)
 
         self.assertTrue(torch.equal(ol.values(), torch.tensor([2])))
         self.assertTrue(torch.allclose(ol.weights(), torch.tensor([0.2])))
@@ -197,14 +204,14 @@ class SplitFeaturesTest(unittest.TestCase):
         )
         mask = torch.tensor([True, False, False, True])
 
-        ol, nol = split_features_by_values_mask(kjt, mask)
+        ol, nol = split_kjt_by_values_mask(kjt, mask)
 
         self.assertEqual(ol.keys(), ["feature_a", "feature_b"])
         self.assertEqual(nol.keys(), ["feature_a", "feature_b"])
 
 
-class RWCollisionHandlerTest(unittest.TestCase):
-    """Unit tests for RWCollisionHandler."""
+class RWOverlapHandlerTest(unittest.TestCase):
+    """Unit tests for RWOverlapHandler."""
 
     def setUp(self) -> None:
         self.tables = [
@@ -227,8 +234,8 @@ class RWCollisionHandlerTest(unittest.TestCase):
         self,
         tables: List[EmbeddingConfig],
         local_rows: int = 8,
-    ) -> RWCollisionHandler:
-        return create_collision_handler(  # pyre-ignore[7]
+    ) -> RWOverlapHandler:
+        return create_overlap_handler(  # pyre-ignore[7]
             sharding_type="row_wise",
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows),
@@ -237,21 +244,14 @@ class RWCollisionHandlerTest(unittest.TestCase):
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
-    def test_is_collision_handler_base(self) -> None:
-        self.assertIsInstance(self.handler, CollisionHandlerBase)
-
-    def test_feature_to_table_offset(self) -> None:
-        self.assertEqual(self.handler._feature_to_table_offset["feature_0"], 0)
-        self.assertEqual(self.handler._feature_to_table_offset["feature_1"], 8)
-
-    def test_remap_feature_values(self) -> None:
+    def test_remap_kjt_values(self) -> None:
         kjt = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
 
-        remapped = self.handler._remap_feature_values(kjt)
+        remapped = self.handler.remap_kjt_values(kjt)
 
         self.assertTrue(torch.equal(remapped, torch.tensor([0, 1, 10, 11])))
 
@@ -261,15 +261,29 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
+        remapped = self.handler.remap_kjt_values(kjt)
 
-        result = self.handler.detect_collisions(kjt)
+        result = self.handler.detect_overlap(remapped, prev_remapped=None)
 
-        self.assertIsInstance(result, CollisionResult)
+        self.assertIsInstance(result, OverlapMasks)
+        assert result.forward_overlap_mask is not None
         self.assertTrue(
             torch.equal(result.forward_overlap_mask, torch.zeros(4, dtype=torch.bool))
         )
         self.assertIsNone(result.backward_overlap_mask)
-        self.assertEqual(result.remapped_feature_values.numel(), 4)
+
+    def test_last_batch_all_ol(self) -> None:
+        """Last batch: current=None → no forward mask, all-True backward."""
+        prev_remapped = torch.tensor([0, 1, 10, 11], dtype=torch.long)
+
+        result = self.handler.detect_overlap(
+            current_remapped=None, prev_remapped=prev_remapped
+        )
+
+        self.assertIsNone(result.forward_overlap_mask)
+        assert result.backward_overlap_mask is not None
+        self.assertTrue(result.backward_overlap_mask.all())
+        self.assertEqual(result.backward_overlap_mask.numel(), 4)
 
     def test_second_batch_with_overlap(self) -> None:
         kjt1 = KeyedJaggedTensor.from_lengths_sync(
@@ -277,27 +291,28 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
-        result1 = self.handler.detect_collisions(kjt1)
+        remapped1 = self.handler.remap_kjt_values(kjt1)
+
         kjt2 = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
             values=torch.tensor([1, 4, 3, 5]),
             lengths=torch.tensor([2, 2]),
         )
+        remapped2 = self.handler.remap_kjt_values(kjt2)
 
-        result2 = self.handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = self.handler.detect_overlap(remapped2, prev_remapped=remapped1)
 
+        assert result.forward_overlap_mask is not None
         self.assertTrue(
             torch.equal(
-                result2.forward_overlap_mask,
+                result.forward_overlap_mask,
                 torch.tensor([True, False, True, False]),
             )
         )
-        assert result2.backward_overlap_mask is not None
+        assert result.backward_overlap_mask is not None
         self.assertTrue(
             torch.equal(
-                result2.backward_overlap_mask,
+                result.backward_overlap_mask,
                 torch.tensor([False, True, False, True]),
             )
         )
@@ -308,20 +323,21 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
-        result1 = self.handler.detect_collisions(kjt1)
+        remapped1 = self.handler.remap_kjt_values(kjt1)
+
         kjt2 = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
             values=torch.tensor([4, 5, 6, 7]),
             lengths=torch.tensor([2, 2]),
         )
+        remapped2 = self.handler.remap_kjt_values(kjt2)
 
-        result2 = self.handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = self.handler.detect_overlap(remapped2, prev_remapped=remapped1)
 
-        self.assertFalse(result2.forward_overlap_mask.any())
-        assert result2.backward_overlap_mask is not None
-        self.assertFalse(result2.backward_overlap_mask.any())
+        assert result.forward_overlap_mask is not None
+        self.assertFalse(result.forward_overlap_mask.any())
+        assert result.backward_overlap_mask is not None
+        self.assertFalse(result.backward_overlap_mask.any())
 
     def test_full_overlap_between_batches(self) -> None:
         kjt = KeyedJaggedTensor.from_lengths_sync(
@@ -329,60 +345,14 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
-        result1 = self.handler.detect_collisions(kjt)
+        remapped = self.handler.remap_kjt_values(kjt)
 
-        result2 = self.handler.detect_collisions(
-            kjt, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = self.handler.detect_overlap(remapped, prev_remapped=remapped)
 
-        self.assertTrue(result2.forward_overlap_mask.all())
-        assert result2.backward_overlap_mask is not None
-        self.assertTrue(result2.backward_overlap_mask.all())
-
-    def test_three_consecutive_batches(self) -> None:
-        """Only adjacent batches matter — checker resets on each update call."""
-        kjt1 = KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.tensor([0, 1, 2, 3]),
-            lengths=torch.tensor([2, 2]),
-        )
-        result1 = self.handler.detect_collisions(kjt1)
-        kjt2 = KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.tensor([4, 5, 6, 7]),
-            lengths=torch.tensor([2, 2]),
-        )
-        result2 = self.handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
-        kjt3 = KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.tensor([0, 1, 2, 3]),
-            lengths=torch.tensor([2, 2]),
-        )
-
-        result3 = self.handler.detect_collisions(
-            kjt3, prev_remapped_feature_values=result2.remapped_feature_values
-        )
-
-        self.assertFalse(result3.forward_overlap_mask.any())
-        assert result3.backward_overlap_mask is not None
-        self.assertFalse(result3.backward_overlap_mask.any())
-
-    def test_reset_clears_checker(self) -> None:
-        kjt = KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.tensor([0, 1, 2, 3]),
-            lengths=torch.tensor([2, 2]),
-        )
-        self.handler.detect_collisions(kjt)
-
-        self.handler.reset()
-
-        mask = self.handler._checker.check_overlap(
-            torch.tensor([0, 1, 2, 3], dtype=torch.long)
-        )
-        self.assertFalse(mask.any())
+        assert result.forward_overlap_mask is not None
+        self.assertTrue(result.forward_overlap_mask.all())
+        assert result.backward_overlap_mask is not None
+        self.assertTrue(result.backward_overlap_mask.all())
 
     def test_variable_length_features(self) -> None:
         """Features with different lengths per batch element."""
@@ -392,23 +362,64 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
             lengths=torch.tensor([3, 1, 1, 3]),
         )
-        result1 = handler.detect_collisions(kjt1)
+        remapped1 = handler.remap_kjt_values(kjt1)
+
         kjt2 = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
             values=torch.tensor([2, 8, 5, 9]),
             lengths=torch.tensor([2, 2]),
         )
+        remapped2 = handler.remap_kjt_values(kjt2)
 
-        result2 = handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = handler.detect_overlap(remapped2, prev_remapped=remapped1)
 
+        assert result.forward_overlap_mask is not None
         self.assertTrue(
             torch.equal(
-                result2.forward_overlap_mask,
+                result.forward_overlap_mask,
                 torch.tensor([True, False, True, False]),
             )
         )
+        assert result.backward_overlap_mask is not None
+        # prev values [0,1,2,3,4,5,6,7] remapped to [0,1,2,3,20,21,22,23]
+        # current values [2,8,5,9] remapped to [2,8,21,25]
+        # backward: prev[i] in current? → [F,F,T,F, F,T,F,F]
+        self.assertTrue(
+            torch.equal(
+                result.backward_overlap_mask,
+                torch.tensor([False, False, True, False, False, True, False, False]),
+            )
+        )
+
+    def test_duplicate_values_in_batch(self) -> None:
+        """Duplicate values within a batch should still detect overlap correctly."""
+        kjt1 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 0, 2, 2]),
+            lengths=torch.tensor([2, 2]),
+        )
+        remapped1 = self.handler.remap_kjt_values(kjt1)
+
+        kjt2 = KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.tensor([0, 1, 3, 2]),
+            lengths=torch.tensor([2, 2]),
+        )
+        remapped2 = self.handler.remap_kjt_values(kjt2)
+
+        result = self.handler.detect_overlap(remapped2, prev_remapped=remapped1)
+
+        assert result.forward_overlap_mask is not None
+        # current [0,1,3,2] remapped [0,1,11,10]: 0 in prev, 1 not, 11 not, 10 in prev
+        self.assertTrue(
+            torch.equal(
+                result.forward_overlap_mask,
+                torch.tensor([True, False, False, True]),
+            )
+        )
+        assert result.backward_overlap_mask is not None
+        # prev [0,0,2,2] remapped [0,0,10,10]: 0 in current, 0 in current, 10 in current, 10 in current
+        self.assertTrue(result.backward_overlap_mask.all())
 
     def test_empty_batch(self) -> None:
         """Empty KJT (all lengths=0) should produce empty masks."""
@@ -417,12 +428,13 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([], dtype=torch.long),
             lengths=torch.tensor([0, 0]),
         )
+        remapped = self.handler.remap_kjt_values(kjt)
 
-        result = self.handler.detect_collisions(kjt)
+        result = self.handler.detect_overlap(remapped, prev_remapped=None)
 
+        assert result.forward_overlap_mask is not None
         self.assertEqual(result.forward_overlap_mask.numel(), 0)
         self.assertIsNone(result.backward_overlap_mask)
-        self.assertEqual(result.remapped_feature_values.numel(), 0)
 
     def test_single_table(self) -> None:
         """Single table — offset is always 0."""
@@ -432,22 +444,21 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2]),
             lengths=torch.tensor([3]),
         )
-        result1 = handler.detect_collisions(kjt1)
+        remapped1 = handler.remap_kjt_values(kjt1)
+
         kjt2 = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0"],
             values=torch.tensor([1, 3]),
             lengths=torch.tensor([2]),
         )
+        remapped2 = handler.remap_kjt_values(kjt2)
 
-        result2 = handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = handler.detect_overlap(remapped2, prev_remapped=remapped1)
 
+        assert result.forward_overlap_mask is not None
+        self.assertTrue(torch.equal(remapped1, torch.tensor([0, 1, 2])))
         self.assertTrue(
-            torch.equal(result1.remapped_feature_values, torch.tensor([0, 1, 2]))
-        )
-        self.assertTrue(
-            torch.equal(result2.forward_overlap_mask, torch.tensor([True, False]))
+            torch.equal(result.forward_overlap_mask, torch.tensor([True, False]))
         )
 
     def test_multiple_features_per_table(self) -> None:
@@ -466,26 +477,27 @@ class RWCollisionHandlerTest(unittest.TestCase):
             values=torch.tensor([0, 1, 2, 3]),
             lengths=torch.tensor([2, 2]),
         )
-        result1 = handler.detect_collisions(kjt1)
+        remapped1 = handler.remap_kjt_values(kjt1)
+
         kjt2 = KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_a", "feature_b"],
             values=torch.tensor([2, 5]),
             lengths=torch.tensor([1, 1]),
         )
+        remapped2 = handler.remap_kjt_values(kjt2)
 
-        result2 = handler.detect_collisions(
-            kjt2, prev_remapped_feature_values=result1.remapped_feature_values
-        )
+        result = handler.detect_overlap(remapped2, prev_remapped=remapped1)
 
+        assert result.forward_overlap_mask is not None
         self.assertEqual(handler._feature_to_table_offset["feature_a"], 0)
         self.assertEqual(handler._feature_to_table_offset["feature_b"], 0)
         self.assertTrue(
-            torch.equal(result2.forward_overlap_mask, torch.tensor([True, False]))
+            torch.equal(result.forward_overlap_mask, torch.tensor([True, False]))
         )
 
 
-class CreateCollisionHandlerTest(unittest.TestCase):
-    """Unit tests for the create_collision_handler factory function."""
+class CreateOverlapHandlerTest(unittest.TestCase):
+    """Unit tests for the create_overlap_handler factory function."""
 
     def test_row_wise_returns_rw_handler(self) -> None:
         tables = [
@@ -497,7 +509,7 @@ class CreateCollisionHandlerTest(unittest.TestCase):
             ),
         ]
 
-        handler = create_collision_handler(
+        handler = create_overlap_handler(
             sharding_type="row_wise",
             device=torch.device("cpu"),
             grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),
@@ -506,7 +518,7 @@ class CreateCollisionHandlerTest(unittest.TestCase):
             checker_type=OverlappingCheckerType.BOOLEAN,
         )
 
-        self.assertIsInstance(handler, RWCollisionHandler)
+        self.assertIsInstance(handler, RWOverlapHandler)
 
     def test_unsupported_sharding_type_raises(self) -> None:
         tables = [
@@ -519,7 +531,7 @@ class CreateCollisionHandlerTest(unittest.TestCase):
         ]
 
         with self.assertRaises(ValueError):
-            create_collision_handler(
+            create_overlap_handler(
                 sharding_type="column_wise",
                 device=torch.device("cpu"),
                 grouped_emb_configs=_make_grouped_configs(tables, local_rows=8),

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -10,19 +10,14 @@
 
 import copy
 import unittest
-from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
-from torchrec.distributed.pec_collision_handlers import (
-    CollisionPermutation,
-    CollisionResult,
-    CollisionSplits,
-    split_features_by_values_mask,
-)
 from torchrec.distributed.pec_embedding import (
+    BackwardPartitionContext,
+    ForwardPartitionContext,
     PECEmbeddingCollectionSharder,
     ShardedPECEmbeddingCollection,
 )
@@ -56,7 +51,7 @@ EMBEDDING_TABLES: List[EmbeddingConfig] = [
         name="table_1",
         feature_names=["feature_1"],
         embedding_dim=8,
-        num_embeddings=16,
+        num_embeddings=8,
     ),
 ]
 
@@ -177,63 +172,35 @@ def _test_sharding(
             loss.backward()
 
 
-@dataclass
-class ExpectedCollisionResult:
-    remapped: List[int]
-    forward_mask: List[bool]
-    backward_mask: List[bool] | None
-
-
-@dataclass
-class ExpectedSplits:
-    input_splits: List[List[int]]
-    output_splits: List[List[int]]
-
-
 def _verify_forward_permute(
-    forward_permute: torch.Tensor,
+    forward_ctx: ForwardPartitionContext | None,
     expected: List[int],
 ) -> None:
-    assert forward_permute.tolist() == expected
+    assert forward_ctx is not None
+    assert forward_ctx.permute.tolist() == expected
 
 
-def _verify_backward_permute(
-    permutation: "CollisionPermutation",
+def _verify_backward_permutes(
+    backward_ctx: BackwardPartitionContext | None,
     expected_ol_permute: List[int] | None,
     expected_nol_permute: List[int] | None,
 ) -> None:
     if expected_ol_permute is None:
-        assert permutation.backward_ol_permute is None
-        assert permutation.backward_nol_permute is None
+        assert backward_ctx is None
     else:
-        assert permutation.backward_ol_permute is not None
-        assert permutation.backward_nol_permute is not None
-        assert permutation.backward_ol_permute.tolist() == expected_ol_permute
+        assert backward_ctx is not None
+        assert backward_ctx.ol_permute.tolist() == expected_ol_permute
         assert expected_nol_permute is not None
-        assert permutation.backward_nol_permute.tolist() == expected_nol_permute
+        assert backward_ctx.nol_permute.tolist() == expected_nol_permute
 
 
-def _verify_collision_result(
-    result: CollisionResult,
-    expected: ExpectedCollisionResult,
+def _verify_forward_splits(
+    forward_ctx: ForwardPartitionContext,
+    expected_input_splits: Tuple[List[int], List[int]],
+    expected_output_splits: Tuple[List[int], List[int]],
 ) -> None:
-    assert result.remapped_feature_values.tolist() == expected.remapped
-    assert result.forward_overlap_mask.tolist() == expected.forward_mask
-    if expected.backward_mask is None:
-        assert result.backward_overlap_mask is None
-    else:
-        assert result.backward_overlap_mask is not None
-        assert result.backward_overlap_mask.tolist() == expected.backward_mask
-
-
-def _verify_collision_splits(
-    all_splits: List[CollisionSplits],
-    expected: ExpectedSplits,
-) -> None:
-    assert len(all_splits) == 1
-    splits = all_splits[0]
-    assert splits.input_splits == expected.input_splits
-    assert splits.output_splits == expected.output_splits
+    assert forward_ctx.splits.input_splits == expected_input_splits
+    assert forward_ctx.splits.output_splits == expected_output_splits
 
 
 def _verify_partition_embeddings(
@@ -299,8 +266,6 @@ def _test_pec_forward_stages(
     kjt_input_per_rank: List[List[KeyedJaggedTensor]],
     sharder: ModuleSharder[nn.Module],
     backend: str,
-    expected_collisions_per_rank: List[List[ExpectedCollisionResult]] | None = None,
-    expected_splits_per_rank: List[List[ExpectedSplits]] | None = None,
     expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
     expected_backward_ol_permutes_per_rank: List[List[List[int] | None]] | None = None,
     expected_backward_nol_permutes_per_rank: List[List[List[int] | None]] | None = None,
@@ -310,20 +275,16 @@ def _test_pec_forward_stages(
     verify_merge: bool = False,
     local_size: Optional[int] = None,
 ) -> None:
-    """Runs PEC forward pipeline stages and verifies against expected results.
+    """Runs PEC forward pipeline using overlap_dist and verifies results.
 
-    Always runs: input_dist → detect_collisions → split →
-        collision_split_dist → permute_dist →
-        compute_and_output_dist_in_partition (OL + NOL).
-    Optionally runs: merge_partitioned_embeddings (when verify_merge=True).
-    Verification for each stage is enabled by providing its expected-output parameter.
-    Partition and merge verification require ref_ec for weight comparison.
+    Pipeline: input_dist → overlap_dist → compute_and_output_dist_in_partition
+    (OL + NOL) → optionally merge_partitioned_embeddings.
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
         sharded_pec = sharded_sparse_arch._pec_ec
         assert isinstance(sharded_pec, ShardedPECEmbeddingCollection)
-        assert len(sharded_pec._collision_handlers) > 0
+        assert len(sharded_pec._overlap_handlers) > 0
 
         if ref_ec is not None:
             copy_state_dict(
@@ -332,7 +293,6 @@ def _test_pec_forward_stages(
             )
 
         batches = kjt_input_per_rank[rank]
-        prev_remapped = None
         prev_ctx = None
         prev_features_list = None
 
@@ -341,79 +301,47 @@ def _test_pec_forward_stages(
             original_lengths = kjt_input.lengths()
             kjt_input = kjt_input.to(ctx.device)
 
-            # Stage 1: input_dist → detect_collisions
+            # Stage 1: input_dist
             pec_ctx = sharded_pec.create_context()
-            pec_ctx.prev_remapped_feature_values = prev_remapped
             dist_input = sharded_pec.input_dist(pec_ctx, kjt_input).wait().wait()
-            results = sharded_pec.detect_collisions(pec_ctx, dist_input)
 
-            if expected_collisions_per_rank is not None:
-                _verify_collision_result(
-                    results[0],
-                    expected_collisions_per_rank[rank][batch_idx],
-                )
-
-            # Stage 2: split features → collision_split_dist
-            ol_features_list = []
-            nol_features_list = []
-            for result, features in zip(results, dist_input):
-                ol, nol = split_features_by_values_mask(
-                    features,
-                    result.forward_overlap_mask,
-                )
-                ol_features_list.append(ol)
-                nol_features_list.append(nol)
-
-            split_awaitables = sharded_pec.collision_split_dist(
-                pec_ctx,
-                nol_features_list,
-            )
-            all_splits = [aw.wait() for aw in split_awaitables]
-
-            if expected_splits_per_rank is not None:
-                _verify_collision_splits(
-                    all_splits,
-                    expected_splits_per_rank[rank][batch_idx],
-                )
-
-            # Stage 3: permute_dist
-            features_list = list(dist_input)
-            permute_awaitables = sharded_pec.permute_dist(
-                pec_ctx,
-                features_list,
-                results,
+            # Stage 2: overlap_dist (fused detect + split + mask dist + compute)
+            results = sharded_pec.overlap_dist(
+                ctx=pec_ctx,
+                dist_input=dist_input,
                 prev_ctx=prev_ctx,
-                prev_features_per_group=prev_features_list,
+                prev_dist_input=prev_features_list,
             )
-            permutations = [aw.wait() for aw in permute_awaitables]
+            forward_ctx, backward_ctx = results[0].wait()
 
             if expected_forward_permutes_per_rank is not None:
                 _verify_forward_permute(
-                    permutations[0].forward_permute,
+                    forward_ctx,
                     expected_forward_permutes_per_rank[rank][batch_idx],
                 )
 
             if expected_backward_ol_permutes_per_rank is not None:
                 assert expected_backward_nol_permutes_per_rank is not None
-                _verify_backward_permute(
-                    permutations[0],
+                _verify_backward_permutes(
+                    backward_ctx,
                     expected_backward_ol_permutes_per_rank[rank][batch_idx],
                     expected_backward_nol_permutes_per_rank[rank][batch_idx],
                 )
 
-            # Stage 4: compute_and_output_dist_in_partition
+            # Stage 3: compute_and_output_dist_in_partition
+            assert forward_ctx is not None
             ol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
                 pec_ctx,
-                ol_features_list[0],
-                all_splits[0],
+                forward_ctx.ol_features,
+                forward_ctx.splits,
                 is_overlapped=True,
             )
             assert len(ol_awaitables) == 1
 
             nol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
                 pec_ctx,
-                nol_features_list[0],
-                all_splits[0],
+                forward_ctx.nol_features,
+                forward_ctx.splits,
                 is_overlapped=False,
             )
             assert len(nol_awaitables) == 1
@@ -433,14 +361,14 @@ def _test_pec_forward_stages(
                     ctx.device,
                 )
 
-            # Stage 5: merge_partitioned_embeddings
+            # Stage 4: merge_partitioned_embeddings
             if verify_merge:
                 assert ref_ec is not None
                 lazy_result = sharded_pec.merge_partitioned_embeddings(
                     pec_ctx,
                     ol_awaitables,
                     nol_awaitables,
-                    permutations,
+                    [forward_ctx],
                 )
                 jt_dict = lazy_result.wait()
                 _verify_merged_output(
@@ -453,62 +381,50 @@ def _test_pec_forward_stages(
                     ctx.device,
                 )
 
-            prev_remapped = [r.remapped_feature_values for r in results]
             prev_ctx = pec_ctx
-            prev_features_list = features_list
+            prev_features_list = dist_input
 
 
-# Cross-shard data: each rank has values in both shard 0 (0-7) and shard 1 (8-15)
+# Cross-shard data for uneven tables (table_0: 16 rows, table_1: 8 rows).
+# With world_size=2 RW sharding:
+#   table_0: block_size=8, shard 0 rows 0-7, shard 1 rows 8-15
+#   table_1: block_size=4, shard 0 rows 0-3, shard 1 rows 4-7
+# stride=2 (batch_size=2 per rank), 2 batches per rank.
 CROSS_SHARD_KJT_INPUT_PER_RANK = [
     [
+        # Rank 0 batch 0
+        # f0: [0,8,2] → shard0:[0,2], shard1:[8]
+        # f1: [1,5,3] → shard0:[1,3], shard1:[5]
         KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([0, 8, 2, 10, 4, 12]),
+            values=torch.LongTensor([0, 8, 2, 1, 5, 3]),
             lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
+        # Rank 0 batch 1 (overlaps with batch 0: f0: 0, f1: 1)
+        # f0: [0,9,3] → shard0:[0,3], shard1:[9]
+        # f1: [1,6,2] → shard0:[1,2], shard1:[6]
         KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([0, 8, 3, 11, 4, 13]),
-            lengths=torch.LongTensor([2, 1, 1, 2]),
-        ),
-    ],
-    [
-        KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([1, 9, 5, 11, 6, 13]),
-            lengths=torch.LongTensor([2, 1, 1, 2]),
-        ),
-        KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([1, 9, 7, 14, 6, 15]),
-            lengths=torch.LongTensor([2, 1, 1, 2]),
-        ),
-    ],
-]
-
-TWO_BATCH_KJT_INPUT_PER_RANK = [
-    [
-        KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
-            lengths=torch.LongTensor([2, 1, 1, 2]),
-        ),
-        KeyedJaggedTensor.from_lengths_sync(
-            keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([1, 3, 5, 7, 4, 6]),
+            values=torch.LongTensor([0, 9, 3, 1, 6, 2]),
             lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
     ],
     [
+        # Rank 1 batch 0
+        # f0: [1,10,5] → shard0:[1,5], shard1:[10]
+        # f1: [4,2,7] → shard0:[2], shard1:[4,7]
         KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
-            lengths=torch.LongTensor([1, 2, 2, 1]),
+            values=torch.LongTensor([1, 10, 5, 4, 2, 7]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
+        # Rank 1 batch 1 (overlaps with batch 0: f0: 1, f1: 4)
+        # f0: [1,11,7] → shard0:[1,7], shard1:[11]
+        # f1: [4,3,6] → shard0:[3], shard1:[4,6]
         KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
-            values=torch.LongTensor([8, 10, 9, 11, 13, 15]),
-            lengths=torch.LongTensor([1, 2, 2, 1]),
+            values=torch.LongTensor([1, 11, 7, 4, 3, 6]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
     ],
 ]
@@ -525,24 +441,13 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
     def test_sharding_rw(self) -> None:
         WORLD_SIZE = 2
 
-        kjt_input_per_rank = [
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=["feature_0", "feature_1"],
-                values=torch.LongTensor([0, 1, 2, 3, 4, 5]),
-                lengths=torch.LongTensor([2, 1, 1, 2]),
-            ),
-            KeyedJaggedTensor.from_lengths_sync(
-                keys=["feature_0", "feature_1"],
-                values=torch.LongTensor([6, 7, 8, 9, 10, 11]),
-                lengths=torch.LongTensor([1, 2, 2, 1]),
-            ),
-        ]
-
         self._run_multi_process_test(
             callable=_test_sharding,
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
-            kjt_input_per_rank=kjt_input_per_rank,
+            kjt_input_per_rank=[
+                batches[0] for batches in CROSS_SHARD_KJT_INPUT_PER_RANK
+            ],
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
         )
@@ -551,117 +456,20 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    def test_detect_collisions(self) -> None:
-        """Verifies exact collision masks and remapped values."""
+    def test_overlap_dist_forward_permute(self) -> None:
+        """Verifies exact forward_permute values from overlap_dist."""
         WORLD_SIZE = 2
 
-        # RW sharding with block_size=8: rank 0 owns IDs 0-7, rank 1 owns 8-15.
-        # Remapped = local_value + table_offset (table_0 offset=0, table_1 offset=8).
-        expected_collisions_per_rank = [
-            [
-                ExpectedCollisionResult(
-                    remapped=[0, 1, 2, 6, 7, 11, 12, 13],
-                    forward_mask=[False] * 8,
-                    backward_mask=None,
-                ),
-                ExpectedCollisionResult(
-                    remapped=[1, 3, 5, 15, 12, 14],
-                    forward_mask=[True, False, False, False, True, False],
-                    backward_mask=[
-                        False,
-                        True,
-                        False,
-                        False,
-                        False,
-                        False,
-                        True,
-                        False,
-                    ],
-                ),
-            ],
-            [
-                ExpectedCollisionResult(
-                    remapped=[0, 9, 10, 11],
-                    forward_mask=[False] * 4,
-                    backward_mask=None,
-                ),
-                ExpectedCollisionResult(
-                    remapped=[0, 2, 1, 11, 13, 15],
-                    forward_mask=[True, False, False, True, False, False],
-                    backward_mask=[True, False, False, True],
-                ),
-            ],
-        ]
-
-        self._run_multi_process_test(
-            callable=_test_pec_forward_stages,
-            world_size=WORLD_SIZE,
-            tables=EMBEDDING_TABLES,
-            kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
-            expected_collisions_per_rank=expected_collisions_per_rank,
-            sharder=PECEmbeddingCollectionSharder(),
-            backend="nccl",
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
-    def test_collision_split_dist(self) -> None:
-        """Verifies exact collision split values per rank."""
-        WORLD_SIZE = 2
-
-        expected_splits_per_rank = [
-            [
-                ExpectedSplits(
-                    input_splits=[[0, 0], [6, 2]],
-                    output_splits=[[0, 0], [6, 0]],
-                ),
-                ExpectedSplits(
-                    input_splits=[[2, 0], [4, 0]],
-                    output_splits=[[2, 0], [4, 0]],
-                ),
-            ],
-            [
-                ExpectedSplits(
-                    input_splits=[[0, 0], [0, 4]],
-                    output_splits=[[0, 0], [2, 4]],
-                ),
-                ExpectedSplits(
-                    input_splits=[[0, 2], [0, 4]],
-                    output_splits=[[0, 2], [0, 4]],
-                ),
-            ],
-        ]
-
-        self._run_multi_process_test(
-            callable=_test_pec_forward_stages,
-            world_size=WORLD_SIZE,
-            tables=EMBEDDING_TABLES,
-            kjt_input_per_rank=TWO_BATCH_KJT_INPUT_PER_RANK,
-            expected_splits_per_rank=expected_splits_per_rank,
-            sharder=PECEmbeddingCollectionSharder(),
-            backend="nccl",
-        )
-
-    @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
-    )
-    def test_permute_dist(self) -> None:
-        """Verifies exact forward_permute values with cross-shard partial overlap."""
-        WORLD_SIZE = 2
-
-        # Batch 0: no overlap → forward_permute = upt = [0,3,1,4,2,5]
-        # Batch 1: partial overlap → forward_permute derived from received mask + upt
+        # Batch 0: no overlap → forward_permute = upt
+        # Batch 1: partial overlap → forward_permute derived from post-dist mask + upt
         expected_forward_permutes_per_rank = [
             [
-                [0, 3, 1, 4, 2, 5],
-                [0, 2, 5, 3, 1, 4],
+                [0, 4, 1, 2, 5, 3],
+                [0, 4, 3, 1, 5, 2],
             ],
             [
                 [0, 3, 1, 4, 2, 5],
-                [0, 2, 3, 4, 1, 5],
+                [0, 4, 3, 2, 1, 5],
             ],
         ]
 
@@ -679,32 +487,19 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    def test_backward_permute_dist(self) -> None:
-        """Verifies backward_permute and backward_num_ol with cross-shard overlap.
-
-        Batch 0: no backward (first batch) → backward_permute=None, num_ol=0.
-        Batch 1: backward mask from batch 0's values overlapping with batch 1.
-
-        Received bwd mask (bucketized): rank0=[T,F,T,T,F,F], rank1=[T,F,T,T,T,T]
-        recat = invert_permute(batch0_upt) = invert_permute([0,3,1,4,2,5]) = [0,2,4,1,3,5]
-        backward_permute = cat([recat[where(mask)], recat[where(~mask)]])
-
-        Rank 0: where(mask)=[0,2,3], recat[[0,2,3]]=[0,4,1]
-                where(~mask)=[1,4,5], recat[[1,4,5]]=[2,3,5]
-                backward_permute=[0,4,1, 2,3,5], num_ol=3
-        Rank 1: where(mask)=[0,2,3,4,5], recat[[0,2,3,4,5]]=[0,4,1,3,5]
-                where(~mask)=[1], recat[[1]]=[2]
-                backward_permute=[0,4,1,3,5, 2], num_ol=5
-        """
+    def test_overlap_dist_backward_permutes(self) -> None:
+        """Verifies backward ol/nol permutes from overlap_dist."""
         WORLD_SIZE = 2
 
+        # Batch 0: no prev batch → backward permutes are None
+        # Batch 1: backward permutes computed from backward mask
         expected_backward_ol_permutes_per_rank = [
-            [None, [0, 4, 1]],
-            [None, [0, 4, 1, 3, 5]],
+            [None, [0, 3, 5]],
+            [None, [0, 4, 3]],
         ]
         expected_backward_nol_permutes_per_rank = [
-            [None, [2, 3, 5]],
-            [None, [2]],
+            [None, [2, 1, 4]],
+            [None, [2, 1, 5]],
         ]
 
         self._run_multi_process_test(
@@ -725,16 +520,19 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
     def test_compute_and_output_dist_in_partition(self) -> None:
         """Tests OL/NOL embeddings match expected weight rows.
 
-        Uses cross-shard partial overlap data. num_embeddings=16, world_size=2,
-        block_size=8. Shard 0 stores original rows 0-7, shard 1 stores 8-15.
+        Uses uneven cross-shard data. table_0: 16 rows (block_size=8),
+        table_1: 8 rows (block_size=4). world_size=2.
 
-        Expected values manually traced through:
+        Expected values traced through:
         1. block_bucketize → which values go to which shard
         2. KJTAllToAll + recat [0,2,1,3] → feature-major on shard
-        3. collision mask (batch 1): shard0=[T,F,T,F,T,T], shard1=[T,T,T,T,F,F]
-        4. split → lookup on each shard's TBE
-        5. forward_recat to rank-major → embedding AllToAll → trainer
-        6. output = [from_shard0, from_shard1]
+        3. remap with per-table offsets (shard 0: t0 offset=0, t1 offset=8)
+        4. overlap mask (batch 1 vs batch 0 remapped values)
+        5. split → lookup → embedding AllToAll → rank receives
+        6. output order: [from_shard0, from_shard1]
+
+        Batch 0: all NOL (first batch, no overlap).
+        Batch 1 shard 0 mask=[T,F,T,F,T,T,T], shard 1 mask=[T,F,T,T,F].
         """
         WORLD_SIZE = 2
 
@@ -743,40 +541,26 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             device=torch.device("cpu"),
         )
 
-        # Expected OL/NOL rows as (table_name, original_id).
-        # Output order: [from_shard0, from_shard1], rank-major within each.
-        #
-        # --- Batch 0: no overlap, all NOL ---
-        # Shard 0 recat rank-major:
-        #   trainer0 ← [t0[0],t0[2],t1[4]], trainer1 ← [t0[1],t0[5],t1[6]]
-        # Shard 1 recat rank-major:
-        #   trainer0 ← [t0[8],t1[10],t1[12]], trainer1 ← [t0[9],t1[11],t1[13]]
-        #
-        # --- Batch 1: shard0 mask=[T,F,T,F,T,T], shard1=[T,T,T,T,F,F] ---
-        # Shard 0 OL: trainer0 ← [t0[0],t1[4]], trainer1 ← [t0[1],t1[6]]
-        # Shard 0 NOL: trainer0 ← [t0[3]], trainer1 ← [t0[7]]
-        # Shard 1 OL: trainer0 ← [t0[8],t1[11],t1[13]], trainer1 ← [t0[9]]
-        # Shard 1 NOL: trainer0 ← [], trainer1 ← [t1[14],t1[15]]
         T0 = "table_0"
         T1 = "table_1"
         expected_ol: Dict[int, List[List[Tuple[str, int]]]] = {
             0: [
                 [],  # batch 0: no overlap
-                [(T0, 0), (T1, 4), (T0, 8), (T1, 11), (T1, 13)],
+                [(T0, 0), (T1, 1), (T1, 2)],
             ],
             1: [
                 [],
-                [(T0, 1), (T1, 6), (T0, 9)],
+                [(T0, 1), (T1, 3), (T1, 4)],
             ],
         }
         expected_nol: Dict[int, List[List[Tuple[str, int]]]] = {
             0: [
-                [(T0, 0), (T0, 2), (T1, 4), (T0, 8), (T1, 10), (T1, 12)],
-                [(T0, 3)],
+                [(T0, 0), (T0, 2), (T1, 1), (T1, 3), (T0, 8), (T1, 5)],
+                [(T0, 3), (T0, 9), (T1, 6)],
             ],
             1: [
-                [(T0, 1), (T0, 5), (T1, 6), (T0, 9), (T1, 11), (T1, 13)],
-                [(T0, 7), (T1, 14), (T1, 15)],
+                [(T0, 1), (T0, 5), (T1, 2), (T0, 10), (T1, 4), (T1, 7)],
+                [(T0, 7), (T0, 11), (T1, 6)],
             ],
         }
 
@@ -810,6 +594,62 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
+            sharder=PECEmbeddingCollectionSharder(),
+            backend="nccl",
+            ref_ec=ref_ec,
+            verify_merge=True,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_single_shard_features(self) -> None:
+        """Tests overlap_dist when one shard receives no features.
+
+        All values in shard 1's range (table_0: 8-15, table_1: 4-7),
+        so shard 0 gets nothing after input_dist. Verifies mask_dist,
+        splits, permutes, and merge handle empty KJTs on the empty shard.
+        """
+        WORLD_SIZE = 2
+
+        ref_ec = EmbeddingCollection(
+            tables=EMBEDDING_TABLES,
+            device=torch.device("cpu"),
+        )
+
+        # table_0 shard1: [8,15], table_1 shard1: [4,7]
+        shard1_only_input = [
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([8, 9, 4, 5]),
+                    lengths=torch.LongTensor([2, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([8, 10, 5, 6]),
+                    lengths=torch.LongTensor([2, 2]),
+                ),
+            ],
+            [
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([12, 13, 6, 7]),
+                    lengths=torch.LongTensor([2, 2]),
+                ),
+                KeyedJaggedTensor.from_lengths_sync(
+                    keys=["feature_0", "feature_1"],
+                    values=torch.LongTensor([12, 14, 7, 4]),
+                    lengths=torch.LongTensor([2, 2]),
+                ),
+            ],
+        ]
+        self._run_multi_process_test(
+            callable=_test_pec_forward_stages,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=shard1_only_input,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
             ref_ec=ref_ec,


### PR DESCRIPTION
Summary:
# Context

PEC (Pipelined Embedding Collection) overlaps embedding lookups across consecutive batches by partitioning features into overlapped (OL) and nonoverlapped (NOL) sets. This diff refactors the collision detection system into a cleaner overlap-centric API.

# Why rename "collision" to "overlap"

The original naming (`CollisionHandlerBase`, `detect_collisions`, `CollisionResult`) suggests hash collision semantics, which is misleading. What PEC actually does is detect set intersection between consecutive batches — which values from the current batch also appeared in the previous batch. "Overlap" directly describes this relationship and makes the API self-documenting. The new names (`OverlapHandler`, `detect_overlap`, `OverlapMasks`, `overlap_dist`) clearly convey that we are partitioning by batch-to-batch value overlap, not resolving hash collisions.

# New API of PEC EC: `overlap_dist`

Previously three separate stages: `detect_collisions` → `collision_split_dist` (SplitsAllToAll) → `permute_dist` (mask AllToAll + permute). The fused `overlap_dist`:

- Eliminates `collision_split_dist` — splits computed locally from received mask via `segment_sum_csr`, no SplitsAllToAll needed
- Reduces AllToAll operations per batch from 3 to 2 (mask AllToAll only, can further merge later to a single one)
- Handles first/normal/last batch in a single loop via None masks from `detect_overlap`
- Returns `OverlapDistOutput = (ForwardPartitionContext | None, BackwardPartitionContext | None)` per sharding group

# Why the handler API is decomposed this way

The old `CollisionHandlerBase` had two large methods that each did multiple things. The new `OverlapHandler` decomposes into six focused methods:

- `remap_kjt_values`: makes values globally unique across tables within a shard (sharding-specific offset computation)
- `detect_overlap`: pure overlap detection from remapped values (no side effects, no state mutation)
- `mask_dist`: the only collective — AllToAll for the overlap mask
- `compute_splits`: local computation from post-dist + pre-dist masks, no communication
- `compute_forward_permute`: builds merge permutation for [OL, NOL] → original order
- `compute_backward_permutes`: builds gradient split indices for backward

This separates sharding-specific logic (remap, mask permutation order) from sharding-agnostic orchestration (`overlap_dist`). A new sharding type only implements these six methods.

`ForwardPartitionContext` / `BackwardPartitionContext` split reflects different lifecycles: forward is consumed immediately for compute, backward is set later by the next batch's `overlap_dist` and consumed during `loss.backward()`.

Reviewed By: TroyGarden

Differential Revision: D105464810


