### PR TITLE
[detailed][data transfer] overcome copy engine contention - add chunked_copy_ to split large H2D/D2H copies

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -37,6 +37,7 @@ from torchrec.distributed.benchmark.base import (
     cmd_conf,
 )
 from torchrec.distributed.collective_utils import create_on_rank_and_share_result
+from torchrec.distributed.memory_stashing import chunked_copy_
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     run_multi_process_func,
@@ -1070,12 +1071,13 @@ def copy_engine_contention(
     """
     Test copy engine contention between two streams issuing PCIe transfers.
 
-    h2d_stream: 3 consecutive large H2D copies (saturates copy engine)
+    h2d_stream: one large H2D transfer split into ``trunk_count`` trunks via
+                ``chunked_copy_`` (saturates copy engine)
     main stream: 1 small D2H copy + 2 small H2D copies (interleaved with
                  small compute ops)
 
-    When dummy_compute=True, a tiny compute op (tensor.add_(1)) is inserted
-    between each large H2D copy on the h2d_stream, testing whether the copy
+    When dummy_compute=True, ``chunked_copy_`` inserts a tiny compute op
+    (tensor.add_(1)) between trunks on the h2d_stream, testing whether the copy
     engine treats back-to-back copies differently from compute-separated ones.
     """
     small_size = 1024
@@ -1085,14 +1087,16 @@ def copy_engine_contention(
         h2d_stream = torch.cuda.Stream()
 
     with record_function("## allocate tensors ##"):
-        # 3 large H2D sources for h2d_stream (pinned CPU → GPU)
-        large_h2d_sources = [
-            torch.full(
-                (num_concat * dim // 5, dim),
-                fill_value=float(ctx.rank + i + 1),
-            ).pin_memory()
-            for i in range(trunk_count)
-        ]
+        # One large H2D source (pinned CPU -> GPU), copied in trunks via
+        # chunked_copy_. The chunk size is one trunk, so the transfer is split
+        # into ``trunk_count`` back-to-back copies on the copy engine.
+        trunk_rows = num_concat * dim // 5
+        large_h2d_source = torch.full(
+            (trunk_count * trunk_rows, dim),
+            fill_value=float(ctx.rank + 1),
+        ).pin_memory()
+        large_h2d_device = torch.empty_like(large_h2d_source, device=ctx.device)
+        trunk_size_bytes = trunk_rows * dim * large_h2d_source.element_size()
 
         # 1 small D2H source on GPU
         d2h_source = torch.full(
@@ -1111,19 +1115,17 @@ def copy_engine_contention(
     with record_function("## pre-copy compute ##"):
         _compute(dim=dim, num_mul=num_mul * 5, num_concat=num_concat, ctx=ctx)
 
-    # --- h2d_stream: 3 consecutive large H2D copies ---
-    with record_function("## 3x large h2d on h2d_stream ##"):
-        large_h2d_devices = []
+    # --- h2d_stream: one large H2D copy, trunked via chunked_copy_ ---
+    with record_function("## large trunked h2d on h2d_stream ##"):
         with torch.cuda.stream(h2d_stream):
-            dummy_tensor = torch.empty(1, device=ctx.device)
             h2d_stream.wait_stream(main_stream)
-            for i, src in enumerate(large_h2d_sources):
-                with record_function(f"## large h2d {i} ##"):
-                    t = src.to(ctx.device, non_blocking=True)
-                    t.record_stream(main_stream)
-                    large_h2d_devices.append(t)
-                    if dummy_compute:
-                        dummy_tensor.add_(1)
+            chunked_copy_(
+                large_h2d_device,
+                large_h2d_source,
+                chunk_size_bytes=trunk_size_bytes,
+                dummy_compute=dummy_compute,
+            )
+            large_h2d_device.record_stream(main_stream)
 
     # --- main stream: compute, small d2h, compute, small h2d, compute, small h2d ---
     with record_function("## small compute 0 ##"):
@@ -1151,16 +1153,8 @@ def copy_engine_contention(
         h2d_stream.synchronize()
         torch.cuda.synchronize()
 
-        # validate large H2D copies
-        large_correct = all(
-            bool(
-                torch.allclose(
-                    large_h2d_devices[i],
-                    torch.full_like(large_h2d_devices[i], float(ctx.rank + i + 1)),
-                )
-            )
-            for i in range(trunk_count)
-        )
+        # validate large H2D copy
+        large_correct = bool(torch.all(large_h2d_device == float(ctx.rank + 1)).item())
 
         # validate small D2H copy
         d2h_correct = bool(torch.all(d2h_cpu_buffer == float(ctx.rank + 10)).item())
@@ -1204,6 +1198,28 @@ def copy_engine_contention_dummy_compute(
         num_concat=num_concat,
         ctx=ctx,
         dummy_compute=True,
+    )
+
+
+def copy_engine_contention_dummy_compute_10x_trunk(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    # Same as copy_engine_contention_dummy_compute but with 10x the trunk count
+    # (3 -> 30), so each trunk is smaller and the dummy compute op fires far
+    # more often between trunks on the copy engine.
+    return copy_engine_contention(
+        _batch_inputs=_batch_inputs,
+        dim=dim,
+        num_mul=num_mul,
+        num_concat=num_concat,
+        ctx=ctx,
+        dummy_compute=True,
+        trunk_count=30,
     )
 
 
@@ -1513,6 +1529,8 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = copy_engine_contention
             case "copy_engine_contention_dummy_compute":
                 func = copy_engine_contention_dummy_compute
+            case "copy_engine_contention_dummy_compute_10x_trunk":
+                func = copy_engine_contention_dummy_compute_10x_trunk
             case "h2d_execution_order":
                 func = h2d_execution_order
             case "a2a_d2h_contention":

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -35,6 +35,90 @@ def _tensor_size_text(tensor: Union[List[torch.Tensor], torch.Tensor]) -> str:
     return f"{size_mb / 1024:.2f} GB"
 
 
+def chunked_copy_(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    chunk_size_bytes: int = 512 * 1024**2,  # 512 MiB
+    non_blocking: bool = True,
+    dummy_compute: bool = True,
+) -> None:
+    """Copy ``src`` into ``dst`` in byte-bounded chunks to ease copy-engine contention.
+
+    A single bulk ``copy_`` (an H2D restore or a D2H stash) saturates the CUDA
+    copy engine until it finishes, serializing every same-direction copy from
+    other streams behind it (see the ``copy_engine_execution_order`` study).
+    Splitting the transfer into chunks of at most ``chunk_size_bytes`` bytes —
+    with a tiny dummy compute op enqueued between chunks — breaks the back-to-back
+    readiness of consecutive same-stream copies, so the copy engine yields
+    between chunks and lets other streams slip their (typically small) copies
+    into the gaps. This reduces, but does not eliminate, the contention latency.
+
+    The copy runs on the current CUDA stream; wrap the call in
+    ``with torch.cuda.stream(...)`` to target a specific stream.
+
+    Args:
+        dst: Destination tensor, written in place.
+        src: Source tensor with the same number of elements and dtype as ``dst``.
+        chunk_size_bytes: Maximum size of each chunk in bytes (default 512 MiB).
+            Values <= 0 disable chunking and fall back to a single un-chunked
+            ``copy_``.
+        non_blocking: Passed through to each per-chunk ``copy_`` for async DMA.
+        dummy_compute: If True, enqueue a tiny ``add_`` between chunks so the
+            copy engine yields to other streams. The study shows chunking alone
+            does not yield — under current-stream-first scheduling consecutive
+            same-stream copies run back-to-back as one uninterrupted block.
+
+    Note:
+        ``dst`` and ``src`` must be contiguous so that flat 1-D slicing aliases
+        their storage; non-contiguous tensors fall back to a single ``copy_``.
+    """
+    if dst.numel() != src.numel():
+        raise ValueError(
+            f"chunked_copy_ size mismatch: dst has {dst.numel()} elements, "
+            f"src has {src.numel()}"
+        )
+
+    numel = dst.numel()
+
+    # Fall back to a plain copy when chunking is disabled, the tensor is empty,
+    # or the layout cannot be safely flattened into an aliasing view.
+    if (
+        chunk_size_bytes <= 0
+        or numel == 0
+        or not dst.is_contiguous()
+        or not src.is_contiguous()
+    ):
+        dst.copy_(src, non_blocking=non_blocking)
+        return
+
+    chunk_elems = max(1, chunk_size_bytes // dst.element_size())
+    if chunk_elems >= numel:
+        dst.copy_(src, non_blocking=non_blocking)
+        return
+
+    dst_flat = dst.view(-1)
+    src_flat = src.view(-1)
+
+    # Reused single-element scratch tensor for the inter-chunk dummy op, so we
+    # do not allocate per chunk. Allocate it directly on the GPU side of the
+    # transfer (dst for H2D, src for D2H).
+    # Citrine C3: create the scratch tensor directly on device, not on CPU.
+    cuda_device = dst.device if dst.is_cuda else src.device if src.is_cuda else None
+    dummy = (
+        torch.ones(1, device=cuda_device)
+        if dummy_compute and cuda_device is not None
+        else None
+    )
+
+    for start in range(0, numel, chunk_elems):
+        end = min(start + chunk_elems, numel)
+        dst_flat[start:end].copy_(src_flat[start:end], non_blocking=non_blocking)
+        # Break same-stream copy readiness so the copy engine checks other
+        # streams before the next chunk runs (no dummy op after the last chunk).
+        if dummy is not None and end < numel:
+            dummy.add_(1)
+
+
 class MemoryStashingManager:
     """
     Class-level manager that holds shared resources (streams, threads, etc.)

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -7,19 +7,22 @@
 
 # pyre-strict
 
+import math
 import unittest
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+import hypothesis.strategies as st
 import torch
+from hypothesis import given, settings
 from torch import nn
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
-from torchrec.distributed.memory_stashing import MemoryStashingManager
+from torchrec.distributed.memory_stashing import chunked_copy_, MemoryStashingManager
 from torchrec.modules.embedding_configs import DataType, PoolingType
 
 
@@ -912,6 +915,180 @@ class TestEmsConfigWiring(unittest.TestCase):
                 eb_config.stash_weights,
                 f"{eb_config.name} should have stash_weights=False when EMS disabled",
             )
+
+
+def _expected_num_chunks(numel: int, element_size: int, chunk_size_bytes: int) -> int:
+    """Mirror chunked_copy_'s chunk arithmetic to predict the per-chunk op count."""
+    chunk_elems = max(1, chunk_size_bytes // element_size)
+    return math.ceil(numel / chunk_elems)
+
+
+def _filled(
+    shape: Tuple[int, ...], dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    """Create a deterministically-filled tensor of the given dtype/device."""
+    if dtype.is_floating_point:
+        return torch.randn(shape, device=device).to(dtype)
+    return torch.randint(-1000, 1000, shape, dtype=dtype, device=device)
+
+
+class ChunkedCopyTest(unittest.TestCase):
+    """Tests for chunked_copy_ exercising real cross-device (H2D / D2H) transfers.
+
+    ``chunked_copy_`` exists to chunk host<->device copies, so every test moves
+    data between CPU and CUDA (src and dst on different devices) rather than
+    CPU->CPU. Requires a GPU; skipped otherwise.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        self.device = torch.device("cuda:0")
+
+    def _src_dst(
+        self, shape: Tuple[int, ...], dtype: torch.dtype, direction: str
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Build (src, dst) on opposite devices for the given direction."""
+        host = _filled(shape, dtype, torch.device("cpu"))
+        if direction == "h2d":  # CPU src -> CUDA dst
+            return host.pin_memory(), torch.zeros(
+                shape, dtype=dtype, device=self.device
+            )
+        # d2h: CUDA src -> CPU dst
+        return host.to(self.device), torch.zeros(shape, dtype=dtype).pin_memory()
+
+    @given(
+        direction=st.sampled_from(["h2d", "d2h"]),
+        dtype=st.sampled_from(
+            [torch.float32, torch.float16, torch.float64, torch.int32]
+        ),
+        dims=st.lists(st.integers(min_value=1, max_value=64), min_size=1, max_size=3),
+        chunk_size_bytes=st.sampled_from([256, 1024, 65536, 1024**2]),
+    )
+    @settings(max_examples=100, deadline=None)
+    def test_numerical_correctness_h2d_and_d2h(
+        self,
+        direction: str,
+        dtype: torch.dtype,
+        dims: List[int],
+        chunk_size_bytes: int,
+    ) -> None:
+        """Chunked H2D/D2H copy reproduces the source bit-for-bit across shapes."""
+        src, dst = self._src_dst(tuple(dims), dtype, direction)
+        chunked_copy_(dst, src, chunk_size_bytes=chunk_size_bytes)
+        torch.cuda.synchronize()
+        # Exact match: copy_ between same dtype is lossless.
+        self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
+
+    def test_default_chunk_size_copies_correctly(self) -> None:
+        """Calling without chunk_size_bytes uses the default and copies correctly."""
+        src, dst = self._src_dst((10000,), torch.float32, "h2d")
+        chunked_copy_(dst, src)  # no chunk_size_bytes -> use default
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
+
+    def test_h2d_in_place_and_location(self) -> None:
+        """H2D writes dst in place and keeps it on the GPU (no realloc)."""
+        src, dst = self._src_dst((50000,), torch.float32, "h2d")
+        ptr_before = dst.data_ptr()
+
+        # 64 KiB chunks -> many chunks, exercising the loop + dummy compute.
+        chunked_copy_(dst, src, chunk_size_bytes=64 * 1024, dummy_compute=True)
+        torch.cuda.synchronize()
+
+        self.assertTrue(dst.is_cuda)
+        self.assertEqual(dst.data_ptr(), ptr_before)
+        self.assertEqual(dst.shape, src.shape)
+        self.assertEqual(dst.dtype, src.dtype)
+        self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
+
+    def test_d2h_in_place_and_location(self) -> None:
+        """D2H writes dst in place and keeps it on the host."""
+        src, dst = self._src_dst((50000,), torch.float32, "d2h")
+        ptr_before = dst.data_ptr()
+
+        chunked_copy_(dst, src, chunk_size_bytes=64 * 1024, dummy_compute=True)
+        torch.cuda.synchronize()
+
+        self.assertFalse(dst.is_cuda)
+        self.assertEqual(dst.data_ptr(), ptr_before)
+        self.assertTrue(torch.equal(dst, src.cpu()))
+
+    def test_source_is_not_mutated(self) -> None:
+        """Copying does not modify the source tensor (including with dummy_compute)."""
+        src, dst = self._src_dst((1000,), torch.float32, "h2d")
+        src_snapshot = src.clone()
+        chunked_copy_(dst, src, chunk_size_bytes=1024, dummy_compute=True)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(src, src_snapshot))
+
+    def test_size_mismatch_raises(self) -> None:
+        """Mismatched element counts raise ValueError."""
+        dst = torch.zeros(100, device=self.device)
+        src = torch.randn(99)
+        with self.assertRaises(ValueError):
+            chunked_copy_(dst, src, chunk_size_bytes=1024)
+
+    def test_zero_and_negative_chunk_size_copies_correctly(self) -> None:
+        """chunk_size_bytes <= 0 disables chunking but still copies correctly."""
+        for chunk_size_bytes in (0, -1):
+            with self.subTest(nbytes=chunk_size_bytes):
+                src, dst = self._src_dst((1000,), torch.float32, "h2d")
+                chunked_copy_(dst, src, chunk_size_bytes=chunk_size_bytes)
+                torch.cuda.synchronize()
+                self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
+
+    def test_empty_tensor_is_noop(self) -> None:
+        """Empty tensors copy without error and stay empty."""
+        src = torch.randn(0, device=self.device)
+        dst = torch.zeros(0)
+        chunked_copy_(dst, src, chunk_size_bytes=1024)
+        self.assertEqual(dst.numel(), 0)
+
+    def test_non_contiguous_stays_correct(self) -> None:
+        """Non-contiguous dst/src (fallback path) still copy correctly across devices."""
+        # Non-contiguous CPU source (transposed view) -> contiguous CUDA dst.
+        src = torch.randn(20, 10).t()
+        dst = torch.zeros(10, 20, device=self.device)
+        self.assertFalse(src.is_contiguous())
+        chunked_copy_(dst, src, chunk_size_bytes=256)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(dst.cpu(), src))
+
+        # Non-contiguous CUDA destination (transposed view) <- contiguous CPU src.
+        src2 = torch.randn(10, 20)
+        dst2 = torch.zeros(20, 10, device=self.device).t()
+        self.assertFalse(dst2.is_contiguous())
+        chunked_copy_(dst2, src2, chunk_size_bytes=256)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(dst2.cpu(), src2))
+
+    def test_dummy_compute_count_matches_chunks(self) -> None:
+        """With dummy_compute, exactly (num_chunks - 1) add_ ops are enqueued."""
+        numel = 50000
+        src, dst = self._src_dst((numel,), torch.float32, "h2d")
+        chunk_size_bytes = 64 * 1024
+        expected_chunks = _expected_num_chunks(
+            numel, dst.element_size(), chunk_size_bytes
+        )
+        self.assertGreater(expected_chunks, 1)
+
+        real_add = torch.Tensor.add_
+        add_calls: List[int] = []
+
+        def counting_add(self: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+            add_calls.append(1)
+            return real_add(self, *args, **kwargs)
+
+        with patch.object(torch.Tensor, "add_", counting_add):
+            chunked_copy_(
+                dst, src, chunk_size_bytes=chunk_size_bytes, dummy_compute=True
+            )
+        torch.cuda.synchronize()
+
+        # A dummy op sits between consecutive chunks: one fewer than chunk count.
+        self.assertEqual(len(add_calls), expected_chunks - 1)
+        self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
# Chunked Copy Design to Mitigate CUDA Copy Engine Contention

## TL;DR

- **Problem**: a bulk H2D/D2H `copy_` (EMS embedding restore, optimizer-state restore, `copy_batch_to_gpu`) saturates the GPU's single same-direction DMA copy engine, stalling small copies — and the dense compute that depends on them — on every other stream (see [Copy Engine Contention Study](https://github.com/meta-pytorch/torchrec/pull/4303)).
- **Why naive chunking fails**: the copy engine is priority-blind and uses current-stream-first scheduling, so consecutive same-stream chunks run back-to-back as one block (see [Copy Engine Execution Order](https://github.com/meta-pytorch/torchrec/pull/4315)).
- **Solution**: `chunked_copy_` splits the transfer into byte-bounded trunks and inserts a tiny dummy compute op between trunks, forcing the copy engine to yield so blocked streams slip their small copies into the gaps.

## 1. Background

While productionalizing EMS (Embedding Memory Stashing) on the OmniFM model, we observed that the main CUDA stream stalls whenever the EMS restoring stream is active — even though there is no data dependency or explicit stream/event synchronization between them. The root cause is copy engine contention: the restoring stream issues large H2D transfers to reload stashed embeddings, and these saturate the GPU's H2D DMA copy engine. When FSDP on the main stream then issues a small H2D copy (e.g., gathering a weight shard), that copy is queued behind the large restoring transfer in the copy engine's FIFO, blocking the entire main stream until the current DMA chunk completes.

<img width="3914" height="1746" alt="image" src="https://github.com/user-attachments/assets/9cf3a48a-5902-41cd-8c22-12d5d39c640e" />

The [trace](https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=aps_traces&trace_path=tree%2Ftraces%2Fdynocli%2Faps-V5_0427tk_128gpu_ems_jkOn_uniarch-d28eb1bff2%2F0%2Frank-26.May_28_00_40_42.7459.pt.trace.json.gz) above shows the OmniFM training iteration on rank 26 of a 128-GPU run. The red arrow highlights the critical contention point: the EMS restoring stream is performing a large H2D embedding restore, which blocks a small H2D copy on the main GPU stream, stalling the dense forward/backward pass until the copy engine drains.

## 2. GPU Copy Engine Architecture

NVIDIA GPUs expose a limited number of **DMA copy engines** (also called copy queues or CE). These are hardware units separate from the SMs (compute cores):

- **H2D and D2H share the same PCIe link** but can use separate copy engines (one for each direction on most modern GPUs)
- **Same-direction transfers serialize** on the same copy engine — two H2D copies from different streams still go through the same H2D copy engine in FIFO order
- Copy engines operate independently from the SM compute pipeline — a compute kernel running on SMs does not block a copy, and vice versa

> [!WARNING]
> **The following is not confirmed by public NVIDIA documentation:**
> **CUDA stream priority does not affect copy engine scheduling.** Stream priority (`cudaStreamCreateWithPriority`) controls how the CUDA runtime prioritizes **compute kernels** on SMs. The copy engines have their own FIFO queues and process transfers in submission order, regardless of the originating stream's priority.

## 3. Initial Idea

Since the contention comes from the EMS restore occupying the H2D copy engine with one monolithic transfer (5–10 GB, ~100–200 ms), a natural mitigation is to break that transfer into smaller chunks. If the restore is split into, say, three pieces, there are now gaps between chunks where the copy engine's FIFO can drain. If we additionally assign the EMS stream a lower CUDA priority, the hope is that the main stream's (default priority) small H2D can preempt or at least interleave between the EMS chunks, unblocking the dense forward/backward pass much earlier.

<img width="1614" height="1172" alt="image" src="https://github.com/user-attachments/assets/517643fd-78df-46de-9f37-55a27c277134" />

The diagram contrasts the two approaches. **Top**: current behavior — the bulk EMS restore blocks the main stream's small H2D via copy engine contention, delaying FSDP/dense compute. **Bottom**: the proposed fix — chunk the restore into three pieces on a low-priority EMS stream, so the high-priority main stream can slip its small H2D into the gaps between chunks. This motivated the benchmark experiment below to verify whether stream priority actually affects copy engine scheduling (it does not — see Section 5.3).

## 4. Experiment Design

The `copy_engine_contention` benchmark in `benchmark_comms.py` uses two streams: an **h2d_stream** (low priority) saturating the H2D copy engine with 3 consecutive large copies (~6 ms each), and the **main stream** (default priority) issuing a small D2H and two H2D copies interleaved with compute.

```
h2d_stream:  |== large H2D 0 ==|== large H2D 1 ==|== large H2D 2 ==|
main stream: |comp|d2h|comp|h2d|comp|h2d|  comp  |
                            ^^^      ^^^
                    small H2D contends with large H2D
                    on the same copy engine
```

If stream priority works on copy engines, the small H2D copies on the main stream should slip into the gaps between large chunks (between H2D 0–1 or 1–2), so the subsequent compute on the main stream is not blocked waiting for the copy engine to drain.


```bash
python -m torchrec.distributed.benchmark.benchmark_comms \
    a2a_single --name=copy_engine_contention
```

## 5. Benchmark Results

Unfortunately, the benchmark does not confirm the initial hypothesis. The small H2D copies on the main stream are still blocked by the 3 large H2D copies on the h2d_stream, even though the h2d_stream has lower priority, while the D2H copy on the main stream is not blocked.

<img width="4480" height="972" alt="image" src="https://github.com/user-attachments/assets/25c7f2d6-0ae2-48a7-9746-3c58d80ebf49" />

The [trace](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) shows the benchmark execution. The main thread (top) issues CPU-side operations. On the GPU side, **stream 7** runs the main stream's compute and small copies, while **stream 28** runs the 3 large H2D copies (`Memcpy HtoD (Pinned -> Device)`). The 3 flags on stream 7 mark (left to right) the small D2H copy and the 2 small H2D copies — the H2D copies are visibly delayed, waiting for the large transfers on stream 28 to complete.


* Small H2D copies are delayed by large H2D copies

When the h2d_stream's large H2D transfers are in flight, the small H2D copies on the main stream are queued behind them in the copy engine's FIFO. The small H2D copy does not begin until the current large chunk finishes its DMA transfer, even though the small copy is on a higher-priority stream.

* Small D2H copy is NOT delayed

The D2H copy on the main stream runs on a **separate copy engine** from the H2D copies. Since each direction has its own DMA engine, the D2H transfer proceeds immediately regardless of H2D congestion.

* Stream priority has no effect on copy engine scheduling

Setting `h2d_stream` to lower priority (`priority=1`) vs default priority produces identical copy latencies in the trace. The copy engine ignores stream priority entirely — it processes transfers in submission (FIFO) order.

This was verified by comparing traces with `low_priority=True` (default) and `low_priority=False`.

## 6. Implications

**EMS restore contention**
- Stream priority combined with chunked copies does not solve the contention — the copy engine is priority-blind.
- A potential workaround is to eliminate H2D copies from the main stream entirely (currently only a few small ones occur nearby), so the main stream's compute is never blocked waiting on the copy engine.

**copy_batch_to_gpu contention**
* The same copy engine contention can affect `copy_batch_to_gpu` in `TrainPipelineSparseDist`, a standard step in RecSys model training.
* If its large H2D transfer overlaps with small H2D copies from other pipeline stages (e.g., embedding stashing, optimizer state transfers), those small copies will be delayed, and blocking main stream execution.

## 7. Encountered Problem

The benchmark above left one puzzle: chunking the bulk transfer did **not** create the expected gaps for the main stream's small H2D to slip into, and the H2D copy engine queue did not appear to be filled in CPU issuing order — suggesting the scheduling is more subtle than a simple FIFO.

This was answered in the follow-up [Copy Engine Execution Order study](../tech-docs/copy_engine_execution_order.md): the copy engine uses **readiness-based dispatch** with **current-stream-first** scheduling. After finishing a copy it checks the *same* stream first, so consecutive same-stream chunks run back-to-back as one uninterrupted block — chunking alone never yields the engine. The gap only opens if the next chunk is made *not ready* when the previous one finishes, e.g. by inserting a tiny compute op between chunks. See the execution-order study and benchmark: [#4315](https://github.com/meta-pytorch/torchrec/pull/4315).

Remaining open items:
- We did not find authoritative NVIDIA/CUDA/PyTorch documentation describing copy engine scheduling internals; the model above is reverse-engineered from traces.
- Does the behavior differ across hardware (A100 vs H100 vs B200, or NVIDIA vs AMD)? Newer architectures or vendors may expose more copy engines or different scheduling policies.

## 8. Mitigation: Chunked Copy with Dummy Compute

Building on the execution-order finding, we add a small utility `chunked_copy_` (in [memory_stashing.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/memory_stashing.py)) that splits a bulk H2D/D2H transfer into byte-bounded *trunks* and enqueues a tiny dummy compute op between trunks. The dummy op breaks the back-to-back readiness of consecutive same-stream copies, forcing the copy engine to check other streams and serve their small copies in the gap.

```python
def chunked_copy_(
    dst: torch.Tensor,
    src: torch.Tensor,
    chunk_size_bytes: int = 512 * 1024**2,  # 512 MiB
    non_blocking: bool = True,
    dummy_compute: bool = True,
) -> None:
    ...
```

- **Byte-bounded trunks** sliced from flat 1-D views that alias `dst`/`src` storage, so each chunk writes in place (same `data_ptr`, no realloc).
- **Dummy compute between trunks** (`dummy_compute=True`): a reused single-element `add_` on the GPU side of the transfer, skipped after the last trunk. This is the active ingredient — chunking alone does not yield.
- **Safe fallbacks**: empty tensors, `chunk_size_bytes <= 0`, non-contiguous layouts, or a single covering chunk fall back to one `copy_`; element-count mismatch raises `ValueError`.

The util is dogfooded in the `copy_engine_contention` benchmarks: the bulk H2D (fixed total size) is now trunked via `chunked_copy_`, with `dummy_compute` and `trunk_count` exposed as variants.

```bash
# baseline: bulk H2D trunked, no dummy op between trunks (engine stays occupied)
python -m torchrec.distributed.benchmark.benchmark_comms a2a_single --name=copy_engine_contention

# dummy compute op between trunks so the copy engine yields between trunks
python -m torchrec.distributed.benchmark.benchmark_comms a2a_single --name=copy_engine_contention_dummy_compute

# same total payload, 10x more (smaller) trunks -> more frequent gaps
python -m torchrec.distributed.benchmark.benchmark_comms a2a_single --name=copy_engine_contention_dummy_compute_10x_trunk
```

## 9. Results

1. **`copy_engine_contention` (no dummy)** — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
   - **Blocking / contention**: the bulk trunks run back-to-back as one block; the main stream's small H2D copies are fully blocked until the whole transfer drains (D2H is unaffected — separate engine).
   - **Bandwidth**: best — one large contiguous DMA keeps the copy engine at peak throughput with no per-trunk gaps.
   - **Runtime**: worst for the main stream — its dependent compute is stalled for the full bulk-transfer duration.

<img width="5022" height="2040" alt="image" src="https://github.com/user-attachments/assets/010f4b06-7707-483d-b852-298710adb5fb" />

2. **`copy_engine_contention_dummy_compute`** — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
   - **Blocking / contention**: the dummy `add_` between trunks makes the copy engine yield, so the main stream's small H2D copies slip into the gaps instead of waiting for the full transfer.
   - **Bandwidth**: slightly lower than baseline — the inter-trunk gaps and dummy op leave the copy engine briefly idle.
   - **Runtime**: the main stream unblocks much earlier; the bulk transfer itself takes marginally longer, but the dependent compute starts sooner.

<img width="5042" height="1996" alt="image" src="https://github.com/user-attachments/assets/73226775-2b39-4d18-9153-a8ec0814366c" />

3. **`copy_engine_contention_dummy_compute_10x_trunk`** — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_10x_trunk_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_10x_trunk_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
   - **Blocking / contention**: same total payload split into 10× more (smaller) trunks → gaps open far more often, so a blocked copy waits at most one small trunk rather than a third of the payload.
   - **Bandwidth**: lowest — many small trunks plus per-trunk launch/dummy overhead reduce DMA efficiency.
   - **Runtime**: tightest contention latency for the main stream, at the cost of higher total bulk-transfer time — illustrating the trunk-size trade-off.

<img width="5034" height="2000" alt="image" src="https://github.com/user-attachments/assets/ed5fe80d-8b73-4235-a186-3f1e55cc26a2" />

| Case | Trunk size | Main-stream compute delay | Copy-engine bandwidth | Copy-data runtime |
|--|--|--|--|--|
| 3 trunks, no dummy | 320 MiB | 14.4 ms | 54.6 GB/s | 18.3 ms |
| 3 trunks + dummy | 320 MiB | 6.3 ms | 54.1 GB/s | 18.1 ms |
| 30 trunks + dummy | 32 MiB | 1.1 ms | 52.3 GB/s | 19.5 ms |

Compute delay is the main stream's stall waiting on the copy engine. For the same bulk payload, finer trunks drop the delay sharply (14.4 → 6.3 → 1.1 ms) while total copy-data runtime stays roughly flat (18.3 → 19.5 ms) and bandwidth dips only slightly (54.6 → 52.3 GB/s) — the contention win far outweighs the small copy-engine cost.

## 10. Discussion

- The **dummy compute op is the active ingredient** — chunking alone leaves the engine occupied back-to-back. We use a tiny `tensor.add_(1)` to break same-stream readiness, but it need not be this specific op: a cheaper kernel (or even a no-op-ish marker) may suffice, and the same yield might be achievable through other means (e.g. stream/event settings) without an explicit compute op. We did not dig further here.
- **Trunk size is the knob**: smaller trunks tighten the latency bound (a blocked copy waits at most one trunk), with a floor where per-trunk launch/dummy overhead and reduced DMA efficiency dominate.
- The mitigation **reduces, but does not eliminate**, contention: a blocked stream still waits for the in-flight trunk before slipping in.

## 11. Traces and References
**Traces**
- [OmniFM V5 128-GPU EMS run, rank 26 (Perfetto)](https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=aps_traces&trace_path=tree%2Ftraces%2Fdynocli%2Faps-V5_0427tk_128gpu_ems_jkOn_uniarch-d28eb1bff2%2F0%2Frank-26.May_28_00_40_42.7459.pt.trace.json.gz) — EMS restoring stream blocking main stream
- [Benchmark traces (Manifold)](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D107052549)
- [Benchmark trace (Perf Doctor)](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
- [Benchmark trace (Perfetto)](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D107052549/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)

**Chunked copy mitigation (D92349217)**
- [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D92349217)
- copy_engine_contention — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
- copy_engine_contention_dummy_compute — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)
- copy_engine_contention_dummy_compute_10x_trunk — [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_10x_trunk_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D92349217/trace-copy_engine_contention_dummy_compute_10x_trunk_nccl-rank0.json.gz&bucket=torchrec_benchmark_traces)

**References**
- [Copy Engine Execution Order study](../tech-docs/copy_engine_execution_order.md) — reverse-engineered scheduling model (readiness-based dispatch, current-stream-first)
- [Copy engine execution order PR — meta-pytorch/torchrec#4315](https://github.com/meta-pytorch/torchrec/pull/4315)
- [Chunked copy mitigation PR — meta-pytorch/torchrec#4303](https://github.com/meta-pytorch/torchrec/pull/4303)
- [CUDA Programming Guide: Stream Priorities](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#stream-priorities)
- [CUDA Caching Allocator internals](https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html) — per-stream memory reservation
- Benchmark source: [`benchmark_comms.py`](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/benchmark/benchmark_comms.py) (`copy_engine_contention`); util: [memory_stashing.py](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/memory_stashing.py) (`chunked_copy_`)

Differential Revision: D92349217


