### PR TITLE
Apply the filtered build matrix to Validate Binaries

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -30,13 +30,57 @@ on:
         type: string
 
 jobs:
-  validate-binaries:
-    uses: pytorch/test-infra/.github/workflows/validate-domain-library.yml@main
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package_type: "wheel"
-      os: "linux"
+      package-type: wheel
+      os: linux
       channel: ${{ inputs.channel }}
-      repository: "meta-pytorch/torchrec"
-      smoke_test: "source ./.github/scripts/validate_binaries.sh"
-      with_cuda: enable
-      with_rocm: false
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: enable
+      with-rocm: false
+  filter-matrix:
+    needs: generate-matrix
+    runs-on: linux.24_04.4x
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+    - uses: actions/setup-python@v4
+    - name: Checkout torchrec repository
+      uses: actions/checkout@v4
+      with:
+        repository: meta-pytorch/torchrec
+        # filter.py is release-branch specific, so it must come from the ref
+        # being validated rather than from the default branch
+        ref: ${{ inputs.ref || github.ref }}
+    - name: Filter Generated Build Matrix
+      id: filter
+      env:
+        MAT: ${{ needs.generate-matrix.outputs.matrix }}
+      run: |
+        set -ex
+        MATRIX_BLOB="$(python .github/scripts/filter.py)"
+        echo "${MATRIX_BLOB}"
+        echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+  validate-binaries:
+    needs: filter-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.filter-matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    name: "linux-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: ${{ matrix.validation_runner }}
+      repository: meta-pytorch/torchrec
+      ref: ${{ inputs.ref || github.ref }}
+      job-name: "linux-${{ matrix.package_type }}-${{ matrix.python_version }}-${{ matrix.desired_cuda }}"
+      binary-matrix: ${{ toJSON(matrix) }}
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export SMOKE_TEST="source ./.github/scripts/validate_binaries.sh"
+        eval $SMOKE_TEST


### PR DESCRIPTION
Summary:
## 1. Context

`Validate Binaries` delegated to `pytorch/test-infra`'s `validate-domain-library.yml`, which generates its own build matrix. That matrix does not pass through `.github/scripts/filter.py`, so validation exercised combinations TorchRec never publishes wheels for, while `build-wheels-linux.yml` filters those same combinations out. The build matrix and the validation matrix had drifted apart, and the exclusions in `filter.py` (currently `cu132` and python 3.15, both pending FBGEMM support) only applied to one of them.

## 2. Approach

1. **Mirror the build workflow's shape**: `generate-matrix` -> `filter-matrix` -> fan-out, the same three-job structure `build-wheels-linux.yml` already uses, so a combination that is excluded from the build is excluded from validation by construction rather than by two lists kept in sync by hand.
2. **Run `filter.py` from the ref under validation**: the `filter-matrix` checkout pins `ref: ${{ inputs.ref || github.ref }}` rather than defaulting to the main branch. `filter.py` is release-branch specific, so validating a release branch has to use that branch's exclusions, not main's.
3. **Fan out per combination**: `validate-binaries` becomes a matrix job over the filtered set, invoking `linux_job_v2.yml` with `binary-matrix: ${{ toJSON(matrix) }}` so the harness exports the `MATRIX_*` variables `validate_binaries.sh` reads (`MATRIX_PYTHON_VERSION`, `MATRIX_GPU_ARCH_TYPE`, `MATRIX_GPU_ARCH_VERSION`, `MATRIX_CHANNEL`). The smoke test itself is unchanged.
4. **`fail-fast: false`**: one broken combination reports as a single red cell instead of cancelling the rest, which matters when the point of the run is to find out which combinations are broken.

## 3. Analysis

1. **Risk**: medium. No library code changes, but this rewrites a release-gating workflow, and GitHub Actions wiring cannot be exercised locally — the first real signal is a manual `workflow_dispatch`.
2. **Behavior change**: the validated set shrinks to the filtered matrix. That is the intent, but it means combinations previously reported on will silently stop being covered; `filter.py` is now the single place that decides coverage for both build and validation.
3. **Permissions on the scheduled path**: `validate-binaries` requests `id-token: write` at job level. `validate-nightly-binaries.yml` calls this workflow without granting any permissions, and a called workflow cannot escalate beyond what its caller was granted. The direct `workflow_dispatch` path is unaffected. See the Test Plan for what to watch.
4. **Container image**: `linux_job_v2.yml` is invoked without an explicit `docker-image`, so the run depends on its default carrying conda and the matching CUDA runtime; `validate_binaries.sh` is conda-based throughout.

## 4. Changes

1. **`.github/workflows/validate-binaries.yml`**: replaces the single `validate-domain-library.yml` delegation with `generate-matrix` (`generate_binary_build_matrix.yml`, channel-aware, CUDA enabled), `filter-matrix` (runs `filter.py` against the validated ref), and a per-combination `validate-binaries` matrix job on `linux_job_v2.yml` that sources the existing `validate_binaries.sh`.

Differential Revision: D115807397


