### PR TITLE
Fix the AMD Triton TBE Kernel (#4548)

### DIFF
--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
@@ -261,7 +261,7 @@ def get_grid_size(
         return (
             min(_AMD_FIXED_GRID, max_num_runs),
             min(_AMD_FIXED_GRID, max_long_run_programs),
-            min(_AMD_FIXED_GRID, max_long_run_programs),
+            max_long_runs,
         )
 
     if use_clc:


### PR DESCRIPTION
Summary:

There are some issue with the current AMD triton TBE implementation. We will fix some bug for it.

Test Command
```
buck2 run mode/opt-amd-gpu -m rocm70 -c fbcode.nvcc_arch=mi350 -c fbcode.rocm_arch=mi350 -c fbcode.enable_gpu_sections=true -c fbcode.use_link_groups=true -c fbcode.triton_backend=amd -c sigrid.skip_tritoncc=true //deeplearning/fbgemm/fbgemm_gpu/fb/triton:triton_table_batched_embeddings_bench -- device --alpha=1.0 --batch-size=294912 --num-tables=66 --num-embeddings=13164873,13164873,1000,49537,13164873,13164873,13164873,13164873,61791,524757,7685380,51920,1000,13164873,500000,19327,72993,5000,13164873,132058,773,294,679,195677,13164873,80855,16992630,5000,189056,5000,8000000,102,113,600741,5000,29325,285698,1005371,50000,30726,607,308,591,621,727,648,390,449,678,708,726,581,137,100,100,728,328,724,429,570,192,5000,511788,2,2,2 --embedding-dim=128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,64,128,128,128,128,128,128,128,128,128,128,128,128,128,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,128,128,4,4,4 --bag-size=120,86,86,83,77,77,70,47,43,34,24,22,20,15,11,11,8,7,7,7,5,5,5,5,5,4,5,3,2,1,1,1,1,1,1,1,1,1,1,1,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,1,1,1,1,1 --iters=1 --warmup-runs=0 --optimizer=exact_row_wise_adagrad
```

Reviewed By: axeisghost, haoyan1023

Differential Revision: D115624428


