### PR TITLE
Do not classify stuck shutdown as failure (#4531)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -626,7 +626,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     def shutdown(self) -> None:
         """Two-phase shutdown: stop the update thread, then the compute thread.
         Idempotent — safe under explicit call + atexit. Best-effort: a worker that
-        fails to join is logged (with a failure event), never raised, so metric
+        fails to join is logged, never raised, so metric
         teardown cannot mask an in-flight training error or fail an otherwise
         successful job. Both workers are daemon threads, so an abandoned one cannot
         block process exit."""
@@ -707,22 +707,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
 
         if self.update_thread.is_alive():
-            self._log_event(
-                "shutdown",
-                EventType.FAILURE,
-                correctness_metadata,
-                error_message="update thread did not shut down gracefully",
-            )
             logger.warning(
                 f"update thread did not shut down gracefully. remaining queue size: {self.update_queue.qsize()}"
             )
         if self.compute_thread.is_alive():
-            self._log_event(
-                "shutdown",
-                EventType.FAILURE,
-                correctness_metadata,
-                error_message="compute thread did not shut down gracefully",
-            )
             logger.warning(
                 f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
             )

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -415,7 +415,7 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.cpu_module.compute_thread, "is_alive", return_value=True
         ), patch.object(
             self.cpu_module, "_log_event"
-        ), patch(
+        ) as mock_log_event, patch(
             "torchrec.metrics.cpu_offloaded_metric_module.logger"
         ) as mock_logger:
             self.cpu_module.shutdown()  # must not raise
@@ -431,6 +431,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             ),
             "expected a non-fatal 'did not shut down gracefully' warning",
         )
+        mock_log_event.assert_called_once()
+        self.assertEqual(mock_log_event.call_args.args[0], "shutdown")
+        self.assertEqual(mock_log_event.call_args.args[1], EventType.SUCCESS)
 
     def test_format_thread_stack(self) -> None:
         # Not-started thread: ident is None.


### PR DESCRIPTION
Summary:

Stop reporting best-effort metric-thread join timeouts as RecMetrics failures. Genuine worker exceptions continue to emit failure events.

Reviewed By: micrain

Differential Revision: D115585738


