### PR TITLE
Fix per-feature boundary lost by ZCH index dedup (#4525)

### DIFF
--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -95,6 +95,7 @@ class EmbeddingCollectionContext(Multistreamable):
         Union[InferSequenceShardingContext, SequenceShardingContext]
     ]
     input_features: List[KeyedJaggedTensor] = field(default_factory=list)
+    reverse_indices: List[torch.Tensor] = field(default_factory=list)
     # VBE-Attributes for EBC
     inverse_indices: Optional[Tuple[List[str], torch.Tensor]] = None
     variable_batch_per_feature: bool = False
@@ -106,6 +107,8 @@ class EmbeddingCollectionContext(Multistreamable):
         for f in self.input_features:
             # pyrefly: ignore[bad-argument-type]
             f.record_stream(stream)
+        for r in self.reverse_indices:
+            r.record_stream(stream)
         if self.inverse_indices is not None:
             self.inverse_indices[1].record_stream(stream)
 
@@ -205,6 +208,88 @@ def create_mc_sharding(
         raise ValueError(f"Sharding not supported {sharding_type}")
 
 
+def _restore_dedup_feature_boundary(
+    input_lengths: torch.Tensor,
+    num_features: int,
+    unique_indices: torch.Tensor,
+    reverse_indices: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Puts back the per-feature boundary that ``fbgemm.jagged_unique_indices`` drops.
+
+    ``_create_dedup_indices`` gives every feature of a table the same hash range, so
+    the op dedups all of a table's features together. It cannot tell which feature a
+    surviving id came from, so it just splits the total evenly over the table's
+    (feature, batch) slots. With one feature per table that is fine. With two
+    features of very different lengths it is not: a 33-long feature and a 1280-long
+    feature both come back as roughly 656, so ids end up under the wrong feature.
+
+    That matters because ZCH decides whether to insert an id based on which feature
+    it arrived under - a feature whose name ends in the read-only suffix is looked up
+    but never written. Ids moved to the wrong feature get written when they should
+    not be. Per-feature TTL eviction reads the same lengths, so a wrong split also
+    hands ids the wrong feature's TTL.
+
+    This walks each surviving id back to the first feature it appeared in, regroups
+    the values so each feature is contiguous again, and recounts. Ids sent by both
+    features still collapse to one row, so we keep the dedup saving.
+
+    Returns the corrected ``(lengths, unique_indices, reverse_indices)``.
+    """
+    device = unique_indices.device
+    num_unique = unique_indices.numel()
+    # lengths are int64 to match what the op returns
+    if num_unique == 0:
+        return (
+            torch.zeros(input_lengths.numel(), dtype=torch.int64, device=device),
+            unique_indices,
+            reverse_indices,
+        )
+
+    stride = input_lengths.numel() // num_features
+    # KJT lengths are feature major, so segment -> feature is a plain repeat.
+    # output_size is known, and passing it keeps repeat_interleave from syncing.
+    feature_per_value = torch.repeat_interleave(
+        torch.arange(num_features, device=device).repeat_interleave(stride),
+        input_lengths.long(),
+        output_size=reverse_indices.numel(),
+    )
+    # include_self=False so the initial value is ignored wherever a row was actually
+    # referenced. Every unique row has at least one source position, but falling back
+    # to feature 0 keeps an unreferenced row in range for the scatter_add_ below
+    # rather than letting it index out of bounds.
+    #
+    # amin only ranges over the features that actually sent the id, so an id is
+    # attributed to a writable feature only if a writable feature sent it - ids only
+    # a read-only feature sent can never be written, whatever the feature order. For
+    # an id sent by both, the lowest feature index wins, which is model config order
+    # (EmbeddingConfig.feature_names).
+    feature_per_unique = torch.zeros(
+        num_unique, dtype=torch.int64, device=device
+    ).scatter_reduce_(
+        0, reverse_indices, feature_per_value, reduce="amin", include_self=False
+    )
+
+    permute = torch.argsort(feature_per_unique, stable=True)
+    inverse_permute = torch.empty_like(permute)
+    inverse_permute[permute] = torch.arange(num_unique, device=device)
+
+    # scatter_add rather than bincount, which would force a device to host sync
+    counts = torch.zeros(num_features, dtype=torch.int64, device=device).scatter_add_(
+        0, feature_per_unique, torch.ones_like(feature_per_unique)
+    )
+    # Only the per-feature totals need to be right; how a feature's ids are spread
+    # over its batch slots is undone later by reverse_indices. Spread them evenly,
+    # like the op does, because block_bucketize_sparse_features runs one thread per
+    # slot and slows down badly when one slot holds most of the ids. Attributing each
+    # id to the exact slot it came from is fewer lines but measured ~28x slower there.
+    lengths = counts.div(stride, rounding_mode="floor").repeat_interleave(stride) + (
+        torch.arange(stride, device=device).repeat(num_features)
+        < (counts % stride).repeat_interleave(stride)
+    )
+    return lengths, unique_indices[permute], inverse_permute[reverse_indices]
+
+
 class ShardedManagedCollisionCollection(
     ShardedModule[
         KJTList,
@@ -229,6 +314,7 @@ class ShardedManagedCollisionCollection(
         ],
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
         use_index_dedup: bool = False,
+        restore_dedup_feature_boundary: bool = False,
     ) -> None:
         # pyrefly: ignore[missing-attribute]
         super().__init__()
@@ -266,6 +352,11 @@ class ShardedManagedCollisionCollection(
         self._create_output_dists()
         self._use_index_dedup = use_index_dedup
         logger.info(f"MC EC index dedup enabled: {self._use_index_dedup}.")
+        self._restore_dedup_feature_boundary = restore_dedup_feature_boundary
+        logger.info(
+            f"MC dedup feature boundary restore enabled: "
+            f"{self._restore_dedup_feature_boundary}."
+        )
         self._initialize_torch_state()
         self.post_lookup_tracker_fn: Optional[
             Callable[
@@ -648,6 +739,14 @@ class ShardedManagedCollisionCollection(
             )[-1]
             <= torch.iinfo(torch.int64).max
         ), "EC Dedup requires the mc collection to have a cumuluative 'hash_input_size' kwarg to be less than max int64.  Please reduce values of individual tables to meet this constraint (ie. 2**54 is typically a good value)."
+        # per sharding group, true when the restore is turned on and any of the
+        # group's tables binds more than one feature, which is the case that loses
+        # its feature boundary - see _restore_dedup_feature_boundary
+        self._dedup_needs_boundary_restore: List[bool] = [
+            self._restore_dedup_feature_boundary
+            and any(feature_count > 1 for feature_count in feature_splits)
+            for feature_splits in self._sharding_per_table_feature_splits
+        ]
         for i, (feature_splits, input_splits) in enumerate(
             zip(
                 self._sharding_per_table_feature_splits,
@@ -688,6 +787,11 @@ class ShardedManagedCollisionCollection(
         features_by_sharding = []
 
         for i, kjt in enumerate(features):
+            # jagged_unique_indices derives the batch size as total_B / num_features,
+            # and the per-feature regrouping below relies on the same uniform stride
+            assert (
+                not kjt.variable_stride_per_key()
+            ), "EC Dedup does not support variable stride per key"
             hash_offsets = self.get_buffer(f"_dedup_hash_offsets_{i}")
             feature_offsets = self.get_buffer(f"_dedup_feature_offsets_{i}")
             (
@@ -701,6 +805,13 @@ class ShardedManagedCollisionCollection(
                 kjt.offsets().to(torch.int64),
                 kjt.values().to(torch.int64),
             )
+            if self._dedup_needs_boundary_restore[i]:
+                lengths, unique_indices, reverse_indices = (
+                    _restore_dedup_feature_boundary(
+                        kjt.lengths(), len(kjt.keys()), unique_indices, reverse_indices
+                    )
+                )
+                offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
             # Gather weights for unique indices if present.
             # Since unique_indices[reverse_indices[i]] == indices[i],
             # we can directly assign: dedup_weights[reverse_indices[i]] = weights[i]
@@ -723,7 +834,6 @@ class ShardedManagedCollisionCollection(
             )
 
             ctx.input_features.append(kjt)
-            # pyrefly: ignore[missing-attribute]
             ctx.reverse_indices.append(reverse_indices)
             features_by_sharding.append(dedup_features)
         return features_by_sharding
@@ -1132,8 +1242,12 @@ class ManagedCollisionCollectionSharder(
     def __init__(
         self,
         qcomm_codecs_registry: Optional[Dict[str, QuantizedCommCodecs]] = None,
+        restore_dedup_feature_boundary: bool = False,
     ) -> None:
         super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
+        # only has an effect when index dedup is on and a table binds more than one
+        # feature, see _restore_dedup_feature_boundary
+        self._restore_dedup_feature_boundary = restore_dedup_feature_boundary
 
     # pyrefly: ignore[bad-override]
     def shard(
@@ -1163,6 +1277,7 @@ class ManagedCollisionCollectionSharder(
             device=device,
             embedding_shardings=embedding_shardings,
             use_index_dedup=use_index_dedup,
+            restore_dedup_feature_boundary=self._restore_dedup_feature_boundary,
         )
 
     def shardable_parameters(

--- a/torchrec/distributed/tests/test_mc_dedup_feature_boundary.py
+++ b/torchrec/distributed/tests/test_mc_dedup_feature_boundary.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import copy
+import unittest
+from typing import cast, Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torchrec.distributed.embedding import EmbeddingCollectionSharder
+from torchrec.distributed.mc_embedding import (
+    ManagedCollisionEmbeddingCollectionSharder,
+    ShardedManagedCollisionEmbeddingCollection,
+)
+from torchrec.distributed.mc_modules import (
+    _restore_dedup_feature_boundary,
+    ManagedCollisionCollectionContext,
+    ManagedCollisionCollectionSharder,
+    ShardedManagedCollisionCollection,
+)
+from torchrec.distributed.shard import _shard_modules
+from torchrec.distributed.sharding_plan import construct_module_sharding_plan, row_wise
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.modules.embedding_configs import EmbeddingConfig
+from torchrec.modules.embedding_modules import EmbeddingCollection
+from torchrec.modules.hash_mc_modules import HashZchManagedCollisionModule
+from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
+from torchrec.modules.mc_modules import ManagedCollisionCollection
+from torchrec.optim.apply_optimizer_in_backward import apply_optimizer_in_backward
+from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+_HASH_SIZE = 100_000
+_STRIDE = 2  # batch size
+
+WORLD_SIZE = 2
+_ZCH_SIZE = 128
+_TABLE = "table_0"
+_WRITE_FEATURE = "media"
+_READ_ONLY_FEATURE = "media_readonly"
+_NUM_WRITE_IDS = 4
+_NUM_READ_ONLY_IDS = 40
+
+
+def _dedup(
+    values: torch.Tensor, lengths: torch.Tensor, num_features: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Runs the dedup op with the buffers ``_create_dedup_indices`` builds for a single
+    table binding ``num_features`` features: one shared hash range, one feature group.
+    """
+    device = values.device
+    hash_offsets = torch.tensor(
+        [0] * num_features + [_HASH_SIZE], dtype=torch.int64, device=device
+    )
+    feature_offsets = torch.tensor(
+        [0] * num_features + [num_features], dtype=torch.int64, device=device
+    )
+    lengths_, _, unique_indices, reverse_indices = (
+        torch.ops.fbgemm.jagged_unique_indices(
+            hash_offsets,
+            feature_offsets,
+            torch.ops.fbgemm.asynchronous_complete_cumsum(lengths),
+            values,
+        )
+    )
+    return lengths_, unique_indices, reverse_indices
+
+
+def _per_feature(lengths: torch.Tensor, num_features: int) -> List[int]:
+    return lengths.view(num_features, -1).sum(dim=1).tolist()
+
+
+def _lengths(counts: List[int], device: torch.device) -> torch.Tensor:
+    """Per-feature totals -> a feature major KJT lengths tensor of stride _STRIDE."""
+    return torch.tensor(
+        [
+            count // _STRIDE + (1 if b < count % _STRIDE else 0)
+            for count in counts
+            for b in range(_STRIDE)
+        ],
+        dtype=torch.int64,
+        device=device,
+    )
+
+
+class _DedupOnlyCollection:
+    """
+    Carries just the state ``ShardedManagedCollisionCollection._dedup_indices`` reads
+    off ``self``, so the method can be exercised without standing up a sharded module.
+    """
+
+    def __init__(
+        self, num_features: int, device: torch.device, restore: bool = True
+    ) -> None:
+        self._buffers: Dict[str, torch.Tensor] = {
+            "_dedup_hash_offsets_0": torch.tensor(
+                [0] * num_features + [_HASH_SIZE], dtype=torch.int64, device=device
+            ),
+            "_dedup_feature_offsets_0": torch.tensor(
+                [0] * num_features + [num_features], dtype=torch.int64, device=device
+            ),
+        }
+        self._dedup_needs_boundary_restore: List[bool] = [restore and num_features > 1]
+
+    def get_buffer(self, name: str) -> torch.Tensor:
+        return self._buffers[name]
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available(), "fbgemm.jagged_unique_indices is CUDA only"
+)
+class McDedupFeatureBoundaryTest(unittest.TestCase):
+    """
+    A managed collision table that binds more than one feature gives all of its
+    features one shared hash range, so ``fbgemm.jagged_unique_indices`` dedups them as
+    a single group and cannot say which feature a surviving row came from. These tests
+    cover the boundary that ``_restore_dedup_feature_boundary`` puts back.
+
+    Shapes mirror a ranking model where a HASH_ZCH table binds a short write feature
+    of candidate ids and a long read-only feature of user history.
+    """
+
+    def setUp(self) -> None:
+        self.device = torch.device("cuda")
+        torch.manual_seed(0)
+        self.ids: torch.Tensor = torch.randperm(_HASH_SIZE, device=self.device)
+
+    def _run_dedup_indices(
+        self, kjt: KeyedJaggedTensor, restore: bool
+    ) -> Tuple[KeyedJaggedTensor, ManagedCollisionCollectionContext]:
+        ctx = ManagedCollisionCollectionContext(sharding_contexts=[])
+        dedup_kjt = ShardedManagedCollisionCollection._dedup_indices(
+            cast(
+                ShardedManagedCollisionCollection,
+                _DedupOnlyCollection(len(kjt.keys()), self.device, restore=restore),
+            ),
+            ctx,
+            [kjt],
+        )[0]
+        return dedup_kjt, ctx
+
+    def test_dedup_op_loses_feature_boundary(self) -> None:
+        """
+        Pins the upstream behavior being corrected: the op returns the group's unique
+        count spread evenly over the group's slots rather than the real per-feature
+        counts. If this fails, the op has learned per-feature attribution and
+        ``_restore_dedup_feature_boundary`` can be dropped.
+        """
+        write_len, read_len = 33, 1280
+        values = self.ids[: write_len + read_len]
+        lengths, unique_indices, _ = _dedup(
+            values, _lengths([write_len, read_len], self.device), 2
+        )
+
+        self.assertEqual(unique_indices.numel(), write_len + read_len)
+        self.assertEqual(_per_feature(lengths, 2), [657, 656])
+
+    def test_restore_feature_boundary(self) -> None:
+        write_len, read_len = 33, 1280
+        values = self.ids[: write_len + read_len]
+        input_lengths = _lengths([write_len, read_len], self.device)
+        _, unique_indices, reverse_indices = _dedup(values, input_lengths, 2)
+
+        lengths, unique_indices, reverse_indices = _restore_dedup_feature_boundary(
+            input_lengths, 2, unique_indices, reverse_indices
+        )
+
+        self.assertEqual(_per_feature(lengths, 2), [write_len, read_len])
+        # the write feature's segment holds exactly the ids it sent, nothing borrowed
+        # from the read-only feature
+        torch.testing.assert_close(
+            unique_indices[:write_len].sort().values, values[:write_len].sort().values
+        )
+        torch.testing.assert_close(unique_indices[reverse_indices], values)
+
+        # the 2D weights of the write path are gathered through reverse_indices, so
+        # they have to survive the regrouping too
+        weights = torch.rand(values.numel(), 4, device=self.device)
+        dedup_weights = torch.empty(
+            unique_indices.numel(), 4, dtype=weights.dtype, device=self.device
+        )
+        dedup_weights[reverse_indices] = weights
+        torch.testing.assert_close(dedup_weights[reverse_indices], weights)
+
+    def test_restore_feature_boundary_with_duplicate_and_shared_ids(self) -> None:
+        """
+        Dedup still collapses repeats, including ids sent by both features. A shared id
+        is attributed to the first feature that carried it, which is the write feature,
+        so a candidate that is also in history is still inserted rather than gated.
+        """
+        write_len, hist_len, shared_len = 33, 600, 5
+        write_ids = self.ids[:write_len]
+        hist_ids = self.ids[write_len : write_len + hist_len]
+        read_values = torch.cat([hist_ids, hist_ids, write_ids[:shared_len]])
+        values = torch.cat([write_ids, read_values])
+        input_lengths = _lengths([write_len, read_values.numel()], self.device)
+        _, unique_indices, reverse_indices = _dedup(values, input_lengths, 2)
+
+        lengths, unique_indices, reverse_indices = _restore_dedup_feature_boundary(
+            input_lengths, 2, unique_indices, reverse_indices
+        )
+
+        self.assertEqual(unique_indices.numel(), write_len + hist_len)
+        self.assertEqual(_per_feature(lengths, 2), [write_len, hist_len])
+        torch.testing.assert_close(
+            unique_indices[:write_len].sort().values, write_ids.sort().values
+        )
+        torch.testing.assert_close(unique_indices[reverse_indices], values)
+
+    def test_dedup_indices_keeps_feature_boundary(self) -> None:
+        """End to end through ``_dedup_indices``, covering the wiring and the gate."""
+        write_len, read_len = 33, 1280
+        kjt = KeyedJaggedTensor(
+            keys=[_WRITE_FEATURE, _READ_ONLY_FEATURE],
+            values=self.ids[: write_len + read_len],
+            lengths=_lengths([write_len, read_len], self.device),
+        )
+
+        dedup_kjt, ctx = self._run_dedup_indices(kjt, restore=True)
+
+        self.assertEqual(dedup_kjt.length_per_key(), [write_len, read_len])
+        torch.testing.assert_close(
+            dedup_kjt[_WRITE_FEATURE].values().sort().values,
+            kjt[_WRITE_FEATURE].values().sort().values,
+        )
+        torch.testing.assert_close(
+            dedup_kjt.values()[ctx.reverse_indices[0]], kjt.values()
+        )
+
+    def test_dedup_indices_skips_restore_when_disabled(self) -> None:
+        """
+        With restore_dedup_feature_boundary off, _dedup_indices leaves the op's even
+        split alone. Pins that the knob actually gates the work.
+        """
+        write_len, read_len = 33, 1280
+        kjt = KeyedJaggedTensor(
+            keys=[_WRITE_FEATURE, _READ_ONLY_FEATURE],
+            values=self.ids[: write_len + read_len],
+            lengths=_lengths([write_len, read_len], self.device),
+        )
+
+        dedup_kjt, _ = self._run_dedup_indices(kjt, restore=False)
+
+        self.assertEqual(dedup_kjt.length_per_key(), [657, 656])
+
+    def test_restore_feature_boundary_with_three_features(self) -> None:
+        counts = [11, 517, 42]
+        values = self.ids[: sum(counts)]
+        input_lengths = _lengths(counts, self.device)
+        _, unique_indices, reverse_indices = _dedup(values, input_lengths, 3)
+
+        lengths, unique_indices, reverse_indices = _restore_dedup_feature_boundary(
+            input_lengths, 3, unique_indices, reverse_indices
+        )
+
+        self.assertEqual(_per_feature(lengths, 3), counts)
+        torch.testing.assert_close(unique_indices[reverse_indices], values)
+
+
+class _ReadOnlyFeatureSparseArch(nn.Module):
+    """
+    One HASH_ZCH table bound to a write feature and a read-only feature, the binding
+    that loses its per-feature boundary under index dedup.
+    """
+
+    def __init__(self, table: EmbeddingConfig, device: torch.device) -> None:
+        super().__init__()
+        self._mc_ec: ManagedCollisionEmbeddingCollection = (
+            ManagedCollisionEmbeddingCollection(
+                EmbeddingCollection(tables=[table], device=device),
+                ManagedCollisionCollection(
+                    managed_collision_modules={
+                        table.name: HashZchManagedCollisionModule(
+                            zch_size=table.num_embeddings,
+                            device=device,
+                            total_num_buckets=WORLD_SIZE,
+                            input_hash_size=0,
+                            enable_per_feature_lookups=True,
+                            read_only_suffix="_readonly",
+                        )
+                    },
+                    embedding_configs=[table],
+                ),
+            )
+        )
+
+    def forward(self, kjt: KeyedJaggedTensor) -> torch.Tensor:
+        ec_out, _ = self._mc_ec(kjt)
+        return torch.cat([ec_out[key].values() for key in kjt.keys()]).sum()
+
+
+def _test_read_only_feature_is_never_inserted(
+    rank: int,
+    world_size: int,
+    table: EmbeddingConfig,
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    local_size: Optional[int] = None,
+) -> None:
+    """
+    Build the real module, run a lookup, then read the ZCH identity buffer.
+
+    Only the candidates the write feature sent may be inserted. Without the boundary
+    restore the even split moves roughly half the read-only history ids under the
+    write feature, which inserts them and is what filled the table up in production.
+    """
+    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+        sparse_arch = _ReadOnlyFeatureSparseArch(table, torch.device("meta"))
+        apply_optimizer_in_backward(
+            RowWiseAdagrad,
+            # pyrefly: ignore[bad-argument-type]
+            [sparse_arch._mc_ec._embedding_collection.embeddings[_TABLE].weight],
+            {"lr": 0.01},
+        )
+        module_sharding_plan = construct_module_sharding_plan(
+            sparse_arch._mc_ec,
+            per_param_sharding={_TABLE: row_wise(num_buckets=world_size)},
+            local_size=ctx.local_size,
+            world_size=world_size,
+            device_type="cuda",
+            sharder=sharder,
+        )
+        sharded_sparse_arch = _shard_modules(
+            module=copy.deepcopy(sparse_arch),
+            plan=ShardingPlan({"_mc_ec": module_sharding_plan}),
+            # pyrefly: ignore[bad-argument-type]
+            env=ShardingEnv.from_process_group(ctx.pg),
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        # this runs in a worker process, so there is no TestCase instance to use;
+        # a bare one still reports failures as test failures rather than as
+        # AssertionError from library code
+        tc = unittest.TestCase()
+
+        mc_ec = sharded_sparse_arch._mc_ec
+        tc.assertIsInstance(mc_ec, ShardedManagedCollisionEmbeddingCollection)
+        mcc = cast(
+            ShardedManagedCollisionEmbeddingCollection, mc_ec
+        )._managed_collision_collection
+        tc.assertTrue(mcc._use_index_dedup, "this test needs index dedup enabled")
+        tc.assertTrue(
+            mcc._restore_dedup_feature_boundary,
+            "this test needs the boundary restore enabled",
+        )
+
+        # a short write feature next to a long read-only one: that length gap is what
+        # the even split smears across the feature boundary
+        write_ids = [1000 + rank * 100 + i for i in range(_NUM_WRITE_IDS)]
+        read_only_ids = [5000 + rank * 1000 + i for i in range(_NUM_READ_ONLY_IDS)]
+        kjt = KeyedJaggedTensor.from_lengths_sync(
+            keys=[_WRITE_FEATURE, _READ_ONLY_FEATURE],
+            values=torch.tensor(write_ids + read_only_ids, dtype=torch.int64),
+            lengths=torch.tensor(
+                [len(write_ids), len(read_only_ids)], dtype=torch.int64
+            ),
+        ).to(ctx.device)
+
+        sharded_sparse_arch(kjt)
+
+        identities = mcc._managed_collision_modules[_TABLE]._hash_zch_identities
+        tc.assertIsInstance(identities, torch.Tensor)
+        occupied = (cast(torch.Tensor, identities) != -1).sum()
+        dist.all_reduce(occupied, group=ctx.pg)
+        expected = world_size * _NUM_WRITE_IDS
+        tc.assertEqual(
+            int(occupied),
+            expected,
+            f"{int(occupied)} slots written, expected {expected} (the candidates only)",
+        )
+
+
+@skip_if_asan_class
+class McDedupReadOnlyFeatureTest(MultiProcessTestBase):
+    @unittest.skipIf(
+        torch.cuda.device_count() < WORLD_SIZE,
+        f"needs {WORLD_SIZE} GPUs",
+    )
+    def test_read_only_feature_is_never_inserted(self) -> None:
+        self._run_multi_process_test(
+            callable=_test_read_only_feature_is_never_inserted,
+            world_size=WORLD_SIZE,
+            table=EmbeddingConfig(
+                name=_TABLE,
+                num_embeddings=_ZCH_SIZE,
+                embedding_dim=8,
+                feature_names=[_WRITE_FEATURE, _READ_ONLY_FEATURE],
+            ),
+            sharder=ManagedCollisionEmbeddingCollectionSharder(
+                ec_sharder=EmbeddingCollectionSharder(use_index_dedup=True),
+                mc_sharder=ManagedCollisionCollectionSharder(
+                    restore_dedup_feature_boundary=True
+                ),
+            ),
+            backend="nccl",
+        )


### PR DESCRIPTION
Summary:

When a managed collision table has more than one feature, index dedup can move
ids from one feature to another.

All features of a table share one hash range (see `_create_dedup_indices`), so
`fbgemm.jagged_unique_indices` dedups them together. The op cannot tell which
feature each surviving id came from, so it just splits the total evenly over the
table's (feature, batch) slots. That is fine for a table with one feature. With
two features of very different lengths it is not: a 33 long feature and a 1280
long feature both come back as roughly 656, so ids end up under the wrong
feature.

This is a correctness problem and not just wrong bookkeeping, because ZCH decides
whether to insert an id from the name of the feature it arrived under: a feature
whose name ends in the read-only suffix is looked up but never written. Ids moved
to the wrong feature get written when they should not be.

The fix walks each surviving id back to the first feature it appeared in,
regroups the values so each feature is contiguous again, and recounts. Ids sent
by both features still collapse into one row, so we keep the dedup saving. It
only runs when a table actually has more than one feature, so the common path is
unchanged.

Also declares the `reverse_indices` field that `_dedup_indices` already appends
to. `mc_modules` has its own local `EmbeddingCollectionContext` that was missing
it, so sharding a `ManagedCollisionCollection` on its own with dedup enabled
raised `AttributeError`. It only worked through
`ManagedCollisionEmbeddingCollection`, whose context comes from `embedding.py`.

Differential Revision: D115457342


