### PR TITLE
Preserve unquantized embedding tables through sharding

### DIFF
--- a/torchrec/distributed/quant_state.py
+++ b/torchrec/distributed/quant_state.py
@@ -176,6 +176,16 @@ class ShardedQuantEmbeddingModuleState(
                 # end of weight shards section
 
                 # weight_qscale & weight_qbias section:
+                if (tbe_split_qscale is None) != (tbe_split_qbias is None):
+                    raise RuntimeError(
+                        "Quantized table must provide both qscale and qbias: "
+                        f"table={table.name}, data_type={table.data_type}, "
+                        f"qscale_is_none={tbe_split_qscale is None}, "
+                        f"qbias_is_none={tbe_split_qbias is None}"
+                    )
+                if tbe_split_qscale is None:
+                    continue
+
                 # For RW - ShardedTensorBase
                 # For CW - List[Tensor] that logically corresponds to the same unsharded Tensor, but present on each sharded rank
                 for (

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -147,6 +147,42 @@ class InferShardingsTest(unittest.TestCase):
         super().setUp()
         set_propogate_device(True)
 
+    def test_tw_mixed_float_and_int8_split_scale_bias_cpu(self) -> None:
+        device = torch.device("cpu")
+        mi = create_test_model(
+            num_embeddings=16,
+            emb_dim=8,
+            world_size=1,
+            batch_size=2,
+            dense_device=device,
+            sparse_device=device,
+            num_features=2,
+            num_weighted_features=0,
+        )
+        mi.quant_model = quantize(
+            module=mi.model,
+            inplace=False,
+            quant_state_dict_split_scale_bias=True,
+            per_table_weight_dtypes={
+                "table_0": torch.float,
+                "table_1": torch.quint8,
+            },
+        )
+
+        sharded_model = shard_qebc(
+            mi,
+            sharding_type=ShardingType.TABLE_WISE,
+            device=device,
+        )
+        state_keys = sharded_model.state_dict().keys()
+
+        self.assertTrue(any(key.endswith("table_0.weight") for key in state_keys))
+        self.assertFalse(any("table_0.weight_q" in key for key in state_keys))
+        self.assertTrue(
+            any(key.endswith("table_1.weight_qscale") for key in state_keys)
+        )
+        self.assertTrue(any(key.endswith("table_1.weight_qbias") for key in state_keys))
+
     @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",


### PR DESCRIPTION
Summary:
PNI constructs TorchRec per-table weight dtype maps from `select_quantization_dtype()`. A `None` result means that the table must remain unquantized. Omitting that table applies the TorchRec default INT8 dtype, while passing `None` directly is invalid. Either behavior can disagree with the floating-point weight produced by sparse weight processing.

Record every table explicitly across the ADS EBC, IG, retrieval, legacy sparse-arch, and variable-length embedding quantization paths. Explicit INT8, INT4, INT2, and float-to-half selections are preserved. Tables excluded from quantization retain their existing `EmbeddingBag.weight.dtype`, so FP32 and FP16 weights are not implicitly converted.

Mixed floating and quantized tables can return no qscale/qbias for the floating TBE when split scale/bias state is enabled. Preserve the floating table weight state without creating quantization-parameter state, and reject asymmetric qscale/qbias pairs.

Together, these changes keep the selected table representation consistent through PNI quantization and TorchRec sharding.

Differential Revision: D113501049


