### PR TITLE
Give planner value types a fast `__deepcopy__` (#4496)

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -27,6 +27,8 @@ from torchrec.distributed.planner.storage_reservations import (
 from torchrec.distributed.planner.types import (
     BasicCommsBandwidths,
     CustomTopologyData,
+    DeviceHardware,
+    EmoConfig,
     HardwareConfig,
     hash_planner_context_inputs,
     KernelConfig,
@@ -2364,3 +2366,70 @@ class ShardingOptionDetailTest(unittest.TestCase):
         )
         detail = ShardingOptionDetail.from_sharding_option(sharding_option)
         self.assertIsNone(detail.total_perf)
+
+
+class TestValueTypeDeepcopy(unittest.TestCase):
+    """`Perf`, `Storage` and `DeviceHardware` define `__deepcopy__` to skip the
+    generic reflective copy, which the partitioner runs millions of times per plan.
+    These tests pin the semantics that fast path has to preserve."""
+
+    def _perf(self, base: float = 1.0) -> Perf:
+        return Perf(
+            fwd_compute=base,
+            fwd_comms=base + 1,
+            bwd_compute=base + 2,
+            bwd_comms=base + 3,
+            input_dist_comms=base + 4,
+            prefetch_compute=base + 5,
+        )
+
+    def test_perf_deepcopy_is_equal_and_independent(self) -> None:
+        original = self._perf()
+        copied = deepcopy(original)
+        self.assertEqual(original, copied)
+        self.assertIsNot(original, copied)
+        copied.fwd_compute = 99.0
+        self.assertEqual(original.fwd_compute, 1.0)
+
+    def test_storage_deepcopy_is_equal_and_independent(self) -> None:
+        original = Storage(hbm=1, ddr=2, ssd=3)
+        copied = deepcopy(original)
+        self.assertEqual(original, copied)
+        self.assertIsNot(original, copied)
+        copied.hbm = 99
+        self.assertEqual(original.hbm, 1)
+
+    def test_device_hardware_deepcopy_copies_children(self) -> None:
+        original = DeviceHardware(
+            rank=3, storage=Storage(hbm=1, ddr=2, ssd=3), perf=self._perf()
+        )
+        copied = deepcopy(original)
+        self.assertEqual(original, copied)
+        self.assertIsNot(original.storage, copied.storage)
+        self.assertIsNot(original.perf, copied.perf)
+        copied.storage.hbm = 99
+        copied.perf.fwd_compute = 99.0
+        self.assertEqual(original.storage.hbm, 1)
+        self.assertEqual(original.perf.fwd_compute, 1.0)
+
+    def test_deepcopy_preserves_aliasing(self) -> None:
+        # Two devices sharing one Storage/Perf must still share after the copy,
+        # which is what registering in `memo` buys us.
+        storage = Storage(hbm=1, ddr=2, ssd=3)
+        perf = self._perf()
+        devices = [
+            DeviceHardware(rank=0, storage=storage, perf=perf),
+            DeviceHardware(rank=1, storage=storage, perf=perf),
+        ]
+        copied = deepcopy(devices)
+        self.assertIs(copied[0].storage, copied[1].storage)
+        self.assertIs(copied[0].perf, copied[1].perf)
+        self.assertIsNot(copied[0].storage, storage)
+
+    def test_topology_deepcopy_is_independent(self) -> None:
+        # Storage reservation deepcopies the topology and then mutates hbm in place.
+        topology = Topology(world_size=2, compute_device="cuda")
+        reserved = deepcopy(topology)
+        for device in reserved.devices:
+            device.storage.hbm = 7
+        self.assertTrue(all(d.storage.hbm != 7 for d in topology.devices))

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -127,6 +127,22 @@ class Perf:
             )
         )
 
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "Perf":
+        # Every field is a float, so the generic deepcopy walk (__reduce_ex__ ->
+        # _reconstruct -> _deepcopy_dict) is pure overhead.  The partitioner copies
+        # devices once per candidate host per proposal, which makes this one of the
+        # hottest paths in planning.
+        result = Perf(
+            fwd_compute=self.fwd_compute,
+            fwd_comms=self.fwd_comms,
+            bwd_compute=self.bwd_compute,
+            bwd_comms=self.bwd_comms,
+            input_dist_comms=self.input_dist_comms,
+            prefetch_compute=self.prefetch_compute,
+        )
+        memo[id(self)] = result
+        return result
+
 
 # ---- TOPOLOGY ---- #
 
@@ -161,6 +177,12 @@ class Storage:
     def fits_in(self, other: "Storage") -> bool:
         return self.hbm <= other.hbm and self.ddr <= other.ddr and self.ssd <= other.ssd
 
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "Storage":
+        # See Perf.__deepcopy__: all-scalar fields, copied on the partitioner hot path.
+        result = Storage(hbm=self.hbm, ddr=self.ddr, ssd=self.ssd)
+        memo[id(self)] = result
+        return result
+
 
 @dataclass
 class DeviceHardware:
@@ -184,6 +206,17 @@ class DeviceHardware:
             and self.storage == other.storage
             and self.perf == other.perf
         )
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "DeviceHardware":
+        # Children go through deepcopy() rather than being rebuilt directly so that
+        # objects aliased across a single copy stay aliased in the result.
+        result = DeviceHardware(
+            rank=self.rank,
+            storage=deepcopy(self.storage, memo),
+            perf=deepcopy(self.perf, memo),
+        )
+        memo[id(self)] = result
+        return result
 
 
 class CustomTopologyData:


### PR DESCRIPTION
Summary:

`GreedyPerfPartitioner._cohost_partition` and `_multi_hosts_partition` call
`copy.deepcopy(devices)` once per candidate host per proposal, and storage
reservation deepcopies the whole `Topology`.  `DeviceHardware`, `Storage` and
`Perf` hold nothing but ints and floats, but they have no `__deepcopy__`, so
each one goes through the generic reflective path: `__reduce_ex__` ->
`_reconstruct` -> `_deepcopy_dict`, plus a `_keep_alive` append and an atomic
`deepcopy` per field.  That expands one device into roughly 20 recursive calls
and one host into roughly 170.

Profiling a 64-table, world-size-16 plan showed `copy.deepcopy` accounting for
14.5M calls and 67% of total planner time, which is pure copying overhead for
objects that are three scalars wide.

This adds `__deepcopy__` to all three types.  Children still go through
`deepcopy(child, memo)` rather than being rebuilt directly, and each result is
registered in `memo`, so objects aliased within a single copy stay aliased and
the observable semantics are unchanged.  `GreedyPerfPartitioner.partition`
already hand-builds its device copies for exactly this reason, so this just
extends the same idea to the paths that still went through `deepcopy`.

Measured on a local benchmark, 64 tables, world size 16, 6 reps per arm:

| | before | after |
| plan() wall clock | 19.80s | 11.03s |
| `deepcopy` calls | 14.5M | 1.55M |

which is a 44% reduction in planning time.  The win grows with table count and
world size, since both scale the number of partition attempts.

This changes no sharding decisions, only how the intermediate device state is
copied, so sharding plans and therefore NE are bit-identical.

Reviewed By: micrain

Differential Revision: D114901075


