### PR TITLE
Generalize compute_and_output_dist_in_partition to per-group lists (#4501)

### DIFF
--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -548,28 +548,30 @@ class ShardedPECEmbeddingCollection(
     def compute_and_output_dist_in_partition(
         self,
         ctx: PECEmbeddingCollectionContext,
-        features: KeyedJaggedTensor,
-        overlap_splits: OverlapSplits,
+        features: List[KeyedJaggedTensor],
+        overlap_splits: List[OverlapSplits],
         is_overlapped: bool,
     ) -> List[Awaitable[torch.Tensor]]:
         """Performs embedding lookup and output AllToAll for one partition.
 
         Looks up embeddings for the partition's features using the inner
-        EC's lookup module, then AllToAll's the results back using
+        EC's lookup modules, then AllToAll's the results back using
         partition-specific splits from ForwardPartitionContext.splits.
+        Iterates over sharding groups, zipping the per-group features and
+        splits with the inner EC's per-group lookups.
 
         Called twice per batch: once for OL (is_overlapped=True) and
-        once for NOL (is_overlapped=False). The partition may be empty
+        once for NOL (is_overlapped=False). A partition may be empty
         (e.g., first batch OL when no overlap exists) — empty lookups
         and zero-length AllToAll segments are handled correctly.
 
         Args:
             ctx: PEC context (sharding_contexts must be set from
                 input_dist).
-            features: partition features (OL or NOL KJT from
-                ForwardPartitionContext).
-            overlap_splits: per-rank OL/NOL split sizes from
-                ForwardPartitionContext.splits.
+            features: per-sharding-group partition features (OL or NOL KJT
+                from ForwardPartitionContext), one per sharding group.
+            overlap_splits: per-sharding-group per-rank OL/NOL split sizes
+                from ForwardPartitionContext.splits, one per sharding group.
             is_overlapped: True for overlapped partition (index 0 in
                 splits), False for nonoverlapped (index 1).
 
@@ -581,7 +583,9 @@ class ShardedPECEmbeddingCollection(
         awaitables: List[Awaitable[torch.Tensor]] = []
 
         with torch.no_grad():
-            for lookup, odist, sharding_ctx, sharding_type in zip(
+            for feature, splits, lookup, odist, sharding_ctx, sharding_type in zip(
+                features,
+                overlap_splits,
                 ec._lookups,
                 ec._output_dists,
                 ctx.sharding_contexts,
@@ -590,15 +594,13 @@ class ShardedPECEmbeddingCollection(
                 partition_ctx = copy(sharding_ctx)
 
                 # Replace full-batch lengths with this partition's lengths.
-                partition_ctx.lengths_after_input_dist = features.lengths().view(
-                    -1, features.stride()
+                partition_ctx.lengths_after_input_dist = feature.lengths().view(
+                    -1, feature.stride()
                 )
 
                 # Map overlap splits to embedding AllToAll context
-                partition_ctx.input_splits = overlap_splits.input_splits[partition_idx]
-                partition_ctx.output_splits = overlap_splits.output_splits[
-                    partition_idx
-                ]
+                partition_ctx.input_splits = splits.input_splits[partition_idx]
+                partition_ctx.output_splits = splits.output_splits[partition_idx]
 
                 # In RW sharding, upt maps positions in the full (pre-split)
                 # batch — wrong size for a partition. Reordering is handled by
@@ -606,7 +608,7 @@ class ShardedPECEmbeddingCollection(
                 partition_ctx.unbucketize_permute_tensor = None
 
                 embedding_dim = ec._embedding_dim_for_sharding_type(sharding_type)
-                embs = lookup(features)
+                embs = lookup(feature)
                 awaitables.append(odist(embs.view(-1, embedding_dim), partition_ctx))
 
         return awaitables

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -293,17 +293,18 @@ def _pec_forward(
     fwd_next, bwd_cur = results_next[0].wait()
     assert bwd_cur is not None
 
-    # Compute OL/NOL
+    # Compute OL/NOL. compute_and_output_dist_in_partition takes per-sharding-group
+    # lists; this RW-only test has a single group, so wrap in single-element lists.
     ol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
         pec_ctx,
-        fwd_ctx.ol_features,
-        fwd_ctx.splits,
+        [fwd_ctx.ol_features],
+        [fwd_ctx.splits],
         is_overlapped=True,
     )
     nol_awaitables = sharded_pec.compute_and_output_dist_in_partition(
         pec_ctx,
-        fwd_ctx.nol_features,
-        fwd_ctx.splits,
+        [fwd_ctx.nol_features],
+        [fwd_ctx.splits],
         is_overlapped=False,
     )
 


### PR DESCRIPTION
Summary:

## Context

`compute_and_output_dist_in_partition` took a single `features` / `splits` while looping over all lookups -- correct only for a single sharding group. The upcoming train pipeline must iterate over all sharding groups.

## Approach

- Make `compute_and_output_dist_in_partition` take per-sharding-group lists for `features` and `overlap_splits`, zipping them with the inner EC per-group `lookups` / `output_dists`. This matches `merge_partitioned_embeddings` and `grad_dist`, which already take per-group lists.
- Existing single-group (RW-only) callers in `test_pec_embedding.py` wrap their args in single-element lists.
- Picks up an autodeps normalization on the `pec_embedding` BUCK target.

Reviewed By: TroyGarden

Differential Revision: D110148591


