### PR TITLE
Add PECGradientApply and end-to-end backward test

### DIFF
--- a/torchrec/distributed/pec_comm_ops.py
+++ b/torchrec/distributed/pec_comm_ops.py
@@ -10,24 +10,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Callable, List, Tuple
 
 import torch
 import torch.distributed as dist
 from torchrec.distributed.pec_collision_handlers import OverlapSplits
+from torchrec.distributed.types import Awaitable
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 @dataclass
 class PECAll2AllSeqInfo:
     """Metadata for PEC backward gradient re-split and distribution.
 
-    Created by merge_partitioned_embeddings during forward. Read by
-    PECAll2AllSeqWait during backward to re-split and distribute gradients.
-
-    After backward, the pipeline reads the gradient outputs below and is
-    responsible for waiting on the OL AllToAll and applying both OL/NOL
-    gradients to TBE. A dedicated gradient manager class for wait + apply
-    will be added in a future diff.
+    Created by merge_partitioned_embeddings during forward. When
+    backward_ctxs is passed to merge, backward fields are populated
+    automatically. Read by PECAll2AllSeqWait during backward to re-split
+    gradients and create PECGradientApply instances.
 
     Attributes:
         forward_permute: Permute tensor for merging [ol, nol] → original order.
@@ -35,11 +34,10 @@ class PECAll2AllSeqInfo:
         backward_nol_permute: Original-order indices for NOL gradient split.
         backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
         pg: Process group for gradient AllToAll.
-
-    Gradient outputs (set by PECAll2AllSeqWait.backward):
-        ol_grad_work: Async work handle for OL gradient AllToAll.
-        ol_grad_local: Output buffer for OL gradient AllToAll.
-        nol_grad: NOL gradient tensor for deferred AllToAll.
+        ol_grad_apply: OL gradient applier (set by PECAll2AllSeqWait.backward).
+            dist() already called.
+        nol_grad_apply: NOL gradient applier (set by PECAll2AllSeqWait.backward).
+            Pipeline calls dist() later.
     """
 
     forward_permute: torch.Tensor
@@ -48,10 +46,9 @@ class PECAll2AllSeqInfo:
     backward_splits: OverlapSplits | None = None
     pg: dist.ProcessGroup | None = None
 
-    # Gradient outputs — set by PECAll2AllSeqWait.backward
-    ol_grad_work: dist.Work | None = None
-    ol_grad_local: torch.Tensor | None = None
-    nol_grad: torch.Tensor | None = None
+    # Gradient appliers — set by PECAll2AllSeqWait.backward
+    ol_grad_apply: "PECGradientApply | None" = None
+    nol_grad_apply: "PECGradientApply | None" = None
 
 
 def _grad_dist(
@@ -98,66 +95,160 @@ def _grad_dist(
 
 
 class PECAll2AllSeqWait(torch.autograd.Function):
-    """PEC gradient intercept — merges embeddings in forward, re-splits gradients in backward.
+    """PEC gradient intercept — merges embeddings in forward, re-splits
+    gradients in backward.
 
-    Forward: merges OL/NOL embeddings using forward_permute from backward_ctx.permutation.
+    Forward: merges OL/NOL embeddings using forward_permute.
 
-    Backward: permutes gradient to bucketized order, splits by backward
-    overlap mask (using pre-computed ol/nol indices from backward_permute),
-    starts async OL gradient AllToAll (stored on backward_ctx for pipeline to wait),
-    saves NOL gradient on backward_ctx for deferred processing.
+    Backward: splits gradient into OL/NOL via backward_ol_permute and
+    backward_nol_permute (pre-composed with recat, so index_select
+    produces rank-major order directly). Creates PECGradientApply
+    instances for each partition — OL dist() starts immediately,
+    NOL dist() is deferred to the pipeline.
 
-    Gradient propagation stops here (returns None) — the pipeline applies
-    gradients to TBE separately.
+    Gradient propagation stops here (returns None) — PECGradientApply
+    handles the AllToAll wait and TBE backward application.
     """
 
     @staticmethod
     # pyre-ignore[14]
     def forward(
         ctx: torch.autograd.function.FunctionCtx,
-        backward_ctx: PECAll2AllSeqInfo,
+        autograd_ctx: PECAll2AllSeqInfo,
         ol_embs: torch.Tensor,
         nol_embs: torch.Tensor,
+        grad_anchor: torch.Tensor,
     ) -> torch.Tensor:
-        ctx.backward_ctx = backward_ctx  # pyre-ignore[16]
+        ctx.autograd_ctx = autograd_ctx  # pyre-ignore[16]
 
         merged_embs = torch.cat([ol_embs, nol_embs], dim=0)
-        return torch.index_select(merged_embs, 0, backward_ctx.forward_permute)
+        return torch.index_select(merged_embs, 0, autograd_ctx.forward_permute)
 
     @staticmethod
     # pyre-ignore[14]
     def backward(
         ctx: torch.autograd.function.FunctionCtx,
         grad_output: torch.Tensor,
-    ) -> Tuple[None, None, None]:
-        backward_ctx: PECAll2AllSeqInfo = ctx.backward_ctx  # pyre-ignore[16]
-        splits = backward_ctx.backward_splits
+    ) -> Tuple[None, None, None, None]:
+        autograd_ctx: PECAll2AllSeqInfo = ctx.autograd_ctx  # pyre-ignore[16]
+        splits = autograd_ctx.backward_splits
 
-        assert backward_ctx.backward_ol_permute is not None
-        assert backward_ctx.backward_nol_permute is not None
+        assert autograd_ctx.backward_ol_permute is not None
+        assert autograd_ctx.backward_nol_permute is not None
         assert splits is not None
-        assert backward_ctx.pg is not None
-
-        _, embedding_dim = grad_output.shape
+        assert autograd_ctx.pg is not None
 
         # Split gradient into ol/nol. Permute indices are pre-composed
         # with recat, so index_select produces rank-major order directly.
-        ol_grad = grad_output.index_select(0, backward_ctx.backward_ol_permute)
-        nol_grad = grad_output.index_select(0, backward_ctx.backward_nol_permute)
+        ol_grad = grad_output.index_select(0, autograd_ctx.backward_ol_permute)
+        nol_grad = grad_output.index_select(0, autograd_ctx.backward_nol_permute)
 
-        # 3. Start async reverse AllToAll for OL grad
-        ol_grad_work, ol_grad_local = _grad_dist(
+        # OL: create applier and start AllToAll immediately
+        autograd_ctx.ol_grad_apply = PECGradientApply(
             ol_grad,
             input_splits=splits.input_splits[0],
             output_splits=splits.output_splits[0],
-            embedding_dim=embedding_dim,
-            pg=backward_ctx.pg,
+            pg=autograd_ctx.pg,
         )
-        backward_ctx.ol_grad_work = ol_grad_work
-        backward_ctx.ol_grad_local = ol_grad_local
+        autograd_ctx.ol_grad_apply.dist()
 
-        # 4. Save NOL grad for pipeline (deferred AllToAll).
-        # Pipeline reads NOL splits from backward_ctx.backward_splits directly.
-        backward_ctx.nol_grad = nol_grad
+        # NOL: create applier, pipeline calls dist() later
+        autograd_ctx.nol_grad_apply = PECGradientApply(
+            nol_grad,
+            input_splits=splits.input_splits[1],
+            output_splits=splits.output_splits[1],
+            pg=autograd_ctx.pg,
+        )
 
-        return (None, None, None)
+        return (None, None, None, None)
+
+
+class PECGradientApply:
+    """Handles gradient AllToAll and application to TBE for one partition.
+
+    Created by PECAll2AllSeqWait.backward — one for OL, one for NOL.
+    Short-lived: exists for one batch, consumed by apply().
+
+    Lifecycle:
+        1. __init__: holds the re-split gradient
+        2. dist(): starts async gradient AllToAll
+        3. apply(): waits AllToAll, re-lookups features in TBE, calls
+           embs.backward(grad) to push gradient through TBE kernel
+
+    For OL: dist() is called in PECAll2AllSeqWait.backward (immediate).
+    For NOL: dist() is called by the pipeline (deferred).
+    """
+
+    def __init__(
+        self,
+        grad: torch.Tensor,
+        input_splits: List[int],
+        output_splits: List[int],
+        pg: dist.ProcessGroup,
+    ) -> None:
+        self._grad = grad
+        self._input_splits = input_splits
+        self._output_splits = output_splits
+        self._pg = pg
+        self._work: dist.Work | None = None
+        self._grad_buffer: torch.Tensor | None = None
+
+    def dist(self) -> None:
+        """Starts async gradient reverse AllToAll. Idempotent — no-op if already started."""
+        if self._work is not None:
+            return
+
+        embedding_dim = self._grad.shape[1]
+        self._work, self._grad_buffer = _grad_dist(
+            self._grad,
+            input_splits=self._input_splits,
+            output_splits=self._output_splits,
+            embedding_dim=embedding_dim,
+            pg=self._pg,
+        )
+        self._grad = None  # type: ignore[assignment]
+
+    def apply(
+        self,
+        features: KeyedJaggedTensor,
+        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
+        embedding_dim: int,
+    ) -> None:
+        """Waits AllToAll and applies gradient to TBE via re-lookup + backward."""
+        assert self._work is not None
+        assert self._grad_buffer is not None
+
+        self._work.wait()
+
+        if features.values().numel() > 0:
+            with torch.enable_grad():
+                embs = lookup_fn(features).view(-1, embedding_dim)
+                if embs.numel() > 0:
+                    embs.backward(self._grad_buffer.view(-1, embedding_dim))
+        self._work = None
+        self._grad_buffer = None
+
+
+class PECGradUpdateAwaitable(Awaitable[None]):
+    """Awaitable that applies gradient to TBE on wait.
+
+    Wraps a PECGradientApply instance. On wait(), calls apply() which
+    waits on the AllToAll and pushes gradient through TBE's backward kernel
+    via re-lookup.
+    """
+
+    def __init__(
+        self,
+        applier: PECGradientApply,
+        features: KeyedJaggedTensor,
+        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
+        embedding_dim: int,
+    ) -> None:
+        super().__init__()
+        self._applier = applier
+        self._features = features
+        self._lookup_fn = lookup_fn
+        self._embedding_dim = embedding_dim
+
+    def _wait_impl(self) -> None:
+        self._applier.apply(self._features, self._lookup_fn, self._embedding_dim)

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -34,7 +34,11 @@ from torchrec.distributed.pec_collision_handlers import (
     OverlapSplits,
     split_kjt_by_values_mask,
 )
-from torchrec.distributed.pec_comm_ops import PECAll2AllSeqInfo, PECAll2AllSeqWait
+from torchrec.distributed.pec_comm_ops import (
+    PECAll2AllSeqInfo,
+    PECAll2AllSeqWait,
+    PECGradUpdateAwaitable,
+)
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import (
     Awaitable,
@@ -160,8 +164,9 @@ class BackwardPartitionContext:
 
     Produced by OverlapDistAwaitable on wait. Contains the previous
     batch's features re-split by overlap with the current batch, for
-    gradient re-routing during backward. The pipeline sets these on
-    PECAll2AllSeqInfo before calling loss.backward().
+    gradient re-routing during backward. Passed to
+    merge_partitioned_embeddings which sets the corresponding fields
+    on PECAll2AllSeqInfo.
 
     Attributes:
         splits: per-rank OL/NOL split sizes for gradient AllToAll.
@@ -283,14 +288,14 @@ class PECEmbeddingCollectionContext(EmbeddingCollectionContext):
         remapped_kjt_values: Cached remapped values per sharding group,
             set by overlap_dist. Used by the next batch's overlap_dist
             to detect overlap without re-remapping.
-        backward_ctx_per_group: PECAll2AllSeqInfo per sharding group,
-            set by merge_partitioned_embeddings. The pipeline sets
-            backward fields from the next batch's overlap_dist, then
-            read by PECAll2AllSeqWait during loss.backward().
+        autograd_ctx_per_sharding: PECAll2AllSeqInfo per sharding group,
+            set by merge_partitioned_embeddings. When backward_ctxs is
+            passed to merge, backward fields are populated automatically.
+            Read by PECAll2AllSeqWait during loss.backward().
     """
 
     remapped_kjt_values: List[torch.Tensor] | None = None
-    backward_ctx_per_group: List[PECAll2AllSeqInfo] | None = None
+    autograd_ctx_per_sharding: List[PECAll2AllSeqInfo] | None = None
 
 
 class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
@@ -305,7 +310,7 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
         self,
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
-        backward_ctxs: List[PECAll2AllSeqInfo],
+        autograd_ctxs: List[PECAll2AllSeqInfo],
         features_per_sharding: List[KeyedJaggedTensor],
         embedding_names_per_sharding: List[List[str]],
         need_indices: bool,
@@ -315,7 +320,7 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
         # PEC-specific: partition awaitables and gradient intercept (per group)
         self._overlapped_awaitables = overlapped_awaitables
         self._nonoverlapped_awaitables = nonoverlapped_awaitables
-        self._backward_ctxs = backward_ctxs
+        self._autograd_ctxs = autograd_ctxs
 
         # From EC: used by construct_jagged_tensors to build output
         self._features_per_sharding = features_per_sharding
@@ -329,17 +334,29 @@ class PECEmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
     def _wait_impl(self) -> Dict[str, JaggedTensor]:
         jt_dict: Dict[str, JaggedTensor] = {}
 
-        for ol_aw, nol_aw, bwd_ctx, features, embedding_names in zip(
+        for ol_aw, nol_aw, autograd_ctx, features, embedding_names in zip(
             self._overlapped_awaitables,
             self._nonoverlapped_awaitables,
-            self._backward_ctxs,
+            self._autograd_ctxs,
             self._features_per_sharding,
             self._embedding_names_per_sharding,
         ):
             ol_embs = ol_aw.wait()
             nol_embs = nol_aw.wait()
 
-            embeddings = PECAll2AllSeqWait.apply(bwd_ctx, ol_embs, nol_embs)
+            # grad_anchor is a dummy tensor that ensures autograd tracks this
+            # node even though OL/NOL embeddings are computed under no_grad.
+            grad_anchor = torch.empty(
+                0,
+                device=ol_embs.device,
+                requires_grad=True,
+            )
+            embeddings = PECAll2AllSeqWait.apply(
+                autograd_ctx,
+                ol_embs,
+                nol_embs,
+                grad_anchor,
+            )
 
             jt_dict.update(
                 construct_jagged_tensors(
@@ -563,31 +580,34 @@ class ShardedPECEmbeddingCollection(
         ec = self._embedding_collection
         awaitables: List[Awaitable[torch.Tensor]] = []
 
-        for lookup, odist, sharding_ctx, sharding_type in zip(
-            ec._lookups,
-            ec._output_dists,
-            ctx.sharding_contexts,
-            ec._sharding_type_to_sharding,
-        ):
-            partition_ctx = copy(sharding_ctx)
+        with torch.no_grad():
+            for lookup, odist, sharding_ctx, sharding_type in zip(
+                ec._lookups,
+                ec._output_dists,
+                ctx.sharding_contexts,
+                ec._sharding_type_to_sharding,
+            ):
+                partition_ctx = copy(sharding_ctx)
 
-            # Replace full-batch lengths with this partition's lengths.
-            partition_ctx.lengths_after_input_dist = features.lengths().view(
-                -1, features.stride()
-            )
+                # Replace full-batch lengths with this partition's lengths.
+                partition_ctx.lengths_after_input_dist = features.lengths().view(
+                    -1, features.stride()
+                )
 
-            # Map overlap splits to embedding AllToAll context
-            partition_ctx.input_splits = overlap_splits.input_splits[partition_idx]
-            partition_ctx.output_splits = overlap_splits.output_splits[partition_idx]
+                # Map overlap splits to embedding AllToAll context
+                partition_ctx.input_splits = overlap_splits.input_splits[partition_idx]
+                partition_ctx.output_splits = overlap_splits.output_splits[
+                    partition_idx
+                ]
 
-            # In RW sharding, upt maps positions in the full (pre-split) batch —
-            # wrong size for a partition. Reordering is handled by RW handler
-            # if needed.
-            partition_ctx.unbucketize_permute_tensor = None
+                # In RW sharding, upt maps positions in the full (pre-split)
+                # batch — wrong size for a partition. Reordering is handled by
+                # RW handler if needed.
+                partition_ctx.unbucketize_permute_tensor = None
 
-            embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
-            embs = lookup(features)
-            awaitables.append(odist(embs.view(-1, embedding_dim), partition_ctx))
+                embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
+                embs = lookup(features)
+                awaitables.append(odist(embs.view(-1, embedding_dim), partition_ctx))
 
         return awaitables
 
@@ -597,6 +617,7 @@ class ShardedPECEmbeddingCollection(
         overlapped_awaitables: List[Awaitable[torch.Tensor]],
         nonoverlapped_awaitables: List[Awaitable[torch.Tensor]],
         forward_ctxs: List[ForwardPartitionContext],
+        backward_ctxs: List[BackwardPartitionContext] | None = None,
     ) -> LazyAwaitable[Dict[str, JaggedTensor]]:
         """Creates a LazyAwaitable that merges OL/NOL embeddings on wait.
 
@@ -605,11 +626,10 @@ class ShardedPECEmbeddingCollection(
         and sets up the autograd graph for gradient re-split in backward),
         then constructs the final Dict[str, JaggedTensor] output.
 
-        Also creates one PECAll2AllSeqInfo per sharding group (with only
-        forward_permute set) and stores them on PEC context. The
-        pipeline is responsible for setting backward fields (splits,
-        permutes) from the next batch's overlap_dist result before
-        calling loss.backward().
+        Creates one PECAll2AllSeqInfo per sharding group and stores them
+        on PEC context. If backward_ctxs is provided, populates the
+        backward fields (splits, permutes) so the caller does not need
+        to wire them manually before loss.backward().
 
         Args:
             ctx: PEC context (sharding_contexts must be set from
@@ -620,20 +640,30 @@ class ShardedPECEmbeddingCollection(
                 compute_and_output_dist_in_partition(is_overlapped=False).
             forward_ctxs: ForwardPartitionContexts from overlap_dist,
                 one per sharding group.
+            backward_ctxs: BackwardPartitionContexts from overlap_dist,
+                one per sharding group. If provided, backward fields are
+                set on PECAll2AllSeqInfo automatically.
 
         Returns:
             LazyAwaitable resolving to Dict[str, JaggedTensor].
         """
         ec = self._embedding_collection
 
-        backward_ctxs = [
+        autograd_ctx_per_sharding = [
             PECAll2AllSeqInfo(
                 forward_permute=fc.permute,
                 pg=self._env.process_group,
             )
             for fc in forward_ctxs
         ]
-        ctx.backward_ctx_per_group = backward_ctxs
+
+        if backward_ctxs is not None:
+            for info, bwd in zip(autograd_ctx_per_sharding, backward_ctxs):
+                info.backward_splits = bwd.splits
+                info.backward_ol_permute = bwd.ol_permute
+                info.backward_nol_permute = bwd.nol_permute
+
+        ctx.autograd_ctx_per_sharding = autograd_ctx_per_sharding
 
         features_per_sharding = [
             sharding_ctx.features_before_input_dist
@@ -642,12 +672,67 @@ class ShardedPECEmbeddingCollection(
         return PECEmbeddingCollectionAwaitable(
             overlapped_awaitables=overlapped_awaitables,
             nonoverlapped_awaitables=nonoverlapped_awaitables,
-            backward_ctxs=backward_ctxs,
+            autograd_ctxs=autograd_ctx_per_sharding,
             features_per_sharding=features_per_sharding,
             embedding_names_per_sharding=ec._embedding_names_per_sharding,
             need_indices=ec._need_indices,
             features_to_permute_indices=ec._features_to_permute_indices,
         )
+
+    def grad_dist(
+        self,
+        ctx: PECEmbeddingCollectionContext,
+        backward_features: KJTList,
+        is_overlapped: bool,
+    ) -> List[Awaitable[None]]:
+        """Kicks off gradient AllToAll for one partition and returns awaitables.
+
+        For OL: dist() was already started in PECAll2AllSeqWait.backward
+        (idempotent, so calling again is a no-op).
+        For NOL: dist() starts here.
+
+        When the returned awaitables are waited, they complete the AllToAll
+        and apply the gradient to TBE via re-lookup.
+
+        Args:
+            ctx: PEC context with autograd_ctx_per_sharding populated by
+                backward.
+            backward_features: previous batch's OL or NOL features for
+                gradient re-lookup (one per sharding group).
+            is_overlapped: True for OL partition, False for NOL.
+
+        Returns:
+            List of awaitables, one per sharding group.
+        """
+        assert ctx.autograd_ctx_per_sharding is not None
+        ec = self._embedding_collection
+
+        awaitables: List[Awaitable[None]] = []
+        for autograd_ctx, feature, lookup, sharding_type in zip(
+            ctx.autograd_ctx_per_sharding,
+            backward_features,
+            ec._lookups,
+            ec._sharding_type_to_sharding,
+        ):
+            embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
+            grad_apply = (
+                autograd_ctx.ol_grad_apply
+                if is_overlapped
+                else autograd_ctx.nol_grad_apply
+            )
+            assert grad_apply is not None
+
+            grad_apply.dist()
+            awaitables.append(
+                PECGradUpdateAwaitable(
+                    grad_apply,
+                    feature,
+                    lookup,
+                    embedding_dim,
+                )
+            )
+
+        return awaitables
 
 
 class PECEmbeddingCollectionSharder(BaseEmbeddingSharder[PECEmbeddingCollection]):

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -10,14 +10,18 @@
 
 import copy
 import unittest
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
+from torchrec.distributed.embedding_types import KJTList
 from torchrec.distributed.pec_embedding import (
     BackwardPartitionContext,
     ForwardPartitionContext,
+    PECEmbeddingCollectionContext,
     PECEmbeddingCollectionSharder,
     ShardedPECEmbeddingCollection,
 )
@@ -29,6 +33,7 @@ from torchrec.distributed.test_utils.multi_process import (
 )
 from torchrec.distributed.test_utils.test_sharding import copy_state_dict
 from torchrec.distributed.types import (
+    Awaitable,
     ModuleSharder,
     ShardingEnv,
     ShardingPlan,
@@ -54,6 +59,11 @@ EMBEDDING_TABLES: List[EmbeddingConfig] = [
         num_embeddings=8,
     ),
 ]
+
+
+# =============================================================================
+# Unit tests (no distributed setup)
+# =============================================================================
 
 
 class PECEmbeddingCollectionTest(unittest.TestCase):
@@ -97,6 +107,11 @@ class PECEmbeddingCollectionSharderTest(unittest.TestCase):
         self.assertEqual(params["table_0"].shape, (16, 8))
 
 
+# =============================================================================
+# Model & sharding helpers
+# =============================================================================
+
+
 class PECSparseArch(nn.Module):
     """Simple model wrapping PECEmbeddingCollection for sharded testing."""
 
@@ -132,7 +147,9 @@ def _shard_pec(
 
     module_sharding_plan = construct_module_sharding_plan(
         sparse_arch._pec_ec,
-        per_param_sharding={table.name: row_wise() for table in tables},
+        per_param_sharding={
+            table.name: row_wise(compute_kernel="fused") for table in tables
+        },
         local_size=local_size,
         world_size=ctx.world_size,
         device_type="cuda" if torch.cuda.is_available() else "cpu",
@@ -146,6 +163,341 @@ def _shard_pec(
         sharders=[sharder],
         device=ctx.device,
     )
+
+
+@dataclass
+class _PECForwardResult:
+    """Result of _pec_forward for one batch."""
+
+    # Pipeline contexts (passed to backward)
+    pec_ctx: PECEmbeddingCollectionContext
+    fwd_ctx: ForwardPartitionContext
+    bwd_ctx: BackwardPartitionContext
+
+    # Intermediate: partitioned embeddings before merge
+    ol_awaitables: List[Awaitable[torch.Tensor]]
+    nol_awaitables: List[Awaitable[torch.Tensor]]
+
+    # Final: merged output (populated when should_merge_partitions=True)
+    jt_dict: Dict[str, JaggedTensor]
+
+    # Original input (for verification against ref_ec)
+    original_values: torch.Tensor
+    original_lengths: torch.Tensor
+    device: torch.device
+
+
+@dataclass
+class _PECState:
+    """PEC state across batches."""
+
+    sharded_pec: ShardedPECEmbeddingCollection
+    pec_ctx: PECEmbeddingCollectionContext
+    dist_input: KJTList
+    fwd_ctx: ForwardPartitionContext
+    batches: List[KeyedJaggedTensor]
+    device: torch.device
+
+
+VerifyFn = Optional[
+    Callable[[_PECForwardResult, EmbeddingCollection | None, int, int], None]
+]
+
+
+def _pec_pre_forward(
+    tables: List[EmbeddingConfig],
+    ctx: MultiProcessContext,
+    sharder: ModuleSharder[nn.Module],
+    batches: List[KeyedJaggedTensor],
+    ref_ec: EmbeddingCollection | None = None,
+    local_size: Optional[int] = None,
+) -> _PECState:
+    """Shard PEC, copy weights, input_dist + overlap_dist for batch 0."""
+    sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
+    sharded_pec = sharded_sparse_arch._pec_ec
+    assert isinstance(sharded_pec, ShardedPECEmbeddingCollection)
+    assert len(sharded_pec._overlap_handlers) > 0
+
+    if ref_ec is not None:
+        copy_state_dict(
+            sharded_pec._embedding_collection.state_dict(),
+            ref_ec.state_dict(),
+        )
+
+    kjt_0 = batches[0].to(ctx.device)
+    pec_ctx = sharded_pec.create_context()
+    dist_input = sharded_pec.input_dist(pec_ctx, kjt_0).wait().wait()
+
+    results_0 = sharded_pec.overlap_dist(ctx=pec_ctx, dist_input=dist_input)
+    fwd_ctx, _ = results_0[0].wait()
+    assert fwd_ctx is not None
+
+    return _PECState(
+        sharded_pec=sharded_pec,
+        pec_ctx=pec_ctx,
+        dist_input=dist_input,
+        fwd_ctx=fwd_ctx,
+        batches=batches,
+        device=ctx.device,
+    )
+
+
+def _pec_forward(
+    state: _PECState,
+    batch_idx: int,
+    rank: int = 0,
+    ref_ec: EmbeddingCollection | None = None,
+    verify_fn: VerifyFn = None,
+    should_merge_partitions: bool = True,
+) -> _PECForwardResult:
+    """PEC forward: lookahead overlap_dist + compute + optional merge + verify.
+
+    Args:
+        verify_fn: called with (result, ref_ec, rank, batch_idx) after
+            merge (or directly if should_merge_partitions=False). Use
+            partial to bind expected data.
+        should_merge_partitions: if True, run merge_partitioned_embeddings
+            before verify_fn. If False, skip merge and call verify_fn
+            directly.
+    """
+    sharded_pec = state.sharded_pec
+    batches = state.batches
+    pec_ctx = state.pec_ctx
+    dist_input = state.dist_input
+    fwd_ctx = state.fwd_ctx
+
+    original_values = batches[batch_idx].values()
+    original_lengths = batches[batch_idx].lengths()
+
+    # Lookahead: input_dist + overlap_dist for next batch
+    if batch_idx + 1 < len(batches):
+        next_kjt = batches[batch_idx + 1].to(state.device)
+        next_pec_ctx = sharded_pec.create_context()
+        next_dist_input = sharded_pec.input_dist(next_pec_ctx, next_kjt).wait().wait()
+        results_next = sharded_pec.overlap_dist(
+            ctx=next_pec_ctx,
+            dist_input=next_dist_input,
+            prev_ctx=pec_ctx,
+            prev_dist_input=dist_input,
+        )
+    else:
+        results_next = sharded_pec.overlap_dist(
+            ctx=None,
+            dist_input=None,
+            prev_ctx=pec_ctx,
+            prev_dist_input=dist_input,
+        )
+        next_pec_ctx = None
+        next_dist_input = None
+
+    fwd_next, bwd_cur = results_next[0].wait()
+    assert bwd_cur is not None
+
+    # Compute OL/NOL
+    ol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
+        pec_ctx,
+        fwd_ctx.ol_features,
+        fwd_ctx.splits,
+        is_overlapped=True,
+    )
+    nol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
+        pec_ctx,
+        fwd_ctx.nol_features,
+        fwd_ctx.splits,
+        is_overlapped=False,
+    )
+
+    result = _PECForwardResult(
+        pec_ctx=pec_ctx,
+        fwd_ctx=fwd_ctx,
+        bwd_ctx=bwd_cur,
+        ol_awaitables=ol_awaitables,
+        nol_awaitables=nol_awaitables,
+        original_values=original_values,
+        original_lengths=original_lengths,
+        jt_dict={},
+        device=state.device,
+    )
+
+    if should_merge_partitions:
+        result.jt_dict = sharded_pec.merge_partitioned_embeddings(
+            pec_ctx,
+            ol_awaitables,
+            nol_awaitables,
+            [fwd_ctx],
+            [bwd_cur],
+        ).wait()
+
+    if verify_fn is not None:
+        verify_fn(result, ref_ec, rank, batch_idx)
+
+    # Advance state
+    if fwd_next is not None:
+        state.fwd_ctx = fwd_next
+
+    if next_pec_ctx is not None:
+        assert next_dist_input is not None
+        state.pec_ctx = next_pec_ctx
+        state.dist_input = next_dist_input
+
+    return result
+
+
+def _pec_backward(
+    state: _PECState,
+    result: _PECForwardResult,
+) -> None:
+    """PEC backward: loss.backward(), grad_dist."""
+    pec_pred = torch.cat(
+        [result.jt_dict[k].values() for k in result.jt_dict],
+        dim=0,
+    )
+    pec_pred.mean().backward()
+
+    ol_grad_aw = state.sharded_pec.grad_dist(
+        result.pec_ctx,
+        KJTList([result.bwd_ctx.ol_features]),
+        is_overlapped=True,
+    )
+    ol_grad_aw[0].wait()
+
+    nol_grad_aw = state.sharded_pec.grad_dist(
+        result.pec_ctx,
+        KJTList([result.bwd_ctx.nol_features]),
+        is_overlapped=False,
+    )
+    nol_grad_aw[0].wait()
+
+
+def _verify_partition_embeddings(
+    embs: torch.Tensor,
+    expected_specs: List[Tuple[str, int]],
+    ref_ec: EmbeddingCollection,
+    device: torch.device,
+) -> None:
+    assert embs.shape[0] == len(expected_specs)
+    if len(expected_specs) > 0:
+        expected_tensor = torch.stack(
+            [
+                # pyre-ignore[16]: embeddings[tname] is nn.Embedding
+                ref_ec.embeddings[tname].weight[oid]
+                for tname, oid in expected_specs
+            ]
+        ).to(device)
+        torch.testing.assert_close(embs, expected_tensor)
+
+
+def _verify_fwd_permutes(
+    result: _PECForwardResult,
+    ref_ec: EmbeddingCollection | None,
+    rank: int,
+    batch_idx: int,
+    expected_per_rank: List[List[List[int]]],
+) -> None:
+    assert result.fwd_ctx is not None
+    assert result.fwd_ctx.permute.tolist() == expected_per_rank[rank][batch_idx]
+
+
+def _verify_bwd_permutes(
+    result: _PECForwardResult,
+    ref_ec: EmbeddingCollection | None,
+    rank: int,
+    batch_idx: int,
+    expected_ol_per_rank: List[List[List[int]]],
+    expected_nol_per_rank: List[List[List[int]]],
+) -> None:
+    assert result.bwd_ctx.ol_permute.tolist() == expected_ol_per_rank[rank][batch_idx]
+    assert result.bwd_ctx.nol_permute.tolist() == expected_nol_per_rank[rank][batch_idx]
+
+
+def _verify_ol_nol_partitions(
+    result: _PECForwardResult,
+    ref_ec: EmbeddingCollection | None,
+    rank: int,
+    batch_idx: int,
+    expected_ol_per_rank: Dict[int, List[List[Tuple[str, int]]]],
+    expected_nol_per_rank: Dict[int, List[List[Tuple[str, int]]]],
+) -> None:
+    assert ref_ec is not None
+    _verify_partition_embeddings(
+        result.ol_awaitables[0].wait(),
+        expected_ol_per_rank[rank][batch_idx],
+        ref_ec,
+        result.device,
+    )
+    _verify_partition_embeddings(
+        result.nol_awaitables[0].wait(),
+        expected_nol_per_rank[rank][batch_idx],
+        ref_ec,
+        result.device,
+    )
+
+
+def _verify_merged_output(
+    result: _PECForwardResult,
+    ref_ec: EmbeddingCollection | None,
+    rank: int,
+    batch_idx: int,
+    tables: List[EmbeddingConfig],
+    batches_per_rank: List[List[KeyedJaggedTensor]],
+) -> None:
+    """Verifies merged PEC output matches ref EC for the given batch."""
+    assert ref_ec is not None
+    kjt_input = batches_per_rank[rank][batch_idx].to(result.device)
+
+    feature_to_table = {}
+    for table in tables:
+        for fname in table.feature_names:
+            feature_to_table[fname] = table.name
+
+    assert set(result.jt_dict.keys()) == set(feature_to_table.keys())
+
+    stride = kjt_input.stride()
+    offset = 0
+    for feat_idx, fname in enumerate(kjt_input.keys()):
+        tname = feature_to_table[fname]
+        feat_lengths = result.original_lengths[
+            feat_idx * stride : (feat_idx + 1) * stride
+        ]
+        num_values = feat_lengths.sum().item()
+        feat_ids = result.original_values[offset : offset + num_values]
+
+        actual_jt = result.jt_dict[fname]
+        torch.testing.assert_close(actual_jt.lengths().cpu(), feat_lengths)
+        if num_values > 0:
+            expected_embs = torch.stack(
+                [
+                    # pyre-ignore[16]
+                    ref_ec.embeddings[tname].weight[vid.item()]
+                    for vid in feat_ids
+                ]
+            ).to(result.device)
+            torch.testing.assert_close(actual_jt.values(), expected_embs)
+        offset += num_values
+
+
+def _verify_weights_match(
+    tables: List[EmbeddingConfig],
+    sharded_pec: ShardedPECEmbeddingCollection,
+    ref_ec: EmbeddingCollection,
+    device: torch.device,
+) -> None:
+    """Forward all indices through both models and compare outputs."""
+    verify_kjt = KeyedJaggedTensor.from_lengths_sync(
+        keys=[t.feature_names[0] for t in tables],
+        values=torch.cat([torch.arange(t.num_embeddings) for t in tables]),
+        lengths=torch.LongTensor([t.num_embeddings for t in tables]),
+    )
+
+    with torch.no_grad():
+        ref_out = ref_ec(verify_kjt)
+        pec_out = sharded_pec(verify_kjt.to(device))
+
+    for fname in ref_out:
+        torch.testing.assert_close(
+            pec_out[fname].values(),
+            ref_out[fname].values().to(device),
+        )
 
 
 def _test_sharding(
@@ -172,93 +524,6 @@ def _test_sharding(
             loss.backward()
 
 
-def _verify_forward_permute(
-    forward_ctx: ForwardPartitionContext | None,
-    expected: List[int],
-) -> None:
-    assert forward_ctx is not None
-    assert forward_ctx.permute.tolist() == expected
-
-
-def _verify_backward_permutes(
-    backward_ctx: BackwardPartitionContext | None,
-    expected_ol_permute: List[int] | None,
-    expected_nol_permute: List[int] | None,
-) -> None:
-    if expected_ol_permute is None:
-        assert backward_ctx is None
-    else:
-        assert backward_ctx is not None
-        assert backward_ctx.ol_permute.tolist() == expected_ol_permute
-        assert expected_nol_permute is not None
-        assert backward_ctx.nol_permute.tolist() == expected_nol_permute
-
-
-def _verify_forward_splits(
-    forward_ctx: ForwardPartitionContext,
-    expected_input_splits: Tuple[List[int], List[int]],
-    expected_output_splits: Tuple[List[int], List[int]],
-) -> None:
-    assert forward_ctx.splits.input_splits == expected_input_splits
-    assert forward_ctx.splits.output_splits == expected_output_splits
-
-
-def _verify_partition_embeddings(
-    embs: torch.Tensor,
-    expected_specs: List[Tuple[str, int]],
-    ref_ec: EmbeddingCollection,
-    device: torch.device,
-) -> None:
-    assert embs.shape[0] == len(expected_specs)
-    if len(expected_specs) > 0:
-        expected_tensor = torch.stack(
-            [
-                # pyre-ignore[16]: embeddings[tname] is nn.Embedding
-                ref_ec.embeddings[tname].weight[oid]
-                for tname, oid in expected_specs
-            ]
-        ).to(device)
-        torch.testing.assert_close(embs, expected_tensor)
-
-
-def _verify_merged_output(
-    jt_dict: Dict[str, JaggedTensor],
-    kjt_input: KeyedJaggedTensor,
-    original_values: torch.Tensor,
-    original_lengths: torch.Tensor,
-    tables: List[EmbeddingConfig],
-    ref_ec: EmbeddingCollection,
-    device: torch.device,
-) -> None:
-    feature_to_table = {}
-    for table in tables:
-        for fname in table.feature_names:
-            feature_to_table[fname] = table.name
-
-    assert set(jt_dict.keys()) == set(feature_to_table.keys())
-
-    stride = kjt_input.stride()
-    offset = 0
-    for feat_idx, fname in enumerate(kjt_input.keys()):
-        tname = feature_to_table[fname]
-        feat_lengths = original_lengths[feat_idx * stride : (feat_idx + 1) * stride]
-        num_values = feat_lengths.sum().item()
-        feat_ids = original_values[offset : offset + num_values]
-
-        actual_jt = jt_dict[fname]
-        torch.testing.assert_close(actual_jt.lengths().cpu(), feat_lengths)
-        if num_values > 0:
-            expected_embs = torch.stack(
-                [
-                    # pyre-ignore[16]: embeddings[tname] is nn.Embedding
-                    ref_ec.embeddings[tname].weight[vid.item()]
-                    for vid in feat_ids
-                ]
-            ).to(device)
-            torch.testing.assert_close(actual_jt.values(), expected_embs)
-        offset += num_values
-
-
 def _test_pec_forward_stages(
     tables: List[EmbeddingConfig],
     rank: int,
@@ -266,130 +531,83 @@ def _test_pec_forward_stages(
     kjt_input_per_rank: List[List[KeyedJaggedTensor]],
     sharder: ModuleSharder[nn.Module],
     backend: str,
-    expected_forward_permutes_per_rank: List[List[List[int]]] | None = None,
-    expected_backward_ol_permutes_per_rank: List[List[List[int] | None]] | None = None,
-    expected_backward_nol_permutes_per_rank: List[List[List[int] | None]] | None = None,
     ref_ec: EmbeddingCollection | None = None,
-    expected_ol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
-    expected_nol_per_rank: Dict[int, List[List[Tuple[str, int]]]] | None = None,
-    verify_merge: bool = False,
+    verify_fn: VerifyFn = None,
+    should_merge_partitions: bool = True,
     local_size: Optional[int] = None,
 ) -> None:
-    """Runs PEC forward pipeline using overlap_dist and verifies results.
+    """Runs PEC forward pipeline, calling verify_fn per batch."""
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        batches = kjt_input_per_rank[rank]
+        state = _pec_pre_forward(
+            tables,
+            ctx,
+            sharder,
+            batches,
+            ref_ec,
+            local_size,
+        )
 
-    Pipeline: input_dist → overlap_dist → compute_and_output_dist_in_partition
-    (OL + NOL) → optionally merge_partitioned_embeddings.
+        for i in range(len(batches)):
+            _pec_forward(
+                state,
+                i,
+                rank=rank,
+                ref_ec=ref_ec,
+                verify_fn=verify_fn,
+                should_merge_partitions=should_merge_partitions,
+            )
+
+
+def _test_pec_grad_update(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    world_size: int,
+    kjt_input_per_rank: List[List[KeyedJaggedTensor]],
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    ref_ec: EmbeddingCollection,
+    learning_rate: float = 0.01,
+    local_size: Optional[int] = None,
+) -> None:
+    """Tests full train loop and verifies weights match ref_ec.
+
+    Each step: ref_ec processes all ranks' batches (matching AllToAll
+    redistribution), PEC runs the normal pipeline. After all batches,
+    a full-index KJT lookup verifies the weights converged identically.
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
-        sharded_sparse_arch = _shard_pec(tables, ctx, sharder, local_size)
-        sharded_pec = sharded_sparse_arch._pec_ec
-        assert isinstance(sharded_pec, ShardedPECEmbeddingCollection)
-        assert len(sharded_pec._overlap_handlers) > 0
-
-        if ref_ec is not None:
-            copy_state_dict(
-                sharded_pec._embedding_collection.state_dict(),
-                ref_ec.state_dict(),
-            )
-
         batches = kjt_input_per_rank[rank]
-        prev_ctx = None
-        prev_features_list = None
+        state = _pec_pre_forward(tables, ctx, sharder, batches, ref_ec, local_size)
 
-        for batch_idx, kjt_input in enumerate(batches):
-            original_values = kjt_input.values()
-            original_lengths = kjt_input.lengths()
-            kjt_input = kjt_input.to(ctx.device)
+        ref_optimizer = torch.optim.SGD(
+            ref_ec.parameters(), lr=learning_rate, foreach=True
+        )
 
-            # Stage 1: input_dist
-            pec_ctx = sharded_pec.create_context()
-            dist_input = sharded_pec.input_dist(pec_ctx, kjt_input).wait().wait()
+        for i in range(len(batches)):
+            ref_optimizer.zero_grad()
+            ref_out = ref_ec(kjt_input_per_rank[rank][i])
+            torch.cat(
+                [ref_out[k].values() for k in ref_out],
+                dim=0,
+            ).mean().backward()
+            ref_optimizer.step()
 
-            # Stage 2: overlap_dist (fused detect + split + mask dist + compute)
-            results = sharded_pec.overlap_dist(
-                ctx=pec_ctx,
-                dist_input=dist_input,
-                prev_ctx=prev_ctx,
-                prev_dist_input=prev_features_list,
-            )
-            forward_ctx, backward_ctx = results[0].wait()
+            result = _pec_forward(state, i)
+            _pec_backward(state, result)
 
-            if expected_forward_permutes_per_rank is not None:
-                _verify_forward_permute(
-                    forward_ctx,
-                    expected_forward_permutes_per_rank[rank][batch_idx],
-                )
+        _verify_weights_match(tables, state.sharded_pec, ref_ec, ctx.device)
 
-            if expected_backward_ol_permutes_per_rank is not None:
-                assert expected_backward_nol_permutes_per_rank is not None
-                _verify_backward_permutes(
-                    backward_ctx,
-                    expected_backward_ol_permutes_per_rank[rank][batch_idx],
-                    expected_backward_nol_permutes_per_rank[rank][batch_idx],
-                )
 
-            # Stage 3: compute_and_output_dist_in_partition
-            assert forward_ctx is not None
-            ol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
-                pec_ctx,
-                forward_ctx.ol_features,
-                forward_ctx.splits,
-                is_overlapped=True,
-            )
-            assert len(ol_awaitables) == 1
-
-            nol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
-                pec_ctx,
-                forward_ctx.nol_features,
-                forward_ctx.splits,
-                is_overlapped=False,
-            )
-            assert len(nol_awaitables) == 1
-
-            if ref_ec is not None and expected_ol_per_rank is not None:
-                _verify_partition_embeddings(
-                    ol_awaitables[0].wait(),
-                    expected_ol_per_rank[rank][batch_idx],
-                    ref_ec,
-                    ctx.device,
-                )
-            if ref_ec is not None and expected_nol_per_rank is not None:
-                _verify_partition_embeddings(
-                    nol_awaitables[0].wait(),
-                    expected_nol_per_rank[rank][batch_idx],
-                    ref_ec,
-                    ctx.device,
-                )
-
-            # Stage 4: merge_partitioned_embeddings
-            if verify_merge:
-                assert ref_ec is not None
-                lazy_result = sharded_pec.merge_partitioned_embeddings(
-                    pec_ctx,
-                    ol_awaitables,
-                    nol_awaitables,
-                    [forward_ctx],
-                )
-                jt_dict = lazy_result.wait()
-                _verify_merged_output(
-                    jt_dict,
-                    kjt_input,
-                    original_values,
-                    original_lengths,
-                    tables,
-                    ref_ec,
-                    ctx.device,
-                )
-
-            prev_ctx = pec_ctx
-            prev_features_list = dist_input
-
+# =============================================================================
+# Test data
+# =============================================================================
 
 # Cross-shard data for uneven tables (table_0: 16 rows, table_1: 8 rows).
 # With world_size=2 RW sharding:
 #   table_0: block_size=8, shard 0 rows 0-7, shard 1 rows 8-15
 #   table_1: block_size=4, shard 0 rows 0-3, shard 1 rows 4-7
-# stride=2 (batch_size=2 per rank), 2 batches per rank.
+# stride=2 (batch_size=2 per rank), 3 batches per rank.
 CROSS_SHARD_KJT_INPUT_PER_RANK = [
     [
         # Rank 0 batch 0
@@ -406,6 +624,14 @@ CROSS_SHARD_KJT_INPUT_PER_RANK = [
         KeyedJaggedTensor.from_lengths_sync(
             keys=["feature_0", "feature_1"],
             values=torch.LongTensor([0, 9, 3, 1, 6, 2]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
+        ),
+        # Rank 0 batch 2 (overlaps with batch 1: f0: 0,3, f1: 2)
+        # f0: [0,10,3] → shard0:[0,3], shard1:[10]
+        # f1: [2,4,0] → shard0:[2,0], shard1:[4]
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([0, 10, 3, 2, 4, 0]),
             lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
     ],
@@ -426,8 +652,21 @@ CROSS_SHARD_KJT_INPUT_PER_RANK = [
             values=torch.LongTensor([1, 11, 7, 4, 3, 6]),
             lengths=torch.LongTensor([2, 1, 1, 2]),
         ),
+        # Rank 1 batch 2 (overlaps with batch 1: f0: 1,7, f1: 4,6)
+        # f0: [1,12,7] → shard0:[1,7], shard1:[12]
+        # f1: [4,0,6] → shard0:[0], shard1:[4,6]
+        KeyedJaggedTensor.from_lengths_sync(
+            keys=["feature_0", "feature_1"],
+            values=torch.LongTensor([1, 12, 7, 4, 0, 6]),
+            lengths=torch.LongTensor([2, 1, 1, 2]),
+        ),
     ],
 ]
+
+
+# =============================================================================
+# Multi-process tests
+# =============================================================================
 
 
 @skip_if_asan_class
@@ -460,27 +699,21 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         """Verifies exact forward_permute values from overlap_dist."""
         WORLD_SIZE = 2
 
-        # Batch 0: no overlap → forward_permute = upt
-        # Batch 1: partial overlap → forward_permute derived from post-dist mask + upt
-        expected_forward_permutes_per_rank = [
-            [
-                [0, 4, 1, 2, 5, 3],
-                [0, 4, 3, 1, 5, 2],
-            ],
-            [
-                [0, 3, 1, 4, 2, 5],
-                [0, 4, 3, 2, 1, 5],
-            ],
-        ]
-
         self._run_multi_process_test(
             callable=_test_pec_forward_stages,
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
-            expected_forward_permutes_per_rank=expected_forward_permutes_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
+            should_merge_partitions=False,
+            verify_fn=partial(
+                _verify_fwd_permutes,
+                expected_per_rank=[
+                    [[0, 4, 1, 2, 5, 3], [0, 4, 3, 1, 5, 2], [0, 5, 1, 2, 3, 4]],
+                    [[0, 3, 1, 4, 2, 5], [0, 4, 3, 2, 1, 5], [0, 5, 1, 2, 4, 3]],
+                ],
+            ),
         )
 
     @unittest.skipIf(
@@ -491,26 +724,25 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         """Verifies backward ol/nol permutes from overlap_dist."""
         WORLD_SIZE = 2
 
-        # Batch 0: no prev batch → backward permutes are None
-        # Batch 1: backward permutes computed from backward mask
-        expected_backward_ol_permutes_per_rank = [
-            [None, [0, 3, 5]],
-            [None, [0, 4, 3]],
-        ]
-        expected_backward_nol_permutes_per_rank = [
-            [None, [2, 1, 4]],
-            [None, [2, 1, 5]],
-        ]
-
         self._run_multi_process_test(
             callable=_test_pec_forward_stages,
             world_size=WORLD_SIZE,
             tables=EMBEDDING_TABLES,
             kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
-            expected_backward_ol_permutes_per_rank=expected_backward_ol_permutes_per_rank,
-            expected_backward_nol_permutes_per_rank=expected_backward_nol_permutes_per_rank,
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
+            should_merge_partitions=False,
+            verify_fn=partial(
+                _verify_bwd_permutes,
+                expected_ol_per_rank=[
+                    [[0, 3, 5], [0, 2, 5, 4], [0, 2, 3, 5, 1, 4]],
+                    [[0, 4, 3], [0, 2, 3, 5], [0, 2, 4, 1, 3, 5]],
+                ],
+                expected_nol_per_rank=[
+                    [[2, 1, 4], [3, 1], []],
+                    [[2, 1, 5], [4, 1], []],
+                ],
+            ),
         )
 
     @unittest.skipIf(
@@ -518,51 +750,15 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
         "Not enough GPUs, this test requires at least two GPUs",
     )
     def test_compute_and_output_dist_in_partition(self) -> None:
-        """Tests OL/NOL embeddings match expected weight rows.
-
-        Uses uneven cross-shard data. table_0: 16 rows (block_size=8),
-        table_1: 8 rows (block_size=4). world_size=2.
-
-        Expected values traced through:
-        1. block_bucketize → which values go to which shard
-        2. KJTAllToAll + recat [0,2,1,3] → feature-major on shard
-        3. remap with per-table offsets (shard 0: t0 offset=0, t1 offset=8)
-        4. overlap mask (batch 1 vs batch 0 remapped values)
-        5. split → lookup → embedding AllToAll → rank receives
-        6. output order: [from_shard0, from_shard1]
-
-        Batch 0: all NOL (first batch, no overlap).
-        Batch 1 shard 0 mask=[T,F,T,F,T,T,T], shard 1 mask=[T,F,T,T,F].
-        """
+        """Tests OL/NOL embeddings match expected weight rows."""
         WORLD_SIZE = 2
+        T0 = "table_0"
+        T1 = "table_1"
 
         ref_ec = EmbeddingCollection(
             tables=EMBEDDING_TABLES,
             device=torch.device("cpu"),
         )
-
-        T0 = "table_0"
-        T1 = "table_1"
-        expected_ol: Dict[int, List[List[Tuple[str, int]]]] = {
-            0: [
-                [],  # batch 0: no overlap
-                [(T0, 0), (T1, 1), (T1, 2)],
-            ],
-            1: [
-                [],
-                [(T0, 1), (T1, 3), (T1, 4)],
-            ],
-        }
-        expected_nol: Dict[int, List[List[Tuple[str, int]]]] = {
-            0: [
-                [(T0, 0), (T0, 2), (T1, 1), (T1, 3), (T0, 8), (T1, 5)],
-                [(T0, 3), (T0, 9), (T1, 6)],
-            ],
-            1: [
-                [(T0, 1), (T0, 5), (T1, 2), (T0, 10), (T1, 4), (T1, 7)],
-                [(T0, 7), (T0, 11), (T1, 6)],
-            ],
-        }
 
         self._run_multi_process_test(
             callable=_test_pec_forward_stages,
@@ -572,8 +768,34 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
             ref_ec=ref_ec,
-            expected_ol_per_rank=expected_ol,
-            expected_nol_per_rank=expected_nol,
+            should_merge_partitions=False,
+            verify_fn=partial(
+                _verify_ol_nol_partitions,
+                expected_ol_per_rank={
+                    0: [
+                        [],
+                        [(T0, 0), (T1, 1), (T1, 2)],
+                        [(T0, 0), (T0, 3), (T1, 2), (T1, 4)],
+                    ],
+                    1: [
+                        [],
+                        [(T0, 1), (T1, 3), (T1, 4)],
+                        [(T0, 1), (T0, 7), (T1, 4), (T1, 6)],
+                    ],
+                },
+                expected_nol_per_rank={
+                    0: [
+                        [(T0, 0), (T0, 2), (T1, 1), (T1, 3), (T0, 8), (T1, 5)],
+                        [(T0, 3), (T0, 9), (T1, 6)],
+                        [(T1, 0), (T0, 10)],
+                    ],
+                    1: [
+                        [(T0, 1), (T0, 5), (T1, 2), (T0, 10), (T1, 4), (T1, 7)],
+                        [(T0, 7), (T0, 11), (T1, 6)],
+                        [(T1, 0), (T0, 12)],
+                    ],
+                },
+            ),
         )
 
     @unittest.skipIf(
@@ -597,7 +819,11 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
             ref_ec=ref_ec,
-            verify_merge=True,
+            verify_fn=partial(
+                _verify_merged_output,
+                tables=EMBEDDING_TABLES,
+                batches_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
+            ),
         )
 
     @unittest.skipIf(
@@ -653,5 +879,43 @@ class ShardedPECEmbeddingCollectionTest(MultiProcessTestBase):
             sharder=PECEmbeddingCollectionSharder(),
             backend="nccl",
             ref_ec=ref_ec,
-            verify_merge=True,
+            verify_fn=partial(
+                _verify_merged_output,
+                tables=EMBEDDING_TABLES,
+                batches_per_rank=shard1_only_input,
+            ),
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_grad_update(self) -> None:
+        """Tests full pipeline: overlap_dist → compute → merge → backward → grad apply.
+
+        Uses 3 batches to exercise the complete pipeline ordering where
+        batch i's backward data comes from batch i+1's overlap_dist.
+        After all batches, verifies that sharded PEC weights match an
+        unsharded ref EC trained with the same data and optimizer.
+        """
+        WORLD_SIZE = 2
+        LEARNING_RATE = 0.01
+
+        torch.manual_seed(42)
+        ref_ec = EmbeddingCollection(
+            tables=EMBEDDING_TABLES,
+            device=torch.device("cpu"),
+        )
+
+        self._run_multi_process_test(
+            callable=_test_pec_grad_update,
+            world_size=WORLD_SIZE,
+            tables=EMBEDDING_TABLES,
+            kjt_input_per_rank=CROSS_SHARD_KJT_INPUT_PER_RANK,
+            sharder=PECEmbeddingCollectionSharder(
+                fused_params={"learning_rate": LEARNING_RATE},
+            ),
+            backend="nccl",
+            ref_ec=ref_ec,
+            learning_rate=LEARNING_RATE,
         )


### PR DESCRIPTION
Summary:
# Context

PEC backward needs to re-split the merged gradient into OL/NOL partitions, AllToAll them back to owning shards, and apply the weight updates via TBE. This diff adds the gradient application infrastructure and an end-to-end test verifying that sharded PEC training produces the same weight updates as an unsharded reference model.

# New API: `grad_dist`

It takes a single partition at a time (`is_overlapped` flag), kicks off its AllToAll, returns awaitables — **caller (pipelines) controls ordering**
- `PECGradientApply`: manages one partition's gradient lifecycle — AllToAll redistribution → wait → re-lookup features through TBE → `embs.backward(grad_buffer)` to trigger fused optimizer update
- `PECGradUpdateAwaitable`: wraps `PECGradientApply` in the `Awaitable` pattern
- `PECAll2AllSeqWait.backward`: creates two `PECGradientApply` instances (OL and NOL), starts OL AllToAll immediately, defers NOL to the pipeline for overlap with other compute

# Gradient Interception & Resplit

- `compute_and_output_dist_in_partition` runs under `torch.no_grad()` — embedding lookup and output AllToAll do not create an autograd graph
- Gradients flow through a separate, manually-managed path via `PECAll2AllSeqWait.backward()` -> `PECGradientApply`
- A zero-element `grad_anchor` tensor with `requires_grad=True` is passed to `PECAll2AllSeqWait.apply` so its output has `requires_grad=True` even though OL/NOL inputs don't
- `PECAll2AllSeqWait.backward` returns `None` for all inputs, severing gradient propagation — actual gradient application happens through `PECGradientApply.apply()`

# Tests

Add an E2E test to verify the correctness:
* Use a non-sharded EC updated with SGD optimizer with the same params
* Embeddings in non-sharded EC and PEC EC should match perfectly after several batches.

Also improved the readability of the original forward tests in stages with a callback & partial func pattern.

Reviewed By: TroyGarden

Differential Revision: D105717556


