### PR TITLE
get_weights_list: gather position weights on the index's device (#4512)

### DIFF
--- a/torchrec/modules/feature_processor_.py
+++ b/torchrec/modules/feature_processor_.py
@@ -157,7 +157,17 @@ def get_weights_list(
     seqs = torch.split(cat_seq, features.length_per_key())
     for key, seq in zip(features.keys(), seqs):
         if key in position_weights.keys():
-            weights_list.append(torch.gather(position_weights[key], dim=0, index=seq))
+            # Gather on the index's device. PositionWeightedModuleCollection caches
+            # plain references in `position_weights_dict`, which (unlike the
+            # `position_weights` ParameterDict) does NOT follow a module `.to(device)`
+            # -- so under GPU preproc (the `local` net exported on cuda) the param can
+            # still be on cpu while `seq` is cuda, tripping
+            # FakeTensorDeviceMismatchError("... found at least two devices, cpu and
+            # cuda:0") during PT2/sigmoid export. Mirrors the `device=` already used by
+            # the else-branch below; a no-op when both are already co-located.
+            weights_list.append(
+                torch.gather(position_weights[key].to(seq.device), dim=0, index=seq)
+            )
         else:
             weights_list.append(
                 torch.ones(seq.shape[0], device=features.values().device)


### PR DESCRIPTION
Summary:

`PositionWeightedModuleCollection` keeps the position weights in TWO places:
  * `self.position_weights` -- an `nn.ParameterDict`, which DOES follow a module `.to(device)`
  * `self.position_weights_dict` -- a PLAIN dict of references captured at __init__, which does NOT

`forward` passes the plain dict to `get_weights_list`, so once the module has been moved to cuda the
params handed to `torch.gather` are still on cpu while `seq` (derived from the input) is on cuda:

  FakeTensorDeviceMismatchError: Expected all tensors to be on the same device,
  but found at least two devices, cpu and cuda:0

seen during PT2/sigmoid export of a GPU-preproc `local` net (ads mtml_ctr_instagram_model), at
  torch.gather(...position_weighted_fp_collection.position_weights..., dim=0, index=offsets_to_range...)

Gather on the index's device. This mirrors the `device=features.values().device` that the sibling
else-branch a few lines below already uses, and is a no-op when the tensors are already co-located.

(The deeper cleanup -- making `position_weights_dict` follow `.to()`, e.g. by rebuilding it from the
ParameterDict in `_apply`/`to`, or dropping the plain-dict cache entirely -- is left to torchrec owners;
this is the minimal, behaviour-preserving fix at the point of use.)

Reviewed By: georgiaphillips

Differential Revision: D114461889


