### PR TITLE
[detailed][maglev] bake input_dist into the maglev benchmark pipeline

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_maglev.py
+++ b/torchrec/distributed/benchmark/benchmark_maglev.py
@@ -13,11 +13,19 @@ Benchmark for the Maglev staged pipeline (MVP).
 Measures the microbatched 1F1B schedule
 (:func:`~torchrec.distributed.maglev.pipeline.run_1f1b`) of a K-stage Maglev
 model across per-stage process groups (one hardware scale-up domain, HSD, each),
-including the cross-HSD activation / gradient hand-off. Each stage is an
-``EmbeddingBagCollection`` feature partition plus dense compute
+including the input distribution and the cross-HSD activation / gradient
+hand-off. Each stage is an ``EmbeddingBagCollection`` feature partition plus
+dense compute
 (:class:`~torchrec.distributed.test_utils.test_model.MaglevTestStage`, shared
-with the correctness test). One measured iteration is one full 1F1B pass over
-``num_microbatches`` microbatches.
+with the correctness test).
+
+Input distribution: every rank holds a full per-stage input set and all-to-alls
+it over its "cascade" (one rank per stage) via
+:func:`~torchrec.distributed.maglev.input_dist.input_dist`, so each rank ends up
+with ``num_stages`` microbatches for its own stage. A queue driver decouples the
+microbatch count from the stage count (more microbatches -> several rounds per
+pass; fewer -> drained a pass at a time). One measured iteration is this
+input-dist plus one full 1F1B pass over ``num_microbatches`` microbatches.
 
 Runs on GPU + nccl by default (the cross-HSD P2P hand-off and the profiler path
 are CUDA-only); `all_rank_traces` defaults on so every stage's HSD shows up in
@@ -41,6 +49,7 @@ from typing import List
 logger: logging.Logger = logging.getLogger(__name__)
 
 import torch
+import torch.distributed as dist
 from torch import nn
 from torchrec.distributed.benchmark.base import (
     BenchFuncConfig,
@@ -50,8 +59,10 @@ from torchrec.distributed.benchmark.base import (
     CPUMemoryStats,
     GPUMemoryStats,
 )
+from torchrec.distributed.maglev.input_dist import input_dist
 from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
 from torchrec.distributed.maglev.stage import (
+    build_cascade_process_groups,
     build_handoff_process_groups,
     build_stage_process_groups,
     EmbeddingShard,
@@ -183,6 +194,62 @@ def _make_input(
     )
 
 
+class _InputDistDriver:
+    """Feeds the 1F1B schedule with microbatches produced by ``input_dist``.
+
+    Each rank holds a *full set* of inputs (one ``ModelInput`` per stage); one
+    :func:`input_dist` round over the rank's cascade all-to-alls that set so the
+    rank receives ``num_stages`` inputs for its own stage -- i.e. ``num_stages``
+    microbatches per round. :meth:`take` refills a FIFO queue with whole rounds
+    until it holds at least ``n`` microbatches, then hands back ``n`` and keeps
+    the remainder, decoupling the microbatch count from the stage count:
+
+    * more microbatches than stages (e.g. 8 wanted, 4 stages) -> 2 rounds/pass;
+    * fewer (e.g. 8 wanted, 16 stages) -> one round every other pass, drained
+      ``n`` at a time from the queue.
+
+    The refill count is a deterministic function of ``(queue length, n)`` and the
+    queue starts empty on every rank, so all ranks in a cascade call
+    :func:`input_dist` the same number of times and stay in lock-step.
+
+    Args:
+        send: this rank's full input set; ``send[s]`` is destined for stage ``s``.
+        example: template carrier for reconstruction (a local-stage ModelInput).
+        cascade_pg: the cascade process group (size == num stages) to exchange over.
+    """
+
+    def __init__(
+        self,
+        send: List[ModelInput],
+        example: ModelInput,
+        cascade_pg: dist.ProcessGroup,
+    ) -> None:
+        self._send = send
+        self._example = example
+        self._pg = cascade_pg
+        self._queue: List[ModelInput] = []
+        # Monotonic input-dist round counter, tags the profiler ranges.
+        self._batch_id = 0
+
+    def take(self, n: int) -> List[ModelInput]:
+        while len(self._queue) < n:
+            # Same handle drives both phases: CPU/gloo sizes, CUDA/nccl data.
+            # input_dist returns a LazyAwaitable; wait() completes the exchange.
+            self._queue.extend(
+                input_dist(
+                    self._send,
+                    self._example,
+                    pg_gloo=self._pg,
+                    pg_nccl=self._pg,
+                    batch_id=self._batch_id,
+                ).wait()
+            )
+            self._batch_id += 1
+        out = self._queue[:n]
+        self._queue = self._queue[n:]
+        return out
+
+
 # single-rank runner
 def runner(
     rank: int,
@@ -213,19 +280,30 @@ def runner(
 
         # Collective: every rank builds every stage's process group.
         stage_pgs = build_stage_process_groups(stage_ranks)
-        # Build hand-off pgs up front (before any DMP sharding) so all new_group
-        # collectives stay contiguous and cannot deadlock against sharding comms.
+        # Build hand-off + cascade pgs up front (before any DMP sharding) so all
+        # new_group collectives stay contiguous and cannot deadlock against
+        # sharding comms. Cascade pgs (one rank per stage) carry the input-dist
+        # all-to-all; every rank builds all of them in the same order.
         handoff_pgs = build_handoff_process_groups(stage_ranks)
+        cascade_pgs = build_cascade_process_groups(stage_ranks)
         my_stage_index = rank // ranks_per_stage
+        position = rank - my_stage_index * ranks_per_stage
+        cascade_pg = cascade_pgs[position]
 
+        # All stages' table configs (identical on every rank) so each rank can
+        # generate a full per-stage input set for the input-dist all-to-all.
+        all_tables = [
+            _make_tables(
+                s,
+                run_option.num_tables,
+                run_option.num_embeddings,
+                run_option.emb_dim,
+            )
+            for s in range(num_stages)
+        ]
         # This rank's stage (weights seeded by stage index so an HSD's two DP
         # ranks start identical -> grad all-reduce keeps them in lock-step).
-        tables = _make_tables(
-            my_stage_index,
-            run_option.num_tables,
-            run_option.num_embeddings,
-            run_option.emb_dim,
-        )
+        tables = all_tables[my_stage_index]
         torch.manual_seed(_WEIGHT_SEED + my_stage_index)
         module = MaglevTestStage(
             tables=tables,
@@ -258,16 +336,27 @@ def runner(
         # a plain SGD. (Citrine C2: foreach=True in the dense/replicated SGD.)
         optimizer = stage.configure_optimizer(run_option.lr)
 
-        # Microbatch inputs for this rank's stage; labels only on the last stage.
-        micro_inputs: List[ModelInput] = [
+        # Full per-stage input set for this rank (send[s] is destined for stage
+        # s's rank in the cascade). Generated once, outside the measured region --
+        # data loading is not what we benchmark; the input-dist all-to-all itself
+        # runs inside _func_to_benchmark via the driver.
+        send_set: List[ModelInput] = [
             _make_input(
-                tables,
+                all_tables[s],
                 run_option.batch_size,
                 run_option.num_float_features,
                 device,
             )
-            for _ in range(run_option.num_microbatches)
+            for s in range(num_stages)
         ]
+        # Reconstruction template: a local-stage input (== the item this rank
+        # sends to itself at cascade index my_stage_index).
+        driver = _InputDistDriver(
+            send=send_set,
+            example=send_set[my_stage_index],
+            cascade_pg=cascade_pg,
+        )
+
         labels: List[torch.Tensor] = []
         if pipeline.is_last:
             labels = [
@@ -279,13 +368,16 @@ def runner(
             bench_inputs: List[ModelInput],
             pipeline: MaglevPipeline,
             optimizer: torch.optim.Optimizer,
-            micro_inputs: List[ModelInput],
+            driver: _InputDistDriver,
+            num_microbatches: int,
             labels: List[torch.Tensor],
             criterion: nn.Module,
         ) -> None:
-            # One measured iteration = one full 1F1B pass over all microbatches
+            # One measured iteration = the input-dist all-to-all for this pass's
+            # microbatches (refilling the queue as needed) + one full 1F1B pass
             # (warmup + steady 1F1B + cooldown), including the cross-HSD hand-off
             # and the per-batch DP grad all-reduce + optimizer step.
+            micro_inputs = driver.take(num_microbatches)
             run_1f1b(
                 pipeline=pipeline,
                 microbatch_inputs=micro_inputs,
@@ -301,7 +393,8 @@ def runner(
             benchmark_func_kwargs={
                 "pipeline": pipeline,
                 "optimizer": optimizer,
-                "micro_inputs": micro_inputs,
+                "driver": driver,
+                "num_microbatches": run_option.num_microbatches,
                 "labels": labels,
                 "criterion": criterion,
             },

--- a/torchrec/distributed/maglev/input_dist.py
+++ b/torchrec/distributed/maglev/input_dist.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Flatten structured data to a list of tensors, rebuild it, and all-to-all it.
+
+Used to move structured cross-stage "carriers" across HSD boundaries. A carrier
+(dataclass of tensors / ``KeyedJaggedTensor`` / nested containers) is flattened to
+a flat list of tensors on the sender and rebuilt on the receiver from a known
+*example* (template) instance. Only tensors cross the wire; every non-tensor part
+-- dataclass field values that are scalars/strings, container shapes, dict keys,
+and a ``KeyedJaggedTensor``'s feature keys -- is supplied by the example.
+
+Supported structure: ``torch.Tensor``, ``KeyedJaggedTensor``, dataclasses, and
+nested ``list`` / ``tuple`` / ``dict``; any other value is a non-tensor leaf
+(carried by the example, not transferred).
+
+On top of flatten/unflatten this module provides a two-phase all-to-all of a list
+of carriers (:func:`input_dist`): :func:`input_size_dist` exchanges the small
+tensor-size metadata over a cheap CPU/gloo group, then :func:`input_data_dist`
+moves the bulk tensors over an nccl group with the sizes learned in phase one.
+Both phases issue their collectives with ``async_op=True`` and return a
+:class:`~torchrec.distributed.types.LazyAwaitable`, so the caller can overlap
+other work and ``wait()`` only when the result is needed.
+"""
+
+import math
+from dataclasses import fields, is_dataclass
+from typing import Any, Dict, Iterator, List, Tuple, TypeVar
+
+import torch
+import torch.distributed as dist
+from torch.autograd.profiler import record_function
+from torchrec.distributed.types import LazyAwaitable
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+T = TypeVar("T")
+
+
+def _kjt_tensor_fields(kjt: KeyedJaggedTensor) -> List[Tuple[str, torch.Tensor]]:
+    """The KJT's tensor members in a fixed order: values, [weights], lengths|offsets.
+
+    A KJT always has values and exactly one length representation (lengths *or*
+    offsets); weights are present only for weighted features. Flatten and rebuild
+    use this same order so they line up.
+    """
+    out: List[Tuple[str, torch.Tensor]] = [("values", kjt.values())]
+    weights = kjt.weights_or_none()
+    if weights is not None:
+        out.append(("weights", weights))
+    lengths = kjt.lengths_or_none()
+    if lengths is not None:
+        out.append(("lengths", lengths))
+    else:
+        out.append(("offsets", kjt.offsets()))
+    return out
+
+
+def flatten_to_tensors(obj: Any) -> List[torch.Tensor]:
+    """Collect every tensor in ``obj`` into a flat list (deterministic DFS order).
+
+    Recurses through dataclasses, lists/tuples, and dicts (in field / iteration /
+    key order), and expands each ``KeyedJaggedTensor`` into its tensor members
+    (see :func:`_kjt_tensor_fields`). Non-tensor leaves are ignored.
+
+    Args:
+        obj: the structured value to flatten.
+
+    Returns:
+        List[torch.Tensor]: the tensors, in the order a matching ``example`` is
+        walked by :func:`unflatten_from_tensors`.
+    """
+    out: List[torch.Tensor] = []
+    _flatten(obj, out)
+    return out
+
+
+def _flatten(obj: Any, out: List[torch.Tensor]) -> None:
+    if isinstance(obj, torch.Tensor):
+        out.append(obj)
+    elif isinstance(obj, KeyedJaggedTensor):
+        for _name, tensor in _kjt_tensor_fields(obj):
+            out.append(tensor)
+    elif is_dataclass(obj) and not isinstance(obj, type):
+        for f in fields(obj):
+            _flatten(getattr(obj, f.name), out)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            _flatten(item, out)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            _flatten(value, out)
+    # else: non-tensor leaf -> nothing to collect.
+
+
+def unflatten_from_tensors(tensors: List[torch.Tensor], example: T) -> T:
+    """Rebuild a value shaped like ``example`` from a flat list of tensors.
+
+    ``tensors`` must be in the order :func:`flatten_to_tensors` produces for a
+    value with the same structure as ``example``. Tensor (and KJT) slots are
+    filled from ``tensors`` in order; every non-tensor part is copied from
+    ``example``. Assumes dataclasses are constructible from their fields as
+    keyword arguments.
+
+    Args:
+        tensors: the flattened tensors (e.g. received over the wire).
+        example: a template instance defining the structure and non-tensor
+            values.
+
+    Returns:
+        A new value of the same type/structure as ``example``.
+
+    Raises:
+        ValueError: if ``tensors`` has too few or too many tensors for
+            ``example``.
+    """
+    it = iter(tensors)
+    result: T = _unflatten(example, it)
+    remaining = sum(1 for _ in it)
+    if remaining:
+        raise ValueError(
+            f"too many tensors for the example: {len(tensors)} given, "
+            f"{len(tensors) - remaining} used"
+        )
+    return result
+
+
+def _unflatten(example: Any, it: Iterator[torch.Tensor]) -> Any:
+    if isinstance(example, torch.Tensor):
+        return _next(it)
+    if isinstance(example, KeyedJaggedTensor):
+        return _rebuild_kjt(example, it)
+    if is_dataclass(example) and not isinstance(example, type):
+        kwargs = {
+            f.name: _unflatten(getattr(example, f.name), it) for f in fields(example)
+        }
+        return type(example)(**kwargs)
+    if isinstance(example, tuple):
+        values = [_unflatten(item, it) for item in example]
+        # Preserve namedtuple type (constructed positionally) vs plain tuple.
+        if hasattr(example, "_fields"):
+            return type(example)(*values)
+        return type(example)(values)
+    if isinstance(example, list):
+        return [_unflatten(item, it) for item in example]
+    if isinstance(example, dict):
+        return {key: _unflatten(value, it) for key, value in example.items()}
+    # Non-tensor leaf: reuse the example's value.
+    return example
+
+
+def _rebuild_kjt(
+    example: KeyedJaggedTensor, it: Iterator[torch.Tensor]
+) -> KeyedJaggedTensor:
+    parts: Dict[str, torch.Tensor] = {
+        name: _next(it) for name, _tensor in _kjt_tensor_fields(example)
+    }
+    return KeyedJaggedTensor(
+        keys=example.keys(),
+        values=parts["values"],
+        weights=parts.get("weights"),
+        lengths=parts.get("lengths"),
+        offsets=parts.get("offsets"),
+    )
+
+
+def _next(it: Iterator[torch.Tensor]) -> torch.Tensor:
+    try:
+        return next(it)
+    except StopIteration:
+        raise ValueError(
+            "not enough tensors to reconstruct the example structure"
+        ) from None
+
+
+class _InputSizeAwaitable(
+    LazyAwaitable[Tuple[List[List[torch.Tensor]], List[List[int]]]]
+):
+    """Awaitable for the size-metadata all-to-all (:func:`input_size_dist`).
+
+    ``wait()`` completes the async exchange and returns ``(flat_send, recv_sizes)``:
+    the flattened send tensors (available immediately, threaded through so phase two
+    need not re-flatten) and ``recv_sizes[i][k]`` -- the dim-0 size of slot ``k`` of
+    the carrier rank ``i`` is sending to this rank.
+    """
+
+    def __init__(
+        self,
+        # pyre-ignore[2]: dist work handle has no public type
+        work: Any,
+        flat_send: List[List[torch.Tensor]],
+        recv_sizes: torch.Tensor,
+        batch_id: int,
+    ) -> None:
+        super().__init__()
+        self._work = work
+        self._flat_send = flat_send
+        self._recv_sizes = recv_sizes
+        self._batch_id = batch_id
+
+    def _wait_impl(self) -> Tuple[List[List[torch.Tensor]], List[List[int]]]:
+        with record_function(f"## input_size_dist wait batch{self._batch_id} ##"):
+            if self._work is not None:
+                self._work.wait()
+            return self._flat_send, self._recv_sizes.tolist()
+
+
+class _InputDataAwaitable(LazyAwaitable[List[T]]):
+    """Awaitable for the bulk tensor all-to-all (:func:`input_data_dist`).
+
+    ``wait()`` completes the per-dtype async exchanges, slices each fused receive
+    buffer back into its tensor slots, then regroups them per source rank and
+    reconstructs each carrier from ``example``.
+    """
+
+    def __init__(
+        self,
+        # pyre-ignore[2]: dist work handles have no public type
+        works: List[Any],
+        out_bufs: List[torch.Tensor],
+        in_bufs: List[torch.Tensor],
+        bucket_slots: List[List[int]],
+        recv_sizes: List[List[int]],
+        row_elems: List[int],
+        trailing: List[Tuple[int, ...]],
+        example: T,
+        world_size: int,
+        num_tensors: int,
+        batch_id: int,
+    ) -> None:
+        super().__init__()
+        self._works = works
+        self._out_bufs = out_bufs
+        # Held only to keep the send buffers alive until the collectives complete.
+        self._in_bufs = in_bufs
+        self._bucket_slots = bucket_slots
+        self._recv_sizes = recv_sizes
+        self._row_elems = row_elems
+        self._trailing = trailing
+        self._example = example
+        self._world_size = world_size
+        self._num_tensors = num_tensors
+        self._batch_id = batch_id
+
+    def _wait_impl(self) -> List[T]:
+        with record_function(f"## input_data_dist wait batch{self._batch_id} ##"):
+            for work in self._works:
+                if work is not None:
+                    work.wait()
+            # recv_slot[(k, i)] = slot k of the carrier received from rank i. Each
+            # fused buffer is laid out source-major then slot-major, matching the
+            # destination-major / slot-major send layout in input_data_dist.
+            recv_slot: Dict[Tuple[int, int], torch.Tensor] = {}
+            for buf, slots in zip(self._out_bufs, self._bucket_slots):
+                pos = 0
+                for i in range(self._world_size):
+                    for k in slots:
+                        rows = self._recv_sizes[i][k]
+                        n = rows * self._row_elems[k]
+                        recv_slot[(k, i)] = buf[pos : pos + n].view(
+                            rows, *self._trailing[k]
+                        )
+                        pos += n
+            recv: List[T] = []
+            for i in range(self._world_size):
+                recv_tensors = [recv_slot[(k, i)] for k in range(self._num_tensors)]
+                recv.append(unflatten_from_tensors(recv_tensors, self._example))
+            return recv
+
+
+def input_size_dist(
+    send: List[T],
+    pg_gloo: dist.ProcessGroup,
+    batch_id: int = 0,
+) -> LazyAwaitable[Tuple[List[List[torch.Tensor]], List[List[int]]]]:
+    """Phase one: flatten each carrier and async all-to-all the tensor-size metadata.
+
+    ``send`` must have one carrier per rank in ``pg_gloo`` (``send[j]`` is destined
+    for rank ``j``). Each carrier is flattened to the same number ``K`` of tensors
+    (the homogeneity assumption), and only each tensor's dim-0 size varies between
+    carriers -- trailing dims and dtype are fixed per slot and recovered from the
+    example in phase two. This issues an async all-to-all of a small ``[W, K]``
+    integer matrix of dim-0 sizes over the (cheap, CPU) gloo group so every rank
+    learns the sizes of the tensors it is about to receive.
+
+    Args:
+        send: one carrier per destination rank; ``send[j]`` goes to rank ``j``.
+        pg_gloo: a gloo process group used only for the tiny size exchange.
+        batch_id: identifier for this input batch, used only to tag the profiler
+            ranges (``## input_size_dist batch{batch_id} ##``).
+
+    Returns:
+        A :class:`LazyAwaitable` whose ``wait()`` yields ``(flat_send, recv_sizes)``:
+        ``flat_send[j]`` is the flattened tensors of ``send[j]`` (threaded through so
+        phase two need not re-flatten), and ``recv_sizes[i][k]`` is the dim-0 size of
+        slot ``k`` of the carrier rank ``i`` is sending to this rank.
+
+    Raises:
+        ValueError: if ``len(send)`` does not match the group size, or the carriers
+            do not all flatten to the same number of tensors.
+    """
+    world_size = dist.get_world_size(pg_gloo)
+    if len(send) != world_size:
+        raise ValueError(
+            f"expected one carrier per rank: got {len(send)} for world size "
+            f"{world_size}"
+        )
+    flat_send: List[List[torch.Tensor]] = [flatten_to_tensors(item) for item in send]
+    num_tensors = len(flat_send[0])
+    for j, tensors in enumerate(flat_send):
+        if len(tensors) != num_tensors:
+            raise ValueError(
+                f"carriers must flatten to the same tensor count: send[0] has "
+                f"{num_tensors}, send[{j}] has {len(tensors)}"
+            )
+
+    with record_function(f"## input_size_dist batch{batch_id} ##"):
+        send_sizes = torch.tensor(
+            [[t.shape[0] for t in tensors] for tensors in flat_send],
+            dtype=torch.int64,
+        )
+        recv_sizes = torch.empty_like(send_sizes)
+        work = dist.all_to_all_single(
+            recv_sizes, send_sizes, group=pg_gloo, async_op=True
+        )
+    return _InputSizeAwaitable(work, flat_send, recv_sizes, batch_id)
+
+
+def input_data_dist(
+    flat_send: List[List[torch.Tensor]],
+    recv_sizes: List[List[int]],
+    example: T,
+    pg_nccl: dist.ProcessGroup,
+    batch_id: int = 0,
+) -> LazyAwaitable[List[T]]:
+    """Phase two: async all-to-all the bulk tensors and rebuild the carriers.
+
+    Issues one async :func:`torch.distributed.all_to_all_single` per *dtype*: the
+    tensor slots are bucketed by dtype (read from ``example``), and within a bucket
+    every slot is flattened to 1-D and concatenated into one fused buffer, so a
+    single collective moves all same-dtype slots at once. This mirrors TorchRec's
+    ``KJTAllToAll``, which keeps native dtypes (never byte-packs) but fuses what it
+    can -- here a mixed-dtype carrier collapses to one collective per distinct dtype
+    rather than one per slot. The returned awaitable's ``wait()`` completes the
+    collectives, slices each fused buffer back into its slots, regroups per source
+    rank, and reconstructs each carrier with :func:`unflatten_from_tensors`.
+
+    Args:
+        flat_send: per-destination flattened tensors, from :func:`input_size_dist`.
+        recv_sizes: per-source dim-0 sizes, from :func:`input_size_dist`.
+        example: template carrier defining structure, dtypes, and non-tensor parts.
+        pg_nccl: an nccl process group carrying the (CUDA) tensor data.
+        batch_id: identifier for this input batch, used only to tag the profiler
+            ranges (``## input_data_dist batch{batch_id} ##``).
+
+    Returns:
+        A :class:`LazyAwaitable` whose ``wait()`` yields ``recv`` with ``recv[i]``
+        the carrier received from rank ``i``.
+    """
+    world_size = len(flat_send)
+    num_tensors = len(flat_send[0])
+    example_flat = flatten_to_tensors(example)
+    # Per-slot layout from the example: elements per dim-0 row and the trailing shape
+    # (only dim-0 varies between carriers, so these are fixed per slot).
+    row_elems = [math.prod(t.shape[1:]) for t in example_flat]
+    trailing = [tuple(t.shape[1:]) for t in example_flat]
+    # Bucket slots by dtype in first-seen order. The example is a shared template, so
+    # every rank derives the same buckets and the per-dtype collectives line up.
+    buckets: Dict[torch.dtype, List[int]] = {}
+    for k in range(num_tensors):
+        buckets.setdefault(example_flat[k].dtype, []).append(k)
+
+    device = flat_send[0][0].device
+    # pyre-ignore[33]: dist work handles have no public type
+    works: List[Any] = []
+    out_bufs: List[torch.Tensor] = []
+    in_bufs: List[torch.Tensor] = []
+    bucket_slots: List[List[int]] = []
+    with record_function(f"## input_data_dist batch{batch_id} ##"):
+        for dtype, slots in buckets.items():
+            # Destination-major, then slot-major: chunk j (-> rank j) is this rank's
+            # slots for j laid end to end; input_split_sizes marks the j boundaries.
+            in_splits = [
+                sum(flat_send[j][k].numel() for k in slots) for j in range(world_size)
+            ]
+            in_buf = torch.cat(
+                [flat_send[j][k].reshape(-1) for j in range(world_size) for k in slots]
+            )
+            out_splits = [
+                sum(recv_sizes[i][k] * row_elems[k] for k in slots)
+                for i in range(world_size)
+            ]
+            out_buf = torch.empty(sum(out_splits), dtype=dtype, device=device)
+            with record_function(f"## input_data_dist batch{batch_id} {dtype} ##"):
+                work = dist.all_to_all_single(
+                    out_buf, in_buf, out_splits, in_splits, group=pg_nccl, async_op=True
+                )
+            works.append(work)
+            out_bufs.append(out_buf)
+            in_bufs.append(in_buf)
+            bucket_slots.append(slots)
+
+    return _InputDataAwaitable(
+        works,
+        out_bufs,
+        in_bufs,
+        bucket_slots,
+        recv_sizes,
+        row_elems,
+        trailing,
+        example,
+        world_size,
+        num_tensors,
+        batch_id,
+    )
+
+
+def input_dist(
+    send: List[T],
+    example: T,
+    pg_gloo: dist.ProcessGroup,
+    pg_nccl: dist.ProcessGroup,
+    batch_id: int = 0,
+) -> LazyAwaitable[List[T]]:
+    """All-to-all a list of structured carriers: one per rank in, one per rank out.
+
+    Chains :func:`input_size_dist` (size metadata over gloo) and
+    :func:`input_data_dist` (bulk tensor data over nccl). ``send[j]`` is delivered
+    to rank ``j``; the returned awaitable's ``wait()`` yields ``recv[i]`` -- the
+    carrier from rank ``i``.
+
+    The size exchange is awaited here (its result is needed to lay out the data
+    collectives), then the data all-to-alls are launched async and returned as a
+    :class:`LazyAwaitable` so the caller can overlap work before ``wait()``.
+
+    Args:
+        send: one carrier per destination rank; ``send[j]`` goes to rank ``j``.
+        example: template carrier defining structure, dtypes, and non-tensor parts.
+        pg_gloo: gloo group for the size-metadata exchange.
+        pg_nccl: nccl group for the tensor-data exchange.
+        batch_id: identifier for this input batch, threaded to both phases to tag
+            the profiler ranges.
+
+    Returns:
+        A :class:`LazyAwaitable` whose ``wait()`` yields ``recv`` with ``recv[i]``
+        the carrier received from rank ``i``.
+    """
+    flat_send, recv_sizes = input_size_dist(send, pg_gloo, batch_id).wait()
+    return input_data_dist(flat_send, recv_sizes, example, pg_nccl, batch_id)

--- a/torchrec/distributed/maglev/stage.py
+++ b/torchrec/distributed/maglev/stage.py
@@ -113,6 +113,38 @@ def build_handoff_process_groups(
     return act_pg, grad_pg
 
 
+def build_cascade_process_groups(
+    stage_ranks: List[List[int]],
+) -> List[dist.ProcessGroup]:
+    """Create one process group per pipeline "cascade" for input distribution.
+
+    A *cascade* is the set of same-position ranks across all stages:
+    ``cascade_pgs[c]`` groups ``stage_ranks[0][c], stage_ranks[1][c], ...`` and so
+    has one rank per stage (size == the number of stages). It is the group over
+    which a rank's full per-stage input set is all-to-all'd so every rank ends up
+    holding its own stage's inputs -- one microbatch contributed by each stage's
+    rank in the cascade (see the benchmark's input-dist driver).
+
+    Like :func:`build_stage_process_groups` / :func:`build_handoff_process_groups`,
+    ``dist.new_group`` is collective: every rank creates every cascade group in the
+    same order, and building these up front (before any DMP sharding) keeps all
+    ``new_group`` collectives contiguous. The group inherits the job's backend
+    (``cpu:gloo,cuda:nccl``), so the same handle drives both the CPU/gloo size
+    exchange and the CUDA/nccl data exchange.
+
+    Args:
+        stage_ranks: ``stage_ranks[i]`` is the global ranks of stage ``i``'s HSD;
+            every stage must have the same number of ranks (cascades).
+    """
+    num_cascades = len(stage_ranks[0]) if stage_ranks else 0
+    pgs: List[dist.ProcessGroup] = []
+    for c in range(num_cascades):
+        ranks = [stage_ranks[s][c] for s in range(len(stage_ranks))]
+        pg = cast(dist.ProcessGroup, dist.new_group(ranks=ranks))
+        pgs.append(pg)
+    return pgs
+
+
 def _all_reduce_dense(params: List[nn.Parameter], stage_pg: dist.ProcessGroup) -> None:
     """DP-average the given params' grads across the HSD's ranks (once per step)."""
     world_size = stage_pg.size()

--- a/torchrec/distributed/maglev/tests/test_input_dist.py
+++ b/torchrec/distributed/maglev/tests/test_input_dist.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.maglev.input_dist import (
+    flatten_to_tensors,
+    input_data_dist,
+    input_dist,
+    input_size_dist,
+    unflatten_from_tensors,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+@dataclass
+class _Carrier:
+    name: str  # non-tensor leaf
+    activation: torch.Tensor
+    extras: List[torch.Tensor]
+    pair: Tuple[torch.Tensor, int]  # mixed tensor + non-tensor
+    named: Dict[str, torch.Tensor]
+    features: KeyedJaggedTensor
+
+
+def _kjt(values: torch.Tensor) -> KeyedJaggedTensor:
+    return KeyedJaggedTensor(
+        keys=["f1", "f2"],
+        values=values,
+        lengths=torch.tensor([1, 2, 1, 2], dtype=torch.int64),
+    )
+
+
+def _example() -> _Carrier:
+    return _Carrier(
+        name="carrier",
+        activation=torch.zeros(2, 3),
+        extras=[torch.zeros(4), torch.zeros(5)],
+        pair=(torch.zeros(1), 7),
+        named={"a": torch.zeros(2), "b": torch.zeros(3)},
+        features=_kjt(torch.zeros(6, dtype=torch.int64)),
+    )
+
+
+def _instance() -> _Carrier:
+    return _Carrier(
+        name="carrier",
+        activation=torch.randn(2, 3),
+        extras=[torch.randn(4), torch.randn(5)],
+        pair=(torch.randn(1), 7),
+        named={"a": torch.randn(2), "b": torch.randn(3)},
+        features=_kjt(torch.randint(0, 10, (6,), dtype=torch.int64)),
+    )
+
+
+class InputDistTest(unittest.TestCase):
+    def test_flatten_count(self) -> None:
+        tensors = flatten_to_tensors(_instance())
+        # activation(1) + extras(2) + pair tensor(1) + named(2) + kjt values+lengths(2)
+        self.assertEqual(len(tensors), 8)
+        for t in tensors:
+            self.assertIsInstance(t, torch.Tensor)
+
+    def test_roundtrip(self) -> None:
+        obj = _instance()
+        rebuilt = unflatten_from_tensors(flatten_to_tensors(obj), _example())
+
+        self.assertIsInstance(rebuilt, _Carrier)
+        self.assertEqual(rebuilt.name, "carrier")
+        torch.testing.assert_close(rebuilt.activation, obj.activation)
+        self.assertEqual(len(rebuilt.extras), 2)
+        for got, want in zip(rebuilt.extras, obj.extras):
+            torch.testing.assert_close(got, want)
+        torch.testing.assert_close(rebuilt.pair[0], obj.pair[0])
+        self.assertEqual(rebuilt.pair[1], 7)  # non-tensor leaf from example
+        torch.testing.assert_close(rebuilt.named["a"], obj.named["a"])
+        torch.testing.assert_close(rebuilt.named["b"], obj.named["b"])
+        self.assertEqual(rebuilt.features.keys(), ["f1", "f2"])
+        torch.testing.assert_close(rebuilt.features.values(), obj.features.values())
+        torch.testing.assert_close(rebuilt.features.lengths(), obj.features.lengths())
+
+    def test_non_tensor_comes_from_example(self) -> None:
+        obj = _instance()
+        example = _example()
+        example.name = "from_example"
+        rebuilt = unflatten_from_tensors(flatten_to_tensors(obj), example)
+        # ``name`` is a non-tensor leaf, so it is taken from the example.
+        self.assertEqual(rebuilt.name, "from_example")
+
+    def test_dict_of_kjt_roundtrip(self) -> None:
+        obj = {
+            "a": _kjt(torch.randint(0, 10, (6,), dtype=torch.int64)),
+            "b": _kjt(torch.randint(0, 10, (6,), dtype=torch.int64)),
+        }
+        example = {
+            "a": _kjt(torch.zeros(6, dtype=torch.int64)),
+            "b": _kjt(torch.zeros(6, dtype=torch.int64)),
+        }
+        tensors = flatten_to_tensors(obj)
+        # Two KJTs, each contributing values + lengths.
+        self.assertEqual(len(tensors), 4)
+
+        rebuilt = unflatten_from_tensors(tensors, example)
+        self.assertEqual(list(rebuilt.keys()), ["a", "b"])
+        for key in ("a", "b"):
+            torch.testing.assert_close(rebuilt[key].values(), obj[key].values())
+            torch.testing.assert_close(rebuilt[key].lengths(), obj[key].lengths())
+            self.assertEqual(rebuilt[key].keys(), ["f1", "f2"])
+
+    def test_too_few_tensors_raises(self) -> None:
+        tensors = flatten_to_tensors(_instance())
+        with self.assertRaises(ValueError):
+            unflatten_from_tensors(tensors[:-1], _example())
+
+    def test_too_many_tensors_raises(self) -> None:
+        tensors = flatten_to_tensors(_instance())
+        with self.assertRaises(ValueError):
+            unflatten_from_tensors(tensors + [torch.zeros(1)], _example())
+
+
+_DENSE_DIM = 4
+_NUM_FEATURES = 2
+
+
+@dataclass
+class _Batch:
+    dense: torch.Tensor
+    features: KeyedJaggedTensor
+    label: torch.Tensor
+    extras: List[torch.Tensor]
+    meta: Dict[str, torch.Tensor]
+    ids: torch.Tensor  # int32: a third dtype bucket, with a trailing dim
+    tag: str  # non-tensor leaf: must come from the example
+
+
+def _make_kjt(src: int, dst: int, batch_size: int) -> KeyedJaggedTensor:
+    g = torch.Generator().manual_seed(1009 * src + dst + 1)
+    lengths = torch.randint(
+        0, 3, (_NUM_FEATURES * batch_size,), generator=g, dtype=torch.int64
+    )
+    values = torch.randint(
+        0, 100, (int(lengths.sum()),), generator=g, dtype=torch.int64
+    )
+    return KeyedJaggedTensor(keys=["f1", "f2"], values=values, lengths=lengths)
+
+
+def _make_carrier(src: int, dst: int) -> _Batch:
+    """Deterministic carrier rank ``src`` sends to rank ``dst``.
+
+    Content and batch size are pure functions of ``(src, dst)`` so any rank can
+    reconstruct the expected value. Batch size varies with both to exercise the
+    per-item / per-slot variable dim-0 sizing; ``extras`` mixes two different
+    dim-0 sizes on purpose. Dtypes span three buckets -- float32 (``dense`` /
+    ``label`` / ``extras`` / ``meta``), int64 (the KJT), and int32 (``ids``) -- so
+    ``input_data_dist``'s dtype bucketing runs three fused all-to-alls.
+    """
+    batch_size = 1 + src + dst
+    dense = torch.full((batch_size, _DENSE_DIM), float(10 * src + dst))
+    label = torch.arange(batch_size, dtype=torch.float32) + src
+    extras = [
+        torch.full((batch_size,), float(src)),
+        torch.full((batch_size + 1,), float(dst)),
+    ]
+    meta = {"m": torch.full((batch_size, 2), float(src - dst))}
+    ids = (torch.arange(batch_size * 3, dtype=torch.int32) + (10 * src + dst)).reshape(
+        batch_size, 3
+    )
+    return _Batch(
+        dense=dense,
+        features=_make_kjt(src, dst, batch_size),
+        label=label,
+        extras=extras,
+        meta=meta,
+        ids=ids,
+        tag="batch",
+    )
+
+
+def _run_all_to_all(rank: int, world_size: int) -> None:
+    with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo") as ctx:
+        pg = ctx.pg
+        assert pg is not None
+
+        send = [_make_carrier(src=rank, dst=dst) for dst in range(world_size)]
+        # Structure/dtype template; its sizes and content are irrelevant.
+        example = _make_carrier(src=0, dst=0)
+        example.tag = "from_example"
+
+        # gloo stands in for nccl here: all_to_all_single is backend-agnostic, so
+        # the same group drives both the size and the data phase in the test.
+        recv = input_dist(send, example, pg_gloo=pg, pg_nccl=pg).wait()
+
+        assert (
+            len(recv) == world_size
+        ), f"expected {world_size} carriers, got {len(recv)}"
+        for src in range(world_size):
+            expected = _make_carrier(src=src, dst=rank)
+            got = recv[src]
+            torch.testing.assert_close(got.dense, expected.dense)
+            torch.testing.assert_close(got.label, expected.label)
+            torch.testing.assert_close(got.ids, expected.ids)
+            assert got.ids.dtype == torch.int32
+            assert len(got.extras) == 2
+            for g_t, e_t in zip(got.extras, expected.extras):
+                torch.testing.assert_close(g_t, e_t)
+            torch.testing.assert_close(got.meta["m"], expected.meta["m"])
+            assert got.features.keys() == ["f1", "f2"]
+            torch.testing.assert_close(
+                got.features.values(), expected.features.values()
+            )
+            torch.testing.assert_close(
+                got.features.lengths(), expected.features.lengths()
+            )
+            # non-tensor leaf comes from the example, not the sender.
+            assert got.tag == "from_example", got.tag
+
+
+class InputAllToAllTest(MultiProcessTestBase):
+    def test_all_to_all_roundtrip(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_all_to_all,
+            world_size=4,
+        )
+
+
+class InputDistInProcessTest(unittest.TestCase):
+    """In-process (single-rank, gloo) coverage of the dist entry points.
+
+    A ``world_size == 1`` all-to-all is the identity (``send[0]`` -> self), so this
+    exercises ``input_size_dist`` / ``input_data_dist`` / ``input_dist`` and their
+    awaitables in the test process (unlike the multi-process test, whose spawned
+    workers run outside coverage) without needing more than one rank.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, store=dist.HashStore()
+        )
+
+    def tearDown(self) -> None:
+        dist.destroy_process_group()
+        super().tearDown()
+
+    def test_input_dist_single_rank(self) -> None:
+        pg = dist.group.WORLD
+        assert pg is not None
+        send = [_make_carrier(src=0, dst=0)]
+        example = _make_carrier(src=0, dst=0)
+        example.tag = "from_example"
+
+        recv = input_dist(send, example, pg_gloo=pg, pg_nccl=pg).wait()
+
+        self.assertEqual(len(recv), 1)
+        got = recv[0]
+        torch.testing.assert_close(got.dense, send[0].dense)
+        torch.testing.assert_close(got.label, send[0].label)
+        torch.testing.assert_close(got.ids, send[0].ids)
+        self.assertEqual(got.ids.dtype, torch.int32)
+        torch.testing.assert_close(got.features.values(), send[0].features.values())
+        torch.testing.assert_close(got.features.lengths(), send[0].features.lengths())
+        self.assertEqual(got.tag, "from_example")
+
+    def test_size_then_data_phase(self) -> None:
+        pg = dist.group.WORLD
+        assert pg is not None
+        send = [_make_carrier(src=0, dst=0)]
+        example = _make_carrier(src=0, dst=0)
+
+        flat_send, recv_sizes = input_size_dist(send, pg).wait()
+        # One carrier -> one row; sizes match the flattened tensors' dim-0.
+        self.assertEqual(len(recv_sizes), 1)
+        self.assertEqual(recv_sizes[0], [t.shape[0] for t in flat_send[0]])
+
+        recv = input_data_dist(flat_send, recv_sizes, example, pg).wait()
+        self.assertEqual(len(recv), 1)
+        torch.testing.assert_close(recv[0].dense, send[0].dense)


### PR DESCRIPTION
Summary:
# Wire `input_dist` into the Maglev benchmark

## 1. Context

Continuing the Maglev prototype, this change bakes the input distribution (`input_dist`, [#4466](https://github.com/meta-pytorch/torchrec/pull/4466)) into the benchmark. The base benchmark ([#4465](https://github.com/meta-pytorch/torchrec/pull/4465)) covers only the 1F1B compute, with each rank already holding its own stage inputs — but a real run produces inputs per rank and must distribute them to the owning HSD first. Running `input_dist` inside the training iteration step makes the benchmark cover that distribution, not just the pipeline compute.

## 2. Approach

1. **How inputs are distributed.** Each rank holds a full per-stage input set (one ModelInput per stage) and all-to-alls it over its **cascade** — the same-position ranks across all stages, one rank per stage. After the exchange each rank holds num_stages inputs for its own stage, i.e. num_stages microbatches per round.

2. **`build_cascade_process_groups`** (in stage.py) creates one process group per cascade, built up front (before any DMP sharding) so all new_group collectives stay contiguous and cannot deadlock against the per-stage sharding collectives. The group inherits the job backend (cpu:gloo, cuda:nccl), so the same handle drives both the CPU/gloo size exchange and the CUDA/nccl data exchange of `input_dist`.

3. **`_InputDistDriver`** (in benchmark_maglev.py) owns a FIFO microbatch queue and decouples the microbatch count from the stage count: take(n) refills the queue with whole `input_dist` rounds — each `input_dist` round yields num_stages microbatches — until it holds n, hands back n, and keeps the remainder.
   - More microbatches than stages → several rounds per pass (4 stages / 8 microbatches → 2 rounds).
   - Fewer → one round drained a pass at a time (16 stages / 8 microbatches).

   The refill count is deterministic and the queue starts empty on every rank, so all cascade members call `input_dist` the same number of times and stay in lock-step.

<img width="2298" height="572" alt="image" src="https://github.com/user-attachments/assets/d1d7fc18-74db-476a-8f6b-1629c332c6b3" />

*The `_InputDistDriver` queue absorbs the count mismatch: each dataloader.next → cascade `input_dist` round **enqueues a whole batch** of num_stages micro-batched stage inputs (right), while pp.mb_forward **dequeues one microbatch at a time** (left) — enqueue and dequeue are decoupled (enqueue per-round, dequeue per-microbatch).*

## 3. Benchmark

**Setup**

Same benchmark_maglev.py as the base benchmark ([#4465](https://github.com/meta-pytorch/torchrec/pull/4465)) — GPU + nccl, 8 ranks / 4 stages / 2-per-stage — now with the cascade `input_dist` inside each iteration: one iteration = the input-dist all-to-all for the pass's microbatches + one full 1F1B pass.

**Repro command** (OSS):

```
python -m torchrec.distributed.benchmark.benchmark_maglev --world_size=8 --num_stages=4 --ranks_per_stage=2 --batch_size=1024 --num_microbatches=8
```

**Validation**

<img width="4546" height="1706" alt="image" src="https://github.com/user-attachments/assets/528f5fe4-9d8f-43d5-8ee6-4353849fd0a7" />

*The trace ([rank 0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces)):*

1. **Two `input_dist` rounds per pass** — 8 microbatches / 4 stages = 2 rounds (the batch24 / batch25 ranges).
2. **Size exchange on gloo, data exchange on nccl** — a gloo:all_to_all carries the per-tensor row counts (input_size_dist), then nccl the payloads (input_data_dist); both are record_function ranges, distinct from the intra-HSD embedding all-to-all and the cross-HSD P2P hand-off.
3. **Two nccl all-to-alls per data exchange** — one per tensor dtype (float32 and int64).

**Traces** (per-stage HSD; all-rank traces on by default). Each cell links Perfetto (rank) and Perf Doctor (PD) for the two ranks of that HSD:
[maglev-mvp-traces.zip](https://github.com/user-attachments/files/30529303/maglev-mvp-traces.zip)

| Stage 0 (ranks 0,1) | Stage 1 (ranks 2,3) | Stage 2 (ranks 4,5) | Stage 3 (ranks 6,7) |
|--|--|--|--|
| [rank 0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) | [rank 2](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 3](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) | [rank 4](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 5](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) | [rank 6](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces)<br> [rank 7](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) · [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D113477459/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |

## 4. Analysis

1. **What the trace captures.** One iteration covers the cascade `input_dist` for the pass's microbatches plus one full 1F1B pass, so the trace shows a realistic step (input distribution + staged compute). The full per-stage input set is generated once, up front — outside what the trace captures.
2. **Microbatch = per-rank intake batch (assumption).** The pipeline does not split a batch into smaller microbatches or fuse batches together — each rank's intake ModelInput becomes exactly one microbatch. So a trainer's per-rank batch size *is* the microbatch size, and each cascade `input_dist` round contributes num_stages microbatches (one per source rank).
3. **Cascade is orthogonal to the HSD.** Each rank sits in two independent groupings: its stage's HSD (the 2-rank DP group, carrying sharding and the activation/gradient hand-off) and a cascade (one rank per stage, size = num_stages) carrying the input-dist all-to-all.
4. **Awaitable design — overlap not yet wired.** `input_dist` returns a `LazyAwaitable`: the size and data exchanges are issued asynchronously and block only when the result is consumed, so the distribution can in principle be pipelined with compute — issue the next round's exchange while the current microbatches run, hiding it behind the pipeline. The driver keeps that seam but does not use it yet; it drains each round before the pass, so `input_dist` currently sits ahead of the 1F1B compute rather than overlapping it (visible in the trace above).

## 5. Changes

1. **stage.py**: `build_cascade_process_groups` — one group per cascade (same-position ranks across stages, size = num_stages), built up front, inheriting the job backend (cpu:gloo, cuda:nccl).
2. **benchmark_maglev.py**: `_InputDistDriver` (FIFO microbatch queue, whole-round `input_dist` refill); each iteration now runs the cascade `input_dist` before the 1F1B pass.

Differential Revision: D113477459


