### PR TITLE
Fix test failure with execute_all_batches = False (#4503)

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipeline_prefetch_sparse_dist.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipeline_prefetch_sparse_dist.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 
 import torch
 from hypothesis import given, settings, strategies as st
+from parameterized import parameterized
 from torch import nn
 from torch.optim import Optimizer
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -249,22 +250,47 @@ class PrefetchTrainPipelineTest(PrefetchTrainPipelineTestBase):
         self.assertIsNotNone(output1)
         self.assertIsNotNone(output2)
 
+    def _drain_pipeline(self, num_batches: int, execute_all_batches: bool) -> int:
+        """Runs a pipeline to exhaustion and returns how many outputs it produced."""
+        pipeline, dataloader, _, _ = self._create_pipeline(
+            num_batches=num_batches, execute_all_batches=execute_all_batches
+        )
+        outputs = []
+        try:
+            for _ in range(num_batches + 5):
+                outputs.append(pipeline.progress(dataloader))
+        except StopIteration:
+            pass
+        return len(outputs)
+
+    @parameterized.expand(
+        [
+            # (name, num_batches, execute_all_batches, expected_outputs)
+            # Keep num_batches well above the pipeline's 2-batch lookahead so the
+            # two rows expect clearly distinct counts.
+            ("drains_in_flight", 7, True, 7),
+            ("drops_in_flight", 7, False, 5),
+        ]
+    )
     @unittest.skipIf(
         not torch.cuda.is_available(),
         "Not enough GPUs, this test requires at least one GPU",
     )
-    def test_execute_all_batches_false(self) -> None:
-        """Test pipeline behavior with execute_all_batches=False."""
-        pipeline, dataloader, _, _ = self._create_pipeline(execute_all_batches=False)
+    def test_execute_all_batches_controls_drain(
+        self,
+        _name: str,
+        num_batches: int,
+        execute_all_batches: bool,
+        expected_outputs: int,
+    ) -> None:
+        """`execute_all_batches` decides whether in-flight batches are drained.
 
-        outputs = []
-        try:
-            for _ in range(10):
-                outputs.append(pipeline.progress(dataloader))
-        except StopIteration:
-            pass
-
-        self.assertGreater(len(outputs), 0)
+        On, the pipeline drains and yields one output per batch. Off, it stops as
+        soon as the dataloader is exhausted, dropping the 2 batches in flight.
+        """
+        self.assertEqual(
+            self._drain_pipeline(num_batches, execute_all_batches), expected_outputs
+        )
 
     @unittest.skipIf(
         not torch.cuda.is_available(),

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -2105,8 +2105,9 @@ class PrefetchTrainPipelineSparseDist(TrainPipelineSparseDist[In, Out]):
         Args:
             dataloader_iter: Iterator that produces training batches.
         """
-        # pipeline is already filled
-        if len(self.batches) >= 3:
+        # pipeline is already filled: fill_pipeline primes 2 batches, and progress
+        # holds 2 at its start (it enqueues a 3rd, then dequeues one at the end).
+        if len(self.batches) >= 2:
             return
 
         # executes last batch in pipeline


### PR DESCRIPTION
Summary:

## Problem

`PrefetchTrainPipelineSparseDist.fill_pipeline` guarded its "pipeline is
already filled" early-return on `len(self.batches) >= 3`, but the pipeline only
ever holds 2 batches at the top of `progress`: `fill_pipeline` primes 2, then
each `progress` enqueues a 3rd and dequeues one at the end.

So that guard never fired in steady state. The next guard is disabled when
`execute_all_batches=False`, so every steady-state `progress` fell through into
the warm-up body and re-ran it on batches already in flight:

- `_init_pipelined_modules` takes its already-pipelined branch and re-runs
  `start_sparse_data_dist` on `batches[0]`, which was already input-dist'ed
- `_prefetch(contexts[0])` prefetches the same batch a second time
- `start_sparse_data_dist(batches[1], contexts[1])` re-runs a collective the
  previous iteration already kicked off
- two extra `enqueue_batch` calls over-draw the dataloader

The duplicate prefetch perturbs LXU cache state under `fused_uvm_caching`, so
pipelined and non-pipelined training diverge numerically from iteration 2
onward. The over-draw pulled 13 batches from a 12-batch loader, raising a
premature `StopIteration`.

This affects any `execute_all_batches=False` caller of the prefetch pipeline,
not just tests --
`PrefetchTrainPipelineSparseDistTest.test_equal_to_non_pipelined` is simply
where it surfaced.

## Fix

Align the threshold with the pipeline's actual depth at that point. The
`_execute_all_batches` guard is retained and is still reached while draining
(`len(self.batches) == 1`).

The other three pipelines already agree on this and are unaffected:

| Pipeline | fill primes | guard | steady state |
| --- | --- | --- | --- |
| `TrainPipelineSparseDist` | 2 | `>= 2` | 2 |
| `TrainPipelineSemiSync` | 3 | `>= 3` | 3 |
| `EvalPipelineFusedSparseDist` | 2 | `>= 2` | 2 |
| `PrefetchTrainPipelineSparseDist` | 2 | `>= 3` | 2 |

Note the rule is "threshold must match depth", not "threshold must be 2" --
`TrainPipelineSemiSync` runs a depth of 3 and is self-consistent. Only the
prefetch pipeline was off by one.

## Test coverage

`:test_train_pipeline_prefetch_sparse_dist` was missing the
`gpu-remote-execution` platform, so all 12 of its tests landed on CPU hosts and
silently skipped on `torch.cuda.is_available()`. Adding the platform makes them
run.

`test_execute_all_batches_false` asserted only
`assertGreater(len(outputs), 0)`, so it exercised the buggy path but could not
detect it. It is replaced by a parameterized
`test_execute_all_batches_controls_drain` that asserts exact output counts for
both flag values.

`arc lint -a` also migrated this directory's BUCK from `//caffe2:_torch` to
`fbsource//third-party/pypi/torch:torch` (autodeps-mandated once
`train_pipelines.py` is touched; the same swap D112034320 applied to sibling
targets).

Reviewed By: TroyGarden

Differential Revision: D115094974


