### PR TITLE
int4 (quint4x2) sparse output sample request correction (#4541)

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -914,6 +914,12 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(self._emb_modules)
         setattr(self, MODULE_ATTR_CACHE_FEATURES_ORDER, cache_features_order)
 
+    def _apply_maybe_quint4x2_to_int8(self, embedding: torch.Tensor) -> torch.Tensor:
+        # Overridable seam for the quint4x2 -> uint8 reinterpret. The base uses
+        # the portable int_repr()-based op; subclasses may swap in a zero-copy
+        # variant. Both keep the fx op name that downstream graph passes detect.
+        return _maybe_quint4x2_to_int8(embedding)
+
     def forward(
         self,
         features: KeyedJaggedTensor,
@@ -965,7 +971,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 if self.register_tbes
                 else emb_module.forward(indices=indices, offsets=offsets)
             )
-            lookup = _maybe_quint4x2_to_int8(lookup)
+            lookup = self._apply_maybe_quint4x2_to_int8(lookup)
             if getattr(self, MODULE_ATTR_USE_UNFLATTENED_LENGTHS_FOR_BATCHING, False):
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
                 lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)


### PR DESCRIPTION
Summary:

Reland of D110435026 (previously reverted), rebased onto fbcode/warm.


depends on D99737694, D82366293

Enables int4 (quint4x2) sparse-embedding output for the Blue Reels VDD standalone HSTU TGIF publish path, and fixes the serving warmup shape mismatch that int4 exposed.

Enabling int4:
- `MODEL_TGIF_PUBLISHER_CONFIG` now uses `predict_model_sparse_output_dtype="int4"`.
- `DenseQuantizationPass` no longer force-disables quint4x2 sparse output for non-distributed-inference models (the block that reset `sparse_output_dtype = None` for quint4x2 without `distributed_inference_config` is removed), so the on-device int4 dequant path is used.
- Adds a local int4 test config (`MODEL_TGIF_MULTI_PUBLISHER_CONFIG_IEN` / `TgifMultiPublishIENMixin` / `ToyTgifMultiPublishIENConfigProvider`) and updates the toy `train-publish` script for local int4 IEN publishes.

The warmup bug this exposed:
int4 models failed serving warmup on `merge.forward` with `mat1 and mat2 shapes cannot be multiplied (12x1152 and 640x512)`, even though real production traffic served correctly (the failure only reproduced against the TGIF-synthesized warmup sample, so `disable_incontainer_warmup=True` masked it).

Root cause: the on-device int4 dequant path halves the packed embedding width across the `remote_request_only` -> `merge` boundary. This halving is gated by `quint4x2_dequant_on_device_enabled`, derived from `fx_graph_contains_quint4x2_to_int8`, and two problems left it off so the merge warmup sample was captured (and shape-propagated) at the un-halved 2x width while the real model uses the halved width:

1. `fx_graph_contains_quint4x2_to_int8` matched the op via `"_quint4x2_to_int8" in str(node.target).split(".")`. The real op, `torchrec.modules.utils._maybe_quint4x2_to_int8`, is a plain `torch.fx.wrap` function, so its `call_function` node target is the function object whose `str()` is `<function ... at 0x..>` (no dots) and whose name is `_maybe_quint4x2_to_int8` (not `_quint4x2_to_int8`). The detector never matched real models and always returned False. Fixed to match by `target.__name__` for the function-object case and to use the correct `_maybe_quint4x2_to_int8` name for the dotted-segment (OpOverload/string) case.

2. `tgif/lib/utils.py::generate_submod_inputs_for_packing` captures the per-subnet warmup sample inputs (`merge.forward.sample_input.pt`) by running the split model under a bare `SplitDispatchMode()`, which defaults `quint4x2_dequant_on_device_enabled=False`, so the captured merge sample was 2x too wide. It now detects the on-device dequant op on the `remote_request_only` subnet and threads the flag. For consistency the flag is also threaded through the other `SplitDispatchMode` call sites used by `DenseQuantizationPass`: `tgif/fx/tgif_split.py::shape_prop_with_debug` and the new `dense_quantization_pass.py` helpers.

Also includes a zero-copy `_maybe_quint4x2_to_int8` variant for `QuantNoShardEmbeddingCollection`: `torchrec/quant/embedding_modules.py` exposes an overridable `_apply_maybe_quint4x2_to_int8` seam (default = OSS `int_repr()` copy), and `torchrec/fb/inference/noshard_ebc.py` overrides it with the zero-copy `torch.ops.gr.quantized_to_uint8_view` variant used on the TGIF serving path.

Backward compatible: the new kwarg is only passed when the detector is importable; older `light` bases that predate it fall back to the default `SplitDispatchMode()`.

Non-DI on-device path (the residual drift that reverted the original D110435026):
The revert of D110435026 was caused by the NON-DI on-device int4 path (e.g. cfr_cint / MI300X) where the sample-side and module-side decided the int4 merge-boundary width independently and disagreed when `distributed_inference_config` was absent -- SEVs S683543 (cfr_main_feed_mtml_roo_hstu CFR cogwheel, step online_train_publish_full_only, AOTI `512x2176 and 1088x512`) and S683708 (mvai_ifr_main serving warmup). This diff makes the width decision a single source of truth and forwards the already-halved sample on the non-DI path:
- Adds a shared predicate `quint4x2_dequant_on_device_enabled(model)` in `tgif/lib/utils.py`; both the module shape-prop (`dense_quantization_pass`) and the warmup-sample capture (`_build_submod_split_dispatch_mode`) derive from it, so the captured sample width can never diverge from the merge module width.
- `tgif/publish/simple_tgif_ien_executor.py` reuses the pre-halved `submod_to_inputs` for DI OR non-DI on-device int4 (previously DI-only). Otherwise the lowering worker regenerates the merge sample from the full `model_inputs` under a flag-less dispatch mode at 2x width.
- Defense-in-depth: `workspace_preparation.prepare_sample_input` builds its regeneration `SplitDispatchMode` from the same shared predicate instead of a bare `SplitDispatchMode()` (takes effect once ien.lower is re-cut; the executor change above is the trunk-side fix that unblocks the cogwheel).

Reviewed By: pklund, jcwchen

Differential Revision: D114774706


