### PR TITLE
[detailed][maglev] Maglev MVP: staged HSD pipeline + benchmark (#4465)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_maglev.py
+++ b/torchrec/distributed/benchmark/benchmark_maglev.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Benchmark for the Maglev staged pipeline (MVP).
+
+Measures the microbatched 1F1B schedule
+(:func:`~torchrec.distributed.maglev.pipeline.run_1f1b`) of a K-stage Maglev
+model across per-stage process groups (one hardware scale-up domain, HSD, each),
+including the cross-HSD activation / gradient hand-off. Each stage is an
+``EmbeddingBagCollection`` feature partition plus dense compute
+(:class:`~torchrec.distributed.test_utils.test_model.MaglevTestStage`, shared
+with the correctness test). One measured iteration is one full 1F1B pass over
+``num_microbatches`` microbatches.
+
+Runs on GPU + nccl by default (the cross-HSD P2P hand-off and the profiler path
+are CUDA-only); `all_rank_traces` defaults on so every stage's HSD shows up in
+the traces. Pass ``--device_type=cpu`` for the portable gloo repro (no traces on
+that path).
+
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_maglev -- --profile_dir=/tmp/maglev_traces
+
+OSS (external):
+    python -m torchrec.distributed.benchmark.benchmark_maglev --profile_dir=/tmp/maglev_traces
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import List
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+import torch
+from torch import nn
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    BenchmarkResult,
+    cmd_conf,
+    CPUMemoryStats,
+    GPUMemoryStats,
+)
+from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
+from torchrec.distributed.maglev.stage import (
+    build_handoff_process_groups,
+    build_stage_process_groups,
+    EmbeddingShard,
+    Replicated,
+    StageWrapper,
+)
+from torchrec.distributed.test_utils.model_input import ModelInput
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    run_multi_process_func,
+)
+from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
+from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+# Weights are seeded per stage so an HSD's two DP ranks start identical (the
+# sharded path builds DMP with init_parameters=False, so it relies on this).
+# Inputs are left unseeded -- values don't affect a throughput benchmark.
+_WEIGHT_SEED = 100
+
+
+@dataclass
+class RunOptions(BenchFuncConfig):
+    """Configuration for the Maglev pipeline benchmark.
+
+    Args:
+        name (str): Human-readable benchmark name. Default is "maglev".
+        world_size (int): Total number of ranks. Must equal
+            ``num_stages * ranks_per_stage``. Default is 8.
+        num_benchmarks (int): Number of measured iterations (each one full 1F1B
+            pass). Default is 12.
+        num_profiles (int): Number of profiling iterations (CUDA only; unused on
+            the CPU path). Default is 2.
+        num_stages (int): Number of Maglev stages (one HSD each). Default is 4.
+        ranks_per_stage (int): Ranks per stage's HSD (intra-HSD data
+            parallelism). Default is 2.
+        batch_size (int): Per-microbatch batch size ``B``. Default is 8192, which
+            with ``stage_dim`` gives a 128 MiB cross-stage activation (past NCCL's
+            ~64 MiB P2P buffer cliff).
+        num_microbatches (int): Number of microbatches per 1F1B pass.
+            Default is 8.
+        num_tables (int): Embedding tables per stage (one feature each). Default is 8.
+        num_embeddings (int): Rows per embedding table. Default is 1000000.
+        emb_dim (int): Embedding dimension ``D``. Default is 256.
+        num_float_features (int): Width of each stage's dense/float feature input.
+            Default is 64.
+        stage_dim (int): Width of the activation carried between stages.
+            Default is 4096 (128 MiB activation with the default batch size).
+        lr (float): Learning rate for the per-stage SGD optimizer.
+            Default is 0.05.
+        shard_embeddings (bool): Shard each stage's embedding tables within its
+            HSD via DMP scoped to the stage's process group (real intra-HSD
+            embedding sharding; the lookup all-to-all stays local to the pg).
+            Default is True. Requires ``device_type="cuda"`` (nccl) -- gloo cannot
+            P2P the CUDA activations between stages.
+        output_json (bool): Print the result as JSON instead of a table.
+            Default is False.
+        all_rank_traces (bool): Export a profiler trace from every rank (not just
+            rank 0) so each stage's HSD is captured. Default is True. Traces are
+            only emitted when ``profile_dir`` is set and ``device_type`` is
+            "cuda".
+    """
+
+    name: str = "maglev"
+    world_size: int = 8
+    num_benchmarks: int = 12
+    num_profiles: int = 2
+    num_stages: int = 4
+    ranks_per_stage: int = 2
+    # Heavy default: batch_size * stage_dim * 4B = 8192 * 4096 * 4 = 128 MiB
+    # cross-stage activation, past NCCL's ~64 MiB P2P buffer cliff, so the
+    # hand-off exercises the large-payload (rendezvous) path -- see the parity
+    # handoff pgs in stage.py and tech-docs/nccl_p2p_execution_order_buffer_size.md.
+    batch_size: int = 8192
+    num_microbatches: int = 8
+    # Heavier embedding tables: 1M rows * 256 dim * 8 tables per stage.
+    num_tables: int = 8
+    num_embeddings: int = 1_000_000
+    emb_dim: int = 256
+    num_float_features: int = 64
+    stage_dim: int = 4096
+    lr: float = 0.05
+    # Intra-HSD embedding sharding (DMP per stage), scoped to each stage's pg so
+    # the lookup all-to-all stays local to the HSD. Requires nccl (cuda).
+    shard_embeddings: bool = True
+    output_json: bool = False
+    # Capture a trace from every rank so each stage's HSD shows up, not only
+    # rank 0's stage (traces are emitted only when profile_dir is set on CUDA).
+    all_rank_traces: bool = True
+    # Benchmark on GPU by default (nccl P2P for the cross-HSD hand-off); the
+    # profiler path is CUDA-only. Pass --device_type=cpu for the portable
+    # gloo repro (no traces on that path).
+    device_type: str = "cuda"
+    profile_dir: str = "."
+
+
+def _make_tables(
+    stage_index: int,
+    num_tables: int,
+    num_embeddings: int,
+    emb_dim: int,
+) -> List[EmbeddingBagConfig]:
+    """This stage's feature partition: ``num_tables`` disjoint 1-feature tables.
+
+    Reuses the shared :class:`EmbeddingTablesConfig` generator, namespaced per
+    stage via ``name_prefix`` so each stage's tables/features are disjoint.
+    """
+    return EmbeddingTablesConfig(
+        num_unweighted_features=num_tables,
+        num_weighted_features=0,
+        embedding_feature_dim=emb_dim,
+        base_row_size=num_embeddings,
+    ).generate_tables(name_prefix=f"s{stage_index}_")[0]
+
+
+def _make_input(
+    tables: List[EmbeddingBagConfig],
+    batch_size: int,
+    num_float_features: int,
+    device: torch.device,
+) -> ModelInput:
+    """A ModelInput (float + sparse) for the given tables (canonical generator)."""
+    return ModelInput.generate(
+        batch_size=batch_size,
+        tables=tables,
+        weighted_tables=[],
+        num_float_features=num_float_features,
+        device=device,
+    )
+
+
+# single-rank runner
+def runner(
+    rank: int,
+    world_size: int,
+    run_option: RunOptions,
+) -> BenchmarkResult:
+    run_option.set_log_level()
+
+    num_stages = run_option.num_stages
+    ranks_per_stage = run_option.ranks_per_stage
+    assert world_size == num_stages * ranks_per_stage, (
+        f"world_size ({world_size}) must equal num_stages ({num_stages}) * "
+        f"ranks_per_stage ({ranks_per_stage})"
+    )
+
+    # CUDA uses nccl for the cross-HSD P2P hand-off (falls back to gloo for the
+    # CPU repro). The profiler path is CUDA-only, so traces require device_type=cuda.
+    backend = "cpu:gloo,cuda:nccl" if run_option.device_type == "cuda" else "gloo"
+    with MultiProcessContext(rank=rank, world_size=world_size, backend=backend) as ctx:
+        device = ctx.device
+        criterion = nn.MSELoss()
+
+        # HSD layout: contiguous rank groups, one stage per HSD.
+        stage_ranks: List[List[int]] = [
+            list(range(s * ranks_per_stage, (s + 1) * ranks_per_stage))
+            for s in range(num_stages)
+        ]
+
+        # Collective: every rank builds every stage's process group.
+        stage_pgs = build_stage_process_groups(stage_ranks)
+        # Build hand-off pgs up front (before any DMP sharding) so all new_group
+        # collectives stay contiguous and cannot deadlock against sharding comms.
+        handoff_pgs = build_handoff_process_groups(stage_ranks)
+        my_stage_index = rank // ranks_per_stage
+
+        # This rank's stage (weights seeded by stage index so an HSD's two DP
+        # ranks start identical -> grad all-reduce keeps them in lock-step).
+        tables = _make_tables(
+            my_stage_index,
+            run_option.num_tables,
+            run_option.num_embeddings,
+            run_option.emb_dim,
+        )
+        torch.manual_seed(_WEIGHT_SEED + my_stage_index)
+        module = MaglevTestStage(
+            tables=tables,
+            stage_dim=run_option.stage_dim,
+            is_first=(my_stage_index == 0),
+            num_float_features=run_option.num_float_features,
+            device=device,
+        )
+        parallelizer = (
+            EmbeddingShard(embedding_lr=run_option.lr)
+            if run_option.shard_embeddings
+            else Replicated()
+        )
+        stage = StageWrapper(
+            module=module,
+            stage_pg=stage_pgs[my_stage_index],
+            stage_index=my_stage_index,
+            parallelizer=parallelizer,
+        )
+        pipeline = MaglevPipeline(
+            stage=stage,
+            stage_ranks=stage_ranks,
+            global_rank=rank,
+            activation_shape=torch.Size([run_option.batch_size, run_option.stage_dim]),
+            device=device,
+            handoff_pgs=handoff_pgs,
+        )
+
+        # Sharded: CombinedOptimizer(fused embedding + dense SGD). Replicated:
+        # a plain SGD. (Citrine C2: foreach=True in the dense/replicated SGD.)
+        optimizer = stage.configure_optimizer(run_option.lr)
+
+        # Microbatch inputs for this rank's stage; labels only on the last stage.
+        micro_inputs: List[ModelInput] = [
+            _make_input(
+                tables,
+                run_option.batch_size,
+                run_option.num_float_features,
+                device,
+            )
+            for _ in range(run_option.num_microbatches)
+        ]
+        labels: List[torch.Tensor] = []
+        if pipeline.is_last:
+            labels = [
+                torch.randn(run_option.batch_size, run_option.stage_dim, device=device)
+                for _ in range(run_option.num_microbatches)
+            ]
+
+        def _func_to_benchmark(
+            bench_inputs: List[ModelInput],
+            pipeline: MaglevPipeline,
+            optimizer: torch.optim.Optimizer,
+            micro_inputs: List[ModelInput],
+            labels: List[torch.Tensor],
+            criterion: nn.Module,
+        ) -> None:
+            # One measured iteration = one full 1F1B pass over all microbatches
+            # (warmup + steady 1F1B + cooldown), including the cross-HSD hand-off
+            # and the per-batch DP grad all-reduce + optimizer step.
+            run_1f1b(
+                pipeline=pipeline,
+                microbatch_inputs=micro_inputs,
+                optimizer=optimizer,
+                labels=labels if pipeline.is_last else None,
+                criterion=criterion if pipeline.is_last else None,
+            )
+
+        result = benchmark_func(
+            bench_inputs=[],
+            prof_inputs=[],
+            func_to_benchmark=_func_to_benchmark,
+            benchmark_func_kwargs={
+                "pipeline": pipeline,
+                "optimizer": optimizer,
+                "micro_inputs": micro_inputs,
+                "labels": labels,
+                "criterion": criterion,
+            },
+            # One 1F1B pass consumes num_microbatches per-rank batches.
+            sample_count=run_option.batch_size * run_option.num_microbatches,
+            **run_option.benchmark_func_kwargs(rank=rank),
+        )
+
+        return result
+
+
+# a standalone function to run the benchmark in multi-process mode
+def run_maglev(run_option: RunOptions) -> BenchmarkResult:
+    benchmark_res_per_rank = run_multi_process_func(
+        func=runner,
+        world_size=run_option.world_size,
+        run_option=run_option,
+    )
+
+    # Combine results from all ranks: timing from rank 0, memory stats per rank.
+    world_size = run_option.world_size
+    total_benchmark_res = BenchmarkResult(
+        short_name=benchmark_res_per_rank[0].short_name,
+        gpu_elapsed_time=benchmark_res_per_rank[0].gpu_elapsed_time,
+        cpu_elapsed_time=benchmark_res_per_rank[0].cpu_elapsed_time,
+        cpu_utilization=benchmark_res_per_rank[0].cpu_utilization,
+        normalized_cpu_utilization=benchmark_res_per_rank[0].normalized_cpu_utilization,
+        gpu_mem_stats=[
+            GPUMemoryStats(rank, 0, 0, 0, 0, 0) for rank in range(world_size)
+        ],
+        cpu_mem_stats=[CPUMemoryStats(rank, 0) for rank in range(world_size)],
+        qps=benchmark_res_per_rank[0].qps,
+        rank=0,
+    )
+
+    for res in benchmark_res_per_rank:
+        # Each rank's BenchmarkResult carries at most 1 GPU and 1 CPU measurement.
+        if len(res.gpu_mem_stats) > 0:
+            total_benchmark_res.gpu_mem_stats[res.rank] = res.gpu_mem_stats[0]
+        if len(res.cpu_mem_stats) > 0:
+            total_benchmark_res.cpu_mem_stats[res.rank] = res.cpu_mem_stats[0]
+
+    return total_benchmark_res
+
+
+# command-line interface
+@cmd_conf
+def main(run_option: RunOptions) -> None:
+    result = run_maglev(run_option=run_option)
+
+    # Print from the parent process so the result is always visible (rank-0
+    # worker logging has no stream handler under the spawn pool).
+    if run_option.output_json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print(result.prettify())
+        print(f"\nMarkdown format:\n{result}")
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[not-callable]
+    main()

--- a/torchrec/distributed/maglev/__init__.py
+++ b/torchrec/distributed/maglev/__init__.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Maglev: staged, HSD-aligned recommender execution for TorchRec (MVP).
+
+This package holds the systems skeleton of Maglev:
+
+* :class:`~torchrec.distributed.maglev.module.MaglevModuleList` -- the
+  ``ModuleList``-like API where each entry is a stage.
+* :class:`~torchrec.distributed.maglev.stage.StageWrapper` -- binds a stage to
+  its process group (one hardware scale-up domain, HSD).
+* :class:`~torchrec.distributed.maglev.pipeline.MaglevPipeline` -- hooks the
+  stages together across HSDs (forward activation + backward gradient hand-off).
+
+Modeling components (Maglev Indexers / Induct) and the zero-bubble Maglev Rail
+schedule are intentionally out of scope for the MVP; the API leaves room for
+them to slot in later.
+"""
+
+from torchrec.distributed.maglev.module import MaglevModuleList
+from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
+from torchrec.distributed.maglev.stage import (
+    build_stage_process_groups,
+    EmbeddingShard,
+    Replicated,
+    StageParallelizer,
+    StageWrapper,
+)
+
+__all__ = [
+    "MaglevModuleList",
+    "MaglevPipeline",
+    "run_1f1b",
+    "StageWrapper",
+    "StageParallelizer",
+    "Replicated",
+    "EmbeddingShard",
+    "build_stage_process_groups",
+]

--- a/torchrec/distributed/maglev/module.py
+++ b/torchrec/distributed/maglev/module.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, List
+
+import torch
+import torch.nn as nn
+
+
+class MaglevModuleList(nn.ModuleList):
+    """An ordered ``ModuleList`` of Maglev stages that chains them in ``forward``.
+
+    ``forward`` runs the stages in order, threading each stage's output into the
+    next::
+
+        out_i = stage_i(stage_inputs[i], out_{i-1})   with   out_{-1} = None
+
+    This is the single-process reference execution -- the in-process analogue of
+    the pipeline-parallel ``MaglevPipeline`` (which runs only the stage a given
+    rank owns and transfers the activation across HSD boundaries). Both must
+    produce identical numerics; that equivalence is what the correctness test
+    checks. Container behavior (``len``, indexing, iteration) is inherited from
+    ``nn.ModuleList``.
+
+    Args:
+        stages: the ordered stage modules. Each stage's ``forward`` takes
+            ``(stage_input, prev_output)`` and returns its output activation
+            (``prev_output=None`` for the first stage).
+
+    Example::
+
+        model = MaglevModuleList([stage0, stage1])
+        out = model([stage_input0, stage_input1])
+    """
+
+    def __init__(self, stages: List[nn.Module]) -> None:
+        if len(stages) == 0:
+            raise ValueError("MaglevModuleList requires at least one stage")
+        super().__init__(stages)
+
+    def preproc(self, model_input: Any) -> List[Any]:
+        """Split the raw model input into one input per stage.
+
+        This is the seam where feature partitioning / indexing lives (the Maglev
+        Indexer). The MVP is a passthrough: ``model_input`` is already the list of
+        per-stage inputs. Runs under ``torch.no_grad()`` (see :meth:`forward`).
+
+        Args:
+            model_input: the raw batch to partition across stages.
+
+        Returns:
+            List[Any]: one input per stage, index-aligned with the stage list.
+        """
+        return model_input
+
+    def forward(self, model_input: Any) -> Any:
+        """Chain the stages, threading each stage's output into the next.
+
+        :meth:`preproc` (run under ``torch.no_grad()``) splits ``model_input``
+        into one input per stage; each stage's output feeds the next as
+        ``prev_output`` (``None`` for the first stage).
+
+        Args:
+            model_input: the raw batch; ``preproc`` partitions it into one input
+                per stage. Inputs may be of any (per-stage) type.
+
+        Returns:
+            Any: the last stage's output (e.g. the final prediction). The
+            inter-stage carrier type may differ from the final output type, so
+            both input and output are typed ``Any``.
+        """
+        with torch.no_grad():
+            stage_inputs = self.preproc(model_input)
+
+        if len(stage_inputs) != len(self):
+            raise ValueError(
+                f"expected {len(self)} stage inputs, got {len(stage_inputs)}"
+            )
+        prev_output: Any = None
+        for stage, stage_input in zip(self, stage_inputs):
+            prev_output = stage(stage_input, prev_output)
+        assert prev_output is not None  # guaranteed: at least one stage
+        return prev_output

--- a/torchrec/distributed/maglev/pipeline.py
+++ b/torchrec/distributed/maglev/pipeline.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Callable, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from torch.autograd.profiler import record_function
+from torchrec.distributed.maglev.stage import build_handoff_process_groups, StageWrapper
+
+LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+
+
+class MaglevPipeline:
+    """Drives a staged Maglev model across per-stage HSDs.
+
+    This is the pipeline-parallel analogue of the sequential loop in
+    ``WukongMaglev.forward`` (legokit/backbones/maglev_prototype.py): instead of
+    iterating stages in one process, each stage lives on a disjoint set of ranks
+    (its HSD) and the activation is handed between HSDs over the network.
+
+    A rank owns exactly one stage. The hand-off is **by position**: the rank at
+    position ``p`` in HSD ``i`` exchanges with the rank at position ``p`` in HSD
+    ``i ± 1``. Forward activations flow ``i -> i+1``; backward gradients flow
+    ``i+1 -> i``. The two ranks of an HSD are data-parallel lanes; gradients are
+    averaged across them (:meth:`StageWrapper.reduce_gradients`).
+
+    The hand-off runs over **two direction-split process groups** (``act_pg`` for
+    forward activations, ``grad_pg`` for backward gradients, built by
+    :func:`build_handoff_process_groups`) rather than P2P over the default (world)
+    group. A boundary's forward activation and backward gradient thus land on
+    *different* communicators (separate NCCL streams instead of serializing), and
+    each communicator carries a single flow direction (recv-then-send per rank,
+    never send-first). Both are separate from each stage's intra-HSD sharded
+    all-to-all; interleaving P2P with that on the world group deadlocks once the
+    stages are sharded with DMP. See
+    ``tech-docs/nccl_p2p_execution_order_buffer_size.md`` (sections 4-5).
+
+    Two drivers are provided:
+
+    * :meth:`step` -- a single-batch forward-then-backward pass (used by the
+      correctness test). Blocking send/recv form a matched wave; no deadlock.
+    * :meth:`forward_micro` / :meth:`backward_micro` + :func:`run_1f1b` -- a
+      microbatched 1F1B schedule (used by the benchmark). Activations are
+      received with blocking recv (strict dependency, forms a wave) and sent
+      with non-blocking isend whose completion is deferred to
+      :meth:`wait_sends`, which keeps the schedule deadlock-free.
+
+    Every comm (activation/gradient send+recv) and the forward/backward compute
+    is wrapped in a ``record_function`` range tagged with the microbatch id
+    (``## recv_act mb3 ##`` etc.), so profiler traces show which microbatch each
+    operation belongs to.
+
+    Args:
+        stage: this rank's :class:`StageWrapper`.
+        stage_ranks: ``stage_ranks[i]`` is the global ranks of stage ``i``'s HSD.
+            Every stage must have the same number of ranks (same position layout).
+        global_rank: this process's global rank.
+        activation_shape: shape of the activation handed between stages.
+        device: device the stage runs on.
+        dtype: dtype of the activation / gradient tensors.
+    """
+
+    def __init__(
+        self,
+        stage: StageWrapper,
+        stage_ranks: List[List[int]],
+        global_rank: int,
+        activation_shape: torch.Size,
+        device: torch.device,
+        dtype: torch.dtype = torch.float32,
+        handoff_pgs: Optional[Tuple[dist.ProcessGroup, dist.ProcessGroup]] = None,
+    ) -> None:
+        self.stage = stage
+        self.stage_ranks = stage_ranks
+        self.global_rank = global_rank
+        self.num_stages: int = len(stage_ranks)
+        self.activation_shape = activation_shape
+        self.device = device
+        self.dtype = dtype
+
+        # Locate this rank's stage and its position within that stage's HSD.
+        stage_index = -1
+        position = -1
+        for s_idx, ranks in enumerate(stage_ranks):
+            if global_rank in ranks:
+                stage_index = s_idx
+                position = ranks.index(global_rank)
+                break
+        if stage_index < 0:
+            raise ValueError(
+                f"rank {global_rank} not found in stage_ranks {stage_ranks}"
+            )
+        if stage_index != stage.stage_index:
+            raise ValueError(
+                f"rank {global_rank} owns stage {stage_index} but the StageWrapper "
+                f"is for stage {stage.stage_index}"
+            )
+        self.stage_index: int = stage_index
+        self.position: int = position
+
+        # Two direction-split P2P communicators (see build_handoff_process_groups):
+        # forward activations go on ``act_pg``, backward gradients on ``grad_pg``,
+        # so a boundary's two directions land on different communicators (separate
+        # streams) and each carries a single flow direction (recv-then-send, never
+        # send-first). When sharding, pass ``handoff_pgs`` built *before* any DMP so
+        # the two ``new_group`` collectives stay contiguous; otherwise built here.
+        if handoff_pgs is None:
+            handoff_pgs = build_handoff_process_groups(stage_ranks)
+        self._act_pg, self._grad_pg = handoff_pgs
+
+        # Per-direction pg for this stage: activations on act_pg, gradients on
+        # grad_pg (None where this stage has no neighbor on that side).
+        self._recv_act_pg: Optional[dist.ProcessGroup] = (
+            None if self.is_first else self._act_pg
+        )
+        self._send_act_pg: Optional[dist.ProcessGroup] = (
+            None if self.is_last else self._act_pg
+        )
+        self._recv_grad_pg: Optional[dist.ProcessGroup] = (
+            None if self.is_last else self._grad_pg
+        )
+        self._send_grad_pg: Optional[dist.ProcessGroup] = (
+            None if self.is_first else self._grad_pg
+        )
+
+        # 1F1B state: FIFO of in-flight microbatches (with their microbatch id,
+        # for profiler labels) and deferred send handles.
+        self._pending: List[
+            Tuple[Optional[torch.Tensor], torch.Tensor, Optional[torch.Tensor], int]
+        ] = []
+        # pyre-ignore[4]: dist work handle has no public type
+        self._send_work: List[Tuple[Any, torch.Tensor]] = []
+
+    @property
+    def is_first(self) -> bool:
+        return self.stage_index == 0
+
+    @property
+    def is_last(self) -> bool:
+        return self.stage_index == self.num_stages - 1
+
+    def _prev_rank(self) -> int:
+        """Global rank at this position in the previous HSD."""
+        return self.stage_ranks[self.stage_index - 1][self.position]
+
+    def _next_rank(self) -> int:
+        """Global rank at this position in the next HSD."""
+        return self.stage_ranks[self.stage_index + 1][self.position]
+
+    def _recv(
+        self, src: int, pg: dist.ProcessGroup, requires_grad: bool
+    ) -> torch.Tensor:
+        tensor = torch.empty(
+            self.activation_shape, device=self.device, dtype=self.dtype
+        )
+        dist.recv(tensor, src=src, group=pg)
+        if requires_grad:
+            # Make it a leaf that requires grad so backward yields its grad to
+            # hand back to the previous stage.
+            tensor.requires_grad_(True)
+        return tensor
+
+    def _isend(self, tensor: torch.Tensor, dst: int, pg: dist.ProcessGroup) -> None:
+        # Non-blocking send; the buffer is kept alive until wait_sends().
+        buf = tensor.detach().contiguous()
+        work = dist.isend(buf, dst=dst, group=pg)
+        self._send_work.append((work, buf))
+
+    def wait_sends(self) -> None:
+        """Complete all deferred non-blocking sends."""
+        for work, _buf in self._send_work:
+            work.wait()
+        self._send_work.clear()
+
+    # ---- single-batch driver (correctness) ----
+
+    def step(
+        self,
+        stage_input: Any,
+        optimizer: torch.optim.Optimizer,
+        label: Optional[torch.Tensor] = None,
+        criterion: Optional[LossFn] = None,
+    ) -> Optional[torch.Tensor]:
+        """Run one forward + backward + optimizer step for a single batch.
+
+        Returns the loss on the last stage, ``None`` on every other stage.
+        ``label`` and ``criterion`` are required on (and only used by) the last
+        stage.
+        """
+        optimizer.zero_grad()
+
+        prev_output: Optional[torch.Tensor] = None
+        if not self.is_first:
+            assert self._recv_act_pg is not None
+            with record_function("## recv_act mb0 ##"):
+                prev_output = self._recv(
+                    self._prev_rank(), self._recv_act_pg, requires_grad=True
+                )
+
+        with record_function("## forward mb0 ##"):
+            output = self.stage(stage_input, prev_output)
+
+        if not self.is_last:
+            assert self._send_act_pg is not None
+            with record_function("## send_act mb0 ##"):
+                dist.send(
+                    output.detach().contiguous(),
+                    dst=self._next_rank(),
+                    group=self._send_act_pg,
+                )
+
+        loss: Optional[torch.Tensor] = None
+        if self.is_last:
+            if criterion is None or label is None:
+                raise ValueError("last stage requires both `criterion` and `label`")
+            with record_function("## backward mb0 ##"):
+                loss = criterion(output, label)
+                loss.backward()
+        else:
+            assert self._recv_grad_pg is not None
+            grad_output = torch.empty(
+                output.shape, device=self.device, dtype=self.dtype
+            )
+            with record_function("## recv_grad mb0 ##"):
+                dist.recv(grad_output, src=self._next_rank(), group=self._recv_grad_pg)
+            with record_function("## backward mb0 ##"):
+                output.backward(grad_output)
+
+        if not self.is_first:
+            assert prev_output is not None and prev_output.grad is not None
+            assert self._send_grad_pg is not None
+            with record_function("## send_grad mb0 ##"):
+                dist.send(
+                    prev_output.grad.contiguous(),
+                    dst=self._prev_rank(),
+                    group=self._send_grad_pg,
+                )
+
+        self.stage.reduce_gradients()
+        optimizer.step()
+        return loss
+
+    # ---- microbatched 1F1B driver (benchmark) ----
+
+    def forward_micro(
+        self,
+        stage_input: Any,
+        label: Optional[torch.Tensor] = None,
+        microbatch_id: int = 0,
+    ) -> None:
+        """One microbatch forward: recv activation, compute, send activation.
+
+        ``microbatch_id`` tags the profiler ranges (and is carried on the pending
+        FIFO to the matching backward) so a trace shows which microbatch each
+        comm/compute belongs to.
+        """
+        prev_output: Optional[torch.Tensor] = None
+        if not self.is_first:
+            assert self._recv_act_pg is not None
+            with record_function(f"## recv_act mb{microbatch_id} ##"):
+                prev_output = self._recv(
+                    self._prev_rank(), self._recv_act_pg, requires_grad=True
+                )
+
+        with record_function(f"## forward mb{microbatch_id} ##"):
+            output = self.stage(stage_input, prev_output)
+
+        if not self.is_last:
+            assert self._send_act_pg is not None
+            with record_function(f"## send_act mb{microbatch_id} ##"):
+                self._isend(output, self._next_rank(), self._send_act_pg)
+
+        self._pending.append((prev_output, output, label, microbatch_id))
+
+    def backward_micro(
+        self, criterion: Optional[LossFn] = None
+    ) -> Optional[torch.Tensor]:
+        """One microbatch backward: recv grad, backward, send input grad.
+
+        Gradients accumulate across microbatches (no ``zero_grad`` here); the
+        caller runs the DP all-reduce and optimizer step once per batch. Profiler
+        ranges are tagged with the ``microbatch_id`` recorded at forward time.
+        """
+        prev_output, output, label, microbatch_id = self._pending.pop(0)
+
+        loss: Optional[torch.Tensor] = None
+        if self.is_last:
+            if criterion is None or label is None:
+                raise ValueError("last stage requires both `criterion` and `label`")
+            with record_function(f"## backward mb{microbatch_id} ##"):
+                loss = criterion(output, label)
+                loss.backward()
+        else:
+            assert self._recv_grad_pg is not None
+            grad_output = torch.empty(
+                output.shape, device=self.device, dtype=self.dtype
+            )
+            with record_function(f"## recv_grad mb{microbatch_id} ##"):
+                dist.recv(grad_output, src=self._next_rank(), group=self._recv_grad_pg)
+            with record_function(f"## backward mb{microbatch_id} ##"):
+                output.backward(grad_output)
+
+        if not self.is_first:
+            assert prev_output is not None and prev_output.grad is not None
+            assert self._send_grad_pg is not None
+            with record_function(f"## send_grad mb{microbatch_id} ##"):
+                self._isend(prev_output.grad, self._prev_rank(), self._send_grad_pg)
+
+        return loss
+
+
+def run_1f1b(
+    pipeline: MaglevPipeline,
+    microbatch_inputs: List[Any],
+    optimizer: torch.optim.Optimizer,
+    labels: Optional[List[torch.Tensor]] = None,
+    criterion: Optional[LossFn] = None,
+) -> List[float]:
+    """Run one 1F1B (one-forward-one-backward) pass over ``microbatch_inputs``.
+
+    Standard PipeDream-flush schedule: each stage runs ``num_warmup`` forwards,
+    then interleaves 1 forward / 1 backward in steady state, then drains the
+    remaining backwards in cooldown. ``num_warmup = num_stages - stage_index - 1``
+    (clamped to the microbatch count), so deeper stages warm up less and the
+    send/recv pairs line up across ranks.
+
+    Returns the per-microbatch losses observed on the last stage (empty on
+    other stages). Gradients are accumulated across all microbatches, then
+    DP-averaged and applied with a single optimizer step.
+    """
+    num_stages = pipeline.num_stages
+    num_micro = len(microbatch_inputs)
+    stage_index = pipeline.stage_index
+    num_warmup = min(num_stages - stage_index - 1, num_micro)
+    num_steady = num_micro - num_warmup
+
+    def _label(idx: int) -> Optional[torch.Tensor]:
+        return labels[idx] if labels is not None else None
+
+    optimizer.zero_grad()
+    losses: List[float] = []
+
+    fwd_idx = 0
+    bwd_idx = 0
+
+    # Warmup: fill the pipeline.
+    for _ in range(num_warmup):
+        pipeline.forward_micro(microbatch_inputs[fwd_idx], _label(fwd_idx), fwd_idx)
+        fwd_idx += 1
+
+    # Steady state: one forward, one backward.
+    for _ in range(num_steady):
+        pipeline.forward_micro(microbatch_inputs[fwd_idx], _label(fwd_idx), fwd_idx)
+        fwd_idx += 1
+        loss = pipeline.backward_micro(criterion)
+        bwd_idx += 1
+        if loss is not None:
+            losses.append(loss.item())
+
+    # Cooldown: drain remaining backwards.
+    for _ in range(num_warmup):
+        loss = pipeline.backward_micro(criterion)
+        bwd_idx += 1
+        if loss is not None:
+            losses.append(loss.item())
+
+    pipeline.wait_sends()
+    pipeline.stage.reduce_gradients()
+    optimizer.step()
+    return losses

--- a/torchrec/distributed/maglev/stage.py
+++ b/torchrec/distributed/maglev/stage.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+from typing import Any, cast, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
+from torchrec.optim.optimizers import in_backward_optimizer_filter
+
+
+def build_stage_process_groups(
+    stage_ranks: List[List[int]],
+) -> List[dist.ProcessGroup]:
+    """Create one process group per Maglev stage (one HSD each).
+
+    ``dist.new_group`` is a **collective**: every rank in the job must call it
+    for every stage, in the same order, even though a rank ends up owning only
+    one of the returned groups. Returns the list of stage process groups,
+    index-aligned with ``stage_ranks``.
+
+    Args:
+        stage_ranks: ``stage_ranks[i]`` is the list of global ranks that make up
+            stage ``i``'s HSD.
+    """
+    pgs: List[dist.ProcessGroup] = []
+    for ranks in stage_ranks:
+        # Collective across the whole job; returns a handle only ranks in
+        # ``ranks`` can actually communicate over. (``new_group`` is typed
+        # ProcessGroup | int | None; on member ranks it is a ProcessGroup.)
+        pg = cast(dist.ProcessGroup, dist.new_group(ranks=ranks))
+        pgs.append(pg)
+    return pgs
+
+
+def _remap_plan_to_pg_devices(
+    plan: ShardingPlan, stage_pg: dist.ProcessGroup, device: torch.device
+) -> None:
+    """Rewrite each shard's placement device to the sub-pg rank's actual device.
+
+    The planner builds the plan over a size-``N`` topology, so it emits
+    *group-local* ranks/devices: ``rank:0/cuda:0``, ``rank:1/cuda:1`` for a 2-rank
+    stage. But shard placements are interpreted against the *global* rank space
+    (DMP maps ``placement.rank()`` back through the pg, and the shard tensor lives
+    on the process's actual device). For a stage whose ranks are global ``{2,3}``
+    on ``cuda:{2,3}`` the group-local plan is wrong twice over -- rank 0 is not in
+    the pg, and the device is cuda:0 not cuda:2. Remap group-local rank ``r`` to
+    global rank ``g = get_global_rank(stage_pg, r)`` on ``cuda:{g % device_count}``
+    (single-host assumption). Deterministic given ``(plan, stage_pg)``, so every
+    rank in the pg produces the same result.
+    """
+    if device.type != "cuda":
+        return
+    device_count = torch.cuda.device_count()
+    for module_plan in plan.plan.values():
+        # ModuleShardingPlan is dict-like at runtime (param name -> ParameterSharding).
+        # pyrefly: ignore[missing-attribute]
+        for param_sharding in module_plan.values():
+            spec = getattr(param_sharding, "sharding_spec", None)
+            if spec is None:
+                continue
+            for shard in spec.shards:
+                g = dist.get_global_rank(stage_pg, shard.placement.rank())
+                dev = g % device_count if device_count else 0
+                shard.placement = torch.distributed._remote_device(
+                    f"rank:{g}/cuda:{dev}"
+                )
+
+
+def build_handoff_process_groups(
+    stage_ranks: List[List[int]],
+) -> Tuple[dist.ProcessGroup, dist.ProcessGroup]:
+    """Create the two direction-split P2P communicators for the pipeline hand-off.
+
+    Returns ``(act_pg, grad_pg)`` -- two full-membership NCCL communicators, split
+    by what they carry: ``act_pg`` for the forward activations (downstream,
+    ``i -> i+1``) and ``grad_pg`` for the backward gradients (upstream,
+    ``i+1 -> i``). Splitting the hand-off by direction puts a boundary's two
+    directions on *different* communicators, so they run on separate NCCL streams
+    instead of serializing on one; and each communicator carries a single flow
+    direction (each rank does recv-then-send on it, never send-first), which avoids
+    the symmetric send-first deadlock and the >64 MiB rendezvous hang that a shared
+    bidirectional communicator hits.
+
+    This mirrors ``torch.distributed.pipelining``'s optional per-direction split
+    (``pp_p2p_downstream`` / ``pp_p2p_upstream``); see the study in
+    ``tech-docs/nccl_p2p_execution_order_buffer_size.md`` (sections 4-5). Both
+    groups are separate from each stage's ``stage_pg`` (the intra-HSD sharded
+    all-to-all), so the P2P never interleaves with the sharding collectives.
+    ``dist.new_group`` is collective: every rank builds both groups in the same
+    order, up front (before any DMP sharding) so the ``new_group`` calls stay
+    contiguous.
+    """
+    all_ranks = sorted({r for ranks in stage_ranks for r in ranks})
+    act_pg = cast(dist.ProcessGroup, dist.new_group(ranks=all_ranks))
+    grad_pg = cast(dist.ProcessGroup, dist.new_group(ranks=all_ranks))
+    return act_pg, grad_pg
+
+
+def _all_reduce_dense(params: List[nn.Parameter], stage_pg: dist.ProcessGroup) -> None:
+    """DP-average the given params' grads across the HSD's ranks (once per step)."""
+    world_size = stage_pg.size()
+    if world_size == 1:
+        return
+    for param in params:
+        if param.grad is not None:
+            dist.all_reduce(param.grad, group=stage_pg)
+            param.grad /= world_size
+
+
+class StageParallelizer(abc.ABC):
+    """Strategy for mapping a stage module onto its HSD process group.
+
+    Encapsulates the three things that vary by parallelism scheme: how the module
+    is transformed (:meth:`parallelize`), how its optimizer is built
+    (:meth:`build_optimizer`), and how its gradients are reduced
+    (:meth:`reduce_gradients`).
+
+    **Invariant:** implementations must configure any data-parallelism so
+    gradients are NOT reduced during backward. The pipeline accumulates across
+    microbatches and reduces once, via :meth:`reduce_gradients`, after all
+    microbatch backwards (see ``run_1f1b``). This keeps the 1F1B schedule
+    decoupled from per-backward DP collectives.
+    """
+
+    @abc.abstractmethod
+    def parallelize(
+        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
+    ) -> nn.Module:
+        """Transform ``module`` for ``stage_pg`` (shard/wrap) and return it."""
+        ...
+
+    @abc.abstractmethod
+    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
+        """Build the optimizer for the parallelized ``module``."""
+        ...
+
+    @abc.abstractmethod
+    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
+        """Complete the once-per-step DP gradient reduction over ``stage_pg``."""
+        ...
+
+
+class Replicated(StageParallelizer):
+    """Full replica per rank; grads are DP-averaged over the HSD.
+
+    The numerics-transparent path the correctness test compares against a
+    single-process reference.
+
+    Example::
+
+        stage = StageWrapper(module, stage_pg, stage_index, Replicated())
+    """
+
+    def parallelize(
+        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
+    ) -> nn.Module:
+        return module
+
+    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
+        return torch.optim.SGD(module.parameters(), lr=lr, foreach=True)
+
+    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
+        _all_reduce_dense(list(module.parameters()), stage_pg)
+
+
+class EmbeddingShard(StageParallelizer):
+    """Shard the stage's ``EmbeddingBagCollection`` within its HSD via DMP.
+
+    The EBC tables are sharded over ``stage_pg`` (the lookup all-to-all stays
+    local to the HSD -- no global cross-HSD embedding exchange), and the embedding
+    optimizer is fused into the TBE backward (``apply_optimizer_in_backward``).
+    Dense params stay replicated and are DP-averaged by :meth:`reduce_gradients`;
+    ``init_data_parallel=False`` keeps them out of DDP so the pipeline's manual
+    1F1B backward drives them (the pipeline-safe dense-DP mode). See
+    :func:`_remap_plan_to_pg_devices` for the sub-pg placement fix.
+
+    Args:
+        embedding_lr: learning rate for the fused (in-backward) embedding
+            optimizer.
+
+    Example::
+
+        stage = StageWrapper(module, stage_pg, stage_index, EmbeddingShard())
+    """
+
+    def __init__(self, embedding_lr: float = 0.05) -> None:
+        self._embedding_lr = embedding_lr
+        # Dense (non-sharded) params to DP-average once per step.
+        self._dense_params: List[nn.Parameter] = []
+
+    def parallelize(
+        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
+    ) -> nn.Module:
+        sharders: List[ModuleSharder[nn.Module]] = [
+            cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder())
+        ]
+
+        # Fuse the embedding optimizer into the TBE backward *before* DMP so the
+        # sharder builds it into the kernel (sparse params train in backward).
+        emb_params = [
+            p
+            for m in module.modules()
+            if isinstance(m, EmbeddingBagCollection)
+            for p in m.parameters()
+        ]
+        if not emb_params:
+            raise ValueError(
+                "EmbeddingShard requires an EmbeddingBagCollection in the stage"
+            )
+        apply_optimizer_in_backward(
+            torch.optim.SGD, emb_params, {"lr": self._embedding_lr}
+        )
+
+        # Plan + shard scoped to this stage's HSD; the embedding all-to-all runs
+        # only over ``stage_pg`` (world_size == the HSD's rank count).
+        env = ShardingEnv.from_process_group(stage_pg)
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(world_size=stage_pg.size(), compute_device=device.type)
+        )
+        # NOTE: not planner.collective_plan(): it broadcasts from group-local rank
+        # 0 but passes it as a *global* broadcast src, which deadlocks for any
+        # stage whose pg does not contain global rank 0 (stages 1..N-1). Compute
+        # the plan on the pg's leader and broadcast with the correct global src.
+        if stage_pg.rank() == 0:
+            plan_holder: List[Optional[ShardingPlan]] = [planner.plan(module, sharders)]
+        else:
+            plan_holder = [None]
+        if stage_pg.size() > 1:
+            dist.broadcast_object_list(
+                plan_holder, src=dist.get_global_rank(stage_pg, 0), group=stage_pg
+            )
+        plan = plan_holder[0]
+        assert plan is not None
+        # The planner places shards on cuda:{group-local-rank}; remap to this
+        # stage's actual device ordinals (cuda:2/3 for stage 1, etc.).
+        _remap_plan_to_pg_devices(plan, stage_pg, device)
+        dmp = DistributedModelParallel(
+            module=module,
+            env=env,
+            device=device,
+            plan=plan,
+            sharders=sharders,
+            init_data_parallel=False,
+            init_parameters=False,
+        )
+        self._dense_params = [
+            p for _, p in in_backward_optimizer_filter(dmp.named_parameters())
+        ]
+        return dmp
+
+    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
+        dense_optim = KeyedOptimizerWrapper(
+            dict(in_backward_optimizer_filter(module.named_parameters())),
+            lambda params: torch.optim.SGD(params, lr=lr, foreach=True),
+        )
+        dmp = cast(DistributedModelParallel, module)
+        return CombinedOptimizer([dmp.fused_optimizer, dense_optim])
+
+    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
+        # Only the dense params need DP averaging; the sharded embedding grads are
+        # handled locally by the fused (in-backward) optimizer.
+        _all_reduce_dense(self._dense_params, stage_pg)
+
+
+class StageWrapper(nn.Module):
+    """Binds a Maglev stage module to its HSD process group via a parallelizer.
+
+    The :class:`StageParallelizer` decides how the stage is mapped onto
+    ``stage_pg`` -- replicated, embedding-sharded, etc. -- and owns optimizer
+    construction and the once-per-step gradient reduction. The wrapper itself is a
+    thin delegator, so new parallelism schemes (FSDP/TP on the dense sub-arch) are
+    added as new parallelizers without changing the wrapper or the pipeline.
+
+    Args:
+        module: the stage module, following the ``forward(stage_input,
+            prev_output)`` contract.
+        stage_pg: the process group for this stage's HSD.
+        stage_index: this stage's position in the pipeline.
+        parallelizer: the parallelization strategy. Defaults to
+            :class:`Replicated`.
+
+    Example::
+
+        stage = StageWrapper(module, stage_pg, stage_index, EmbeddingShard())
+        opt = stage.configure_optimizer(lr=0.05)
+    """
+
+    def __init__(
+        self,
+        module: nn.Module,
+        stage_pg: dist.ProcessGroup,
+        stage_index: int,
+        parallelizer: Optional[StageParallelizer] = None,
+    ) -> None:
+        super().__init__()
+        self._stage_pg: dist.ProcessGroup = stage_pg
+        self.stage_index: int = stage_index
+        self._parallelizer: StageParallelizer = parallelizer or Replicated()
+        device: torch.device = next(module.parameters()).device
+        self.module: nn.Module = self._parallelizer.parallelize(
+            module, stage_pg, device
+        )
+
+    @property
+    def stage_pg(self) -> dist.ProcessGroup:
+        return self._stage_pg
+
+    def forward(
+        self, stage_input: Any, prev_output: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Run the wrapped stage.
+
+        Args:
+            stage_input: this stage's own input (its feature partition).
+            prev_output: the previous stage's activation, or ``None`` for the
+                first stage.
+
+        Returns:
+            torch.Tensor: this stage's output activation.
+        """
+        return self.module(stage_input, prev_output)
+
+    def configure_optimizer(self, lr: float) -> torch.optim.Optimizer:
+        """Build the optimizer matching this stage's parallelizer."""
+        return self._parallelizer.build_optimizer(self.module, lr)
+
+    def reduce_gradients(self) -> None:
+        """Complete the once-per-step DP gradient reduction for this stage."""
+        self._parallelizer.reduce_gradients(self.module, self._stage_pg)

--- a/torchrec/distributed/maglev/tests/__init__.py
+++ b/torchrec/distributed/maglev/tests/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/distributed/maglev/tests/test_module.py
+++ b/torchrec/distributed/maglev/tests/test_module.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import random
+from typing import List
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.maglev.module import MaglevModuleList
+from torchrec.distributed.maglev.pipeline import MaglevPipeline
+from torchrec.distributed.maglev.stage import build_stage_process_groups, StageWrapper
+from torchrec.distributed.test_utils.model_input import ModelInput
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
+from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+_WEIGHT_SEED = 100
+_INPUT_SEED = 500
+_LABEL_SEED = 900
+
+
+def _make_tables(
+    stage_index: int,
+    num_tables: int,
+    num_embeddings: int,
+    emb_dim: int,
+) -> List[EmbeddingBagConfig]:
+    """This stage's feature partition: disjoint 1-feature tables, namespaced per stage."""
+    return EmbeddingTablesConfig(
+        num_unweighted_features=num_tables,
+        num_weighted_features=0,
+        embedding_feature_dim=emb_dim,
+        base_row_size=num_embeddings,
+    ).generate_tables(name_prefix=f"s{stage_index}_")[0]
+
+
+def _make_input(
+    tables: List[EmbeddingBagConfig],
+    batch_size: int,
+    num_float_features: int,
+    seed: int,
+    device: torch.device,
+) -> ModelInput:
+    """Deterministic ModelInput (float + sparse), identical on every rank.
+
+    ``ModelInput.generate`` draws from both the ``torch`` and ``random`` RNGs and
+    has no seed argument, so seed both here to make the inputs reproducible across
+    ranks (required for the distributed-vs-single-process comparison).
+    """
+    torch.manual_seed(seed)
+    random.seed(seed)
+    return ModelInput.generate(
+        batch_size=batch_size,
+        tables=tables,
+        weighted_tables=[],
+        num_float_features=num_float_features,
+        device=device,
+    )
+
+
+def _build_stage(
+    stage_index: int,
+    num_tables: int,
+    num_embeddings: int,
+    emb_dim: int,
+    num_float_features: int,
+    stage_dim: int,
+    device: torch.device,
+) -> MaglevTestStage:
+    """Build a stage with deterministic weights (seeded by stage index)."""
+    tables = _make_tables(stage_index, num_tables, num_embeddings, emb_dim)
+    torch.manual_seed(_WEIGHT_SEED + stage_index)
+    return MaglevTestStage(
+        tables=tables,
+        stage_dim=stage_dim,
+        is_first=(stage_index == 0),
+        num_float_features=num_float_features,
+        device=device,
+    )
+
+
+def _run_correctness(
+    rank: int,
+    world_size: int,
+    num_stages: int,
+    ranks_per_stage: int,
+    batch_size: int,
+    num_tables: int,
+    num_embeddings: int,
+    emb_dim: int,
+    num_float_features: int,
+    stage_dim: int,
+) -> None:
+    # CPU + gloo keeps the 8-rank repro portable (no 8-GPU requirement).
+    with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo"):
+        device = torch.device("cpu")
+        criterion = nn.MSELoss()
+
+        stage_ranks: List[List[int]] = [
+            list(range(s * ranks_per_stage, (s + 1) * ranks_per_stage))
+            for s in range(num_stages)
+        ]
+        # Collective: every rank builds every stage's process group.
+        stage_pgs = build_stage_process_groups(stage_ranks)
+        my_stage_index = rank // ranks_per_stage
+
+        # Deterministic per-stage inputs / label, identical on every rank (so the
+        # two DP lanes of an HSD see the same data and the DP all-reduce is an
+        # identity -- keeping the distributed grads exactly comparable to the
+        # single-process reference).
+        all_tables = [
+            _make_tables(s, num_tables, num_embeddings, emb_dim)
+            for s in range(num_stages)
+        ]
+        stage_inputs = [
+            _make_input(
+                all_tables[s], batch_size, num_float_features, _INPUT_SEED + s, device
+            )
+            for s in range(num_stages)
+        ]
+        torch.manual_seed(_LABEL_SEED)
+        label = torch.randn(batch_size, stage_dim, device=device)
+
+        # ---- distributed pipeline: forward + backward for this rank's stage ----
+        stage_module = _build_stage(
+            my_stage_index,
+            num_tables,
+            num_embeddings,
+            emb_dim,
+            num_float_features,
+            stage_dim,
+            device,
+        )
+        stage = StageWrapper(
+            module=stage_module,
+            stage_pg=stage_pgs[my_stage_index],
+            stage_index=my_stage_index,
+        )
+        pipeline = MaglevPipeline(
+            stage=stage,
+            stage_ranks=stage_ranks,
+            global_rank=rank,
+            activation_shape=torch.Size([batch_size, stage_dim]),
+            device=device,
+        )
+        # lr=0: weights are unchanged, grads remain populated for comparison.
+        optimizer = torch.optim.SGD(stage.parameters(), lr=0.0, foreach=True)
+        dist_loss = pipeline.step(
+            stage_input=stage_inputs[my_stage_index],
+            optimizer=optimizer,
+            label=label if pipeline.is_last else None,
+            criterion=criterion if pipeline.is_last else None,
+        )
+
+        # ---- single-process reference: the whole MaglevModuleList in-process ----
+        ref_stages: List[nn.Module] = [
+            _build_stage(
+                s,
+                num_tables,
+                num_embeddings,
+                emb_dim,
+                num_float_features,
+                stage_dim,
+                device,
+            )
+            for s in range(num_stages)
+        ]
+        ref_model = MaglevModuleList(ref_stages)
+        ref_out = ref_model(stage_inputs)
+        ref_loss = criterion(ref_out, label)
+        ref_loss.backward()
+
+        # 1. Last-stage loss matches the reference.
+        if pipeline.is_last:
+            assert dist_loss is not None
+            torch.testing.assert_close(dist_loss, ref_loss)
+
+        # 2. This stage's gradients (after DP all-reduce) match the reference
+        #    stage's gradients => forward + backward numerics of the pipeline
+        #    wrapper match the hand-written single-process model.
+        ref_params = dict(ref_stages[my_stage_index].named_parameters())
+        checked = 0
+        for name, param in stage.module.named_parameters():
+            assert param.grad is not None, f"no grad for {name}"
+            ref_grad = ref_params[name].grad
+            assert ref_grad is not None, f"no reference grad for {name}"
+            torch.testing.assert_close(param.grad, ref_grad)
+            checked += 1
+        assert checked > 0, "no parameters were checked"
+
+
+class MaglevPipelineTest(MultiProcessTestBase):
+    def test_pipeline_matches_single_process(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_correctness,
+            world_size=8,
+            num_stages=4,
+            ranks_per_stage=2,
+            batch_size=16,
+            num_tables=6,
+            num_embeddings=64,
+            emb_dim=8,
+            num_float_features=8,
+            stage_dim=12,
+        )

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -201,21 +201,23 @@ class EmbeddingTablesConfig:
 
     def generate_tables(
         self,
+        name_prefix: str = "",
     ) -> List[List[EmbeddingBagConfig]]:
         """
         Generate embedding bag configurations for both unweighted and weighted features.
 
         This function creates two lists of EmbeddingBagConfig objects:
-        1. Unweighted tables: Named as "table_{i}" with feature names "feature_{i}"
-        2. Weighted tables: Named as "weighted_table_{i}" with feature names "weighted_feature_{i}"
+        1. Unweighted tables: Named as "{name_prefix}table_{i}" with feature names "{name_prefix}feature_{i}"
+        2. Weighted tables: Named as "{name_prefix}weighted_table_{i}" with feature names "{name_prefix}weighted_feature_{i}"
 
         For both types, the number of embeddings scales with the feature index,
         calculated as max(i + 1, 100) * 1000.
 
         Args:
-            num_unweighted_features (int): Number of unweighted features to generate.
-            num_weighted_features (int): Number of weighted features to generate.
-            embedding_feature_dim (int): Dimension of the embedding vectors.
+            name_prefix (str): Prefix prepended to every generated table and feature
+                name. Defaults to "" (unchanged names). Pass a distinct prefix per
+                caller to get disjoint table/feature sets -- e.g. one partition per
+                pipeline stage.
 
         Returns:
             Tuple[List[EmbeddingBagConfig], List[EmbeddingBagConfig]]: A tuple containing
@@ -227,8 +229,8 @@ class EmbeddingTablesConfig:
             EmbeddingBagConfig(
                 num_embeddings=max(i + 1, 100) * self.base_row_size // 100,
                 embedding_dim=self.embedding_feature_dim,
-                name="table_" + str(i),
-                feature_names=["feature_" + str(i)],
+                name=name_prefix + "table_" + str(i),
+                feature_names=[name_prefix + "feature_" + str(i)],
                 data_type=self.table_data_type,
                 stash_weights=self.stash_weights,
             )
@@ -238,8 +240,8 @@ class EmbeddingTablesConfig:
             EmbeddingBagConfig(
                 num_embeddings=max(i + 1, 100) * self.base_row_size // 100,
                 embedding_dim=self.embedding_feature_dim,
-                name="weighted_table_" + str(i),
-                feature_names=["weighted_feature_" + str(i)],
+                name=name_prefix + "weighted_table_" + str(i),
+                feature_names=[name_prefix + "weighted_feature_" + str(i)],
                 data_type=self.table_data_type,
                 stash_weights=self.stash_weights,
             )

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -2964,3 +2964,129 @@ def _get_default_rtol_and_atol(
     actual_rtol, actual_atol = _DTYPE_PRECISIONS.get(actual.dtype, (0.0, 0.0))
     expected_rtol, expected_atol = _DTYPE_PRECISIONS.get(expected.dtype, (0.0, 0.0))
     return max(actual_rtol, expected_rtol), max(actual_atol, expected_atol)
+
+
+class MaglevScaledAdd(nn.Module):
+    """Per-feature scaled residual sum ``a * (1 + alpha) + b * (1 + beta)``.
+
+    Lightweight analogue of ``ScaledAdd`` in the Maglev reference
+    (legokit/backbones/maglev_prototype.py), used by :class:`MaglevTestStage` to
+    fold the previous stage's activation into the current stage.
+
+    Args:
+        dim: width of the per-element learned scales.
+        device: device to build the parameters on.
+
+    Example::
+
+        m = MaglevScaledAdd(8)
+        out = m(torch.randn(2, 8), torch.randn(2, 8))
+    """
+
+    def __init__(self, dim: int, device: Optional[torch.device] = None) -> None:
+        super().__init__()
+        self.alpha: nn.Parameter = nn.Parameter(torch.zeros(dim, device=device))
+        self.beta: nn.Parameter = nn.Parameter(torch.zeros(dim, device=device))
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        """Combine two tensors with per-element learned scales.
+
+        Args:
+            a: first operand.
+            b: second operand.
+
+        Returns:
+            torch.Tensor: ``a * (1 + alpha) + b * (1 + beta)``.
+        """
+        return a * (1 + self.alpha) + b * (1 + self.beta)
+
+
+class MaglevTestStage(nn.Module):
+    """One Maglev stage for tests and benchmarks.
+
+    A self-contained stage that owns its feature partition (sparse + dense) and
+    consumes a :class:`ModelInput`:
+
+    * ``ebc`` pools this stage's sparse features (``stage_input.idlist_features``)
+      into ``(B, sum(F_t * D_t))``; ``input_proj`` projects that to ``stage_dim``.
+      (Unsharded here; sharding within the HSD is a follow-up.)
+    * ``dense`` projects this stage's float features
+      (``stage_input.float_features``, ``(B, num_float_features)``) to
+      ``stage_dim`` and adds them in (disabled when ``num_float_features == 0``).
+    * non-first stages fold in the previous stage's activation via
+      :class:`MaglevScaledAdd` (the Induct-style residual hand-off),
+    * ``block`` is the stage's dense compute.
+
+    The first stage (``is_first=True``) takes no incoming activation. The output
+    is a ``(B, stage_dim)`` tensor -- the activation handed to the next stage.
+
+    Args:
+        tables: this stage's embedding tables (its sparse feature partition).
+        stage_dim: width of the stage activation carried between stages.
+        is_first: whether this is the first stage (no incoming activation).
+        num_float_features: width of this stage's float feature input. 0 disables
+            the dense path.
+        device: device to build the stage on.
+
+    Example::
+
+        from torchrec.distributed.test_utils.model_input import ModelInput
+
+        tables = [EmbeddingBagConfig(name="t", embedding_dim=8, num_embeddings=16,
+                                     feature_names=["f"])]
+        stage = MaglevTestStage(tables, stage_dim=12, is_first=True, num_float_features=4)
+        mi = ModelInput.generate(batch_size=2, tables=tables, weighted_tables=[],
+                                 num_float_features=4)
+        out = stage(mi, None)
+    """
+
+    def __init__(
+        self,
+        tables: List[EmbeddingBagConfig],
+        stage_dim: int,
+        is_first: bool,
+        num_float_features: int = 0,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self.is_first = is_first
+        self.ebc: EmbeddingBagCollection = EmbeddingBagCollection(
+            tables=tables, device=device
+        )
+        in_dim = sum(t.embedding_dim * len(t.feature_names) for t in tables)
+        self.input_proj: nn.Linear = nn.Linear(in_dim, stage_dim, device=device)
+        self.dense: Optional[nn.Linear] = (
+            nn.Linear(num_float_features, stage_dim, device=device)
+            if num_float_features > 0
+            else None
+        )
+        self.scaled_add: Optional[MaglevScaledAdd] = (
+            None if is_first else MaglevScaledAdd(stage_dim, device=device)
+        )
+        self.block: nn.Linear = nn.Linear(stage_dim, stage_dim, device=device)
+
+    def forward(
+        self,
+        stage_input: "ModelInput",
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Run this stage over its ``ModelInput`` and the previous activation.
+
+        Args:
+            stage_input: this stage's ``ModelInput`` (float + sparse features).
+            prev_output: the previous stage's ``(B, stage_dim)`` activation, or
+                ``None`` for the first stage.
+
+        Returns:
+            torch.Tensor: this stage's ``(B, stage_dim)`` output activation.
+        """
+        kjt = stage_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
+        pooled = self.ebc(kjt).values()  # (B, in_dim)
+        x = self.input_proj(pooled)  # (B, stage_dim)
+        if self.dense is not None:
+            x = x + self.dense(stage_input.float_features)  # add dense features
+        if not self.is_first:
+            assert prev_output is not None and self.scaled_add is not None
+            x = self.scaled_add(prev_output, x)
+        return torch.relu(self.block(x))


### PR DESCRIPTION
Summary:

# Maglev MVP: staged HSD pipeline + 1F1B benchmark

## 1. Context

Maglev decomposes a monolithic recommender into a sequence of **stages**, each bound to one hardware scale-up domain (HSD) and chained by pipeline parallelism, so feature interaction and embedding exchange stay local to a scale-up domain instead of going through a global all-to-all — the motivation for Maglev.

This diff builds the **systems skeleton** — the API and the pipeline mechanics: a staged model, per-stage process groups, and a microbatched 1F1B pipeline that hands the cross-stage activation peer-to-peer across HSD boundaries. The modeling components (Maglev Indexers / Induct) and the zero-bubble Maglev Rail schedule are deferred, with seams left to slot them in behind this API.

<img width="1722" height="686" alt="image" src="https://github.com/user-attachments/assets/273460fb-4261-45db-9da5-8c87d7f4a8f8" />

*Traditional ranking model (consolidated features, one HSD) vs. Maglev (Indexer disaggregates features across HSD 0–3; Induct carries the cross-stage residual).*

## 2. Approach

1. **`MaglevModuleList` — staged model + preproc seam.** An nn.ModuleList subclass that chains stages in forward (out_i = stage_i(input_i, out_{i-1}), with out_{-1} = None). It is the single-process reference the correctness test compares the distributed pipeline against. Stage input and output are typed Any, since the inter-stage carrier and the final prediction may differ. The `preproc` method — run under no-grad — is the seam where feature partitioning and indexing (the Indexer) will live; the MVP is a passthrough.
   - `preproc` converts a unified input batch into the per-stage input list — for when the dataloader emits a single dataclass rather than an already-partitioned list.
   - the stage output is currently a single tensor of fixed shape (known at model init), kept as-is for the MVP. Later we can recover the shape via torch.export (PT2 IR), or let the user declare it.

2. **`StageWrapper` + `StageParallelizer` — bind a stage to its HSD.** StageWrapper binds a stage module to its HSD process group via a StageParallelizer strategy that owns the module transform, the optimizer, and the once-per-step DP gradient reduction:
   - `Replicated` — full replica per rank; dense grads DP-averaged over the HSD. The numerics-transparent path the correctness test checks.
   - `EmbeddingShard` — shards the stage's EmbeddingBagCollection within its HSD via DMP scoped to the stage pg (the lookup all-to-all stays local to the HSD), fuses the embedding optimizer into the TBE backward, and keeps dense params out of DDP (init_data_parallel=False) so the 1F1B backward drives them (manual all-reduce once per step — the pipeline-safe dense-DP mode).
   - finer / more advanced per-stage sharding is deferred to a later effort.

3. **Process groups, built up front.** `build_stage_process_groups` creates the per-stage (HSD) groups; `build_handoff_process_groups` creates the two direction-split hand-off communicators — `act_pg` (forward activations, i→i+1) and `grad_pg` (backward gradients, i+1→i), both full-membership. All are built with collective new_group before any sharding so they cannot deadlock against the sharding collectives.
   - a stage's sparse and dense parts may want different sharding (under different process groups); also deferred.

4. **`MaglevPipeline` — drive the one stage a rank owns.** Transfers the activation forward (stage i to i+1) and the gradient backward (i+1 to i) by position, **split by direction**: activations go on `act_pg`, gradients on `grad_pg`. A boundary's two directions thus land on different communicators — separate NCCL streams instead of serializing on one — and each communicator carries a single flow direction (each rank does recv-then-send, never send-first), which avoids both the symmetric send-first deadlock and the >64 MiB rendezvous hang a shared bidirectional communicator would hit. This mirrors `torch.distributed.pipelining`'s optional per-direction split (`pp_p2p_downstream` / `pp_p2p_upstream`); see the NCCL P2P study, `tech-docs/nccl_p2p_execution_order_buffer_size.md`. Two drivers:
   - `step` — single-batch forward-then-backward, used by the correctness test.
   - 1F1B — `forward_micro` / `backward_micro` + `run_1f1b`, used by the benchmark: standard PipeDream-flush warmup / steady-1F1B / cooldown, grads accumulated across microbatches and DP-reduced once. Blocking recv + deferred non-blocking isend keep the schedule deadlock-free.

   Every comm and the forward/backward compute is wrapped in a record_function range tagged with the microbatch id so traces are readable.

<img width="2558" height="1146" alt="image" src="https://github.com/user-attachments/assets/097bcc92-4324-4794-aec0-4ee529a56ba5" />

*`MaglevModuleList` (single-process reference) → stage sharder / DMP → the sharded Maglev pipeline; the per-stage input list is fed per stage and position.*

### 2.1 Sub-pg sharding gotchas

Sharding a stage onto a group that excludes global rank 0 (stages 1..N-1) trips several TorchRec assumptions that rank 0 is in the group. Handled by: computing the plan on the group leader and broadcasting with the correct global source; init_parameters=False (each stage's DP ranks are seeded identically); building all process groups up front (so the hand-off collectives don't interleave with per-stage sharding collectives); and `_remap_plan_to_pg_devices`, which rewrites the planner's group-local shard placements to the sub-group's actual global ranks and devices (single-host assumption).

## 3. Benchmark

**Setup**

`benchmark_maglev.py` — GPU + nccl, 8 ranks / 4 stages / 2-per-stage, one full 1F1B pass timed via benchmark_func.

The benchmark feeds each stage its input directly and times one full 1F1B pass over the sharded pipeline; distributing the model input across stages is out of scope here and is covered in a follow-up (D113477459).


**Repro command** (OSS):

```
python -m torchrec.distributed.benchmark.benchmark_maglev --world_size=8 --num_stages=4 --ranks_per_stage=2 --batch_size=1024 --num_microbatches=8
```

**Validation**

The traces confirm the three mechanics the skeleton must get right:

1. **Intra-HSD embedding lookup** — [rank 0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) (mb7 forward + mb4 backward): the stage's sharded lookup keeps its input dist, output dist, and backward all-to-all within the stage's HSD.
<img width="2510" height="851" alt="image" src="https://github.com/user-attachments/assets/a8ba15df-a3de-4192-a8be-4d0f366e0603" />

2. **Cross-stage P2P hand-off** — [rank 3](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces): the activation (forward) and gradient (backward) transfer peer-to-peer between adjacent stages.
<img width="2506" height="867" alt="image" src="https://github.com/user-attachments/assets/d0fc25e4-98df-4bee-a66c-859c94ddb2f4" />

3. **1F1B execution order** — forward and backward microbatches interleave across the stages in 1F1B order.
<img width="1320" height="202" alt="image" src="https://github.com/user-attachments/assets/e3fc3aed-462d-46b1-a71e-44c280e7e92d" />

   Per-stage traces (position 0 of each stage):

|||
|--|--|
| [rank 0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces)<br><img width="4800" height="1708" alt="image" src="https://github.com/user-attachments/assets/ab6afe92-8069-4d38-af24-46e089bec1d1" />| [rank 2](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces)<br><img width="4942" height="1750" alt="image" src="https://github.com/user-attachments/assets/435f464d-3565-4659-b2d3-c67cb613a7a9" />|
| [rank 4](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces)<br><img width="4972" height="1870" alt="image" src="https://github.com/user-attachments/assets/ecf4d67d-33b5-444e-95b3-584a44a34e06" />| [rank 6](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces)<br><img width="2435" height="855" alt="image" src="https://github.com/user-attachments/assets/29e4b547-2ccc-448f-ab2b-7817e1e9f646" />|


**Traces** (per-stage HSD; all-rank traces on by default). Each cell links Perfetto (rank) and Perf Doctor (PD) for the two ranks of that HSD:
[maglev-mvp-traces.zip](https://github.com/user-attachments/files/30529332/maglev-mvp-traces.zip)

| Stage 0 (ranks 0,1) | Stage 1 (ranks 2,3) | Stage 2 (ranks 4,5) | Stage 3 (ranks 6,7) |
|--|--|--|--|
| [rank 0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) | [rank 2](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 3](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) | [rank 4](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 5](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) | [rank 6](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 7](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113175114/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |

## 4. Analysis

1. **What this de-risks.** The whole Maglev model–system co-design is expressible on today's TorchRec primitives: staged model authoring, per-stage embedding sharding scoped to a sub-pg, cross-HSD peer-to-peer hand-off, and a microbatched 1F1B schedule all compose in a single run — and the traces confirm the properties that matter (the embedding all-to-all stays inside the HSD; activations/gradients move only between adjacent stages; the pipeline stays busy). Numerically the distributed path is identical to the single-process reference (last-stage loss and every per-stage gradient), so the modeling work (Indexers / Induct) can build behind this API without re-opening the systems layer.

2. **Not zero-bubble yet.** The schedule is plain 1F1B, so warmup and cooldown bubbles remain — the idle (gray) regions in the traces. Removing them with an exact-synchronous zero-bubble schedule (Maglev Rail) is the main follow-up; this diff is the substrate it swaps `run_1f1b` out for.

3. **Optimizer-step semantics.** The fused embedding optimizer steps per microbatch while dense steps once per pass. That is fine for a throughput benchmark but is not exact training semantics; the two need reconciling before this drives real training.

4. **Correctness coverage gap.** The test gives both DP lanes of an HSD identical data, so the intra-HSD all-reduce is an identity — it pins down the pipeline + sub-pg sharding numerics, but not distinct-lane DP averaging. Extending the reference to average over two lanes closes the gap.

5. **Portability and scope.** GPU P2P of the cross-HSD activation needs nccl (gloo can't P2P CUDA tensors); `--device_type=cpu` is a portable gloo repro. The device remap assumes a single host (one CUDA device per global rank), so multi-host is untested. The change is additive — no existing public APIs are touched.

## 5. Changes

1. **module.py**: `MaglevModuleList` (nn.ModuleList subclass) with the chaining forward and the preproc partitioning seam.
2. **stage.py**: `StageWrapper`; the StageParallelizer strategy (Replicated, EmbeddingShard); build_stage_process_groups and build_handoff_process_groups (direction-split `act_pg` / `grad_pg`); _remap_plan_to_pg_devices.
3. **pipeline.py**: `MaglevPipeline` with the step driver and the 1F1B driver (forward_micro / backward_micro / run_1f1b); record_function trace ranges.
4. **benchmark_maglev.py**: RunOptions parsed by cmd_conf; a per-rank runner that builds the sharded per-stage model + pipeline and times one full 1F1B pass, launched with run_multi_process_func. Modeled on benchmark_train_pipeline.py. GPU + nccl by default; --device_type=cpu for a portable repro.
5. **test_model.py**: `MaglevTestStage` (EBC + dense + MaglevScaledAdd residual, is_first flag) and MaglevScaledAdd, reused by the test and the benchmark.
6. **test_module.py**: 8-rank correctness test (distributed pipeline vs single-process reference).

Differential Revision: D113175114


