### PR TITLE
[detailed][distributed] Expose ProcessGroupNCCL internal comm stream to Python

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -24,7 +24,7 @@ see README.md for more details
 import logging
 import threading
 from dataclasses import dataclass, fields
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, cast, Dict, List
 
 import torch
 import torch.distributed as dist
@@ -894,6 +894,128 @@ def cuda_event_wait(
             f"{n_side_matmuls} matmuls ({cpu_mat_dim}x{cpu_mat_dim}); compare the "
             f"## side-thread matmul ## slices against the spin variant in the trace"
         )
+
+
+@dataclass
+class CommStreamAccessConfig(CommsConfig):
+    """
+    run commands:
+    1. contend (default): comm1 (a2a on ctx.pg) and comm2 (all_reduce on ar_pg)
+       overlap on their own pg-managed comm streams and contend for interconnect
+       bandwidth, slowing the critical-path comm1
+    > python -m torchrec.distributed.benchmark.benchmark_comms comm_stream_access \
+        --name=contend
+
+    2. serialized: make ar_pg's comm stream wait on ctx.pg's comm stream (via the
+       exposed comm stream handle) so comm2 is queued after comm1 and comm1 runs
+       contention-free
+    > python -m torchrec.distributed.benchmark.benchmark_comms comm_stream_access \
+        --name=serialized \
+        --serialized=True
+
+    use case:
+        each NCCL process group owns an internal CUDA stream that its async
+        collectives (async_op=True) run on, so two PGs (a2a ctx.pg + all_reduce
+        ar_pg) run on distinct comm streams and can overlap and contend --
+        slowing the collective on the critical path. This reaches each pg-managed
+        comm stream from Python via the (private)
+        ProcessGroupNCCL._get_comm_stream_info() binding. With serialized=True it
+        makes ar_pg's comm stream wait on ctx.pg's comm stream (a stream-to-
+        stream wait, no CPU / main-stream sync), so the critical-path a2a runs
+        contention-free -- ordering that Work.wait() alone cannot express.
+        Compare the comm1 (a2a) vs comm2 (all_reduce) overlap between the two
+        runs in the chrome trace.
+        see the nccl_comm_stream_access design doc for the diagram
+    """
+
+    serialized: bool = False
+    needs_ar_pg: bool = True
+    all_rank_traces: bool = True
+
+
+@register_benchmark(CommStreamAccessConfig)
+def comm_stream_access(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    serialized: bool = False,
+    ar_pg: dist.ProcessGroup | None = None,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Order two collectives across process groups using their exposed comm streams.
+
+    comm1 = all_to_all on ctx.pg (critical path; op1-b waits on it);
+    comm2 = all_reduce on ar_pg (off critical path, larger, bandwidth-hungry).
+    - serialized=False: comm1 and comm2 overlap on their own comm streams and
+      contend, slowing comm1.
+    - serialized=True: ar_pg's comm stream waits on ctx.pg's comm stream, so
+      comm1 runs contention-free and finishes sooner.
+    """
+
+    def pg_comm_stream(pg: dist.ProcessGroup) -> torch.cuda.Stream:
+        # the internal comm stream only exists once the communicator is
+        # initialized, so call this only after a collective has run on `pg`
+        backend = cast(dist.ProcessGroupNCCL, pg._get_backend(ctx.device))
+        sid, didx, dtype = backend._get_comm_stream_info()
+        return torch.cuda.Stream(stream_id=sid, device_index=didx, device_type=dtype)
+
+    with record_function("## setup ##"):
+        assert ctx.pg is not None and ar_pg is not None
+        # warm up both communicators so their internal comm streams exist
+        dist.barrier(group=ctx.pg)
+        dist.barrier(group=ar_pg)
+        a2a_stream = pg_comm_stream(ctx.pg)
+        ar_stream = pg_comm_stream(ar_pg)
+        assert (
+            a2a_stream.cuda_stream != ar_stream.cuda_stream
+        ), "expected the two process groups to own distinct comm streams"
+        logger.info(
+            f"[rank-{ctx.rank}] a2a comm stream {a2a_stream.cuda_stream:#x}, "
+            f"all_reduce comm stream {ar_stream.cuda_stream:#x}, "
+            f"serialized={serialized}"
+        )
+
+    with record_function("## pre-comms compute ##"):
+        input_a = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+        input_b = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat * 2, ctx=ctx)
+        out_a = torch.zeros_like(input_a)
+        out_b = input_b.clone()
+
+    with record_function("## op1-a: launch comm1 (a2a) on ctx.pg ##"):
+        req1 = dist.all_to_all_single(
+            output=out_a, input=input_a, group=ctx.pg, async_op=True
+        )
+        assert req1 is not None
+
+    with record_function("## op2-a: launch comm2 (all_reduce) on ar_pg ##"):
+        if serialized:
+            # make ar_pg's comm stream wait on ctx.pg's comm stream so comm2 is
+            # queued after comm1 -- a stream-to-stream wait, no CPU / main-stream
+            # sync. This cross-pg ordering needs the exposed comm stream handle.
+            ar_stream.wait_stream(a2a_stream)
+        req2 = dist.all_reduce(out_b, op=dist.ReduceOp.SUM, group=ar_pg, async_op=True)
+        assert req2 is not None
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## op1-b: critical-path consumer waits on comm1 ##"):
+        req1.wait()
+        checks_a = _validate(out_a, ctx)
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=out_a[0])
+
+    with record_function("## wait comm2 and validate ##"):
+        req2.wait()
+        # all_reduce(SUM) of values from rank 0 in (0,1) and rank 1 in (1,2)
+        # produces sums in (1,3), so int values >= 1
+        checks_b = torch.all(out_b.to(torch.int) >= 1)
+        checks = DeviceToHostTensorAwaitable(checks_a & checks_b)
+
+    with record_function("## assert ##"):
+        assert checks.item()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
# Exposing the ProcessGroupNCCL Comm Stream to Python

## TL;DR

- Each process group (PG) manages its **own comm stream** — the collectives run under that PG (e.g. all_to_all, all_reduce) are all assigned to that one stream.
- In large-scale training there are often **multiple PGs** in use (e.g. 2D sharding); without a handle to the comm stream, arranging comm ops across them is very difficult.
- This diff walks through a common scenario where that's needed and adds support to **expose the comm stream** to Python.

## 1. Current async_op comm behavior

When a collective is issued with async_op=True:

```python
work = dist.all_to_all_single(output, input, group=pg, async_op=True)
# ... unrelated compute ...
work.wait()
```

- The call returns a Work handle immediately. The NCCL kernel is **not** enqueued on the current/main stream.
- Instead, ProcessGroupNCCL enqueues it on an **internal per-device comm stream** it manages (tracked in `ncclStreams_`, keyed by device). Each process group owns its own comm stream, distinct from the main stream and from any caller-created side stream. Two different PGs (e.g. an all-to-all PG and an all-reduce PG) run on **different** comm streams.
- Synchronization is meant to flow through Work.wait(), which does two things:
  1. makes the current stream wait on the comm stream's completion, and
  2. performs caching-allocator tensor stashing (record_stream-style) so the collective's input/output tensors are not freed and reused while the async kernel is still reading/writing them.
- From Python there was **no accessor for this internal stream**. A related binding, `_comm_ptr`, exposes the communicator pointer, but nothing exposed the stream the kernels actually run on.

## 2. Why access the comm stream

**Motivation: serialize contending collectives across process groups**

Training jobs commonly run multiple process groups — e.g. a table-wise all-to-all PG and a data-parallel all-reduce PG — and **each PG owns its own comm stream**, so their collectives can run concurrently on the GPU. That concurrency is not always a win: two NCCL kernels in flight at once contend for interconnect bandwidth and SMs, so both run slower.

<img width="1964" height="1602" alt="image" src="https://github.com/user-attachments/assets/453508f0-adc9-4640-987c-89516b7509c8" />

- **Top — the problem.** op1-a launches comm1 on PG1's comm stream (on the critical path: op1-b waits on it); op2-a launches comm2 on PG2's comm stream. Because they sit on **different** streams, they overlap and contend — so *both* run slower, including the critical-path comm1.
- **Single-PG would be fine.** If both collectives shared one PG (one comm stream), comm2 would simply be **queued after** comm1 — no contention. The contention is a side effect of splitting them across PGs.
- **Bottom — the fix.** With the comm stream reachable from Python, make the off-critical-path comm2 **wait on** comm1 (a stream-to-stream wait / event on the exposed stream). comm1 then runs contention-free and finishes sooner → op1-b starts earlier → the critical path shrinks. Crucially this ordering is expressed **stream-to-stream**, without the CPU / main-stream sync that Work.wait() would impose.

This cross-PG ordering is not expressible from Python today: Work.wait() only syncs a collective to the current stream; there is no handle to make one PG's comm stream wait on another's.

**Other uses**

- **Exact completion / timing** — record a CUDA event directly on the comm stream to measure when the collective kernel actually runs and finishes, instead of inferring it from the main stream.
- **Multi-PG introspection** — confirm that different process groups run on distinct comm streams (the new benchmark asserts the a2a PG and the all-reduce PG own different streams).

**Why it's marked unsafe.** Work you enqueue on this stream directly is **not watchdog-monitored**, and gating on it manually **bypasses the allocator-safety stashing** that Work.wait() performs — which can lead to use-after-free of collective tensors. The recommended pattern remains async_op=True plus Work.wait(); use the raw stream only to observe, or to add ordering on top of (not in place of) wait()'s safety.

## 3. Why it wasn't exposed before

**[Not fully verified]** The comm stream is a deliberately internal implementation detail (`ncclStreams_`, keyed by device — a `protected` member, so unreachable from Python). The async-collective safety model is built around the Work object, not the raw stream — exposing the stream invites callers to step outside that model:

- **The safety contract lives in Work, not the stream.** A collective runs on the comm stream while its input/output tensors were allocated on the current stream. To stop the caching allocator from freeing/reusing a tensor while the NCCL kernel is still using it, ProcessGroupNCCL holds those tensors in a per-Work tensor shelf (`stashed_for_allocator_safety_`) and only releases them when the work completes (unstash driven by the watchdog / Work.wait()). Historically this used record_stream; stashing is now the default (the TORCH_NCCL_AVOID_RECORD_STREAMS knob is deprecated). Gate on the raw comm stream and skip Work.wait(), and none of this lifetime management runs → **use-after-free**.
- **Stream ordering is already handled internally.** The Sync Streams helper makes the comm stream wait on the current stream (via an event) *before* the collective, and Work.wait() makes the current stream wait on the comm stream *after* — so under normal use there is no reason for callers to touch the stream at all.
- **Watchdog coverage.** Work enqueued by ProcessGroupNCCL is monitored for timeout/abort; anything launched on the stream externally is not (the same caveat the existing `_comm_ptr` binding carries).
- **Backend-agnostic abstraction.** c10d's public surface is backend-neutral; a per-device NCCL comm stream is an NCCL-specific internal, so it lived in `ncclStreams_` rather than on the ProcessGroup interface.

Net: the historical stance is "synchronize through Work, don't touch the stream." This change keeps that default and only adds a **read-only, warning-labeled** escape hatch for advanced ordering/observation on top of Work.wait().

## 4. Discussion

- **Why not async_op=False?** With async_op=False the caller already controls which stream the collective runs on, so no new API is needed. In practice the collectives live in model code that we usually can't change, and async_op=True is pervasive across production models — pushing a base-infra change for a benefit only a handful of models need isn't worth it. Exposing the comm stream is the lighter-touch path; the accessor is guarded with prominent "use at your own risk" warnings.
- **Read-only, not a safe ordering API.** The accessor only hands back the existing pooled stream; it does not wrap the unsafe parts. Serializing comm2 behind comm1 with wait_stream still relies on the caller keeping the standard async_op + Work.wait() path for correctness, so the allocator-safety stashing still runs. A natural follow-up is a higher-level helper that expresses "run this collective after that one" while preserving stashing and watchdog coverage, so users never touch the raw stream.
- **Long-term support surface.** Any real usage means the behavior has to be supported effectively forever. That argues for keeping the accessor private (underscore-prefixed, read-only) and heavily warning-labeled, and for limiting adoption to the few models that truly need it.
- **Cross-backend consistency.** Should the same capability exist for RCCL and GLOO, not just NCCL? Baking it into the NCCL backend makes the behavior backend-specific.
- **Alternative: a custom Python wrapper backend.** Instead of baking stream exposure into the shipped NCCL backend, route the few PGs that need it through a custom backend that wraps NCCL — either registered under its own name (`Backend.register_backend("nccl_custom", creator_fn, devices=["cuda"])`, then init_process_group / new_group with that backend) or by wrapping specific subgroups directly. The wrapper delegates the collectives to an inner NCCL PG (no reimplementation) and adds only the stream accessor / ordering helper, so the core backends stay clean, the support burden is contained, and the behavior could span RCCL/GLOO too.

  **[Claude suggestion]** the comm stream is owned by the NCCL backend (`ncclStreams_`), and Python can't reach it without a C++ hook — so a pure-Python wrapper still needs a small accessor on the NCCL side (this diff). Keeping the accessor fully out of the shipped NCCL files would instead mean writing the custom backend in C++ as a subclass of ProcessGroupNCCL; since `ncclStreams_` is already `protected`, such a subclass can read it directly. So the realistic options are:
    - **(1) Minimal C++ accessor (this diff) + a Python wrapper API** — smallest core change; the ordering API lives in the wrapper.
    - **(2) A C++ custom backend subclassing ProcessGroupNCCL** — reads the already-`protected` `ncclStreams_` directly, keeping the accessor out of the shipped NCCL files, at the cost of a whole backend to maintain.

## 5. The change (high level)

- **getCommStream()** — returns the current device's comm stream from `ncclStreams_`, checking the communicator is initialized (so it must be called *after* the first collective on the PG).
- **pybind `_get_comm_stream_info()`** — private accessor returning the (stream_id, device_index, device_type) triple (the same triple torch.cuda.current_stream() uses), with a warning docstring mirroring `_comm_ptr`. Returning the triple rather than a Stream keeps CUDA-Python construction out of the backend-agnostic c10d binding (which also builds for non-CUDA) and lets Python rebuild the *exact* pooled stream (no new stream created). Mirrored across the fbcode and xplat copies.
- **Benchmark** — comm_stream_access warms up two PGs (a2a ctx.pg = comm1, critical path; all-reduce ar_pg = comm2, larger), reads each comm stream, and asserts they are **distinct**. It demos both cases from the diagram: serialized=False lets comm1 and comm2 overlap and contend, while serialized=True issues ar_stream.wait_stream(a2a_stream) so comm2 is queued behind comm1 and the critical-path a2a runs contention-free. Correctness is gated with Work.wait(); the overlap-vs-serialized behavior (and the resulting comm1 speedup) is visible in the chrome traces linked in the References below.

  ```bash
  python -m torchrec.distributed.benchmark.benchmark_comms comm_stream_access --name=contend
  python -m torchrec.distributed.benchmark.benchmark_comms comm_stream_access --name=serialized --serialized=True
  ```

Python consumer usage:

```python
backend = pg._get_backend(device)          # ProcessGroupNCCL backend
sid, didx, dtype = backend._get_comm_stream_info()
comm_stream = torch.cuda.Stream(
    stream_id=sid, device_index=didx, device_type=dtype)
```

Contend (rank 0) — all_to_all (stream 23) overlaps all_reduce (stream 27); both contend:
<img width="2331" height="441" alt="image" src="https://github.com/user-attachments/assets/0ed8e843-c5db-45d8-a2ff-5d787b07b9ea" />

Serialized (rank 0) — all_reduce is queued behind all_to_all, so the critical-path a2a runs alone:
<img width="2099" height="403" alt="image" src="https://github.com/user-attachments/assets/2b3c0c87-30f5-4df2-8ab4-a0950236341f" />

## References

- Diff: [D113044025](https://www.internalfb.com/diff/D113044025) (draft) — *Expose ProcessGroupNCCL internal comm stream to Python*
- Related existing binding: `_comm_ptr` (exposes the communicator pointer, with the same safety caveats)

**Benchmark traces**

Captured from comm_stream_access on 2 GPUs, uploaded to the [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D113044025). Compare the a2a (comm1) kernel in the contend vs serialized traces: with contention it overlaps the all_reduce and runs longer; serialized, it runs alone and finishes sooner.

| case | rank 0 | rank 1 |
|--|--|--|
| contend | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_contend-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_contend-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_contend-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_contend-rank1.json.gz&bucket=torchrec_benchmark_traces) |
| serialized | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_serialized-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_serialized-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_serialized-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-comm_stream_access_serialized-rank1.json.gz&bucket=torchrec_benchmark_traces) |

Differential Revision: D113044025


