### PR TITLE
Add `pip_lib_validation.sh` to validate published wheels on devgpu

### DIFF
--- a/torchrec/.claude/skills/release-cut/SKILL.md
+++ b/torchrec/.claude/skills/release-cut/SKILL.md
@@ -142,6 +142,33 @@ Beyond checking that the workflows succeed, the user should also inspect the **r
    Successfully installed torch-2.10.0+cpu
    ```
 
+### Local Wheel Validation on a devgpu (Meta-internal)
+
+The `Validate binaries` workflow covers a fixed matrix. To exercise the published wheels directly across every python and CUDA variant, run `fbcode/torchrec/fb/scripts/pip_lib_validation.sh` from a devgpu inside fbsource. It creates one conda env per combination, pip-installs `torch` / `fbgemm-gpu` / `torchrec` from `download.pytorch.org`, imports each, and prints a pass/fail summary.
+
+```bash
+# full matrix for the 1.8 release line; CHANNEL defaults to test
+PYTHON="3.10 3.11 3.12 3.13 3.14" CUDA="cpu cu126 cu130" \
+  fbcode/torchrec/fb/scripts/pip_lib_validation.sh 1.8
+```
+
+The argument names the torchrec/fbgemm-gpu release line (`8`, `1.8`, `v1.8` and `v1.8.0` are equivalent); torch is derived as `2.(minor + 5)`. `CHANNEL=nightly` and `CHANNEL=release` check the other channels — `test` is the correct one before promotion (Step 14), for the same reason `Validate binaries` uses it. A healthy run ends with `15/15 passed`.
+
+**Interpreting an `undefined symbol` failure.** If importing `fbgemm_gpu` raises `OSError: ... undefined symbol: ...`, the `.so` exists but was built against a different libtorch than the `torch` it resolved to. Confirm which symbol is missing before escalating:
+
+```bash
+# what fbgemm needs vs what libc10 provides
+nm -D --undefined-only <site-packages>/fbgemm_gpu/<failing>.so | c++filt | grep -i cow
+nm -D --defined-only  <site-packages>/torch/lib/libc10.so     | c++filt | grep -i cow
+```
+
+A genuine mismatch means the published `fbgemm-gpu` wheel needs an FBGEMM-side rebuild against the final torch — it is not a torchrec-side fix, and it blocks the release. Rule out a stale conda env first (the script reuses an env whose name matches, and the name encodes only python and CUDA, not the release line), by removing the envs and re-running:
+
+```bash
+conda env list
+for e in $(conda env list | awk '/^pip_validation_/{print $1}'); do conda env remove -yn "$e"; done
+```
+
 ## Step 11 — Create a Release Candidate Tag
 
 Create a release candidate tag following the naming pattern `v<version>-rc<N>` (e.g., `v1.5.0-rc1` for the first candidate):


### PR DESCRIPTION
Summary:
## 1. Context

Ahead of a release cut we need to confirm that the `torch` / `fbgemm-gpu` / `torchrec` wheels published to `download.pytorch.org` actually install and import together on a devgpu, across the python and CUDA variants we ship. This was being done by hand, one combination at a time.

## 2. Approach

1. **Version derivation from one argument**: `./pip_lib_validation.sh 1.8` installs torchrec 1.8 + fbgemm-gpu 1.8 + torch 2.13, using the `1.X -> torch 2.(X+5)` release pairing. The argument accepts `8`, `1.8`, `v1.8` and `v1.8.0` interchangeably; the major is constrained to `1`, so a torch version such as `2.13` is rejected rather than silently read as minor 13. `TORCHREC` / `FBGEMM_GPU` / `TORCH` override individually.
2. **Channel-aware index URL**: `CHANNEL` selects `nightly` / `test` / `release`. The stable channel is served from the bare `/whl/<cuda>` path while the others use `/whl/<channel>/<cuda>`, so `release` branches separately.
3. **Matrix over python x cuda**: `PYTHON` and `CUDA` accept space-separated lists; each combination gets its own conda env and runs install-then-import for all three libs.
4. **Per-combination isolation**: each combination runs in a subshell with `set -e` re-armed inside it, so a failure stops that combination but not the matrix. A pass/fail table is printed at the end and the script exits non-zero if any combination failed.

## 3. Analysis

1. **Risk**: low — internal dev tooling under `fb/scripts/` plus a skill doc, no library code and no build targets.
2. **`set -e` subtlety**: the loop deliberately avoids `if run_combo ...; then`, because bash disables `-e` inside any command whose status is tested, which would let a failing combination continue through its remaining install steps.
3. **Disk**: a full matrix leaves one conda env per combination, each with its own torch. The header documents the list and bulk-remove commands.
4. **Already caught a real break**: the 1.8 line on the test channel fails to import `fbgemm_gpu` with an `undefined symbol` error. `fbgemm-gpu 1.8.0+cpu` requires `c10::impl::cow::materialize_cow_storage(c10::StorageImpl&)`, while `torch 2.13.0+cpu` exports `c10::impl::cow::materialize_cow(c10::StorageImpl*)` — the function was renamed and its signature changed. No torch library in the env exports the old symbol, and the failing `.so` is owned by the 1.8.0 wheel (single dist-info, no orphaned `.so` files), so this is an upstream mismatch needing an FBGEMM-side rebuild, not a stale env. Details in the Test Plan.

## 4. Changes

1. **`fbcode/torchrec/fb/scripts/pip_lib_validation.sh`** (new, derived from `setup_devbox.sh`): argument/env parsing with validation, channel-aware index URL, `run_combo` install-and-import routine, matrix driver with pass/fail summary, and header docs covering usage, env overrides, and conda env cleanup.
2. **`fbcode/torchrec/.claude/skills/release-cut/SKILL.md`**: adds a "Local Wheel Validation on a devgpu" subsection under Step 10, covering the run command, why `test` is the right channel before promotion, how to read an `undefined symbol` failure with `nm -D`, and the conda env cleanup.

Tensors and Dynamic neural networks in Python with strong GPU acceleration
Home-page: https://pytorch.org
Author:
Author-email: PyTorch Team <packages@pytorch.org>
License: BSD-3-Clause
Location: /home/hhy/.conda/envs/pip_validation_3.14_cu130/lib/python3.14/site-packages
Requires: cuda-bindings, cuda-toolkit, filelock, fsspec, jinja2, networkx, nvidia-cublas, nvidia-cudnn-cu13, nvidia-cusparselt-cu13, nvidia-nccl-cu13, nvidia-nvshmem-cu13, setuptools, sympy, triton, typing-extensions
Required-by: tensordict, torchmetrics
---
Name: fbgemm_gpu
Version: 1.7.0+cu130

Home-page: https://github.com/pytorch/fbgemm
Author: FBGEMM Team
Author-email: packages@pytorch.org
License: BSD-3
Location: /home/hhy/.conda/envs/pip_validation_3.14_cu130/lib/python3.14/site-packages
Requires: numpy
Required-by: torchrec
---
Name: torchrec
Version: 1.7.0+cu130
TorchRec: Pytorch library for recommendation systems
Home-page: https://github.com/meta-pytorch/torchrec
Author: TorchRec Team
Author-email: packages@pytorch.org
License: BSD-3
Location: /home/hhy/.conda/envs/pip_validation_3.14_cu130/lib/python3.14/site-packages
Requires: fbgemm-gpu, iopath, pyre-extensions, tensordict, torchmetrics, tqdm
Required-by:

*************************
matrix summary
*************************

PASS  python 3.10  cpu
PASS  python 3.10  cu126
PASS  python 3.10  cu130
PASS  python 3.11  cpu
PASS  python 3.11  cu126
PASS  python 3.11  cu130
PASS  python 3.12  cpu
PASS  python 3.12  cu126
PASS  python 3.12  cu130
PASS  python 3.13  cpu
PASS  python 3.13  cu126
PASS  python 3.13  cu130
PASS  python 3.14  cpu
PASS  python 3.14  cu126
PASS  python 3.14  cu130

15/15 passed
```

(The three `Summary:` lines inside the pasted `pip show` output are indented by two spaces on purpose: at column 0 the commit-message parser reads them as field headers and `jf submit` warns `Field "summary" occurs twice in commit message!`.)

* test channel with 1.8 -- surfaces a real wheel incompatibility

```
PYTHON=3.10 fbcode/torchrec/fb/scripts/pip_lib_validation.sh 1.8
```

`torch==2.13` and `fbgemm-gpu==1.8` install cleanly, then `import fbgemm_gpu` fails:

```
OSError: .../fbgemm_gpu/fbgemm_gpu_tbe_utils.so: undefined symbol:
_ZN3c104impl3cow23materialize_cow_storageERNS_11StorageImplE

FAIL  python 3.10  cpu  (exit 1)
0/1 passed
```

Root-caused to an ABI mismatch rather than a bad env:

```
$ nm -D --undefined-only .../fbgemm_gpu/fbgemm_gpu_tbe_utils.so | c++filt | grep -i cow
  U c10::impl::cow::materialize_cow_storage(c10::StorageImpl&)

$ nm -D --defined-only .../torch/lib/libc10.so | c++filt | grep -i cow
  T c10::impl::cow::materialize_cow(c10::StorageImpl*)
```

The function was renamed and its signature changed (reference -> pointer); no library under `torch/lib/` exports the old symbol. Env contamination ruled out: a single `fbgemm_gpu-1.8.0+cpu.dist-info`, the failing `.so` is listed in that wheel's `RECORD`, and no orphaned `.so` files on disk. This needs an FBGEMM-side rebuild against final torch 2.13.

* lint and syntax

```
arc lint fbcode/torchrec/fb/scripts/pip_lib_validation.sh
arc lint fbcode/torchrec/.claude/skills/release-cut/SKILL.md
bash -n fbcode/torchrec/fb/scripts/pip_lib_validation.sh
```

Script lint reports only the pre-existing `SC1091` advice for the sourced `common_utils.sh`; SKILL.md clean; syntax clean.

* version argument parsing — accepted `9`, `v9`, `1.9`, `v1.9`, `1.9.0`, `v1.9.0` (all resolve to torchrec 1.9 / fbgemm-gpu 1.9 / torch 2.14) and the no-arg default (1.8 / 2.13). Rejected with exit 1: `2.14` (torch-shaped, major != 1), `abc`, `1.`, `v`, `x1.9`, `1.9.0.1`.

* override precedence — `TORCH=`, `FBGEMM_GPU=` and `TORCHREC=` each win over the value derived from the argument.

* matrix driver — exercised with a stubbed `run_combo` failing one of four combinations: the failing combination stopped at its failing step, the other three ran to completion, the summary reported `3/4 passed`, and the script exited 1.

* `CONDA_ENV_NAME` guard — rejected when combined with a multi-combination matrix, accepted for a single combination.

Differential Revision: D115375410


