### PR TITLE
[detailed][data transfer] CUDA Copy Engine Contention Study - Add benchmark for CUDA copy engine contention

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -848,6 +848,7 @@ def competing_comms(
         out_b.record_stream(stream_b)
         with torch.cuda.stream(stream_b):
             if wait_for_comm1:
+                assert req_a is not None
                 req_a.wait()
             stream_b.wait_stream(main_stream)
             req_b = dist.all_reduce(
@@ -862,6 +863,8 @@ def competing_comms(
         _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
 
     with record_function("## wait and validate ##"):
+        assert req_a is not None
+        assert req_b is not None
         req_a.wait()
         req_b.wait()
         main_stream.wait_stream(stream_a)
@@ -1054,6 +1057,137 @@ def data_copy_no_record_stream(
     )
 
 
+def copy_engine_contention(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    low_priority: bool = True,
+    trunk_count: int = 3,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Test copy engine contention between two streams issuing PCIe transfers.
+
+    h2d_stream: 3 consecutive large H2D copies (saturates copy engine)
+    main stream: 1 small D2H copy + 2 small H2D copies (interleaved with
+                 small compute ops)
+
+    When low_priority=True, h2d_stream gets lower priority than main stream,
+    testing whether stream priority affects copy engine scheduling.
+    """
+    small_size = 1024
+
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        if low_priority:
+            h2d_stream = torch.cuda.Stream(priority=1)
+        else:
+            h2d_stream = torch.cuda.Stream()
+
+    with record_function("## allocate tensors ##"):
+        # 3 large H2D sources for h2d_stream (pinned CPU → GPU)
+        large_h2d_sources = [
+            torch.full(
+                (num_concat * dim // 5, dim),
+                fill_value=float(ctx.rank + i + 1),
+            ).pin_memory()
+            for i in range(trunk_count)
+        ]
+
+        # 1 small D2H source on GPU
+        d2h_source = torch.full(
+            (small_size,), fill_value=float(ctx.rank + 10), device=ctx.device
+        )
+        d2h_cpu_buffer = torch.empty_like(d2h_source, device="cpu").pin_memory()
+
+        # 2 small H2D sources (pinned CPU)
+        small_h2d_sources = [
+            torch.full(
+                (small_size,), fill_value=float(ctx.rank + 20 + i), dtype=torch.int32
+            ).pin_memory()
+            for i in range(2)
+        ]
+
+    with record_function("## pre-copy compute ##"):
+        _compute(dim=dim, num_mul=num_mul * 5, num_concat=num_concat, ctx=ctx)
+
+    # --- h2d_stream: 3 consecutive large H2D copies ---
+    with record_function("## 3x large h2d on h2d_stream ##"):
+        large_h2d_devices = []
+        with torch.cuda.stream(h2d_stream):
+            h2d_stream.wait_stream(main_stream)
+            for i, src in enumerate(large_h2d_sources):
+                with record_function(f"## large h2d {i} ##"):
+                    t = src.to(ctx.device, non_blocking=True)
+                    t.record_stream(main_stream)
+                    large_h2d_devices.append(t)
+
+    # --- main stream: compute, small d2h, compute, small h2d, compute, small h2d ---
+    with record_function("## small compute 0 ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx)
+
+    with record_function("## small d2h on main stream ##"):
+        d2h_cpu_buffer.copy_(d2h_source, non_blocking=True)
+
+    with record_function("## small compute 1 ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx)
+
+    with record_function("## small h2d 0 on main stream ##"):
+        small_h2d_device_0 = small_h2d_sources[0].to(ctx.device, non_blocking=True)
+
+    with record_function("## small compute 2 ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx)
+
+    with record_function("## small h2d 1 on main stream ##"):
+        small_h2d_device_1 = small_h2d_sources[1].to(ctx.device, non_blocking=True)
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        h2d_stream.synchronize()
+        torch.cuda.synchronize()
+
+        # validate large H2D copies
+        large_correct = all(
+            bool(
+                torch.allclose(
+                    large_h2d_devices[i],
+                    torch.full_like(large_h2d_devices[i], float(ctx.rank + i + 1)),
+                )
+            )
+            for i in range(trunk_count)
+        )
+
+        # validate small D2H copy
+        d2h_correct = bool(torch.all(d2h_cpu_buffer == float(ctx.rank + 10)).item())
+
+        # validate small H2D copies
+        small_h2d_correct_0 = bool(
+            torch.all(small_h2d_device_0 == ctx.rank + 20).item()
+        )
+        small_h2d_correct_1 = bool(
+            torch.all(small_h2d_device_1 == ctx.rank + 21).item()
+        )
+
+        logger.info(
+            f"[rank-{ctx.rank}] low_priority={low_priority}: "
+            f"large_h2d={large_correct}, d2h={d2h_correct}, "
+            f"small_h2d_0={small_h2d_correct_0}, small_h2d_1={small_h2d_correct_1}"
+        )
+
+    with record_function("## post-copy compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## assert ##"):
+        assert large_correct, f"Large H2D validation failed on rank {ctx.rank}"
+        assert d2h_correct, f"D2H validation failed on rank {ctx.rank}"
+        assert small_h2d_correct_0, f"Small H2D 0 validation failed on rank {ctx.rank}"
+        assert small_h2d_correct_1, f"Small H2D 1 validation failed on rank {ctx.rank}"
+
+
 def a2a_d2h_contention(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
@@ -1224,6 +1358,8 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = data_copy_record_stream
             case "data_copy_no_record_stream":
                 func = data_copy_no_record_stream
+            case "copy_engine_contention":
+                func = copy_engine_contention
             case "a2a_d2h_contention":
                 func = a2a_d2h_contention
             case "a2a_d2h_sequential":


### PR DESCRIPTION
Summary:
# CUDA Copy Engine Contention Study

## 1. Background

While productionalizing EMS (Embedding Memory Stashing) on the OmniFM model, we observed that the main CUDA stream stalls whenever the EMS restoring stream is active — even though there is no data dependency or explicit stream/event synchronization between them. The root cause is copy engine contention: the restoring stream issues large H2D transfers to reload stashed embeddings, and these saturate the GPU's H2D DMA copy engine. When FSDP on the main stream then issues a small H2D copy (e.g., gathering a weight shard), that copy is queued behind the large restoring transfer in the copy engine's FIFO, blocking the entire main stream until the current DMA chunk completes.

<img width="3914" height="1746" alt="image" src="https://github.com/user-attachments/assets/9cf3a48a-5902-41cd-8c22-12d5d39c640e" />

The [trace](https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=aps_traces&trace_path=tree%2Ftraces%2Fdynocli%2Faps-V5_0427tk_128gpu_ems_jkOn_uniarch-d28eb1bff2%2F0%2Frank-26.May_28_00_40_42.7459.pt.trace.json.gz) above shows the OmniFM training iteration on rank 26 of a 128-GPU run. The red arrow highlights the critical contention point: the EMS restoring stream is performing a large H2D embedding restore, which blocks a small H2D copy on the main GPU stream, stalling the dense forward/backward pass until the copy engine drains.

## 2. GPU Copy Engine Architecture

NVIDIA GPUs expose a limited number of **DMA copy engines** (also called copy queues or CE). These are hardware units separate from the SMs (compute cores):

- **H2D and D2H share the same PCIe link** but can use separate copy engines (one for each direction on most modern GPUs)
- **Same-direction transfers serialize** on the same copy engine — two H2D copies from different streams still go through the same H2D copy engine in FIFO order
- Copy engines operate independently from the SM compute pipeline — a compute kernel running on SMs does not block a copy, and vice versa

WARNING: **The following is not confirmed by public NVIDIA documentation:**
> **CUDA stream priority does not affect copy engine scheduling.** Stream priority (`cudaStreamCreateWithPriority`) controls how the CUDA runtime prioritizes **compute kernels** on SMs. The copy engines have their own FIFO queues and process transfers in submission order, regardless of the originating stream's priority.

## 3. Initial Idea

Since the contention comes from the EMS restore occupying the H2D copy engine with one monolithic transfer (5–10 GB, ~100–200 ms), a natural mitigation is to break that transfer into smaller chunks. If the restore is split into, say, three pieces, there are now gaps between chunks where the copy engine's FIFO can drain. If we additionally assign the EMS stream a lower CUDA priority, the hope is that the main stream's (default priority) small H2D can preempt or at least interleave between the EMS chunks, unblocking the dense forward/backward pass much earlier.

<img width="1614" height="1172" alt="image" src="https://github.com/user-attachments/assets/517643fd-78df-46de-9f37-55a27c277134" />

The diagram contrasts the two approaches. **Top**: current behavior — the bulk EMS restore blocks the main stream's small H2D via copy engine contention, delaying FSDP/dense compute. **Bottom**: the proposed fix — chunk the restore into three pieces on a low-priority EMS stream, so the high-priority main stream can slip its small H2D into the gaps between chunks. This motivated the benchmark experiment below to verify whether stream priority actually affects copy engine scheduling (it does not — see Section 5.3).

## 4. Experiment Design

The `copy_engine_contention` benchmark in `benchmark_comms.py` uses two streams: an **h2d_stream** (low priority) saturating the H2D copy engine with 3 consecutive large copies (~6 ms each), and the **main stream** (default priority) issuing a small D2H and two H2D copies interleaved with compute.

```
h2d_stream:  |== large H2D 0 ==|== large H2D 1 ==|== large H2D 2 ==|
main stream: |comp|d2h|comp|h2d|comp|h2d|  comp  |
                            ^^^      ^^^
                    small H2D contends with large H2D
                    on the same copy engine
```

If stream priority works on copy engines, the small H2D copies on the main stream should slip into the gaps between large chunks (between H2D 0–1 or 1–2), so the subsequent compute on the main stream is not blocked waiting for the copy engine to drain.

```bash
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_comms -- \
    a2a_single --name=copy_engine_contention
```

## 5. Benchmark Results

Unfortunately, the benchmark does not confirm the initial hypothesis. The small H2D copies on the main stream are still blocked by the 3 large H2D copies on the h2d_stream, even though the h2d_stream has lower priority, while the D2H copy on the main stream is not blocked.

<img width="4480" height="972" alt="image" src="https://github.com/user-attachments/assets/25c7f2d6-0ae2-48a7-9746-3c58d80ebf49" />

The [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) shows the benchmark execution. The main thread (top) issues CPU-side operations. On the GPU side, **stream 7** runs the main stream's compute and small copies, while **stream 28** runs the 3 large H2D copies (`Memcpy HtoD (Pinned -> Device)`). The 3 flags on stream 7 mark (left to right) the small D2H copy and the 2 small H2D copies — the H2D copies are visibly delayed, waiting for the large transfers on stream 28 to complete.

* Small H2D copies are delayed by large H2D copies

When the h2d_stream's large H2D transfers are in flight, the small H2D copies on the main stream are queued behind them in the copy engine's FIFO. The small H2D copy does not begin until the current large chunk finishes its DMA transfer, even though the small copy is on a higher-priority stream.

* Small D2H copy is NOT delayed

The D2H copy on the main stream runs on a **separate copy engine** from the H2D copies. Since each direction has its own DMA engine, the D2H transfer proceeds immediately regardless of H2D congestion.

* Stream priority has no effect on copy engine scheduling

Setting `h2d_stream` to lower priority (`priority=1`) vs default priority produces identical copy latencies in the trace. The copy engine ignores stream priority entirely — it processes transfers in submission (FIFO) order.

This was verified by comparing traces with `low_priority=True` (default) and `low_priority=False`.

## 6. Implications

**EMS restore contention**
- Stream priority combined with chunked copies does not solve the contention — the copy engine is priority-blind.
- A potential workaround is to eliminate H2D copies from the main stream entirely (currently only a few small ones occur nearby), so the main stream's compute is never blocked waiting on the copy engine.

**copy_batch_to_gpu contention**
* The same copy engine contention can affect `copy_batch_to_gpu` in `TrainPipelineSparseDist`, a standard step in RecSys model training.
* If its large H2D transfer overlaps with small H2D copies from other pipeline stages (e.g., embedding stashing, optimizer state transfers), those small copies will be delayed, and blocking main stream execution.

## 7. Open Questions

- We did not find authoritative documentation (NVIDIA, CUDA, or PyTorch) describing copy engine scheduling internals. Current understanding is pieced together from internet forums and empirical traces — official confirmation would strengthen these conclusions.
- Does the copy engine behavior differ across hardware types (e.g., A100 vs H100 vs B200, or NVIDIA vs AMD)? Newer architectures or different vendors may expose more copy engines or different scheduling policies.
- In a separate benchmark, the H2D copy engine queue does not appear to be filled in CPU issuing order, suggesting there may be more subtle scheduling logic beyond simple FIFO.

## 8. Traces and References
**Traces**
- [OmniFM V5 128-GPU EMS run, rank 26 (Perfetto)](https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=aps_traces&trace_path=tree%2Ftraces%2Fdynocli%2Faps-V5_0427tk_128gpu_ems_jkOn_uniarch-d28eb1bff2%2F0%2Frank-26.May_28_00_40_42.7459.pt.trace.json.gz) — EMS restoring stream blocking main stream
- [Benchmark traces (Manifold)](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D107052549)
- [Benchmark trace (Perf Doctor)](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
- [Benchmark trace (Perfetto)](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)

**References**
- [CUDA Programming Guide: Stream Priorities](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-priorities)
- [CUDA Caching Allocator internals](https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html) — per-stream memory reservation
- Benchmark source: [`benchmark_comms.py`](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/benchmark/benchmark_comms.py) (`copy_engine_contention`)

Differential Revision: D107052549
