### PR TITLE
Skip shape exchange for fixed metric states (#4535)

### DIFF
--- a/torchrec/metrics/cali_free_ne.py
+++ b/torchrec/metrics/cali_free_ne.py
@@ -121,6 +121,8 @@ class CaliFreeNEMetricComputation(RecMetricComputation):
         allow_missing_label_with_zero_weight (bool): allow missing label to have weight 0, instead of throwing exception.
     """
 
+    _use_fixed_shape_sync: bool = True
+
     def __init__(
         self,
         *args: Any,

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -104,6 +104,8 @@ class NEMetricComputation(RecMetricComputation):
         include_logloss (bool): return vanilla logloss as one of metrics results, on top of NE.
     """
 
+    _use_fixed_shape_sync: bool = True
+
     def __init__(
         self,
         *args: Any,

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -11,11 +11,13 @@ import abc
 import copy
 import inspect
 import itertools
+import logging
 import math
 import weakref
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -39,6 +41,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.profiler import record_function
 from torchmetrics import Metric
+from torchmetrics.utilities.distributed import gather_all_tensors
 
 try:
     from torchrec.distributed.logging_handlers import (
@@ -59,6 +62,7 @@ except Exception:
             pass
 
 
+from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.types import get_tensor_size_bytes
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
@@ -72,6 +76,8 @@ from torchrec.pt2.utils import pt2_compile_callable
 
 
 RecModelOutput = Union[torch.Tensor, Dict[str, torch.Tensor]]
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -130,6 +136,7 @@ def _snapshot_init_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 MAX_BUFFER_COUNT = 1000
+_FIXED_SHAPE_SYNC_ENABLED = "pytorch/torchrec:enable_fixed_shape_metric_sync"
 _WINDOW_BUFFER_REGISTRY: weakref.WeakValueDictionary[int, Any] = (
     torch.__dict__.setdefault(
         "_torchrec_window_buffer_registry", weakref.WeakValueDictionary()
@@ -152,6 +159,51 @@ def _window_buffer_aggregate_state(
 ) -> None:
     _WINDOW_BUFFER_REGISTRY[buffer_handle]._aggregate_state_impl(
         window_state, curr_state, size
+    )
+
+
+@lru_cache(maxsize=16)
+def _supports_fixed_shape_sync(dist_sync_fn: Callable) -> bool:
+    try:
+        return "assume_same_shape" in inspect.signature(dist_sync_fn).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _default_sync_supports_fixed_shape() -> bool:
+    return _supports_fixed_shape_sync(gather_all_tensors)
+
+
+def _fixed_shape_gather(
+    result: torch.Tensor, group: Optional[Any] = None
+) -> List[torch.Tensor]:
+    return gather_all_tensors(result, group, assume_same_shape=True)
+
+
+def _resolve_fixed_shape_sync_on_leader(use_fixed_shape_sync: bool) -> bool:
+    if not use_fixed_shape_sync or not _default_sync_supports_fixed_shape():
+        return False
+    return torch._utils_internal.justknobs_check(
+        _FIXED_SHAPE_SYNC_ENABLED, default=False
+    )
+
+
+def _resolve_fixed_shape_sync(
+    process_group: Optional[dist.ProcessGroup],
+    use_fixed_shape_sync: bool,
+) -> bool:
+    if not dist.is_available() or not dist.is_initialized():
+        return False
+    group: Optional[dist.ProcessGroup] = (
+        process_group if process_group is not None else dist.group.WORLD
+    )
+    if group is None:
+        return False
+    return invoke_on_rank_and_broadcast_result(
+        pg=group,
+        rank=0,
+        func=_resolve_fixed_shape_sync_on_leader,
+        use_fixed_shape_sync=use_fixed_shape_sync,
     )
 
 
@@ -231,8 +283,11 @@ class RecMetricComputation(Metric, abc.ABC):
             where all examples have 0 weights for a batch.
         process_group (Optional[ProcessGroup]): the process group used for the
             communication. Will use the default process group if not specified.
+            Fixed-shape sync resolves its rollout decision across the group on the
+            first distributed synchronization for each process group and caches it.
     """
 
+    _use_fixed_shape_sync: bool = False
     _batch_window_buffers: Optional[Dict[str, WindowBuffer]]
 
     def __init__(
@@ -286,6 +341,67 @@ class RecMetricComputation(Metric, abc.ABC):
                 persistent=True,
             )
         self._compute_mode: RecComputeMode = compute_mode
+        self._seen_dist_sync_paths: Set[str] = set()
+        self._fixed_shape_sync_enablement: Dict[dist.ProcessGroup, bool] = {}
+
+    def _has_fixed_shape_state_contract(self) -> bool:
+        defaults: Optional[Mapping[str, Any]] = getattr(self, "_defaults", None)
+        return (
+            self._use_fixed_shape_sync
+            and defaults is not None
+            and all(isinstance(default, torch.Tensor) for default in defaults.values())
+        )
+
+    def _should_use_fixed_shape_sync(
+        self, process_group: Optional[dist.ProcessGroup]
+    ) -> bool:
+        if not self._use_fixed_shape_sync or process_group is None:
+            return False
+        if process_group not in self._fixed_shape_sync_enablement:
+            self._fixed_shape_sync_enablement[process_group] = (
+                _resolve_fixed_shape_sync(
+                    process_group,
+                    self._has_fixed_shape_state_contract(),
+                )
+            )
+        return self._fixed_shape_sync_enablement[process_group]
+
+    def _sync_dist(
+        self,
+        dist_sync_fn: Optional[Callable] = None,
+        process_group: Optional[Any] = None,
+    ) -> None:
+        if dist_sync_fn is None:
+            dist_sync_fn = gather_all_tensors
+        uses_default_sync = dist_sync_fn is gather_all_tensors
+        sync_process_group = cast(
+            Optional[dist.ProcessGroup],
+            process_group or self.process_group or dist.group.WORLD,
+        )
+        uses_fixed_shape_sync = uses_default_sync and self._should_use_fixed_shape_sync(
+            sync_process_group
+        )
+        if uses_fixed_shape_sync:
+            dist_sync_fn = _fixed_shape_gather
+            sync_path = "fixed_shape"
+        elif uses_default_sync:
+            sync_path = "variable_shape"
+        else:
+            sync_path = "custom"
+        should_log_sync_path = (
+            self._my_rank == 0 and sync_path not in self._seen_dist_sync_paths
+        )
+
+        super()._sync_dist(dist_sync_fn, sync_process_group)
+
+        if should_log_sync_path:
+            logger.info(
+                "RecMetric distributed sync path: metric=%s path=%s states=%d",
+                type(self).__name__,
+                sync_path,
+                len(getattr(self, "_defaults", {})),
+            )
+            self._seen_dist_sync_paths.add(sync_path)
 
     @staticmethod
     def get_window_state_name(state_name: str) -> str:

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -10,11 +10,13 @@
 import abc
 import inspect
 import itertools
+import logging
 import math
 import weakref
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -38,6 +40,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.profiler import record_function
 from torchmetrics import Metric
+from torchmetrics.utilities.distributed import gather_all_tensors
 
 try:
     from torchrec.distributed.logging_handlers import (
@@ -58,6 +61,7 @@ except Exception:
             pass
 
 
+from torchrec.distributed.collective_utils import invoke_on_rank_and_broadcast_result
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.types import get_tensor_size_bytes
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
@@ -72,6 +76,8 @@ from torchrec.pt2.utils import pt2_compile_callable
 
 RecModelOutput = Union[torch.Tensor, Dict[str, torch.Tensor]]
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class MetricComputationReport:
@@ -85,8 +91,19 @@ DefaultValueT = TypeVar("DefaultValueT")
 ComputeIterType = Iterator[
     Tuple[RecTaskInfo, MetricNameBase, torch.Tensor, MetricPrefix, str]
 ]
+StateShapeContract = Tuple[
+    Tuple[
+        str,
+        Optional[Tuple[int, ...]],
+        Optional[Tuple[int, ...]],
+        Optional[str],
+    ],
+    ...,
+]
 
 MAX_BUFFER_COUNT = 1000
+_FIXED_SHAPE_SYNC_ENABLED = "pytorch/torchrec:enable_fixed_shape_metric_sync"
+_ORIGINAL_GATHER_ALL_TENSORS = gather_all_tensors
 _WINDOW_BUFFER_REGISTRY: weakref.WeakValueDictionary[int, Any] = (
     torch.__dict__.setdefault(
         "_torchrec_window_buffer_registry", weakref.WeakValueDictionary()
@@ -109,6 +126,51 @@ def _window_buffer_aggregate_state(
 ) -> None:
     _WINDOW_BUFFER_REGISTRY[buffer_handle]._aggregate_state_impl(
         window_state, curr_state, size
+    )
+
+
+@lru_cache(maxsize=16)
+def _supports_fixed_shape_sync(dist_sync_fn: Callable) -> bool:
+    try:
+        return "assume_same_shape" in inspect.signature(dist_sync_fn).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _default_sync_supports_fixed_shape() -> bool:
+    return _supports_fixed_shape_sync(gather_all_tensors)
+
+
+def _fixed_shape_gather(
+    result: torch.Tensor, group: Optional[Any] = None
+) -> List[torch.Tensor]:
+    return gather_all_tensors(result, group, assume_same_shape=True)
+
+
+def _resolve_fixed_shape_sync_on_leader(use_fixed_shape_sync: bool) -> bool:
+    if not use_fixed_shape_sync or not _default_sync_supports_fixed_shape():
+        return False
+    return torch._utils_internal.justknobs_check(
+        _FIXED_SHAPE_SYNC_ENABLED, default=False
+    )
+
+
+def _resolve_fixed_shape_sync(
+    process_group: Optional[dist.ProcessGroup],
+    use_fixed_shape_sync: bool,
+) -> bool:
+    if not use_fixed_shape_sync or not dist.is_available() or not dist.is_initialized():
+        return False
+    group: Optional[dist.ProcessGroup] = (
+        process_group if process_group is not None else dist.group.WORLD
+    )
+    if group is None:
+        return False
+    return invoke_on_rank_and_broadcast_result(
+        pg=group,
+        rank=0,
+        func=_resolve_fixed_shape_sync_on_leader,
+        use_fixed_shape_sync=use_fixed_shape_sync,
     )
 
 
@@ -174,8 +236,11 @@ class RecMetricComputation(Metric, abc.ABC):
             where all examples have 0 weights for a batch.
         process_group (Optional[ProcessGroup]): the process group used for the
             communication. Will use the default process group if not specified.
+            Fixed-shape sync requires the group to be initialized at construction.
+            Its rollout decision remains fixed for the lifetime of the computation.
     """
 
+    _use_fixed_shape_sync: bool = False
     _batch_window_buffers: Optional[Dict[str, WindowBuffer]]
 
     def __init__(
@@ -229,6 +294,165 @@ class RecMetricComputation(Metric, abc.ABC):
                 persistent=True,
             )
         self._compute_mode: RecComputeMode = compute_mode
+        self._seen_dist_sync_paths: Set[str] = set()
+        self._fixed_shape_sync_process_group: Optional[dist.ProcessGroup] = (
+            process_group if process_group is not None else dist.group.WORLD
+        )
+        self._fixed_shape_sync_contract_device: Optional[torch.device] = None
+        self._fixed_shape_sync_rank_contract_has_tensor_states: bool = False
+        self._fixed_shape_sync_has_rank_invariant_shapes: Optional[bool] = None
+        self._fixed_shape_sync_is_enabled: bool = _resolve_fixed_shape_sync(
+            self._fixed_shape_sync_process_group,
+            self._use_fixed_shape_sync,
+        )
+
+    def _has_fixed_shape_state_contract(self) -> bool:
+        defaults: Optional[Mapping[str, Any]] = getattr(self, "_defaults", None)
+        if not self._use_fixed_shape_sync or defaults is None:
+            return False
+        return all(
+            isinstance(default, torch.Tensor)
+            and isinstance(state := getattr(self, name, None), torch.Tensor)
+            and state.shape == default.shape
+            for name, default in defaults.items()
+        )
+
+    def _get_rank_invariant_state_shape_contract(
+        self, process_group: dist.ProcessGroup
+    ) -> Optional[StateShapeContract]:
+        defaults: Mapping[str, Any] = getattr(self, "_defaults", {})
+        local_contract: StateShapeContract = tuple(
+            (
+                name,
+                tuple(default.shape) if isinstance(default, torch.Tensor) else None,
+                (
+                    tuple(state.shape)
+                    if isinstance(state := getattr(self, name, None), torch.Tensor)
+                    else None
+                ),
+                state.device.type if isinstance(state, torch.Tensor) else None,
+            )
+            for name, default in defaults.items()
+        )
+        contracts: List[Optional[StateShapeContract]] = [None] * process_group.size()
+        dist.all_gather_object(contracts, local_contract, group=process_group)
+        first_contract = contracts[0]
+        if first_contract is None or not all(
+            contract == first_contract for contract in contracts
+        ):
+            return None
+        return first_contract
+
+    def _get_fixed_shape_sync_contract_device(self) -> Optional[torch.device]:
+        defaults: Mapping[str, Any] = getattr(self, "_defaults", {})
+        for name in defaults:
+            state = getattr(self, name, None)
+            if isinstance(state, torch.Tensor):
+                return state.device
+        return None
+
+    def _all_ranks_have_fixed_shape_state_contract(
+        self, process_group: dist.ProcessGroup, device: torch.device
+    ) -> bool:
+        local_contract = torch.tensor(
+            self._has_fixed_shape_state_contract(),
+            dtype=torch.uint8,
+            device=device,
+        )
+        dist.all_reduce(local_contract, op=dist.ReduceOp.MIN, group=process_group)
+        return bool(local_contract)
+
+    def _sync_dist(
+        self,
+        dist_sync_fn: Optional[Callable] = None,
+        process_group: Optional[Any] = None,
+    ) -> None:
+        if dist_sync_fn is None:
+            dist_sync_fn = gather_all_tensors
+        uses_default_sync = (
+            dist_sync_fn is gather_all_tensors
+            or dist_sync_fn is _ORIGINAL_GATHER_ALL_TENSORS
+        )
+        sync_process_group = (
+            process_group if process_group is not None else dist.group.WORLD
+        )
+        can_use_fixed_shape_sync = (
+            uses_default_sync
+            and self._fixed_shape_sync_is_enabled
+            and sync_process_group is self._fixed_shape_sync_process_group
+        )
+        has_fixed_shape_contract = False
+        has_rank_invariant_shapes = True
+        if can_use_fixed_shape_sync:
+            fixed_shape_process_group = cast(dist.ProcessGroup, sync_process_group)
+            if self._fixed_shape_sync_has_rank_invariant_shapes is None:
+                rank_invariant_contract = self._get_rank_invariant_state_shape_contract(
+                    fixed_shape_process_group
+                )
+                has_rank_invariant_shapes = rank_invariant_contract is not None
+                self._fixed_shape_sync_has_rank_invariant_shapes = (
+                    has_rank_invariant_shapes
+                )
+                self._fixed_shape_sync_rank_contract_has_tensor_states = (
+                    rank_invariant_contract is not None
+                    and any(
+                        device_type is not None
+                        for _, _, _, device_type in rank_invariant_contract
+                    )
+                )
+                self._fixed_shape_sync_contract_device = (
+                    self._get_fixed_shape_sync_contract_device()
+                )
+                has_fixed_shape_contract = (
+                    has_rank_invariant_shapes and self._has_fixed_shape_state_contract()
+                )
+            elif not self._fixed_shape_sync_has_rank_invariant_shapes:
+                has_rank_invariant_shapes = False
+            elif self._fixed_shape_sync_rank_contract_has_tensor_states:
+                has_fixed_shape_contract = (
+                    self._all_ranks_have_fixed_shape_state_contract(
+                        fixed_shape_process_group,
+                        cast(
+                            torch.device,
+                            self._fixed_shape_sync_contract_device,
+                        ),
+                    )
+                )
+                if not has_fixed_shape_contract:
+                    has_rank_invariant_shapes = (
+                        self._get_rank_invariant_state_shape_contract(
+                            fixed_shape_process_group
+                        )
+                        is not None
+                    )
+            else:
+                has_fixed_shape_contract = self._has_fixed_shape_state_contract()
+        if not has_rank_invariant_shapes:
+            raise RecMetricException(
+                f"{type(self).__name__} fixed-shape states differ across ranks"
+            )
+        uses_fixed_shape_sync = can_use_fixed_shape_sync and has_fixed_shape_contract
+        if uses_fixed_shape_sync:
+            dist_sync_fn = _fixed_shape_gather
+            sync_path = "fixed_shape"
+        elif uses_default_sync:
+            sync_path = "variable_shape"
+        else:
+            sync_path = "custom"
+        should_log_sync_path = (
+            self._my_rank == 0 and sync_path not in self._seen_dist_sync_paths
+        )
+
+        super()._sync_dist(dist_sync_fn, process_group)
+
+        if should_log_sync_path:
+            logger.info(
+                "RecMetric distributed sync path: metric=%s path=%s states=%d",
+                type(self).__name__,
+                sync_path,
+                len(getattr(self, "_defaults", {})),
+            )
+            self._seen_dist_sync_paths.add(sync_path)
 
     @staticmethod
     def get_window_state_name(state_name: str) -> str:

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -133,9 +133,10 @@ class AUCMetricCompileTest(unittest.TestCase):
         # module attributes as dynamic to isolate the AUC list-length recompiles,
         # then assert the recompile limit is never hit so this stays a regression
         # guard.
-        with patch.object(
-            torch._dynamo.config, "allow_unspec_int_on_nn_module", True
-        ), patch.object(torch._dynamo.config, "fail_on_recompile_limit_hit", True):
+        with (
+            patch.object(torch._dynamo.config, "allow_unspec_int_on_nn_module", True),
+            patch.object(torch._dynamo.config, "fail_on_recompile_limit_hit", True),
+        ):
             for _ in range(10):
                 compiled_update(
                     predictions={DefaultTaskInfo.name: model_output["predictions"][0]},

--- a/torchrec/metrics/tests/test_auc.py
+++ b/torchrec/metrics/tests/test_auc.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import unittest
-from typing import Dict, Iterable, List, Optional, Type, Union
+from typing import cast, Dict, Iterable, List, Optional, Type, Union
 from unittest.mock import patch
 
 import torch
@@ -18,6 +18,7 @@ from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.rec_metric import (
     RecComputeMode,
     RecMetric,
+    RecMetricComputation,
     RecMetricException,
     RecTaskInfo,
 )
@@ -133,9 +134,10 @@ class AUCMetricCompileTest(unittest.TestCase):
         # module attributes as dynamic to isolate the AUC list-length recompiles,
         # then assert the recompile limit is never hit so this stays a regression
         # guard.
-        with patch.object(
-            torch._dynamo.config, "allow_unspec_int_on_nn_module", True
-        ), patch.object(torch._dynamo.config, "fail_on_recompile_limit_hit", True):
+        with (
+            patch.object(torch._dynamo.config, "allow_unspec_int_on_nn_module", True),
+            patch.object(torch._dynamo.config, "fail_on_recompile_limit_hit", True),
+        ):
             for _ in range(10):
                 compiled_update(
                     predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
@@ -166,6 +168,25 @@ class AUCMetricCompileTest(unittest.TestCase):
 class AUCMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = AUCMetric
     task_name: str = "auc"
+
+    def test_variable_shape_sync_path(self) -> None:
+        auc = AUCMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[DefaultTaskInfo],
+        )
+        computation = cast(RecMetricComputation, auc._metrics_computations[0])
+
+        with (
+            patch.object(torch.distributed, "get_world_size", return_value=1),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            computation.sync(distributed_available=lambda: True)
+
+        barrier.assert_called()
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
 
     def test_unfused_auc(self) -> None:
         rec_metric_value_test_launcher(

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -7,28 +7,103 @@
 
 # pyre-strict
 
+import os
+import tempfile
 import unittest
+from contextlib import contextmanager
 from functools import partial, update_wrapper
-from typing import Callable, Dict, Optional, Type
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Type
+from unittest.mock import patch
 
 import torch
+import torchrec.metrics.rec_metric as rec_metric
+from torchrec.metrics.auc import AUCMetric
+from torchrec.metrics.metrics_config import DefaultTaskInfo
 from torchrec.metrics.ne import (
     compute_cross_entropy,
     compute_logloss,
     compute_ne,
     NEMetric,
 )
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricComputation
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_accuracy_test_helper,
     rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
     sync_test_helper,
     TestMetric,
 )
 
+try:
+    from pyjk import PyPatchJustKnobs as _PyPatchJustKnobs
+except ImportError:
+    _PyPatchJustKnobs = None
+
 
 WORLD_SIZE = 4
+
+
+@contextmanager
+def _single_rank_gloo() -> Iterator[torch.distributed.ProcessGroup]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method=f"file://{os.path.join(tmpdir, 'rdzv')}",
+            world_size=1,
+            rank=0,
+        )
+        process_group = cast(
+            torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+        )
+        try:
+            yield process_group
+        finally:
+            torch.distributed.destroy_process_group()
+
+
+@contextmanager
+def _fixed_shape_sync_patch(enabled: bool) -> Iterator[None]:
+    if _PyPatchJustKnobs is None:
+        raise RuntimeError("PyPatchJustKnobs is unavailable")
+    with _PyPatchJustKnobs().patch(
+        "pytorch/torchrec:enable_fixed_shape_metric_sync", enabled
+    ):
+        yield
+
+
+def _fixed_shape_sync_enablement_broadcast_test() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.distributed.init_process_group(
+        backend="gloo",
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        with _fixed_shape_sync_patch(rank == 0):
+            process_group = cast(
+                torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+            )
+            ne = NEMetric(
+                world_size=world_size,
+                my_rank=rank,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            if not rec_metric._resolve_fixed_shape_sync(process_group, rank == 0):
+                raise AssertionError("rank-zero eligibility was not broadcast")
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            if computation._fixed_shape_sync_enablement:
+                raise AssertionError("fixed-shape sync was initialized eagerly")
+            computation.sync(distributed_available=lambda: True)
+            if computation._fixed_shape_sync_enablement.get(process_group) is not True:
+                raise AssertionError("rank-zero decision was not broadcast")
+            if rank == 0 and "fixed_shape" not in computation._seen_dist_sync_paths:
+                raise AssertionError("fixed-shape sync path was not used")
+    finally:
+        torch.distributed.destroy_process_group()
 
 
 class TestNEMetric(TestMetric):
@@ -114,6 +189,199 @@ class NEMetricTest(unittest.TestCase):
     target_clazz: Type[RecMetric] = NEMetric
     target_compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION
     task_name: str = "ne"
+
+    @staticmethod
+    def _set_distinct_sync_states(
+        computation: RecMetricComputation,
+    ) -> Dict[str, torch.Tensor]:
+        defaults = cast(Dict[str, Any], cast(Any, computation)._defaults)
+        expected: Dict[str, torch.Tensor] = {}
+        for value, name in enumerate(defaults, start=1):
+            state = cast(torch.Tensor, getattr(computation, name))
+            state.fill_(value)
+            expected[name] = state.clone()
+        return expected
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_path(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            self.assertFalse(computation._fixed_shape_sync_enablement)
+            computation.sync(distributed_available=lambda: True)
+
+        self.assertTrue(computation._fixed_shape_sync_enablement[process_group])
+        self.assertIn("fixed_shape", computation._seen_dist_sync_paths)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_disabled_uses_variable_shape_path(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(False),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_uses_explicit_process_group(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+        ):
+            alternate_process_group = cast(
+                torch.distributed.ProcessGroup,
+                torch.distributed.new_group(ranks=[0]),
+            )
+            try:
+                ne = NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=1,
+                    tasks=[DefaultTaskInfo],
+                    process_group=process_group,
+                )
+                computation = cast(RecMetricComputation, ne._metrics_computations[0])
+                self.assertTrue(computation._should_use_fixed_shape_sync(process_group))
+                self.assertTrue(
+                    computation._should_use_fixed_shape_sync(alternate_process_group)
+                )
+                self.assertCountEqual(
+                    computation._fixed_shape_sync_enablement,
+                    [process_group, alternate_process_group],
+                )
+                computation.sync(
+                    process_group=alternate_process_group,
+                    distributed_available=lambda: True,
+                )
+                self.assertIn("fixed_shape", computation._seen_dist_sync_paths)
+            finally:
+                torch.distributed.destroy_process_group(alternate_process_group)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_enablement_is_broadcast_from_rank_zero(self) -> None:
+        rec_metric_accuracy_test_helper(
+            world_size=2,
+            entry_point=_fixed_shape_sync_enablement_broadcast_test,
+        )
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_metric_without_fixed_shape_sync_uses_variable_path(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+        ):
+            auc = AUCMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, auc._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_upstream_gather_without_fixed_shape_support_uses_variable_path(
+        self,
+    ) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(
+                rec_metric, "_default_sync_supports_fixed_shape", return_value=False
+            ),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    def test_custom_sync_path_is_unchanged(self) -> None:
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[DefaultTaskInfo],
+        )
+        computation = cast(RecMetricComputation, ne._metrics_computations[0])
+        expected = self._set_distinct_sync_states(computation)
+        synced_tensors: List[torch.Tensor] = []
+
+        def custom_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            synced_tensors.append(tensor)
+            return [tensor]
+
+        computation.sync(
+            dist_sync_fn=custom_sync,
+            distributed_available=lambda: True,
+        )
+
+        self.assertEqual(len(synced_tensors), len(expected))
+        for actual, expected_tensor in zip(synced_tensors, expected.values()):
+            torch.testing.assert_close(actual, expected_tensor)
+        for name, expected_tensor in expected.items():
+            torch.testing.assert_close(getattr(computation, name), expected_tensor)
+
+    def test_sync_path_is_recorded_after_success(self) -> None:
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[DefaultTaskInfo],
+        )
+        computation = cast(RecMetricComputation, ne._metrics_computations[0])
+
+        def failing_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            raise RuntimeError("sync failed")
+
+        def successful_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            return [tensor]
+
+        with patch.object(rec_metric.logger, "info") as log_info:
+            with self.assertRaisesRegex(RuntimeError, "sync failed"):
+                computation._sync_dist(failing_sync)
+            self.assertNotIn("custom", computation._seen_dist_sync_paths)
+            log_info.assert_not_called()
+
+            computation._sync_dist(successful_sync)
+            self.assertIn("custom", computation._seen_dist_sync_paths)
+            log_info.assert_called_once()
+
+            computation._sync_dist(successful_sync)
+            log_info.assert_called_once()
 
     def test_ne_unfused(self) -> None:
         rec_metric_value_test_launcher(

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -7,28 +7,181 @@
 
 # pyre-strict
 
+import os
+import tempfile
 import unittest
+from contextlib import contextmanager
 from functools import partial, update_wrapper
-from typing import Callable, Dict, Optional, Type
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Type
+from unittest.mock import patch, PropertyMock
 
 import torch
+import torchrec.metrics.rec_metric as rec_metric
+from torchrec.metrics.auc import AUCMetric
+from torchrec.metrics.metrics_config import DefaultTaskInfo, RecTaskInfo
 from torchrec.metrics.ne import (
     compute_cross_entropy,
     compute_logloss,
     compute_ne,
     NEMetric,
 )
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricComputation
 from torchrec.metrics.test_utils import (
     metric_test_helper,
+    rec_metric_accuracy_test_helper,
     rec_metric_gpu_sync_test_launcher,
     rec_metric_value_test_launcher,
     sync_test_helper,
     TestMetric,
 )
 
+try:
+    from pyjk import PyPatchJustKnobs as _PyPatchJustKnobs
+except ImportError:
+    _PyPatchJustKnobs = None
+
 
 WORLD_SIZE = 4
+
+
+@contextmanager
+def _single_rank_gloo() -> Iterator[torch.distributed.ProcessGroup]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method=f"file://{os.path.join(tmpdir, 'rdzv')}",
+            world_size=1,
+            rank=0,
+        )
+        process_group = cast(
+            torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+        )
+        try:
+            yield process_group
+        finally:
+            torch.distributed.destroy_process_group()
+
+
+@contextmanager
+def _fixed_shape_sync_patch(enabled: bool) -> Iterator[None]:
+    if _PyPatchJustKnobs is None:
+        raise RuntimeError("PyPatchJustKnobs is unavailable")
+    with _PyPatchJustKnobs().patch(
+        "pytorch/torchrec:enable_fixed_shape_metric_sync", enabled
+    ):
+        yield
+
+
+def _fixed_shape_sync_enablement_broadcast_test() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.distributed.init_process_group(
+        backend="gloo",
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        with (
+            _fixed_shape_sync_patch(rank == 0),
+            patch.object(
+                rec_metric,
+                "_default_sync_supports_fixed_shape",
+                return_value=rank == 0,
+            ),
+        ):
+            process_group = cast(
+                torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+            )
+            ne = NEMetric(
+                world_size=world_size,
+                my_rank=rank,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            if not computation._fixed_shape_sync_is_enabled:
+                raise AssertionError("rank-zero enablement was not broadcast")
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def _fixed_shape_sync_rank_dependent_shape_test() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.distributed.init_process_group(
+        backend="gloo",
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        with (
+            _fixed_shape_sync_patch(True),
+            patch.object(
+                rec_metric,
+                "_default_sync_supports_fixed_shape",
+                return_value=True,
+            ),
+        ):
+            process_group = cast(
+                torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+            )
+            ne = NEMetric(
+                world_size=world_size,
+                my_rank=rank,
+                batch_size=1,
+                tasks=[RecTaskInfo(name=f"task_{index}") for index in range(rank + 1)],
+                compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            try:
+                computation.sync(distributed_available=lambda: True)
+            except rec_metric.RecMetricException as error:
+                if "fixed-shape states differ across ranks" not in str(error):
+                    raise
+            else:
+                raise AssertionError("rank-dependent shapes were accepted")
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def _fixed_shape_sync_late_rank_dependent_shape_test() -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.distributed.init_process_group(
+        backend="gloo",
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        with _fixed_shape_sync_patch(True):
+            process_group = cast(
+                torch.distributed.ProcessGroup, torch.distributed.group.WORLD
+            )
+            ne = NEMetric(
+                world_size=world_size,
+                my_rank=rank,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+            computation.unsync()
+            if rank == 1:
+                state_name = next(iter(cast(Any, computation)._defaults))
+                state = cast(torch.Tensor, getattr(computation, state_name))
+                setattr(computation, state_name, state.new_zeros((2, *state.shape)))
+            try:
+                computation.sync(distributed_available=lambda: True)
+            except rec_metric.RecMetricException as error:
+                if "fixed-shape states differ across ranks" not in str(error):
+                    raise
+            else:
+                raise AssertionError("late rank-dependent shapes were accepted")
+    finally:
+        torch.distributed.destroy_process_group()
 
 
 class TestNEMetric(TestMetric):
@@ -114,6 +267,357 @@ class NEMetricTest(unittest.TestCase):
     target_clazz: Type[RecMetric] = NEMetric
     target_compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION
     task_name: str = "ne"
+
+    @staticmethod
+    def _set_distinct_sync_states(
+        computation: RecMetricComputation,
+    ) -> Dict[str, torch.Tensor]:
+        defaults = cast(Dict[str, Any], cast(Any, computation)._defaults)
+        expected: Dict[str, torch.Tensor] = {}
+        for value, name in enumerate(defaults, start=1):
+            state = cast(torch.Tensor, getattr(computation, name))
+            state.fill_(value)
+            expected[name] = state.clone()
+        return expected
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_path(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather") as all_gather,
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        barrier.assert_not_called()
+        self.assertGreater(all_gather.call_count, 0)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_validates_rank_shapes_once(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(
+                torch.distributed,
+                "all_gather_object",
+                wraps=torch.distributed.all_gather_object,
+            ) as all_gather_object,
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+            computation.unsync()
+            computation.sync(distributed_available=lambda: True)
+
+        all_gather_object.assert_called_once()
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_disabled_uses_variable_shape_path(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(False),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        barrier.assert_called()
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_uses_variable_path_for_different_group(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            alternate_process_group = torch.distributed.new_group(ranks=[0])
+            try:
+                ne = NEMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=1,
+                    tasks=[DefaultTaskInfo],
+                    process_group=process_group,
+                )
+                computation = cast(RecMetricComputation, ne._metrics_computations[0])
+                computation.sync(
+                    process_group=alternate_process_group,
+                    distributed_available=lambda: True,
+                )
+                self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+            finally:
+                torch.distributed.destroy_process_group(alternate_process_group)
+
+        barrier.assert_called()
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_uses_variable_path_for_changed_state_shape(
+        self,
+    ) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+            computation.unsync()
+            state_name = next(iter(cast(Any, computation)._defaults))
+            state = cast(torch.Tensor, getattr(computation, state_name))
+            setattr(computation, state_name, state.new_zeros((2, *state.shape)))
+
+            computation.sync(distributed_available=lambda: True)
+
+        barrier.assert_called()
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_enablement_is_broadcast_from_rank_zero(self) -> None:
+        rec_metric_accuracy_test_helper(
+            world_size=2,
+            entry_point=_fixed_shape_sync_enablement_broadcast_test,
+        )
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_rejects_rank_dependent_shapes(self) -> None:
+        rec_metric_accuracy_test_helper(
+            world_size=2,
+            entry_point=_fixed_shape_sync_rank_dependent_shape_test,
+        )
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_fixed_shape_sync_rejects_late_rank_dependent_shapes(self) -> None:
+        rec_metric_accuracy_test_helper(
+            world_size=2,
+            entry_point=_fixed_shape_sync_late_rank_dependent_shape_test,
+        )
+
+    def test_missing_default_process_group_skips_enablement_broadcast(self) -> None:
+        with (
+            patch.object(torch.distributed, "is_initialized", return_value=True),
+            patch.object(
+                type(torch.distributed.group),
+                "WORLD",
+                new_callable=PropertyMock,
+                return_value=None,
+            ),
+            patch.object(
+                rec_metric, "invoke_on_rank_and_broadcast_result"
+            ) as broadcast,
+        ):
+            NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+            )
+
+        broadcast.assert_not_called()
+
+    def test_metric_without_fixed_shape_sync_skips_enablement_broadcast(
+        self,
+    ) -> None:
+        with patch.object(
+            rec_metric, "invoke_on_rank_and_broadcast_result"
+        ) as broadcast:
+            AUCMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+            )
+
+        broadcast.assert_not_called()
+
+    @unittest.skipIf(_PyPatchJustKnobs is None, "PyPatchJustKnobs is unavailable")
+    def test_empty_state_defaults_are_trivially_fixed_shape(self) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            _fixed_shape_sync_patch(True),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            defaults = cast(Any, computation)._defaults
+            cast(Any, computation)._defaults = {}
+            try:
+                computation.sync(distributed_available=lambda: True)
+                barrier.assert_not_called()
+                self.assertIn("fixed_shape", computation._seen_dist_sync_paths)
+            finally:
+                cast(Any, computation)._defaults = defaults
+
+    def test_upstream_gather_without_fixed_shape_support_uses_variable_path(
+        self,
+    ) -> None:
+        with (
+            _single_rank_gloo() as process_group,
+            patch.object(
+                rec_metric, "_default_sync_supports_fixed_shape", return_value=False
+            ),
+            patch.object(torch.distributed, "barrier") as barrier,
+            patch.object(torch.distributed, "all_gather"),
+        ):
+            ne = NEMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, ne._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        barrier.assert_called()
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    def test_default_sync_support_tracks_rebound_gather(self) -> None:
+        def legacy_gather(
+            result: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            return [result]
+
+        def fixed_shape_gather(
+            result: torch.Tensor,
+            group: Optional[Any] = None,
+            *,
+            assume_same_shape: bool = False,
+        ) -> List[torch.Tensor]:
+            return [result]
+
+        with patch.object(rec_metric, "gather_all_tensors", legacy_gather):
+            self.assertFalse(rec_metric._default_sync_supports_fixed_shape())
+        with patch.object(rec_metric, "gather_all_tensors", fixed_shape_gather):
+            self.assertTrue(rec_metric._default_sync_supports_fixed_shape())
+
+    def test_default_sync_classification_survives_rebound_gather(self) -> None:
+        def rebound_gather(
+            result: torch.Tensor,
+            group: Optional[Any] = None,
+            *,
+            assume_same_shape: bool = False,
+        ) -> List[torch.Tensor]:
+            return [result]
+
+        with (
+            _single_rank_gloo() as process_group,
+            patch.object(rec_metric, "gather_all_tensors", rebound_gather),
+        ):
+            metric = AUCMetric(
+                world_size=1,
+                my_rank=0,
+                batch_size=1,
+                tasks=[DefaultTaskInfo],
+                process_group=process_group,
+            )
+            computation = cast(RecMetricComputation, metric._metrics_computations[0])
+            computation.sync(distributed_available=lambda: True)
+
+        self.assertIn("variable_shape", computation._seen_dist_sync_paths)
+
+    def test_custom_sync_path_is_unchanged(self) -> None:
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[DefaultTaskInfo],
+        )
+        computation = cast(RecMetricComputation, ne._metrics_computations[0])
+        expected = self._set_distinct_sync_states(computation)
+        synced_tensors: List[torch.Tensor] = []
+
+        def custom_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            synced_tensors.append(tensor)
+            return [tensor]
+
+        computation.sync(
+            dist_sync_fn=custom_sync,
+            distributed_available=lambda: True,
+        )
+
+        self.assertEqual(len(synced_tensors), len(expected))
+        for actual, expected_tensor in zip(synced_tensors, expected.values()):
+            torch.testing.assert_close(actual, expected_tensor)
+        for name, expected_tensor in expected.items():
+            torch.testing.assert_close(getattr(computation, name), expected_tensor)
+
+    def test_sync_path_is_recorded_after_success(self) -> None:
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=[DefaultTaskInfo],
+        )
+        computation = cast(RecMetricComputation, ne._metrics_computations[0])
+
+        def failing_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            raise RuntimeError("sync failed")
+
+        def successful_sync(
+            tensor: torch.Tensor, group: Optional[Any] = None
+        ) -> List[torch.Tensor]:
+            return [tensor]
+
+        with patch.object(rec_metric.logger, "info") as log_info:
+            with self.assertRaisesRegex(RuntimeError, "sync failed"):
+                computation._sync_dist(failing_sync)
+            self.assertNotIn("custom", computation._seen_dist_sync_paths)
+            log_info.assert_not_called()
+
+            computation._sync_dist(successful_sync)
+            self.assertIn("custom", computation._seen_dist_sync_paths)
+            log_info.assert_called_once_with(
+                "RecMetric distributed sync path: metric=%s path=%s states=%d",
+                type(computation).__name__,
+                "custom",
+                len(cast(Any, computation)._defaults),
+            )
+
+            computation._sync_dist(successful_sync)
+            log_info.assert_called_once()
 
     def test_ne_unfused(self) -> None:
         rec_metric_value_test_launcher(


### PR DESCRIPTION
Summary:

Reduce distributed RecMetric synchronization overhead when metric state shapes are fixed across ranks. Metrics with variable state shapes and custom synchronization retain their existing behavior.

Reviewed By: kaanbaloglu

Differential Revision: D115732360


