### PR TITLE
[detailed][distributed] Study of NCCL P2P execution order and buffer size

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -896,6 +896,206 @@ def cuda_event_wait(
         )
 
 
+@dataclass
+class P2PConfig(CommsConfig):
+    """
+    run commands:
+    1. default: async isend + async irecv, everything on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_comms p2p_comm_buffer
+
+    2. larger buffer: sweep the transfer size to see the buffer-size effect
+    > python -m torchrec.distributed.benchmark.benchmark_comms p2p_comm_buffer \
+        --name=64mb \
+        --size_mb=64
+
+    use case:
+        probe NCCL point-to-point execution order and buffer-size sensitivity. Both
+        ranks send to and recv from each other on a single communicator (ctx.pg) with
+        everything on the main stream, but only rank 0 runs a heavy pre-comms compute
+        before firing, so rank 1 posts its send/recv early and idles until rank 0 catches
+        up -- the trace shows how NCCL orders the two matching transfers under that skew.
+        Both the send and the recv are async (isend/irecv), issued back-to-back on the
+        main stream and joined later via req.wait(), so the CPU posts both and the
+        following main-stream compute without blocking on either. Compare across --size_mb
+        to see the buffer-size effect: small (eager-protocol) payloads complete without the
+        peer's matching op posted yet, while large (rendezvous) payloads depend on the
+        execution order across ranks (all_rank_traces captures both ranks).
+    """
+
+    # point-to-point buffer size in MiB (float32 payload)
+    size_mb: float = 4
+    all_rank_traces: bool = True
+
+
+# bidirectional point-to-point exchange between 2 ranks
+@register_benchmark(P2PConfig)
+def p2p_comm_buffer(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    size_mb: float,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Rank 0 and rank 1 exchange a buffer: each sends a tensor filled with its own
+    rank id to the peer and receives the peer's. Only rank 0 runs a heavy
+    pre-comms compute, so the two ranks arrive at the P2P at different times.
+
+    One communicator (ctx.pg), everything on the main stream. The async send
+    (isend) and async recv (irecv) are issued back-to-back so they serialize on
+    the single communicator -- no concurrent multi-stream use of one communicator
+    (that corrupts its channel state -> illegal memory access). Both are async, so
+    the CPU posts them and the following main-stream compute without blocking; both
+    are joined later via req.wait().
+    """
+    assert ctx.world_size == 2, "p2p_comm_buffer requires exactly 2 ranks"
+    rank = ctx.rank
+    peer = 1 - rank
+    numel = max(1, int(size_mb * 1024 * 1024) // 4)
+
+    with record_function("## setup ##"):
+        # send buffer carries this rank's id; recv buffer starts at -1 so an
+        # incomplete transfer fails the peer-id validation below
+        send_buf = torch.full((numel,), float(rank), device=ctx.device)
+        recv_buf = torch.full((numel,), -1.0, device=ctx.device)
+
+    # NCCL brings up each P2P connection lazily on first use, via a two-sided
+    # handshake that exchanges the ring-buffer / IPC handles the sender writes into
+    # and the receiver drains -- no bytes move until it completes. If the symmetric
+    # isend/irecv below were the first use, both ranks would send first and each
+    # rank's setup would wait on the peer's not-yet-reached recv: a first-use cycle
+    # that hangs (size-independent -- it's connection setup, not bandwidth). One
+    # matched send/recv here brings a connection up first, which breaks the cycle
+    # (the peer's later isend then returns immediately, so it reaches the recv that
+    # completes the other direction) and the exchange below runs on an established
+    # link.
+    with record_function("## P2P comm lazy init ##"):
+        seed = torch.empty(1, device=ctx.device)
+        if rank == 0:
+            dist.recv(seed, src=peer, group=ctx.pg)  # 1->0
+        else:
+            dist.send(seed, dst=peer, group=ctx.pg)  # 1->0
+
+    # only rank 0 has heavy compute before firing, creating the arrival skew
+    if rank == 0:
+        with record_function("## pre-comms compute ##"):
+            _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## async send ##"):
+        send_req = dist.isend(send_buf, dst=peer, group=ctx.pg)
+
+    with record_function("## async recv ##"):
+        recv_req = dist.irecv(recv_buf, src=peer, group=ctx.pg)
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        assert send_req is not None and recv_req is not None
+        recv_req.wait()
+        send_req.wait()
+        checks = DeviceToHostTensorAwaitable(torch.all(recv_buf.to(torch.int) == peer))
+
+    with record_function("## post-comms compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
+@dataclass
+class P2PBatchConfig(CommsConfig):
+    """
+    run commands:
+    1. default: batched bidirectional P2P via batch_isend_irecv
+    > python -m torchrec.distributed.benchmark.benchmark_comms p2p_batch_comms
+
+    2. larger buffer: sweep the transfer size to see the buffer-size effect
+    > python -m torchrec.distributed.benchmark.benchmark_comms p2p_batch_comms \
+        --name=64mb \
+        --size_mb=64
+
+    use case:
+        2-rank bidirectional exchange of three buffers each way (two of size_mb, one of
+        half that -- 2 equal, 1 different), submitted together as one P2POp list of 3
+        isends + 3 irecvs through batch_isend_irecv, which wraps them all in a single
+        ncclGroupStart/End. Grouping makes the matching send/recv co-resident, so --
+        unlike the separate isend/irecv in p2p_comm_buffer -- it needs no manual seed and
+        no ordering trick: the first-use P2P connection is brought up inside the group.
+        Compare against p2p_comm_buffer to see the batched-vs-separate tradeoff, and sweep
+        --size_mb for the buffer-size effect (all_rank_traces captures both ranks).
+    """
+
+    # point-to-point buffer size in MiB (float32 payload)
+    size_mb: float = 4
+    all_rank_traces: bool = True
+
+
+# bidirectional point-to-point exchange between 2 ranks via batch_isend_irecv
+@register_benchmark(P2PBatchConfig)
+def p2p_batch_comms(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    size_mb: float,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Rank 0 and rank 1 exchange three buffers with a single batch_isend_irecv over
+    a P2POp list of 3 isends + 3 irecvs (two buffers of size_mb, one of half that
+    -- 2 equal, 1 different). batch_isend_irecv coalesces every op into one
+    ncclGroupStart/End, so all matching send/recv are co-resident and the first-use
+    P2P connection comes up inside the group -- no seed needed (cf. p2p_comm_buffer,
+    whose separate isend/irecv require a seeding send/recv). Only rank 0 runs a
+    heavy pre-comms compute, so the ranks reach the P2P skewed.
+    """
+    assert ctx.world_size == 2, "p2p_batch_comms requires exactly 2 ranks"
+    rank = ctx.rank
+    peer = 1 - rank
+    numel = max(1, int(size_mb * 1024 * 1024) // 4)
+    # 3 transfers each way: two of size_mb, one of half that (2 equal, 1 different)
+    sizes = [numel, numel, max(1, numel // 2)]
+
+    with record_function("## setup ##"):
+        # send buffers carry this rank's id; recv buffers start at -1 so an
+        # incomplete transfer fails the peer-id validation below
+        send_bufs = [torch.full((n,), float(rank), device=ctx.device) for n in sizes]
+        recv_bufs = [torch.full((n,), -1.0, device=ctx.device) for n in sizes]
+
+    # only rank 0 has heavy compute before firing, creating the arrival skew
+    if rank == 0:
+        with record_function("## pre-comms compute ##"):
+            _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## batch_isend_irecv ##"):
+        p2p_op_list = [
+            dist.P2POp(dist.isend, buf, peer, group=ctx.pg) for buf in send_bufs
+        ] + [dist.P2POp(dist.irecv, buf, peer, group=ctx.pg) for buf in recv_bufs]
+        reqs = dist.batch_isend_irecv(p2p_op_list)
+
+    with record_function("## irrelevant compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## wait and validate ##"):
+        for req in reqs:
+            req.wait()
+        checks = DeviceToHostTensorAwaitable(
+            torch.stack(
+                [torch.all(buf.to(torch.int) == peer) for buf in recv_bufs]
+            ).all()
+        )
+
+    with record_function("## post-comms compute ##"):
+        _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## assert ##"):
+        assert checks.item()
+
+
 if __name__ == "__main__":
     # pyrefly: ignore[missing-attribute]
     _cc.main()


### PR DESCRIPTION
Summary:
# Study of NCCL P2P Execution Order and Buffer Size

## TL;DR

- Point-to-point (P2P) send/recv is the backbone of pipeline parallelism (PP); this study uses micro-benchmarks to probe NCCL P2P behavior under execution-order skew and growing payload size.
- Investigates how the P2P exchange hangs, and how to avoid it.
- Reviews how existing libraries run the exchange, and explores overlapping the comms with compute.


## 1. Background

Point-to-point (P2P) send/recv is the backbone of pipeline parallelism (PP): the model is split into stages across devices, and adjacent stages hand tensors directly to one another. Under a 1F1B schedule each stage receives an activation from the previous stage and sends its output to the next on the forward pass, then receives a gradient from the next stage and sends one back to the previous on the backward pass — so every stage boundary is a bidirectional P2P link, driven in both directions each step.

<img width="1320" height="202" alt="image" src="https://github.com/user-attachments/assets/4c33ffaa-950e-4772-b7d7-91a94ba5e86e" />

*1F1B schedule: each stage recvs from the previous stage then sends to the next — in both the forward and backward pass — so every boundary is a bidirectional P2P link.*

A vanilla PP implementation by Claude caught our attention: it wraps recv → compute → send into a single functional block per microbatch — logically clean, but with a potential conflict in the P2P exchange:

<img width="3058" height="636" alt="image" src="https://github.com/user-attachments/assets/976282a9-39c2-49db-9f25-6f282be55dc4" />

For example, device-1 sends its forward mb-4 activation to device-2 and then receives the backward mb-1 gradient back, while device-2 sends backward mb-1 to device-1 and then receives forward mb-4 — so both sides *send first, then recv*.

Surprisingly, this does not hang. To understand the underlying NCCL / `torch.distributed` P2P behavior, the two benchmarks below reproduce it locally.

## 2. P2P communications

Standard NCCL P2P APIs (`dist.isend`, `dist.irecv`, `dist.batch_isend_irecv`) are serialized internally on a single communication stream per `ProcessGroup`. True concurrent P2P across multiple CUDA streams (e.g. for pipeline parallelism or ring-attention overlap) requires either multiple `ProcessGroup`s or PyTorch's newer SymmetricMemory ([pytorch#67158](https://github.com/pytorch/pytorch/issues/67158)).

Whether P2P is issued as async ops (`isend`/`irecv`) or as sync ops on a side stream, they all land on that single per-`ProcessGroup` stream, so adjacent send/recv serialize rather than overlap.

<img width="3664" height="762" alt="image" src="https://github.com/user-attachments/assets/32c2be7b-e3a9-408e-aab0-560afdd5504a" />

*Both ranks send first (neither is receiving yet), which looks like it should deadlock. In practice it doesn't: NCCL's internal buffer (64 MiB in this case) absorbs the send so it returns and the exchange still completes. Beyond that buffer size — or if the send/recv order is swapped — it hangs.*

**A first-use caveat.** On a connection's *first* use, a symmetric `isend`-then-`irecv` on both ranks hangs: NCCL sets up each P2P link lazily via a two-sided handshake, so if both ranks send first with no prior successful comm on that link, each waits on the peer's not-yet-posted recv — a first-use cycle. This is size-independent: it hangs even when the payload is far smaller than the buffer above.

An alternative is `batch_isend_irecv`: all operations in the list are treated as a single batch, so the relative ordering of sends vs. receives does not matter and cannot deadlock ([docs](https://docs.pytorch.org/docs/2.13/distributed.html#torch.distributed.distributed_c10d.batch_isend_irecv)). The coalesced batch also appears as a single op in the trace: individual transfers can't be waited on separately, only the batch as a whole — so the results are ready only once every op in it completes.

<img width="1606" height="948" alt="image" src="https://github.com/user-attachments/assets/eff56d15-2699-4567-8541-72d719c54088" />

*`batch_isend_irecv` fuses the whole list into one op: the user can only wait on the fused op as a whole, not on an individual transfer — a recv that finished early isn't observable until the fused op completes.*


## 3. Benchmark

Two micro-benchmarks reproduce the 2-rank P2P exchange so the behavior above shows up in a trace.

```bash
# separate async isend/irecv, seeded, swept over transfer size
python -m torchrec.distributed.benchmark.benchmark_comms \
    p2p_comm_buffer --name=<sz>MB --size_mb=<sz>

# 3 sends + 3 recvs via batch_isend_irecv(P2POp list)
python -m torchrec.distributed.benchmark.benchmark_comms \
    p2p_batch_comms --name=<sz>MB --size_mb=<sz>
```

Both run a bidirectional exchange on a single communicator. Rank 0 does a heavy pre-comms compute before firing while rank 1 does not (rank 0 is the straggler), so the two ranks reach the P2P at different times — the trace shows how NCCL orders the two matching transfers under that skew. Each rank fills its send tensor with its own rank id so we can validate the received data.

- **`p2p_comm_buffer`** — separate async isend + irecv, issued back-to-back so they serialize on the single communicator; `--size_mb` sets the per-transfer payload size.
- **`p2p_batch_comms`** — the same exchange, but 3 sends + 3 recvs (two payloads of size_mb, one of half that) submitted as one `P2POp` list through `batch_isend_irecv`; `--size_mb` sets the payload size.


Traces (2 GPUs) — Perfetto links per rank; full set (with Perf Doctor) in the [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D113044025). A link means the config passed; **hangs** means it failed.
[NCCL_P2P_Comms.zip](https://github.com/user-attachments/files/30513917/NCCL_P2P_Comms.zip)

| payload | `p2p_comm_buffer` (separate) | `p2p_batch_comms` (batched) |
|--|--|--|
| 20 MiB | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_20MB-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_20MB-rank1.json.gz&bucket=torchrec_benchmark_traces) | pass |
| 32 MiB | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_32MB-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_32MB-rank1.json.gz&bucket=torchrec_benchmark_traces) | pass |
| 64 MiB | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_64MB-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_comm_buffer_64MB-rank1.json.gz&bucket=torchrec_benchmark_traces) | pass |
| 65 MiB | **hangs** (no trace) | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_batch_comms_65MB-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_batch_comms_65MB-rank1.json.gz&bucket=torchrec_benchmark_traces) |
| 128 MiB | n/a | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_batch_comms_128MB-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113044025/trace-p2p_batch_comms_128MB-rank1.json.gz&bucket=torchrec_benchmark_traces) |


Separate `isend`/`irecv` breaks somewhere between 64 MiB and 65 MiB. `batch_isend_irecv` coalesces the whole `P2POp` list into one `ncclGroupStart/End`, which makes matching send/recv co-resident — so it needs **no seed** and clears the 64→65 MiB cliff, scaling past it to 128 MiB.


## 4. How real pipeline frameworks handle P2P

The benchmark mirrors the cross-stage hand-off in pipeline parallelism. The real question a production framework answers is how to run this 2-way exchange without hanging — order the ops so no send waits on an unposted recv.

<img width="1888" height="654" alt="image" src="https://github.com/user-attachments/assets/e64e281f-3b5b-4e05-9820-9694bb3adbcb" />

*Both stages fire the cross-stage send/recv as one batch_isend_irecv between their forward and backward compute blocks, at the same step — so the two ranks' batches match. The exchange runs as a distinct phase, not overlapped with compute.*

**torch.distributed.pipelining** (in caffe2/torch/distributed/pipelining) uses a single shared process group for all stages (defaults to the world/default pg), addresses peers by global rank, and routes every cross-stage transfer through `batch_isend_irecv` over P2POp lists. An optional per-direction split (`p2p_per_direction`, default off) adds two full-membership communicators — pp_p2p_downstream for activations, pp_p2p_upstream for gradients — shared by all stages, never per-adjacent-pair. Ordering is enforced by the schedule, not by separate groups:

1. Each recv is generated paired with the producer's send, so both ranks post compatible ops — "we let a sender on another rank put our recv ops in place… to ensure a non-hanging ordering."
2. A recv is waited right before the compute that consumes it; a send is issued after the producing compute and deferred to fuse with the next batch.
3. Opposite directions between a stage pair are fused into one batched group — the 1F1B steady state fires forward-sends with backward-recvs, then backward-sends with forward-recvs, as mixed batches. The neighbor builds the mirror batch, so NCCL matches them without a FIFO cycle.

This is the same principle p2p_batch_comms exercises: co-locating opposing send/recv in one batched op lets NCCL pair them directly, so no send waits on an unposted recv.

<!-- maglev run_1f1b comparison to be added -->

**Megatron** (vendored under xlformers) also uses a single pipeline-model-parallel group spanning all stages, with next-rank / prev-rank helpers picking the adjacent peer. It offers two paths:

- **Batched** (the default) — like pipelining, opposing send/recv go through a single `batch_isend_irecv`.
- **Non-batched** — individual isend / irecv, ordered by rank parity to sidestep the symmetric send-first deadlock: even ranks send-then-recv, odd ranks recv-then-send. No neighbor pair both sends first, so no FIFO cycle forms and no send waits on an unposted recv. (A ring-exchange path also exists.)

The common thread is how each keeps the bidirectional exchange from hanging: no send ever waits on a recv that has not been posted. Two ways to get there — fuse the opposing ops into one batched call (pipelining, and Megatron's default), or order send/recv by rank parity so one side recvs first (Megatron's non-batched path).

### Overlapping the P2P with compute

Ideally the cross-stage transfer would run alongside stage compute so it is hidden:

<img width="2074" height="474" alt="image" src="https://github.com/user-attachments/assets/aa17b271-be43-4863-9b9a-30bc26fb67ae" />

*Each stage issues the recv for its next microbatch and the send of its current output alongside ongoing compute, so the P2P transfers overlap the fwd/bwd work rather than stall it.*

Neither framework does this for the cross-stage P2P, though: each `batch_isend_irecv` is waited immediately — right before the compute that consumes its recv — so the exchange runs as its own phase and comm and compute alternate rather than overlap.

Because the exchange is not hidden, its placement and ordering matter:

<img width="1914" height="770" alt="image" src="https://github.com/user-attachments/assets/ab262ac4-9e25-4e53-8128-14a99a8a7ec9" />

*Comms run on a side stream and the two stages stagger their send/recv (device-1 send-then-recv, device-2 recv-then-send). The recv still sits on the critical path — the consuming compute cannot start until it lands, so the recv is exposed. That is why the send/recv order matters.*

Whether the comms can be hidden at all depends on how evenly the stages finish. If every stage aligns perfectly — each rank finishing its compute at the same instant — the exchange lands squarely on the critical path with no idle compute to overlap it, so the comms are fully exposed. In practice stages rarely finish together; the skew between a faster and a slower rank leaves room to slip the transfer under the straggler's compute — the faster rank posts its send ahead, the slower rank picks it up when ready, and the staggered order lets the slower rank reach its next compute sooner ("slower rank can start quicker" in the figure).


## Discussion

The exposure above is schedulable. When we know which rank or stage tends to run faster, we can order the send/recv pair deliberately so the exchange waits on the straggler instead of the quicker rank — otherwise the P2P easily blocks the faster rank on the slower one.

A more aggressive option is to split the exchange across multiple process groups, so opposing send/recv pairs land on distinct communicators and streams instead of serializing on one — then only genuinely dependent ops block each other, and independent transfers run concurrently. This can be done in two levels:

- `odd_to_even` / `even_to_odd` — put send and recv on different PGs (streams) so the two directions issue in parallel instead of blocking each other.
- `act_odd_even`, `act_even_odd`, `grad_odd_even`, `grad_even_odd` — further split by upstream vs downstream neighbor, so a delayed neighbor on one side does not stall the exchange with the other.

The cost is the extra process groups: each is its own NCCL communicator with its own buffers and setup. Per-communicator memory is dominated by `NCCL_BUFFSIZE` (default 4 MiB) × channel count × number of connections — on the order of tens of MiB of GPU memory per communicator — plus a collective handshake at creation.

Reviewed By: malaybag

Differential Revision: D113044025


