### PR TITLE
Batch compatible metric output clones (#4506)

### DIFF
--- a/torchrec/metrics/benchmark_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/benchmark_cpu_offloaded_metric_module.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    BenchmarkResult,
+    cmd_conf,
+)
+from torchrec.metrics.cpu_offloaded_metric_module import _foreach_clone_dict
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RunOptions(BenchFuncConfig):
+    name: str = "zorm_clone_helper"
+    world_size: int = 1
+    num_profiles: int = 1
+    num_benchmarks: int = 7
+    profile_dir: str = ""
+    device_type: str = "cuda"
+    memory_snapshot: bool = False
+
+    warmups: int = 2
+    dependency_delay_cycles: int = 245_000_000
+    prefill_kernel_count: int = 64
+    tensor_count_multiplier: int = 1
+
+
+def _add_tensors(
+    model_out: dict[str, torch.Tensor],
+    prefix: str,
+    count: int,
+    shape: tuple[int, ...],
+    device: torch.device,
+) -> None:
+    for index in range(count):
+        model_out[f"{prefix}_{index}"] = torch.ones(
+            shape,
+            dtype=torch.float32,
+            device=device,
+        )
+
+
+def make_production_like_model_out(
+    device: torch.device, tensor_count_multiplier: int
+) -> dict[str, torch.Tensor]:
+    model_out: dict[str, torch.Tensor] = {}
+    for replica in range(tensor_count_multiplier):
+        prefix = f"replica_{replica}"
+        _add_tensors(model_out, f"{prefix}_column", 864, (4096, 1), device)
+        _add_tensors(model_out, f"{prefix}_vector", 62, (4096,), device)
+        _add_tensors(model_out, f"{prefix}_scalar", 32, (), device)
+        _add_tensors(model_out, f"{prefix}_two_column", 1, (4096, 2), device)
+        _add_tensors(model_out, f"{prefix}_five_column", 1, (4096, 5), device)
+        _add_tensors(model_out, f"{prefix}_wide", 1, (4096, 512), device)
+        model_out[f"{prefix}_non_dense_stride_4"] = torch.ones(
+            (4096, 4), dtype=torch.float32, device=device
+        )[:, :1]
+        model_out[f"{prefix}_non_dense_stride_7"] = torch.ones(
+            (4096, 7), dtype=torch.float32, device=device
+        )[:, :1]
+        model_out[f"{prefix}_double_scalar"] = torch.ones(
+            (), dtype=torch.float64, device=device
+        )
+        model_out[f"{prefix}_int_labels"] = torch.ones(
+            (4096,), dtype=torch.int64, device=device
+        )
+    return model_out
+
+
+def _prepare_queue_pressure(
+    dependency_delay_cycles: int,
+    prefill_kernel_count: int,
+    dependency_stream: torch.cuda.Stream,
+    prefill_tensor: torch.Tensor,
+) -> None:
+    current_stream = torch.cuda.current_stream()
+    dependency_stream.wait_stream(current_stream)
+    with torch.cuda.stream(dependency_stream):
+        if dependency_delay_cycles > 0:
+            # pyrefly: ignore[missing-module-attribute]
+            torch.cuda._sleep(dependency_delay_cycles)
+    current_stream.wait_stream(dependency_stream)
+    for _ in range(prefill_kernel_count):
+        prefill_tensor.add_(1)
+
+
+def _host_wall_time_ms(result: BenchmarkResult) -> torch.Tensor:
+    return torch.where(
+        result.cpu_utilization > 0,
+        result.cpu_elapsed_time / result.cpu_utilization,
+        torch.zeros_like(result.cpu_elapsed_time),
+    )
+
+
+def runner(run_option: RunOptions) -> BenchmarkResult:
+    if run_option.device_type != "cuda" or not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if run_option.world_size != 1:
+        raise ValueError("This benchmark supports world_size=1")
+    if run_option.tensor_count_multiplier < 1:
+        raise ValueError("tensor_count_multiplier must be positive")
+
+    device = torch.device(run_option.device_type, 0)
+    torch.cuda.set_device(0)
+    model_out = make_production_like_model_out(
+        device, run_option.tensor_count_multiplier
+    )
+    dependency_stream = torch.cuda.Stream(device=device)
+    prefill_tensor = torch.ones((4096,), dtype=torch.float32, device=device)
+    result_ref: Any = None
+
+    def clone_model_out(_bench_inputs: list[dict[str, Any]]) -> None:
+        nonlocal result_ref
+        _prepare_queue_pressure(
+            run_option.dependency_delay_cycles,
+            run_option.prefill_kernel_count,
+            dependency_stream,
+            prefill_tensor,
+        )
+        result_ref = _foreach_clone_dict(model_out)
+
+    for _ in range(run_option.warmups):
+        torch.cuda.synchronize()
+        clone_model_out([])
+    torch.cuda.synchronize()
+
+    logger.info(
+        "Benchmarking %d tensors / %d bytes on %s",
+        len(model_out),
+        sum(t.numel() * t.element_size() for t in model_out.values()),
+        torch.cuda.get_device_name(device),
+    )
+    result = benchmark_func(
+        rank=0,
+        func_to_benchmark=clone_model_out,
+        bench_inputs=[{}],
+        prof_inputs=[{}] * run_option.num_profiles,
+        benchmark_func_kwargs={},
+        sample_count=0,
+        **run_option.benchmark_func_kwargs(),
+    )
+
+    host_wall_time_ms = _host_wall_time_ms(result)
+    logger.info(
+        "Host submission (P50/P90): %.2f / %.2f ms",
+        torch.quantile(host_wall_time_ms, 0.5, interpolation="nearest").item(),
+        torch.quantile(host_wall_time_ms, 0.9, interpolation="nearest").item(),
+    )
+    logger.info(result.prettify())
+    return result
+
+
+@cmd_conf
+def main(run_option: RunOptions) -> None:
+    run_option.set_log_level()
+    print(BenchmarkResult.print_table([runner(run_option)]))
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[not-callable]
+    main()

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -176,24 +176,43 @@ def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
 
 
 def _foreach_clone_dict(d: Mapping[str, Any]) -> Dict[str, Any]:
-    """Batched clone of tensor values; one PyBind crossing for N tensors."""
+    """Clone tensor values while preserving their mapping keys."""
     tensor_keys: list[str] = []
     tensor_values: list[torch.Tensor] = []
-    out: Dict[str, Any] = {}
+    out: Dict[str, Any] = dict(d)
     for k, v in d.items():
         if isinstance(v, torch.Tensor):
             tensor_keys.append(k)
             tensor_values.append(v)
-        else:
-            out[k] = v
     if tensor_values:
-        # no_grad bypasses the autograd dispatch on _foreach_clone, which
-        # rejects integer dtypes (e.g., int labels/required_inputs).
-        with torch.no_grad():
-            cloned = torch._foreach_clone(tensor_values)
+        cloned = _foreach_clone_tensors(tensor_values)
         for k, t in zip(tensor_keys, cloned):
             out[k] = t
     return out
+
+
+def _foreach_clone_tensors(tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+    groups: dict[tuple[torch.device, torch.dtype], list[tuple[int, torch.Tensor]]] = {}
+    fallback: list[tuple[int, torch.Tensor]] = []
+    for index, tensor in enumerate(tensors):
+        if (
+            tensor.layout == torch.strided
+            and torch.ops.aten.is_non_overlapping_and_dense.default(tensor)
+        ):
+            groups.setdefault((tensor.device, tensor.dtype), []).append((index, tensor))
+        else:
+            fallback.append((index, tensor))
+
+    cloned: dict[int, torch.Tensor] = {}
+    # A heterogeneous list makes CUDA foreach clone fall back for every tensor.
+    with torch.no_grad():
+        for group in groups.values():
+            group_clones = torch._foreach_clone([tensor for _, tensor in group])
+            for (index, _), clone in zip(group, group_clones):
+                cloned[index] = clone
+        for index, tensor in fallback:
+            cloned[index] = tensor.clone()
+    return [cloned[index] for index in range(len(tensors))]
 
 
 def _foreach_clone_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
@@ -205,8 +224,7 @@ def _foreach_clone_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
             out[k] = v
     top_keys = [k for k, v in out.items() if isinstance(v, torch.Tensor)]
     if top_keys:
-        with torch.no_grad():
-            cloned = torch._foreach_clone([out[k] for k in top_keys])
+        cloned = _foreach_clone_tensors([out[k] for k in top_keys])
         for k, t in zip(top_keys, cloned):
             out[k] = t
     return out

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -1973,6 +1973,26 @@ class MergeUpdateJobsTest(unittest.TestCase):
 
 
 class ForeachCloneTest(unittest.TestCase):
+    def _assert_mixed_dtype_and_layout_clone_preserves_values(
+        self, device: torch.device
+    ) -> None:
+        base = torch.arange(24, dtype=torch.float32, device=device).reshape(4, 6)
+        src = {
+            "dense": torch.arange(8, dtype=torch.float32, device=device).reshape(4, 2),
+            "non_dense": base[:, :2],
+            "double": torch.tensor(1.25, dtype=torch.float64, device=device),
+            "labels": torch.tensor([1, 2, 3, 4], dtype=torch.int64, device=device),
+            "metadata": "preserved",
+        }
+
+        snapshot = _foreach_clone_dict(src)
+
+        self.assertEqual(snapshot["metadata"], "preserved")
+        self.assertEqual(list(snapshot), list(src))
+        for key in ("dense", "non_dense", "double", "labels"):
+            self.assertIsNot(snapshot[key], src[key])
+            torch.testing.assert_close(snapshot[key], src[key])
+
     def test_int_tensors_clone_without_autograd_error(self) -> None:
         d = {
             "labels": torch.tensor([0, 1, 0], dtype=torch.int64),
@@ -2020,6 +2040,13 @@ class ForeachCloneTest(unittest.TestCase):
         torch.testing.assert_close(
             snapshot["labels"], torch.tensor([0, 1, 0], dtype=torch.int64)
         )
+
+    def test_mixed_dtype_and_layout_clone_preserves_values(self) -> None:
+        self._assert_mixed_dtype_and_layout_clone_preserves_values(torch.device("cpu"))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+    def test_mixed_dtype_and_layout_cuda_clone_preserves_values(self) -> None:
+        self._assert_mixed_dtype_and_layout_clone_preserves_values(torch.device("cuda"))
 
 
 class LoadStateDictDevicePinTest(unittest.TestCase):


### PR DESCRIPTION
Summary:

Group compatible metric output tensors before cloning so CUDA can use its multi-tensor path. Preserve the existing fallback for unsupported layouts and restore the original mapping order.

Reviewed By: yashasingh

Differential Revision: D114267173


