### PR TITLE
Add tpu as a compute device to planner and DMP (#4543)

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -838,7 +838,7 @@ class ShardedEmbeddingBagCollection(
                     device_ids=(
                         [self._device]
                         if self._device is not None
-                        and (self._device.type in {"cuda", "mtia"})
+                        and (self._device.type in {"cuda", "mtia", "tpu"})
                         else None
                     ),
                     process_group=self._env.process_group,

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -115,6 +115,10 @@ def kernel_bw_lookup(
             "cuda",
             EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
         ): hbm_to_ddr_mem_bw,
+        # TODO: revisit update the values
+        ("tpu", EmbeddingComputeKernel.DENSE.value): 0.5 * hbm_mem_bw,
+        ("tpu", EmbeddingComputeKernel.FUSED.value): 1 * hbm_mem_bw,
+        ("tpu", EmbeddingComputeKernel.QUANT.value): 1 * hbm_mem_bw,
     }
 
     if (

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -111,7 +111,9 @@ class EmbeddingEnumerator(Enumerator):
             use_exact_enumerate_order if use_exact_enumerate_order else False
         )
         memory_type = (
-            "hbm_cap" if topology.compute_device in {"cuda", "mtia"} else "ddr_cap"
+            "hbm_cap"
+            if topology.compute_device in {"cuda", "mtia", "tpu"}
+            else "ddr_cap"
         )
         self._device_memory_sizes: Optional[
             List[int]

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -723,7 +723,7 @@ class KernelConfig(TopologyConfigBase):
     def validate(self) -> None:
         """Validate kernel configuration parameters."""
         # Match Topology class validation: compute_device must be valid
-        valid_devices = {"cuda", "mtia", "cpu"}
+        valid_devices = {"cuda", "mtia", "cpu", "tpu"}
         if self.compute_device not in valid_devices:
             raise ValueError(
                 f"compute_device must be one of {valid_devices}, got '{self.compute_device}'"
@@ -1021,6 +1021,7 @@ class Topology:
             "cpu",
             "cuda",
             "mtia",
+            "tpu",
         ], f"unsupported compute device {compute_device}"
         if pod_size and pod_size > world_size:
             raise ValueError(
@@ -1031,7 +1032,7 @@ class Topology:
         self._world_size = world_size
 
         hbm_per_device = [0] * world_size
-        if self._compute_device == "cuda" or self._compute_device == "mtia":
+        if self._compute_device in ["cuda", "mtia", "tpu"]:
             hbm_per_device = [hbm_cap if hbm_cap is not None else HBM_CAP] * world_size
         ddr_cap_per_rank = [ddr_cap if ddr_cap is not None else DDR_CAP] * world_size
         ssd_cap_per_rank = [ssd_cap if ssd_cap is not None else SSD_CAP] * world_size

--- a/torchrec/distributed/planner/utils.py
+++ b/torchrec/distributed/planner/utils.py
@@ -184,7 +184,7 @@ def placement(
     """
 
     param_device = compute_device
-    if compute_device in {"cuda", "mtia"}:
+    if compute_device in {"cuda", "mtia", "tpu"}:
         param_device = torch.device(compute_device, rank % local_size)
     return f"rank:{rank}/{param_device}"
 

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -57,6 +57,8 @@ def get_device_type() -> str:
         device_type = "cuda"
     elif torch.mtia.is_available():
         device_type = "mtia"
+    elif hasattr(torch, "tpu") and torch.tpu.is_available():
+        device_type = "tpu"
     else:
         device_type = "cpu"
     return device_type


### PR DESCRIPTION
Summary:

Context
---------

TorchRec decides accelerator behaviour from hardcoded device-type sets scattered across the planner, DMP, and the sharded EBC. A new backend isn't rejected by these; it just silently fall. through to the CPU branch, so the failures are late and misleading rather than a clean "unsupported device".

This diff effectively sets it up so that it accepts "tpu" alongside "cuda", "mtia".  This is the first diff where DistributedModelParallel runs end-to-end on TPU

Implementation
------------------

Adds "tpu" to the accelerator device sets:

* `planner/types.py`: allow in Topology and kernel-config
* `planner/enumerators.py` TPU memory as hbm_cap, not `ddr_cap`
* `planner/utils.py` build `ran:N/tpu:M` placement strings
* `planner/constants.py`: builds placeholder bandwidth entries for kernels so perf estimator doesn't return KeyError
* `embeddingbag.py` pass device_ids to DDP for TPU
*  `distributed/utils.py`: get_device_type returns tpu

Reviewed By: kausv

Differential Revision: D107305597


