### PR TITLE
Persist the Manifold plan-cache key (input_context_hash) on the XDB registry (#4547)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 from torchrec.distributed.planner.protocols import PlannerExecutor
 from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
 from torchrec.distributed.planner.types import (
+    PlannerErrorType,
     PlannerSessionContext,
     ShardingPlanRequest,
     ShardingPlanResult,
@@ -215,6 +216,10 @@ class ShardingPlannerAPI(abc.ABC):
             success=False,
             sharding_plan=None,
             planner_failure_reason=f"{type(error).__name__}: {error}",
+            # Classify these isolated non-PlannerError failures as OTHER instead of
+            # leaving planner_error_type NULL, so the failure taxonomy panel counts
+            # them rather than dropping them.
+            planner_error_type=PlannerErrorType.OTHER,
             estimated_max_hbm_bytes=0,
             estimated_max_ddr_bytes=0,
             request_hash=ctx.request.request_hash,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2830,6 +2830,14 @@ class PlannerSessionContext:
     # capture_search_space is set (SKU -> url); surfaced as search_space_url on the
     # planner_runs Scuba row. Empty when capture is off.
     search_space_urls: Dict[str, str] = field(default_factory=dict)
+    # Planner-input context hash per SKU (SKU -> hash as str), recorded by the
+    # Manifold sink that computes it. This is the key the Manifold plan cache is
+    # addressed by ({job_name}-planner_input_context_hash_{hash}/...), so persisting
+    # it is what lets a later run find a reusable plan. Distinct from
+    # request_hash: it is computed post reserve()+enumerate() and covers the
+    # resolved topology + enumerated search space, not just the request params.
+    # Empty when the sink could not compute it (missing enumerator/reservation).
+    input_context_hash: Dict[str, str] = field(default_factory=dict)
     # External trace / job identifier (the MAST job name) this planning session
     # corresponds to. Links the request/session to the launching job for
     # cross-system correlation. Populated by the caller/adapter (None off-MAST,


### PR DESCRIPTION
Summary:

The Manifold plan cache is addressed by `planner_input_context_hash` --
`{model_entity_id}/{job_name}-planner_input_context_hash_{hash}/v{ver}/attempt{n}`
-- but nothing durable recorded that key per SKU, so a later run had no way to
find a reusable plan. The registry stored `request_hash`, which is a *different*
hash: it covers the request params only, while the cache key is computed after
`reserve()` + `enumerate()` and folds in the resolved topology and the enumerated
search space. They are not interchangeable, so the reuse loop could not be closed
by joining on what it already had.

The value is only computable inside `ManifoldStats.log` (it needs the enumerator
and storage reservation, neither of which is on the session context), and it was
being discarded there after building the path. This threads it back:

- `PlannerSessionContext.input_context_hash: Dict[str, str]` -- per SKU, since
  topology is part of the hash and therefore differs across a TC_ANY sweep.
- `ManifoldStats` takes the session + its SKU and records the hash where it is
  already computed. Best-effort: a failure to record must never break the plan
  upload. The legacy path passes neither and is unchanged -- it still reaches the
  same hash through the XDB `planner_stats` row it writes.
- `planner_result` gains `input_context_hash` + `idx_input_context_hash` so the
  key is both stored and queryable (the existing `planner_stats` column is only
  reachable via `WHERE plan_id = %s`, which is backwards for reuse lookup).

Empty string when the sink could not compute the hash, so rows stay well-formed.

NOTE: needs the AOSC alter below applied to `xdb.planner_db` BEFORE this lands --
otherwise every result INSERT fails on the unknown column, the shared multi-table
transaction rolls back, and the whole registry silently writes nothing:

  ALTER TABLE planner_result
    ADD COLUMN input_context_hash VARCHAR(64) NOT NULL DEFAULT '',
    ADD KEY idx_input_context_hash (input_context_hash);

Differential Revision: D115918136


