### PR TITLE
Add TestPECMixedEmbeddingSparseArch test model

### DIFF
--- a/torchrec/distributed/pec_collision_handlers.py
+++ b/torchrec/distributed/pec_collision_handlers.py
@@ -7,7 +7,14 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# For the same reason, do not use string forward references in dataclass fields.
 
 import abc
 from dataclasses import dataclass
@@ -15,13 +22,37 @@ from typing import Dict, List, Tuple
 
 import torch
 import torch.distributed as dist
-from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
 from torchrec.distributed.embedding_types import GroupedEmbeddingConfig
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import Awaitable
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.pec_embedding_modules import OverlappingCheckerType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+# TensorAllToAllValuesAwaitable was added to dist_data.py after older torch
+# package exports were frozen. During repackaging the old PackageImporter
+# resolves dist_data from that frozen snapshot, which may predate the symbol.
+# PEC training code is never executed from those packages, so the fallback
+# only needs to keep module import working.
+try:
+    from torchrec.distributed.dist_data import TensorAllToAllValuesAwaitable
+except ImportError:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.pec_collision_handlers.import_failure."
+        "TensorAllToAllValuesAwaitable"
+    )
+
+    _TENSOR_A2A_UNAVAILABLE = (
+        "TensorAllToAllValuesAwaitable is unavailable in this torch package "
+        "export; PEC training is not supported here."
+    )
+
+    class TensorAllToAllValuesAwaitable:  # type: ignore[misc]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError(_TENSOR_A2A_UNAVAILABLE)
+
+        def wait(self) -> torch.Tensor:
+            raise RuntimeError(_TENSOR_A2A_UNAVAILABLE)
 
 
 @dataclass
@@ -151,6 +182,30 @@ class OverlapSplits:
     output_splits: Tuple[List[int], List[int]]
 
 
+class MaskDistAwaitable(Awaitable[Tuple[torch.Tensor, torch.Tensor]]):
+    """Wraps TensorAllToAllValuesAwaitable for mask AllToAll.
+
+    On wait, returns (post_dist_mask, pre_dist_mask):
+    - post_dist_mask: bool mask after AllToAll
+    - pre_dist_mask: bool mask before AllToAll (needed by compute_splits)
+    """
+
+    def __init__(
+        self,
+        awaitable: TensorAllToAllValuesAwaitable,
+        pre_dist_mask: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self._awaitable = awaitable
+        self._pre_dist_mask = pre_dist_mask
+
+    def _wait_impl(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self._awaitable.wait().bool(), self._pre_dist_mask
+
+
+# Declared before OverlapHandler because its method annotations reference
+# MaskDistAwaitable, and without PEP 563 those are evaluated at class-body
+# execution time (see the torch.package NOTE at the top of this file).
 class OverlapHandler(abc.ABC):
     """Interface for PEC overlap detection and distribution handlers.
 
@@ -232,27 +287,6 @@ class OverlapHandler(abc.ABC):
         in rank-major order for AllToAll alignment.
         """
         ...
-
-
-class MaskDistAwaitable(Awaitable[Tuple[torch.Tensor, torch.Tensor]]):
-    """Wraps TensorAllToAllValuesAwaitable for mask AllToAll.
-
-    On wait, returns (post_dist_mask, pre_dist_mask):
-    - post_dist_mask: bool mask after AllToAll
-    - pre_dist_mask: bool mask before AllToAll (needed by compute_splits)
-    """
-
-    def __init__(
-        self,
-        awaitable: TensorAllToAllValuesAwaitable,
-        pre_dist_mask: torch.Tensor,
-    ) -> None:
-        super().__init__()
-        self._awaitable = awaitable
-        self._pre_dist_mask = pre_dist_mask
-
-    def _wait_impl(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self._awaitable.wait().bool(), self._pre_dist_mask
 
 
 class RWOverlapHandler(OverlapHandler):

--- a/torchrec/distributed/pec_comm_ops.py
+++ b/torchrec/distributed/pec_comm_ops.py
@@ -7,7 +7,15 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# This is also why PECGradientApply is declared before PECAll2AllSeqInfo: the
+# fields referencing it must be real annotations, not string forward refs.
 
 from dataclasses import dataclass
 from typing import Callable, List, Tuple
@@ -17,38 +25,6 @@ import torch.distributed as dist
 from torchrec.distributed.pec_collision_handlers import OverlapSplits
 from torchrec.distributed.types import Awaitable
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-
-
-@dataclass
-class PECAll2AllSeqInfo:
-    """Metadata for PEC backward gradient re-split and distribution.
-
-    Created by merge_partitioned_embeddings during forward. When
-    backward_ctxs is passed to merge, backward fields are populated
-    automatically. Read by PECAll2AllSeqWait during backward to re-split
-    gradients and create PECGradientApply instances.
-
-    Attributes:
-        forward_permute: Permute tensor for merging [ol, nol] → original order.
-        backward_ol_permute: Original-order indices for OL gradient split.
-        backward_nol_permute: Original-order indices for NOL gradient split.
-        backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
-        pg: Process group for gradient AllToAll.
-        ol_grad_apply: OL gradient applier (set by PECAll2AllSeqWait.backward).
-            Pipeline calls dist() via grad_dist.
-        nol_grad_apply: NOL gradient applier (set by PECAll2AllSeqWait.backward).
-            Pipeline calls dist() via grad_dist.
-    """
-
-    forward_permute: torch.Tensor
-    backward_ol_permute: torch.Tensor | None = None
-    backward_nol_permute: torch.Tensor | None = None
-    backward_splits: OverlapSplits | None = None
-    pg: dist.ProcessGroup | None = None
-
-    # Gradient appliers — set by PECAll2AllSeqWait.backward
-    ol_grad_apply: "PECGradientApply | None" = None
-    nol_grad_apply: "PECGradientApply | None" = None
 
 
 def _grad_dist(
@@ -92,6 +68,104 @@ def _grad_dist(
     assert req is not None
 
     return req, output_buffer
+
+
+class PECGradientApply:
+    """Handles gradient AllToAll and application to TBE for one partition.
+
+    Created by PECAll2AllSeqWait.backward — one for OL, one for NOL.
+    Short-lived: exists for one batch, consumed by apply().
+
+    Lifecycle:
+        1. __init__: holds the re-split gradient
+        2. dist(): starts async gradient AllToAll
+        3. apply(): waits AllToAll, re-lookups features in TBE, calls
+           embs.backward(grad) to push gradient through TBE kernel
+
+    dist() is called by the pipeline via grad_dist for both partitions —
+    OL before the optimizer step, NOL deferred to the next batch.
+    """
+
+    def __init__(
+        self,
+        grad: torch.Tensor,
+        input_splits: List[int],
+        output_splits: List[int],
+        pg: dist.ProcessGroup,
+    ) -> None:
+        self._grad = grad
+        self._input_splits = input_splits
+        self._output_splits = output_splits
+        self._pg = pg
+        self._work: dist.Work | None = None
+        self._grad_buffer: torch.Tensor | None = None
+
+    def dist(self) -> None:
+        """Starts async gradient reverse AllToAll. Idempotent — no-op if already started."""
+        if self._work is not None:
+            return
+
+        embedding_dim = self._grad.shape[1]
+        self._work, self._grad_buffer = _grad_dist(
+            self._grad,
+            input_splits=self._input_splits,
+            output_splits=self._output_splits,
+            embedding_dim=embedding_dim,
+            pg=self._pg,
+        )
+        self._grad = None  # type: ignore[assignment]
+
+    def apply(
+        self,
+        features: KeyedJaggedTensor,
+        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
+        embedding_dim: int,
+    ) -> None:
+        """Waits AllToAll and applies gradient to TBE via re-lookup + backward."""
+        assert self._work is not None
+        assert self._grad_buffer is not None
+
+        self._work.wait()
+
+        if features.values().numel() > 0:
+            with torch.enable_grad():
+                embs = lookup_fn(features).view(-1, embedding_dim)
+                if embs.numel() > 0:
+                    embs.backward(self._grad_buffer.view(-1, embedding_dim))
+        self._work = None
+        self._grad_buffer = None
+
+
+@dataclass
+class PECAll2AllSeqInfo:
+    """Metadata for PEC backward gradient re-split and distribution.
+
+    Created by merge_partitioned_embeddings during forward. When
+    backward_ctxs is passed to merge, backward fields are populated
+    automatically. Read by PECAll2AllSeqWait during backward to re-split
+    gradients and create PECGradientApply instances.
+
+    Attributes:
+        forward_permute: Permute tensor for merging [ol, nol] → original order.
+        backward_ol_permute: Original-order indices for OL gradient split.
+        backward_nol_permute: Original-order indices for NOL gradient split.
+        backward_splits: Per-rank OL/NOL split sizes for gradient AllToAll.
+        pg: Process group for gradient AllToAll.
+        ol_grad_apply: OL gradient applier (set by PECAll2AllSeqWait.backward).
+            Pipeline calls dist() via grad_dist.
+        nol_grad_apply: NOL gradient applier (set by PECAll2AllSeqWait.backward).
+            Pipeline calls dist() via grad_dist.
+    """
+
+    forward_permute: torch.Tensor
+    backward_ol_permute: torch.Tensor | None = None
+    backward_nol_permute: torch.Tensor | None = None
+    backward_splits: OverlapSplits | None = None
+    pg: dist.ProcessGroup | None = None
+
+    # Gradient appliers — set by PECAll2AllSeqWait.backward
+    ol_grad_apply: PECGradientApply | None = None
+    nol_grad_apply: PECGradientApply | None = None
 
 
 class PECAll2AllSeqWait(torch.autograd.Function):
@@ -161,72 +235,6 @@ class PECAll2AllSeqWait(torch.autograd.Function):
         )
 
         return (None, None, None, None)
-
-
-class PECGradientApply:
-    """Handles gradient AllToAll and application to TBE for one partition.
-
-    Created by PECAll2AllSeqWait.backward — one for OL, one for NOL.
-    Short-lived: exists for one batch, consumed by apply().
-
-    Lifecycle:
-        1. __init__: holds the re-split gradient
-        2. dist(): starts async gradient AllToAll
-        3. apply(): waits AllToAll, re-lookups features in TBE, calls
-           embs.backward(grad) to push gradient through TBE kernel
-
-    dist() is called by the pipeline via grad_dist for both partitions —
-    OL before the optimizer step, NOL deferred to the next batch.
-    """
-
-    def __init__(
-        self,
-        grad: torch.Tensor,
-        input_splits: List[int],
-        output_splits: List[int],
-        pg: dist.ProcessGroup,
-    ) -> None:
-        self._grad = grad
-        self._input_splits = input_splits
-        self._output_splits = output_splits
-        self._pg = pg
-        self._work: dist.Work | None = None
-        self._grad_buffer: torch.Tensor | None = None
-
-    def dist(self) -> None:
-        """Starts async gradient reverse AllToAll. Idempotent — no-op if already started."""
-        if self._work is not None:
-            return
-
-        embedding_dim = self._grad.shape[1]
-        self._work, self._grad_buffer = _grad_dist(
-            self._grad,
-            input_splits=self._input_splits,
-            output_splits=self._output_splits,
-            embedding_dim=embedding_dim,
-            pg=self._pg,
-        )
-        self._grad = None  # type: ignore[assignment]
-
-    def apply(
-        self,
-        features: KeyedJaggedTensor,
-        lookup_fn: Callable[[KeyedJaggedTensor], torch.Tensor],
-        embedding_dim: int,
-    ) -> None:
-        """Waits AllToAll and applies gradient to TBE via re-lookup + backward."""
-        assert self._work is not None
-        assert self._grad_buffer is not None
-
-        self._work.wait()
-
-        if features.values().numel() > 0:
-            with torch.enable_grad():
-                embs = lookup_fn(features).view(-1, embedding_dim)
-                if embs.numel() > 0:
-                    embs.backward(self._grad_buffer.view(-1, embedding_dim))
-        self._work = None
-        self._grad_buffer = None
 
 
 class PECGradUpdateAwaitable(Awaitable[None]):

--- a/torchrec/distributed/pec_embedding.py
+++ b/torchrec/distributed/pec_embedding.py
@@ -8,7 +8,14 @@
 
 # pyre-strict
 
-from __future__ import annotations
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+# For the same reason, do not use string forward references in dataclass fields.
 
 from copy import copy
 from dataclasses import dataclass

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -44,6 +44,7 @@ from torchrec.modules.mc_modules import (
     ManagedCollisionModule,
     MCHManagedCollisionModule,
 )
+from torchrec.modules.pec_embedding_modules import PECEmbeddingCollection
 from torchrec.modules.regroup import KTRegroupAsDict
 from torchrec.sparse.jagged_tensor import _to_offsets, KeyedJaggedTensor, KeyedTensor
 from torchrec.streamable import Pipelineable
@@ -2945,6 +2946,158 @@ class TestMixedEmbeddingSparseArch(TestSparseNNBase, CopyableMixin):
                 cat_emb = torch.cat([ebc_embeddings, ec_embeddings], dim=1)
                 self._restore_callback = restore
                 return cat_emb
+
+        return torch.cat([ebc_embeddings, ec_embeddings], dim=1)
+
+
+class TestPECMixedEmbeddingSparseArch(TestSparseNNBase, CopyableMixin):
+    """
+    Test model that handles both EmbeddingBagCollection and PECEmbeddingCollection tables.
+
+    Mirrors TestMixedEmbeddingSparseArch but wraps the EmbeddingCollection in a
+    PECEmbeddingCollection so the sharded model exercises the PEC train pipeline.
+
+    Args:
+        tables: List[EmbeddingBagConfig] | List[EmbeddingConfig].
+        num_float_features: number of dense features.
+        weighted_tables: Optional[List[EmbeddingBagConfig]].
+        embedding_groups: Optional[Dict[str, List[str]]].
+        dense_device: Optional[torch.device].
+        sparse_device: Optional[torch.device].
+        over_arch_clazz: over-arch module class.
+        device: device for the embedding modules.
+    """
+
+    def __init__(
+        self,
+        tables: Union[List[EmbeddingBagConfig], List[EmbeddingConfig]],
+        num_float_features: int = 10,
+        weighted_tables: Optional[List[EmbeddingBagConfig]] = None,
+        embedding_groups: Optional[Dict[str, List[str]]] = None,
+        dense_device: Optional[torch.device] = None,
+        sparse_device: Optional[torch.device] = None,
+        over_arch_clazz: Type[nn.Module] = TestMixedSequenceOverArch,
+        device: Optional[torch.device] = None,
+        dense_arch_hidden_sizes: Optional[List[int]] = None,
+    ) -> None:
+        if weighted_tables is None:
+            weighted_tables = []
+        super().__init__(
+            tables=cast(List[BaseEmbeddingConfig], tables),
+            weighted_tables=cast(Optional[List[BaseEmbeddingConfig]], weighted_tables),
+            embedding_groups=embedding_groups,
+            dense_device=dense_device,
+            sparse_device=sparse_device,
+        )
+        if device is None:
+            device = torch.device("cpu")
+
+        ebc_tables: List[EmbeddingBagConfig] = []
+        ec_tables: List[EmbeddingConfig] = []
+
+        for table in tables:
+            if isinstance(table, EmbeddingBagConfig):
+                ebc_tables.append(table)
+            elif isinstance(table, EmbeddingConfig):
+                ec_tables.append(table)
+            else:
+                raise ValueError(f"Unsupported table type: {type(table)}")
+
+        self.ebc: Optional[EmbeddingBagCollection] = None
+        if ebc_tables:
+            self.ebc = EmbeddingBagCollection(
+                tables=ebc_tables,
+                device=device,
+            )
+
+        self.pec_ec: Optional[PECEmbeddingCollection] = None
+        if ec_tables:
+            self.pec_ec = PECEmbeddingCollection(
+                EmbeddingCollection(
+                    tables=ec_tables,
+                    device=device,
+                )
+            )
+            self.ec_embedding_dim = self.pec_ec.embedding_dim()
+
+        self._ebc_features: List[str] = [
+            feature for table in ebc_tables for feature in table.feature_names
+        ]
+
+        self._ec_features: List[str] = [
+            feature for table in ec_tables for feature in table.feature_names
+        ]
+
+        self.dense = TestDenseArch(
+            num_float_features,
+            device=dense_device,
+            dense_arch_hidden_sizes=dense_arch_hidden_sizes,
+        )
+        self.over: nn.Module = over_arch_clazz(ebc_tables, ec_tables, [], device)
+        self.register_buffer(
+            "dummy_ones",
+            torch.ones(1, device=dense_device),
+        )
+
+    def dense_forward(
+        self, input: ModelInput, sparse_output: torch.Tensor
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        dense_r = self.dense(input.float_features)
+        over_r = self.over(dense_r, sparse_output)
+        # pyrefly: ignore[unsupported-operation]
+        pred = torch.sigmoid(torch.mean(over_r, dim=1)) + self.dummy_ones
+        if self.training:
+            return (
+                torch.nn.functional.binary_cross_entropy_with_logits(pred, input.label),
+                pred,
+            )
+        else:
+            return pred
+
+    def forward(
+        self,
+        input: ModelInput,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        return self.dense_forward(input, self.sparse_forward(input))
+
+    def sparse_forward(
+        self,
+        input: ModelInput,
+    ) -> torch.Tensor:
+        """
+        Forward pass that processes features through both EBC and PEC-EC modules.
+
+        Args:
+            input: Input features for both EBC and PEC-EC.
+
+        Returns:
+            Concatenated embeddings from all modules.
+        """
+        features = input.idlist_features
+        ebc_embeddings = torch.empty(0)
+        ec_embeddings = torch.empty(0)
+
+        # Process EmbeddingBagCollection features.
+        # EBC internally filters features based on its configured table feature names.
+        if self.ebc is not None and self._ebc_features:
+            ebc_result = self.ebc(features)
+            ebc_embeddings = ebc_result.values()
+
+        # Process PECEmbeddingCollection features.
+        # The EC internally filters features based on its configured table feature names.
+        if self.pec_ec is not None and self._ec_features:
+            ec_result = self.pec_ec(features)
+            padded_embeddings = [
+                torch.ops.fbgemm.jagged_2d_to_dense(
+                    values=ec_result[e].values(),
+                    offsets=ec_result[e].offsets(),
+                    max_sequence_length=20,
+                ).view(-1, 20 * self.ec_embedding_dim)
+                for e in self._ec_features
+            ]
+
+            # Concatenate all EC embeddings along the feature dimension.
+            ec_embeddings = torch.cat(padded_embeddings, dim=1)
 
         return torch.cat([ebc_embeddings, ec_embeddings], dim=1)
 

--- a/torchrec/distributed/train_pipeline/runtime_forwards.py
+++ b/torchrec/distributed/train_pipeline/runtime_forwards.py
@@ -10,7 +10,7 @@
 import itertools
 import logging
 from contextlib import nullcontext
-from typing import Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import cast, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import distributed as dist
@@ -33,9 +33,14 @@ except ImportError:
 
 from torchrec.distributed.embedding_sharding import KJTSplitsAllToAllMeta
 from torchrec.distributed.model_parallel import ShardedModule
+from torchrec.distributed.pec_embedding import (
+    PECEmbeddingCollectionContext,
+    ShardedPECEmbeddingCollection,
+)
 from torchrec.distributed.train_pipeline.pipeline_context import (
     CPUEmbeddingTrainPipelineContext,
     EmbeddingTrainPipelineContext,
+    PECTrainPipelineContext,
     PrefetchTrainPipelineContext,
     TrainPipelineContext,
 )
@@ -283,6 +288,48 @@ class InSyncEmbeddingPipelinedForward(EmbeddingPipelinedForward):
     ) -> None:
         # doing nothing
         pass
+
+
+class PECPipelinedForward(InSyncEmbeddingPipelinedForward):
+    """Shared in-sync pipelined forward for PEC and non-PEC modules.
+
+    Both retrieve embeddings computed one stage ahead — nothing is computed
+    inline. PEC modules (ShardedPECEmbeddingCollection) merge their precomputed
+    OL/NOL partitions via merge_partitioned_embeddings; non-PEC modules use the
+    inherited InSyncEmbeddingPipelinedForward path (embedding_a2a_requests, with
+    a no-op detach so loss.backward flows through to the fused-TBE update).
+
+    Used by TrainPipelinePEC.
+    """
+
+    # pyre-ignore[2,3]
+    def __call__(self, *input, **kwargs):
+        if not isinstance(self._module, ShardedPECEmbeddingCollection):
+            return super().__call__(*input, **kwargs)
+
+        ctx = self._context
+        assert isinstance(ctx, PECTrainPipelineContext)
+        name = self._name
+
+        pec_ctx = cast(PECEmbeddingCollectionContext, ctx.module_contexts[name])
+
+        # OL/NOL awaitables and forward ctxs are forward-only -> pop.
+        ol_awaitables = ctx.pec_ol_awaitables.pop(name)
+        nol_awaitables = ctx.pec_nol_awaitables.pop(name)
+        forward_ctxs = ctx.pec_forward_ctxs.pop(name)
+
+        # Backward ctxs are read non-destructively: they are also needed after
+        # forward (OL grad + deferred NOL). Always present by forward time
+        # (overlap_dist of the next batch / finalize runs earlier this progress).
+        backward_ctxs = ctx.pec_backward_ctxs[name]
+
+        return self._module.merge_partitioned_embeddings(
+            pec_ctx,
+            ol_awaitables,
+            nol_awaitables,
+            forward_ctxs,
+            backward_ctxs,
+        )
 
 
 class PrefetchPipelinedForward(BaseForward[PrefetchTrainPipelineContext]):


### PR DESCRIPTION
Summary:
## Context

The PEC end-to-end test needs a model that wraps an `EmbeddingCollection` in a `PECEmbeddingCollection`, so the sharded model exercises `TrainPipelinePEC`.

## Approach

- Add `TestPECMixedEmbeddingSparseArch`, mirroring `TestMixedEmbeddingSparseArch` but wrapping its `EmbeddingCollection` in a `PECEmbeddingCollection`. `__init__` splits the tables into EBC and EC configs, builds an `EmbeddingBagCollection` for the former and a `PECEmbeddingCollection(EmbeddingCollection(...))` for the latter, reading the EC dim via `pec_ec.embedding_dim()`.
- `sparse_forward` runs both modules, pads the PEC-EC jagged outputs to a fixed `max_sequence_length` of 20 via `torch.ops.fbgemm.jagged_2d_to_dense`, and concatenates EBC + PEC-EC embeddings along the feature dimension.
- `dense_forward` / `forward` reuse the same `TestDenseArch` + `TestMixedSequenceOverArch` over-arch wiring as the non-PEC mixed model.

Reviewed By: TroyGarden

Differential Revision: D110148599


