### PR TITLE
Fix int32 overflow in variable-batch KJT all-to-all _get_recat

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -140,6 +140,21 @@ _DTYPE_MAX: Dict[torch.dtype, int] = {
 
 _TORCHREC_OVERFLOW_DEBUG: bool = os.environ.get("TORCHREC_OVERFLOW_DEBUG", "0") == "1"
 
+# Opt-in, job-wide widening of the variable-batch KJT all-to-all recat/offset
+# tensors from int32 to int64. Must be set identically on every rank (the dtype
+# is part of the all-to-all collective contract). See _get_recat for why the
+# choice is an explicit flag rather than a data-dependent upcast.
+_TORCHREC_ENABLE_INT64_RECAT: bool = (
+    os.environ.get("TORCHREC_ENABLE_INT64_RECAT", "0") == "1"
+)
+# The recat dtype is fixed for the lifetime of the job by the env var above, so
+# log it once here at import rather than on every KJT all-to-all construction.
+logger.info(
+    "_get_recat: variable-batch recat dtype=%s (TORCHREC_ENABLE_INT64_RECAT=%s)",
+    torch.int64 if _TORCHREC_ENABLE_INT64_RECAT else torch.int32,
+    _TORCHREC_ENABLE_INT64_RECAT,
+)
+
 
 def _collective_tag_from(*parts: object) -> int:
     """Compute a deterministic collective tag from identifying parts.
@@ -312,6 +327,27 @@ def _get_recat(
             output_offset = [0] + list(
                 itertools.accumulate(permuted_batch_size_per_feature)
             )
+            # Default to int32; int64 is an explicit, job-wide opt-in (dtype is
+            # part of the all-to-all contract, so it must not vary with the data).
+            # At large variable-batch scale the offsets can exceed int32 and
+            # overflow the tensors below; log fatal to enable the flag when so.
+            recat_dtype = torch.int64 if _TORCHREC_ENABLE_INT64_RECAT else torch.int32
+            if (
+                recat_dtype == torch.int32
+                and max(input_offset[-1], output_offset[-1])
+                > torch.iinfo(torch.int32).max
+            ):
+                logger.fatal(
+                    "_get_recat: variable-batch offsets exceed the int32 range "
+                    f"(max offset={max(input_offset[-1], output_offset[-1])} > "
+                    f"{torch.iinfo(torch.int32).max}); the int32 recat/offset "
+                    "tensors below will overflow. Set TORCHREC_ENABLE_INT64_RECAT=1 "
+                    "on every rank to widen the KJT all-to-all recat/offset tensors "
+                    "to int64, or reduce the effective batch size. "
+                    f"batch_size_per_rank={batch_size_per_rank}, "
+                    f"local_split={local_split}, num_splits={num_splits}, "
+                    f"stagger={stagger}."
+                )
 
             _check_int_overflow(
                 "_get_recat",
@@ -326,6 +362,7 @@ def _get_recat(
                 "_get_recat",
                 input_offset,
                 "input_offset",
+                target_dtype=recat_dtype,
                 local_split=local_split,
                 num_splits=num_splits,
             )
@@ -333,6 +370,7 @@ def _get_recat(
                 "_get_recat",
                 output_offset,
                 "output_offset",
+                target_dtype=recat_dtype,
                 local_split=local_split,
                 num_splits=num_splits,
             )
@@ -341,21 +379,21 @@ def _get_recat(
                 recat_tensor = torch.tensor(
                     recat,
                     device=device,
-                    dtype=torch.int32,
+                    dtype=recat_dtype,
                 )
                 input_offset_tensor = torch.tensor(
                     input_offset,
                     device=device,
-                    dtype=torch.int32,
+                    dtype=recat_dtype,
                 )
                 output_offset_tensor = torch.tensor(
                     output_offset,
                     device=device,
-                    dtype=torch.int32,
+                    dtype=recat_dtype,
                 )
             except RuntimeError as e:
                 logger.error(
-                    f"_get_recat: int32 tensor creation failed: {e}. "
+                    f"_get_recat: {recat_dtype} tensor creation failed: {e}. "
                     f"batch_size_per_rank={batch_size_per_rank}, "
                     f"input_offset={input_offset}, "
                     f"output_offset={output_offset}, "

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -1525,13 +1525,16 @@ class TestJaggedTensorAllToAll(MultiProcessTestBase):
 
 
 class GetRecatOverflowTest(unittest.TestCase):
-    def test_get_recat_logs_and_raises_on_int32_overflow(self) -> None:
-        """Verify that _get_recat raises RuntimeError and logs context when
-        batch_size_per_rank contains values that overflow int32."""
+    def test_get_recat_warns_and_raises_on_int32_overflow(self) -> None:
+        """By default (TORCHREC_ENABLE_INT64_RECAT unset) the dtype is NOT chosen
+        from the data -- a per-batch upcast could make ranks disagree on the
+        all-to-all dtype. When the accumulated per-feature offsets exceed the
+        int32 range, _get_recat warns (pointing at the opt-in) and then raises
+        when the int32 recat/offset tensors overflow."""
         overflow_value = 2_147_483_648  # INT32_MAX + 1
-        with self.assertRaises(RuntimeError) as ctx, self.assertLogs(
-            level="ERROR"
-        ) as log:
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data._TORCHREC_ENABLE_INT64_RECAT", False
+        ), self.assertRaises(RuntimeError), self.assertLogs(level="WARNING") as log:
             _get_recat(
                 local_split=2,
                 num_splits=4,
@@ -1539,15 +1542,64 @@ class GetRecatOverflowTest(unittest.TestCase):
                 device=torch.device("cpu"),
                 batch_size_per_rank=[32, overflow_value, 32, 32],
             )
-
-        self.assertIn("overflow", str(ctx.exception).lower())
-
         logged = "\n".join(log.output)
         self.assertIn("_get_recat", logged)
-        self.assertIn("batch_size_per_rank", logged)
+        self.assertIn("int32 range", logged)
+        self.assertIn("TORCHREC_ENABLE_INT64_RECAT", logged)
         self.assertIn(str(overflow_value), logged)
-        self.assertIn("input_offset", logged)
-        self.assertIn("output_offset", logged)
+
+    def test_get_recat_uses_int64_when_opted_in(self) -> None:
+        """With TORCHREC_ENABLE_INT64_RECAT enabled, _get_recat builds int64
+        recat + offset tensors (job-wide, rank-consistent) so the downstream
+        fbgemm all-to-all permute can consume offsets beyond the int32 range,
+        without warning. expand_into_jagged_permute is mocked to avoid
+        materializing the multi-billion-element output the large offsets would
+        otherwise allocate."""
+        overflow_value = 2_147_483_648  # INT32_MAX + 1
+        with unittest.mock.patch(
+            "torchrec.distributed.dist_data._TORCHREC_ENABLE_INT64_RECAT", True
+        ), unittest.mock.patch.object(
+            torch.ops.fbgemm,
+            "expand_into_jagged_permute",
+            return_value=torch.zeros(1, dtype=torch.int64),
+        ) as mock_expand, self.assertNoLogs(
+            level="WARNING"
+        ):
+            _get_recat(
+                local_split=2,
+                num_splits=4,
+                stagger=1,
+                device=torch.device("cpu"),
+                batch_size_per_rank=[32, overflow_value, 32, 32],
+            )
+        recat_tensor, input_offset_tensor, output_offset_tensor = (
+            mock_expand.call_args.args[:3]
+        )
+        self.assertEqual(recat_tensor.dtype, torch.int64)
+        self.assertEqual(input_offset_tensor.dtype, torch.int64)
+        self.assertEqual(output_offset_tensor.dtype, torch.int64)
+
+    def test_get_recat_no_warning_when_within_range(self) -> None:
+        """Typical models keep the int32 path with no overflow warning: when the
+        offsets fit in int32, _get_recat builds int32 recat + offset tensors."""
+        with unittest.mock.patch.object(
+            torch.ops.fbgemm,
+            "expand_into_jagged_permute",
+            return_value=torch.zeros(1, dtype=torch.int32),
+        ) as mock_expand, self.assertNoLogs(level="WARNING"):
+            _get_recat(
+                local_split=2,
+                num_splits=4,
+                stagger=1,
+                device=torch.device("cpu"),
+                batch_size_per_rank=[32, 64, 32, 64],
+            )
+        recat_tensor, input_offset_tensor, output_offset_tensor = (
+            mock_expand.call_args.args[:3]
+        )
+        self.assertEqual(recat_tensor.dtype, torch.int32)
+        self.assertEqual(input_offset_tensor.dtype, torch.int32)
+        self.assertEqual(output_offset_tensor.dtype, torch.int32)
 
     def test_get_recat_no_overflow_unchanged_behavior(self) -> None:
         """Verify that _get_recat still returns a valid recat tensor when


### PR DESCRIPTION
Summary:
# Context
`_get_recat` builds the permute and offset tensors for the variable-batch (VBE) KJT all-to-all as int32. At large scale (long sequences x many features x world_size) the accumulated per-feature offsets, and the expanded output permute indices they produce (up to `output_offset[-1]`), exceed the int32 range (2**31 - 1), raising "RuntimeError: value cannot be converted to type int32 without overflow" during the first `input_dist` all-to-all.

Keep the recat and both offset tensors at int32 by default. int64 is now an explicit, job-wide opt-in via the `TORCHREC_ENABLE_INT64_RECAT` env var, which must be set identically on every rank -- the tensor dtype is part of the all-to-all collective contract, so it must not be chosen from the per-batch data (a data-dependent upcast could make ranks disagree on the dtype and corrupt the collective). When the offsets would overflow int32 but the flag is unset, `_get_recat` logs a warning pointing at the env var (or at reducing the effective batch size). Enabling int64 requires the downstream fbgemm sparse-permute kernels to accept an int64 permute (see the companion fbgemm diff); `expand_into_jagged_permute` already dispatches on the permute dtype.

Hit by the CFR main_feed_mtml onn-lwr pairmem run at HSTU seq 10240.

Differential Revision: D112628953


