### PR TITLE
Triton permute_2D_sparse_data for the all2all-sequence permutes (#4502)

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -24,12 +24,60 @@ from torch.autograd.profiler import record_function
 from torchrec.distributed.types import Awaitable, NoWait, QuantizedCommCodecs
 from torchrec.distributed.utils import none_throws
 from torchrec.pt2.checks import is_torchdynamo_compiling
+from torchrec.sparse.triton_permute_2d import (
+    should_use_triton,
+    triton_permute_2d_sparse_data,
+)
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
 except OSError:
     pass
+
+
+# Opt-in, off by default. Routes the three all2all-sequence permutes below
+# through torchrec's Triton kernel instead of fbgemm's.
+#
+# Deliberately here and not on KeyedJaggedTensor: that class is pulled into
+# TorchScript by dper_lib/silvertorch/modules/serving/value_model.py's
+# @torch.jit.interface, which makes a mutable class attribute, a classmethod
+# reading one, and a module-level helper naming the class all fail to compile.
+# comm_ops is not on the scripting path, so none of that applies. These are also
+# the sites that matter: the shape they launch is ~75% of the model's total
+# permute_2D_sparse_data GPU time.
+#
+# Read once at import, matching TORCHREC_ENABLE_FP8_ROWWISE_PADDING above, so no
+# caller has to know this kernel exists.
+_USE_TRITON_PERMUTE_2D: bool = bool(
+    int(os.environ.get("TORCHREC_TRITON_PERMUTE_2D", 0))
+)
+
+
+def _permute_2D_sparse_data(
+    permute: Tensor,
+    lengths: Tensor,
+    values: Tensor,
+    weights: Optional[Tensor],
+    permuted_lengths_sum: Optional[int],
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """fbgemm's permute_2D_sparse_data, or the Triton one when enabled.
+
+    `should_use_triton` decides from shapes alone, so the dispatch itself costs
+    no device synchronisation, and it defers to fbgemm on the segment counts
+    where fbgemm is faster.
+    """
+    if (
+        _USE_TRITON_PERMUTE_2D
+        and values.is_cuda
+        and should_use_triton(permute, lengths, permuted_lengths_sum)
+    ):
+        return triton_permute_2d_sparse_data(
+            permute, lengths, values, weights, permuted_lengths_sum
+        )
+    return torch.ops.fbgemm.permute_2D_sparse_data(
+        permute, lengths, values, weights, permuted_lengths_sum
+    )
 
 
 # OSS
@@ -940,7 +988,7 @@ def all2all_sequence_sync(
                     permuted_lengths_after_sparse_data_all2all,
                     sharded_input_embeddings,
                     _,
-                ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                ) = _permute_2D_sparse_data(
                     forward_recat_tensor,
                     lengths_after_sparse_data_all2all.view(local_T * world_size, -1),
                     sharded_input_embeddings.view(-1),
@@ -1943,7 +1991,7 @@ class All2All_Seq_Req(Function):
                         permuted_lengths_after_sparse_data_all2all,
                         sharded_input_embeddings,
                         _,
-                    ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                    ) = _permute_2D_sparse_data(
                         forward_recat_tensor,
                         lengths_after_sparse_data_all2all.view(
                             local_T * world_size, -1
@@ -2038,7 +2086,7 @@ class All2All_Seq_Req(Function):
         if permuted_lengths_after_sparse_data_all2all is not None:
             with record_function("## All2All_Seq_bwd_permute ##"):
                 if not variable_batch_size:
-                    _, sharded_grad_input, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+                    _, sharded_grad_input, _ = _permute_2D_sparse_data(
                         backward_recat_tensor,
                         permuted_lengths_after_sparse_data_all2all,
                         sharded_grad_input,

--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -32,6 +32,44 @@ except OSError:
     pass
 
 
+# Opt-in, off by default. Routes the three all2all-sequence permutes below
+# through torchrec's Triton kernel instead of fbgemm's.
+#
+# Deliberately here and not on KeyedJaggedTensor: that class is pulled into
+# TorchScript by dper_lib/silvertorch/modules/serving/value_model.py's
+# @torch.jit.interface, which makes a mutable class attribute, a classmethod
+# reading one, and a module-level helper naming the class all fail to compile.
+# comm_ops is not on the scripting path, so none of that applies. These are also
+# the sites that matter: the shape they launch is ~75% of the model's total
+# permute_2D_sparse_data GPU time.
+def _permute_2D_sparse_data(
+    permute: Optional[Tensor],
+    lengths: Tensor,
+    values: Tensor,
+    weights: Optional[Tensor],
+    permuted_lengths_sum: Optional[int],
+) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+    """fbgemm's permute_2D_sparse_data, or the Triton one when enabled.
+
+    `should_use_triton` decides from shapes alone, so the dispatch itself costs
+    no device synchronisation, and it defers to fbgemm on the segment counts
+    where fbgemm is faster.
+    """
+    if get_use_triton_permute_2d() and values.is_cuda and permute is not None:
+        from torchrec.sparse.triton_permute_2d import (
+            should_use_triton,
+            triton_permute_2d_sparse_data,
+        )
+
+        if should_use_triton(permute, lengths, permuted_lengths_sum):
+            return triton_permute_2d_sparse_data(
+                permute, lengths, values, weights, permuted_lengths_sum
+            )
+    return torch.ops.fbgemm.permute_2D_sparse_data(
+        permute, lengths, values, weights, permuted_lengths_sum
+    )
+
+
 # OSS
 try:
     pass
@@ -44,6 +82,7 @@ W = TypeVar("W")
 # TODO: T96382816, NE Parity Backward compatibility
 GRADIENT_DIVISION: bool = True
 USE_SYNC_COLLECTIVES: bool = False
+USE_TRITON_PERMUTE_2D: bool = False
 
 
 def set_gradient_division(val: bool) -> None:
@@ -64,6 +103,15 @@ def set_use_sync_collectives(val: bool) -> None:
 def get_use_sync_collectives() -> bool:
     global USE_SYNC_COLLECTIVES
     return USE_SYNC_COLLECTIVES or is_torchdynamo_compiling()
+
+
+def set_use_triton_permute_2d(val: bool) -> None:
+    global USE_TRITON_PERMUTE_2D
+    USE_TRITON_PERMUTE_2D = val
+
+
+def get_use_triton_permute_2d() -> bool:
+    return USE_TRITON_PERMUTE_2D
 
 
 @contextmanager
@@ -940,7 +988,7 @@ def all2all_sequence_sync(
                     permuted_lengths_after_sparse_data_all2all,
                     sharded_input_embeddings,
                     _,
-                ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                ) = _permute_2D_sparse_data(
                     forward_recat_tensor,
                     lengths_after_sparse_data_all2all.view(local_T * world_size, -1),
                     sharded_input_embeddings.view(-1),
@@ -1943,7 +1991,7 @@ class All2All_Seq_Req(Function):
                         permuted_lengths_after_sparse_data_all2all,
                         sharded_input_embeddings,
                         _,
-                    ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                    ) = _permute_2D_sparse_data(
                         forward_recat_tensor,
                         lengths_after_sparse_data_all2all.view(
                             local_T * world_size, -1
@@ -2038,7 +2086,7 @@ class All2All_Seq_Req(Function):
         if permuted_lengths_after_sparse_data_all2all is not None:
             with record_function("## All2All_Seq_bwd_permute ##"):
                 if not variable_batch_size:
-                    _, sharded_grad_input, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+                    _, sharded_grad_input, _ = _permute_2D_sparse_data(
                         backward_recat_tensor,
                         permuted_lengths_after_sparse_data_all2all,
                         sharded_grad_input,

--- a/torchrec/sparse/triton_permute_2d.py
+++ b/torchrec/sparse/triton_permute_2d.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Triton replacement for `fbgemm.permute_2D_sparse_data`, for the two regimes
+where fbgemm's per-segment launch shape costs more than the copy itself.
+
+fbgemm hands each block 32 consecutive segments and picks uint4 vs scalar loads
+per segment from a 16-byte alignment test. That is efficient when there are few,
+long, aligned segments. It degrades on two axes this model hits hard:
+
+- **many segments**: per-segment overhead dominates. At 5.2M segments averaging
+  0.6 elements it spends 610 us moving 3.1M values.
+- **length skew across keys**: segments are laid out key-major, so a block's cost
+  is set by which key it landed on. Measured on the dominant shape, fbgemm goes
+  1470 -> 1889 -> 2173 us as key-level lognormal sigma goes 4 -> 6 -> 8, while
+  the per-segment Triton kernel stays flat at 1172 -> 1257 -> 1300.
+
+Below ~700k segments fbgemm wins on every traced shape and this module defers to
+it -- see `should_use_triton`. Correctness is `torch.equal`, never a tolerance:
+this is a pure gather-copy with no arithmetic, and a tolerance would hide the
+failure mode that matters, a segment-boundary off-by-one whose values still look
+plausible.
+"""
+
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Segment counts below this went to fbgemm on every shape in the trace: it needs
+# 32-103 us there, against 94-320 us for either Triton kernel. The wins all sit at
+# >=786k segments, the losses all at <=654k, so the split is unambiguous.
+MIN_SEGMENTS = 700_000
+
+# Above this mean segment length one program per segment beats the load-balanced
+# kernel (1172 vs 1522 us at mean 298); below it the ordering reverses and grows
+# to 2.9x by mean 0.6.
+PERSEG_MIN_MEAN = 128
+
+
+@triton.jit
+def _permute_2d_perseg_kernel(
+    values_ptr,
+    out_ptr,
+    w_ptr,
+    w_out_ptr,
+    in_off_ptr,
+    out_off_ptr,
+    permute_ptr,
+    B,
+    n_seg,
+    HAS_W: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """One program per segment, chunked over BLOCK.
+
+    BLOCK=1024 is not a tuning oversight: sweeping 64..1024 on the real shapes
+    under key-stratified skew never beat 1024, because the long-key segments that
+    dominate the runtime are far longer than a block anyway.
+    """
+    pid = tl.program_id(0)
+    if pid >= n_seg:
+        return
+
+    b = pid % B
+    t = pid // B
+    src_t = tl.load(permute_ptr + t)
+
+    out_start = tl.load(out_off_ptr + pid)
+    seg_len = tl.load(out_off_ptr + pid + 1) - out_start
+    in_start = tl.load(in_off_ptr + src_t * B + b)
+
+    for base in range(0, seg_len, BLOCK):
+        offs = base + tl.arange(0, BLOCK)
+        mask = offs < seg_len
+        v = tl.load(values_ptr + in_start + offs, mask=mask)
+        tl.store(out_ptr + out_start + offs, v, mask=mask)
+        if HAS_W:
+            w = tl.load(w_ptr + in_start + offs, mask=mask)
+            tl.store(w_out_ptr + out_start + offs, w, mask=mask)
+
+
+@triton.jit
+def _permute_2d_blocked_kernel(
+    values_ptr,
+    out_ptr,
+    w_ptr,
+    w_out_ptr,
+    in_off_ptr,
+    out_off_ptr,
+    permute_ptr,
+    seg_lo_ptr,
+    seg_hi_ptr,
+    B,
+    n_out,
+    HAS_W: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """One program per BLOCK of *output* elements, not per segment.
+
+    Work per program is exactly BLOCK however the lengths fall, which is the whole
+    point for short segments: giving one program a whole segment wastes a program
+    on ~1 element, and giving one *lane* per segment serialises the tile on its
+    longest member. Each lane binary-searches its own segment inside
+    [seg_lo, seg_hi] -- the only segments this block can touch, precomputed by a
+    sync-free searchsorted -- so the search is a few steps over an offset array
+    small enough to stay cached.
+    """
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    m = offs < n_out
+
+    seg = tl.zeros([BLOCK], tl.int64) + tl.load(seg_lo_ptr + pid)
+    r = tl.zeros([BLOCK], tl.int64) + tl.load(seg_hi_ptr + pid)
+    while tl.max(tl.where(m, r - seg, 0)) > 0:
+        mid = (seg + r + 1) // 2
+        c = tl.load(out_off_ptr + mid) <= offs
+        seg = tl.where(c, mid, seg)
+        r = tl.where(c, r, mid - 1)
+
+    out_start = tl.load(out_off_ptr + seg)
+    src_t = tl.load(permute_ptr + seg // B)
+    src = tl.load(in_off_ptr + src_t * B + seg % B) + (offs - out_start)
+    tl.store(out_ptr + offs, tl.load(values_ptr + src, mask=m), mask=m)
+    if HAS_W:
+        tl.store(w_out_ptr + offs, tl.load(w_ptr + src, mask=m), mask=m)
+
+
+def should_use_triton(
+    permute: torch.Tensor,
+    lengths: torch.Tensor,
+    permuted_lengths_sum: Optional[int],
+) -> bool:
+    """Decided from shapes and the caller's `permuted_lengths_sum` only.
+
+    Nothing here reads device memory, so the dispatch costs no synchronisation.
+    `permuted_lengths_sum` is fbgemm's fifth argument and every internal caller
+    passes it; when it is absent the output size is not knowable without a
+    device-to-host sync, and paying one per call is worse than anything this
+    module can win back.
+    """
+    if permuted_lengths_sum is None:
+        return False
+    n_seg = permute.shape[0] * lengths.shape[1]
+    return n_seg >= MIN_SEGMENTS
+
+
+def triton_permute_2d_sparse_data(
+    permute: torch.Tensor,
+    lengths: torch.Tensor,
+    values: torch.Tensor,
+    weights: Optional[torch.Tensor] = None,
+    permuted_lengths_sum: Optional[int] = None,
+    block: int = 1024,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Returns (permuted_lengths, permuted_values, permuted_weights).
+
+    `permute` is NOT required to be a permutation of range(T): callers select a
+    subset of keys and may repeat one, which is why fbgemm's signature carries a
+    separate `permuted_lengths_sum`. The traced call sites really do this --
+    P=24 against T=51, P=295 against T=267.
+    """
+    B = lengths.shape[1]
+    has_w = weights is not None
+
+    # Indexing by `permute` also covers the subset and repeated-key cases; the
+    # output segment count follows `permute`, not the input's T.
+    permuted_lengths = lengths[permute.long()]
+    n_seg = permuted_lengths.numel()
+
+    # Sized from the caller's sum rather than `permuted_lengths.sum()`: the latter
+    # is an .item() device sync on every call. Sizing it as empty_like(values)
+    # instead is silently wrong under a subset permute -- the trailing rows are
+    # garbage and it surfaces much later as a split_with_sizes size mismatch
+    # inside construct_jagged_tensors.
+    n_out = permuted_lengths_sum
+    if n_out is None:
+        n_out = int(permuted_lengths.sum())
+
+    if n_seg == 0 or values.numel() == 0 or n_out == 0:
+        # fbgemm early-outs on T==0/B==0 (sparse_permute_2d.cu:240-249).
+        return (
+            permuted_lengths,
+            values.new_empty(0) if n_out == 0 else values.clone(),
+            (
+                (weights.new_empty(0) if n_out == 0 else weights.clone())
+                if has_w
+                else None
+            ),
+        )
+
+    # in_off is indexed by *source* segment and out_off by *output* segment; those
+    # counts differ under a subset or repeating permute, so in_off must be sized
+    # from `lengths`, not from n_seg.
+    in_off = torch.zeros(lengths.numel() + 1, dtype=torch.int64, device=values.device)
+    out_off = torch.zeros(n_seg + 1, dtype=torch.int64, device=values.device)
+    torch.cumsum(lengths.reshape(-1), 0, out=in_off[1:])
+    torch.cumsum(permuted_lengths.reshape(-1), 0, out=out_off[1:])
+
+    out = values.new_empty(n_out)
+    w_out = weights.new_empty(n_out) if has_w else values
+
+    if n_out >= n_seg * PERSEG_MIN_MEAN:
+        _permute_2d_perseg_kernel[(n_seg,)](
+            values,
+            out,
+            weights if has_w else values,
+            w_out,
+            in_off,
+            out_off,
+            permute,
+            B,
+            n_seg,
+            HAS_W=has_w,
+            BLOCK=block,
+        )
+    else:
+        nb = triton.cdiv(n_out, block)
+        starts = torch.arange(nb, device=values.device, dtype=torch.int64) * block
+        ends = torch.clamp(starts + block - 1, max=n_out - 1)
+        _permute_2d_blocked_kernel[(nb,)](
+            values,
+            out,
+            weights if has_w else values,
+            w_out,
+            in_off,
+            out_off,
+            permute,
+            torch.searchsorted(out_off, starts, right=True) - 1,
+            torch.searchsorted(out_off, ends, right=True) - 1,
+            B,
+            n_out,
+            HAS_W=has_w,
+            BLOCK=block,
+        )
+
+    return permuted_lengths, out, (w_out if has_w else None)


### PR DESCRIPTION
Summary:

fbgemm's `permute_2D_data_kernel_vec` is a pure gather-copy but runs at
1.16 TB/s on MI350X where a plain contiguous copy of the same bytes does
4.90 TB/s. Two causes: the `uint4` fast path is chosen per segment on a 16-byte
alignment test of the jagged offsets, which holds only 25.1% of the time; and
the hardcoded `dim3(32, 32)` launch is half a gfx950 wavefront, so a 64-lane
wave straddles two segment rows of different lengths.

This adds a Triton replacement behind `TORCHREC_TRITON_PERMUTE_2D`, off by
default, wired into the three all2all-sequence permute sites in `comm_ops.py`
(~75% of this model's `permute_2D_sparse_data` GPU time). `should_use_triton`
gates on shapes alone, so dispatch costs no device sync, and defers to fbgemm
below the segment count where fbgemm wins.

The flag lives in `comm_ops` rather than on `KeyedJaggedTensor` because that
class is TorchScript-compiled via `value_model.py`'s `torch.jit.interface`,
which rejects a mutable class attribute, a classmethod reading one, and a
module-level helper naming the class.

Output is sized from `permuted_lengths.sum()`: `permute` is not required to be a
permutation of `range(T)` -- callers may select a subset of keys or repeat one
-- so `torch.empty_like(values)` leaves trailing garbage rows.

Reviewed By: optimisea

Differential Revision: D115082056


