### PR TITLE
Scope fused Triton selection to supported sharders (#4527)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3913,6 +3913,8 @@ class TritonBatchedFusedEmbeddingBag(
                 fused_bounds_check=fused_bounds_check,
             )
         )
+        if "bounds_check_mode" in fused_params:
+            self._emb_module.bounds_check_mode = fused_params["bounds_check_mode"]
 
         # Create a simple fused optimizer that delegates to the Triton TBE
         self._optim: TritonEmbeddingFusedOptimizer = TritonEmbeddingFusedOptimizer(

--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -3993,6 +3993,8 @@ class TritonBatchedFusedEmbeddingBag(
                 fused_bounds_check=fused_bounds_check,
             )
         )
+        if "bounds_check_mode" in fused_params:
+            self._emb_module.bounds_check_mode = fused_params["bounds_check_mode"]
 
         # Create a simple fused optimizer that delegates to the Triton TBE
         self._optim: TritonEmbeddingFusedOptimizer = TritonEmbeddingFusedOptimizer(

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -487,6 +487,8 @@ def _get_grouping_fused_params(
     if FUSED_PARAM_SSD_TABLE_LIST in grouping_fused_params:
         del grouping_fused_params[FUSED_PARAM_SSD_TABLE_LIST]
 
+    grouping_fused_params.pop("bag_size_hints", None)
+
     if grouping_fused_params.get(USE_ONE_TBE_PER_TABLE, False):
         # Replace with unique value to force it into singleton group.
         # Name is used as unique value so we won't group multiple shard belonging
@@ -550,6 +552,25 @@ def _all_tables_are_quant_kernel(
     Return if all tables have quant compute kernel.
     """
     return all(table.compute_kernel == EmbeddingComputeKernel.QUANT for table in tables)
+
+
+def _get_grouped_bag_size_hints(
+    grouped_tables: List[ShardedEmbeddingTable],
+) -> Optional[List[int]]:
+    grouped_bag_size_hints: List[int] = []
+    # Grouping preserves table order. GroupedEmbeddingConfig.feature_names() uses
+    # the same table and per-table feature order consumed by the TBE.
+    for table in grouped_tables:
+        table_bag_size_hints = (table.fused_params or {}).get("bag_size_hints")
+        if table_bag_size_hints is None:
+            return None
+        if len(table_bag_size_hints) != table.num_features():
+            raise ValueError(
+                f"bag_size_hints for {table.name} must have "
+                f"{table.num_features()} entries, got {len(table_bag_size_hints)}"
+            )
+        grouped_bag_size_hints.extend(table_bag_size_hints)
+    return grouped_bag_size_hints
 
 
 # group tables by `DataType`, `PoolingType`, and `EmbeddingComputeKernel`.
@@ -650,6 +671,11 @@ def group_tables(
             cache_load_factor = _get_weighted_avg_cache_load_factor(grouped_tables)
             if cache_load_factor is not None:
                 per_tbe_fused_params[CACHE_LOAD_FACTOR_STR] = cache_load_factor
+
+            if compute_kernel_type == EmbeddingComputeKernel.FUSED_TRITON:
+                grouped_bag_size_hints = _get_grouped_bag_size_hints(grouped_tables)
+                if grouped_bag_size_hints is not None:
+                    per_tbe_fused_params["bag_size_hints"] = grouped_bag_size_hints
 
             grouped_embedding_configs.append(
                 GroupedEmbeddingConfig(

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -526,6 +526,8 @@ M = TypeVar("M", bound=nn.Module)
 
 
 class BaseEmbeddingSharder(ModuleSharder[M]):
+    supports_fused_triton: bool = False
+
     def __init__(
         self,
         fused_params: Optional[Dict[str, Any]] = None,
@@ -585,6 +587,8 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
                     EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
                 ]
+                if self.supports_fused_triton:
+                    ret.append(EmbeddingComputeKernel.FUSED_TRITON.value)
         else:
             # TODO re-enable model parallel and dense
             ret += [

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -528,6 +528,8 @@ M = TypeVar("M", bound=nn.Module)
 
 
 class BaseEmbeddingSharder(ModuleSharder[M]):
+    supports_fused_triton: bool = False
+
     def __init__(
         self,
         fused_params: Optional[Dict[str, Any]] = None,
@@ -587,6 +589,8 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
                     EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
                 ]
+                if self.supports_fused_triton:
+                    ret.append(EmbeddingComputeKernel.FUSED_TRITON.value)
             if compute_device_type in {"tpu"}:
                 ret += [EmbeddingComputeKernel.UNFUSED_TPU.value]
         else:

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -2266,6 +2266,8 @@ class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]
     This implementation uses non-fused `EmbeddingBagCollection`
     """
 
+    supports_fused_triton: bool = True
+
     @EventLoggingHandler.event_logger(TorchrecComponent.SHARDER)
     def shard(
         self,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -2281,6 +2281,8 @@ class EmbeddingBagCollectionSharder(BaseEmbeddingSharder[EmbeddingBagCollection]
     This implementation uses non-fused `EmbeddingBagCollection`
     """
 
+    supports_fused_triton: bool = True
+
     @EventLoggingHandler.event_logger(TorchrecComponent.SHARDER)
     def shard(
         self,

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -218,6 +218,8 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
 class FeatureProcessedEmbeddingBagCollectionSharder(
     BaseEmbeddingSharder[FeatureProcessedEmbeddingBagCollection]
 ):
+    supports_fused_triton: bool = True
+
     def __init__(
         self,
         ebc_sharder: Optional[EmbeddingBagCollectionSharder] = None,

--- a/torchrec/distributed/mc_embedding_modules.py
+++ b/torchrec/distributed/mc_embedding_modules.py
@@ -39,6 +39,7 @@ from torchrec.distributed.types import (
     ParameterSharding,
     QuantizedCommCodecs,
     ShardingEnv,
+    ShardingType,
 )
 from torchrec.distributed.utils import append_prefix
 from torchrec.modules.embedding_modules import (
@@ -395,12 +396,19 @@ class BaseManagedCollisionEmbeddingCollectionSharder(BaseEmbeddingSharder[M]):
         sharding_type: str,
         compute_device_type: str,
     ) -> List[str]:
-        return [
+        kernels = [
             EmbeddingComputeKernel.FUSED.value,
             EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
             EmbeddingComputeKernel.FUSED_UVM.value,
             EmbeddingComputeKernel.KEY_VALUE.value,
         ]
+        if (
+            compute_device_type == "cuda"
+            and sharding_type != ShardingType.DATA_PARALLEL.value
+            and self._e_sharder.supports_fused_triton
+        ):
+            kernels.append(EmbeddingComputeKernel.FUSED_TRITON.value)
+        return kernels
 
     def sharding_types(self, compute_device_type: str) -> List[str]:
         return list(

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -61,6 +61,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # compute kernels that should only be used if users specified them
 GUARDED_COMPUTE_KERNELS: Set[EmbeddingComputeKernel] = {
+    EmbeddingComputeKernel.FUSED_TRITON,
     EmbeddingComputeKernel.KEY_VALUE,
     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -442,10 +442,15 @@ class EmbeddingEnumerator(Enumerator):
                 if compute_kernel not in GUARDED_COMPUTE_KERNELS
             ]
 
-        # setup filtered_compute_kernels
-        filtered_compute_kernels = list(
-            set(constrained_compute_kernels) & set(allowed_compute_kernels)
-        )
+        if (
+            EmbeddingComputeKernel.FUSED_TRITON.value in constrained_compute_kernels
+            and EmbeddingComputeKernel.FUSED_TRITON.value in allowed_compute_kernels
+        ):
+            filtered_compute_kernels = [EmbeddingComputeKernel.FUSED_TRITON.value]
+        else:
+            filtered_compute_kernels = list(
+                set(constrained_compute_kernels) & set(allowed_compute_kernels)
+            )
 
         # Remove KEY_VALUE if no device has SSD capacity — avoids expanding
         # the search space with infeasible options that fits_in() would reject.

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -62,6 +62,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # compute kernels that should only be used if users specified them
 GUARDED_COMPUTE_KERNELS: Set[EmbeddingComputeKernel] = {
+    EmbeddingComputeKernel.FUSED_TRITON,
     EmbeddingComputeKernel.KEY_VALUE,
     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -493,15 +493,16 @@ class EmbeddingEnumerator(Enumerator):
                 if compute_kernel not in GUARDED_COMPUTE_KERNELS
             ]
 
-        # setup filtered_compute_kernels
-        # Filter in ``allowed_compute_kernels`` order rather than iterating a set:
-        # set-of-str iteration order is PYTHONHASHSEED-dependent, which makes the
-        # search space -- and the planner context hash keyed off it -- differ
-        # between processes.
         constrained_compute_kernel_set = set(constrained_compute_kernels)
         filtered_compute_kernels = [
             k for k in allowed_compute_kernels if k in constrained_compute_kernel_set
         ]
+        if EmbeddingComputeKernel.FUSED_TRITON.value in filtered_compute_kernels:
+            filtered_compute_kernels = [
+                k
+                for k in filtered_compute_kernels
+                if k != EmbeddingComputeKernel.FUSED.value
+            ]
 
         # Remove KEY_VALUE if no device has SSD capacity — avoids expanding
         # the search space with infeasible options that fits_in() would reject.

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -202,6 +202,15 @@ def to_sharding_plan(
             bounds_check_mode=sharding_option.bounds_check_mode,
             output_dtype=sharding_option.output_dtype,
             key_value_params=sharding_option.key_value_params,
+            bag_size_hints=(
+                [
+                    max(0, round(input_length))
+                    for input_length in sharding_option.input_lengths
+                ]
+                if sharding_option.compute_kernel
+                == EmbeddingComputeKernel.FUSED_TRITON.value
+                else None
+            ),
         )
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -204,6 +204,15 @@ def to_sharding_plan(
             bounds_check_mode=sharding_option.bounds_check_mode,
             output_dtype=sharding_option.output_dtype,
             key_value_params=sharding_option.key_value_params,
+            bag_size_hints=(
+                [
+                    max(0, round(input_length))
+                    for input_length in sharding_option.input_lengths
+                ]
+                if sharding_option.compute_kernel
+                == EmbeddingComputeKernel.FUSED_TRITON.value
+                else None
+            ),
         )
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -1044,6 +1044,38 @@ class TestEnumerators(unittest.TestCase):
             },
         )
 
+    def test_fused_triton_compute_kernel_requires_constraint(self) -> None:
+        sharder = EmbeddingBagCollectionSharder()
+        sharding_type = ShardingType.ROW_WISE.value
+        sharder_kernels = sharder.compute_kernels(sharding_type, "cuda")
+
+        unconstrained = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+        )
+        self.assertNotIn(
+            EmbeddingComputeKernel.FUSED_TRITON.value,
+            unconstrained._filter_compute_kernels(
+                "table_0", sharder_kernels, sharding_type
+            ),
+        )
+
+        constrained = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+            constraints={
+                "table_0": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED_TRITON.value]
+                )
+            },
+        )
+        self.assertEqual(
+            constrained._filter_compute_kernels(
+                "table_0", sharder_kernels, sharding_type
+            ),
+            [EmbeddingComputeKernel.FUSED_TRITON.value],
+        )
+
     def test_filter_compute_kernels_mch_ebc(self) -> None:
         constraint = ParameterConstraints(
             compute_kernels=[

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -994,6 +994,32 @@ class TestEnumerators(unittest.TestCase):
             [EmbeddingComputeKernel.FUSED_TRITON.value],
         )
 
+        fallback_constraints = {
+            "table_0": ParameterConstraints(
+                compute_kernels=[
+                    EmbeddingComputeKernel.FUSED_TRITON.value,
+                    EmbeddingComputeKernel.FUSED.value,
+                ]
+            )
+        }
+        fallback = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+            constraints=fallback_constraints,
+        )
+        self.assertEqual(
+            fallback._filter_compute_kernels("table_0", sharder_kernels, sharding_type),
+            [EmbeddingComputeKernel.FUSED_TRITON.value],
+        )
+        self.assertEqual(
+            fallback._filter_compute_kernels(
+                "table_0",
+                [EmbeddingComputeKernel.FUSED.value],
+                sharding_type,
+            ),
+            [EmbeddingComputeKernel.FUSED.value],
+        )
+
     def test_filter_compute_kernels_mch_ebc(self) -> None:
         constraint = ParameterConstraints(
             compute_kernels=[

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -962,6 +962,38 @@ class TestEnumerators(unittest.TestCase):
             },
         )
 
+    def test_fused_triton_compute_kernel_requires_constraint(self) -> None:
+        sharder = EmbeddingBagCollectionSharder()
+        sharding_type = ShardingType.ROW_WISE.value
+        sharder_kernels = sharder.compute_kernels(sharding_type, "cuda")
+
+        unconstrained = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+        )
+        self.assertNotIn(
+            EmbeddingComputeKernel.FUSED_TRITON.value,
+            unconstrained._filter_compute_kernels(
+                "table_0", sharder_kernels, sharding_type
+            ),
+        )
+
+        constrained = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+            constraints={
+                "table_0": ParameterConstraints(
+                    compute_kernels=[EmbeddingComputeKernel.FUSED_TRITON.value]
+                )
+            },
+        )
+        self.assertEqual(
+            constrained._filter_compute_kernels(
+                "table_0", sharder_kernels, sharding_type
+            ),
+            [EmbeddingComputeKernel.FUSED_TRITON.value],
+        )
+
     def test_filter_compute_kernels_mch_ebc(self) -> None:
         constraint = ParameterConstraints(
             compute_kernels=[

--- a/torchrec/distributed/planner/tests/test_enumerators.py
+++ b/torchrec/distributed/planner/tests/test_enumerators.py
@@ -1076,6 +1076,36 @@ class TestEnumerators(unittest.TestCase):
             [EmbeddingComputeKernel.FUSED_TRITON.value],
         )
 
+        fallback_constraints = {
+            "table_0": ParameterConstraints(
+                compute_kernels=[
+                    EmbeddingComputeKernel.FUSED_TRITON.value,
+                    EmbeddingComputeKernel.FUSED.value,
+                    EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+                ]
+            )
+        }
+        fallback = EmbeddingEnumerator(
+            topology=MagicMock(),
+            batch_size=MagicMock(),
+            constraints=fallback_constraints,
+        )
+        self.assertEqual(
+            fallback._filter_compute_kernels("table_0", sharder_kernels, sharding_type),
+            [
+                EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
+                EmbeddingComputeKernel.FUSED_TRITON.value,
+            ],
+        )
+        self.assertEqual(
+            fallback._filter_compute_kernels(
+                "table_0",
+                [EmbeddingComputeKernel.FUSED.value],
+                sharding_type,
+            ),
+            [EmbeddingComputeKernel.FUSED.value],
+        )
+
     def test_filter_compute_kernels_mch_ebc(self) -> None:
         constraint = ParameterConstraints(
             compute_kernels=[

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -215,6 +215,43 @@ def _get_table_names_by_groups(
 
 
 class TestGroupTablesPerRank(unittest.TestCase):
+    def test_triton_bag_size_hints_follow_grouped_feature_order(self) -> None:
+        tables = [
+            ShardedEmbeddingTable(
+                name="table_0",
+                feature_names=["feature_0", "feature_1"],
+                embedding_names=["feature_0", "feature_1"],
+                data_type=DataType.FP16,
+                pooling=PoolingType.SUM,
+                fused_params={"bag_size_hints": [64, 80]},
+                compute_kernel=EmbeddingComputeKernel.FUSED_TRITON,
+                embedding_dim=64,
+                local_cols=64,
+                num_embeddings=64,
+            ),
+            ShardedEmbeddingTable(
+                name="table_1",
+                feature_names=["feature_2"],
+                embedding_names=["feature_2"],
+                data_type=DataType.FP16,
+                pooling=PoolingType.SUM,
+                fused_params={"bag_size_hints": [128]},
+                compute_kernel=EmbeddingComputeKernel.FUSED_TRITON,
+                embedding_dim=64,
+                local_cols=64,
+                num_embeddings=64,
+            ),
+        ]
+
+        table_groups = group_tables([tables])[0]
+
+        self.assertEqual(len(table_groups), 1)
+        self.assertIsNotNone(table_groups[0].fused_params)
+        self.assertEqual(
+            table_groups[0].fused_params.get("bag_size_hints"),
+            [64, 80, 128],
+        )
+
     @given(
         data_type=st.sampled_from([DataType.FP16, DataType.FP32]),
         has_feature_processor=st.sampled_from([False, True]),

--- a/torchrec/distributed/tests/test_utils.py
+++ b/torchrec/distributed/tests/test_utils.py
@@ -20,6 +20,7 @@ import torch.distributed as dist
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import SparseType
 from hypothesis import given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_sharding import bucketize_kjt_before_all2all
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.test_utils.test_model import TestSparseNN
@@ -32,6 +33,7 @@ from torchrec.distributed.types import (
     MultiPassPrefetchConfig,
     ParameterSharding,
     ShardingBucketMetadata,
+    ShardingType,
     ShardMetadata,
 )
 from torchrec.distributed.utils import (
@@ -861,6 +863,22 @@ class AddParamsFromParameterShardingTest(unittest.TestCase):
             "multipass_prefetch_config": MultiPassPrefetchConfig(num_passes=2),
         }
         self.assertEqual(fused_params, expected_fused_params)
+
+    def test_fused_bounds_check_is_only_forwarded_to_triton(self) -> None:
+        fused_params = add_params_from_parameter_sharding(
+            {"fused_bounds_check": True}, self.parameter_sharding
+        )
+        self.assertNotIn("fused_bounds_check", fused_params)
+
+        triton_sharding = ParameterSharding(
+            sharding_type=ShardingType.TABLE_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED_TRITON.value,
+            ranks=[0],
+        )
+        fused_params = add_params_from_parameter_sharding(
+            {"fused_bounds_check": True}, triton_sharding
+        )
+        self.assertTrue(fused_params["fused_bounds_check"])
 
 
 class ConvertFusedParamsTest(unittest.TestCase):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -781,6 +781,8 @@ class ParameterSharding:
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
         output_dtype (Optional[DataType]): output dtype.
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE or PS.
+        bag_size_hints (Optional[List[int]]): expected bag size for each feature,
+            used only by FUSED_TRITON.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -800,6 +802,7 @@ class ParameterSharding:
     bounds_check_mode: Optional[BoundsCheckMode] = None
     output_dtype: Optional[DataType] = None
     key_value_params: Optional[KeyValueParams] = None
+    bag_size_hints: Optional[List[int]] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -816,6 +816,8 @@ class ParameterSharding:
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
         output_dtype (Optional[DataType]): output dtype.
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE or PS.
+        bag_size_hints (Optional[List[int]]): expected bag size for each feature,
+            used only by FUSED_TRITON.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -835,6 +837,7 @@ class ParameterSharding:
     bounds_check_mode: Optional[BoundsCheckMode] = None
     output_dtype: Optional[DataType] = None
     key_value_params: Optional[KeyValueParams] = None
+    bag_size_hints: Optional[List[int]] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -451,6 +451,9 @@ def add_params_from_parameter_sharding(
     if fused_params is None:
         fused_params = {}
 
+    if parameter_sharding.compute_kernel != EmbeddingComputeKernel.FUSED_TRITON.value:
+        fused_params.pop("fused_bounds_check", None)
+
     # update fused_params using params from parameter_sharding
     # this will take precidence over the fused_params provided from sharders
     if parameter_sharding.cache_params is not None:
@@ -481,6 +484,12 @@ def add_params_from_parameter_sharding(
 
     if parameter_sharding.output_dtype is not None:
         fused_params["output_dtype"] = parameter_sharding.output_dtype
+
+    if (
+        parameter_sharding.compute_kernel == EmbeddingComputeKernel.FUSED_TRITON.value
+        and parameter_sharding.bag_size_hints is not None
+    ):
+        fused_params["bag_size_hints"] = parameter_sharding.bag_size_hints
 
     if (
         parameter_sharding.compute_kernel

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -449,6 +449,9 @@ def add_params_from_parameter_sharding(
     if fused_params is None:
         fused_params = {}
 
+    if parameter_sharding.compute_kernel != EmbeddingComputeKernel.FUSED_TRITON.value:
+        fused_params.pop("fused_bounds_check", None)
+
     # update fused_params using params from parameter_sharding
     # this will take precidence over the fused_params provided from sharders
     if parameter_sharding.cache_params is not None:
@@ -479,6 +482,12 @@ def add_params_from_parameter_sharding(
 
     if parameter_sharding.output_dtype is not None:
         fused_params["output_dtype"] = parameter_sharding.output_dtype
+
+    if (
+        parameter_sharding.compute_kernel == EmbeddingComputeKernel.FUSED_TRITON.value
+        and parameter_sharding.bag_size_hints is not None
+    ):
+        fused_params["bag_size_hints"] = parameter_sharding.bag_size_hints
 
     if (
         parameter_sharding.compute_kernel


### PR DESCRIPTION
Summary:

Make sure sharders can pick up between old triton and fused transpose / sorting into fwd.

Reviewed By: axeisghost

Differential Revision: D115121876


