### PR TITLE
[detailed][autograd] Add chained-autograd preallocated-output demo

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_chained_autograd.py
+++ b/torchrec/distributed/benchmark/benchmark_chained_autograd.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Chained-autograd demo for the preallocated-output use case: two autograd
+Functions both write disjoint slots of the same preallocated tensor, chained so
+that op2's forward consumes op1's output. This keeps both backward passes in the
+graph -- the SSD+VBE fix analyzed in
+md-docs/tech-docs/ssd_vbe_bwd_issue_analysis.md.
+
+    pre = torch.empty(4)                 # preallocated output
+    pre = op1(pre, x1)                   # pre[0]=x1[0], pre[1]=x1[1]**2
+    pre = op2(pre, x2)                   # pre[2]=x2[0]**3, pre[3]=x2[1]**4
+    loss = pre.sum()
+
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt \
+        fbcode//torchrec/distributed/benchmark:benchmark_chained_autograd -- \
+        preallocated_output
+
+OSS (external):
+    python -m torchrec.distributed.benchmark.benchmark_chained_autograd \
+        preallocated_output
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Tuple
+
+import torch
+from torch.autograd import Function
+from torchrec.distributed.benchmark.base import BenchFuncConfig, cmd_conf
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# pyrefly: ignore[missing-argument]
+_cc = cmd_conf()
+
+
+def register_benchmark(
+    config: type[BenchFuncConfig],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    Decorator factory: register a function as a CLI subcommand bound to the given
+    config class. The function name becomes the subcommand. Define the config
+    first, then:
+
+    @register_benchmark(MyConfig)
+    def my_bench(arg: MyConfig) -> None: ...
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable[..., None]:
+        func.__annotations__ = {"arg": config, "return": None}
+        # pyrefly: ignore[missing-attribute]
+        _cc.register(func)
+        return func
+
+    return decorator
+
+
+#################################### autograd ops ####################################
+class Op1(Function):
+    """Writes the first two slots of ``pre``: pre[0]=x[0], pre[1]=x[1]**2."""
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def forward(ctx: Any, pre: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        print(f"run op1.forward with pre={pre} x={x}")
+        pre[0] = x[0]
+        pre[1] = x[1] ** 2
+        ctx.save_for_backward(x)
+        # `pre` is an input mutated in place and returned; autograd needs to know
+        ctx.mark_dirty(pre)
+        return pre
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def backward(
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        (x,) = ctx.saved_tensors
+        print(f"run op1.backward with grad_output={grad_output} x={x}")
+        grad_x = torch.stack([grad_output[0], grad_output[1] * 2 * x[1]])
+        # op1 overwrote pre[0:2], so those slots do not depend on the incoming
+        # `pre`; zero them before threading the grad back to the previous op
+        grad_pre = grad_output.clone()
+        grad_pre[0] = 0
+        grad_pre[1] = 0
+        return grad_pre, grad_x
+
+
+class Op2(Function):
+    """Writes the last two slots of ``pre``: pre[2]=x[0]**3, pre[3]=x[1]**4."""
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def forward(ctx: Any, pre: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        print(f"run op2.forward with pre={pre} x={x}")
+        pre[2] = x[0] ** 3
+        pre[3] = x[1] ** 4
+        ctx.save_for_backward(x)
+        ctx.mark_dirty(pre)
+        return pre
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def backward(
+        ctx: Any, grad_output: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        (x,) = ctx.saved_tensors
+        print(f"run op2.backward with grad_output={grad_output} x={x}")
+        grad_x = torch.stack(
+            [grad_output[2] * 3 * x[0] ** 2, grad_output[3] * 4 * x[1] ** 3]
+        )
+        grad_pre = grad_output.clone()
+        grad_pre[2] = 0
+        grad_pre[3] = 0
+        return grad_pre, grad_x
+
+
+###################################### benchmark ######################################
+@dataclass
+class PreallocatedOutputConfig(BenchFuncConfig):
+    name: str = ""
+    world_size: int = 1
+    num_profiles: int = 0
+    num_benchmarks: int = 0
+    x1: List[float] = field(default_factory=lambda: [1.1, 2.1])
+    x2: List[float] = field(default_factory=lambda: [3.1, 4.1])
+
+
+@register_benchmark(PreallocatedOutputConfig)
+def preallocated_output(arg: PreallocatedOutputConfig) -> None:
+    """
+    op1 and op2 write disjoint slots of one preallocated tensor ``pre``.
+    Chaining ``pre = op2(op1(pre, x1), x2)`` -- instead of returning op1's output
+    directly -- keeps both op1.backward and op2.backward in the graph.
+    """
+    arg.set_log_level()
+
+    pre = torch.empty(4)
+    x1 = torch.tensor(arg.x1, requires_grad=True)
+    x2 = torch.tensor(arg.x2, requires_grad=True)
+
+    print(f"initial: pre={pre}")
+    pre = Op1.apply(pre, x1)
+    print(f"after op1: pre={pre}")
+    pre = Op2.apply(pre, x2)
+    print(f"after op2: pre={pre}")
+
+    loss = torch.sum(pre)
+    print(f"loss={loss}")
+    loss.backward()
+    print(f"x1.grad={x1.grad}, x2.grad={x2.grad}")
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[missing-attribute]
+    _cc.main()


### PR DESCRIPTION
Summary:
# Chained Autograd for Preallocated Output Tensors

**Related:**
- [SSD + VBE Backward Issue Analysis](https://docs.google.com/document/d/1KC5AjPQu5ppDReQpTE63U4QvrGj99nsqvL3FgIGCfys) — the original autograd trap
- [Mitigating QPS Regression with SSD Offloading and VBE](https://fb.workplace.com/groups/819640306776968/permalink/1039561818118148/) — the production motivation and daisy-chaining design

---

## TL;DR

When two (or more) ops need to produce one merged output tensor, the naive path allocates each op's output separately and then permutes and concatenates them into the final layout. That merge is expensive: it burns CPU building the permute and spikes GPU memory allocating intermediates.

The optimization is to preallocate the merged output once and let each op write its own slice directly — no concat, no permute copy. But this breaks autograd unless the ops are chained so that each op's output feeds the next op's input. This doc explains why the naive preallocated approach silently drops gradients, how chaining fixes it, and links a minimal runnable demo.

This is the mechanism behind the SSD+VBE merge-output optimization, distilled into a minimal runnable demo (linked below).

## Background: the merge cost and the backward trap

In TorchRec, a lookup module with multiple TBEs (e.g. a regular TBE plus an SSD TBE) produces several embedding outputs that must be merged into a single tensor in a fixed layout. With VBE enabled the merge is a CPU-side split, permute, and concat, which leaves the GPU idle and spikes memory — the root cause of the [30% QPS regression](https://fb.workplace.com/groups/819640306776968/permalink/1039561818118148/).

The fix is to preallocate the output tensor and have each TBE write its embeddings straight into the right offsets. The forward pass is straightforward. The backward pass is the trap.

If you pass the same preallocated tensor to each op independently and return only one of them, autograd sees only that op's backward — the other op's backward is silently dropped and its inputs get no gradient. This is exactly the failure described in the [backward issue analysis](https://docs.google.com/document/d/1KC5AjPQu5ppDReQpTE63U4QvrGj99nsqvL3FgIGCfys).

## The approach: preallocate + daisy-chain

Two rules make it work:

1. Preallocate the output, and have each op write only its own disjoint slice(s) of it in the forward. Mark the tensor dirty with `ctx.mark_dirty` since it is an input mutated in place and returned.
2. Chain the ops — op2 takes op1's output as its input — so both backwards end up in the graph, and autograd runs them in the correct order (op2 first, then op1).

The subtlety is in each op's backward. It receives an incoming gradient shaped like the whole merged tensor and must:

- produce the gradient for its own input from the slice it wrote, and
- thread the incoming gradient back to the previous op, but with its own slots zeroed — those slots were fully overwritten by this op, so the previous op's write into them does not affect the loss.

This zeroing is what keeps the chained gradients numerically identical to computing each op independently.

The pattern for authoring each op (pseudo-code):

```python
class Op(Function):
    staticmethod
    def forward(ctx, pre, x):
        pre[my_slots] = compute(x)        # write ONLY this op's slice(s)
        ctx.save_for_backward(x)          # stash what backward needs
        ctx.mark_dirty(pre)               # pre is mutated in place and returned
        return pre                        # return the shared tensor, not a new one

    staticmethod
    def backward(ctx, grad_output):       # grad_output has the FULL merged shape
        (x,) = ctx.saved_tensors
        grad_x = compute_grad(grad_output[my_slots], x)   # this op's input grad
        grad_pre = grad_output.clone()    # pass-through grad for the previous op
        grad_pre[my_slots] = 0            # zero the slots THIS op overwrote
        return grad_pre, grad_x           # grads for (pre, x)
```

And the driver chains the ops so each output feeds the next op's input:

```python
pre = allocate_output()          # preallocated shared tensor
pre = Op1.apply(pre, x1)         # writes op1's slots
pre = Op2.apply(pre, x2)         # chained: op1's output IS op2's input
loss = pre.sum()
loss.backward()                  # runs op2.backward -> op1.backward, in order
```

<img width="755" height="192" alt="image" src="https://github.com/user-attachments/assets/f4bc668a-54c2-43a8-b2c1-83512b0175e3" />

The figure above (from the [QPS mitigation post](https://fb.workplace.com/groups/819640306776968/permalink/1039561818118148/)) shows the pattern at TBE granularity: the forward chains Empty Emb → TBE 0 → TBE 1 → merged, and the backward runs ∇Grads → Grad fn 1 → Grad fn 0, with each grad-fn passing the full-size gradient to the previous one in the chain.

## Minimal reproduction

The full implementation lives in the benchmark demo — see `benchmark_chained_autograd.py` ([D112267857](https://www.internalfb.com/diff/D112267857), GitHub PR TBD). It uses a preallocated tensor of shape (4,) and two autograd Functions, each owning two disjoint slots:

- op1 writes pre[0] = x1[0] and pre[1] = x1[1]²
- op2 writes pre[2] = x2[0]³ and pre[3] = x2[1]⁴

Each op writes its slots in place, calls `ctx.mark_dirty`, and returns the shared tensor. The driver chains them — op2 takes op1's output — then sums the result and runs backward.

## Walking through the backward

With loss = sum(pre), the gradient entering the chain is all ones, [1, 1, 1, 1].

1. op2's backward receives [1, 1, 1, 1]. It produces the gradient for x2, [3·x2[0]², 4·x2[1]³] = [28.83, 275.684], and passes back [1, 1, 0, 0] — slots 2 and 3 zeroed because op2 overwrote them.
2. op1's backward receives [1, 1, 0, 0]. It produces the gradient for x1, [1, 2·x1[1]] = [1.0, 4.2], and passes back all zeros to the preallocated tensor (which needs no gradient) — discarded.

The zeroing in step 1 is the crux: without it, op1 would receive spurious gradient on slots it does not own, and the result would diverge from the independent computation.

## Why the naive (unchained) approach fails

If instead each op writes against the same preallocated tensor independently — op2 taking the original tensor rather than op1's output — and you return op1's result, the graph for the returned tensor contains only op1's backward. op2's backward never runs, so x2 gets no gradient. Because both ops alias the same storage, the forward values still look correct, which makes the missing gradient especially easy to miss. See the "naive approach fails Autograd" figure in the [QPS mitigation post](https://fb.workplace.com/groups/819640306776968/permalink/1039561818118148/).

## Running the demo

```bash
python -m torchrec.distributed.benchmark.benchmark_chained_autograd preallocated_output
```

Output — both backwards fire, and gradients match the analytic values:

```
after op1: pre=tensor([1.1000e+00, 4.4100e+00, 2.0710e+23, 1.7664e+22], grad_fn=<Op1Backward>)
after op2: pre=tensor([  1.1000,   4.4100,  29.7910, 282.5761], grad_fn=<Op2Backward>)
loss=317.8770751953125
run op2.backward with grad_output=tensor([1., 1., 1., 1.]) x=tensor([3.1000, 4.1000], requires_grad=True)
run op1.backward with grad_output=tensor([1., 1., 0., 0.]) x=tensor([1.1000, 2.1000], requires_grad=True)
x1.grad=tensor([1.0000, 4.2000]), x2.grad=tensor([ 28.8300, 275.6840])
```

Note that op1's backward receives [1, 1, 0, 0] — direct evidence that op2's backward zeroed the slots it overwrote before threading the gradient back.

## Mapping to the real SSD + VBE case

The demo captures the exact autograd contract used in production:

| Demo | SSD + VBE lookup |
| --- | --- |
| preallocated tensor of shape (4,) | preallocated 1D `vbe_output` sized to hold all TBE outputs |
| slots pre[0:2], pre[2:4] | per-TBE offsets from `stride_per_key_per_rank()` |
| op1, op2 write their slots | each TBE's forward kernel writes at `row_output_offsets` |
| op2 takes op1's output | daisy-chaining TBE outputs into the next TBE's input |
| backward returns the pass-through grad with its own slots zeroed | TBE backward passes `grad_outputs` to the next TBE in the chain |

In production this is split across TorchRec (the chaining and the preallocated tensor) and FBGEMM (the kernels that write at offsets and thread `grad_outputs`). The autograd reasoning — preallocate, chain, and thread the full-size gradient back with overwritten slots zeroed — is identical.

## Key takeaways

1. Preallocating a shared output avoids the permute-and-concat merge cost (CPU time and peak memory), which is the whole point of the optimization.
2. Autograd cannot infer the dependency between ops that alias the same storage — you must chain them so every op's backward lands in the graph.
3. Each op's backward must zero the slots it overwrote before passing the gradient upstream, otherwise gradients diverge from the independent computation.
4. `ctx.mark_dirty` is required whenever an op mutates an input in place and returns it.

Differential Revision: D112267857


