### PR TITLE
[detailed][data transfer] Copy Engine Execution Order Study - Add benchmark to decipher cuda copy engine execution order

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -1063,7 +1063,7 @@ def copy_engine_contention(
     num_mul: int,
     num_concat: int,
     ctx: MultiProcessContext,
-    low_priority: bool = True,
+    dummy_compute: bool = False,
     trunk_count: int = 3,
     **_kwargs: Dict[str, Any],
 ) -> None:
@@ -1074,17 +1074,15 @@ def copy_engine_contention(
     main stream: 1 small D2H copy + 2 small H2D copies (interleaved with
                  small compute ops)
 
-    When low_priority=True, h2d_stream gets lower priority than main stream,
-    testing whether stream priority affects copy engine scheduling.
+    When dummy_compute=True, a tiny compute op (tensor.add_(1)) is inserted
+    between each large H2D copy on the h2d_stream, testing whether the copy
+    engine treats back-to-back copies differently from compute-separated ones.
     """
     small_size = 1024
 
     with record_function("## setup ##"):
         main_stream = torch.cuda.current_stream()
-        if low_priority:
-            h2d_stream = torch.cuda.Stream(priority=1)
-        else:
-            h2d_stream = torch.cuda.Stream()
+        h2d_stream = torch.cuda.Stream()
 
     with record_function("## allocate tensors ##"):
         # 3 large H2D sources for h2d_stream (pinned CPU → GPU)
@@ -1117,12 +1115,15 @@ def copy_engine_contention(
     with record_function("## 3x large h2d on h2d_stream ##"):
         large_h2d_devices = []
         with torch.cuda.stream(h2d_stream):
+            dummy_tensor = torch.empty(1, device=ctx.device)
             h2d_stream.wait_stream(main_stream)
             for i, src in enumerate(large_h2d_sources):
                 with record_function(f"## large h2d {i} ##"):
                     t = src.to(ctx.device, non_blocking=True)
                     t.record_stream(main_stream)
                     large_h2d_devices.append(t)
+                    if dummy_compute:
+                        dummy_tensor.add_(1)
 
     # --- main stream: compute, small d2h, compute, small h2d, compute, small h2d ---
     with record_function("## small compute 0 ##"):
@@ -1173,7 +1174,7 @@ def copy_engine_contention(
         )
 
         logger.info(
-            f"[rank-{ctx.rank}] low_priority={low_priority}: "
+            f"[rank-{ctx.rank}] dummy_compute={dummy_compute}: "
             f"large_h2d={large_correct}, d2h={d2h_correct}, "
             f"small_h2d_0={small_h2d_correct_0}, small_h2d_1={small_h2d_correct_1}"
         )
@@ -1186,6 +1187,156 @@ def copy_engine_contention(
         assert d2h_correct, f"D2H validation failed on rank {ctx.rank}"
         assert small_h2d_correct_0, f"Small H2D 0 validation failed on rank {ctx.rank}"
         assert small_h2d_correct_1, f"Small H2D 1 validation failed on rank {ctx.rank}"
+
+
+def copy_engine_contention_dummy_compute(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    return copy_engine_contention(
+        _batch_inputs=_batch_inputs,
+        dim=dim,
+        num_mul=num_mul,
+        num_concat=num_concat,
+        ctx=ctx,
+        dummy_compute=True,
+    )
+
+
+def h2d_execution_order(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Test the execution order of H2D copies across three streams.
+
+    Each stream issues a different amount of compute before its H2D copy,
+    so the copies are submitted to the copy engine at different times.
+    The CPU issues the long-compute stream first, but its copy reaches
+    the copy engine last:
+      stream_c: sync a2a       → H2D copy C (issued first, submitted last)
+      stream_b: medium compute → H2D copy B (issued second)
+      stream_a: short compute  → H2D copy A (issued last, submitted first)
+
+    Check the trace to observe the actual execution order of the H2D
+    copies on the copy engine. If the copy engine is FIFO by GPU-side
+    submission order (not CPU issue order), copy A should start first
+    despite being issued last from the CPU.
+    """
+    copy_size = num_concat * dim // 5
+
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        stream_c = torch.cuda.Stream()
+
+    small_size = 1024
+
+    with record_function("## allocate tensors ##"):
+        # bulk copies
+        src_a = torch.full((copy_size, dim), fill_value=1.0).pin_memory()
+        src_b = torch.full((copy_size, dim), fill_value=2.0).pin_memory()
+        src_c = torch.full((copy_size, dim), fill_value=3.0).pin_memory()
+
+        # small copies before/after each bulk copy (int32 ~ 4 KB each)
+        small_before = [
+            torch.full(
+                (small_size,), fill_value=float(100 + i), dtype=torch.int32
+            ).pin_memory()
+            for i in range(3)
+        ]
+        small_after = [
+            torch.full(
+                (small_size,), fill_value=float(200 + i), dtype=torch.int32
+            ).pin_memory()
+            for i in range(3)
+        ]
+
+    with record_function("## pre-compute ##"):
+        _compute(dim=dim, num_mul=num_mul * 3, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## stream_c: sync a2a + h2d (issued first) ##"):
+        a2a_input = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        a2a_output = torch.zeros_like(a2a_input)
+        with torch.cuda.stream(stream_c):
+            stream_c.wait_stream(main_stream)
+            dist.all_to_all_single(
+                output=a2a_output,
+                input=a2a_input,
+                group=ctx.pg,
+                async_op=False,
+            )
+            small_dev_c_before = small_before[2].to(ctx.device, non_blocking=True)
+            small_dev_c_before += 1
+            dev_c = src_c.to(ctx.device, non_blocking=True)
+            small_dev_c_before -= 1
+            small_dev_c_after = small_after[2].to(ctx.device, non_blocking=True)
+            dev_c.record_stream(main_stream)
+            small_dev_c_before.record_stream(main_stream)
+            small_dev_c_after.record_stream(main_stream)
+
+    with record_function("## stream_b: medium compute + h2d (issued second) ##"):
+        with torch.cuda.stream(stream_b):
+            stream_b.wait_stream(main_stream)
+            _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx)
+            small_dev_b_before = small_before[1].to(ctx.device, non_blocking=True)
+            small_dev_b_before += 1
+            dev_b = src_b.to(ctx.device, non_blocking=True)
+            small_dev_b_before -= 1
+            small_dev_b_after = small_after[1].to(ctx.device, non_blocking=True)
+            dev_b.record_stream(main_stream)
+            small_dev_b_before.record_stream(main_stream)
+            small_dev_b_after.record_stream(main_stream)
+
+    with record_function("## stream_a: short compute + h2d (issued last) ##"):
+        with torch.cuda.stream(stream_a):
+            stream_a.wait_stream(main_stream)
+            _compute(dim=dim, num_mul=1, num_concat=1, ctx=ctx)
+            small_dev_a_before = small_before[0].to(ctx.device, non_blocking=True)
+            small_dev_a_before += 1
+            dev_a = src_a.to(ctx.device, non_blocking=True)
+            small_dev_a_before -= 1
+            small_dev_a_after = small_after[0].to(ctx.device, non_blocking=True)
+            dev_a.record_stream(main_stream)
+            small_dev_a_before.record_stream(main_stream)
+            small_dev_a_after.record_stream(main_stream)
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        torch.cuda.synchronize()
+
+        a_correct = bool(torch.all(dev_a == 1.0).item())
+        b_correct = bool(torch.all(dev_b == 2.0).item())
+        c_correct = bool(torch.all(dev_c == 3.0).item())
+
+        small_correct = (
+            bool(torch.all(small_dev_a_before == 100).item())
+            and bool(torch.all(small_dev_a_after == 200).item())
+            and bool(torch.all(small_dev_b_before == 101).item())
+            and bool(torch.all(small_dev_b_after == 201).item())
+            and bool(torch.all(small_dev_c_before == 102).item())
+            and bool(torch.all(small_dev_c_after == 202).item())
+        )
+
+    with record_function("## post-copy compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## assert ##"):
+        assert a_correct, f"Copy A validation failed on rank {ctx.rank}"
+        assert b_correct, f"Copy B validation failed on rank {ctx.rank}"
+        assert c_correct, f"Copy C validation failed on rank {ctx.rank}"
+        assert small_correct, f"Small copy validation failed on rank {ctx.rank}"
 
 
 def a2a_d2h_contention(
@@ -1360,6 +1511,10 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = data_copy_no_record_stream
             case "copy_engine_contention":
                 func = copy_engine_contention
+            case "copy_engine_contention_dummy_compute":
+                func = copy_engine_contention_dummy_compute
+            case "h2d_execution_order":
+                func = h2d_execution_order
             case "a2a_d2h_contention":
                 func = a2a_d2h_contention
             case "a2a_d2h_sequential":


### PR DESCRIPTION
Summary:
# Copy Engine Execution Order Study

## 1. Background

The [copy engine contention study](cuda_copy_engine_contention.md) suggests that same-direction DMA copies from different CUDA streams serialize on the copy engine, and that stream priority does not help. To find a mitigation for the EMS restore contention, we need to understand the copy engine's execution order — specifically, **how the copy engine decides which copy to run next when multiple streams have pending transfers.**

## 2. Reversed-Engineered Theory

> **Note:** Since NVIDIA does not publicly document copy engine scheduling internals, the following behavior is reverse-engineered from benchmark traces.

Each CUDA stream maintains its own command queue. A `cudaMemcpyAsync` call enqueues a copy on that stream's queue, and the stream executes its operations in order — the copy is dispatched to the copy engine only when all preceding operations (compute kernels, collectives) on that stream have completed. The copy engine itself does not maintain a separate FIFO queue — the streams' command queues are the execution queues. From our experiments, we observe:

1. **Readiness-based dispatch**: the copy engine picks up whatever copy becomes ready next from any stream, irrespective of the CPU-side issue order. A copy that is still waiting behind preceding work on its stream is invisible to the copy engine.
2. **Current-stream-first scheduling**: when the copy engine finishes a copy, it checks the same stream first for the next ready copy. If that stream has another copy ready, it runs immediately — consecutive copies on the same stream are never interleaved by other streams. Only when the current stream has no ready copy does the engine move to the next stream in order.

<img width="1764" height="794" alt="image" src="https://github.com/user-attachments/assets/06d96c3e-359a-4130-bd19-e8da88e61974" />

The diagram illustrates the two observations. Three streams (A, B, C) are created and issued in order from the CPU, each with a preceding operation (op-1, op-2, op-3) of different duration before its H2D copy (h2d-1, h2d-2, h2d-3).
- The CPU thread issues op1–3 and h2d 1–3 for all three streams. The H2D CPU issue order doesn't matter — only CUDA stream order and readiness matter.
- Stream B's op-2 is the shortest and finishes first, so h2d-2 runs first on the copy engine.
- When h2d-2 completes, both stream A (h2d-1) and stream C (h2d-3.1) are ready. The copy engine picks stream C because it is the next stream in order after stream B — not stream A, even though h2d-1 was ready earlier.
- Stream C has two copies (h2d-3.1 and h2d-3.2). After h2d-3.1 completes, both h2d-3.2 (same stream) and h2d-1 (stream A) are ready. The copy engine stays on stream C and runs h2d-3.2 first — same-stream copies run back-to-back without yielding.
- h2d-1 on stream A runs last, after all other streams' ready copies have been served.

## 3. Experiment Design

The `h2d_execution_order` benchmark uses three streams (stream_a, stream_b, stream_c), created and issued in that order. Each stream runs the same combo of operations:

```
| main op | small H2D | dummy op | bulk H2D | dummy op | small H2D |
```

The **main op** varies per stream to control when the combo's copies become ready:

| Stream | Main op | Duration | CPU issue order | Copy readiness |
|--------|---------|----------|-----------------|----------------|
| stream_a | short compute (`num_mul=1`) | shortest | 3rd (issued last) | first |
| stream_b | medium compute (`num_mul`) | longest | 2nd | middle |
| stream_c | sync `all_to_all_single` | medium | 1st (issued first) | last |

The small H2D copies (~4 KB int32) and dummy ops (`tensor += 1`) bracket the bulk H2D copy (~160 MB) as markers in the trace. The dummy ops also ensure the copies are separate operations and not coalesced by the runtime.


### Run command

```bash
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=h2d_execution_order
```

## 4. Results

<img width="2902" height="1052" alt="image" src="https://github.com/user-attachments/assets/b0cd6313-8f7c-450f-9db9-177dab36298b" />

The overall [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107387194/trace-h2d_execution_order_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) shows the three streams executing on the GPU. Stream_a (issued last) completes its short compute and starts its bulk H2D copy first. Stream_b's copy follows, and stream_c's copy (preceded by a sync a2a) runs last.

---

<img width="3672" height="664" alt="image" src="https://github.com/user-attachments/assets/e85cbd4e-a42e-4a5d-8838-7dc3bc294f1b" />

Zoomed in on the copy engine region. Each stream's `Memcpy HtoD (Pinned -> Device)` is visible with the small H2D markers and dummy compute ops bracketing the bulk copy. The dummy ops break the back-to-back readiness of consecutive copies on the same stream, so after each copy completes the copy engine checks other streams before the next copy on the same stream becomes ready — resulting in a **round-robin-style interleaving** across streams.

---

<img width="2696" height="1062" alt="image" src="https://github.com/user-attachments/assets/0c51218b-b888-4474-8c47-e2a7a59f193a" />

The [no-dummy variant trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107387194/trace-h2d_execution_order_no_dummy-rank0.json.gz&bucket=torchrec_benchmark_traces) removes the dummy ops between copies. Without them, all three copies on the same stream are ready back-to-back, and the copy engine runs them consecutively (current-stream-first scheduling) before moving to the next stream. The execution order is still A → B → C (readiness-based), but within each stream, the small H2D markers and bulk copy run as a single uninterrupted block.

## 5. Bonus: Dummy Compute Between Chunks

```bash
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=copy_engine_contention

python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=copy_engine_contention_dummy_compute
```

<img width="4480" height="972" alt="image" src="https://github.com/user-attachments/assets/00392959-8346-48c8-9dc0-ff0fc4bf34b9" />

The [copy_engine_contention trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107387194/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) shows 3 consecutive large H2D copies on the h2d_stream running back-to-back. The main stream's small H2D copies are blocked until all 3 large copies complete — the copy engine stays on the h2d_stream the entire time (current-stream-first scheduling).

> **Note:** The first small copy on the main stream is a D2H transfer, which uses a separate copy engine from the H2D copies and is therefore not blocked by the bulk H2D traffic.

---

<img width="2920" height="922" alt="image" src="https://github.com/user-attachments/assets/5814a28a-546a-4eea-956e-ebc689ca3127" />


The [copy_engine_contention_dummy_compute trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107387194/trace-copy_engine_contention_dummy_compute_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) inserts a tiny compute op (`tensor.add_(1)`) between each large H2D copy on the h2d_stream. The dummy op forces the next copy to wait for the compute to finish on the SMs, creating a gap where the copy engine is free to serve the main stream's small copies. This confirms that breaking large transfers into chunks with interleaved compute can reduce contention for other streams.

## 6. Implications

### Copy engine contention is real

A bulk H2D transfer saturates the copy engine, blocking all other same-direction copies until it completes. Any major host-to-device data movement can stall compute execution on other streams that depend on small H2D copies (e.g., FSDP weight gathering, batch data loading).

### Workaround for memory stashing

Memory stashing features — EMS, optimizer stashing, activation offloading — all face the same problem: a bulk restore payload blocks the main stream's small data copies. Chunking the payload into smaller pieces with dummy compute ops in between gives blocked streams a chance to slip their copies into the gaps. However, this **cannot eliminate the idle time entirely** — by the time the main stream's small copy gets a gap to run, the main stream has already been stalled waiting for the copy engine, so the latency is reduced but not removed.

## 7. References

- [Copy engine contention study](cuda_copy_engine_contention.md) — predecessor study on contention and priority-blindness
- Benchmark source: `fbcode/torchrec/distributed/benchmark/benchmark_comms.py` (`h2d_execution_order`, `copy_engine_contention_dummy_compute`)
- Diffs: [D107387194](https://www.internalfb.com/diff/D107387194) (stacked on [D107052549](https://www.internalfb.com/diff/D107052549))
- [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D107387194)

[copy_engine_order.zip](https://github.com/user-attachments/files/28580656/copy_engine_order.zip)

Differential Revision: D107387194


