### PR TITLE
[detailed][autograd] Splitting a Backward Workload Across Autograd Functions

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_chained_autograd.py
+++ b/torchrec/distributed/benchmark/benchmark_chained_autograd.py
@@ -19,7 +19,23 @@ md-docs/tech-docs/ssd_vbe_bwd_issue_analysis.md.
     pre = op2(pre, x2)                   # pre[2]=x2[0]**3, pre[3]=x2[1]**4
     loss = pre.sum()
 
-Example usage:
+A second use case, ``split_backward``, splits one op's backward across two
+Functions so an output-grad-independent (x-only) step can overlap a long comm:
+
+    y, dummy = op1(x)                    # y=x**2; dummy is a grad-carrying token
+    empty    = op2(x, dummy)             # trivial fwd, x-only bwd
+    z        = all2all(y)                # op3: long-running comm (real collective)
+    loss     = sum(cat([z, empty]))      # op4
+
+op1's x-only gradient factor is computed in op2.backward and handed back to
+op1.backward through ``dummy``'s gradient, so it can run alongside op3's comm.
+This use case runs multi-process (default nccl, world_size=2) so op3 is a real
+all2all; its backward is also an all2all, independent of op2's x-only compute.
+Each op is a named ``record_function`` span, and a chrome trace is exported to
+``--profile_dir`` (default "."). Inspect it at https://ui.perfetto.dev.
+
+Example usage (swap ``preallocated_output`` for ``split_backward`` to run the
+other use case):
 
 Buck2 (internal):
     buck2 run @fbcode//mode/opt \
@@ -33,11 +49,21 @@ OSS (external):
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 from torch.autograd import Function
-from torchrec.distributed.benchmark.base import BenchFuncConfig, cmd_conf
+from torch.autograd.profiler import record_function
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    cmd_conf,
+)
+from torchrec.distributed.comm_ops import AllToAllSingle, pg_name
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    run_multi_process_func,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -73,7 +99,7 @@ class Op1(Function):
     @staticmethod
     # pyrefly: ignore[bad-override]
     def forward(ctx: Any, pre: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-        print(f"run op1.forward with pre={pre} x={x}")
+        logger.info("run op1.forward with pre=%s x=%s", pre, x)
         pre[0] = x[0]
         pre[1] = x[1] ** 2
         ctx.save_for_backward(x)
@@ -87,7 +113,7 @@ class Op1(Function):
         ctx: Any, grad_output: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         (x,) = ctx.saved_tensors
-        print(f"run op1.backward with grad_output={grad_output} x={x}")
+        logger.info("run op1.backward with grad_output=%s x=%s", grad_output, x)
         grad_x = torch.stack([grad_output[0], grad_output[1] * 2 * x[1]])
         # op1 overwrote pre[0:2], so those slots do not depend on the incoming
         # `pre`; zero them before threading the grad back to the previous op
@@ -103,7 +129,7 @@ class Op2(Function):
     @staticmethod
     # pyrefly: ignore[bad-override]
     def forward(ctx: Any, pre: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-        print(f"run op2.forward with pre={pre} x={x}")
+        logger.info("run op2.forward with pre=%s x=%s", pre, x)
         pre[2] = x[0] ** 3
         pre[3] = x[1] ** 4
         ctx.save_for_backward(x)
@@ -116,7 +142,7 @@ class Op2(Function):
         ctx: Any, grad_output: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         (x,) = ctx.saved_tensors
-        print(f"run op2.backward with grad_output={grad_output} x={x}")
+        logger.info("run op2.backward with grad_output=%s x=%s", grad_output, x)
         grad_x = torch.stack(
             [grad_output[2] * 3 * x[0] ** 2, grad_output[3] * 4 * x[1] ** 3]
         )
@@ -126,6 +152,81 @@ class Op2(Function):
         return grad_pre, grad_x
 
 
+class SplitBwdOp1(Function):
+    """op1: y = x ** 2, plus a ``dummy`` token output.
+
+    op1's true x-gradient factors as ``dy/dx = 2*x`` (x-only, expensive) times
+    the incoming ``grad_y``. We move the x-only factor out of this backward and
+    into op2.backward, which hands it back through ``dummy``'s gradient. So
+    op1.backward only does the cheap combine ``grad_dummy * grad_y``.
+    """
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def forward(ctx: Any, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        logger.info("run op1.forward with x.shape=%s", tuple(x.shape))
+        y = x**2
+        # Token output; its value is never read -- only its gradient carries the
+        # x-only factor back from op2.backward. A true ``meta`` tensor can't be
+        # used here: autograd requires a gradient's device to match its tensor's,
+        # so a meta output would reject op2's cuda gradient. Instead build a
+        # zero-storage view -- one real element ``expand``ed to x's shape -- so
+        # forward allocates ~nothing while op2.backward still hands back a full
+        # cuda gradient of shape ``x.shape`` in the backward pass.
+        dummy = x.new_empty(1).expand(x.shape)
+        return y, dummy
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def backward(
+        ctx: Any, grad_y: torch.Tensor, grad_dummy: torch.Tensor
+    ) -> torch.Tensor:
+        with record_function("## op1.backward ##"):
+            logger.info(
+                "run op1.backward with grad_y.device=%s grad_dummy.device=%s",
+                grad_y.device,
+                grad_dummy.device,
+            )
+            # grad_dummy == 2*x, precomputed by op2.backward. Cheap combine only.
+            grad_x = grad_dummy * grad_y
+            return grad_x
+
+
+class SplitBwdOp2(Function):
+    """op2: trivial forward, x-only backward.
+
+    Forward just emits an ``empty`` output consumed by op4 -- the graph edge that
+    gets op2.backward invoked. The real work is in backward: it runs the x-only
+    factor that op1.backward would otherwise compute (``2*x`` for ``y=x**2``, an
+    elementwise op of about the same cost as op1's own backward), and routes the
+    result to op1 through ``dummy``'s gradient.
+    """
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def forward(ctx: Any, x: torch.Tensor, dummy: torch.Tensor) -> torch.Tensor:
+        logger.info("run op2.forward with x.shape=%s", tuple(x.shape))
+        ctx.save_for_backward(x)
+        # Trivial output; value irrelevant, only used to keep op2 in the graph.
+        empty = x.new_empty(0)
+        return empty
+
+    @staticmethod
+    # pyrefly: ignore[bad-override]
+    def backward(
+        ctx: Any, grad_empty: torch.Tensor
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        (x,) = ctx.saved_tensors
+        with record_function("## op2.backward (x-only) ##"):
+            logger.info("run op2.backward with x.shape=%s", tuple(x.shape))
+            # x-only step: depends on x alone, not on any output grad, so it can
+            # run as soon as backward starts and overlap op3's long-running comm.
+            # Elementwise ``2*x`` -- about the same cost as op1's own backward.
+            heavy = 2 * x
+            # ``empty`` does not depend on x, so op2 contributes no grad to x.
+            return None, heavy
+
+
 ###################################### benchmark ######################################
 @dataclass
 class PreallocatedOutputConfig(BenchFuncConfig):
@@ -133,6 +234,9 @@ class PreallocatedOutputConfig(BenchFuncConfig):
     world_size: int = 1
     num_profiles: int = 0
     num_benchmarks: int = 0
+    # Demo logs (op forward/backward traces) are emitted at INFO; override with
+    # --loglevel to quiet them.
+    loglevel: str = "INFO"
     x1: List[float] = field(default_factory=lambda: [1.1, 2.1])
     x2: List[float] = field(default_factory=lambda: [3.1, 4.1])
 
@@ -144,22 +248,139 @@ def preallocated_output(arg: PreallocatedOutputConfig) -> None:
     Chaining ``pre = op2(op1(pre, x1), x2)`` -- instead of returning op1's output
     directly -- keeps both op1.backward and op2.backward in the graph.
     """
+    logging.basicConfig()
     arg.set_log_level()
 
     pre = torch.empty(4)
     x1 = torch.tensor(arg.x1, requires_grad=True)
     x2 = torch.tensor(arg.x2, requires_grad=True)
 
-    print(f"initial: pre={pre}")
+    logger.info("initial: pre=%s", pre)
     pre = Op1.apply(pre, x1)
-    print(f"after op1: pre={pre}")
+    logger.info("after op1: pre=%s", pre)
     pre = Op2.apply(pre, x2)
-    print(f"after op2: pre={pre}")
+    logger.info("after op2: pre=%s", pre)
 
     loss = torch.sum(pre)
-    print(f"loss={loss}")
+    logger.info("loss=%s", loss)
     loss.backward()
-    print(f"x1.grad={x1.grad}, x2.grad={x2.grad}")
+    logger.info("x1.grad=%s, x2.grad=%s", x1.grad, x2.grad)
+
+
+@dataclass
+class SplitBackwardConfig(BenchFuncConfig):
+    name: str = ""
+    world_size: int = 2
+    num_benchmarks: int = 1
+    num_profiles: int = 2
+    profile_dir: str = "."
+    backend: str = "nccl"
+    # Demo logs (op forward/backward traces) are emitted at INFO; override with
+    # --loglevel to quiet them.
+    loglevel: str = "INFO"
+    # Number of elements of ``x`` (and thus of ``y``) that flow through op3's
+    # all2all -- larger means heavier comms. Must be divisible by world_size.
+    comm_numel: int = 4_194_304  # 2^22 fp32 = 16 MiB per rank
+
+
+def _split_backward_iter(
+    _batch_inputs: List[Dict[str, Any]],
+    ctx: MultiProcessContext,
+    comm_numel: int,
+    **_kwargs: Any,
+) -> None:
+    """One measured iteration: build the graph and run fwd + bwd.
+
+    Each op is wrapped in ``record_function`` so it is a named span in the chrome
+    trace. op1/op2 also annotate their backward internally (see the Functions),
+    and op3's all2all backward shows up as a collective under ``## backward ##``.
+    """
+    x = torch.rand(comm_numel, device=ctx.device, requires_grad=True)
+
+    with record_function("## op1.forward (y, dummy) ##"):
+        y, dummy = SplitBwdOp1.apply(x)
+    with record_function("## op2.forward (trivial) ##"):
+        # pyrefly: ignore[missing-attribute]
+        empty = SplitBwdOp2.apply(x, dummy)
+    pg = ctx.pg
+    assert pg is not None
+    with record_function("## op3.forward all2all (comm) ##"):
+        # Real differentiable all2all across ranks -- the long-running comm. Its
+        # backward is itself an all2all, independent of op2's x-only compute.
+        # pyrefly: ignore[missing-attribute]
+        z = AllToAllSingle.apply(y, None, None, pg_name(pg), pg.size(), False)
+    with record_function("## op4.forward sum(cat) ##"):
+        # empty is size 0, so it only routes grad to op2 (not into the sum).
+        loss = torch.sum(torch.cat([z, empty]))
+
+    with record_function("## backward ##"):
+        loss.backward()
+
+    assert x.grad is not None and torch.allclose(x.grad, 2 * x.detach())
+
+
+def _split_backward_worker(
+    rank: int, world_size: int, arg: SplitBackwardConfig
+) -> None:
+    # Spawned worker: ensure a stream handler exists so logger output is emitted,
+    # then apply the level from the config.
+    logging.basicConfig()
+    arg.set_log_level()
+    assert (
+        arg.comm_numel % world_size == 0
+    ), f"comm_numel={arg.comm_numel} must be divisible by world_size={world_size}"
+    name = arg.name or "split_backward"
+    with MultiProcessContext(
+        rank=rank, world_size=world_size, backend=arg.backend
+    ) as ctx:
+        result = benchmark_func(
+            bench_inputs=[],
+            prof_inputs=[],
+            benchmark_func_kwargs={
+                "ctx": ctx,
+                "comm_numel": arg.comm_numel,
+            },
+            func_to_benchmark=_split_backward_iter,
+            rank=rank,
+            sample_count=0,
+            **arg.benchmark_func_kwargs(name=name),
+        )
+        if rank == 0:
+            logger.info("%s", result)
+
+
+@register_benchmark(SplitBackwardConfig)
+def split_backward(arg: SplitBackwardConfig) -> None:
+    """
+    Split op1's backward across two autograd Functions.
+
+        y, dummy = op1(x)          # y = x**2; dummy is a grad-carrying token
+        empty    = op2(x, dummy)   # trivial fwd; x-only bwd
+        z        = all2all(y)      # op3: long-running comm (real collective)
+        loss     = sum(cat([z, empty]))   # op4
+
+    op1's x-gradient is ``2*x * grad_y``. The x-only factor ``2*x`` depends on no
+    output grad; the ``grad_y`` combine is cheap. We compute the x-only factor in
+    op2.backward (an elementwise op of about the same cost as op1's own backward)
+    and pass it to op1.backward through ``dummy``'s gradient. op1.backward needs
+    both grad_y (from op3's all2all backward) and grad_dummy (from op2), so it
+    waits on both -- letting op2's x-only compute overlap op3's comm.
+
+    x feeds both op1 and op2, so x.grad accumulates op1's ``2*x`` (via dummy) and
+    op2's direct ``None``, giving the expected ``2*x``.
+
+    Runs multi-process (default nccl, world_size=2) and, with ``profile_dir`` set
+    (default "."), exports a chrome trace per the ``num_profiles`` profiled
+    iterations -- each op is a named ``record_function`` span in the trace.
+    ``comm_numel`` sizes op3's all2all (heavier comms); the trace shows op2's
+    x-only compute against op3's comm backward.
+    """
+    arg.set_log_level()
+    run_multi_process_func(
+        func=_split_backward_worker,
+        world_size=arg.world_size,
+        arg=arg,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
# Splitting a Backward Workload Across Autograd Functions

## TL;DR

- On a high-pooling-factor unified-embedding (UE) table in the OC HIM model, the TBE backward spends 50+ ms on index-sort (a preprocessing step), making that shard a straggler.
- This aligns with an ongoing TBE effort to move preprocessing work off the backward critical path so it can overlap communication.
- The preprocessing is gradient-independent, but there is no obvious way to wire its result back into the autograd graph — a backward only sees its incoming gradients and its saved ctx.
- We wire it in with a two-dummy-tensor design and validate its correctness and the overlap in a local minimal repro.

## Context: trimming the backward critical path

We recently hit this on a large **unified embedding (UE)** table [in production](https://fb.workplace.com/groups/970281557043698/permalink/2288924365179404/). The table's **pooling factor is very large (3000+)**, and the shard holding it ran its **TBE backward ~50 ms longer** than the other ranks/shards — a straggler that stalls the whole synchronous step behind it.

The extra time is **index-sorting**. Before TBE can scatter gradients into the embedding rows, it sorts the (very many) indices so that updates to the same row are grouped together; with a 3000+ pooling factor there are far more indices to sort, so this shard's sort dominates its backward. Crucially, **the index-sort depends only on the input indices, not on the gradient** — it could run the moment the backward pass starts, well before the embedding gradients arrive.

<img width="4036" height="740" alt="image" src="https://github.com/user-attachments/assets/4fe27340-da13-4349-9bfc-b79f9a7de4ea" />

Trace: [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/traces/dynocli/aps-f1109253568-1109330319/2/rank-115.Jul_08_21_04_42.7671.pt.trace.json.gz&bucket=aps_traces)

That is the opportunity behind an ongoing effort to **split the non-critical work out of the TBE kernel and run it while the GPU is otherwise idle waiting on communication** — the backward collectives that already sit on the critical path (output-dist, grad-dist `all_to_all`, `all_reduce`). If the index-sort overlaps those comms instead of running strictly after the gradient returns, the straggler shrinks.

## Challenge: how to inject data into the autograd graph

In eager PyTorch the backward pass is driven entirely by the **autograd engine**: an op's backward is invoked only once its output gradient is ready, and there is no built-in hook to say "start this input-only sub-computation early" or to route its result into another op's backward. Triggering the isolated workload at the right time — and passing its output to the op that consumes it — has to be expressed *through the autograd graph itself*.

Concretely, the unit of custom backward in PyTorch is a `torch.autograd.Function` with two staticmethods, forward and backward. Its backward has a fixed signature, `backward(ctx, *grad_outputs)`: it receives **exactly one gradient per forward output** and must return **exactly one gradient per forward input**.

```python
class MyOp(torch.autograd.Function):
    staticmethod
    def forward(ctx, x, w):
        ctx.save_for_backward(x, w)   # stash the tensors backward will need
        ctx.alpha = 0.5               # non-tensor state lives on ctx too
        return x @ w

    staticmethod
    def backward(ctx, grad_out):      # one grad in, per forward output
        x, w = ctx.saved_tensors      # the only tensors available here
        return grad_out @ w.T, x.T @ grad_out   # one grad out, per forward input
```

And that is all it has to work with: no self, no reference to the owning module, no reaching into live activations. Anything the backward needs must be captured at **forward** time and parked on ctx — tensors through `ctx.save_for_backward(...)`, everything else (shapes, flags, handles) as plain ctx attributes. So the only channels into and out of a backward are its **incoming output gradients** and its **saved ctx** — which is precisely why routing the isolated workload's input *in*, and its result *out*, has to be smuggled through the autograd graph rather than a normal function call or a shared variable.

The standard TBE op is a concrete instance (left below). Its forward saves what the backward will need into ctx, and the whole backward — the index-sort and the weights update it feeds — runs as one call, with the sorted indices flowing internally between the two. Because it is a single backward call, the index-sort is stuck inside it: it cannot begin until the batched emb grads arrive, even though the sort depends only on the indices, not on that gradient.

<img width="3358" height="826" alt="image" src="https://github.com/user-attachments/assets/e28654d9-3939-47a8-91e4-74c3f035e386" />

We want the split on the right: the index-sort out of the TBE backward so it can run during the comm. But a backward's only inputs are its incoming gradients and its saved ctx, so there is no obvious way to feed the separately-computed sorted indices back into the TBE backward. That injection problem — *how to get data into the autograd graph* — is the crux.

A natural first attempt is to preallocate a buffer in ctx during the forward pass and let the helper (the index-sort) fill it in HBM, so the TBE backward can read the sorted indices straight from ctx. But this is memory-hungry: the buffer must be reserved at forward time and kept alive for the entire forward–backward cycle, even though it is consumed only at the very end of backward — so it inflates peak memory. What we want instead is for the sorted indices to materialize *only* when backward runs, with no persistent buffer held across the step.

## Approach: dummy tensors to wire the autograd graph

The design threads the split-out workload into the graph with **two dummy tensors** — no persistent buffer, no shared globals. Both are near-free in the forward; each exists purely to create the backward edge we need.

<img width="2650" height="756" alt="image" src="https://github.com/user-attachments/assets/d65919aa-6179-4df2-a33f-715fb166d006" />

**1. A dummy from the TBE output — the data channel *in*.** The TBE forward emits an extra output, a dummy token, alongside its embeddings. Its value is never read; its only job is to be consumed by the sibling op, which records a backward edge from the sibling into the TBE backward. The sibling's backward returns the **sorted indices as the gradient of that dummy**, so the autograd engine delivers them into the TBE backward through the gradient channel — a tensor that is allocated only during backward, never held across the forward.

**2. An empty output to the target — the trigger.** The sibling op (the pulled-out index-sort) produces a size-0 `empty` tensor that is stacked onto the model output (the embeddings). This keeps the sibling reachable from the loss, so the engine actually schedules its backward; without it, the sibling would be pruned and its backward never run.

**Walking the autograd graph:**

- **Forward.** TBE fwd produces the batched embeddings (which flow through output-dist) and the dummy token. The sibling fwd consumes the dummy plus the indices and emits an empty tensor, which is stacked onto the embeddings so it reaches the loss.
- **Backward.** Both the embedding-gradient all2all (grad-dist) and the sibling's index-sort depend only on gradients that are ready the instant backward starts, and they have no edge between them — they are independent siblings, so the engine is free to run them at the same time. The sibling computes the sorted indices and returns them as the dummy's gradient. The TBE backward — now without its own sort — receives the sorted indices through the dummy edge and the embedding gradients through its normal input, and does only the scatter/weight update. It is the join point: it waits on **both** the sorted indices (from the sibling) and the emb grads (from the comm). Put the index-sort on a side stream (or the comm on its own) and it overlaps the grad-dist all2all instead of running behind it.

**The dummy token: zero-storage, not `meta`.** The dummy must match the shape of the gradient it carries (the sorted indices), but its forward value is never used, so allocating a full-size buffer would waste HBM. The instinct is to put it on the `meta` device (shape and dtype, no storage), but that fails: autograd's `validate_outputs` requires a gradient's device to match its tensor's device, so a `meta` output rejects the sibling's real cuda gradient. The working alternative keeps a near-zero footprint while staying a genuine cuda tensor — one real element `expand`ed to the full logical shape:

```python
dummy = indices.new_empty(1).expand(indices.shape)   # storage = 1 element; logical shape = indices.shape
```

Forward allocates one element; the backward gradient is a full cuda tensor of the right shape, so device/shape validation passes and the grad-carrying mechanism is untouched.

**When it pays off.** The pattern earns its keep when the split-out part is *expensive* and depends only on the input: a large index-sort, a per-row Jacobian, a normalization statistic — anything that (a) is a pure function of the forward input and (b) would otherwise be computed inside a backward blocked on a collective. The heavier that part and the longer the comm, the larger the latency it can hide.

## Benchmark

The `split_backward` benchmark in `benchmark_chained_autograd.py` ([D112387981](https://www.internalfb.com/diff/D112387981)) exercises the design on a minimal graph that mirrors the TBE case:

```python
y, dummy = op1(x)                         # bwd-trimmed TBE (emits output + dummy)
empty    = op2(dummy)                     # bwd-only sibling (no-op fwd, index-sort bwd)
z        = op3(y)                         # output dist / all_to_all
loss     = op4(torch.stack([empty, z]))   # fold the sibling's output into the loss
```

op1 emits its output plus the dummy; op2 consumes the dummy and does the x-only "heavy" work in its backward; op3 is the all2all; op4 folds op2's empty output into the loss so the sibling stays in the graph. These op labels are the ones used in the trace below.

```bash
python -m torchrec.distributed.benchmark.benchmark_chained_autograd split_backward
```

**Results.** The backward runs in the order the graph dictates:

1. **op4.backward** runs first, producing the gradients for its two branches: the one that flows to op3 through `z`, and a size-0 grad for `empty` that exists only to trigger op2.backward.
2. **op3.backward** (the all2all/comms) and **op2.backward** (index-sort workload) both become runnable at the same time: each depends only on op4's gradient, and there is no edge between them, so they are independent siblings.
3. The all2all is issued on its own NCCL stream, so op2's compute and op3's comm run **concurrently** — the *op2–op3 overlap* in the trace — rather than one after the other.
4. **op1.backward** is the join: it needs both the gradient from op3 (via `y`) and the sorted indices from op2 (via the dummy), so it runs only after both branches finish, then does the combine.

This is the ordering the split design is after: op2's sibling work runs alongside the comm instead of after it, and the split gradient matches the unsplit reference.

<img width="1897" height="540" alt="image" src="https://github.com/user-attachments/assets/d6f1d103-61e7-4dff-86a9-e89099760d4e" />

Trace: [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D112387981) · [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D112387981/trace-split_backward-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D112387981/trace-split_backward-rank0.json.gz&bucket=torchrec_benchmark_traces)


## Next steps

1. **Prototype**
    - Split and refactor the TBE operator
    - TorchRec integration
    - Local pipeline benchmark
2. **Production validation**
    - OC HIM model test run
    - CMF and other head models
3. **Production adoption**
    - Integrate into the major trainer frameworks (APS, MVAI, etc.)
    - Roll out

## References

- [FBGEMM TBE design doc](https://docs.google.com/document/d/1Z8_1zI_4WSF-gsaHKVLY3wUNPyAZSYRJLDSbDZfRE2o/edit?tab=t.0#heading=h.v9g64rvwoghl)
- [Chained Autograd for Preallocated Output Tensors](chained_autograd_preallocated_output.md) — [D112267857](https://www.internalfb.com/diff/D112267857)
- Benchmark demo: [D112387981](https://www.internalfb.com/diff/D112387981)

Reviewed By: aporialiao

Differential Revision: D112387981


