### PR TITLE
Log only throughput (QPS) on the profiler-trace path to drop a metric all-gather (#4475)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -747,7 +747,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         )
 
     @override
-    def async_compute(self) -> DeferrableMetrics:
+    def async_compute(self, *, _throughput_only: bool = False) -> DeferrableMetrics:
         """
         Entry point for asynchronous metric compute. It enqueues a synchronization marker
         to the update queue.
@@ -768,7 +768,12 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             raise self._captured_exception
 
         try:
-            self.update_queue.put_nowait(SynchronizationMarker(metrics_future))
+            self.update_queue.put_nowait(
+                SynchronizationMarker(
+                    metrics_future,
+                    throughput_only=_throughput_only,
+                )
+            )
             self._total_computes_enqueued += 1
             self.update_queue_size_logger.add(self.update_queue.qsize())
         except queue.Full:
@@ -786,6 +791,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
         return DeferrableMetrics(metrics_future)
 
+    @override
+    def compute_throughput(self) -> DeferrableMetrics:
+        return self.async_compute(_throughput_only=True)
+
     def _process_synchronization_marker(
         self, synchronization_marker: SynchronizationMarker
     ) -> None:
@@ -798,15 +807,22 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         """
 
         with record_function("## CPUOffloadedRecMetricModule:sync_marker ##"):
-            if not self.rec_metrics:
-                raise RecMetricException("No metrics to compute.")
-
             if self._captured_exception_event.is_set():
                 synchronization_marker.future.set_exception(
                     self._captured_exception
                     or RecMetricException("compute thread is unavailable")
                 )
                 return
+
+            if synchronization_marker.throughput_only:
+                synchronization_marker.future.set_result(
+                    super().compute_throughput().resolve()
+                )
+                self._total_computes_processed += 1
+                return
+
+            if not self.rec_metrics:
+                raise RecMetricException("No metrics to compute.")
 
             metric_state_snapshot = MetricStateSnapshot.from_metrics(
                 self.rec_metrics,

--- a/torchrec/metrics/metric_job_types.py
+++ b/torchrec/metrics/metric_job_types.py
@@ -80,16 +80,19 @@ class SynchronizationMarker:
     accurately includes all of the metric jobs that were scheduled before it.
     """
 
-    __slots__ = "future"
+    __slots__ = ["future", "throughput_only"]
 
     def __init__(
         self,
         # pyrefly: ignore[implicit-import]
         future: concurrent.futures.Future[Dict[str, MetricValue]],
+        throughput_only: bool = False,
     ) -> None:
         """
         Args:
             future: future to set the result of the compute job. Passed to the MetricComputeJob.
+            throughput_only: whether to compute throughput without creating a MetricComputeJob.
         """
         # pyrefly: ignore[implicit-import]
         self.future: concurrent.futures.Future[Dict[str, MetricValue]] = future
+        self.throughput_only: bool = throughput_only

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -443,6 +443,13 @@ class RecMetricModule(nn.Module):
                     )
         return DeferrableMetrics(ret)
 
+    def compute_throughput(self) -> DeferrableMetrics:
+        r"""Compute throughput metrics without cross-rank collectives."""
+        ret: MetricsResult = {}
+        if self.throughput_metric:
+            ret.update(self.throughput_metric.compute())
+        return DeferrableMetrics(ret)
+
     def local_compute(self) -> DeferrableMetrics:
         r"""local_compute() is called when per-trainer metrics are required. It's
         can be used for debugging. Currently only rec_metrics is supported.

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -431,6 +431,13 @@ class RecMetricModule(nn.Module):
                     )
         return DeferrableMetrics(ret)
 
+    def compute_throughput(self) -> DeferrableMetrics:
+        r"""Compute throughput metrics without cross-rank collectives."""
+        ret: MetricsResult = {}
+        if self.throughput_metric:
+            ret.update(self.throughput_metric.compute())
+        return DeferrableMetrics(ret)
+
     def local_compute(self) -> DeferrableMetrics:
         r"""local_compute() is called when per-trainer metrics are required. It's
         can be used for debugging. Currently only rec_metrics is supported.

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -296,6 +296,24 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.cpu_module.compute,
         )
 
+    def test_compute_throughput_waits_for_updates_without_full_compute(self) -> None:
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        for _ in range(3):
+            self.cpu_module.update(model_out)
+
+        result = self.cpu_module.compute_throughput().resolve()
+
+        self.assertEqual(result["throughput-throughput|total_examples"], 3)
+        self.assertEqual(self.cpu_module._total_updates_processed, 3)
+        self.assertEqual(self.cpu_module._total_computes_processed, 1)
+        self.assertEqual(self.cpu_module.compute_count, 0)
+        self.assertTrue(self.cpu_module.compute_queue.empty())
+
     def test_clone_model_out_false_skips_clone(self) -> None:
         """clone_model_out=False must not call the defensive _foreach_clone."""
         module = self._make_module(clone_model_out=False)

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -9,6 +9,7 @@
 
 import copy
 import dataclasses
+import faulthandler
 import logging
 import multiprocessing
 import os
@@ -231,6 +232,93 @@ class MetricModuleTest(unittest.TestCase):
                 raw_predictions,
                 cast(Dict[str, torch.Tensor], actual_predictions)["task"],
             )
+        )
+
+    def test_compute_throughput_excludes_other_metrics(self) -> None:
+        config = dataclasses.replace(
+            DefaultMetricsConfig,
+            throughput_metric=ThroughputDef(warmup_steps=1),
+            state_metrics=[StateMetricEnum.OPTIMIZERS],
+        )
+        with tempfile.NamedTemporaryFile(delete=True) as backend:
+            dist.init_process_group(
+                backend="gloo",
+                init_method=f"file://{backend.name}",
+                world_size=1,
+                rank=0,
+            )
+            try:
+                metric_module = generate_metric_module(
+                    TestMetricModule,
+                    metrics_config=config,
+                    batch_size=128,
+                    world_size=64,
+                    my_rank=0,
+                    state_metrics_mapping={StateMetricEnum.OPTIMIZERS: MockOptimizer()},
+                    device=torch.device("cpu"),
+                )
+                for _ in range(3):
+                    metric_module.update(gen_test_batch(128))
+
+                throughput_only = metric_module.compute_throughput().resolve()
+                full = metric_module.compute().resolve()
+
+                self.assertIn(
+                    "throughput-throughput|lifetime_throughput", throughput_only
+                )
+                self.assertIn(
+                    "throughput-throughput|window_throughput", throughput_only
+                )
+                self.assertEqual(
+                    set(throughput_only),
+                    {key for key in full if key.startswith("throughput-")},
+                )
+                ne_keys = {key for key in full if key.startswith("ne-")}
+                self.assertTrue(ne_keys)
+                self.assertIn("optimizers-optimizers|learning_rate", full)
+                self.assertTrue(ne_keys.isdisjoint(throughput_only))
+                self.assertNotIn("optimizers-optimizers|learning_rate", throughput_only)
+            finally:
+                dist.destroy_process_group()
+
+    @staticmethod
+    def _run_compute_throughput_collective_free(
+        rank: int, world_size: int, backend: str
+    ) -> None:
+        dist.init_process_group(
+            backend=backend,
+            world_size=world_size,
+            rank=rank,
+        )
+        try:
+            metric_module = generate_metric_module(
+                TestMetricModule,
+                metrics_config=DefaultMetricsConfig,
+                batch_size=128,
+                world_size=world_size,
+                my_rank=rank,
+                state_metrics_mapping={},
+                device=torch.device("cpu"),
+            )
+            metric_module.update(gen_test_batch(128))
+
+            if rank == 0:
+                faulthandler.dump_traceback_later(30, exit=True)
+                try:
+                    ret = metric_module.compute_throughput().resolve()
+                finally:
+                    faulthandler.cancel_dump_traceback_later()
+                assert "throughput-throughput|total_examples" in ret
+
+            dist.barrier()
+        finally:
+            dist.destroy_process_group()
+
+    def test_compute_throughput_is_collective_free(self) -> None:
+        self._run_multi_process_test(
+            world_size=self.WORLD_SIZE,
+            backend="gloo",
+            callable=self._run_compute_throughput_collective_free,
         )
 
     def test_rectask_info(self) -> None:

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -9,6 +9,7 @@
 
 import copy
 import dataclasses
+import faulthandler
 import logging
 import multiprocessing
 import os
@@ -188,6 +189,92 @@ class MetricModuleTest(unittest.TestCase):
                 self.assertTrue("throughput-throughput|total_examples" in ret)
                 self.assertTrue("optimizers-optimizers|learning_rate" in ret)
             dist.destroy_process_group()
+
+    def test_compute_throughput_excludes_other_metrics(self) -> None:
+        config = dataclasses.replace(
+            DefaultMetricsConfig,
+            throughput_metric=ThroughputDef(warmup_steps=1),
+            state_metrics=[StateMetricEnum.OPTIMIZERS],
+        )
+        with tempfile.NamedTemporaryFile(delete=True) as backend:
+            dist.init_process_group(
+                backend="gloo",
+                init_method=f"file://{backend.name}",
+                world_size=1,
+                rank=0,
+            )
+            try:
+                metric_module = generate_metric_module(
+                    TestMetricModule,
+                    metrics_config=config,
+                    batch_size=128,
+                    world_size=64,
+                    my_rank=0,
+                    state_metrics_mapping={StateMetricEnum.OPTIMIZERS: MockOptimizer()},
+                    device=torch.device("cpu"),
+                )
+                for _ in range(3):
+                    metric_module.update(gen_test_batch(128))
+
+                throughput_only = metric_module.compute_throughput().resolve()
+                full = metric_module.compute().resolve()
+
+                self.assertIn(
+                    "throughput-throughput|lifetime_throughput", throughput_only
+                )
+                self.assertIn(
+                    "throughput-throughput|window_throughput", throughput_only
+                )
+                self.assertEqual(
+                    set(throughput_only),
+                    {key for key in full if key.startswith("throughput-")},
+                )
+                self.assertIn("ne-ne|lifetime_ne", full)
+                self.assertIn("optimizers-optimizers|learning_rate", full)
+                self.assertNotIn("ne-ne|lifetime_ne", throughput_only)
+                self.assertNotIn("optimizers-optimizers|learning_rate", throughput_only)
+            finally:
+                dist.destroy_process_group()
+
+    @staticmethod
+    def _run_compute_throughput_collective_free(
+        rank: int, world_size: int, backend: str
+    ) -> None:
+        dist.init_process_group(
+            backend=backend,
+            world_size=world_size,
+            rank=rank,
+        )
+        try:
+            metric_module = generate_metric_module(
+                TestMetricModule,
+                metrics_config=DefaultMetricsConfig,
+                batch_size=128,
+                world_size=world_size,
+                my_rank=rank,
+                state_metrics_mapping={},
+                device=torch.device("cpu"),
+            )
+            metric_module.update(gen_test_batch(128))
+
+            if rank == 0:
+                faulthandler.dump_traceback_later(30, exit=True)
+                try:
+                    ret = metric_module.compute_throughput().resolve()
+                finally:
+                    faulthandler.cancel_dump_traceback_later()
+                assert "throughput-throughput|total_examples" in ret
+
+            dist.barrier()
+        finally:
+            dist.destroy_process_group()
+
+    def test_compute_throughput_is_collective_free(self) -> None:
+        self._run_multi_process_test(
+            world_size=self.WORLD_SIZE,
+            backend="gloo",
+            callable=self._run_compute_throughput_collective_free,
+        )
 
     def test_rectask_info(self) -> None:
         mock_optimizer = MockOptimizer()


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/torchrec/pull/4475

Reviewed By: derekwan1, kaanbaloglu

Differential Revision: D113055486


