### PR TITLE
Use HashStore for single-rank test process groups (#4507)

### DIFF
--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -10,7 +10,6 @@
 import logging
 import os
 import queue
-import random
 import threading
 import time
 import unittest
@@ -48,7 +47,7 @@ from torchrec.metrics.test_utils.mock_metrics import (
     MockRecMetric,
 )
 from torchrec.metrics.throughput import ThroughputMetric
-from torchrec.test_utils import get_free_port, skip_if_asan_class
+from torchrec.test_utils import init_process_group_single_rank, skip_if_asan_class
 
 
 def wait_until_true(
@@ -60,30 +59,6 @@ def wait_until_true(
         time.sleep(interval)
         if time.time() - start_time > timeout:
             raise TimeoutError("Timeout reached while waiting for condition")
-
-
-def _init_process_group_with_retry(backend: str = "gloo", max_retries: int = 5) -> None:
-    """init_process_group on a fresh free port, retrying on "address already in use".
-
-    get_free_port() closes its probe socket before returning, so the port can be taken
-    before the TCPStore binds it. Re-rolling the port per attempt mirrors torch's status
-    quo (torch/testing/_internal/common_utils -> retry_on_connect_failures).
-    """
-    last_error: Optional[RuntimeError] = None
-    for _ in range(max_retries):
-        os.environ["MASTER_PORT"] = str(get_free_port())
-        try:
-            dist.init_process_group(backend=backend)
-            return
-        except RuntimeError as e:
-            msg = str(e).lower()
-            if "address already in use" not in msg:
-                raise
-            last_error = e
-            time.sleep(random.random())
-    raise RuntimeError(
-        f"init_process_group failed after {max_retries} retries"
-    ) from last_error
 
 
 class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
@@ -98,7 +73,6 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
 
         self.mock_metric = MockRecMetric(
@@ -110,7 +84,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
 
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self.cpu_module: CPUOffloadedRecMetricModule = self._make_module(
             throughput_metric=ThroughputMetric(
                 world_size=self.world_size,
@@ -1524,7 +1498,6 @@ class WorkerSideBatchingTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
 
         self.mock_metric = MockRecMetric(
@@ -1536,7 +1509,7 @@ class WorkerSideBatchingTest(unittest.TestCase):
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
 
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
 
     def tearDown(self) -> None:
         if dist.is_initialized():
@@ -2031,7 +2004,6 @@ class LoadStateDictDevicePinTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         self.mock_metric = MockRecMetric(
             world_size=1,
@@ -2041,7 +2013,7 @@ class LoadStateDictDevicePinTest(unittest.TestCase):
             initial_states=self.initial_states,
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
 
     def tearDown(self) -> None:
         if dist.is_initialized():
@@ -2206,9 +2178,8 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self._modules: list[CPUOffloadedRecMetricModule] = []
 
     def tearDown(self) -> None:
@@ -2359,9 +2330,8 @@ class CapUpdateBatchSizeTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self._modules: list[CPUOffloadedRecMetricModule] = []
 
     def tearDown(self) -> None:

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -10,7 +10,6 @@
 import logging
 import os
 import queue
-import random
 import threading
 import time
 import unittest
@@ -48,7 +47,7 @@ from torchrec.metrics.test_utils.mock_metrics import (
     MockRecMetric,
 )
 from torchrec.metrics.throughput import ThroughputMetric
-from torchrec.test_utils import get_free_port, skip_if_asan_class
+from torchrec.test_utils import init_process_group_single_rank, skip_if_asan_class
 
 
 def wait_until_true(
@@ -60,30 +59,6 @@ def wait_until_true(
         time.sleep(interval)
         if time.time() - start_time > timeout:
             raise TimeoutError("Timeout reached while waiting for condition")
-
-
-def _init_process_group_with_retry(backend: str = "gloo", max_retries: int = 5) -> None:
-    """init_process_group on a fresh free port, retrying on "address already in use".
-
-    get_free_port() closes its probe socket before returning, so the port can be taken
-    before the TCPStore binds it. Re-rolling the port per attempt mirrors torch's status
-    quo (torch/testing/_internal/common_utils -> retry_on_connect_failures).
-    """
-    last_error: Optional[RuntimeError] = None
-    for _ in range(max_retries):
-        os.environ["MASTER_PORT"] = str(get_free_port())
-        try:
-            dist.init_process_group(backend=backend)
-            return
-        except RuntimeError as e:
-            msg = str(e).lower()
-            if "address already in use" not in msg:
-                raise
-            last_error = e
-            time.sleep(random.random())
-    raise RuntimeError(
-        f"init_process_group failed after {max_retries} retries"
-    ) from last_error
 
 
 class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
@@ -98,7 +73,6 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
 
         self.mock_metric = MockRecMetric(
@@ -110,7 +84,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
 
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self.cpu_module: CPUOffloadedRecMetricModule = self._make_module(
             throughput_metric=ThroughputMetric(
                 world_size=self.world_size,
@@ -1524,7 +1498,6 @@ class WorkerSideBatchingTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
 
         self.mock_metric = MockRecMetric(
@@ -1536,7 +1509,7 @@ class WorkerSideBatchingTest(unittest.TestCase):
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
 
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
 
     def tearDown(self) -> None:
         if dist.is_initialized():
@@ -2058,7 +2031,6 @@ class LoadStateDictDevicePinTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         self.mock_metric = MockRecMetric(
             world_size=1,
@@ -2068,7 +2040,7 @@ class LoadStateDictDevicePinTest(unittest.TestCase):
             initial_states=self.initial_states,
         )
         self.rec_metrics = RecMetricList([self.mock_metric])
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
 
     def tearDown(self) -> None:
         if dist.is_initialized():
@@ -2233,9 +2205,8 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self._modules: list[CPUOffloadedRecMetricModule] = []
 
     def tearDown(self) -> None:
@@ -2386,9 +2357,8 @@ class CapUpdateBatchSizeTest(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
-        os.environ["MASTER_ADDR"] = "localhost"
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
-        _init_process_group_with_retry("gloo")
+        init_process_group_single_rank("gloo")
         self._modules: list[CPUOffloadedRecMetricModule] = []
 
     def tearDown(self) -> None:

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import io
-import os
 import unittest
 from typing import Any, Dict, List
 
@@ -22,7 +21,7 @@ from torchrec.optim.keyed import (
     KeyedOptimizerWrapper,
     OptimizerWrapper,
 )
-from torchrec.test_utils import get_free_port
+from torchrec.test_utils import init_process_group_single_rank
 
 
 class DummyOptimizerModule:
@@ -76,9 +75,7 @@ class TestKeyedOptimizer(unittest.TestCase):
         )
 
     def test_load_state_dict(self) -> None:
-        os.environ["MASTER_ADDR"] = str("localhost")
-        os.environ["MASTER_PORT"] = str(get_free_port())
-        dist.init_process_group("gloo", rank=0, world_size=1)
+        init_process_group_single_rank("gloo")
 
         # Set up example KeyedOptimizer.
         param_1_t, param_2_t = torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import ctypes
+import logging
 import os
 import random
 import socket
@@ -25,6 +26,8 @@ from torch import nn
 
 TParams = ParameterSpecification("TParams")
 TReturn = TypeVar("TReturn")
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def get_free_port() -> int:
@@ -67,6 +70,30 @@ def get_free_port() -> int:
             raise Exception(
                 f"Binding failed with address 127.0.0.1 while getting free port {e}"
             )
+
+
+def init_process_group_single_rank(backend: str = "gloo", **kwargs: Any) -> None:
+    """init_process_group for a single-rank group, without picking a port first.
+
+    HashStore lives in process memory, so there is no port to lose. Going through
+    MASTER_PORT instead leaves a window where another process can take the port,
+    which surfaces as EADDRINUSE.
+
+    Single-rank only. Spawned ranks cannot share this store object.
+    """
+    already_initialized = dist.is_initialized()
+    try:
+        dist.init_process_group(
+            backend=backend, store=dist.HashStore(), rank=0, world_size=1, **kwargs
+        )
+    except Exception:
+        # A group leaked by an earlier test is the usual cause, and torch's error
+        # for it does not mention that.
+        logger.exception(
+            f"init_process_group_single_rank failed. backend={backend}, "
+            f"already_initialized={already_initialized}"
+        )
+        raise
 
 
 def is_asan() -> bool:

--- a/torchrec/test_utils/__init__.py
+++ b/torchrec/test_utils/__init__.py
@@ -69,6 +69,21 @@ def get_free_port() -> int:
             )
 
 
+def init_process_group_single_rank(backend: str = "gloo", **kwargs: Any) -> None:
+    """init_process_group for a single-rank group, without picking a port first.
+
+    TCPStore binds an ephemeral port itself and never releases it. Going through
+    MASTER_PORT instead leaves a window where another process can take the port,
+    which surfaces as EADDRINUSE.
+
+    Single-rank only. Spawned ranks cannot share this store object.
+    """
+    store = dist.TCPStore("localhost", 0, 1, is_master=True, wait_for_workers=False)
+    dist.init_process_group(
+        backend=backend, store=store, rank=0, world_size=1, **kwargs
+    )
+
+
 def is_asan() -> bool:
     """Determines if the Python interpreter is running with ASAN"""
     return hasattr(ctypes.CDLL(""), "__asan_init")

--- a/torchrec/test_utils/tests/test_init_process_group.py
+++ b/torchrec/test_utils/tests/test_init_process_group.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import unittest
+from contextlib import contextmanager
+from typing import Iterator
+
+import torch.distributed as dist
+from torchrec.test_utils import init_process_group_single_rank
+
+
+@contextmanager
+def _occupied_port() -> Iterator[int]:
+    """Holds a port with a real TCPStore, so a second bind hits the conflict CI hits.
+
+    A raw socket could bind a different address family and silently not collide.
+    """
+    store = dist.TCPStore("localhost", 0, 1, is_master=True, wait_for_workers=False)
+    try:
+        yield store.port
+    finally:
+        del store
+
+
+class InitProcessGroupSingleRankTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_ignores_a_contested_master_port(self) -> None:
+        with _occupied_port() as taken_port:
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(taken_port)
+
+            init_process_group_single_rank("gloo")
+
+        self.assertTrue(dist.is_initialized())
+        self.assertEqual(dist.get_world_size(), 1)
+        self.assertEqual(dist.get_rank(), 0)
+
+    def test_master_port_path_fails_on_a_contested_port(self) -> None:
+        """Control: the env-based path this helper replaces still hits EADDRINUSE."""
+        with _occupied_port() as taken_port:
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(taken_port)
+
+            with self.assertRaises(dist.DistNetworkError) as raised:
+                dist.init_process_group("gloo", rank=0, world_size=1)
+
+        self.assertIn("EADDRINUSE", str(raised.exception))
+        self.assertFalse(dist.is_initialized())

--- a/torchrec/test_utils/tests/test_init_process_group.py
+++ b/torchrec/test_utils/tests/test_init_process_group.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import unittest
+from contextlib import contextmanager
+from typing import Iterator
+from unittest.mock import patch
+
+import torch.distributed as dist
+from torchrec.test_utils import init_process_group_single_rank
+
+
+@contextmanager
+def _occupied_port() -> Iterator[int]:
+    """Holds a port with a real TCPStore, so a second bind hits the conflict CI hits.
+
+    A raw socket could bind a different address family and silently not collide.
+    """
+    store = dist.TCPStore("localhost", 0, 1, is_master=True, wait_for_workers=False)
+    try:
+        yield store.port
+    finally:
+        del store
+
+
+class InitProcessGroupSingleRankTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Restores os.environ wholesale, so the rendezvous vars these tests set do
+        # not outlive them.
+        env = patch.dict(os.environ, {})
+        env.start()
+        self.addCleanup(env.stop)
+
+    def tearDown(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_ignores_a_contested_master_port(self) -> None:
+        with _occupied_port() as taken_port:
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(taken_port)
+
+            init_process_group_single_rank("gloo")
+
+        self.assertTrue(dist.is_initialized())
+        self.assertEqual(dist.get_world_size(), 1)
+        self.assertEqual(dist.get_rank(), 0)
+
+    def test_master_port_path_fails_on_a_contested_port(self) -> None:
+        """Control: the env-based path this helper replaces still hits EADDRINUSE."""
+        with _occupied_port() as taken_port:
+            os.environ["MASTER_ADDR"] = "localhost"
+            os.environ["MASTER_PORT"] = str(taken_port)
+
+            with self.assertRaises(dist.DistNetworkError) as raised:
+                dist.init_process_group("gloo", rank=0, world_size=1)
+
+        self.assertIn("EADDRINUSE", str(raised.exception))
+        self.assertFalse(dist.is_initialized())
+
+    def test_logs_and_reraises_on_failure(self) -> None:
+        init_process_group_single_rank("gloo")
+
+        with self.assertLogs("torchrec.test_utils", level="ERROR") as logs:
+            with self.assertRaises(ValueError):
+                init_process_group_single_rank("gloo")
+
+        self.assertIn("already_initialized=True", logs.output[0])


### PR DESCRIPTION
Summary:

This diff removes the port race from single-rank test setup.

`get_free_port()` closes its probe socket before it returns. Another process can
take the port before torch binds it. A recent OSS CI run hit this in
`test_keyed.py`.

This diff adds `init_process_group_single_rank` to `torchrec/test_utils`. The
helper passes a `dist.HashStore` to `init_process_group`. `HashStore` lives in
process memory, so there is no port to lose. The helper also logs the backend and
whether a group was already live when init fails. Torch's own error for a leaked
group does not mention that. `test_keyed.py` and
`test_cpu_offloaded_metric_module.py` now call the helper. The new test target
sets `PYTORCH_DISABLE_JUSTKNOBS=1`, matching the metrics targets, so the run does
not depend on live JK values.

Reviewed By: Raahul46

Differential Revision: D115119347


