### PR TITLE
Exclude python3.15 from the Linux wheel build matrix

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -64,9 +64,9 @@ def main():
             # fbgemm only supports cuda 12.6, 12.8, and 13.0
             # Re-enable once fbgemm-gpu releases cu132 nightly builds
             continue
-        if entry["python_version"] in ("3.9"):
-            # stop python3.9 support
-            # for python version: https://devguide.python.org/versions/
+        if entry["python_version"] == "3.15":
+            # fbgemm-gpu does not support python3.15 yet
+            # Re-enable once fbgemm-gpu releases python3.15 nightly builds
             continue
         new_matrix_entries.append(entry)
 


### PR DESCRIPTION
Summary:
`fbgemm-gpu` does not publish python3.15 wheels yet, so every python3.15 entry that `pytorch/test-infra`'s `generate_binary_build_matrix.yml` now emits produces a TorchRec wheel that cannot resolve its FBGEMM dependency. Filter those entries out of the `Build Linux Wheels` matrix until FBGEMM catches up.

This mirrors the existing `cu132` exclusion directly above it — same "re-enable once fbgemm-gpu ships it" shape — and keeps TorchRec's build matrix consistent with FBGEMM's version support, which is the stated purpose of `filter.py`.

Also drops the now-dead python3.9 branch: 3.9 is no longer emitted in the generated matrix, so the check can never fire. (It was also written as `in ("3.9")`, which is a bare string rather than a tuple, so it was doing substring matching instead of the intended membership test.)

`.github/scripts/filter.py` is consumed only by `.github/workflows/build-wheels-linux.yml` (the `filter-matrix` job), so the blast radius is limited to that workflow.

Differential Revision: D115363925


