### PR TITLE
Revert D113962248: Optimizer scratch-buffer stashing in MemoryStashingManager (#4495)

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -9,17 +9,7 @@
 
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    runtime_checkable,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -40,11 +30,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 # keep the copy engine yielding often enough for the main stream's small copies
 # to interleave, at a negligible bandwidth cost (see chunked copy design).
 _STASH_CHUNK_SIZE_BYTES: int = 32 * 1024**2
-
-
-@runtime_checkable
-class _ScratchBufferOptimizer(Protocol):
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]: ...
 
 
 def _tensor_size_text(tensor: Union[List[torch.Tensor], torch.Tensor]) -> str:
@@ -167,7 +152,6 @@ class MemoryStashingManager:
     _device_to_host_stream: Optional[torch.cuda.Stream] = None
     _embedding_weight_restore_callbacks: List[Callable[..., None]] = []
     _optimizer_state_restore_callbacks: List[Callable[..., None]] = []
-    _optimizer_scratch_buffer_restore_callbacks: List[Callable[..., None]] = []
     _emo_cache_restore_callbacks: List[Callable[..., None]] = []
     _stash_executor: Optional[ThreadPoolExecutor] = None
     _delay_stash: bool = False
@@ -302,7 +286,6 @@ class MemoryStashingManager:
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
         cls._optimizer_state_restore_callbacks.clear()
-        cls._optimizer_scratch_buffer_restore_callbacks.clear()
         cls._emo_cache_restore_callbacks.clear()
         cls._delay_stash = False
         cls._stash_chunk_size_bytes = _STASH_CHUNK_SIZE_BYTES
@@ -376,23 +359,14 @@ class MemoryStashingManager:
         cls,
         _grad: Optional[torch.Tensor] = None,
         sync_event: Optional[torch.cuda.Event] = None,
-        restore_scratch_buffer: bool = True,
     ) -> None:
-        """Restore copied optimizer state and, optionally, disposable scratch buffer."""
+        """Pop and call all optimizer state restore callbacks in reverse order."""
         cls._log_ems_once(
             "ems_restore_optimizer_state_callbacks",
-            {
-                "num_callbacks": str(len(cls._optimizer_state_restore_callbacks)),
-                "num_scratch_buffer_callbacks": str(
-                    len(cls._optimizer_scratch_buffer_restore_callbacks)
-                ),
-            },
+            {"num_callbacks": str(len(cls._optimizer_state_restore_callbacks))},
         )
         while cls._optimizer_state_restore_callbacks:
             cls._optimizer_state_restore_callbacks.pop()(None, sync_event)
-        if restore_scratch_buffer:
-            while cls._optimizer_scratch_buffer_restore_callbacks:
-                cls._optimizer_scratch_buffer_restore_callbacks.pop()(None, sync_event)
 
     @classmethod
     def restore_optimizer_state_next(
@@ -416,18 +390,6 @@ class MemoryStashingManager:
             )
             cls._optimizer_state_restore_callbacks.pop(0)(None, sync_event)
 
-    @staticmethod
-    def _consume_restore_callback(
-        callback: Callable[..., None],
-        callbacks: List[Callable[..., None]],
-        sync_event: Optional[torch.cuda.Event],
-    ) -> None:
-        try:
-            callbacks.remove(callback)
-        except ValueError:
-            return
-        callback(None, sync_event)
-
     @classmethod
     def _stash_tensors(
         cls,
@@ -437,7 +399,7 @@ class MemoryStashingManager:
         delay: bool = False,
     ) -> Tuple[
         Callable[[Optional[torch.Tensor]], None],
-        Callable[..., None],
+        Callable[[Optional[torch.Tensor]], None],
         Callable[[Optional[torch.Tensor]], None],
     ]:
         """
@@ -1003,77 +965,6 @@ class MemoryStashingManager:
         return await_restore, restore
 
     @classmethod
-    def _release_optimizer_scratch_buffers(
-        cls,
-        optimizer: torch.optim.Optimizer,
-        sync_event: Optional[torch.cuda.Event],
-    ) -> Optional[Callable[..., None]]:
-        if not isinstance(optimizer, _ScratchBufferOptimizer):
-            return None
-        if sync_event is not None:
-            sync_event.synchronize()
-
-        scratch_buffer_storages: list[tuple[torch.UntypedStorage, int]] = []
-        seen_storage_ids: set[int] = set()
-        for scratch_buffer in optimizer.scratch_buffers():
-            storage = scratch_buffer.untyped_storage()
-            storage_id = storage._cdata
-            storage_size = storage.size()
-            if storage_size == 0 or storage_id in seen_storage_ids:
-                continue
-            seen_storage_ids.add(storage_id)
-            scratch_buffer_storages.append((storage, storage_size))
-
-        released_scratch_buffer_bytes = sum(
-            storage_size for _, storage_size in scratch_buffer_storages
-        )
-        if released_scratch_buffer_bytes == 0:
-            return None
-        for storage, _ in scratch_buffer_storages:
-            storage.resize_(0)
-
-        cls._log_ems_once(
-            "ems_stash_optimizer_scratch_buffer_released",
-            {
-                "optimizer": type(optimizer).__name__,
-                "size_bytes": str(released_scratch_buffer_bytes),
-            },
-        )
-
-        def restore_scratch_buffer(
-            _grad: Optional[torch.Tensor] = None,
-            _sync_event: Optional[torch.cuda.Event] = None,
-        ) -> None:
-            restored_scratch_buffer_bytes = 0
-            for storage, storage_size in scratch_buffer_storages:
-                if storage.size() == 0:
-                    storage.resize_(storage_size)
-                    restored_scratch_buffer_bytes += storage_size
-            cls._log_ems_once(
-                "ems_restore_optimizer_scratch_buffer",
-                {
-                    "optimizer": type(optimizer).__name__,
-                    "size_bytes": str(restored_scratch_buffer_bytes),
-                },
-            )
-
-        cls._optimizer_scratch_buffer_restore_callbacks.append(restore_scratch_buffer)
-        return restore_scratch_buffer
-
-    @staticmethod
-    def _collect_optimizer_state_tensors(
-        optimizer: torch.optim.Optimizer,
-    ) -> List[torch.Tensor]:
-        """Collect all stashable CUDA tensors from ``optimizer.state``."""
-        tensors: List[torch.Tensor] = []
-        for _param, state_dict in optimizer.state.items():
-            if not isinstance(state_dict, dict):
-                continue
-            for _state_key, state_value in state_dict.items():
-                tensors.extend(_collect_cuda_tensors_from_value(state_value))
-        return tensors
-
-    @classmethod
     def stash_optimizer_state(
         cls,
         optimizer: torch.optim.Optimizer,
@@ -1134,7 +1025,12 @@ class MemoryStashingManager:
             - Supports nested structures like Shampoo's ShampooKroneckerFactors
         """
         # Collect all CUDA tensors from optimizer state
-        tensors: List[torch.Tensor] = cls._collect_optimizer_state_tensors(optimizer)
+        tensors: List[torch.Tensor] = []
+        for _param, state_dict in optimizer.state.items():
+            if not isinstance(state_dict, dict):
+                continue
+            for _state_key, state_value in state_dict.items():
+                tensors.extend(_collect_cuda_tensors_from_value(state_value))
 
         cls._log_ems_once(
             "ems_stash_optimizer_state_collected",
@@ -1144,33 +1040,11 @@ class MemoryStashingManager:
             },
         )
 
-        scratch_buffer_restore: Callable[..., None] | None = None
-
         if num_slices <= 1:
-            await_restore, tensor_restore, _execute_stash = cls._stash_tensors(
+            await_restore, restore, _execute_stash = cls._stash_tensors(
                 tensors, label="optimizer state", sync_event=sync_event
             )
-            cls._optimizer_state_restore_callbacks.append(tensor_restore)
-            scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
-                optimizer, sync_event
-            )
-
-            def restore(
-                _grad: Optional[torch.Tensor] = None,
-                restore_sync_event: Optional[torch.cuda.Event] = None,
-            ) -> None:
-                cls._consume_restore_callback(
-                    tensor_restore,
-                    cls._optimizer_state_restore_callbacks,
-                    restore_sync_event,
-                )
-                if scratch_buffer_restore is not None:
-                    cls._consume_restore_callback(
-                        scratch_buffer_restore,
-                        cls._optimizer_scratch_buffer_restore_callbacks,
-                        restore_sync_event,
-                    )
-
+            cls._optimizer_state_restore_callbacks.append(restore)
             return await_restore, restore
 
         # Gradual (throttled) restore: partition the dense optimizer state into
@@ -1198,10 +1072,6 @@ class MemoryStashingManager:
             # maps slice k to the k-th hook to fire.
             cls._optimizer_state_restore_callbacks.append(restore_k)
 
-        scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
-            optimizer, sync_event
-        )
-
         def aggregate_await(_grad: Optional[torch.Tensor] = None) -> None:
             """Gate the current stream on EVERY slice's restore completion."""
             for slice_await in slice_awaits:
@@ -1209,21 +1079,11 @@ class MemoryStashingManager:
 
         def restore_all(
             _grad: Optional[torch.Tensor] = None,
-            restore_sync_event: Optional[torch.cuda.Event] = None,
+            sync_event: Optional[torch.cuda.Event] = None,
         ) -> None:
-            """Restore all slices, followed by disposable optimizer scratch buffer."""
+            """Restore all slices (used when no per-hook driver is present)."""
             for slice_restore in slice_restores:
-                cls._consume_restore_callback(
-                    slice_restore,
-                    cls._optimizer_state_restore_callbacks,
-                    restore_sync_event,
-                )
-            if scratch_buffer_restore is not None:
-                cls._consume_restore_callback(
-                    scratch_buffer_restore,
-                    cls._optimizer_scratch_buffer_restore_callbacks,
-                    restore_sync_event,
-                )
+                slice_restore(None, sync_event)
 
         return aggregate_await, restore_all
 

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -512,19 +512,6 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertFalse(MemoryStashingManager.is_enabled())
 
 
-class ScratchBufferOptimizer(torch.optim.SGD):
-    def __init__(
-        self,
-        params: Any,
-        scratch_buffer: torch.Tensor,
-    ) -> None:
-        super().__init__(params, lr=0.01)
-        self._scratch_buffer = scratch_buffer
-
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        return (self._scratch_buffer,)
-
-
 class TestStashOptimizerState(unittest.TestCase):
     """Tests for MemoryStashingManager.stash_optimizer_state method."""
 
@@ -538,87 +525,6 @@ class TestStashOptimizerState(unittest.TestCase):
 
     def tearDown(self) -> None:
         MemoryStashingManager.reset()
-
-    def test_scratch_buffer_only_uses_optimizer_state_stash_restore_api(self) -> None:
-        model = nn.Linear(10, 10).to(self.device)
-        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
-        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
-        scratch_buffer_size = scratch_buffer.untyped_storage().size()
-
-        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(optimizer)
-
-        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
-        self.assertEqual(
-            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
-            1,
-        )
-
-        MemoryStashingManager.restore_optimizer_state()
-        await_restore(None)
-
-        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
-        self.assertEqual(
-            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
-            0,
-        )
-
-    def test_returned_restore_consumes_registered_callbacks(self) -> None:
-        model = nn.Linear(10, 10).to(self.device)
-        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
-        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
-        scratch_buffer_size = scratch_buffer.untyped_storage().size()
-
-        await_restore, restore = MemoryStashingManager.stash_optimizer_state(optimizer)
-        restore(None)
-        await_restore(None)
-
-        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
-        self.assertEqual(MemoryStashingManager._optimizer_state_restore_callbacks, [])
-        self.assertEqual(
-            MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks,
-            [],
-        )
-
-        MemoryStashingManager.restore_optimizer_state()
-        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
-
-    def test_scratch_buffer_restore_can_be_deferred_until_pre_step_guard(self) -> None:
-        model = nn.Linear(10, 10).to(self.device)
-        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
-        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
-
-        MemoryStashingManager.stash_optimizer_state(optimizer)
-        MemoryStashingManager.restore_optimizer_state(restore_scratch_buffer=False)
-
-        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
-        self.assertEqual(
-            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
-            1,
-        )
-
-        MemoryStashingManager.restore_optimizer_state()
-
-        self.assertGreater(scratch_buffer.untyped_storage().size(), 0)
-
-    def test_scratch_buffer_restore_waits_until_all_slices_are_restored(self) -> None:
-        model = nn.Linear(512, 512).to(self.device)
-        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
-        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
-        x = torch.randn(32, 512, device=self.device)
-        model(x).sum().backward()
-        optimizer.step()
-
-        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
-            optimizer, num_slices=2
-        )
-        MemoryStashingManager.restore_optimizer_state_next()
-
-        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
-
-        MemoryStashingManager.restore_optimizer_state()
-        await_restore(None)
-
-        self.assertGreater(scratch_buffer.untyped_storage().size(), 0)
 
     def test_basic_adam_optimizer_stash_and_restore(self) -> None:
         """Test basic stash and restore with Adam optimizer."""

--- a/torchrec/optim/keyed.py
+++ b/torchrec/optim/keyed.py
@@ -414,14 +414,6 @@ class CombinedOptimizer(KeyedOptimizer):
         for _, opt in self._optims:
             opt.save_param_groups(save)
 
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        return tuple(
-            scratch_buffer
-            for _, opt in self._optims
-            if hasattr(opt, "scratch_buffers")
-            for scratch_buffer in opt.scratch_buffers()
-        )
-
     def set_optimizer_step(self, step: int) -> None:
         for _, opt in self._optims:
             if hasattr(opt, "set_optimizer_step"):
@@ -458,11 +450,6 @@ class KeyedOptimizerWrapper(KeyedOptimizer):
     # pyrefly: ignore[bad-override]
     def step(self, closure: Any = None) -> None:
         self._optimizer.step(closure=closure)
-
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        if hasattr(self._optimizer, "scratch_buffers"):
-            return self._optimizer.scratch_buffers()
-        return ()
 
     def set_optimizer_step(self, step: int) -> None:
         if hasattr(self._optimizer, "set_optimizer_step"):
@@ -517,11 +504,6 @@ class OptimizerWrapper(KeyedOptimizer):
 
     def save_param_groups(self, save: bool) -> None:
         self._optimizer.save_param_groups(save)
-
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        if hasattr(self._optimizer, "scratch_buffers"):
-            return self._optimizer.scratch_buffers()
-        return ()
 
     def set_optimizer_step(self, step: int) -> None:
         if hasattr(self._optimizer, "set_optimizer_step"):

--- a/torchrec/optim/semi_sync.py
+++ b/torchrec/optim/semi_sync.py
@@ -290,14 +290,6 @@ class SemisyncOptimizer(KeyedOptimizer):
         ret.append(f"{SEMI_SYNC_GLOBAL_OPTIM_KEY}: {self._global_optimizer.__repr__()}")
         return ", ".join(ret)
 
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        return tuple(
-            scratch_buffer
-            for optimizer in (self._optimizer, self._global_optimizer)
-            if hasattr(optimizer, "scratch_buffers")
-            for scratch_buffer in optimizer.scratch_buffers()
-        )
-
     def set_optimizer_step(self, step: int) -> None:
         for opt in [self._optimizer, self._global_optimizer]:
             if hasattr(opt, "set_optimizer_step"):

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -39,15 +39,6 @@ class DummyOptimizerModule:
         self.tensor.detach().copy_(state_dict["tensor"])
 
 
-class ScratchBufferSGD(torch.optim.SGD):
-    def __init__(self, params: Any, scratch_buffer: torch.Tensor) -> None:
-        super().__init__(params, lr=0.1)
-        self._scratch_buffer = scratch_buffer
-
-    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
-        return (self._scratch_buffer,)
-
-
 class TestKeyedOptimizer(unittest.TestCase):
     def _assert_state_dict_equals(
         self, dict1: Dict[str, Any], dict2: Dict[str, Any]
@@ -225,21 +216,6 @@ class TestKeyedOptimizer(unittest.TestCase):
         self.assertTrue("state" in opt.state_dict())
         self.assertFalse(opt.state_dict()["state"])
 
-    def test_keyed_optimizer_wrapper_scratch_buffers(self) -> None:
-        param = torch.nn.Parameter(torch.ones(1))
-        scratch_buffer = torch.empty(7)
-        capable = KeyedOptimizerWrapper(
-            {"param": param},
-            lambda params: ScratchBufferSGD(params, scratch_buffer),
-        )
-        incapable = KeyedOptimizerWrapper(
-            {"param": param},
-            lambda params: torch.optim.SGD(params, lr=0.1, foreach=True),
-        )
-
-        self.assertEqual(capable.scratch_buffers(), (scratch_buffer,))
-        self.assertEqual(incapable.scratch_buffers(), ())
-
     def test_pickle(self) -> None:
         dense = torch.nn.Parameter(torch.ones((2, 3), dtype=torch.float))
         sparse = torch.nn.Parameter(torch.ones((1, 4), dtype=torch.float))
@@ -262,36 +238,6 @@ class TestKeyedOptimizer(unittest.TestCase):
 
 
 class TestCombinedOptimizer(unittest.TestCase):
-    def test_scratch_buffers_fan_out_through_nested_children(self) -> None:
-        first_scratch_buffer = torch.empty(3)
-        second_scratch_buffer = torch.empty(5)
-        first_param = torch.nn.Parameter(torch.ones(1))
-        second_param = torch.nn.Parameter(torch.ones(1))
-        first = KeyedOptimizerWrapper(
-            {"first": first_param},
-            lambda params: ScratchBufferSGD(params, first_scratch_buffer),
-        )
-        second = KeyedOptimizerWrapper(
-            {"second": second_param},
-            lambda params: ScratchBufferSGD(params, second_scratch_buffer),
-        )
-        incapable = KeyedOptimizer(
-            {"plain": torch.nn.Parameter(torch.ones(1))},
-            {},
-            [],
-        )
-        optimizer = CombinedOptimizer(
-            [
-                ("nested", CombinedOptimizer([("first", first), ("plain", incapable)])),
-                ("second", second),
-            ]
-        )
-
-        self.assertEqual(
-            optimizer.scratch_buffers(),
-            (first_scratch_buffer, second_scratch_buffer),
-        )
-
     def test_pickle(self) -> None:
         # Set up example KeyedOptimizer 1.
         param_1_t = torch.tensor([1.0, 2.0])
@@ -369,20 +315,6 @@ class TestCombinedOptimizer(unittest.TestCase):
 
 
 class TestOptimizerWrapper(unittest.TestCase):
-    def test_scratch_buffers_forwarding(self) -> None:
-        scratch_buffer = torch.empty(11)
-        param = torch.nn.Parameter(torch.ones(1))
-        capable = OptimizerWrapper(
-            KeyedOptimizerWrapper(
-                {"param": param},
-                lambda params: ScratchBufferSGD(params, scratch_buffer),
-            )
-        )
-        incapable = OptimizerWrapper(KeyedOptimizer({"param": param}, {}, []))
-
-        self.assertEqual(capable.scratch_buffers(), (scratch_buffer,))
-        self.assertEqual(incapable.scratch_buffers(), ())
-
     def test_load_state_dict(self) -> None:
         param_1_t = torch.tensor([1.0, 2.0])
         param_1 = Variable(param_1_t)

--- a/torchrec/optim/tests/test_semi_sync.py
+++ b/torchrec/optim/tests/test_semi_sync.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import unittest
-from typing import Any, cast
 from unittest.mock import Mock
 
 import torch
@@ -58,21 +57,6 @@ class TestSemisyncOptimizer(unittest.TestCase):
             global_params=self.global_params,
             optimizer=self.mock_local_optimizer,
             global_optimizer=self.mock_global_optimizer,
-        )
-
-    def test_scratch_buffers_fan_out_to_children(self) -> None:
-        local_scratch_buffer = torch.empty(3)
-        global_scratch_buffer = torch.empty(5)
-        cast(Any, self.mock_local_optimizer).scratch_buffers = Mock(
-            return_value=(local_scratch_buffer,)
-        )
-        cast(Any, self.mock_global_optimizer).scratch_buffers = Mock(
-            return_value=(global_scratch_buffer,)
-        )
-
-        self.assertEqual(
-            self.optimizer.scratch_buffers(),
-            (local_scratch_buffer, global_scratch_buffer),
         )
 
     def test_initialization_with_mocks(self) -> None:


### PR DESCRIPTION
Summary:

D113962248 added the torchrec half of "free DistributedShampoo scratch buffers
during the optimizer-state stash window": the `_ScratchBufferOptimizer` protocol,
`scratch_buffers()` discovery, `_release_optimizer_scratch_buffers`, a second
`_optimizer_scratch_buffer_restore_callbacks` list, the
`restore_optimizer_state(restore_scratch_buffer=...)` parameter, and
`scratch_buffers()` fan-out through `CombinedOptimizer` / `KeyedOptimizerWrapper`
/ `OptimizerWrapper` / `SemiSyncOptimizer`.

None of that machinery is needed. `_global_dist_buffer` is pure scratch that
DistributedShampoo allocates, fills, and consumes entirely within
`update_params()`; it never leaves the optimizer and is not part of `state_dict`.
Routing its free/re-alloc through torchrec meant a cross-repo protocol plus
wrapper fan-out and a parallel callback list, purely so an external caller could
drive a resize the owner could do itself.

Reverting so the feature can be re-implemented inside
`hpc/optimizers/distributed_shampoo/dev/` behind
`DDPDistributedConfig.free_dist_buffer_between_steps`.

Middle of a 3-diff revert stack (on top of the D113962249 revert).

Two deliberate carve-outs -- this is NOT a mechanical `sl backout`:

1. Kept the BUCK dep fix. D113962248 also changed `//caffe2:_torch` ->
   `fbsource//third-party/pypi/torch:torch` in `torchrec/optim/BUCK` and
   `torchrec/optim/tests/BUCK`. `_torch` is a private target that should not be
   depended on directly, so those hunks are left in place.

2. Kept the `staged_cpu_view_for` contiguity fix and its `TestCheckpointWhileStashed`
   tests. D113962248 also replaced the `view.set_(storage, offset, shape, stride)`
   reconstruction with a contiguous `reshape/narrow/view`. That is an unrelated
   correctness fix: `chunked_copy_` fills the pinned buffer in logical/row-major
   order, so rebuilding the view with the source's original (possibly transposed)
   stride hands the DCP stager transposed values -> silently corrupt optimizer
   state on resume. Reverting it would reintroduce that bug.

Original commit changeset: 37123fd3d19f
Original Phabricator Diff: D113962248

Reviewed By: wz337, hjmshi

Differential Revision: D114959521


