### PR TITLE
[detailed][cpu eval] Benchmark for CPU Utilization in CPU–GPU Event Sync

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -1029,6 +1029,7 @@ def _run_cuda_profiling(
     export_stacks: bool,
     all_rank_traces: bool,
     memory_snapshot: bool,
+    profile_all_threads: bool = False,
 ) -> None:
     """Run optional CUDA profiling with chrome trace export and memory snapshot."""
 
@@ -1057,6 +1058,16 @@ def _run_cuda_profiling(
         )
 
     # Optional allocator warm-up to create fragmentation similar to production
+
+    # profile_all_threads uses global RecordFunction callbacks so ops on threads
+    # other than the profiling thread (e.g. raw Python threads spawned by a
+    # benchmark) land in the same trace; the default thread-local callbacks miss
+    # them.
+    experimental_config = (
+        torch.profiler._ExperimentalConfig(profile_all_threads=True)
+        if profile_all_threads
+        else None
+    )
     with torch.profiler.profile(
         activities=[
             torch.profiler.ProfilerActivity.CPU,
@@ -1068,6 +1079,7 @@ def _run_cuda_profiling(
         with_modules=True,
         with_stack=export_stacks,
         on_trace_ready=_trace_handler,
+        experimental_config=experimental_config,
     ) as prof:
         profile_iter_fn(prof)
 
@@ -1104,6 +1116,7 @@ def _run_benchmark_core(
     reset_accumulated_memory_stats: bool = True,
     all_rank_traces: bool = False,
     memory_snapshot: bool = False,
+    profile_all_threads: bool = False,
     sample_count: int = 0,
     test_name: str = "",
 ) -> BenchmarkResult:
@@ -1182,6 +1195,7 @@ def _run_benchmark_core(
             export_stacks=export_stacks,
             all_rank_traces=all_rank_traces,
             memory_snapshot=memory_snapshot,
+            profile_all_threads=profile_all_threads,
         )
 
     # Dump benchmark result to local storage
@@ -1262,6 +1276,7 @@ class BenchFuncConfig:
     export_stacks: bool = False
     all_rank_traces: bool = False
     memory_snapshot: bool = False
+    profile_all_threads: bool = False
     loglevel: str = "WARNING"
     test_name: str = ""
 
@@ -1277,6 +1292,7 @@ class BenchFuncConfig:
             "export_stacks": self.export_stacks,
             "all_rank_traces": self.all_rank_traces,
             "memory_snapshot": self.memory_snapshot,
+            "profile_all_threads": self.profile_all_threads,
             "test_name": self.test_name,
         } | kwargs_to_override
 
@@ -1301,6 +1317,7 @@ def benchmark_func(
     export_stacks: bool = False,
     all_rank_traces: bool = False,
     memory_snapshot: bool = False,
+    profile_all_threads: bool = False,
     sample_count: int = 0,
     test_name: str = "",
 ) -> BenchmarkResult:
@@ -1356,6 +1373,7 @@ def benchmark_func(
         reset_accumulated_memory_stats=True,
         all_rank_traces=all_rank_traces,
         memory_snapshot=memory_snapshot,
+        profile_all_threads=profile_all_threads,
         sample_count=sample_count,
         test_name=test_name,
     )

--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -22,6 +22,7 @@ see README.md for more details
 """
 
 import logging
+import threading
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, List
 
@@ -759,6 +760,150 @@ class TolistOverlapCommsConfig(CommsConfig):
 # pyrefly: ignore[missing-attribute]
 @_cc.register
 def tolist_overlap_comms(arg: TolistOverlapCommsConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+
+
+def benchmark_cuda_event_wait(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    blocking: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Measure how a blocking vs busy-waiting cuda Event.synchronize() affects a
+    concurrent CPU-side workload.
+
+    A long-running GPU kernel is launched on the main stream and an event is
+    recorded right after it. Just before the main thread waits on the event, a
+    side CPU thread starts running pure-CPU matmuls. The main thread then waits
+    on the event:
+
+      - blocking=True:  torch.cuda.Event(blocking=True) maps to
+                        cudaEventBlockingSync, so Event.synchronize() puts the
+                        calling thread to sleep on an OS primitive, leaving the
+                        CPU core free for the side thread.
+      - blocking=False: the default event busy-waits (spins) inside
+                        cudaEventSynchronize, burning a full CPU core that
+                        contends with the side thread.
+
+    The GIL is released both during synchronize() and during the matmuls, so
+    the contention being measured is purely for CPU cores. The side thread runs
+    a fixed number of matmuls wrapped in a single ## side-thread matmul ##
+    slice; under the spin variant (blocking=False) that slice is longer because
+    the spin steals a CPU core. Compare the slice of the blocking and spin runs
+    in the trace.
+
+    The side thread is a raw Python thread, which is invisible to the default
+    profiler (it installs RecordFunction callbacks thread-locally). The runner
+    sets ``profile_all_threads=True`` for this benchmark so the profiler uses
+    global callbacks and the side thread's slice appears in the chrome trace.
+
+    Tip: to amplify the effect, constrain the cores available to the process
+    (e.g. ``taskset -c 0-1``).
+    """
+    # cpu_mat_dim and n_side_matmuls set the side thread's total run time, which
+    # should outlast the event wait so the contention spans the whole wait.
+    cpu_mat_dim = 512
+    n_side_matmuls = 1000
+
+    with record_function("## setup ##"):
+        # single-threaded CPU matmul, so the side thread maps to ~1 core and the
+        # event-wait spin clearly steals cycles from it
+        prev_num_threads = torch.get_num_threads()
+        torch.set_num_threads(1)
+        a = torch.rand(cpu_mat_dim, cpu_mat_dim)
+        b = torch.rand(cpu_mat_dim, cpu_mat_dim)
+        start_gate = threading.Event()
+
+    def _side_compute() -> None:
+        c = a
+        start_gate.wait()
+        # The whole loop is one slice. It shows on the side thread's row only
+        # because the runner sets profile_all_threads=True (global callbacks);
+        # under the default thread-local profiler a raw Python thread fires no
+        # callbacks and is invisible.
+        with record_function("## side-thread matmul ##"):
+            for _ in range(n_side_matmuls):
+                c = a @ b  # recompute (no accumulation) so values stay bounded
+        _ = float(c.sum())  # touch the result so it isn't optimized away
+
+    with record_function("## launch long-running GPU kernel ##"):
+        # A few LARGE matmuls (one kernel launch each) keep the GPU busy for a
+        # long wall-clock time so the event wait is the long pole. Avoid many
+        # small kernels (e.g. a long F.normalize chain): the CPU enqueues them
+        # faster than the GPU drains, overflowing the launch queue ("Command
+        # Buffer Full"), which stalls the CPU on launch instead of on the event.
+        # Bump gpu_mat_dim / gpu_iters if the wait is too short to overlap with
+        # the side-thread compute.
+        gpu_mat_dim = 8192
+        gpu_iters = 50
+        g_a = torch.rand(gpu_mat_dim, gpu_mat_dim, device=ctx.device)
+        # small-magnitude operand keeps repeated matmul from overflowing to inf
+        g_b = (torch.rand(gpu_mat_dim, gpu_mat_dim, device=ctx.device) - 0.5) * 0.01
+        g_out = torch.empty_like(g_a)
+        for _ in range(gpu_iters):
+            torch.mm(g_a, g_b, out=g_out)
+            g_a, g_out = g_out, g_a
+
+    with record_function("## record event ##"):
+        ev = torch.cuda.Event(blocking=blocking)
+        ev.record()
+
+    with record_function("## start side thread ##"):
+        side_thread = threading.Thread(target=_side_compute, name="side_compute")
+        side_thread.start()
+        # release the side thread just before the main thread waits on the event
+        start_gate.set()
+
+    with record_function(f"## event.synchronize(blocking={blocking}) ##"):
+        ev.synchronize()
+
+    with record_function("## join side thread ##"):
+        side_thread.join()
+
+    with record_function("## report ##"):
+        torch.set_num_threads(prev_num_threads)
+        logger.info(
+            f"[rank-{ctx.rank}] blocking={blocking}: side thread ran "
+            f"{n_side_matmuls} matmuls ({cpu_mat_dim}x{cpu_mat_dim}); compare the "
+            f"## side-thread matmul ## slices against the spin variant in the trace"
+        )
+
+
+@dataclass
+class CudaEventWaitConfig(CommsConfig):
+    """
+    run commands:
+    1. blocking (default): Event.synchronize() sleeps the calling thread, leaving
+       the CPU core free for the side thread
+    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
+        --name=blocking
+
+    2. spin: the default cuda Event busy-waits inside synchronize(), burning a
+       CPU core that contends with the side thread
+    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
+        --name=spin \
+        --blocking=False
+
+    use case:
+        measure how a blocking vs busy-waiting cuda Event.synchronize() affects a
+        concurrent CPU-side workload. Compare the ## side-thread matmul ## slice
+        of the two runs in the chrome trace.
+    """
+
+    blocking: bool = True
+    num_profiles: int = 10
+    # capture the raw Python side thread in the chrome trace
+    profile_all_threads: bool = True
+    func: Callable[..., None] = benchmark_cuda_event_wait
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def cuda_event_wait(arg: CudaEventWaitConfig) -> None:
     run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 


### PR DESCRIPTION
Summary:
# CPU Utilization in CPU–GPU Event Sync

## TL;DR

- We are often puzzled by **100% CPU utilization** in benchmarks even when the CPU is just waiting on the GPU. This doc looks into why.
  - The cause: a CPU thread waiting on a CUDA event **spins** (busy-waits) by default, holding a full core for the whole wait.
  - The alternative: a **blocking** event sleeps the thread instead, freeing the core for other CPU work.
  - The benchmark shows concurrent CPU work running faster that way, for the same GPU time.
- It's a tradeoff: spin minimizes wake-up latency; blocking frees a core for concurrent work (e.g. ZORM / CPU eval). Evaluate per sync.

## 1. Motivation

We often notice in benchmarks that a rank's **CPU utilization sits at 100% while the CPU is doing nothing useful** — it is just waiting for the GPU (device) to finish an operation. That idle-but-busy core is not free: CPU utilization is a real resource we want to spend when we deliberately give a rank **extra concurrent CPU-side workload**, for example:

- **ZORM** — offloads RecMetrics computation to the CPU.
- **CPU eval** — offloads embedding lookup to the CPU.

A few things are easy to get wrong here. The **100% is a single core** — the one core running the spinning wait — not the whole machine. A production host has 100+ cores, so one busy core is nowhere near system-wide saturation, and offloaded work rarely starves for a free *core*.

For Python, the scheduling constraint that usually bites is the **GIL**, not raw cores: only one thread runs Python bytecode at a time, so "100% CPU" intuitions about thread starvation are really GIL-scheduling questions. But the CUDA sync **releases the GIL** while it waits — the host-side `synchronize()` parks in native C, not Python, so only the main CPU thread's own progress past the wait is paused (the kernels were already enqueued asynchronously, and the wait itself is GIL-free) — so the spin does **not** block other Python threads through the GIL.

What the spin actually competes for is a **physical core** (its timeslot): a genuinely concurrent CPU workload like ZORM (RecMetrics) or CPU eval (embedding lookup) runs real compute, and when a core pinned at 100% spinning sits next to it, that work gets a smaller share of CPU timeslots — it is **slowed, not blocked**, and only to the extent the rank's cores are already saturated.

To understand what was happening when we saw 100% CPU utilization during a GPU wait, we looked into how the CPU waits on a CUDA event — and found the **blocking** event-sync option, which sleeps the waiting thread instead of spinning. This doc benchmarks and visualizes that difference.

## 2. Background: how a CPU thread "waits" for the GPU

CUDA work is enqueued asynchronously; the CPU launches kernels and returns immediately. To learn when GPU work has finished, the host records an **event** and later calls `event.synchronize()` (or `stream.synchronize()`, `tensor.item()`, a D2H copy followed by a sync, etc.). The semantics of **how** the host waits depend on a flag set when the event is created.

| Feature | `blocking=False` (default) | `blocking=True` |
|---|---|---|
| CPU behavior | Busy-waits / spins in a tight loop | Yields / blocks and goes to sleep |
| CPU utilization | Spikes to 100% on the active core | Extremely low |
| Latency / overhead | Lowest possible; resumes instantly | Higher; due to OS context switching |
| Underlying flag | `cudaEventDefault` | `cudaEventBlockingSync` |
| Best used for | Performance-critical profiling / benchmarking | Co-existing with heavy background CPU tasks |

Source: [NVIDIA Developer forum](https://forums.developer.nvidia.com/t/cudadevicesynchronize-blocking-effect-cudadevicescheduleblockingsync/27065) — blocking effect of `cudaDeviceScheduleBlockingSync`.

> NOTES: **both** modes take the same GPU wall-clock time for the GPU. The difference is entirely in what the **CPU core** does during the wait — spin (consume) vs sleep (yield).

## 3. Approach

The `cuda_event_wait` benchmark recreates the situation we care about — a GPU wait overlapping with useful CPU work on the same rank — and measures how much the wait costs the CPU work:

1. Launch a long-running GPU kernel and record a CUDA event right after it.
2. Start a **side CPU thread** running a fixed compute workload.
3. Have the main thread wait on the event while the side thread runs, in two modes:
   - **blocking** (`--name=blocking`): `Event(blocking=True)` — the waiting thread sleeps and frees its core.
   - **spin** (`--name=spin --blocking=False`): the default event busy-waits and holds its core.

The GPU work is identical in both modes, so the GPU wall-clock is the same; the only thing that changes is whether the waiting core is free for the side thread. Comparing the side thread's runtime (and its slice in the chrome trace) across the two modes shows how much the spin steals.

This is purely a **CPU-core** contention, not a GIL one: the main thread releases the GIL while parked in `synchronize()` (verified in PyTorch source, see References), so the side thread keeps running throughout the wait — it is never blocked, just left with a smaller CPU share under the spin.

Run the two modes:

```bash
# blocking -- Event.synchronize() sleeps the CPU thread, frees the core
python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait --name=blocking

# spin -- cudaEventSynchronize busy-waits and burns a core
python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait --name=spin --blocking=False
```

## 4. Results

The GPU wait takes the same wall-clock time in both modes (the GPU work is identical), so the only variable is whether the waiting core is free for the side thread. The side thread's `## side-thread matmul ##` slice measures that directly.

With the **blocking** event, the main thread sleeps inside `synchronize()` and releases its core; the side thread runs on a free core and finishes its matmuls in **~532 ms**.

<img width="4542" height="1018" alt="image" src="https://github.com/user-attachments/assets/df29c417-ad68-4f6d-b99a-7f6f8edbed38" />

[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D108455279/trace-cuda_event_wait_blocking-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D108455279/trace-cuda_event_wait_blocking-rank0.json.gz&bucket=torchrec_benchmark_traces)

With the **default (spin)** event, the main thread busy-waits inside `cudaEventSynchronize` and holds its core for the whole wait, contending with the side thread; the same matmuls take **~680 ms** — ~148 ms (~28%) longer.

<img width="4516" height="1012" alt="image" src="https://github.com/user-attachments/assets/bc8527bf-a1af-4c4c-86e0-715f5631cd03" />

[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D108455279/trace-cuda_event_wait_spin-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D108455279/trace-cuda_event_wait_spin-rank0.json.gz&bucket=torchrec_benchmark_traces)

[Manifold trace folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D108455279)

## 5. Discussion

When the synchronizing thread is the only thing the process is doing, the spin is harmless — the core would be idle anyway, and busy-waiting even shaves a little wake-up latency off the sync. The cost only shows up when the process runs other CPU work concurrently: input-pipeline threads, host-side collation, background copy/stash threads, or deliberately offloaded compute. There the spinning sync thread **contends for a core** with that work and slows it down — exactly the 100% CPU utilization we set out to explain in [Motivation](#1-motivation).

For the offloaded workloads that motivated this (ZORM RecMetrics, CPU eval embedding lookup), this is worth weighing: a default-event sync overlapping their compute pins a core at 100% doing nothing, taking CPU share away from the offload when cores are tight, whereas routing that wait through `Event(blocking=True)` frees the core for them. The flip side is real too — the spin is not a bug, it is the lowest-latency way to wait, so for short or latency-critical syncs with nothing else to run, the default is the right call. There is no universally better option; the choice depends on whether the sync overlaps meaningful CPU work and how latency-sensitive it is.

Two caveats:

- This is a controlled micro-benchmark with a single long sync. Real steps issue many syncs, so the practical win depends on how much concurrent CPU work actually overlaps a blocking-eligible wait.
- Not every sync exposes the flag. Many device syncs are implicit (`.item()`, `.cpu()`, `print(tensor)`, `torch.cuda.synchronize()`) and use the default spinning behavior; capturing this win means steering the hot, overlap-heavy waits through an event created with `blocking=True`.

## 6. References

- Diff: [D108455279](https://www.internalfb.com/diff/D108455279) — `cuda_event_wait` benchmark
- [`torch.cuda.Event` docs](https://docs.pytorch.org/docs/stable/generated/torch.cuda.Event.html) — the `blocking` flag
- [NVIDIA forum: blocking effect of `cudaDeviceScheduleBlockingSync`](https://forums.developer.nvidia.com/t/cudadevicesynchronize-blocking-effect-cudadevicescheduleblockingsync/27065)
- GIL release on the host-side sync (`gil_scoped_release`): [Event.cpp](https://github.com/pytorch/pytorch/blob/main/torch/csrc/cuda/Event.cpp), [Stream.cpp](https://github.com/pytorch/pytorch/blob/main/torch/csrc/cuda/Stream.cpp), [Module.cpp](https://github.com/pytorch/pytorch/blob/main/torch/csrc/cuda/Module.cpp)

Differential Revision: D108455279


