### PR TITLE
Thread PGO config through the unified planner (#4537)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 from torchrec.distributed.planner.protocols import PlannerExecutor
 from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
 from torchrec.distributed.planner.types import (
+    PlannerErrorType,
     PlannerSessionContext,
     ShardingPlanRequest,
     ShardingPlanResult,
@@ -215,6 +216,10 @@ class ShardingPlannerAPI(abc.ABC):
             success=False,
             sharding_plan=None,
             planner_failure_reason=f"{type(error).__name__}: {error}",
+            # Classify these isolated non-PlannerError failures as OTHER instead of
+            # leaving planner_error_type NULL, so the failure taxonomy panel counts
+            # them rather than dropping them.
+            planner_error_type=PlannerErrorType.OTHER,
             estimated_max_hbm_bytes=0,
             estimated_max_ddr_bytes=0,
             request_hash=ctx.request.request_hash,

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -78,6 +78,9 @@ _BYTES_PER_GB: int = 1024**3
 # Matches EmbeddingShardingPlanner's own heuristical default, so an unset
 # percentage reserves the same fraction the OSS planner would by default.
 _DEFAULT_RESERVATION_PERCENTAGE: float = 0.15
+# Mirrors HeuristicalStorageReservation's own default; used when the config leaves
+# parameter_multiplier unset so the reserved dense footprint is unchanged.
+_DEFAULT_PARAMETER_MULTIPLIER: float = 6.0
 
 # OSS proposer_type selectors -> factory (legacy simple selection path; the
 # richer proposer_config path is handled in _build_proposer).
@@ -209,6 +212,11 @@ class DefaultPlannerProvider(PlannerProvider):
         ):
             return HeuristicalStorageReservation(
                 percentage=percentage,
+                parameter_multiplier=(
+                    cfg.parameter_multiplier
+                    if cfg.parameter_multiplier is not None
+                    else _DEFAULT_PARAMETER_MULTIPLIER
+                ),
                 dense_tensor_estimate=cfg.dense_tensor_estimate,
             )
         if policy == StorageReservationPolicy.FIXED_PERCENTAGE:

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1995,6 +1995,46 @@ class ShardingPlanRequestTest(unittest.TestCase):
         self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
         self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
 
+    def test_request_hash_includes_parameter_multiplier(self) -> None:
+        """parameter_multiplier sizes the reserved dense HBM, so two requests that
+        differ only in it are different requests and must not share a hash."""
+        base = self._create_request().request_hash
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=8.0)
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=8.0)
+            ).request_hash,
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=4.0)
+            ).request_hash,
+        )
+
+    def test_parameter_multiplier_rejects_negative_and_non_finite(self) -> None:
+        for bad in (-1.0, float("nan"), float("inf")):
+            with self.assertRaisesRegex(ValueError, "parameter_multiplier"):
+                PlannerConfig(parameter_multiplier=bad)
+        # 0.0 is a legitimate "reserve no dense footprint" request.
+        self.assertEqual(
+            PlannerConfig(parameter_multiplier=0.0).parameter_multiplier, 0.0
+        )
+
+    def test_planner_config_positional_construction_is_stable(self) -> None:
+        """PlannerConfig is not kw_only, so new fields must be appended, never
+        inserted -- inserting silently rebinds existing positional arguments."""
+        cfg = PlannerConfig(
+            PlannerVariant.OSS,
+            StorageReservationPolicy.HEURISTICAL,
+            0.15,
+            "greedy",
+        )
+        self.assertEqual(cfg.proposer_type, "greedy")
+        self.assertIsNone(cfg.parameter_multiplier)
+
     def test_request_hash_includes_planner_config(self) -> None:
         # planner_config is plan-affecting, so it participates in the content hash.
         base = self._create_request().request_hash

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2830,6 +2830,14 @@ class PlannerSessionContext:
     # capture_search_space is set (SKU -> url); surfaced as search_space_url on the
     # planner_runs Scuba row. Empty when capture is off.
     search_space_urls: Dict[str, str] = field(default_factory=dict)
+    # Planner-input context hash per SKU (SKU -> hash as str), recorded by the
+    # Manifold sink that computes it. This is the key the Manifold plan cache is
+    # addressed by ({job_name}-planner_input_context_hash_{hash}/...), so persisting
+    # it is what lets a later run find a reusable plan. Distinct from
+    # request_hash: it is computed post reserve()+enumerate() and covers the
+    # resolved topology + enumerated search space, not just the request params.
+    # Empty when the sink could not compute it (missing enumerator/reservation).
+    input_context_hash: Dict[str, str] = field(default_factory=dict)
     # External trace / job identifier (the MAST job name) this planning session
     # corresponds to. Links the request/session to the launching job for
     # cross-system correlation. Populated by the caller/adapter (None off-MAST,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -10,6 +10,7 @@
 import abc
 import hashlib
 import logging
+import math
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -2173,6 +2174,13 @@ class PlannerConfig:
     # ignored by every other policy. (Appended last to preserve positional
     # construction of the pre-existing fields.)
     model_base_bytes: Optional[int] = None
+    # Dense-footprint multiplier for the Heuristical and SKU-aware reservations;
+    # None = the reservation's own default (6.0). Plan-affecting (it sizes the
+    # reserved dense HBM), so it is carried here to stay in request_hash -- a
+    # framework that overrides it (e.g. MVAI) must not silently fall back to 6.0.
+    # (Appended last, like model_base_bytes: this dataclass is not kw_only, so
+    # inserting mid-list would silently rebind existing positional arguments.)
+    parameter_multiplier: Optional[float] = None
 
     def request_hash_extension(self) -> Optional[Tuple[object, ...]]:
         """Return package-specific planner config data for the request hash."""
@@ -2204,6 +2212,19 @@ class PlannerConfig:
             raise ValueError(
                 "bwd_compute_multiplier must be non-negative, got "
                 f"{self.bwd_compute_multiplier}"
+            )
+        # Validated here rather than in the provider: the provider resolves this
+        # per-SKU, so a bad value would otherwise surface N times mid-sweep (or as
+        # a nonsensical reservation) instead of once at config construction. NaN is
+        # rejected explicitly -- every comparison against it is False, so a bare
+        # "< 0" check would let it through and silently poison the reserved HBM.
+        if self.parameter_multiplier is not None and (
+            not math.isfinite(self.parameter_multiplier)
+            or self.parameter_multiplier < 0
+        ):
+            raise ValueError(
+                "parameter_multiplier must be a finite non-negative number, got "
+                f"{self.parameter_multiplier}"
             )
 
 
@@ -2375,6 +2396,7 @@ class ShardingPlanRequest:
                     self.planner_config.planner_variant.value,
                     self.planner_config.storage_reservation_policy.value,
                     self.planner_config.storage_reservation_percentage,
+                    self.planner_config.parameter_multiplier,
                     self.planner_config.proposer_type,
                     self.planner_config.partitioner_type,
                     self.planner_config.use_hardware_based_compute,


### PR DESCRIPTION
Summary:

The unified planner path (create_sharding_plan / FbPlannerProvider) dropped
profile-guided-optimization (PGO) config: the neutral, hashable `LpPlannerConfig`
had no `pgo_config` field and the provider's `_lp_kwargs` did not forward one.
Trainer frameworks that use PGO today would therefore silently lose it when routed
through the unified path -- a plan-changing divergence, since PGO expands the
search space, populates the SM_PRESSURE_DELTA dimension, and composes the solver
objective with a shard-type-promotion stage.

Thread PGO through, mirroring the existing `emo_config` handling:
- Add an OSS-safe scalar `PgoConfig` (`optimizer_type`, `dense_param_bytes`,
  `pipeline_overlapped`) on the neutral `LpPlannerConfig`. It is frozen, so it
  participates in `request_hash` -- two requests differing only in PGO signals
  fingerprint differently (otherwise the plan cache would cross them).
- Add `_build_pgo_config` in the fb provider to rebuild the fb `PGOConfig` from the
  OSS projection (forward only set fields) and forward it in `_lp_kwargs` to
  `LinearProgrammingPlanner`.

`pgo_config` defaults to None, so non-PGO plans are functionally unaffected; adding
the field shifts `request_hash` once (a one-time plan-cache recompute), which is
low impact while unified routing is gated off by default.

Differential Revision: D115070611


