### PR TITLE
Restore Pyrefly checks after checker upgrade (#4542)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -501,6 +501,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
                         )
                     )
             # To avoid hasattr in _wait_impl to check self._splits_awaitable
+            # pyrefly: ignore [bad-assignment]
             self._splits_awaitable = None
         else:
             with record_function("## all2all_data:kjt splits ##"):
@@ -511,6 +512,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
                 )
                 input_tensor = torch.stack(input_tensors, dim=1).flatten()
                 self._input_tensor = input_tensor
+                # pyrefly: ignore [bad-assignment]
                 self._splits_awaitable: dist.Work = dist.all_to_all_single(
                     output=self._output_tensor,
                     input=input_tensor,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1951,6 +1951,7 @@ class ShardedEmbeddingBagCollection(
         # register callback if there are features that need mean pooling
         if self._has_mean_pooling_callback:
             awaitable.callbacks.append(
+                # pyrefly: ignore [bad-argument-type]
                 partial(_apply_mean_pooling, divisor=ctx.divisor)
             )
 
@@ -2046,6 +2047,7 @@ class ShardedEmbeddingBagCollection(
         # register callback if there are features that need mean pooling
         if self._has_mean_pooling_callback:
             awaitable.callbacks.append(
+                # pyrefly: ignore [bad-argument-type]
                 partial(_apply_mean_pooling, divisor=ctx.divisor)
             )
 

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -1354,7 +1354,7 @@ class ShardedQuantManagedCollisionEmbeddingCollection(ShardedQuantEmbeddingColle
             ec_sharding_lookups = self._lookups[sharding]
             sharding_mcec_lookups: List[ShardedMCECLookup] = []
             for j, ec_lookup in enumerate(
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 ec_sharding_lookups._embedding_lookups_per_rank
             ):
                 sharding_mcec_lookups.append(
@@ -1403,7 +1403,7 @@ class ShardedQuantManagedCollisionEmbeddingCollection(ShardedQuantEmbeddingColle
             dist_input_i = dist_input[i]
             lookups = self._mcec_lookup[i]
             sharding_ret: List[torch.Tensor] = []
-            # pyrefly: ignore[bad-argument-type]
+            # pyrefly: ignore [bad-argument-type, not-iterable]
             for j, lookup in enumerate(lookups):
                 embedding_result, remapped_kjt = lookup(
                     features=dist_input_i[j],

--- a/torchrec/distributed/quant_embeddingbag.py
+++ b/torchrec/distributed/quant_embeddingbag.py
@@ -835,7 +835,7 @@ class ShardedQuantManagedCollisionEmbeddingBagCollection(
             ebc_sharding_lookups = self._lookups[sharding]
             sharding_mcebc_lookups: List[ShardedMCEBCLookup] = []
             for j, ec_lookup in enumerate(
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 ebc_sharding_lookups._embedding_lookups_per_rank
             ):
                 sharding_mcebc_lookups.append(
@@ -875,7 +875,7 @@ class ShardedQuantManagedCollisionEmbeddingBagCollection(
             dist_input_i = dist_input[i]
             lookups = self._mcebc_lookup[i]
             sharding_ret: List[torch.Tensor] = []
-            # pyrefly: ignore[bad-argument-type]
+            # pyrefly: ignore [bad-argument-type, not-iterable]
             for j, lookup in enumerate(lookups):
                 rank_ret = lookup(
                     features=dist_input_i[j],

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -188,7 +188,7 @@ class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
                     stride=info.param.stride(),
                 )
 
-            # pyrefly: ignore[bad-argument-type]
+            # pyrefly: ignore [bad-argument-type, not-iterable]
             for i, rank in enumerate(info.param_sharding.ranks):
                 # Remap rank by number of replica groups if 2D parallelism is enabled
                 rank = (

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -248,7 +248,7 @@ class BaseGridEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                 )
 
             # Expectation is planner CW shards across a node, so each CW shard will have local_size number of row shards
-            # pyrefly: ignore[bad-argument-type]
+            # pyrefly: ignore [bad-argument-type, not-iterable]
             for i, rank in enumerate(info.param_sharding.ranks):
                 rank = (
                     # pyrefly: ignore[missing-attribute]

--- a/torchrec/distributed/tests/test_quant_pruning.py
+++ b/torchrec/distributed/tests/test_quant_pruning.py
@@ -98,7 +98,7 @@ class QuantPruneTest(unittest.TestCase):
         for module in sharded_model.modules():
             if module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
                 #  `Union[Tensor, Module]`.
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 for i, spec in enumerate(module.embedding_specs):
                     if spec[0] in pruned_dict:
                         self.assertEqual(

--- a/torchrec/inference/tests/test_inference.py
+++ b/torchrec/inference/tests/test_inference.py
@@ -177,7 +177,7 @@ class InferenceTest(unittest.TestCase):
                             pruning_dict[config.name],
                         )
             elif module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 for i, spec in enumerate(module.embedding_specs):
                     if spec[0] in pruning_dict:
                         self.assertEqual(
@@ -222,7 +222,7 @@ class InferenceTest(unittest.TestCase):
         for module in quantized_model.modules():
             if module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
                 num_tbes += 1
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 for i, spec in enumerate(module.embedding_specs):
                     self.assertEqual(spec[3], SparseType.INT4)
 
@@ -297,7 +297,7 @@ class InferenceTest(unittest.TestCase):
 
         for module in quantized_model.modules():
             if module.__class__.__name__ == "IntNBitTableBatchedEmbeddingBagsCodegen":
-                # pyrefly: ignore[bad-argument-type]
+                # pyrefly: ignore [bad-argument-type, not-iterable]
                 for i, spec in enumerate(module.embedding_specs):
                     if spec[0] in expected_num_embeddings:
                         # We only expect the first table to be quantized to int4 due to test set up

--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -127,6 +127,7 @@ class CPUCommsRecMetricModule(RecMetricModule):
         cloned_metrics = []
         for metric in self.rec_metrics.rec_metrics:
             metric = cast(RecMetric, metric)
+            # pyrefly: ignore [bad-instantiation]
             cloned_metric = type(metric)(
                 world_size=metric._world_size,
                 my_rank=metric._my_rank,

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -344,8 +344,7 @@ class TransferTensorsToCpuTest(unittest.TestCase):
             torch.testing.assert_close(tensor, tensors[key])
 
     def test_non_tensor_values_preserved(self) -> None:
-        # pyre-ignore[6]
-        tensors: dict[str, torch.Tensor] = {
+        tensors: dict[str, torch.Tensor | str | int] = {
             "predictions": torch.tensor([1.0]),
             "name": "task1",
             "count": 42,

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -240,6 +240,7 @@ class RecMetricTest(unittest.TestCase):
 
     def test_invalid_window_size(self) -> None:
         with self.assertRaises(ValueError):
+            # pyrefly: ignore [bad-instantiation]
             RecMetric(
                 world_size=8,
                 my_rank=0,
@@ -293,6 +294,7 @@ class RecMetricTest(unittest.TestCase):
                 "prediction": torch.tensor(
                     [0.0, 1.0, 0.0, 1.0], device=torch.device("cuda:0")
                 ),
+                # pyrefly: ignore [bad-assignment]
                 "session_id": ["1", "1", "2", "2"],
             },
             required_inputs_list=["session_id"],

--- a/torchrec/quant/utils.py
+++ b/torchrec/quant/utils.py
@@ -48,7 +48,7 @@ def populate_fx_names(
             # pyrefly: ignore[bad-argument-type]
             emb_dist_module._fx_path = f"embedding_dist.{i}"
             #  `Union[Module, Tensor]`.
-            # pyrefly: ignore[bad-argument-type]
+            # pyrefly: ignore [bad-argument-type, not-iterable]
             for rank, rank_module in enumerate(emb_module._embedding_lookups_per_rank):
                 rank_fx_path = f"{embedding_fx_path}.rank_{rank}"
                 rank_module._fx_path = rank_fx_path


### PR DESCRIPTION
Summary:

# Context

`D113791492` upgraded the pinned Pyrefly binary and exposed stricter diagnostics across 24 TorchRec type-checking targets tracked by `T282796909`. The diagnostics cover existing PyTorch attribute inference, abstract-class test construction, and optional or dictionary narrowing patterns rather than runtime regressions.

# Mitigation

Regenerate suppressions only for the 24 affected targets with `arc pyre check --suppress`. Most edits extend existing ignores with the newly reported diagnostic category; the remaining ignores capture checker-only errors at runtime-validated call sites. This leaves current unrelated TorchRec failures out of scope and does not change runtime behavior.

Reviewed By: gregmacnamara

Differential Revision: D115802440


