### PR TITLE
Add `async_inplace_copy`: offload in-place H2D copy dispatch to a background thread (#4441)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_cpu_bound.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_cpu_bound.yml
@@ -1,0 +1,50 @@
+# CPU-bound variant of sparse_data_dist_base.
+#
+# Purpose: reproduce the low-world-size / comms-light regime (e.g. the customer's
+# 64-trainer job) where the H2D copy DISPATCH is EXPOSED on the compute stream,
+# so async_inplace_copy has real idle to recover. Achieved with:
+#   - many input tensors (num_dummy_tensor: 2000) -> long per-batch CPU copy loop
+#   - small batch + tiny dense/over arch          -> little compute to hide behind
+#   - few small tables, world_size 2, table_wise  -> light comms to hide behind
+#
+# Compare sync vs async (inplace on for both):
+#   ... --yaml_config=.../sparse_cpu_bound.yml --name=cpu_bound_sync
+#   ... --yaml_config=.../sparse_cpu_bound.yml --async_inplace_copy=True --name=cpu_bound_async
+# then run analyze_exposed_copy_idle.py on each trace and compare EXPOSED idle.
+RunOptions:
+  world_size: 2
+  batch_size: 4096
+  num_batches: 20
+  num_benchmarks: 5
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_cpu_bound"
+  memory_snapshot: False
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+  enable_inplace_copy_batch: true
+  kwargs:
+    site_fqn: "sparse.weighted_ebc"
+    sharding_type: "table_wise"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 20
+  num_dummy_tensor: 2000
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"
+  model_config:
+    num_float_features: 100
+    submodule_kwargs:
+      dense_arch_out_size: 16
+      over_arch_out_size: 64
+      over_arch_hidden_layers: 1
+      dense_arch_hidden_sizes: [16]
+      skip_regroup: true
+EmbeddingTablesConfig:
+  num_unweighted_features: 20
+  num_weighted_features: 10
+  embedding_feature_dim: 64
+PlannerConfig:
+  pooling_factors: [20.0]  # Must match ModelInputConfig.feature_pooling_avg

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -60,6 +60,10 @@ class PipelineConfig:
 
     pipeline: str = "base"
     enable_inplace_copy_batch: bool = False
+    # Offload the in-place H2D copy dispatch to a background thread (base flag on
+    # TrainPipelineSparseDist). Only takes effect together with
+    # enable_inplace_copy_batch=True. Applies to the "sparse" pipeline.
+    async_inplace_copy: bool = False
     free_features_storage_early: bool = False
     clear_data_dist_inputs: bool = False
     pipeline_postproc: bool = False
@@ -183,6 +187,17 @@ class PipelineConfig:
                     clear_data_dist_inputs=self.clear_data_dist_inputs,
                     enable_embedding_lookup_prefetch=self.enable_embedding_lookup_prefetch,
                     **self.get_kwargs(emb_lookup_stream=self.emb_lookup_stream),
+                )
+            case "sparse":
+                return TrainPipelineSparseDist(
+                    model=model,
+                    optimizer=opt,
+                    device=device,
+                    enable_inplace_copy_batch=self.enable_inplace_copy_batch,
+                    async_inplace_copy=self.async_inplace_copy,
+                    free_features_storage_early=self.free_features_storage_early,
+                    clear_data_dist_inputs=self.clear_data_dist_inputs,
+                    **self.get_kwargs(),
                 )
             case _:
                 Pipeline = _pipeline_cls[self.pipeline]

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -61,6 +61,10 @@ class PipelineConfig:
 
     pipeline: str = "base"
     enable_inplace_copy_batch: bool = False
+    # Offload the in-place H2D copy dispatch to a background thread (base flag on
+    # TrainPipelineSparseDist). Only takes effect together with
+    # enable_inplace_copy_batch=True. Applies to the "sparse" pipeline.
+    async_inplace_copy: bool = False
     free_features_storage_early: bool = False
     clear_data_dist_inputs: bool = False
     pipeline_postproc: bool = False
@@ -193,6 +197,17 @@ class PipelineConfig:
                     model=model,
                     optimizer=opt,
                     device=device,
+                    **self.get_kwargs(),
+                )
+            case "sparse":
+                return TrainPipelineSparseDist(
+                    model=model,
+                    optimizer=opt,
+                    device=device,
+                    enable_inplace_copy_batch=self.enable_inplace_copy_batch,
+                    async_inplace_copy=self.async_inplace_copy,
+                    free_features_storage_early=self.free_features_storage_early,
+                    clear_data_dist_inputs=self.clear_data_dist_inputs,
                     **self.get_kwargs(),
                 )
             case _:

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -557,6 +557,135 @@ class TrainPipelineSparseDistTest(TrainPipelineSparseDistTestBase):
         not torch.cuda.is_available(),
         "Not enough GPUs, this test requires at least one GPU",
     )
+    @settings(max_examples=4, deadline=None)
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+            ]
+        ),
+        kernel_type=st.sampled_from(
+            [
+                EmbeddingComputeKernel.FUSED.value,
+            ]
+        ),
+        execute_all_batches=st.booleans(),
+    )
+    def test_async_inplace_copy_equal_to_non_pipelined(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        execute_all_batches: bool,
+    ) -> None:
+        """
+        Numerics-parity gate for the background-thread in-place copy
+        (``async_inplace_copy``): offloading the H2D copy dispatch to a worker
+        thread must produce results identical to non-pipelined training. This
+        exercises the cross-thread stream/allocation path that carries the
+        silent-corruption risk.
+        """
+        data = self._generate_data(
+            num_batches=12,
+            batch_size=32,
+        )
+        dataloader = iter(data)
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, {}
+        )
+        (
+            sharded_model_pipelined,
+            optim_pipelined,
+        ) = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, {}
+        )
+        copy_state_dict(
+            sharded_model.state_dict(), sharded_model_pipelined.state_dict()
+        )
+
+        pipeline = self.pipeline_class(
+            model=sharded_model_pipelined,
+            optimizer=optim_pipelined,
+            device=self.device,
+            execute_all_batches=execute_all_batches,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=True,
+        )
+        # The async path must be active and must swap in the Future-aware queue.
+        self.assertTrue(pipeline._async_inplace_copy)
+        self.assertIsNotNone(pipeline._inplace_copy_executor)
+        self.assertEqual(type(pipeline.batches).__name__, "FutureDeque")
+
+        if not execute_all_batches:
+            data = data[:-2]
+
+        for batch in data:
+            # Forward + backward w/o pipelining
+            batch = batch.to(self.device)
+            optim.zero_grad()
+            loss, pred = sharded_model(batch)
+            loss.backward()
+            optim.step()
+
+            # Forward + backward w/ async in-place-copy pipelining
+            pred_pipeline = pipeline.progress(dataloader)
+            torch.testing.assert_close(pred, pred_pipeline)
+
+        self.assertRaises(StopIteration, pipeline.progress, dataloader)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_async_inplace_copy_setup_and_lifecycle(self) -> None:
+        """async_inplace_copy: flag-off is a no-op (plain deque, no worker);
+        flag-on swaps in a FutureDeque + a worker that shuts down cleanly and
+        idempotently."""
+        from torchrec.distributed.train_pipeline.utils import FutureDeque
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model,
+            ShardingType.TABLE_WISE.value,
+            EmbeddingComputeKernel.FUSED.value,
+            {},
+        )
+
+        # Flag off (even with inplace copy on): plain deque, no executor.
+        pipeline_off = self.pipeline_class(
+            model=sharded_model,
+            optimizer=optim,
+            device=self.device,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=False,
+        )
+        self.assertFalse(pipeline_off._async_inplace_copy)
+        self.assertIsNone(pipeline_off._inplace_copy_executor)
+        self.assertNotIsInstance(pipeline_off.batches, FutureDeque)
+
+        # Flag on: FutureDeque + background worker.
+        pipeline_on = self.pipeline_class(
+            model=sharded_model,
+            optimizer=optim,
+            device=self.device,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=True,
+        )
+        self.assertTrue(pipeline_on._async_inplace_copy)
+        self.assertIsNotNone(pipeline_on._inplace_copy_executor)
+        self.assertIsInstance(pipeline_on.batches, FutureDeque)
+
+        # Explicit shutdown clears the executor and is idempotent (no hang/raise).
+        pipeline_on._shutdown_async_inplace_copy()
+        self.assertIsNone(pipeline_on._inplace_copy_executor)
+        pipeline_on._shutdown_async_inplace_copy()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
     @given(execute_all_batches=st.booleans())
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_pipelining_fsdp_pre_trace(self, execute_all_batches: bool) -> None:
@@ -2506,3 +2635,20 @@ class TrainPipelineSparseDistCompAutogradTest(TrainPipelineSparseDistTest):
         execute_all_batches: bool,
     ) -> None:
         super().test_equal_to_non_pipelined()
+
+    @unittest.skip(
+        "async_inplace_copy is a base TrainPipelineSparseDist feature; the compiled-autograd variant uses a different pipeline class and hits the same hypothesis multi-executor HealthCheck as test_equal_to_non_pipelined. Threading x compiled autograd is validated separately."
+    )
+    def test_async_inplace_copy_equal_to_non_pipelined(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        execute_all_batches: bool,
+    ) -> None:
+        super().test_async_inplace_copy_equal_to_non_pipelined()
+
+    @unittest.skip(
+        "Construction-only test; the compiled-autograd variant's tearDown asserts compiled-autograd captures that this test does not trigger. async_inplace_copy is a base TrainPipelineSparseDist feature validated in the eager variant."
+    )
+    def test_async_inplace_copy_setup_and_lifecycle(self) -> None:
+        super().test_async_inplace_copy_setup_and_lifecycle()

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -556,6 +556,135 @@ class TrainPipelineSparseDistTest(TrainPipelineSparseDistTestBase):
         not torch.cuda.is_available(),
         "Not enough GPUs, this test requires at least one GPU",
     )
+    @settings(max_examples=4, deadline=None)
+    @given(
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.COLUMN_WISE.value,
+            ]
+        ),
+        kernel_type=st.sampled_from(
+            [
+                EmbeddingComputeKernel.FUSED.value,
+            ]
+        ),
+        execute_all_batches=st.booleans(),
+    )
+    def test_async_inplace_copy_equal_to_non_pipelined(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        execute_all_batches: bool,
+    ) -> None:
+        """
+        Numerics-parity gate for the background-thread in-place copy
+        (``async_inplace_copy``): offloading the H2D copy dispatch to a worker
+        thread must produce results identical to non-pipelined training. This
+        exercises the cross-thread stream/allocation path that carries the
+        silent-corruption risk.
+        """
+        data = self._generate_data(
+            num_batches=12,
+            batch_size=32,
+        )
+        dataloader = iter(data)
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, {}
+        )
+        (
+            sharded_model_pipelined,
+            optim_pipelined,
+        ) = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, {}
+        )
+        copy_state_dict(
+            sharded_model.state_dict(), sharded_model_pipelined.state_dict()
+        )
+
+        pipeline = self.pipeline_class(
+            model=sharded_model_pipelined,
+            optimizer=optim_pipelined,
+            device=self.device,
+            execute_all_batches=execute_all_batches,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=True,
+        )
+        # The async path must be active and must swap in the Future-aware queue.
+        self.assertTrue(pipeline._async_inplace_copy)
+        self.assertIsNotNone(pipeline._inplace_copy_executor)
+        self.assertEqual(type(pipeline.batches).__name__, "FutureDeque")
+
+        if not execute_all_batches:
+            data = data[:-2]
+
+        for batch in data:
+            # Forward + backward w/o pipelining
+            batch = batch.to(self.device)
+            optim.zero_grad()
+            loss, pred = sharded_model(batch)
+            loss.backward()
+            optim.step()
+
+            # Forward + backward w/ async in-place-copy pipelining
+            pred_pipeline = pipeline.progress(dataloader)
+            torch.testing.assert_close(pred, pred_pipeline)
+
+        self.assertRaises(StopIteration, pipeline.progress, dataloader)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_async_inplace_copy_setup_and_lifecycle(self) -> None:
+        """async_inplace_copy: flag-off is a no-op (plain deque, no worker);
+        flag-on swaps in a FutureDeque + a worker that shuts down cleanly and
+        idempotently."""
+        from torchrec.distributed.train_pipeline.utils import FutureDeque
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model,
+            ShardingType.TABLE_WISE.value,
+            EmbeddingComputeKernel.FUSED.value,
+            {},
+        )
+
+        # Flag off (even with inplace copy on): plain deque, no executor.
+        pipeline_off = self.pipeline_class(
+            model=sharded_model,
+            optimizer=optim,
+            device=self.device,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=False,
+        )
+        self.assertFalse(pipeline_off._async_inplace_copy)
+        self.assertIsNone(pipeline_off._inplace_copy_executor)
+        self.assertNotIsInstance(pipeline_off.batches, FutureDeque)
+
+        # Flag on: FutureDeque + background worker.
+        pipeline_on = self.pipeline_class(
+            model=sharded_model,
+            optimizer=optim,
+            device=self.device,
+            enable_inplace_copy_batch=True,
+            async_inplace_copy=True,
+        )
+        self.assertTrue(pipeline_on._async_inplace_copy)
+        self.assertIsNotNone(pipeline_on._inplace_copy_executor)
+        self.assertIsInstance(pipeline_on.batches, FutureDeque)
+
+        # Explicit shutdown clears the executor and is idempotent (no hang/raise).
+        pipeline_on._shutdown_async_inplace_copy()
+        self.assertIsNone(pipeline_on._inplace_copy_executor)
+        pipeline_on._shutdown_async_inplace_copy()
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
     @given(execute_all_batches=st.booleans())
     @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
     def test_pipelining_fsdp_pre_trace(self, execute_all_batches: bool) -> None:
@@ -2427,3 +2556,20 @@ class TrainPipelineSparseDistCompAutogradTest(TrainPipelineSparseDistTest):
         execute_all_batches: bool,
     ) -> None:
         super().test_equal_to_non_pipelined()
+
+    @unittest.skip(
+        "async_inplace_copy is a base TrainPipelineSparseDist feature; the compiled-autograd variant uses a different pipeline class and hits the same hypothesis multi-executor HealthCheck as test_equal_to_non_pipelined. Threading x compiled autograd is validated separately."
+    )
+    def test_async_inplace_copy_equal_to_non_pipelined(
+        self,
+        sharding_type: str,
+        kernel_type: str,
+        execute_all_batches: bool,
+    ) -> None:
+        super().test_async_inplace_copy_equal_to_non_pipelined()
+
+    @unittest.skip(
+        "Construction-only test; the compiled-autograd variant's tearDown asserts compiled-autograd captures that this test does not trigger. async_inplace_copy is a base TrainPipelineSparseDist feature validated in the eager variant."
+    )
+    def test_async_inplace_copy_setup_and_lifecycle(self) -> None:
+        super().test_async_inplace_copy_setup_and_lifecycle()

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -123,6 +123,7 @@ from torchrec.distributed.train_pipeline.utils import (
     _to_device,
     _wait_for_batch,
     _wait_for_events,
+    AsyncInplaceCopyMixin,
     DataLoadingThread,
     prefetch_embeddings,
     use_context_for_postprocs,
@@ -527,7 +528,7 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
         return output
 
 
-class TrainPipelineSparseDist(TrainPipeline[In, Out]):
+class TrainPipelineSparseDist(TrainPipeline[In, Out], AsyncInplaceCopyMixin[In]):
     """
     This pipeline overlaps device transfer, and `ShardedModule.input_dist()` with
     forward and backward. This helps hide the all2all latency while preserving the
@@ -583,6 +584,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
+        async_inplace_copy: bool = False,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -600,6 +602,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "
             f"execute_all_batches: {self._execute_all_batches} "
             f"enable_inplace_copy_batch: {enable_inplace_copy_batch} "
+            f"async_inplace_copy: {async_inplace_copy} "
             f"free_features_storage_early: {free_features_storage_early}"
         )
 
@@ -646,6 +649,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._dataloader_exhausted: bool = False
         self._context_type: Type[TrainPipelineContext] = context_type
 
+        # Opt-in: offload the in-place H2D copy dispatch to a background thread.
+        # Must run after self.batches / self._memcpy_stream / self._device are set.
+        self._setup_async_inplace_copy(async_inplace_copy, device)
+
         self._model_fwd: Callable[[Optional[In]], Tuple[torch.Tensor, Out]] = (
             custom_model_fwd if custom_model_fwd else model
         )
@@ -682,6 +689,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 f"{self.__class__.__name__}: [Sparse 2D] DMP collection will sync every "
                 f"{self._dmp_collection_sync_interval_batches} batches"
             )
+
+    def __del__(self) -> None:
+        # Best-effort shutdown of the async in-place copy worker (no-op if unused).
+        self._shutdown_async_inplace_copy()
 
     def detach(self) -> torch.nn.Module:
         """
@@ -1085,6 +1096,18 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                     size = _batch_tensor_size(batch)
 
                     log_inplace_copy_batch(size)
+                if self._async_inplace_copy:
+                    # Offload the copy dispatch to the background worker; the Future
+                    # placeholder is resolved lazily (FutureDeque) at consumption.
+                    return (
+                        cast(
+                            In,
+                            self._submit_inplace_copy(
+                                batch, self._device, self._memcpy_stream
+                            ),
+                        ),
+                        context,
+                    )
                 batch = _to_device(
                     batch,
                     self._device,
@@ -2069,6 +2092,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
+        async_inplace_copy: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -2082,6 +2106,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
             clear_data_dist_inputs=clear_data_dist_inputs,
+            async_inplace_copy=async_inplace_copy,
         )
         self._prefetch_stream: Optional[torch.Stream] = (
             (torch.get_device_module(device).Stream())

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -123,6 +123,7 @@ from torchrec.distributed.train_pipeline.utils import (
     _to_device,
     _wait_for_batch,
     _wait_for_events,
+    AsyncInplaceCopyMixin,
     DataLoadingThread,
     prefetch_embeddings,
     use_context_for_postprocs,
@@ -527,7 +528,7 @@ class TrainPipelinePT2(TrainPipelineBase[In, Out]):
         return output
 
 
-class TrainPipelineSparseDist(TrainPipeline[In, Out]):
+class TrainPipelineSparseDist(TrainPipeline[In, Out], AsyncInplaceCopyMixin[In]):
     """
     This pipeline overlaps device transfer, and `ShardedModule.input_dist()` with
     forward and backward. This helps hide the all2all latency while preserving the
@@ -583,6 +584,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
+        async_inplace_copy: bool = False,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -600,6 +602,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "
             f"execute_all_batches: {self._execute_all_batches} "
             f"enable_inplace_copy_batch: {enable_inplace_copy_batch} "
+            f"async_inplace_copy: {async_inplace_copy} "
             f"free_features_storage_early: {free_features_storage_early}"
         )
 
@@ -646,6 +649,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._dataloader_exhausted: bool = False
         self._context_type: Type[TrainPipelineContext] = context_type
 
+        # Opt-in: offload the in-place H2D copy dispatch to a background thread.
+        # Must run after self.batches / self._memcpy_stream / self._device are set.
+        self._setup_async_inplace_copy(async_inplace_copy, device)
+
         self._model_fwd: Callable[[Optional[In]], Tuple[torch.Tensor, Out]] = (
             custom_model_fwd if custom_model_fwd else model
         )
@@ -682,6 +689,10 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 f"{self.__class__.__name__}: [Sparse 2D] DMP collection will sync every "
                 f"{self._dmp_collection_sync_interval_batches} batches"
             )
+
+    def __del__(self) -> None:
+        # Best-effort shutdown of the async in-place copy worker (no-op if unused).
+        self._shutdown_async_inplace_copy()
 
     def detach(self) -> torch.nn.Module:
         """
@@ -1085,6 +1096,18 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                     size = _batch_tensor_size(batch)
 
                     log_inplace_copy_batch(size)
+                if self._async_inplace_copy:
+                    # Offload the copy dispatch to the background worker; the Future
+                    # placeholder is resolved lazily (FutureDeque) at consumption.
+                    return (
+                        cast(
+                            In,
+                            self._submit_inplace_copy(
+                                batch, self._device, self._memcpy_stream
+                            ),
+                        ),
+                        context,
+                    )
                 batch = _to_device(
                     batch,
                     self._device,
@@ -2071,6 +2094,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
+        async_inplace_copy: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -2084,6 +2108,7 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
             enable_inplace_copy_batch=enable_inplace_copy_batch,
             free_features_storage_early=free_features_storage_early,
             clear_data_dist_inputs=clear_data_dist_inputs,
+            async_inplace_copy=async_inplace_copy,
         )
         self._prefetch_stream: Optional[torch.Stream] = (
             (torch.get_device_module(device).Stream())

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -11,13 +11,14 @@ import copy
 import dataclasses
 import logging
 from collections import defaultdict, deque
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import AbstractContextManager
 from threading import Event, Thread
 from typing import (
     Any,
     Callable,
     cast,
+    Deque,
     Dict,
     Generator,
     Generic,
@@ -916,3 +917,97 @@ class FutureDeque(deque):
         if isinstance(item, Future):
             return item.result()
         return item
+
+
+def _init_inplace_copy_worker(device: torch.device) -> None:
+    """ThreadPoolExecutor initializer: bind the single copy worker to the training
+    device so its stream/allocation calls resolve to the correct device (mirrors
+    ``DataLoadingThread.run``)."""
+    device_module = torch.get_device_module(device)
+    if device.type == "cuda" and torch.cuda.is_available():
+        device_module.set_device(device)
+    elif device.type == "mtia" and torch.mtia.is_available():
+        device_module.set_device(device)
+
+
+class AsyncInplaceCopyMixin(Generic[In]):
+    """
+    Opt-in, shared primitive that offloads the in-place H2D batch-copy *dispatch* to a
+    single background thread, so the main thread stays free to dispatch GPU kernels.
+    The batch is returned as a ``Future`` placeholder and resolved lazily (via
+    ``FutureDeque``) at consumption time.
+
+    Gated by ``async_inplace_copy`` (default off). When off, ``_setup_async_inplace_copy``
+    is a no-op and the host pipeline behaves byte-for-byte as before.
+
+    Correctness: in-place copy allocates the destination on the *caller's current
+    stream* (so no ``record_stream`` is needed). A worker thread has its own current
+    stream, so we capture the main thread's current stream at submit time and re-enter
+    it inside the worker — reproducing the synchronous semantics exactly, independent of
+    per-thread-default-stream builds.
+
+    Host must set ``self._device`` / ``self._memcpy_stream`` before calling
+    ``_setup_async_inplace_copy`` and expose ``self.batches``.
+    """
+
+    # Declared so the mixin may swap the host's batch queue for a Future-aware one.
+    batches: Deque[Optional[In]]
+    _async_inplace_copy: bool = False
+    _inplace_copy_executor: Optional[ThreadPoolExecutor] = None
+
+    def _setup_async_inplace_copy(self, enabled: bool, device: torch.device) -> None:
+        requested = enabled
+        if enabled and device.type not in ("cuda", "mtia"):
+            logger.warning(
+                "async_inplace_copy requested on non-accelerator device %s; disabling.",
+                device.type,
+            )
+            enabled = False
+        self._async_inplace_copy = enabled
+        self._inplace_copy_executor = None
+        if not enabled:
+            # Logged unconditionally (both branches) so a trace/log search can
+            # confirm what value actually reached the pipeline, not just the on-case.
+            one_time_rank0_logger.info(
+                "async_inplace_copy: DISABLED (requested=%s, device=%s)",
+                requested,
+                device.type,
+            )
+            return
+        self._inplace_copy_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="inplace_copy",
+            initializer=_init_inplace_copy_worker,
+            initargs=(device,),
+        )
+        # Batch queue must resolve Futures lazily at consumption.
+        self.batches = FutureDeque()
+        one_time_rank0_logger.info(
+            "async_inplace_copy: ENABLED (background H2D copy, device=%s)", device.type
+        )
+
+    def _submit_inplace_copy(
+        self,
+        batch: In,
+        device: torch.device,
+        memcpy_stream: Optional[torch.Stream],
+    ) -> "Future[In]":
+        # Capture the consumer's current stream on the MAIN thread; the worker
+        # re-enters it so the destination is allocated on the consumer stream.
+        alloc_stream = torch.get_device_module(device).current_stream(device)
+
+        def _work() -> In:
+            device_module = torch.get_device_module(device)
+            with device_module.stream(alloc_stream):
+                return _to_device(
+                    batch, device, non_blocking=True, data_copy_stream=memcpy_stream
+                )
+
+        assert self._inplace_copy_executor is not None
+        return self._inplace_copy_executor.submit(_work)
+
+    def _shutdown_async_inplace_copy(self) -> None:
+        executor = self._inplace_copy_executor
+        if executor is not None:
+            executor.shutdown(wait=False)
+            self._inplace_copy_executor = None

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -11,13 +11,14 @@ import copy
 import dataclasses
 import logging
 from collections import defaultdict, deque
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import AbstractContextManager
 from threading import Event, Thread
 from typing import (
     Any,
     Callable,
     cast,
+    Deque,
     Dict,
     Generator,
     Generic,
@@ -998,3 +999,97 @@ class FutureDeque(deque):
         if isinstance(item, Future):
             return item.result()
         return item
+
+
+def _init_inplace_copy_worker(device: torch.device) -> None:
+    """ThreadPoolExecutor initializer: bind the single copy worker to the training
+    device so its stream/allocation calls resolve to the correct device (mirrors
+    ``DataLoadingThread.run``)."""
+    device_module = torch.get_device_module(device)
+    if device.type == "cuda" and torch.cuda.is_available():
+        device_module.set_device(device)
+    elif device.type == "mtia" and torch.mtia.is_available():
+        device_module.set_device(device)
+
+
+class AsyncInplaceCopyMixin(Generic[In]):
+    """
+    Opt-in, shared primitive that offloads the in-place H2D batch-copy *dispatch* to a
+    single background thread, so the main thread stays free to dispatch GPU kernels.
+    The batch is returned as a ``Future`` placeholder and resolved lazily (via
+    ``FutureDeque``) at consumption time.
+
+    Gated by ``async_inplace_copy`` (default off). When off, ``_setup_async_inplace_copy``
+    is a no-op and the host pipeline behaves byte-for-byte as before.
+
+    Correctness: in-place copy allocates the destination on the *caller's current
+    stream* (so no ``record_stream`` is needed). A worker thread has its own current
+    stream, so we capture the main thread's current stream at submit time and re-enter
+    it inside the worker — reproducing the synchronous semantics exactly, independent of
+    per-thread-default-stream builds.
+
+    Host must set ``self._device`` / ``self._memcpy_stream`` before calling
+    ``_setup_async_inplace_copy`` and expose ``self.batches``.
+    """
+
+    # Declared so the mixin may swap the host's batch queue for a Future-aware one.
+    batches: Deque[Optional[In]]
+    _async_inplace_copy: bool = False
+    _inplace_copy_executor: Optional[ThreadPoolExecutor] = None
+
+    def _setup_async_inplace_copy(self, enabled: bool, device: torch.device) -> None:
+        requested = enabled
+        if enabled and device.type not in ("cuda", "mtia"):
+            logger.warning(
+                "async_inplace_copy requested on non-accelerator device %s; disabling.",
+                device.type,
+            )
+            enabled = False
+        self._async_inplace_copy = enabled
+        self._inplace_copy_executor = None
+        if not enabled:
+            # Logged unconditionally (both branches) so a trace/log search can
+            # confirm what value actually reached the pipeline, not just the on-case.
+            one_time_rank0_logger.info(
+                "async_inplace_copy: DISABLED (requested=%s, device=%s)",
+                requested,
+                device.type,
+            )
+            return
+        self._inplace_copy_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="inplace_copy",
+            initializer=_init_inplace_copy_worker,
+            initargs=(device,),
+        )
+        # Batch queue must resolve Futures lazily at consumption.
+        self.batches = FutureDeque()
+        one_time_rank0_logger.info(
+            "async_inplace_copy: ENABLED (background H2D copy, device=%s)", device.type
+        )
+
+    def _submit_inplace_copy(
+        self,
+        batch: In,
+        device: torch.device,
+        memcpy_stream: Optional[torch.Stream],
+    ) -> "Future[In]":
+        # Capture the consumer's current stream on the MAIN thread; the worker
+        # re-enters it so the destination is allocated on the consumer stream.
+        alloc_stream = torch.get_device_module(device).current_stream(device)
+
+        def _work() -> In:
+            device_module = torch.get_device_module(device)
+            with device_module.stream(alloc_stream):
+                return _to_device(
+                    batch, device, non_blocking=True, data_copy_stream=memcpy_stream
+                )
+
+        assert self._inplace_copy_executor is not None
+        return self._inplace_copy_executor.submit(_work)
+
+    def _shutdown_async_inplace_copy(self) -> None:
+        executor = self._inplace_copy_executor
+        if executor is not None:
+            executor.shutdown(wait=False)
+            self._inplace_copy_executor = None


### PR DESCRIPTION
Summary:

In-place batch copy (`enable_inplace_copy_batch`) runs the H2D copy dispatch for the input batch (500+ tensors, ~50ms) synchronously on the main thread. Whether that stall costs throughput is config-dependent: at high trainer counts the copy is hidden behind communication, but at low trainer counts (or comms-light jobs) communication shrinks and the copy is exposed on the compute stream — measured ~35ms/step exposed host-wait idle on a customer's 64-trainer job vs ~0ms on the 112-trainer baseline of the same model.

This adds an opt-in `async_inplace_copy` flag (default `False`) on `TrainPipelineSparseDist`, backed by a new shared `AsyncInplaceCopyMixin` in `utils.py`. When enabled, `inplace_copy_batch_to_gpu` submits the copy to a single-worker `ThreadPoolExecutor` and returns a `Future`; `self.batches` is swapped for a gated `FutureDeque` that resolves the `Future` lazily at consumption. The main thread is freed to keep dispatching GPU kernels instead of blocking on the copy loop.

Correctness: in-place copy allocates the destination on the caller's current stream (so no `record_stream` is needed). Because a worker thread has its own current stream, we capture the main thread's current stream at submit time and re-enter it inside the worker, reproducing the synchronous semantics exactly and independent of per-thread-default-stream builds. The worker also binds to the training device via an executor initializer.

Flag-off is a no-op by construction: when `async_inplace_copy=False` none of the new code path runs and `self.batches` stays a plain `deque`, so existing behavior (incl. the ~7,900 in-place-copy jobs) is preserved without relying on testing. The flag is inherited by subclasses (e.g. APS's `TrainPipelineCustomizedOrderSparseDist`), so enabling it there is a one-flag change with no new class.

Also wires `async_inplace_copy` into `PipelineConfig` for benchmarking, and adds two validation artifacts: a stdlib-only `analyze_exposed_copy_idle.py` (quantifies exposed host-wait idle in the copy window from any Kineto trace) and a `sparse_cpu_bound.yml` benchmark config for the exposed-idle regime.

This is Phase 1 (additive, opt-in). Consolidation of the experimental `TrainPipelineSparseDistT` onto this primitive is a follow-up; `enable_multithreaded_pipeline` and `DataLoadingThread` are left as-is.

Reviewed By: TroyGarden

Differential Revision: D112193190


