### PR TITLE
[detailed][distributed] AMD Comm Stream Allocation Issue

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -893,6 +893,76 @@ def competing_comms_with_req_wait(
     )
 
 
+def tolist_overlap_comms(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    num_comms_rounds: int = 5,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Test whether .tolist() on AMD waits for in-flight async comms to complete.
+
+    Two .tolist() calls for comparison:
+    1. On comms stream: comms launched (async_op) -> compute -> .tolist()
+       while comms are still in flight. On AMD this may block until comms
+       finish; on NVIDIA it should only wait for the compute D2H.
+    2. On main stream: after comms are waited -> compute -> .tolist()
+       This should be fast on both platforms since no comms are in flight.
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        comms_stream = torch.cuda.Stream()
+
+    with record_function("## pre-comms compute ##"):
+        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## comms stream: async comms + tolist during comms ##"):
+        post_comms = torch.zeros_like(pre_comms)
+        post_comms.record_stream(comms_stream)
+        with torch.cuda.stream(comms_stream):
+            comms_stream.wait_stream(main_stream)
+            requests = [
+                dist.all_to_all_single(
+                    output=post_comms,
+                    input=pre_comms,
+                    group=ctx.pg,
+                    async_op=True,
+                )
+                for _ in range(num_comms_rounds)
+            ]
+            compute_result1 = _compute(
+                dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx
+            )
+            _ = compute_result1[0][0].tolist()
+
+            for req in requests:
+                req.wait()
+
+    with record_function("## tolist after comms (no in-flight comms) ##"):
+        compute_result2 = _compute(dim=dim, num_mul=1, num_concat=1, ctx=ctx)
+        _ = compute_result2[0][0].tolist()
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=1, num_concat=1, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        for req in requests:
+            req.wait()
+        main_stream.wait_stream(comms_stream)
+        checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+
+    with record_function("## post-comms compute ##"):
+        _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
+        )
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
 def data_copy_record_stream(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
@@ -1027,7 +1097,7 @@ def a2a_d2h_contention(
         with torch.cuda.stream(comms_stream):
             comms_stream.wait_stream(main_stream)
             if not concurrent:
-                d2h_stream.synchronize()
+                comms_stream.wait_stream(d2h_stream)
             req = dist.all_to_all_single(
                 output=post_comms,
                 input=pre_comms,
@@ -1144,6 +1214,8 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 competing_comms._ar_pg = dist.new_group(
                     ranks=list(range(ctx.world_size))
                 )
+            case s if s.startswith("tolist_overlap_comms"):
+                func = tolist_overlap_comms
             case "data_copy_record_stream":
                 func = data_copy_record_stream
             case "data_copy_no_record_stream":


### PR DESCRIPTION
Summary:
# AMD Comm Stream Allocation Issue

## 1. Context

A recent NCCL hang investigation on AMD initially pointed to `.tolist()` as the cause of a device-wide sync. Further analysis showed that `.tolist()` behavior is fine — the actual issue is most likely how AMD/ROCm allocates comm streams compared to NVIDIA. On NVIDIA, comms run on a dedicated stream that operates independently from compute. On AMD, the stream allocation differs, causing comms and compute to serialize instead of running in parallel.

This study provides a traceable analysis of the difference in stream allocation behavior between the two platforms.

## 2. Prerequisites
### 2.1 Sync Collectives in PyTorch
In PyTorch, [synchronous collectives](https://docs.pytorch.org/docs/2.12/distributed.html) (e.g., `all_reduce`, `all_gather`, `all_to_all`) require all ranks in the process group to join before the operation can proceed. All ranks must issue the collective; the actual data transfer happens once every rank has joined, and the collective typically completes at the same time across ranks. This study uses `all_to_all_single` as the primary example.

<img width="1528" height="656" alt="image" src="https://github.com/user-attachments/assets/7215f2f3-46ac-4b8c-a6f0-6993cf39f9d4" />

The NCCL kernel is usually issued onto a dedicated comm stream rather than the main stream. This allows the main stream to continue executing independent work while the collective runs on the comm stream in parallel. If a subsequent op on the main stream depends on the collective result, it should use an event/stream wait to enforce the execution order.

<img width="1564" height="902" alt="image" src="https://github.com/user-attachments/assets/4ec468c3-31b3-48ca-8fde-dea44e8e1798" />

### 2.2 async_op option
In `torch.distributed`, `async_op` is an optional boolean flag on collective communication functions that controls whether the call blocks the current thread:

- **`async_op=False`** (default): the collective is enqueued onto the comm stream and the calling stream is blocked until the comm stream completes. The CPU thread is not blocked — it can continue issuing work to other streams.
- **`async_op=True`**: the collective is enqueued onto the comm stream and a `Work` handle is returned immediately. The calling stream is not blocked — no stream synchronization happens until the caller explicitly calls `work.wait()`.

In the SPMD model, all processes run the same program. With `async_op=True`, each process enqueues the collective onto its comm stream (maintained by the process group, not accessible to the user) and continues issuing (irrelevant, non-blocking) ops on the main stream in parallel. The comm streams across ranks execute the `all_to_all_single` kernel concurrently.
<img width="1390" height="1330" alt="image" src="https://github.com/user-attachments/assets/11a76e57-0e40-477e-a58b-78b35facefb3" />

### 2.3 TorchRec Use Case
TorchRec's SDD pipeline uses `async_op=True` for the input data dist `all_to_all`, issuing it from a dedicated data dist stream so the main stream can continue with compute from the previous batch. Note that **the data dist stream does not run comm operators itself** — it runs the compute needed for input data preparation (e.g., KJT permute). The `all_to_all` kernel runs on the comm stream, which is maintained by the process group.

The overlap of input data dist `all_to_all` (on the comm stream) with the main stream compute workload is the source of SDD pipeline QPS gain (~7%–15%). The output dist `all_to_all` is issued from the main stream after TBE lookup and sits on the critical path — the main stream is idle while the output `all_to_all` runs, representing an opportunity for better utilization.

<img width="2020" height="564" alt="image" src="https://github.com/user-attachments/assets/9c2de32a-85a0-467f-aea1-1224347eeb44" />


## 3. Investigations
Since the initial `.tolist()` hypothesis could not be isolated in a simple benchmark, we started from fundamental scenarios and compared AMD vs NVIDIA behavior in sync collectives.

### 3.1 `all_to_all_single` with a single calling stream

With a single calling stream, both NVIDIA and AMD show identical behavior for both `async_op` modes.

**`async_op=False`**: the calling (main) stream blocks until the collective completes.

NVIDIA ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="4444" height="528" alt="image" src="https://github.com/user-attachments/assets/2574ca46-b1ab-4d70-8ff5-850b9e2f36ea" />

AMD ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3930" height="570" alt="image" src="https://github.com/user-attachments/assets/6570c277-d429-452a-8ec6-7b4ae92c6b03" />

**`async_op=True`**: the `all_to_all` comms run on the comm stream and overlap with irrelevant ops on the main stream.

NVIDIA ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3826" height="590" alt="image" src="https://github.com/user-attachments/assets/605dd2e2-1b34-4e16-957a-70044413efa3" />

AMD ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3928" height="700" alt="image" src="https://github.com/user-attachments/assets/72b9e6fa-8417-4675-ac92-85da647dded0" />


### 3.2 `all_to_all_single` with multiple compute streams

In TWRW's output dist, there are two consecutive `all_to_all` comms with a compute op (pooling) in between. If the `all_to_all` is issued from the main stream, it is difficult to issue irrelevant ops in the middle of TWRW's output dist without invasive or complicated hooks, so the first `all_to_all` is exposed (compute stream idle). However, if we use a separate stream to issue the `all_to_all` and run the pooling operator, the comms are not exposed and the compute stream is kept busy.

On NVIDIA, this separate stream approach works as expected — a separate stream issues the `all_to_all` and runs the compute ops. The benchmark repeats twice, so two side streams are visible in the trace.

NVIDIA ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="4006" height="750" alt="image" src="https://github.com/user-attachments/assets/8c2e84d2-0f86-4557-9ea1-a94e6d97bb8e" />


However, on AMD the side stream collapses into the main stream — the `all_to_all` and compute ops that should run on the side stream are serialized onto the main stream instead, eliminating the expected parallelism.

AMD ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_amd-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3998" height="686" alt="image" src="https://github.com/user-attachments/assets/64325c37-3cf6-425f-8748-02986f43a97e" />


### 3.3 `.tolist()` with multiple streams

`tensor.tolist()` triggers a device-to-host data transfer and blocks the CPU thread until the transfer completes, then immediately converts the result to a Python list. Since this is CPU-blocking, it should be kept as short as possible.

> **Note**: If the data is not needed immediately, a D2H `LazyAwaitable` can defer the sync ([post](https://fb.workplace.com/groups/811751593969209/permalink/1285164823294548/)).

In this benchmark, we created a scenario with multiple compute streams and a PG-managed comm stream (`async_op=True`). The `.tolist()` calls are issued from both the main stream and the data dist stream. Since `.tolist()` only blocks the CPU thread, it should not interfere with other GPU streams — the `all_to_all` and other ops were already enqueued before the `.tolist()` calls.

<img width="1912" height="840" alt="image" src="https://github.com/user-attachments/assets/9b74ac0a-837a-4cab-9e58-6f55ff1c69fa" />

The benchmark trace confirms the expected behavior — `.tolist()` blocks the CPU but does not interfere with the `all_to_all` or other ops already enqueued on separate streams.

NVIDIA ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="4306" height="748" alt="image" src="https://github.com/user-attachments/assets/207701a2-801d-41ce-b3b0-c49320c67ced" />

On AMD, the second iteration also confirms this behavior (we discuss the first iteration later). This indicates that `.tolist()` behavior on AMD and NVIDIA is fundamentally equivalent.

AMD ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3880" height="762" alt="image" src="https://github.com/user-attachments/assets/57382dd9-1fc6-4e04-b3ab-c6d4e998220c" />

### 3.4 AMD `.tolist()` divergence in first iteration

In the first iteration of the AMD `.tolist()` benchmark, the data dist stream collapses into the main stream (the second iteration does not exhibit this). Normally, `op4` executes before `op3` because they are on different streams — only ops on the same stream preserve CPU issue order (`op1`→`op4` on main, `op2`→`op3` on data dist). When the two compute streams collapse, the execution order becomes `op1`→`op2`→`op3`→`op4`, and `op3` must await the `all_to_all` comm to complete. This causes the `.tolist()` sync to appear much longer in the trace — as if a device-wide sync were issued after the `.tolist()` call.

AMD first iteration ([Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)):
<img width="3842" height="738" alt="image" src="https://github.com/user-attachments/assets/3d9ae5c7-2df8-49fc-a09e-7ff391641fce" />

## 4. Conclusions and Discussions

1. **`.tolist()` is not the root cause.** Both AMD and NVIDIA show equivalent `.tolist()` behavior — it blocks the CPU thread only, without interfering with other GPU streams (section 3.3).

2. **Single-stream collectives behave identically.** With a single calling stream, AMD and NVIDIA produce the same results for both `async_op=False` and `async_op=True` (section 3.1).

3. **Multi-stream scenarios expose AMD stream allocation divergence.** When multiple compute streams are used alongside a PG-managed comm stream, AMD collapses the side streams into the main stream, serializing ops that should run in parallel (section 3.2). This eliminates the comm-compute overlap that NVIDIA achieves.

4. **The stream collapse explains the observed `.tolist()` slowdown.** In the AMD first-iteration case (section 3.4), the data dist stream collapses into the main stream, changing the execution order so that `.tolist()` must wait for the `all_to_all` to complete — mimicking a device-wide sync without one actually being issued.

5. **Potential impact on TorchRec.** The SDD pipeline relies on comm-compute overlap across multiple streams (section 2.3). If AMD's stream allocation collapses these streams, the comm-compute overlap may be reduced, potentially affecting pipeline QPS gains. Further investigation is needed to confirm the impact in production workloads.

> **Disclaimer**: Production models are significantly more complex than the benchmarks used here — they involve multiple process groups, multiple comm and compute streams, and more intricate scheduling. The stream allocation hypothesis identified in this study may not fully explain production behavior, and further validation against real workloads is necessary.

## 5. Reference

1. **Diff**: [D105081660](https://www.internalfb.com/diff/D105081660)
2. **PyTorch fix**: [D102035785](https://www.internalfb.com/diff/D102035785)

### 5.1 Run Commands
OSS (external):
```bash
# 1. NVIDIA device w/o cuda.sync
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=tolist_overlap_comms_nvidia

# 2. NVIDIA device w/ cuda.sync — uncomment torch.cuda.synchronize() in the function
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=tolist_overlap_comms_nvidia_cuda_sync

# 3. AMD device w/o cuda.sync
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=tolist_overlap_comms_amd

# 4. AMD device w/ PyTorch fix
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=tolist_overlap_comms_amd_fix

# 5. NVIDIA/AMD async comms
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=a2a_async_base

# 6. NVIDIA/AMD sync comms
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=a2a_sync_base

# 9. NVIDIA/AMD async twice
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=a2a_async_twice
```

### 5.2 Upload Traces

```bash
DIFF=D105081660 fbcode/torchrec/fb/scripts/trace_to_manifold.sh
```

### 5.3 Results

- [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D105081660)

| name | trace | note |
|------|-------|------|
| 1. NVIDIA w/o cuda.sync | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) | NVIDIA tolist behavior |
| 2. NVIDIA w/ cuda.sync | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_cuda_sync_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_nvidia_cuda_sync_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) | Suspected device-sync tolist (not observed) |
| 3. AMD w/o cuda.sync | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) | AMD tolist behavior |
| 4. AMD w/ PyTorch fix | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_fix_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-tolist_overlap_comms_amd_fix_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) | Same as above, PyTorch fix has no impact |

- Sync vs Async Comms

| name | AMD | NVIDIA | note |
|------|-----|--------|------|
| async comms | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) | AMD and NVIDIA have same behavior |
| sync comms | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_sync_base_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) | Same behavior |
| async twice | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_amd-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D105081660/trace-a2a_async_twice_nvidia-rank0.json.gz&bucket=torchrec_benchmark_traces) | Different behaviors |

Reviewed By: siqihuang

Differential Revision: D105081660

[amd_stream_allocation.zip](https://github.com/user-attachments/files/28433231/amd_stream_allocation.zip)

