### PR TITLE
Keep runtime-device gathers stable under FX tracing

### DIFF
--- a/torchrec/modules/feature_processor.py
+++ b/torchrec/modules/feature_processor.py
@@ -13,8 +13,17 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from torch.fx._symbolic_trace import is_fx_symbolic_tracing
 from torchrec.fx.tracer import is_fx_tracing
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
+
+
+def _position_weight_for_gather(
+    position_weight: torch.Tensor, index: torch.Tensor
+) -> torch.Tensor:
+    if torch.jit.is_scripting() or not is_fx_symbolic_tracing():
+        return position_weight.to(index.device)
+    return position_weight
 
 
 # Will be deprecated soon, please use PositionWeightedProcessor, see full doc below
@@ -101,7 +110,11 @@ class PositionWeightedModule(BaseFeatureProcessor):
                 values=features[key].values(),
                 lengths=features[key].lengths(),
                 offsets=features[key].offsets(),
-                weights=torch.gather(position_weight, dim=0, index=seq),
+                weights=torch.gather(
+                    _position_weight_for_gather(position_weight, seq),
+                    dim=0,
+                    index=seq,
+                ),
             )
         return position_weighted_module_update_features(features, weighted_features)
 
@@ -202,7 +215,11 @@ class PositionWeightedProcessor(BaseGroupedFeatureProcessor):
                 weighted_features_values.append(features_dict[key].values())
                 weighted_features_lengths.append(features_dict[key].lengths())
                 weighted_features_weights.append(
-                    torch.gather(position_weight, dim=0, index=seq)
+                    torch.gather(
+                        _position_weight_for_gather(position_weight, seq),
+                        dim=0,
+                        index=seq,
+                    )
                 )
             return KeyedJaggedTensor.from_lengths_sync(
                 keys=weighted_features_names,
@@ -249,10 +266,13 @@ class PositionWeightedProcessor(BaseGroupedFeatureProcessor):
                 if not has_normal_id_list_feature:
                     processed_features_weights: List[torch.Tensor] = []
                     for feature_index, feature_name in enumerate(feature_names):
+                        seq = seqs[feature_index]
                         processed_weight = torch.gather(
-                            self.position_weights[feature_name],
+                            _position_weight_for_gather(
+                                self.position_weights[feature_name], seq
+                            ),
                             dim=0,
-                            index=seqs[feature_index],
+                            index=seq,
                         )
                         processed_features_weights.append(processed_weight)
                     fp_features = KeyedJaggedTensor(
@@ -282,10 +302,13 @@ class PositionWeightedProcessor(BaseGroupedFeatureProcessor):
                         if feature_name in self.max_feature_lengths:
                             feature_value = feature_values[feature_index]
                             feature_length = feature_lengths[feature_index]
+                            seq = seqs[feature_index]
                             processed_weight = torch.gather(
-                                self.position_weights[feature_name],
+                                _position_weight_for_gather(
+                                    self.position_weights[feature_name], seq
+                                ),
                                 dim=0,
-                                index=seqs[feature_index],
+                                index=seq,
                             )
                             processed_features_names.append(feature_name)
                             processed_features_lengths.append(feature_length)

--- a/torchrec/modules/feature_processor_.py
+++ b/torchrec/modules/feature_processor_.py
@@ -12,10 +12,19 @@ from typing import Dict, List, Mapping, Optional
 
 import torch
 from torch import distributed as dist, nn
+from torch.fx._symbolic_trace import is_fx_symbolic_tracing
 from torch.nn.modules.module import _IncompatibleKeys
 from torchrec.pt2.checks import is_non_strict_exporting
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 from torchrec.types import CopyMixIn
+
+
+def _position_weight_for_gather(
+    position_weight: torch.Tensor, index: torch.Tensor
+) -> torch.Tensor:
+    if torch.jit.is_scripting() or not is_fx_symbolic_tracing():
+        return position_weight.to(index.device)
+    return position_weight
 
 
 class FeatureProcessor(nn.Module):
@@ -97,7 +106,11 @@ class PositionWeightedModule(FeatureProcessor):
             values=features.values(),
             lengths=features.lengths(),
             offsets=features.offsets(),
-            weights=torch.gather(self.position_weight, dim=0, index=seq),
+            weights=torch.gather(
+                _position_weight_for_gather(self.position_weight, seq),
+                dim=0,
+                index=seq,
+            ),
         )
         return weighted_features
 

--- a/torchrec/modules/tests/test_feature_processor.py
+++ b/torchrec/modules/tests/test_feature_processor.py
@@ -59,6 +59,24 @@ class PositionWeightedModuleTest(unittest.TestCase):
         gm = torch.fx.GraphModule(pw, Tracer().trace(pw))
         torch.jit.script(gm)
 
+    def test_default_fx_trace_preserves_gather_graph(self) -> None:
+        graph = torch.fx.Tracer().trace(PositionWeightedModule({"f1": 10}))
+
+        self.assertFalse(
+            any(
+                node.op == "call_method" and node.target == "to" for node in graph.nodes
+            )
+        )
+        self.assertFalse(
+            any(
+                node.op == "call_function"
+                and node.target == getattr
+                and len(node.args) > 1
+                and node.args[1] == "device"
+                for node in graph.nodes
+            )
+        )
+
     def test_populate_weights_PositionWeightedProcessor(self) -> None:
         features_max_length = {"f1": 10, "f2": 3}
         pw = PositionWeightedProcessor(features_max_length)

--- a/torchrec/modules/tests/test_feature_processor_.py
+++ b/torchrec/modules/tests/test_feature_processor_.py
@@ -20,6 +20,24 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class PositionWeightedModuleTest(unittest.TestCase):
+    def test_default_fx_trace_preserves_gather_graph(self) -> None:
+        graph = torch.fx.Tracer().trace(PositionWeightedModule(max_feature_length=10))
+
+        self.assertFalse(
+            any(
+                node.op == "call_method" and node.target == "to" for node in graph.nodes
+            )
+        )
+        self.assertFalse(
+            any(
+                node.op == "call_function"
+                and node.target == getattr
+                and len(node.args) > 1
+                and node.args[1] == "device"
+                for node in graph.nodes
+            )
+        )
+
     def test_populate_weights(self) -> None:
         pw = PositionWeightedModule(max_feature_length=10)
 


### PR DESCRIPTION
Summary:
Reland of D114815151. GPU-preproc publishing can keep position weights on CPU while PT2 emits a runtime CUDA input seam, so gathers normalize weights to the runtime index device.

The reverted version validated H100 publish/replay but missed the long-running APS default-FX stability target. Direct `.to(seq.device)` calls added `getattr` and `to` nodes to the vanilla FX graph and deterministically broke Ads trunk. This version skips only the normalization during symbolic FX tracing, preserving the established graph, while eager, TorchScript, and PT2/export retain the runtime-device correction. Focused default-FX tests cover both TorchRec feature-processor variants.

Future changes to these shared feature processors must run the APS stability target before landing.

Differential Revision: D115500280


