### PR TITLE
SKUAware: expose home_sku on unified PlannerConfig for legacy-path parity (#4522)

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2181,6 +2181,12 @@ class PlannerConfig:
     # (Appended last, like model_base_bytes: this dataclass is not kw_only, so
     # inserting mid-list would silently rebind existing positional arguments.)
     parameter_multiplier: Optional[float] = None
+    # Fixed home SKU the SKU_AWARE margin is anchored to, as a raw string
+    # (e.g. "GRANDTETON", "GB200"). None (default) anchors to the fleet default
+    # home SKU. Consumed only by the SKU_AWARE reservation (mirrors the legacy
+    # APF planner-config field); ignored by every other policy. (Appended last
+    # to preserve positional construction of the pre-existing fields.)
+    home_sku: Optional[str] = None
 
     def request_hash_extension(self) -> Optional[Tuple[object, ...]]:
         """Return package-specific planner config data for the request hash."""


### PR DESCRIPTION
Summary:

The legacy APF SKUAware dispatch (`apf/rec/distributed/parallel.py`) threads a
per-model `home_sku` override into `build_sku_aware_reservation`, so a model
owner can anchor the margin to a non-default home SKU. The unified planner
path (via `PlannerConfig` -> `FbPlannerProvider.build_storage_reservation`)
does not yet expose this override: it anchors to the fleet-default home SKU
regardless of the caller's config, which will silently drop the override when
the APF unified-planner cutover reaches models that use it.

Add a symmetric `home_sku: Optional[str] = None` field to `PlannerConfig` and
thread it through `FbPlannerProvider.build_storage_reservation` into
`build_sku_aware_reservation(home_sku=...)`. When unset (today's default) the
factory anchors to `DEFAULT_HOME_TRAINING_HARDWARE` and behavior is
byte-identical to today; when set the unified path is at full parity with the
legacy APF SKUAware dispatch.

`home_sku` is documented as SKU_AWARE-only in the field comment (mirroring the
existing `model_base_bytes` comment); other policies ignore it.

Reviewed By: isururanawaka

Differential Revision: D115495320


