### PR TITLE
Add PECPipelinedForward (#4509)

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -7,7 +7,14 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# For the same reason, do not use string forward references in dataclass fields.
 
 import abc
 from dataclasses import dataclass
@@ -151,6 +158,30 @@ class OverlapSplits:
     output_splits: Tuple[List[int], List[int]]
 
 
+class MaskDistAwaitable(Awaitable[Tuple[torch.Tensor, torch.Tensor]]):
+    """Wraps TensorAllToAllValuesAwaitable for mask AllToAll.
+
+    On wait, returns (post_dist_mask, pre_dist_mask):
+    - post_dist_mask: bool mask after AllToAll
+    - pre_dist_mask: bool mask before AllToAll (needed by compute_splits)
+    """
+
+    def __init__(
+        self,
+        awaitable: TensorAllToAllValuesAwaitable,
+        pre_dist_mask: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._awaitable = awaitable
+        self._pre_dist_mask = pre_dist_mask
+
+    def _wait_impl(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self._awaitable.wait().bool(), self._pre_dist_mask
+
+
+# Declared before OverlapHandler because its method annotations reference
+# MaskDistAwaitable, and without PEP 563 those are evaluated at class-body
+# execution time (see the torch.package NOTE at the top of this file).
 class OverlapHandler(abc.ABC):
     """Interface for PEC overlap detection and distribution handlers.
 
@@ -232,27 +263,6 @@ class OverlapHandler(abc.ABC):
         in rank-major order for AllToAll alignment.
         """
         ...
-
-
-class MaskDistAwaitable(Awaitable[Tuple[torch.Tensor, torch.Tensor]]):
-    """Wraps TensorAllToAllValuesAwaitable for mask AllToAll.
-
-    On wait, returns (post_dist_mask, pre_dist_mask):
-    - post_dist_mask: bool mask after AllToAll
-    - pre_dist_mask: bool mask before AllToAll (needed by compute_splits)
-    """
-
-    def __init__(
-        self,
-        awaitable: TensorAllToAllValuesAwaitable,
-        pre_dist_mask: torch.Tensor,
-    ) -> None:
-        super().__init__()
-        self._awaitable = awaitable
-        self._pre_dist_mask = pre_dist_mask
-
-    def _wait_impl(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self._awaitable.wait().bool(), self._pre_dist_mask
 
 
 class RWOverlapHandler(OverlapHandler):

--- a/torchrec/distributed/pec_comm_ops.py
+++ b/torchrec/distributed/pec_comm_ops.py
@@ -7,7 +7,15 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# This is also why PECGradientApply is declared before PECAll2AllSeqInfo: the
+# fields referencing it must be real annotations, not string forward refs.
 
 from dataclasses import dataclass
 from typing import Callable, List, Tuple
@@ -17,38 +25,6 @@ import torch.distributed as dist
 from torchrec.distributed.pec_collision_handlers import OverlapSplits
 from torchrec.distributed.types import Awaitable
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-
-
-@dataclass
-class PECAll2AllSeqInfo:
-    """Metadata for PEC backward gradient re-split and distribution.
-
-    Created by merge_partitioned_embeddings during forward. When
-    backward_ctxs is passed to merge, backward fields are populated
-    automatically. Read by PECAll2AllSeqWait during backward to re-split
-    gradients and create PECGradientApply instances.
-
-    Attributes:
-        forward_permute: Permute tensor for merging [ol, nol] → original order.
-        backward_ol_permute: Original-order indices for OL gradient split.
-        backward_nol_permute: Original-order indices for NOL gradient split.
-        backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
-        pg: Process group for gradient AllToAll.
-        ol_grad_apply: OL gradient applier (set by PECAll2AllSeqWait.backward).
-            Pipeline calls dist() via grad_dist.
-        nol_grad_apply: NOL gradient applier (set by PECAll2AllSeqWait.backward).
-            Pipeline calls dist() via grad_dist.
-    """
-
-    forward_permute: torch.Tensor
-    backward_ol_permute: torch.Tensor | None = None
-    backward_nol_permute: torch.Tensor | None = None
-    backward_splits: OverlapSplits | None = None
-    pg: dist.ProcessGroup | None = None
-
-    # Gradient appliers — set by PECAll2AllSeqWait.backward
-    ol_grad_apply: "PECGradientApply | None" = None
-    nol_grad_apply: "PECGradientApply | None" = None
 
 
 def _grad_dist(
@@ -92,6 +68,104 @@ def _grad_dist(
     assert req is not None
 
     return req, output_buffer
+
+
+class PECGradientApply:
+    """Handles gradient AllToAll and application to TBE for one partition.
+
+    Created by PECAll2AllSeqWait.backward — one for OL, one for NOL.
+    Short-lived: exists for one batch, consumed by apply().
+
+    Lifecycle:
+        1. __init__: holds the re-split gradient
+        2. dist(): starts async gradient AllToAll
+        3. apply(): waits AllToAll, re-lookups features in TBE, calls
+           embs.backward(grad) to push gradient through TBE kernel
+
+    dist() is called by the pipeline via grad_dist for both partitions —
+    OL before the optimizer step, NOL deferred to the next batch.
+    """
+
+    def __init__(
+        self,
+        grad: torch.Tensor,
+        input_splits: List[int],
+        output_splits: List[int],
+        pg: dist.ProcessGroup,
+    ) -> None:
+        self._grad = grad
+        self._input_splits = input_splits
+        self._output_splits = output_splits
+        self._pg = pg
+        self._work: dist.Work | None = None
+        self._grad_buffer: torch.Tensor | None = None
+
+    def dist(self) -> None:
+        """Starts async gradient reverse AllToAll. Idempotent — no-op if already started."""
+        if self._work is not None:
+            return
+
+        embedding_dim = self._grad.shape[1]
+        self._work, self._grad_buffer = _grad_dist(
+            self._grad,
+            input_splits=self._input_splits,
+            output_splits=self._output_splits,
+            embedding_dim=embedding_dim,
+            pg=self._pg,
+        )
+        self._grad = None  # type: ignore[assignment]
+
+    def apply(
+        self,
+        features: KeyedJaggedTensor,
+        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
+        embedding_dim: int,
+    ) -> None:
+        """Waits AllToAll and applies gradient to TBE via re-lookup + backward."""
+        assert self._work is not None
+        assert self._grad_buffer is not None
+
+        self._work.wait()
+
+        if features.values().numel() > 0:
+            with torch.enable_grad():
+                embs = lookup_fn(features).view(-1, embedding_dim)
+                if embs.numel() > 0:
+                    embs.backward(self._grad_buffer.view(-1, embedding_dim))
+        self._work = None
+        self._grad_buffer = None
+
+
+@dataclass
+class PECAll2AllSeqInfo:
+    """Metadata for PEC backward gradient re-split and distribution.
+
+    Created by merge_partitioned_embeddings during forward. When
+    backward_ctxs is passed to merge, backward fields are populated
+    automatically. Read by PECAll2AllSeqWait during backward to re-split
+    gradients and create PECGradientApply instances.
+
+    Attributes:
+        forward_permute: Permute tensor for merging [ol, nol] → original order.
+        backward_ol_permute: Original-order indices for OL gradient split.
+        backward_nol_permute: Original-order indices for NOL gradient split.
+        backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
+        pg: Process group for gradient AllToAll.
+        ol_grad_apply: OL gradient applier (set by PECAll2AllSeqWait.backward).
+            Pipeline calls dist() via grad_dist.
+        nol_grad_apply: NOL gradient applier (set by PECAll2AllSeqWait.backward).
+            Pipeline calls dist() via grad_dist.
+    """
+
+    forward_permute: torch.Tensor
+    backward_ol_permute: torch.Tensor | None = None
+    backward_nol_permute: torch.Tensor | None = None
+    backward_splits: OverlapSplits | None = None
+    pg: dist.ProcessGroup | None = None
+
+    # Gradient appliers — set by PECAll2AllSeqWait.backward
+    ol_grad_apply: PECGradientApply | None = None
+    nol_grad_apply: PECGradientApply | None = None
 
 
 class PECAll2AllSeqWait(torch.autograd.Function):
@@ -161,72 +235,6 @@ class PECAll2AllSeqWait(torch.autograd.Function):
         )
 
         return (None, None, None, None)
-
-
-class PECGradientApply:
-    """Handles gradient AllToAll and application to TBE for one partition.
-
-    Created by PECAll2AllSeqWait.backward — one for OL, one for NOL.
-    Short-lived: exists for one batch, consumed by apply().
-
-    Lifecycle:
-        1. __init__: holds the re-split gradient
-        2. dist(): starts async gradient AllToAll
-        3. apply(): waits AllToAll, re-lookups features in TBE, calls
-           embs.backward(grad) to push gradient through TBE kernel
-
-    dist() is called by the pipeline via grad_dist for both partitions —
-    OL before the optimizer step, NOL deferred to the next batch.
-    """
-
-    def __init__(
-        self,
-        grad: torch.Tensor,
-        input_splits: List[int],
-        output_splits: List[int],
-        pg: dist.ProcessGroup,
-    ) -> None:
-        self._grad = grad
-        self._input_splits = input_splits
-        self._output_splits = output_splits
-        self._pg = pg
-        self._work: dist.Work | None = None
-        self._grad_buffer: torch.Tensor | None = None
-
-    def dist(self) -> None:
-        """Starts async gradient reverse AllToAll. Idempotent — no-op if already started."""
-        if self._work is not None:
-            return
-
-        embedding_dim = self._grad.shape[1]
-        self._work, self._grad_buffer = _grad_dist(
-            self._grad,
-            input_splits=self._input_splits,
-            output_splits=self._output_splits,
-            embedding_dim=embedding_dim,
-            pg=self._pg,
-        )
-        self._grad = None  # type: ignore[assignment]
-
-    def apply(
-        self,
-        features: KeyedJaggedTensor,
-        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
-        embedding_dim: int,
-    ) -> None:
-        """Waits AllToAll and applies gradient to TBE via re-lookup + backward."""
-        assert self._work is not None
-        assert self._grad_buffer is not None
-
-        self._work.wait()
-
-        if features.values().numel() > 0:
-            with torch.enable_grad():
-                embs = lookup_fn(features).view(-1, embedding_dim)
-                if embs.numel() > 0:
-                    embs.backward(self._grad_buffer.view(-1, embedding_dim))
-        self._work = None
-        self._grad_buffer = None
 
 
 class PECGradUpdateAwaitable(Awaitable[None]):

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -8,7 +8,14 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# For the same reason, do not use string forward references in dataclass fields.
 
 from copy import copy
 from dataclasses import dataclass

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -10,7 +10,7 @@
 import itertools
 import logging
 from contextlib import nullcontext
-from typing import Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import cast, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import distributed as dist
@@ -33,9 +33,30 @@ except ImportError:
 
 from torchrec.distributed.embedding_sharding import KJTSplitsAllToAllMeta
 from torchrec.distributed.model_parallel import ShardedModule
+
+# This is a safety measure against torch package issues. PEC pulls in
+# torchrec modules (dist_data, modules.utils, ...) that older packages freeze
+# at a revision predating PEC's dependencies, so this import can fail during
+# repackaging. PEC training never runs from such a package, so falling back is
+# safe: ShardedPECEmbeddingCollection is bound to the empty tuple, which makes
+# the isinstance() check in PECPipelinedForward always False and routes every
+# module through the inherited InSync path.
+try:
+    from torchrec.distributed.pec_embedding import (
+        PECEmbeddingCollectionContext,
+        ShardedPECEmbeddingCollection,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.import_failure.pec_embedding"
+    )
+    PECEmbeddingCollectionContext = None  # type: ignore[misc,assignment]
+    ShardedPECEmbeddingCollection = ()  # type: ignore[misc,assignment]
+
 from torchrec.distributed.train_pipeline.pipeline_context import (
     CPUEmbeddingTrainPipelineContext,
     EmbeddingTrainPipelineContext,
+    PECTrainPipelineContext,
     PrefetchTrainPipelineContext,
     TrainPipelineContext,
 )
@@ -283,6 +304,48 @@ class InSyncEmbeddingPipelinedForward(EmbeddingPipelinedForward):
     ) -> None:
         # doing nothing
         pass
+
+
+class PECPipelinedForward(InSyncEmbeddingPipelinedForward):
+    """Shared in-sync pipelined forward for PEC and non-PEC modules.
+
+    Both retrieve embeddings computed one stage ahead — nothing is computed
+    inline. PEC modules (ShardedPECEmbeddingCollection) merge their precomputed
+    OL/NOL partitions via merge_partitioned_embeddings; non-PEC modules use the
+    inherited InSyncEmbeddingPipelinedForward path (embedding_a2a_requests, with
+    a no-op detach so loss.backward flows through to the fused-TBE update).
+
+    Used by TrainPipelinePEC.
+    """
+
+    # pyre-ignore[2,3]
+    def __call__(self, *input, **kwargs):
+        if not isinstance(self._module, ShardedPECEmbeddingCollection):
+            return super().__call__(*input, **kwargs)
+
+        ctx = self._context
+        assert isinstance(ctx, PECTrainPipelineContext)
+        name = self._name
+
+        pec_ctx = cast(PECEmbeddingCollectionContext, ctx.module_contexts[name])
+
+        # OL/NOL awaitables and forward ctxs are forward-only -> pop.
+        ol_awaitables = ctx.pec_ol_awaitables.pop(name)
+        nol_awaitables = ctx.pec_nol_awaitables.pop(name)
+        forward_ctxs = ctx.pec_forward_ctxs.pop(name)
+
+        # Backward ctxs are read non-destructively: they are also needed after
+        # forward (OL grad + deferred NOL). Always present by forward time
+        # (overlap_dist of the next batch / finalize runs earlier this progress).
+        backward_ctxs = ctx.pec_backward_ctxs[name]
+
+        return self._module.merge_partitioned_embeddings(
+            pec_ctx,
+            ol_awaitables,
+            nol_awaitables,
+            forward_ctxs,
+            backward_ctxs,
+        )
 
 
 class PrefetchPipelinedForward(BaseForward[PrefetchTrainPipelineContext]):


### PR DESCRIPTION
Summary:

## Context

`TrainPipelinePEC` needs a pipelined forward that, during the model forward, only retrieves embeddings computed one stage ahead (nothing computed inline) for both PEC and non-PEC modules.

## Approach

- Add `PECPipelinedForward` (subclass of `InSyncEmbeddingPipelinedForward`). PEC modules (`ShardedPECEmbeddingCollection`): merge the precomputed per-sharding-group OL/NOL partition awaitables via `merge_partitioned_embeddings`; OL/NOL awaitables and forward ctxs are forward-only (pop), backward ctxs are read non-destructively since they are also needed after forward (OL grad + deferred NOL). Non-PEC modules: fall through to the inherited InSync path (`embedding_a2a_requests`, no-op detach so `loss.backward` flows to the fused-TBE update).
- InSync (not SemiSync `EmbeddingPipelinedForward`) is required: the latter detaches embeddings and needs a separate embedding-backward, incompatible with the PEC `PECAll2AllSeqWait` gradient intercept.
- autodeps adds the `pec_embedding` dep on the `runtime_forwards` BUCK target.

Reviewed By: TroyGarden

Differential Revision: D110148600


