### PR TITLE
Fix embedding lookup stream synchronization (#4497)

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipeline_fused_sparse_dist.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipeline_fused_sparse_dist.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from hypothesis import given, settings, strategies as st
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.test_utils.test_sharding import copy_state_dict
+from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import (
+    TrainPipelineSparseDistTestBase,
+)
+from torchrec.distributed.train_pipeline.train_pipelines import (
+    TrainPipelineFusedSparseDist,
+)
+from torchrec.distributed.types import ShardingType
+
+_FUSED_PARAMS: dict[str, bool] = {"stochastic_rounding": False}
+_NUM_BATCHES = 12
+_BATCH_SIZE = 32
+
+
+class TrainPipelineFusedSparseDistTest(TrainPipelineSparseDistTestBase):
+    def _assert_equal_to_non_pipelined(
+        self, sharding_type: str, **pipeline_kwargs: object
+    ) -> None:
+        """Runs the pipeline against a non-pipelined reference and compares.
+
+        Args:
+            sharding_type: sharding type for both models.
+            pipeline_kwargs: extra kwargs forwarded to TrainPipelineFusedSparseDist.
+        """
+        data = self._generate_data(
+            num_batches=_NUM_BATCHES,
+            batch_size=_BATCH_SIZE,
+        )
+        dataloader = iter(data)
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, EmbeddingComputeKernel.FUSED.value, _FUSED_PARAMS
+        )
+        (
+            sharded_model_pipelined,
+            optim_pipelined,
+        ) = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, EmbeddingComputeKernel.FUSED.value, _FUSED_PARAMS
+        )
+        copy_state_dict(
+            sharded_model.state_dict(), sharded_model_pipelined.state_dict()
+        )
+
+        pipeline = TrainPipelineFusedSparseDist(
+            model=sharded_model_pipelined,
+            optimizer=optim_pipelined,
+            device=self.device,
+            execute_all_batches=True,
+            # pyre-ignore[6]: kwargs are forwarded verbatim.
+            **pipeline_kwargs,
+        )
+
+        for batch in data[:-2]:
+            batch = batch.to(self.device)
+            optim.zero_grad()
+            loss, pred = sharded_model(batch)
+            loss.backward()
+            optim.step()
+
+            pred_pipeline = pipeline.progress(dataloader)
+
+            torch.testing.assert_close(pred, pred_pipeline)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    @patch("torch._utils_internal.justknobs_check", return_value=True)
+    def test_new_emb_lookup_stream_equal_to_non_pipelined(
+        self, _mock_justknobs_check: MagicMock
+    ) -> None:
+        """
+        Tests that running the embedding lookup on a dedicated stream, rather
+        than reusing the data-dist stream, still matches non-pipelined results.
+        The lookup then consumes input-dist output across a stream boundary.
+        """
+        self._assert_equal_to_non_pipelined(
+            sharding_type=ShardingType.TABLE_WISE.value,
+            emb_lookup_stream="new",
+        )
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    # 8 combinations of the axes below; sample all of them so coverage does not
+    # depend on which examples hypothesis happens to draw.
+    @settings(max_examples=8, deadline=None)
+    @given(
+        enqueue_batch_after_forward=st.booleans(),
+        embedding_lookup_after_data_dist=st.booleans(),
+        sharding_type=st.sampled_from(
+            [
+                ShardingType.TABLE_WISE.value,
+                ShardingType.ROW_WISE.value,
+            ]
+        ),
+    )
+    def test_equal_to_non_pipelined(
+        self,
+        enqueue_batch_after_forward: bool,
+        embedding_lookup_after_data_dist: bool,
+        sharding_type: str,
+    ) -> None:
+        """
+        Tests TrainPipelineFusedSparseDist with various parameter combinations
+        produces same results as non-pipelined execution.
+        """
+        self._assert_equal_to_non_pipelined(
+            sharding_type=sharding_type,
+            enqueue_batch_after_forward=enqueue_batch_after_forward,
+            embedding_lookup_after_data_dist=embedding_lookup_after_data_dist,
+        )

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -71,7 +71,6 @@ from torchrec.distributed.train_pipeline.train_pipelines import (
     PrefetchTrainPipelineSparseDist,
     StagedTrainPipeline,
     TrainPipelineBase,
-    TrainPipelineFusedSparseDist,
     TrainPipelinePT2,
     TrainPipelineSemiSync,
     TrainPipelineSparseDist,
@@ -1692,84 +1691,6 @@ class PrefetchTrainPipelineSparseDistTest(TrainPipelineSparseDistTestBase):
                 torch.testing.assert_close(pred, pred_pipeline, rtol=0, atol=0)
             else:
                 torch.testing.assert_close(pred, pred_pipeline)
-
-
-class TrainPipelineFusedSparseDistTest(TrainPipelineSparseDistTestBase):
-    @unittest.skipIf(
-        not torch.cuda.is_available(),
-        "Not enough GPUs, this test requires at least one GPU",
-    )
-    @settings(max_examples=4, deadline=None)
-    @given(
-        enqueue_batch_after_forward=st.booleans(),
-        embedding_lookup_after_data_dist=st.booleans(),
-        sharding_type=st.sampled_from(
-            [
-                ShardingType.TABLE_WISE.value,
-                ShardingType.ROW_WISE.value,
-            ]
-        ),
-        kernel_type=st.sampled_from(
-            [
-                EmbeddingComputeKernel.FUSED.value,
-            ]
-        ),
-    )
-    def test_equal_to_non_pipelined(
-        self,
-        enqueue_batch_after_forward: bool,
-        embedding_lookup_after_data_dist: bool,
-        sharding_type: str,
-        kernel_type: str,
-    ) -> None:
-        """
-        Tests TrainPipelineFusedSparseDist with various parameter combinations
-        produces same results as non-pipelined execution.
-        """
-        data = self._generate_data(
-            num_batches=12,
-            batch_size=32,
-        )
-        dataloader = iter(data)
-
-        fused_params = {
-            "stochastic_rounding": False,
-        }
-
-        model = self._setup_model()
-        sharded_model, optim = self._generate_sharded_model_and_optimizer(
-            model, sharding_type, kernel_type, fused_params
-        )
-
-        (
-            sharded_model_pipelined,
-            optim_pipelined,
-        ) = self._generate_sharded_model_and_optimizer(
-            model, sharding_type, kernel_type, fused_params
-        )
-        copy_state_dict(
-            sharded_model.state_dict(), sharded_model_pipelined.state_dict()
-        )
-
-        pipeline = TrainPipelineFusedSparseDist(
-            model=sharded_model_pipelined,
-            optimizer=optim_pipelined,
-            device=self.device,
-            execute_all_batches=True,
-            enqueue_batch_after_forward=enqueue_batch_after_forward,
-            embedding_lookup_after_data_dist=embedding_lookup_after_data_dist,
-        )
-
-        for batch in data[:-2]:
-            batch = batch.to(self.device)
-            optim.zero_grad()
-            loss, pred = sharded_model(batch)
-            loss.backward()
-            optim.step()
-
-            pred_pipeline = pipeline.progress(dataloader)
-
-            torch.testing.assert_close(pred, pred_pipeline)
 
 
 class TrainPipelineSparseDistLiteTest(TrainPipelineSparseDistTestBase):

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -10,8 +10,8 @@
 import copy
 import enum
 import unittest
-from typing import Tuple, Union
-from unittest.mock import MagicMock
+from typing import cast, List, NamedTuple, Optional, Tuple, Union
+from unittest.mock import MagicMock, patch
 
 import torch
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -20,8 +20,14 @@ from torchrec.distributed.test_utils.test_model import (
     TestNegSamplingModule,
     TestSparseNN,
 )
-from torchrec.distributed.train_pipeline.pipeline_context import TrainPipelineContext
-from torchrec.distributed.train_pipeline.runtime_forwards import PipelinedForward
+from torchrec.distributed.train_pipeline.pipeline_context import (
+    EmbeddingTrainPipelineContext,
+    TrainPipelineContext,
+)
+from torchrec.distributed.train_pipeline.runtime_forwards import (
+    EmbeddingPipelinedForward,
+    PipelinedForward,
+)
 from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import (
     TrainPipelineSparseDistTestBase,
 )
@@ -29,10 +35,12 @@ from torchrec.distributed.train_pipeline.tracing import CallArgs, PipelinedPostp
 from torchrec.distributed.train_pipeline.utils import (
     _is_data_loading_retriable,
     _rewrite_model,
+    _start_embedding_lookup,
     DataLoadingThread,
 )
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import Awaitable, ShardedModule, ShardingType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.streamable import Multistreamable
 
 
 class ModelType(enum.Enum):
@@ -427,6 +435,250 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         missing_keys, unexpected_keys = sharded_model.load_state_dict(state_dict)
         self.assertEqual(missing_keys, [])
         self.assertEqual(unexpected_keys, [])
+
+
+# ~50ms on a modern GPU: long enough that a consumer on an unordered stream
+# reliably reads the input-dist output before it has been written.
+_INPUT_DIST_DELAY_CYCLES = 100_000_000
+
+# Fills the KJT before the input dist writes it, so an embedding lookup that runs
+# too early reads this instead of the real values.
+_PRE_INPUT_DIST_SENTINEL = -1
+
+
+@enum.unique
+class _StreamCase(enum.Enum):
+    """Call shapes `_start_embedding_lookup` sees across its callers.
+
+    Named for where the embedding lookup runs relative to the source (data-dist)
+    and target streams.
+    """
+
+    LOOKUP_ON_NEW = enum.auto()
+    LOOKUP_ON_SOURCE = enum.auto()
+    LOOKUP_ON_TARGET = enum.auto()
+    SOURCE_UNSET = enum.auto()
+    NO_STREAMS = enum.auto()
+
+
+class _DelayedInputDistAwaitable(Awaitable[KeyedJaggedTensor]):
+    """Input-dist awaitable that simulates a slow input dist racing the lookup.
+
+    `wait()` enqueues a long GPU delay and then the write on whatever stream is
+    current, which is the source (data-dist) stream, and never synchronizes the
+    host. An embedding lookup running on an unordered stream therefore reads the
+    KJT before it has been written -- the race `_start_embedding_lookup` is
+    responsible for preventing.
+    """
+
+    def __init__(self, kjt: KeyedJaggedTensor, values: torch.Tensor) -> None:
+        super().__init__()
+        self._kjt = kjt
+        self._values = values
+
+    def _wait_impl(self) -> KeyedJaggedTensor:
+        torch.cuda._sleep(_INPUT_DIST_DELAY_CYCLES)
+        self._kjt.values().copy_(self._values)
+        return self._kjt
+
+
+class _RecordingModuleContext(Multistreamable):
+    """Module context that remembers every stream it was recorded on.
+
+    Makes the `record_stream` calls that register the KJT and the module context
+    for caching-allocator lifetime tracking observable. `_start_embedding_lookup`
+    records both on the same streams, and a real KJT forwards `record_stream` to
+    its tensors without leaving a trace, so the streams collected here stand for
+    both calls.
+    """
+
+    def __init__(self) -> None:
+        self.recorded_streams: List[torch.Stream] = []
+
+    def record_stream(self, stream: torch.Stream) -> None:
+        self.recorded_streams.append(stream)
+
+
+class _StreamProbeModule:
+    """Test double for a pipelined `ShardedModule`, replacing the TBE lookup.
+
+    Implements only the surface `_start_embedding_lookup` touches: a `forward`
+    carrying the module name, and `compute_and_output_dist`. Instead of an
+    embedding lookup it copies the KJT it is handed, on whatever stream is
+    current, so the values the embedding-lookup stream actually read can be
+    asserted on directly rather than inferred from embedding outputs.
+    """
+
+    def __init__(self, observed: torch.Tensor) -> None:
+        self.observed = observed
+        # Assigned after construction, since the forward refers back to us.
+        self.forward: Optional[EmbeddingPipelinedForward] = None
+
+    def compute_and_output_dist(
+        self, ctx: Multistreamable, kjt: KeyedJaggedTensor
+    ) -> torch.Tensor:
+        self.observed.copy_(kjt.values())
+        return self.observed
+
+
+def _pipeline_module(
+    name: str, context: EmbeddingTrainPipelineContext, observed: torch.Tensor
+) -> _StreamProbeModule:
+    """Builds a probe module carrying the forward `_rewrite_model` would install.
+
+    `_rewrite_model` replaces a `ShardedModule`'s bound `forward` with an
+    `EmbeddingPipelinedForward`, which is where `_start_embedding_lookup` reads
+    the module name from, so the forward has to be attached after construction.
+    """
+    module = _StreamProbeModule(observed)
+    module.forward = EmbeddingPipelinedForward(
+        name=name,
+        args=CallArgs(args=[], kwargs={}),
+        module=cast(ShardedModule, module),
+        context=context,
+    )
+    return module
+
+
+class _StreamSetup(NamedTuple):
+    """Resolved streams for one `_start_embedding_lookup` call shape.
+
+    Attributes:
+        source_stream: the `source_stream` argument.
+        target_stream: the `target_stream` argument.
+        lookup_stream: stream entered before the call, mirroring the caller's
+            `stream_context(emb_lookup_stream)`. `None` leaves the default stream
+            current, which is what the callers without a stream context do.
+        expected_recorded: streams the module context must be recorded on.
+    """
+
+    source_stream: Optional[torch.cuda.Stream]
+    target_stream: Optional[torch.cuda.Stream]
+    lookup_stream: Optional[torch.cuda.Stream]
+    expected_recorded: List[torch.cuda.Stream]
+
+
+def _build_stream_setup(case: _StreamCase, device: torch.device) -> _StreamSetup:
+    """Builds the streams for one call shape of `_start_embedding_lookup`."""
+    default_stream = torch.cuda.current_stream(device)
+    source_stream = torch.cuda.Stream(device=device)
+    match case:
+        case _StreamCase.NO_STREAMS:
+            # No caller reaches this today: target_stream is always
+            # `current_stream()`, which is non-None even on CPU. Pins the
+            # helper's guard for the case where no device stream is resolvable.
+            return _StreamSetup(None, None, None, [])
+        case _StreamCase.SOURCE_UNSET:
+            # No data-dist stream, as on a CPU device, so the current stream
+            # comes from target_stream.
+            return _StreamSetup(None, default_stream, None, [default_stream])
+        case _StreamCase.LOOKUP_ON_TARGET:
+            # emb_lookup_stream="current", and the TrainPipelineSemiSync call shape.
+            return _StreamSetup(source_stream, default_stream, None, [default_stream])
+        case _StreamCase.LOOKUP_ON_SOURCE:
+            # emb_lookup_stream="data_dist", the TrainPipelineFusedSparseDist
+            # default. The lookup runs on the stream that allocated the KJT, so
+            # only the target stream needs recording.
+            return _StreamSetup(
+                source_stream,
+                default_stream,
+                source_stream,
+                [default_stream],
+            )
+        case _StreamCase.LOOKUP_ON_NEW:
+            # emb_lookup_stream="new": source, target and lookup are all distinct.
+            lookup_stream = torch.cuda.Stream(device=device)
+            return _StreamSetup(
+                source_stream,
+                default_stream,
+                lookup_stream,
+                [lookup_stream, default_stream],
+            )
+
+
+class StartEmbeddingLookupTest(unittest.TestCase):
+    """Tests the stream contract of `_start_embedding_lookup`.
+
+    Steps the helper performs:
+      1. Waits for the input-dist output on `source_stream`.
+      2. Runs `compute_and_output_dist` on the current stream, which callers set
+         to their embedding-lookup stream.
+
+    Expected behavior when those two streams differ:
+      - The current stream waits on an event recorded on `source_stream`. CUDA
+        orders nothing between two streams on its own, so without that edge the
+        lookup reads input-dist output that has not been written yet.
+      - The KJT and module context are recorded on the current stream, so the
+        caching allocator cannot reuse their memory while the lookup reads it.
+      - A stream serving two of these roles at once is recorded only once.
+    """
+
+    def _run_start_embedding_lookup(
+        self, setup: _StreamSetup, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor, _RecordingModuleContext]:
+        """Runs `_start_embedding_lookup` once for the given stream setup.
+
+        Returns:
+            The values the input dist writes, the values the embedding lookup
+            actually read, and the module context that recorded the streams.
+        """
+        name = "sharded_ebc"
+        num_values = 16
+        expected = torch.arange(num_values, dtype=torch.int64, device=device)
+        kjt = KeyedJaggedTensor(
+            keys=["feature_0"],
+            values=torch.full_like(expected, _PRE_INPUT_DIST_SENTINEL),
+            lengths=torch.ones(num_values, dtype=torch.int64, device=device),
+        )
+        observed = torch.full_like(expected, _PRE_INPUT_DIST_SENTINEL)
+        module_context = _RecordingModuleContext()
+        context = EmbeddingTrainPipelineContext(
+            input_dist_tensors_requests={
+                name: _DelayedInputDistAwaitable(kjt, expected)
+            },
+            module_contexts={name: module_context},
+        )
+        # The fixtures above are filled on the default stream but read below on
+        # source_stream and the lookup stream. PyTorch creates streams with
+        # cudaStreamNonBlocking, so they are not implicitly ordered against the
+        # default stream; drain it so a stale fixture read cannot masquerade as
+        # the race under test.
+        torch.cuda.synchronize(device)
+
+        with torch.cuda.stream(setup.lookup_stream):
+            _start_embedding_lookup(
+                module=cast(ShardedModule, _pipeline_module(name, context, observed)),
+                context=context,
+                source_stream=setup.source_stream,
+                target_stream=setup.target_stream,
+                stream_context=torch.cuda.stream,
+            )
+        # `observed` is written on the lookup stream; wait for it before reading.
+        torch.cuda.synchronize(device)
+        return expected, observed, module_context
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    @patch("torch._utils_internal.justknobs_check", return_value=True)
+    def test_stream_combinations(self, _mock_justknobs_check: MagicMock) -> None:
+        """
+        Tests every stream combination `_start_embedding_lookup` is called with,
+        asserting for each that the lookup read the fully written input-dist
+        output and that the module context recorded exactly the expected streams.
+        """
+        device = torch.device("cuda:0")
+        for case in _StreamCase:
+            with self.subTest(streams=case.name):
+                setup = _build_stream_setup(case, device)
+                expected, observed, module_context = self._run_start_embedding_lookup(
+                    setup, device
+                )
+                torch.testing.assert_close(observed, expected)
+                self.assertCountEqual(
+                    module_context.recorded_streams, setup.expected_recorded
+                )
 
 
 class _RetryableDataError(Exception):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -294,13 +294,20 @@ def _start_data_dist(
     _fuse_input_dist_splits(context)
 
 
-def _start_embedding_lookup(
+def _start_embedding_lookup_legacy(
     module: ShardedModule,
     context: EmbeddingTrainPipelineContext,
     source_stream: Optional[torch.Stream],
     target_stream: Optional[torch.Stream],
     stream_context: Callable[..., AbstractContextManager[Any, Any]],
 ) -> None:
+    """Records the KJT and module context on target_stream only.
+
+    Retained so `killswitch_emb_lookup_stream_sync` can fall back to it. Races
+    when the embedding lookup runs on a stream other than source_stream: nothing
+    orders the lookup after the stream producing its input, and the stream that
+    actually consumes the KJT is never registered with the caching allocator.
+    """
     # pyrefly: ignore[missing-attribute]
     module_context = context.module_contexts[module.forward.name]
     with stream_context(source_stream):
@@ -313,6 +320,81 @@ def _start_embedding_lookup(
     output_dist_out = module.compute_and_output_dist(module_context, kjt)
     # pyrefly: ignore[missing-attribute]
     context.embedding_a2a_requests[module.forward.name] = output_dist_out
+
+
+def _start_embedding_lookup_stream_synced(
+    module: ShardedModule,
+    context: EmbeddingTrainPipelineContext,
+    source_stream: Optional[torch.Stream],
+    target_stream: Optional[torch.Stream],
+    stream_context: Callable[..., AbstractContextManager[Any, Any]],
+) -> None:
+    """Orders the embedding lookup against the stream producing its input.
+
+    The lookup runs on whatever stream the caller made current, which need not be
+    source_stream or target_stream. When it differs from source_stream, CUDA
+    orders nothing between them, so this records an event on source_stream and
+    has the consumer wait on it, and registers the KJT and module context with
+    every stream that consumes them.
+    """
+    # pyrefly: ignore[missing-attribute]
+    name = module.forward.name
+    module_context = context.module_contexts[name]
+
+    # The caller may have made a third stream current for the lookup itself, so
+    # this is not necessarily source_stream or target_stream.
+    current_stream = None
+    device_stream = source_stream or target_stream
+    if device_stream:
+        current_stream = torch.get_device_module(device_stream.device).current_stream()
+
+    # Waiting here keeps the collective-completion wait and the recat kernels off
+    # the consumer stream, and their output in the data-dist allocator pool.
+    with stream_context(source_stream):
+        kjt = context.input_dist_tensors_requests[name].wait()
+        source_event = (
+            source_stream.record_event()
+            if source_stream is not None and source_stream != current_stream
+            else None
+        )
+
+    # Without this edge the lookup could read input-dist output on a stream that
+    # never waited for the stream producing it.
+    if current_stream is not None and source_event is not None:
+        current_stream.wait_event(source_event)
+
+    consumer_streams = {s for s in (current_stream, target_stream) if s is not None}
+    # source_stream allocated them, and record_stream no-ops on a block's own
+    # allocating stream. discard() rather than `!= source_stream`: torch.Stream
+    # richcompare returns False for every op against None, so `!=` would drop
+    # every stream whenever source_stream is None.
+    consumer_streams.discard(source_stream)
+    for stream in consumer_streams:
+        kjt.record_stream(stream)
+        module_context.record_stream(stream)
+
+    context.embedding_a2a_requests[name] = module.compute_and_output_dist(
+        module_context, kjt
+    )
+
+
+def _start_embedding_lookup(
+    module: ShardedModule,
+    context: EmbeddingTrainPipelineContext,
+    source_stream: Optional[torch.Stream],
+    target_stream: Optional[torch.Stream],
+    stream_context: Callable[..., AbstractContextManager[Any, Any]],
+) -> None:
+    if torch._utils_internal.justknobs_check(
+        "pytorch/torchrec:killswitch_emb_lookup_stream_sync",
+    ):
+        _start_embedding_lookup_stream_synced(
+            module, context, source_stream, target_stream, stream_context
+        )
+    else:
+        _start_embedding_lookup_legacy(
+            module, context, source_stream, target_stream, stream_context
+        )
 
 
 def _fuse_input_dist_splits(context: TrainPipelineContext) -> None:


### PR DESCRIPTION
Summary:

## Problem

`_start_embedding_lookup` waits for the input-dist output on `source_stream`,
then runs `compute_and_output_dist` on whatever stream the caller made current.
When those two streams differ, two things go wrong:

- **No ordering.** CUDA orders nothing between two streams on its own, so the
  lookup can read input-dist output before it has been written.
- **No lifetime registration.** The stream actually consuming the KJT was never
  recorded with the caching allocator, which can then hand that memory to
  another allocation while the lookup is still reading it.

This affects `emb_lookup_stream="new"` and `"current"`, and the semi-sync
pipeline call shape. The `"data_dist"` default is unaffected for ordering, since
the lookup runs on the same stream that produced the data.

## Fix

- Record an event on `source_stream` after the awaitable resolves, and have the
  current stream wait on it.
- Record `kjt` and the module context on the current stream. Both outlive the
  lookup: the fused TBE saves the KJT indices and offsets for a backward that
  runs on the target stream, and the output-dist wait runs there over
  module-context tensors.
- Record the target stream only when it differs from the current stream.
  `record_stream` already no-ops on a block's own allocating stream, so a stream
  serving two roles only needs recording once.
- Remove stale imports and the corresponding autodeps entry.

## Test reorganization

Moves the fused pipeline tests out of the catch-all `test_train_pipelines.py`
into `test_train_pipeline_fused_sparse_dist.py`, matching the layout already
used for the prefetch pipeline. While moving:

- Drops `kernel_type=st.sampled_from([EmbeddingComputeKernel.FUSED.value])`, a
  single-valued strategy that consumed a hypothesis axis without varying
  anything.
- Raises `max_examples` from 4 to 8 so all 8 combinations of the remaining axes
  run, instead of half being sampled per run.
- Adds parity coverage for `emb_lookup_stream="new"`, which had none.

Reviewed By: TroyGarden, gregmacnamara

Differential Revision: D112034320


