### PR TITLE
Make LP planner aware of EMS weight stashing (#4519)

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -9,7 +9,7 @@
 
 import copy
 import logging
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 from torch import nn
@@ -52,6 +52,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingCollection,
 )
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
+from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 from torchrec.modules.mc_embedding_modules import (
     BaseManagedCollisionEmbeddingCollection,
 )
@@ -284,6 +285,9 @@ class EmbeddingEnumerator(Enumerator):
                                 feature_names=feature_names,
                                 output_dtype=output_dtype,
                                 key_value_params=key_value_params,
+                                stash_weights=self._get_stash_weights(
+                                    name, child_module
+                                ),
                             )
                         )
                 if not sharding_options_per_table:
@@ -350,6 +354,46 @@ class EmbeddingEnumerator(Enumerator):
 
         # If table with matching name not found, return None
         return None
+
+    def _get_stash_weights(self, parameter: str, module: nn.Module) -> bool:
+        """Whether EMS (embedding memory stashing) stashes this table's weights.
+
+        Reads the per-table ``stash_weights`` flag, which is set on the embedding
+        config before planning by the training framework. The planner uses this to
+        reflect the HBM that stashing frees in its storage estimates. Returns
+        ``False`` when the module/table has no such config.
+
+        Args:
+            parameter (str): name of the embedding table.
+            module (nn.Module): module to be sharded.
+
+        Returns:
+            bool: the table's ``stash_weights`` flag, or False if not found.
+        """
+        embedding_configs: Sequence[Any]
+        if isinstance(module, EmbeddingBagCollection):
+            embedding_configs = module.embedding_bag_configs()
+        elif isinstance(module, FeatureProcessedEmbeddingBagCollection):
+            # FP-EBC wraps an EmbeddingBagCollection; the enumerator hands the
+            # outer FP-EBC here, so unwrap to the inner EBC's configs. The training
+            # framework flags these tables for stashing by recursing into the inner
+            # EBC, so the planner must read them the same way -- otherwise it
+            # under-counts the HBM stashing frees for feature-processed tables.
+            embedding_configs = module._embedding_bag_collection.embedding_bag_configs()
+        elif isinstance(module, EmbeddingCollection):
+            embedding_configs = module.embedding_configs()
+        else:
+            # Other pooled-embedding modules may expose their per-table
+            # configs via a tables() accessor.
+            tables_fn = getattr(module, "tables", None)
+            if not callable(tables_fn):
+                return False
+            embedding_configs = cast(Sequence[Any], tables_fn())
+
+        for config in embedding_configs:
+            if config.name == parameter:
+                return bool(getattr(config, "stash_weights", False))
+        return False
 
     @property
     def sharder_map(self) -> Dict[str, ModuleSharder[nn.Module]]:

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -9,7 +9,7 @@
 
 import math
 import unittest
-from typing import cast, List
+from typing import cast, List, NamedTuple
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -40,6 +40,8 @@ from torchrec.distributed.test_utils.test_model import (
 )
 from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.feature_processor_ import PositionWeightedModuleCollection
+from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 
 EXPECTED_RW_SHARD_SIZES = [
     [[13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [9, 20]],
@@ -553,6 +555,86 @@ class TestEnumerators(unittest.TestCase):
         )
         self.addCleanup(_get_optimizer_multipler_patcher.stop)
         self._get_optimizer_multipler_mock = _get_optimizer_multipler_patcher.start()
+
+    def test_get_stash_weights_ebc(self) -> None:
+        # EMS stash awareness: the enumerator reads the per-table stash_weights flag
+        # off EmbeddingBagCollection configs (set before planning).
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="stash_table",
+                    feature_names=["f0"],
+                    stash_weights=True,
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="plain_table",
+                    feature_names=["f1"],
+                ),
+            ],
+        )
+        self.assertTrue(self.enumerator._get_stash_weights("stash_table", ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("plain_table", ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("missing_table", ebc))
+
+    def test_get_stash_weights_via_tables_accessor(self) -> None:
+        # FB pooled-embedding modules (e.g. VariableLengthEmbeddingArch) expose their
+        # per-table configs via tables(); the enumerator reads stash_weights through
+        # that accessor without importing the FB module type.
+        class _FakeConfig(NamedTuple):
+            name: str
+            stash_weights: bool
+
+        class _FakeVLEModule(torch.nn.Module):
+            def tables(self) -> List[_FakeConfig]:
+                return [
+                    _FakeConfig("vle_stash", True),
+                    _FakeConfig("vle_plain", False),
+                ]
+
+        module = _FakeVLEModule()
+        self.assertTrue(self.enumerator._get_stash_weights("vle_stash", module))
+        self.assertFalse(self.enumerator._get_stash_weights("vle_plain", module))
+        self.assertFalse(self.enumerator._get_stash_weights("missing", module))
+
+    def test_get_stash_weights_unknown_module_returns_false(self) -> None:
+        # A module that exposes no embedding configs contributes no stashing.
+        self.assertFalse(self.enumerator._get_stash_weights("any", torch.nn.Module()))
+
+    def test_get_stash_weights_fp_ebc(self) -> None:
+        # FeatureProcessedEmbeddingBagCollection (e.g. position_ebc /
+        # score_bucketize_ebc) wraps an EmbeddingBagCollection. The enumerator hands
+        # _get_stash_weights the OUTER FP-EBC, which is neither an EBC/EC nor exposes
+        # a tables() accessor, so the flag must be read by unwrapping the inner EBC's
+        # configs -- mirroring how the training framework marks them via recursion.
+        inner_ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="fp_stash_table",
+                    feature_names=["f0"],
+                    stash_weights=True,
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="fp_plain_table",
+                    feature_names=["f1"],
+                ),
+            ],
+            is_weighted=True,
+        )
+        fp_ebc = FeatureProcessedEmbeddingBagCollection(
+            inner_ebc,
+            PositionWeightedModuleCollection(max_feature_lengths={"f0": 10, "f1": 10}),
+        )
+        self.assertTrue(self.enumerator._get_stash_weights("fp_stash_table", fp_ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("fp_plain_table", fp_ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("missing_table", fp_ebc))
 
     def test_dp_sharding(self) -> None:
         sharding_options = self.enumerator.enumerate(

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1303,6 +1303,10 @@ class ShardingOption:
             by the planner to produce a more balanced plan.
         key_value_params (Optional[KeyValueParams]): Params for SSD TBE, either
             for SSD or PS.
+        stash_weights (bool): whether EMS (embedding memory stashing) stashes this
+            table's weights GPU->CPU during the dense forward/backward. Set on the
+            table config before planning; the planner reflects the HBM that stashing
+            frees in its storage estimates.
     """
 
     def __init__(
@@ -1326,6 +1330,7 @@ class ShardingOption:
         output_dtype: Optional[DataType] = None,
         key_value_params: Optional[KeyValueParams] = None,
         num_poolings: Optional[List[float]] = None,
+        stash_weights: bool = False,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -1353,6 +1358,7 @@ class ShardingOption:
         self.output_dtype: Optional[DataType] = output_dtype
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
+        self.stash_weights: bool = stash_weights
 
         child_module = module[1]
         self._module_type_key: str = (


### PR DESCRIPTION
Summary:

Add `EmbeddingEnumerator._get_stash_weights()`, which reads each embedding table's per-table config flag and populates a new additive `ShardingOption.stash_weights: bool` field (default `False`), so a planner can reflect embedding weights that are memory-stashed (freed) at runtime in its HBM storage estimates.

Reviewed By: aporialiao

Differential Revision: D109475885


