### PR TITLE
[detailed][data transfer] All-to-All vs Device-to-Host Contention

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -1048,6 +1048,101 @@ def data_copy_no_record_stream(
     )
 
 
+def a2a_d2h_contention(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    concurrent: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Compare resource contention between all_to_all_single (NVLink/network)
+    and device-to-host copy (PCIe). When concurrent=True, both run on
+    separate streams simultaneously — contention on shared resources (PCIe,
+    memory bandwidth) will show up as increased latency in the trace.
+    When concurrent=False, D2H waits for all2all to complete first,
+    providing a contention-free baseline for comparison.
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        comms_stream = torch.cuda.Stream()
+        d2h_stream = torch.cuda.Stream()
+
+    with record_function("## pre-comms compute ##"):
+        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## allocate d2h tensors ##"):
+        d2h_source = torch.full(
+            (num_concat * dim, dim),
+            fill_value=float(ctx.rank + 1),
+            device=ctx.device,
+        )
+        cpu_buffer = torch.empty_like(d2h_source, device="cpu").pin_memory()
+
+    with record_function("## barrier — align ranks ##"):
+        dist.barrier(group=ctx.pg)
+
+    with record_function("## d2h copy on d2h_stream ##"):
+        with torch.cuda.stream(d2h_stream):
+            d2h_stream.wait_stream(main_stream)
+            cpu_buffer.copy_(d2h_source, non_blocking=True)
+
+    with record_function("## all2all on comms_stream ##"):
+        post_comms = torch.zeros_like(pre_comms)
+        post_comms.record_stream(comms_stream)
+        with torch.cuda.stream(comms_stream):
+            comms_stream.wait_stream(main_stream)
+            if not concurrent:
+                d2h_stream.synchronize()
+            req = dist.all_to_all_single(
+                output=post_comms,
+                input=pre_comms,
+                group=ctx.pg,
+                async_op=True,
+            )
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        assert req is not None
+        req.wait()
+        main_stream.wait_stream(comms_stream)
+        d2h_stream.synchronize()
+        checks_a2a = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+        expected = float(ctx.rank + 1)
+        d2h_correct = bool(torch.all(cpu_buffer == expected).item())
+
+    with record_function("## post-comms compute ##"):
+        _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
+        )
+
+    with record_function("## assert ##"):
+        assert checks_a2a.item()
+        assert d2h_correct, f"D2H copy validation failed on rank {ctx.rank}"
+
+
+def a2a_d2h_sequential(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    return a2a_d2h_contention(
+        _batch_inputs=_batch_inputs,
+        dim=dim,
+        num_mul=num_mul,
+        num_concat=num_concat,
+        ctx=ctx,
+        concurrent=False,
+    )
+
+
 # single-rank runner
 def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) -> None:
     if arg.backend == "nccl":
@@ -1123,6 +1218,10 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = data_copy_record_stream
             case "data_copy_no_record_stream":
                 func = data_copy_no_record_stream
+            case "a2a_d2h_contention":
+                func = a2a_d2h_contention
+            case "a2a_d2h_sequential":
+                func = a2a_d2h_sequential
             case _:
                 raise ValueError(f"Unknown benchmark name: {arg.name}")
 

--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -893,6 +893,74 @@ def competing_comms_with_req_wait(
     )
 
 
+def tolist_overlap_comms(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    num_comms_rounds: int = 5,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Test whether .tolist() on AMD waits for in-flight async comms to complete.
+
+    Two .tolist() calls for comparison:
+    1. On comms stream: comms launched (async_op) -> compute -> .tolist()
+       while comms are still in flight. On AMD this may block until comms
+       finish; on NVIDIA it should only wait for the compute D2H.
+    2. On main stream: after comms are waited -> compute -> .tolist()
+       This should be fast on both platforms since no comms are in flight.
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        comms_stream = torch.cuda.Stream()
+
+    with record_function("## pre-comms compute ##"):
+        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## comms stream: async comms + tolist during comms ##"):
+        post_comms = torch.zeros_like(pre_comms)
+        post_comms.record_stream(comms_stream)
+        with torch.cuda.stream(comms_stream):
+            comms_stream.wait_stream(main_stream)
+            requests = [
+                dist.all_to_all_single(
+                    output=post_comms,
+                    input=pre_comms,
+                    group=ctx.pg,
+                    async_op=True,
+                )
+                for _ in range(num_comms_rounds)
+            ]
+            compute_result1 = _compute(
+                dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx
+            )
+            _ = compute_result1[0][0].tolist()
+
+            for req in requests:
+                req.wait()
+
+    with record_function("## tolist after comms (no in-flight comms) ##"):
+        compute_result2 = _compute(dim=dim, num_mul=1, num_concat=1, ctx=ctx)
+        _ = compute_result2[0][0].tolist()
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=1, num_concat=1, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        main_stream.wait_stream(comms_stream)
+        checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+
+    with record_function("## post-comms compute ##"):
+        _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
+        )
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
 def data_copy_record_stream(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
@@ -1049,6 +1117,8 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 competing_comms._ar_pg = dist.new_group(
                     ranks=list(range(ctx.world_size))
                 )
+            case s if s.startswith("tolist_overlap_comms"):
+                func = tolist_overlap_comms
             case "data_copy_record_stream":
                 func = data_copy_record_stream
             case "data_copy_no_record_stream":


### PR DESCRIPTION
Summary:
Add two new benchmark use cases to measure resource contention between `all_to_all_single` (NVLink/network) and device-to-host copy (PCIe). Also fixes a BUCK dep typo (`_torch` → `torch`).

## Context

In pipelined recommendation model training, device-to-host (D2H) copies and NCCL collectives can overlap on the GPU timeline. D2H copies use the PCIe bus, while `all_to_all_single` uses NVLink (intra-node) or the network (inter-node). Although they target different physical links, they share resources at the GPU level — the copy engine, memory controller, and L2 cache bandwidth. If these shared resources create contention, overlapping D2H with all2all would inflate collective latency and hurt training throughput.

This study benchmarks concurrent vs sequential execution of `all_to_all_single` and a pinned-memory D2H copy to determine whether contention exists in practice.

## Approach

Two benchmark functions are added to `benchmark_comms.py`:

1. **`a2a_d2h_contention`** (`concurrent=True`): Both operations launch on separate CUDA streams simultaneously. The D2H copy runs on `d2h_stream`, the all2all runs on `comms_stream`, and irrelevant compute runs on the main stream — all three overlap.

2. **`a2a_d2h_sequential`** (`concurrent=False`): The `comms_stream` calls `d2h_stream.synchronize()` before issuing the all2all, so the D2H copy completes first. This provides a contention-free baseline.

### Stream topology

```
main:  [pre-comms] ── [irrelevant compute] ── [wait] ── [post-comms]
           │                                     ▲
           ├─ d2h:   [D2H copy]                  │
           │            │ (sequential: sync)     │
           └─ comms: ───┴── [all2all] ───────────┘
```

### Validation

|rank|sequential (baseline)|contention (concurrent)|
|--|--|--|
|rank0|<img width="4578" height="1136" alt="image" src="https://github.com/user-attachments/assets/25d33921-f5e7-416f-af9b-e93678e131b7" />|<img width="4590" height="1154" alt="image" src="https://github.com/user-attachments/assets/46560ba2-52b5-4ba8-805b-a0d5a856bb1e" />|
|rank1|<img width="4580" height="1142" alt="image" src="https://github.com/user-attachments/assets/52be98c5-b64c-474d-b988-82955ff749a5" />|<img width="4572" height="1142" alt="image" src="https://github.com/user-attachments/assets/2501c4ab-1fa1-494c-8a31-f1d94bc91840" />|

[a2a_d2h_contention.zip](https://github.com/user-attachments/files/28323371/a2a_d2h_contention.zip)
- **All2all correctness**: Each rank sends its rank-indexed data; the receiver validates via `_validate()` + `DeviceToHostTensorAwaitable`.
- **D2H correctness**: The CPU pinned buffer is checked against the expected fill value (`rank + 1`).

## Results

The `all_to_all_single` runs for ~3 ms in both cases. The concurrent and sequential traces show comparable latency, confirming that the D2H copy does not measurably impact the all2all collective — no meaningful contention on shared GPU resources (PCIe, memory controller, L2) for this workload.

This is expected: D2H copies through the PCIe copy engine and NCCL NVLink collectives use largely independent data paths on modern GPUs. The copy engine handles host transfers while NVLink traffic goes through dedicated NVSwitch ports, so the two operations do not compete for the same bandwidth.

## Implications

- **Safe to overlap**: D2H copies (e.g., transferring sparse features or intermediate results to CPU) can be freely overlapped with NCCL all2all without degrading collective performance.
- **Pipeline design**: Training pipelines that need to offload data to host memory during the communication phase can do so without adding serialization barriers.
- **Caveat**: This result holds for the tested tensor sizes and GPU architecture. Extremely large D2H transfers that saturate the memory controller or L2 could behave differently — worth re-testing if the workload profile changes significantly.

Differential Revision: D106542547


