### PR TITLE
Add stage to balance per-rank stashed memory

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -277,7 +277,9 @@ def create_sharding_infos_by_sharding_device_group(
                         total_num_buckets=config.total_num_buckets,
                         use_virtual_table=config.use_virtual_table,
                         virtual_table_eviction_policy=config.virtual_table_eviction_policy,
-                        stash_weights=getattr(config, "stash_weights", False),
+                        stash_weights=MemoryStashingManager.resolve_stash_weights(
+                            table_name, config
+                        ),
                     ),
                     param_sharding=parameter_sharding,
                     param=param,
@@ -716,6 +718,9 @@ class ShardedEmbeddingCollection(
                             use_virtual_table=config.use_virtual_table,
                             virtual_table_eviction_policy=config.virtual_table_eviction_policy,
                             enable_embedding_update=config.enable_embedding_update,
+                            stash_weights=MemoryStashingManager.resolve_stash_weights(
+                                table_name, config
+                            ),
                         ),
                         param_sharding=parameter_sharding,
                         param=param,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -326,7 +326,9 @@ def create_sharding_infos_by_sharding_device_group(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
-                    stash_weights=getattr(config, "stash_weights", False),
+                    stash_weights=MemoryStashingManager.resolve_stash_weights(
+                        table_name, config
+                    ),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,
@@ -960,7 +962,9 @@ class ShardedEmbeddingBagCollection(
                         getattr(config, "virtual_table_eviction_policy", None)
                         # TODO: Need to check if attribute exists for BC
                     ),
-                    stash_weights=getattr(config, "stash_weights", False),
+                    stash_weights=MemoryStashingManager.resolve_stash_weights(
+                        table_name, config
+                    ),
                 ),
                 param_sharding=parameter_sharding,
                 param=param,

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Protocol,
     runtime_checkable,
+    Set,
     Tuple,
     Union,
 )
@@ -182,6 +183,7 @@ class MemoryStashingManager:
     # ``chunked_copy_``'s ``chunk_size_bytes``. Defaults to
     # ``_STASH_CHUNK_SIZE_BYTES``; override via ``set_trunk_size``.
     _stash_chunk_size_bytes: int = _STASH_CHUNK_SIZE_BYTES
+    _stashed_tables: Optional[Set[str]] = None
 
     @classmethod
     def _log_ems_once(
@@ -243,6 +245,27 @@ class MemoryStashingManager:
     def is_enabled(cls) -> bool:
         """Return whether memory stashing streams have been initialized."""
         return cls._device_to_host_stream is not None
+
+    @classmethod
+    def set_stashed_tables(cls, tables: Optional[Set[str]]) -> None:
+        """Set the table names selected for stashing by the planner, or None to clear."""
+        cls._stashed_tables = tables
+
+    @classmethod
+    def get_stashed_tables(cls) -> Optional[Set[str]]:
+        """Return the planner-selected stashed table names, or None if not set."""
+        return cls._stashed_tables
+
+    @classmethod
+    def resolve_stash_weights(cls, table_name: str, config: Any) -> bool:
+        """Resolve whether a table should be stashed.
+
+        Checks the planner-selected table set first. Falls back to the
+        per-table ``stash_weights`` attribute on the config object.
+        """
+        if cls._stashed_tables is not None:
+            return table_name in cls._stashed_tables
+        return getattr(config, "stash_weights", False)
 
     @classmethod
     def set_streams(
@@ -308,6 +331,7 @@ class MemoryStashingManager:
         cls._stash_chunk_size_bytes = _STASH_CHUNK_SIZE_BYTES
         cls._pending_stash_callbacks.clear()
         cls._staged_storage_buffers.clear()
+        cls._stashed_tables = None
         if cls._stash_executor is not None:
             cls._stash_executor.shutdown(wait=False)
             cls._stash_executor = None

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -9,7 +9,7 @@
 
 import copy
 import logging
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 from torch import nn
@@ -52,6 +52,7 @@ from torchrec.modules.embedding_modules import (
     EmbeddingCollection,
 )
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
+from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 from torchrec.modules.mc_embedding_modules import (
     BaseManagedCollisionEmbeddingCollection,
 )
@@ -284,6 +285,9 @@ class EmbeddingEnumerator(Enumerator):
                                 feature_names=feature_names,
                                 output_dtype=output_dtype,
                                 key_value_params=key_value_params,
+                                stash_weights=self._get_stash_weights(
+                                    name, child_module
+                                ),
                             )
                         )
                 if not sharding_options_per_table:
@@ -350,6 +354,46 @@ class EmbeddingEnumerator(Enumerator):
 
         # If table with matching name not found, return None
         return None
+
+    def _get_stash_weights(self, parameter: str, module: nn.Module) -> bool:
+        """Whether EMS (embedding memory stashing) stashes this table's weights.
+
+        Reads the per-table ``stash_weights`` flag, which is set on the embedding
+        config before planning by the training framework. The planner uses this to
+        reflect the HBM that stashing frees in its storage estimates. Returns
+        ``False`` when the module/table has no such config.
+
+        Args:
+            parameter (str): name of the embedding table.
+            module (nn.Module): module to be sharded.
+
+        Returns:
+            bool: the table's ``stash_weights`` flag, or False if not found.
+        """
+        embedding_configs: Sequence[Any]
+        if isinstance(module, EmbeddingBagCollection):
+            embedding_configs = module.embedding_bag_configs()
+        elif isinstance(module, FeatureProcessedEmbeddingBagCollection):
+            # FP-EBC wraps an EmbeddingBagCollection; the enumerator hands the
+            # outer FP-EBC here, so unwrap to the inner EBC's configs. The training
+            # framework flags these tables for stashing by recursing into the inner
+            # EBC, so the planner must read them the same way -- otherwise it
+            # under-counts the HBM stashing frees for feature-processed tables.
+            embedding_configs = module._embedding_bag_collection.embedding_bag_configs()
+        elif isinstance(module, EmbeddingCollection):
+            embedding_configs = module.embedding_configs()
+        else:
+            # Other pooled-embedding modules may expose their per-table
+            # configs via a tables() accessor.
+            tables_fn = getattr(module, "tables", None)
+            if not callable(tables_fn):
+                return False
+            embedding_configs = cast(Sequence[Any], tables_fn())
+
+        for config in embedding_configs:
+            if config.name == parameter:
+                return bool(getattr(config, "stash_weights", False))
+        return False
 
     @property
     def sharder_map(self) -> Dict[str, ModuleSharder[nn.Module]]:

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -9,7 +9,7 @@
 
 import math
 import unittest
-from typing import cast, List
+from typing import cast, List, NamedTuple
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -40,6 +40,8 @@ from torchrec.distributed.test_utils.test_model import (
 )
 from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.feature_processor_ import PositionWeightedModuleCollection
+from torchrec.modules.fp_embedding_modules import FeatureProcessedEmbeddingBagCollection
 
 EXPECTED_RW_SHARD_SIZES = [
     [[13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [13, 20], [9, 20]],
@@ -553,6 +555,86 @@ class TestEnumerators(unittest.TestCase):
         )
         self.addCleanup(_get_optimizer_multipler_patcher.stop)
         self._get_optimizer_multipler_mock = _get_optimizer_multipler_patcher.start()
+
+    def test_get_stash_weights_ebc(self) -> None:
+        # EMS stash awareness: the enumerator reads the per-table stash_weights flag
+        # off EmbeddingBagCollection configs (set before planning).
+        ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="stash_table",
+                    feature_names=["f0"],
+                    stash_weights=True,
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="plain_table",
+                    feature_names=["f1"],
+                ),
+            ],
+        )
+        self.assertTrue(self.enumerator._get_stash_weights("stash_table", ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("plain_table", ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("missing_table", ebc))
+
+    def test_get_stash_weights_via_tables_accessor(self) -> None:
+        # FB pooled-embedding modules (e.g. VariableLengthEmbeddingArch) expose their
+        # per-table configs via tables(); the enumerator reads stash_weights through
+        # that accessor without importing the FB module type.
+        class _FakeConfig(NamedTuple):
+            name: str
+            stash_weights: bool
+
+        class _FakeVLEModule(torch.nn.Module):
+            def tables(self) -> List[_FakeConfig]:
+                return [
+                    _FakeConfig("vle_stash", True),
+                    _FakeConfig("vle_plain", False),
+                ]
+
+        module = _FakeVLEModule()
+        self.assertTrue(self.enumerator._get_stash_weights("vle_stash", module))
+        self.assertFalse(self.enumerator._get_stash_weights("vle_plain", module))
+        self.assertFalse(self.enumerator._get_stash_weights("missing", module))
+
+    def test_get_stash_weights_unknown_module_returns_false(self) -> None:
+        # A module that exposes no embedding configs contributes no stashing.
+        self.assertFalse(self.enumerator._get_stash_weights("any", torch.nn.Module()))
+
+    def test_get_stash_weights_fp_ebc(self) -> None:
+        # FeatureProcessedEmbeddingBagCollection (e.g. position_ebc /
+        # score_bucketize_ebc) wraps an EmbeddingBagCollection. The enumerator hands
+        # _get_stash_weights the OUTER FP-EBC, which is neither an EBC/EC nor exposes
+        # a tables() accessor, so the flag must be read by unwrapping the inner EBC's
+        # configs -- mirroring how the training framework marks them via recursion.
+        inner_ebc = EmbeddingBagCollection(
+            tables=[
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="fp_stash_table",
+                    feature_names=["f0"],
+                    stash_weights=True,
+                ),
+                EmbeddingBagConfig(
+                    num_embeddings=100,
+                    embedding_dim=16,
+                    name="fp_plain_table",
+                    feature_names=["f1"],
+                ),
+            ],
+            is_weighted=True,
+        )
+        fp_ebc = FeatureProcessedEmbeddingBagCollection(
+            inner_ebc,
+            PositionWeightedModuleCollection(max_feature_lengths={"f0": 10, "f1": 10}),
+        )
+        self.assertTrue(self.enumerator._get_stash_weights("fp_stash_table", fp_ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("fp_plain_table", fp_ebc))
+        self.assertFalse(self.enumerator._get_stash_weights("missing_table", fp_ebc))
 
     def test_dp_sharding(self) -> None:
         sharding_options = self.enumerator.enumerate(

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1303,6 +1303,10 @@ class ShardingOption:
             by the planner to produce a more balanced plan.
         key_value_params (Optional[KeyValueParams]): Params for SSD TBE, either
             for SSD or PS.
+        stash_weights (bool): whether EMS (embedding memory stashing) stashes this
+            table's weights GPU->CPU during the dense forward/backward. Set on the
+            table config before planning; the planner reflects the HBM that stashing
+            frees in its storage estimates.
     """
 
     def __init__(
@@ -1326,6 +1330,7 @@ class ShardingOption:
         output_dtype: Optional[DataType] = None,
         key_value_params: Optional[KeyValueParams] = None,
         num_poolings: Optional[List[float]] = None,
+        stash_weights: bool = False,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -1353,6 +1358,7 @@ class ShardingOption:
         self.output_dtype: Optional[DataType] = output_dtype
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
+        self.stash_weights: bool = stash_weights
 
         child_module = module[1]
         self._module_type_key: str = (

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -1717,5 +1717,63 @@ class TestCheckpointWhileStashed(unittest.TestCase):
         torch.testing.assert_close(cpu_src, original.cpu())
 
 
+class TestResolveStashWeights(unittest.TestCase):
+    """The runtime seam that decides which tables stash: resolve_stash_weights and
+    the planner-selection set/get. This is the code path that keeps every rank's
+    stashed set identical, so it needs direct coverage."""
+
+    def setUp(self) -> None:
+        MemoryStashingManager.reset()
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+
+    def _config(self, stash_weights: bool) -> Mock:
+        cfg = Mock()
+        cfg.stash_weights = stash_weights
+        return cfg
+
+    def test_default_falls_back_to_config_flag(self) -> None:
+        # No planner selection -> resolve from the per-table config flag.
+        self.assertIsNone(MemoryStashingManager.get_stashed_tables())
+        self.assertTrue(
+            MemoryStashingManager.resolve_stash_weights("t", self._config(True))
+        )
+        self.assertFalse(
+            MemoryStashingManager.resolve_stash_weights("t", self._config(False))
+        )
+
+    def test_config_missing_flag_defaults_false(self) -> None:
+        cfg = Mock(spec=[])  # no stash_weights attribute
+        self.assertFalse(MemoryStashingManager.resolve_stash_weights("t", cfg))
+
+    def test_selection_overrides_config_by_membership(self) -> None:
+        MemoryStashingManager.set_stashed_tables({"a", "b"})
+        self.assertEqual(MemoryStashingManager.get_stashed_tables(), {"a", "b"})
+        # Membership decides, regardless of the config flag.
+        self.assertTrue(
+            MemoryStashingManager.resolve_stash_weights("a", self._config(False))
+        )
+        self.assertFalse(
+            MemoryStashingManager.resolve_stash_weights("c", self._config(True))
+        )
+
+    def test_empty_selection_stashes_nothing(self) -> None:
+        # An empty (non-None) set means "stash no tables", overriding the config.
+        MemoryStashingManager.set_stashed_tables(set())
+        self.assertFalse(
+            MemoryStashingManager.resolve_stash_weights("a", self._config(True))
+        )
+
+    def test_reset_clears_selection(self) -> None:
+        MemoryStashingManager.set_stashed_tables({"a"})
+        MemoryStashingManager.reset()
+        self.assertIsNone(MemoryStashingManager.get_stashed_tables())
+        # Back to config fallback after reset.
+        self.assertTrue(
+            MemoryStashingManager.resolve_stash_weights("a", self._config(True))
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Add `MemoryStashingManager.resolve_stash_weights()` plus `set_stashed_tables()` / `get_stashed_tables()` -- a runtime seam that lets a planner-selected table set decide which embedding tables stash their weights, falling back to the per-table `stash_weights` config flag when unset -- and have the sharded `EmbeddingCollection` / `EmbeddingBagCollection` consult it when deciding what to stash.

On the planner side, add a stage that balances per-rank stashed memory on top of the awareness path (which stashes all `stash_weights`-flagged tables, moving weights HBM->DDR), and expose that stage's regression tolerances as configuration so they can be tuned per job.

## Problem

Awareness stashes every flagged table and minimizes max HBM, but does nothing to balance the *stashed volume* across ranks. If one rank stashes far more weight than others it does disproportionate D2H/H2D copy traffic every iteration -> copy-engine serialization -> QPS regression. We want to flatten per-rank stashed volume, trading a little perf and HBM balance for it.

## Design (single stage on the main solver)

- Every flagged table is stashed (one variant per table -- no budget, no selection, no resident/stashed swapping in this diff).
- New object dimension (reuses `STASH_HBM_DIM`) = per-shard weights-only HBM freed by stashing (`weights_only_hbm_bytes`) for flagged shards, 0 otherwise.
- New goal `GoalType.BALANCE_MAX_STASH` (`BalanceSpec` MAX) at tuple position 6, immediately after `BALANCE_MAX_STORAGE`(5); `MIN_SM_PRESSURE` renumbered 6->7 (stash-balance outranks PGO SM-pressure).
- New final stage `_create_stash_balance_stage` (last in `_build_stages`) minimizes max per-rank stashed memory via single-fast cross-rank moves, with `higherPriorityObjConfig` allowing `BALANCE_MAX_PERF` and `BALANCE_MAX_STORAGE` to each worsen up to their own tolerance.
- Everything is gated on `has_stash` (any shard flagged): when false, no dimension, no goal, no stage are added -> a no-stash run is byte-identical to before.

## Configuration surface (new in this revision)

`RebalancerShardSolver` already accepted per-stage tolerances, and `LinearProgrammingPlanner` already forwarded them, but no caller outside the solver's own tests ever set a value -- every path resolved them to `None` and fell back to the single global `allowed_worsening_percentage`. They were dead plumbing. This revision wires them through:

- `hbm_balance_perf_worsening_percentage` -- perf regression the HBM-balance stage may accept.
- `stash_balance_perf_worsening_percentage` -- perf regression the stash-balance stage may accept.
- `stash_balance_hbm_worsening_percentage` -- HBM-balance regression the stash-balance stage may accept while flattening per-rank stashed memory.

All three are added to the APS planner config (`LinearProgrammingTorchRecPlanner`, reachable as `training.planner.planner_type.*`) and forwarded from `_get_planner_builder`. They are deliberately on the *planner* config rather than any stashing config, alongside the other solver knobs.

All three are `Optional[float]` defaulting to `None`. The two Perf tolerances then resolve to `allowed_worsening_percentage`. The stash-balance HBM tolerance instead resolves to the new `DEFAULT_STASH_BALANCE_HBM_WORSENING_PERCENTAGE` (15.0), set in the solver fallback so every trainer framework picks it up -- see the sweep below for why the global 5% is the wrong default for a min-max objective. Values are percentages on the same scale as `allowed_worsening_percentage` (`15` means 15%, not 0.15).

This does not widen the blast radius of the diff. Plans only change for models that already have `stash_weights` tables, because `_stash_balance_hbm_worsening_percentage` is read in exactly one place -- `_create_stash_balance_stage` -- and that stage is only appended when `_has_stash`. For a model without stashing there is no dimension, no goal and no stage at any tolerance value, so the plan is byte-identical to before this diff. For a model with stashing the plan moves because this diff introduces the stage at all; the default only chooses how far.

Matching flags are added to `lp_planner_dry_run` so the tolerances can be swept offline against a saved planner input set.

## Why the tolerance needs to be settable

On a 96-GPU production-scale run the stage worked but stopped against its HBM tolerance: it drove max per-rank stashed memory from 19.36 to 12.28 GiB (-36.6%) and then halted with the HBM-balance term at 4.98% of its 5% budget. Eleven ranks were left bunched within 1.2 GB of the cap, where a min-max objective has almost no gradient left.

Replaying that job's own planner inputs offline and sweeping only `stash_balance_hbm_worsening_percentage` (the run with no flags set reproduces the production solve bit for bit):

| tolerance | max per-rank stash | critical path | max HBM | stash stdev |
| --- | --- | --- | --- | --- |
| 5 (default) | 12.279 GiB | 337.109 ms | 53.964 GB | 2.324 |
| 10 | 10.969 GiB (-10.7%) | 345.464 ms (+2.48%) | 54.122 GB | 2.094 |
| 15 | 8.941 GiB (-27.2%) | 345.183 ms (+2.39%) | 54.278 GB | 1.375 |
| 20 | 8.941 GiB (-27.2%) | 344.969 ms (+2.33%) | 54.434 GB | 1.406 |

At 15% the top band collapses from `12.28 12.17 12.12 12.04 12.01 ...` to `8.94 8.94 8.93 8.90 8.90 ...` and no rank exceeds 9 GB (21 did at the default). Total stashed volume and the minimum rank are unchanged, as expected for a min-max objective.

Saturation past 15% is structural, not a tolerance effect: the constraint still binds at 20% (19.94% of budget consumed) but cannot help further, because the largest indivisible unit is a single column-wise shard of the biggest table family at 8.345 GB, which already exceeds the perfectly-flat share. Finer column-wise splitting would be needed to move that floor.

## Why a dedicated knob rather than raising the global one

Raising `allowed_worsening_percentage` needs no new config, but it loosens every stage at once and is markedly less efficient per unit of stash saved:

| setting | stash saved | perf cost | ms perf per GiB saved |
| --- | --- | --- | --- |
| stash-balance HBM tolerance 15 | 3.338 GiB | 8.07 ms | 2.42 |
| global allowed-worsening 10 | 3.884 GiB | 31.57 ms | 8.13 |
| global allowed-worsening 15 | 3.014 GiB | 15.32 ms | 5.08 |
| global allowed-worsening 20 | 3.338 GiB | 57.84 ms | 17.33 |

The global sweep is also non-monotonic, since loosening every stage simultaneously changes the search path unpredictably.

## Removed (deferred to the follow-up budget diff)

The prior sub-solver `stash_selection_solve`, the `stash_hbm_budget_gb` config and plumbing, budgeted subset selection, resident/stashed dual variants and swapping, and the post-solve `apply_weights_only_stash` helper. Budget-bounded selection is re-introduced in the next diff in the stack.

## Per-diff isolation check (4 GPUs, shrunk model, real data)

Measured directly from runtime per-rank stash logs on all 4 ranks, not inferred from the plan:

| Plan | per-rank stashed (min - max) | spread | max/min | mean |
| --- | --- | --- | --- | --- |
| Awareness only | 3.430 - 3.631 GB | 0.202 GB | 1.06x | 3.518 GB |
| + this balance stage | 3.483 - 3.534 GB | 0.051 GB | 1.01x | 3.518 GB |

Awareness balances HBM rather than stash volume, which pushes stash spread up (0.102 -> 0.202 GB); this stage flattens it to 0.051 GB (~4x tighter) and drops the max rank 3.631 -> 3.534 GB. Mean is unchanged -- same tables, better balanced. On that shrunk job the absolute imbalance is small because the ranks start near-balanced; the 96-GPU numbers above are the representative case.

Reviewed By: mserturk

Differential Revision: D105619142


