### PR TITLE
Support VBE in GRID_SHARD output-dist (#4456)

### DIFF
--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Set, Tuple, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -290,6 +290,12 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
     def embedding_names(self) -> List[str]:
         return self._combined_embedding_names
 
+    def uncombined_embedding_dims(self) -> List[int]:
+        return self._embedding_dims
+
+    def uncombined_embedding_names(self) -> List[str]:
+        return self._embedding_names
+
     def embedding_names_per_rank(self) -> List[List[str]]:
         raise NotImplementedError
 
@@ -377,18 +383,14 @@ class GridPooledEmbeddingDist(
             if qcomm_codecs_registry
             else None
         )
-        self._intra_dist: Optional[
-            Union[
-                PooledEmbeddingsReduceScatter,
-                VariableBatchPooledEmbeddingsReduceScatter,
-            ]
+        self._intra_dist: Optional[PooledEmbeddingsReduceScatter] = None
+        self._cross_dist: Optional[PooledEmbeddingsAllToAll] = None
+        self._variable_intra_dist: Optional[
+            VariableBatchPooledEmbeddingsReduceScatter
         ] = None
-        self._cross_dist: Optional[
-            Union[
-                PooledEmbeddingsAllToAll,
-                VariableBatchPooledEmbeddingsAllToAll,
-            ]
-        ] = None
+        self._variable_cross_dist: Optional[VariableBatchPooledEmbeddingsAllToAll] = (
+            None
+        )
         self._callbacks = callbacks
 
     @EventLoggingHandler.event_logger(
@@ -412,7 +414,35 @@ class GridPooledEmbeddingDist(
         if self._intra_dist is None or self._cross_dist is None:
             self._create_output_dist_modules(sharding_ctx)
         local_rank = self._rank % self._intra_pg.size()
-        if sharding_ctx is not None and len(set(sharding_ctx.batch_size_per_rank)) > 1:
+        current_node = self._rank // self._intra_pg.size()
+        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
+            (
+                batch_size_per_rank_per_feature_by_cross_group,
+                batch_size_per_feature_sum_by_cross_group,
+            ) = self._preprocess_batch_size_per_rank_per_feature(
+                self._intra_pg.size(),
+                self._cross_pg.size(),
+                sharding_ctx.batch_size_per_rank_per_feature,
+            )
+            rs_result = cast(
+                VariableBatchPooledEmbeddingsReduceScatter, self._variable_intra_dist
+            )(
+                local_embs,
+                batch_size_per_rank_per_feature=batch_size_per_feature_sum_by_cross_group,
+                embedding_dims=self._emb_dim_per_node_per_feature[current_node],
+            ).wait()
+            return cast(
+                VariableBatchPooledEmbeddingsAllToAll, self._variable_cross_dist
+            )(
+                rs_result,
+                batch_size_per_rank_per_feature=batch_size_per_rank_per_feature_by_cross_group[
+                    local_rank
+                ],
+                batch_size_per_feature_pre_a2a=sharding_ctx.batch_size_per_feature_pre_a2a,
+            )
+        elif (
+            sharding_ctx is not None and len(set(sharding_ctx.batch_size_per_rank)) > 1
+        ):
             # preprocess batch_size_per_rank
             (
                 batch_size_per_rank_by_cross_group,
@@ -457,9 +487,61 @@ class GridPooledEmbeddingDist(
 
         return batch_size_per_rank_by_cross_group, batch_size_sum_by_cross_group
 
+    def _preprocess_batch_size_per_rank_per_feature(
+        self,
+        local_size: int,
+        nodes: int,
+        batch_size_per_rank_per_feature_stagger: List[List[int]],
+    ) -> Tuple[List[List[List[int]]], List[List[int]]]:
+        """
+        Reorders `batch_size_per_rank_per_feature_stagger` so it's aligned with
+        reordered features after AlltoAll.
+        """
+        if not batch_size_per_rank_per_feature_stagger:
+            return [[]] * local_size, []
+        batch_size_per_rank_per_feature_by_cross_group: List[List[List[int]]] = []
+        batch_size_per_feature_sum_by_cross_group: List[List[int]] = []
+        for local_rank in range(local_size):
+            batch_size_by_node_per_rank_per_feature: List[List[int]] = []
+            batch_size_per_feature_sum = [0] * len(
+                batch_size_per_rank_per_feature_stagger[0]
+            )
+            for node in range(nodes):
+                batch_size = batch_size_per_rank_per_feature_stagger[
+                    local_rank * nodes + node
+                ]
+                batch_size_by_node_per_rank_per_feature.append(batch_size)
+                batch_size_per_feature_sum = [
+                    sum(x) for x in zip(batch_size_per_feature_sum, batch_size)
+                ]
+            batch_size_per_rank_per_feature_by_cross_group.append(
+                batch_size_by_node_per_rank_per_feature
+            )
+            batch_size_per_feature_sum_by_cross_group.append(batch_size_per_feature_sum)
+
+        return (
+            batch_size_per_rank_per_feature_by_cross_group,
+            batch_size_per_feature_sum_by_cross_group,
+        )
+
     def _create_output_dist_modules(
         self, sharding_ctx: Optional[EmbeddingShardingContext] = None
     ) -> None:
+        if sharding_ctx is not None and sharding_ctx.variable_batch_per_feature:
+            self._variable_intra_dist = VariableBatchPooledEmbeddingsReduceScatter(
+                pg=self._intra_pg,
+                codecs=self._intra_codecs,
+            )
+            # No permute callback here (unlike the plain cross_dist below): the
+            # ragged output is reassembled globally by
+            # VariableBatchEmbeddingBagCollectionAwaitable using uncombined_embedding_dims/names().
+            self._variable_cross_dist = VariableBatchPooledEmbeddingsAllToAll(
+                pg=self._cross_pg,
+                emb_dim_per_rank_per_feature=self._emb_dim_per_node_per_feature,
+                device=self._device,
+                callbacks=None,
+                codecs=self._cross_codecs,
+            )
         self._intra_dist = PooledEmbeddingsReduceScatter(
             pg=self._intra_pg,
             codecs=self._intra_codecs,

--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.comm import _CROSS_PG, _INTRA_PG
+from torchrec.distributed import comm as _comm
 from torchrec.test_utils import (
     get_free_port,
     init_distributed_single_host,
@@ -113,10 +113,20 @@ class MultiProcessContext:
         return self
 
     def __exit__(self, exc_type, exc_instance, traceback) -> None:
-        if _INTRA_PG is not None:
-            dist.destroy_process_group(_INTRA_PG)
-        if _CROSS_PG is not None:
-            dist.destroy_process_group(_CROSS_PG)
+        # Access via `_comm.X`, not `from comm import X`: a `from`-import snapshots
+        # the value at import time, so a re-entered context would see the stale handle.
+        if _comm._INTRA_PG is not None:
+            dist.destroy_process_group(_comm._INTRA_PG)
+            _comm._INTRA_PG = None
+        if _comm._CROSS_PG is not None:
+            dist.destroy_process_group(_comm._CROSS_PG)
+            _comm._CROSS_PG = None
+        if _comm._INTRA_PG_2D is not None:
+            dist.destroy_process_group(_comm._INTRA_PG_2D)
+            _comm._INTRA_PG_2D = None
+        if _comm._CROSS_PG_2D is not None:
+            dist.destroy_process_group(_comm._CROSS_PG_2D)
+            _comm._CROSS_PG_2D = None
         dist.destroy_process_group(self.pg)
         torch.use_deterministic_algorithms(False)
         if torch.cuda.is_available() and self.disable_cuda_tf_32:

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -796,10 +796,8 @@ class ModelInput(Pipelineable):
         indices_dtype: torch.dtype,
         offsets_dtype: torch.dtype,
         lengths_dtype: torch.dtype,
+        is_weighted: bool = False,
     ) -> Tuple[KeyedJaggedTensor, List[KeyedJaggedTensor]]:
-        is_weighted = (
-            True if tables and getattr(tables[0], "is_weighted", False) else False
-        )
 
         feature_num_embeddings = {}
 
@@ -907,6 +905,7 @@ class ModelInput(Pipelineable):
                     indices_dtype=indices_dtype,
                     offsets_dtype=offsets_dtype,
                     lengths_dtype=lengths_dtype,
+                    is_weighted=True,
                 )
             )
         else:

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -797,10 +797,8 @@ class ModelInput(Pipelineable):
         indices_dtype: torch.dtype,
         offsets_dtype: torch.dtype,
         lengths_dtype: torch.dtype,
+        is_weighted: bool = False,
     ) -> Tuple[KeyedJaggedTensor, List[KeyedJaggedTensor]]:
-        is_weighted = (
-            True if tables and getattr(tables[0], "is_weighted", False) else False
-        )
 
         feature_num_embeddings = {}
 
@@ -908,6 +906,7 @@ class ModelInput(Pipelineable):
                     indices_dtype=indices_dtype,
                     offsets_dtype=offsets_dtype,
                     lengths_dtype=lengths_dtype,
+                    is_weighted=True,
                 )
             )
         else:

--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -13,7 +13,15 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Type
 import torch
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from hypothesis import assume, given, Phase, settings, strategies as st, Verbosity
+from hypothesis import (
+    assume,
+    example,
+    given,
+    Phase,
+    settings,
+    strategies as st,
+    Verbosity,
+)
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
@@ -297,12 +305,37 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         pooling=st.sampled_from([PoolingType.SUM]),
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
+        variable_batch_per_feature=st.booleans(),
     )
     @settings(
         verbosity=Verbosity.verbose,
         max_examples=1,
         deadline=None,
         phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
+    @example(
+        sharder_type=SharderType.EMBEDDING_BAG_COLLECTION.value,
+        kernel_type=EmbeddingComputeKernel.FUSED.value,
+        qcomms_config=None,
+        apply_optimizer_in_backward_config={
+            "embedding_bags": (torch.optim.SGD, {"lr": 0.01}),
+        },
+        pooling=PoolingType.SUM,
+        use_inter_host_allreduce=False,
+        custom_all_reduce=False,
+        variable_batch_per_feature=True,
+    )
+    @example(
+        sharder_type=SharderType.EMBEDDING_BAG_COLLECTION.value,
+        kernel_type=EmbeddingComputeKernel.FUSED.value,
+        qcomms_config=None,
+        apply_optimizer_in_backward_config={
+            "embedding_bags": (torch.optim.SGD, {"lr": 0.01}),
+        },
+        pooling=PoolingType.SUM,
+        use_inter_host_allreduce=False,
+        custom_all_reduce=False,
+        variable_batch_per_feature=False,
     )
     def test_sharding_grid_2D(
         self,
@@ -315,6 +348,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         pooling: PoolingType,
         use_inter_host_allreduce: bool,
         custom_all_reduce: bool,
+        variable_batch_per_feature: bool,
     ) -> None:
         if (
             self.device == torch.device("cpu")
@@ -373,6 +407,7 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
             pooling=pooling,
             use_inter_host_allreduce=use_inter_host_allreduce,
             custom_all_reduce=custom_all_reduce,
+            variable_batch_per_feature=variable_batch_per_feature,
         )
 
     @unittest.skipIf(

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -479,3 +479,51 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             global_constant_batch=global_constant_batch,
             pooling=pooling,
         )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 3,
+        "Not enough GPUs, this test requires at least four GPUs",
+    )
+    @given(
+        variable_batch_per_feature=st.booleans(),
+        global_constant_batch=st.booleans(),
+    )
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=2,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
+    def test_sharding_grid_variable_batch(
+        self,
+        variable_batch_per_feature: bool,
+        global_constant_batch: bool,
+    ) -> None:
+        # GRID_SHARD requires explicit per-table constraints; min_partition is
+        # half of each table's embedding_dim (16, 24, 32, 40, 16, 24) so it
+        # spans both of the 2 node-groups (world_size=4, local_size=2).
+        constraints = {
+            name: ParameterConstraints(
+                min_partition=min_partition,
+                sharding_types=[ShardingType.GRID_SHARD.value],
+            )
+            for name, min_partition in zip(self.table_names, [8, 12, 16, 20, 8, 12])
+        }
+        self._test_sharding(
+            # pyrefly: ignore[bad-argument-type]
+            sharders=[
+                create_test_sharder(
+                    SharderType.EMBEDDING_BAG_COLLECTION.value,
+                    ShardingType.GRID_SHARD.value,
+                    EmbeddingComputeKernel.FUSED.value,
+                    device=torch.device("cuda"),
+                ),
+            ],
+            backend="nccl",
+            world_size=4,
+            local_size=2,
+            constraints=constraints,
+            variable_batch_per_feature=variable_batch_per_feature,
+            has_weighted_tables=False,
+            global_constant_batch=global_constant_batch,
+        )


### PR DESCRIPTION
Summary:

GRID_SHARD's output-dist never supported VBE (variable batch size per
feature): it imported the VBE reduce-scatter/AllToAll classes but never
constructed or dispatched to them, so a VBE table sharded as GRID_SHARD
crashed instead of training.

- `GridPooledEmbeddingDist`: added the VBE branch to `forward()` and
  `_create_output_dist_modules`, mirroring `TwRwPooledEmbeddingSharding`.
- `GridPooledEmbeddingSharding`: added `uncombined_embedding_dims()`/
  `uncombined_embedding_names()` (previously inherited the base-class
  default of just returning the already-combined dims/names). These are
  needed for `VariableBatchEmbeddingBagCollectionAwaitable` to correctly
  reassemble grid's column-wise shards from the ragged VBE output; without
  them the VBE cross-dist must not attach grid's usual CW-reassembly
  permute callback, since that op requires a rectangular tensor and the
  ragged output isn't one.
- `MultiProcessContext.__exit__` (test util): fixed a stale-handle bug --
  process groups were read via a `from`-import, which snapshots the value
  at import time, so 2D-parallel groups (`_INTRA_PG_2D`/`_CROSS_PG_2D`)
  leaked on every exit instead of being destroyed. This caused intermittent
  NCCL bind failures across repeated 2D-parallel test runs.
- `ModelInput._generate_variable_batch_features` (test util): fixed
  weighted-table detection, which checked an `is_weighted` attribute that
  doesn't exist on `EmbeddingBagConfig`, silently generating unweighted
  inputs for weighted tables. Now takes an explicit `is_weighted` param.

Reviewed By: spmex

Differential Revision: D113194607


