### PR TITLE
Always log a planner_runs row on planning failure (+ classify)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 from torchrec.distributed.planner.protocols import PlannerExecutor
 from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
 from torchrec.distributed.planner.types import (
+    PlannerErrorType,
     PlannerSessionContext,
     ShardingPlanRequest,
     ShardingPlanResult,
@@ -215,6 +216,10 @@ class ShardingPlannerAPI(abc.ABC):
             success=False,
             sharding_plan=None,
             planner_failure_reason=f"{type(error).__name__}: {error}",
+            # Classify these isolated non-PlannerError failures as OTHER instead of
+            # leaving planner_error_type NULL, so the failure taxonomy panel counts
+            # them rather than dropping them.
+            planner_error_type=PlannerErrorType.OTHER,
             estimated_max_hbm_bytes=0,
             estimated_max_ddr_bytes=0,
             request_hash=ctx.request.request_hash,


### PR DESCRIPTION
Summary:
Two gaps in `torchrec_planner_runs` failure coverage:

1. `create_sharding_plan` called `orchestrator.plan()` with no guard, then logged
   the Scuba row afterward. On the production path an unexpected (non-PlannerError)
   exception -- provider/topology build, model factory, broadcast, etc. -- propagates
   straight out, so `maybe_record_planner_runs` never runs and the failure is
   invisible (indistinguishable from "never ran"). Wrap the call: on exception,
   log a synthesized `success=False` row per target (with `planner_error_type` set,
   `PlannerError.error_type` if available else OTHER) and then re-raise so the caller
   still sees the error. Dry-run isolates per-SKU errors into results and does not
   raise here, so in practice this is the production single-target path.

2. The dry-run collect-and-continue `_failed_result` left `planner_error_type=None`,
   so those isolated non-PlannerError failures were NULL in the taxonomy panel.
   Classify them as OTHER so they're counted.

Together: a planning failure now always produces a classifiable planner_runs row.

Differential Revision: D115741705


