### PR TITLE
Support Uploading Benchmark Results To Scuba

### DIFF
--- a/torchrec/distributed/test_utils/benchmark_utils/benchmark_launcher.py
+++ b/torchrec/distributed/test_utils/benchmark_utils/benchmark_launcher.py
@@ -82,7 +82,7 @@ def _coerce(value: str) -> Any:
     return value
 
 
-def _parse_forwarded_kwargs(unknown: List[str]) -> Dict[str, Any]:
+def parse_forwarded_kwargs(unknown: List[str]) -> Dict[str, Any]:
     """Parse leftover ``--key=value`` / ``--key value`` args into benchmark kwargs.
 
     Unrecognized args are benchmark-specific options (e.g. ``--batch_size``,
@@ -115,8 +115,13 @@ def _parse_forwarded_kwargs(unknown: List[str]) -> Dict[str, Any]:
     return kwargs
 
 
-def _parse_args() -> Tuple[argparse.Namespace, Dict[str, Any]]:
-    parser = argparse.ArgumentParser(description=__doc__)
+def add_benchmark_args(parser: argparse.ArgumentParser) -> None:
+    """Register the shared benchmark-selection and dispatch arguments on ``parser``.
+
+    Exposed so internal wrappers can build their CLI on top of the SAME arguments
+    this launcher uses -- then dispatch through :func:`run_benchmark` -- instead of
+    re-declaring the arguments and drifting whenever the benchmark framework changes.
+    """
     parser.add_argument(
         "--mode",
         choices=["local", "remote"],
@@ -151,21 +156,44 @@ def _parse_args() -> Tuple[argparse.Namespace, Dict[str, Any]]:
         default=None,
         help="process-group backend (defaults to nccl on GPU, gloo otherwise).",
     )
+    # Named after the ``profile_dir`` kwarg the benchmark runners consume, so the flag,
+    # the forwarded kwarg and the runner argument are all one name. Accept both
+    # spellings so callers using the hyphen (--profile-dir) and the underscore
+    # (--profile_dir) convention both resolve to the same destination.
+    parser.add_argument(
+        "--profile-dir",
+        "--profile_dir",
+        dest="profile_dir",
+        type=str,
+        default="",
+        help="directory to write structured results (torchrec_benchmark_*.json) "
+        "and any traces/snapshots into. Empty (default) disables result dumping. "
+        "Each rank writes its own per-rank file here.",
+    )
+
+
+def _parse_args() -> Tuple[argparse.Namespace, Dict[str, Any]]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_benchmark_args(parser)
     # Use parse_known_args so argparse does not fail (exit code 2) on the leftover
     # args: these are either torchrun/fb.dist.ddp injections (e.g. --local-rank,
     # dropped) or benchmark-specific options (e.g. --batch_size, --dim) that we
     # forward to the selected benchmark_runner.
     args, unknown = parser.parse_known_args()
-    extra_kwargs = _parse_forwarded_kwargs(unknown)
+    extra_kwargs = parse_forwarded_kwargs(unknown)
     if extra_kwargs:
         logger.info("forwarding benchmark kwargs: %s", extra_kwargs)
     return args, extra_kwargs
 
 
-def main() -> None:
-    logging.basicConfig(level=logging.INFO)
-    args, extra_kwargs = _parse_args()
+def run_benchmark(args: argparse.Namespace, extra_kwargs: Dict[str, Any]) -> None:
+    """Dispatch to the selected benchmark runner for the requested mode.
 
+    ``args`` must carry the attributes added by :func:`add_benchmark_args`
+    (``mode`` / ``benchmark`` / ``name`` / ``world_size`` / ``backend`` /
+    ``profile_dir``); ``extra_kwargs`` are benchmark-specific options forwarded
+    verbatim to the runner.
+    """
     runner: Callable[..., Any] = _BENCHMARKS[args.benchmark]
 
     if args.mode == "local":
@@ -191,6 +219,7 @@ def main() -> None:
             world_size=args.world_size,
             backend=args.backend,
             name=args.name,
+            profile_dir=args.profile_dir,
             **extra_kwargs,
         )
     else:  # remote
@@ -201,8 +230,15 @@ def main() -> None:
             runner,
             backend=args.backend,
             name=args.name,
+            profile_dir=args.profile_dir,
             **extra_kwargs,
         )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    args, extra_kwargs = _parse_args()
+    run_benchmark(args, extra_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
## Context

A MAST benchmark run's results only exist as per-rank JSON on the worker hosts and are lost when the job exits. Persisting them needs Scuba (`rfe.scubadata`) and Manifold, which the OSS launcher in `torchrec/distributed/` must not depend on.

## Approach

Keep the OSS launcher upload-agnostic and add a thin internal worker under `fb/` that reuses its CLI (`add_benchmark_args`, `parse_forwarded_kwargs`) and dispatch (`run_benchmark`), then uploads results from local rank 0 on each host. One benchmark CLI, two entry points -- a new benchmark flag lands once and both paths inherit it.

## Launch paths

Blue = open source (`torchrec/distributed/`), red = internal (`torchrec/fb/`), yellow = on-disk artifacts, green = internal stores.

```lang=mermaid
flowchart TB
    devOSS(["OSS developer<br>torchx run dist.ddp -j 1x2<br>-m ...benchmark_utils.benchmark_launcher"]):::user
    devINT(["Meta developer<br>buck2 run benchmark_torchx_launcher"]):::user

    subgraph DRIVER["Internal driver -- devserver"]
        TXL["<b>benchmark_torchx_launcher.py</b><br>fb/distributed/benchmark/<br>picks where + how big"]:::int
        BUCKF["<b>BUCK</b><br>fb/distributed/benchmark/<br>_penv xar to fbpkg image"]:::int
        TXL -. "image" .-> BUCKF
    end

    subgraph RANK["Per-rank process -- MAST rank or local worker"]
        BRW["<b>benchmark_remote_worker.py</b><br>fb/distributed/benchmark/<br>pins mode=remote, defaults profile_dir"]:::int
        BL["<b>benchmark_launcher.py</b><br>distributed/test_utils/benchmark_utils/<br>add_benchmark_args, run_benchmark"]:::oss
        PRUN["<b>process_runner.py</b><br>distributed/test_utils/<br>spawns ranks, builds ctx = device + pg"]:::oss
        RUNNER["<b>benchmark_primitive.py</b><br>distributed/benchmark/<br>dispatch on --name"]:::oss
        BASE["<b>base.py</b> + <b>utils.py</b><br>distributed/benchmark/<br>timing, profiling, dump_benchmark_result"]:::oss
    end

    ART[("profile_dir per host<br>torchrec_benchmark_*.json<br>trace-*.json.gz, memory-*.pickle")]:::art

    subgraph UPLOAD["Internal upload -- local rank 0 on each host"]
        MANU["<b>manifold_utils.py</b>"]:::int
        RESU["<b>result_uploader.py</b>"]:::int
    end

    MANIFOLD[("Manifold<br>traces + snapshots")]:::store
    SCUBA[("Scuba<br>benchmark metrics")]:::store

    devOSS -->|"torchrun-placed ranks<br>--mode=remote"| BL
    devINT --> TXL
    TXL -->|"fb.dist.ddp under torchrun"| BRW
    BRW -->|"imports the OSS CLI"| BL
    BL --> PRUN
    PRUN -->|"ctx, rank, world_size"| RUNNER
    RUNNER --> BASE
    BASE --> ART
    ART --> MANU
    MANU -->|"URLs"| RESU
    MANU --> MANIFOLD
    RESU --> SCUBA

    classDef oss fill:#dbeafe,stroke:#1e40af,color:#0f172a
    classDef int fill:#fee2e2,stroke:#b91c1c,color:#0f172a
    classDef art fill:#fef3c7,stroke:#b45309,color:#0f172a
    classDef store fill:#dcfce7,stroke:#15803d,color:#0f172a
    classDef user fill:#f1f5f9,stroke:#475569,color:#0f172a
```

The internal path composes rather than forks: the TorchX launcher only decides *where* and *how big*, then submits a MAST job whose worker pins `mode = "remote"`, calls the OSS `run_benchmark`, and ships traces/snapshots to Manifold and metrics to Scuba.

## Notes

1. `--profile-dir` / `--profile_dir` is now on the shared CLI, matching the `profile_dir` kwarg the runners consume. Empty (OSS default) disables dumping; the internal worker defaults it to `/var/tmp/torchrec-bench` so the uploaders have files to read.
2. Accelerator presets now point at `torchrec_benchmark_internal` / `_amd`, which must be built and published before launching (commands in the BUCK comments).
3. `profile_dir` is host-local, so upload runs once per host from local rank 0 -- a single global-rank-0 upload would see only its own host's files and silently drop every other host's ranks. Every host passes the same run ID (the MAST job name) as both the Scuba `session_id` and the Manifold leaf directory, so a multi-host run stays one session and one directory instead of one of each per host.
4. Sharing the Manifold directory means the hosts race to create it. `mkdir` is now called with `ignoreExistingLeafDir=True` (its exist_ok behavior) -- without it the losing host dies on a 409 predicate failure, which is what killed the first multi-host run.

## Changes

1. **`benchmark_launcher.py`**: extracted `add_benchmark_args` / `run_benchmark`, made `parse_forwarded_kwargs` public, added `--profile-dir` and forwarded it on both dispatch paths.
2. **`benchmark_remote_worker.py`** (new): internal per-rank MAST entry; adds `--purpose` / `--manifold_ttl_days`, uploads from local rank 0 on each host, and derives the shared run ID from `MAST_HPC_JOB_NAME` for both uploaders.
3. **`benchmark_torchx_launcher.py`**: worker module and preset images switched to the internal ones; forwards `--profile_dir` / `--purpose` / `--manifold_ttl_days`.
4. **`result_uploader.py`**: `upload_results_to_scuba` takes an optional `session_id` so several uploaders can group their samples into one session; still mints a UUID when omitted.
5. **`manifold_utils.py`**: `upload_results_to_manifold` takes an optional `run_id` used as the leaf directory (timestamp fallback unchanged), and `mkdir` runs with `ignoreExistingLeafDir=True` so concurrent uploaders share one directory.
6. **`BUCK`**: `benchmark_remote_worker` (live) and `_penv` (xar) binaries plus the `torchrec_benchmark_internal[_amd]` fbpkg builders.

Reviewed By: TroyGarden

Differential Revision: D109752368


