### PR TITLE
Add sharded relay reduce-scatter tests and benchmarks (#4550)

### DIFF
--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -120,6 +120,12 @@ class ShardedRelayState:
     # Grow-only flat buffer for the active group: dtype → tensor.
     # Packed before allreduce, unpacked after.
     _active_flat_cache: dict[torch.dtype, torch.Tensor] = field(default_factory=dict)
+    # Grow-only flat OUTPUT buffer for the active group (reduce-scatter
+    # out-of-place path): dtype → tensor. Holds recv_count elements; unused on
+    # the in-place path (where the output aliases the input's local block).
+    _active_output_flat_cache: dict[torch.dtype, torch.Tensor] = field(
+        default_factory=dict
+    )
     # Grow-only flat scratch buffer for helper groups: (group_idx, dtype) → tensor.
     # Each helper group has its own buffer (no aliasing) because phase-sync
     # processes all groups simultaneously.
@@ -452,7 +458,9 @@ def _get_helper_flat_buf(
     other across training steps.
 
     The buffer is sized to ``total``, which should be
-    _passthrough_helper_size(per_group_total_counts[g], ...).
+    _passthrough_helper_size(count_g, ...) for the count the kernel receives for
+    this group -- the group total for allreduce/reduce-scatter, the per-segment
+    count for all-to-all.
     """
     key = (group_idx, dtype)
     existing = state._helper_flat_cache.get(key)
@@ -463,30 +471,279 @@ def _get_helper_flat_buf(
 
 
 def _passthrough_helper_size(
-    total_g: int,
+    count_g: int,
     sparse_group_size: int,
     num_chunks: int,
 ) -> int:
     """Compute the passthrough helper buffer size for one group.
 
+    ``count_g`` is the per-group element count that the KERNEL receives for this
+    group, which is not always the caller's group total. Allreduce and
+    reduce-scatter hand the kernel their group total, so they pass that;
+    all-to-all hands it segmentCounts[g], so it passes the per-segment count. The
+    kernel derives its chunking from whichever count it was given, so the helper
+    size has to be derived from that same value -- passing a group total where the
+    kernel sees a segment count (or the reverse) mis-sizes the buffer.
+
+    ``num_chunks`` must equal the kernel's numHelpers + 1.
+
     Returns the allocation size (in elements) for the two-slot passthrough
     helper buffer:
 
-        min(total_g, sparse_group_size × chunk_aligned)
+        min(count_g, sparse_group_size × chunk_aligned)
 
-    where chunk_aligned = (total_g // num_chunks) rounded down to
-    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to total_g when
-    total_g < num_chunks × 128.
+    where chunk_aligned = (count_g // num_chunks) rounded down to
+    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to count_g when
+    count_g < num_chunks × 128.
 
     This is the canonical Python-side mirror of the C++ ``minRequired``
     formula in TorchCommRCCLX.cpp.
     """
     CHUNK_ALIGN_ELEMENTS = 128
-    chunk = total_g // num_chunks
+    chunk = count_g // num_chunks
     chunk_aligned = (chunk // CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS
     if chunk_aligned == 0:
-        chunk_aligned = total_g
-    return min(total_g, sparse_group_size * chunk_aligned)
+        chunk_aligned = count_g
+    return min(count_g, sparse_group_size * chunk_aligned)
+
+
+def _get_active_output_flat_buf(
+    state: ShardedRelayState,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat OUTPUT buffer for the active group.
+
+    Used by the reduce-scatter out-of-place path to receive the reduced
+    output block (recv_count elements). Separate from _active_flat_cache so
+    that the input (2 x recv_count) and output (recv_count) buffers do not
+    evict each other.
+    """
+    existing = state._active_output_flat_cache.get(dtype)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._active_output_flat_cache[dtype] = torch.empty(
+            total, dtype=dtype, device=device
+        )
+    buf = state._active_output_flat_cache[dtype]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _pack_into_flat(tensor_list: list[torch.Tensor], flat: torch.Tensor) -> None:
+    """Copy each tensor in ``tensor_list`` into successive slices of ``flat``.
+
+    Batched device-to-device pack: ``torch.cat(out=)`` writes all tensors into
+    the destination in a single fused kernel, replacing N individual copy_()
+    calls (N = number of embedding tables, ~101 for BM-FM). Each copy_() incurs
+    a separate kernel launch (~1-5us on AMD); fusing them eliminates ~100
+    launches per pack. Fills the first ``sum(numel)`` elements of ``flat``
+    (which the caller may size larger); tensors must be contiguous.
+    """
+    if not tensor_list:
+        return
+    total = sum(t.numel() for t in tensor_list)
+    dst = flat if flat.numel() == total else flat.narrow(0, 0, total)
+    torch.cat([t.flatten() for t in tensor_list], out=dst)
+
+
+def _unpack_from_flat(flat: torch.Tensor, tensor_list: list[torch.Tensor]) -> None:
+    """Scatter successive slices of ``flat`` back into each tensor.
+
+    Inverse of :func:`_pack_into_flat`. ``torch._foreach_copy_`` dispatches all
+    N copies as a single batched op; ``split()`` yields views (no allocation),
+    so this is still a pure HBM copy but with one launch instead of N.
+    """
+    if not tensor_list:
+        return
+    total = sum(t.numel() for t in tensor_list)
+    src = flat if flat.numel() == total else flat.narrow(0, 0, total)
+    slices = src.split([t.numel() for t in tensor_list])
+    torch._foreach_copy_(
+        tensor_list, [s.view(t.shape) for s, t in zip(slices, tensor_list)]
+    )
+
+
+def reduce_scatter_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    input_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+    op: dist.ReduceOp = dist.ReduceOp.SUM,
+    in_place: bool = False,
+) -> None:
+    """
+    Perform reduce-scatter using the fused sharded relay algorithm.
+
+    Reduce-scatter analogue of allreduce_tensors_with_sharded_relay. For each
+    dtype, the active group's input tensors are packed into a single flat send
+    buffer (holding nActiveRanks x recv_count elements: block[i] is the slice
+    destined for active index i), ONE fused call reduce-scatters all groups
+    simultaneously (phase-synchronized, no XGMI contention), and the reduced
+    output block (recv_count elements) is unpacked into the caller's output
+    tensors.
+
+    In-place vs out-of-place
+    ------------------------
+    ``in_place`` controls the internal flat output buffer for the active group:
+
+    - ``in_place=True``: the kernel writes the output into the input flat
+      buffer's local-contribution block (a view at ownBlockOffset). This
+      exercises the kernel's in-place path and avoids a separate output
+      allocation.
+    - ``in_place=False``: a separate grow-only flat output buffer is used,
+      exercising the kernel's out-of-place path.
+
+    Either way, results are unpacked into ``output_tensors_dict``. (Reduce-scatter
+    is inherently out-of-place at the tensor level since the input is
+    nActiveRanks x larger than the output; ``in_place`` only selects the internal
+    buffer strategy / kernel code path.)
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        input_tensors_dict: Send tensors grouped by dtype. The active group's
+            tensors for a dtype must total nActiveRanks x recv_count elements.
+        output_tensors_dict: Receive tensors grouped by dtype. The active
+            group's tensors for a dtype must total recv_count elements.
+        annotation: Profiling annotation string for record_function.
+        op: Reduction op (ReduceOp.SUM or ReduceOp.AVG).
+        in_place: Select the internal output-buffer strategy / kernel path.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    local_rank = state.local_rank
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    # This rank's index among its group's active ranks (0 or 1 for size-2).
+    my_active_index = local_rank % sparse_group_size
+
+    with record_function(f"{annotation}_fused_sharded_relay_reduce_scatter"):
+        for dtype, my_input_list in input_tensors_dict.items():
+            if not my_input_list:
+                continue
+
+            my_input_total = sum(t.numel() for t in my_input_list)
+            if my_input_total == 0:
+                continue
+
+            if my_input_total % sparse_group_size != 0:
+                raise ValueError(
+                    f"reduce_scatter_tensors_with_sharded_relay: active input total "
+                    f"({my_input_total}) for dtype {dtype} must be divisible by "
+                    f"sparse_group_size ({sparse_group_size})."
+                )
+            my_recv_count = my_input_total // sparse_group_size
+
+            my_output_list = output_tensors_dict.get(dtype, [])
+            my_output_total = sum(t.numel() for t in my_output_list)
+            if my_output_total != my_recv_count:
+                raise ValueError(
+                    f"reduce_scatter_tensors_with_sharded_relay: active output total "
+                    f"({my_output_total}) for dtype {dtype} must equal recv_count "
+                    f"({my_recv_count} = input_total/{sparse_group_size})."
+                )
+
+            device = my_input_list[0].device
+
+            # --- Step 1: Metadata (allgather recv counts once, cache forever) ---
+            meta_key = "rs_" + annotation + str(dtype)
+            per_group_recv_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_recv_tensor = torch.tensor(
+                        [my_recv_count], dtype=torch.int64, device=device
+                    )
+                    all_recv_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_recv_list,
+                        my_recv_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_recv_counts = [
+                        int(all_recv_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same recv count."
+                    )
+                    per_group_recv_counts = [my_recv_count] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_recv_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat reduce-scatter metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_recv_counts={per_group_recv_counts}"
+                )
+            else:
+                per_group_recv_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build per-group tensors ---
+            # Each group contributes ONE contiguous tensor. The active group's
+            # per-table inputs are packed into a single flat send buffer (the
+            # single-segment zero-copy fast path); helper groups pass a single
+            # passthrough scratch buffer. The reduced output block is unpacked
+            # into my_output_list after the call.
+            input_group_tensors: list[torch.Tensor] = []
+            output_group_tensors: list[torch.Tensor] = []
+
+            unpack_flat: torch.Tensor | None = None
+
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    in_flat = _get_active_flat_buf(state, my_input_total, dtype, device)
+                    _pack_into_flat(my_input_list, in_flat)
+                    input_group_tensors.append(in_flat)
+                    if in_place:
+                        # In-place: the output block is the owned-block view
+                        # inside the input flat (offset
+                        # my_active_index * recv_count), so
+                        # activeOutSegPtr == activeInSegPtr + ownBlockOffset.
+                        out_view = in_flat.narrow(
+                            0, my_active_index * my_recv_count, my_recv_count
+                        )
+                        output_group_tensors.append(out_view)
+                        unpack_flat = out_view
+                    else:
+                        out_flat = _get_active_output_flat_buf(
+                            state, my_recv_count, dtype, device
+                        )
+                        output_group_tensors.append(out_flat)
+                        unpack_flat = out_flat
+                else:
+                    recv_count_g = per_group_recv_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        recv_count_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    # Helper uses one two-slot scratch buffer for send and recv.
+                    input_group_tensors.append(helper_buf)
+                    output_group_tensors.append(helper_buf)
+
+            # --- Step 4: ONE fused call — all groups, phase-synchronized ---
+            state.fused.reduce_scatter_multi_group(
+                input_tensors=input_group_tensors,
+                output_tensors=output_group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=precomputed_active_ranks,
+                op=op,
+                skip_validation=True,
+            )
+
+            # --- Step 5: Unpack the active-group result into caller tensors ---
+            if unpack_flat is not None:
+                _unpack_from_flat(unpack_flat, my_output_list)
 
 
 def allreduce_tensors_with_sharded_relay(

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -362,6 +362,46 @@ def bench_kernel_direct(
 
 
 # ---------------------------------------------------------------------------
+# Benchmark D: fused reduce-scatter (sharded relay)
+# ---------------------------------------------------------------------------
+
+
+def bench_reduce_scatter_flat(
+    fused: Any,
+    input_flat: torch.Tensor,
+    output_flat: torch.Tensor,
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    helper_bufs: list[torch.Tensor],
+    per_group_recv_counts: list[int],
+) -> None:
+    """ONE fused reduce-scatter call across all sparse groups.
+
+    Each helper group passes its single passthrough scratch buffer.
+    """
+    input_group_tensors: list[torch.Tensor] = []
+    output_group_tensors: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            input_group_tensors.append(input_flat)
+            output_group_tensors.append(output_flat)
+        else:
+            input_group_tensors.append(helper_bufs[g])
+            output_group_tensors.append(helper_bufs[g])
+
+    fused.reduce_scatter_multi_group(
+        input_tensors=input_group_tensors,
+        output_tensors=output_group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_recv_counts=per_group_recv_counts,
+        all_active_ranks=all_active_ranks,
+        op=dist.ReduceOp.AVG,
+        skip_validation=True,
+    )
+
+
+# ---------------------------------------------------------------------------
 # NCCL baseline: 4 parallel 2-rank dist.all_reduce calls
 # ---------------------------------------------------------------------------
 
@@ -511,6 +551,28 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     if rank == 0:
         results_dict["A"] = (mean_serial, std_serial)
+
+    # NCCL reduce-scatter baseline on the same 2-rank sub-group PG.
+    # Free the allreduce tensors first to reclaim HBM. recv_count =
+    # prod_total // 2 so the input (2 x recv_count) matches the sharded-relay
+    # reduce-scatter benchmark's active footprint.
+    my_tensors = []
+    torch.cuda.empty_cache()
+    rs_recv = prod_totals[my_sparse_group] // 2
+    rs_in = torch.ones(2 * rs_recv, dtype=dtype, device=device)
+    rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
+
+    # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
+    def run_rs_baseline() -> None:
+        rs_in.fill_(1.0)
+        dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
+        rs_out.div_(sparse_group_size)
+
+    mean_rs_base, std_rs_base = _measure_ms(run_rs_baseline, warmup, bench_iters)
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_rs"] = (mean_rs_base, std_rs_base)
 
     dist.destroy_process_group()
 
@@ -724,6 +786,49 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     torch.cuda.synchronize()
     peak_hbm_bytes = torch.cuda.max_memory_allocated()
 
+    # -------------------------------------------------------------------------
+    # Benchmark D: fused reduce-scatter. Release the Bench C kernel tensors
+    # first to reclaim HBM — reduce-scatter's input buffer is 2x its output
+    # (two blocks), so the active footprint is larger than allreduce's.
+    # Reassign (instead of `del`) so the run_kernel closure stays valid.
+    # -------------------------------------------------------------------------
+    kernel_tensor = torch.empty(0, dtype=dtype, device=device)
+    kernel_scratch = []
+    torch.cuda.empty_cache()
+
+    # recv_count = prod_total // 2 so the input (2 x recv_count) matches the
+    # allreduce active footprint (one prod_total per group).
+    rs_recv_counts = [t // 2 for t in prod_totals]
+    my_rs_recv = rs_recv_counts[my_sparse_group]
+    rs_input = torch.ones(2 * my_rs_recv, dtype=dtype, device=device)
+    rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
+    rs_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            rs_helper_bufs.append(rs_output)  # unused for the active group
+        else:
+            rs_helper_size_g = _passthrough_helper_size(
+                rs_recv_counts[g], sparse_group_size, num_chunks
+            )
+            rs_helper_bufs.append(
+                torch.empty(rs_helper_size_g, dtype=dtype, device=device)
+            )
+
+    def run_reduce_scatter() -> None:
+        rs_input.fill_(1.0)
+        bench_reduce_scatter_flat(
+            fused=fused,
+            input_flat=rs_input,
+            output_flat=rs_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=rs_helper_bufs,
+            per_group_recv_counts=rs_recv_counts,
+        )
+
+    mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
+
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
         kernel_bytes = kernel_elements * dtype.itemsize
@@ -733,9 +838,25 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
         bench_a_mean = float(results_dict["A"][0]) if "A" in results_dict else 0.0
         bench_a_std = float(results_dict["A"][1]) if "A" in results_dict else 0.0
+        bench_a_rs_mean = (
+            float(results_dict["A_rs"][0]) if "A_rs" in results_dict else 0.0
+        )
+        bench_a_rs_std = (
+            float(results_dict["A_rs"][1]) if "A_rs" in results_dict else 0.0
+        )
+
+        rs_output_bytes = my_rs_recv * dtype.itemsize
+
+        def rs_bw(nbytes: int, ms: float) -> float:
+            # Reduce-scatter busBW factor for n active ranks is (n-1)/n.
+            return (
+                (sparse_group_size - 1) / sparse_group_size * nbytes / (ms / 1000) / 1e9
+                if ms > 0
+                else 0.0
+            )
 
         print("\n" + "=" * 72)
-        print(f"Sharded Relay Allreduce Benchmark — MI350X ({world_size} GPUs)")
+        print(f"Sharded Relay Benchmark — MI350X ({world_size} GPUs)")
         print("=" * 72)
         print(f"  dtype:          {dtype}")
         print(f"  num_tables:     {num_tables}")
@@ -744,23 +865,26 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             f"({table_size * dtype.itemsize / 1024 / 1024:.1f} MB)"
         )
         print(f"  total data/grp: {total_bytes / 1024 / 1024:.1f} MB")
+
+        # ----- ALLREDUCE -----
         print()
+        print("-" * 72)
+        print("ALLREDUCE")
+        print("-" * 72)
         if bench_a_mean > 0:
-            print(f"  [A] COALESCED ({num_tables} tensors, allreduce_coalesced):")
+            print(f"  [A] NCCL COALESCED (baseline, {num_tables} tensors):")
             print(
                 f"       {bench_a_mean:.2f} ms  ±  {bench_a_std:.2f} ms  |  "
                 f"{bw(total_bytes, bench_a_mean):.1f} GB/s"
             )
         else:
-            print("  [A] COALESCED: N/A")
-        print()
-        print("  [B] FUSED FLAT (1 call, passthrough helpers, phase-sync kernel):")
+            print("  [A] NCCL COALESCED (baseline): N/A")
+        print("  [B] SHARDED RELAY (1 fused call, passthrough helpers):")
         print(
             f"       {mean_fused:.2f} ms  ±  {std_fused:.2f} ms  |  "
             f"{bw(total_bytes, mean_fused):.1f} GB/s"
         )
         print(f"       Peak HBM: {peak_hbm_bytes / 1024 / 1024 / 1024:.2f} GiB")
-        print()
         print(
             f"  [C] KERNEL DIRECT (1 large tensor, {kernel_bytes / 1024 / 1024:.0f} MB):"
         )
@@ -768,10 +892,43 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             f"       {mean_kernel:.2f} ms  ±  {std_kernel:.2f} ms  |  "
             f"{bw(kernel_bytes, mean_kernel):.1f} GB/s"
         )
+        if bench_a_mean > 0 and mean_fused > 0:
+            speedup_ar = bench_a_mean / mean_fused
+            print(
+                f"  >> Allreduce speedup (NCCL coalesced → sharded relay): "
+                f"{speedup_ar:.2f}x"
+            )
+
+        # ----- REDUCE-SCATTER -----
         print()
-        if bench_a_mean > 0:
-            speedup_ab = bench_a_mean / mean_fused if mean_fused > 0 else float("inf")
-            print(f"  A→B speedup (coalesced → fused flat):  {speedup_ab:.2f}x")
+        print("-" * 72)
+        print("REDUCE-SCATTER")
+        print("-" * 72)
+        if bench_a_rs_mean > 0:
+            print(
+                f"  [A] NCCL reduce_scatter_tensor (baseline, "
+                f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+            )
+            print(
+                f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
+                f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
+            )
+        else:
+            print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+        )
+        print(
+            f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
+            f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
+        )
+        if bench_a_rs_mean > 0 and mean_rs > 0:
+            speedup_rs = bench_a_rs_mean / mean_rs
+            print(
+                f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
+                f"{speedup_rs:.2f}x"
+            )
         print("=" * 72)
 
     dist.barrier()

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -41,8 +41,15 @@ BM-FM production numbers (from aps-bm_fm_amd_srinathb_20260420_200640-ea51247ebd
       [479_250_475, 553_440_942, 634_386_550, 560_128_334]
       ≈ 1.8–2.4 GiB per group (fp32)
 
-The production per-group totals above are the defaults.  Run with no extra flags:
+The production per-group totals above are capped to a 1 GiB-per-group default so
+the benchmark fits alongside other work on a shared GPU host and in CI.  Run with
+no extra flags:
     buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+        //torchrec/distributed/tests:bench_sharded_relay_perf
+
+Production scale (uncapped, needs an otherwise-idle host):
+    BENCH_TABLE_SIZE=12002982488 BENCH_KERNEL_SIZE_GB=22.4 \\
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
         //torchrec/distributed/tests:bench_sharded_relay_perf
 
 Optimizer-sync scale (fp32):
@@ -57,8 +64,8 @@ Small-scale smoke run (101 tables × 1M elements ≈ 100M per group):
 Environment variables (all optional):
     BENCH_DTYPE          bf16|fp16|fp32   (default: fp16)
     BENCH_NUM_TABLES     int              (default: 1)
-    BENCH_TABLE_SIZE     int              (default: production total for active group)
-    BENCH_KERNEL_SIZE_GB float            (default: production total for active group)
+    BENCH_TABLE_SIZE     int              (default: capped production total, <=1 GiB/group)
+    BENCH_KERNEL_SIZE_GB float            (default: capped production total, <=1 GiB/group)
     BENCH_WARMUP_ITERS   int              (default: 5)
     BENCH_BENCH_ITERS    int              (default: 20)
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
@@ -135,6 +142,18 @@ _PROD_TOTALS_FP32: list[int] = [
     634_386_550,  # group 2
     560_128_334,  # group 3
 ]
+
+# The production totals above are ~22 GiB per group, which needs ~69 GiB per rank
+# once helper and scratch buffers are included and OOMs whenever the host is
+# shared (or in CI). Cap the per-group default and use BENCH_TABLE_SIZE /
+# BENCH_KERNEL_SIZE_GB to measure at production scale on an idle host.
+_DEFAULT_MAX_BYTES_PER_GROUP: int = 1024**3  # 1 GiB
+
+
+def _default_totals(dtype: torch.dtype) -> list[int]:
+    totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    cap = _DEFAULT_MAX_BYTES_PER_GROUP // dtype.itemsize
+    return [min(total, cap) for total in totals]
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +456,7 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
         for g in range(num_sparse_groups)
     ]
 
-    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    prod_totals = _default_totals(dtype)
 
     num_tables = _env_int("BENCH_NUM_TABLES", 1)
     table_sizes_all = [
@@ -550,7 +569,7 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     ]
 
     # Production per-group totals: groups have heterogeneous sizes matching BM-FM.
-    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    prod_totals = _default_totals(dtype)
 
     # Tensors for Benchmark B.
     # Default: one flat tensor per group at the production total for this rank's

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -40,9 +40,11 @@ import torch
 import torch.distributed as dist
 from torchrec.distributed.sharded_relay_utils import (
     _get_active_flat_buf,
+    _get_active_output_flat_buf,
     _get_helper_flat_buf,
     _passthrough_helper_size,
     allreduce_tensors_with_sharded_relay,
+    reduce_scatter_tensors_with_sharded_relay,
     ShardedRelayState,
 )
 
@@ -704,17 +706,19 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
 
     def test_passthrough_size_matches_2x_chunkSize_for_realistic_totals(self) -> None:
         """BM-FM fp16: ~12B elements per group, 8 ranks, 2 active → numChunks=7."""
-        total_g = 12_002_982_488
-        sparse_group_size = 2
-        num_chunks = 7  # (8 - 2) + 1
-        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
-        chunk = total_g // num_chunks
-        chunk_aligned = (chunk // 128) * 128
-        expected = sparse_group_size * chunk_aligned
-        self.assertEqual(result, expected)
-        # Sanity: result should be ~2/7 of total, much less than total
-        self.assertLess(result, total_g)
-        self.assertGreater(result, 0)
+        # Worked out by hand from the contract rather than re-derived with the
+        # implementation's own expression -- recomputing
+        # sparse_group_size * align_down(total_g // num_chunks, 128) here would
+        # move both sides of the assertion together and could never fail:
+        #
+        #   12_002_982_488 // 7 = 1_714_711_784   (remainder 0)
+        #   align_down(.., 128) = 1_714_711_680   (trims 104 elements)
+        #   2 * 1_714_711_680   = 3_429_423_360   (< total_g, so no clamp)
+        result = _passthrough_helper_size(12_002_982_488, 2, 7)
+        self.assertEqual(result, 3_429_423_360)
+        # Each of the 2 slots is a whole number of 128-element chunks, which is
+        # the property the alignment exists for.
+        self.assertEqual(result % (2 * 128), 0)
 
     def test_passthrough_size_falls_back_to_total_for_tiny_counts(self) -> None:
         """When total_g < num_chunks * CACHE_LINE_SIZE, chunkSize falls back to total_g."""
@@ -737,16 +741,10 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
 
     def test_python_meets_cpp_min_required_at_alignment_boundary(self) -> None:
         """At exact alignment boundaries, Python and C++ formulas agree."""
-        # total_g = 7 * 128 * k for some k → exact alignment, no remainder
-        total_g = 7 * 128 * 1000  # 896_000
-        sparse_group_size = 2
-        num_chunks = 7
-        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
-        chunk = total_g // num_chunks  # 128_000
-        chunk_aligned = (chunk // 128) * 128  # 128_000
-        expected = min(total_g, sparse_group_size * chunk_aligned)
-        self.assertEqual(result, expected)
-        self.assertEqual(result, 256_000)
+        # total_g = 7 * 128 * 1000 = 896_000 divides evenly by num_chunks * 128,
+        # so nothing is lost to alignment: 896_000 // 7 = 128_000, which is
+        # already 128-aligned, and 2 * 128_000 = 256_000 stays under total_g.
+        self.assertEqual(_passthrough_helper_size(7 * 128 * 1000, 2, 7), 256_000)
 
     def test_total_per_rank_helper_memory_is_6x_chunkSize(self) -> None:
         """
@@ -759,12 +757,380 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
         helper_per_group = _passthrough_helper_size(
             total_g, sparse_group_size, num_chunks
         )
-        chunk = total_g // num_chunks
-        chunk_aligned = (chunk // 128) * 128
-        self.assertEqual(helper_per_group, sparse_group_size * chunk_aligned)
-        # 3 helper groups per rank
-        total_helper = 3 * helper_per_group
-        self.assertEqual(total_helper, 6 * chunk_aligned)
+        # Literals rather than a re-derivation of the implementation's own
+        # expression, which would make these assertions unfalsifiable:
+        # align_down(12_002_982_488 // 7, 128) = 1_714_711_680, and the helper
+        # buffer holds 2 of those chunks.
+        self.assertEqual(helper_per_group, 3_429_423_360)
+        # 3 helper groups per rank, so 3 x 2 = 6 aligned chunks in total:
+        # 6 * 1_714_711_680.
+        self.assertEqual(3 * helper_per_group, 10_288_270_080)
+
+
+# ---------------------------------------------------------------------------
+# Tests for reduce_scatter_tensors_with_sharded_relay (flat-concat approach)
+# ---------------------------------------------------------------------------
+
+
+class FlatReduceScatterTest(unittest.TestCase):
+    """Tests for the reduce-scatter flat-concat helper.
+
+    The active group's input is packed into ONE contiguous flat buffer holding
+    nActiveRanks x recv_count elements (two blocks for sparse_group_size=2);
+    the output holds recv_count elements.  fused.reduce_scatter_multi_group is
+    a MagicMock that records every call (one tensor per group).
+    """
+
+    def _call_count(self, state: ShardedRelayState) -> int:
+        return state.fused.reduce_scatter_multi_group.call_count
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.reduce_scatter_multi_group.call_args_list
+
+    def test_returns_immediately_when_no_tensors(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(state, {}, {}, "test")
+        self.assertEqual(self._call_count(state), 0)
+
+    def test_single_call_recv_count_is_half_input_total(self) -> None:
+        state = _make_state(rank=0)
+        # input total 200 -> recv_count 100 (sparse_group_size=2)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["per_group_recv_counts"][state.my_sparse_group], 100)
+
+    def test_single_call_per_dtype(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {
+                torch.float16: [torch.zeros(40, dtype=torch.float16)],
+                torch.float32: [torch.zeros(40, dtype=torch.float32)],
+            },
+            {
+                torch.float16: [torch.zeros(20, dtype=torch.float16)],
+                torch.float32: [torch.zeros(20, dtype=torch.float32)],
+            },
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 2)
+
+    def test_active_input_and_output_buffer_sizes(self) -> None:
+        state = _make_state(rank=0)
+        in_sizes = [100, 200, 300]  # total 600 -> recv 300
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(s) for s in in_sizes]},
+            {torch.float32: [torch.zeros(300)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertEqual(kwargs["per_group_recv_counts"][my_g], 300)
+        # Active group's inputs are packed into ONE contiguous flat buffer.
+        self.assertEqual(kwargs["input_tensors"][my_g].numel(), 600)
+        self.assertEqual(kwargs["output_tensors"][my_g].numel(), 300)
+
+    def test_raises_when_input_total_not_divisible_by_group_size(self) -> None:
+        state = _make_state(rank=0)  # sparse_group_size=2
+        with self.assertRaises(ValueError):
+            reduce_scatter_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(101)]},  # odd
+                {torch.float32: [torch.zeros(50)]},
+                "test",
+            )
+
+    def test_raises_when_output_total_mismatches_recv_count(self) -> None:
+        state = _make_state(rank=0)
+        with self.assertRaises(ValueError):
+            reduce_scatter_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(200)]},  # recv 100
+                {torch.float32: [torch.zeros(90)]},  # wrong
+                "test",
+            )
+
+    def test_helper_buffers_passthrough_sized_and_distinct(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},  # recv 200
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        recv = kwargs["per_group_recv_counts"]
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            expected = _passthrough_helper_size(
+                recv[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(in_tensors[g].numel(), expected)
+            # Helper uses one scratch buffer for both send and recv.
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_output_is_separate_flat_buffer(self) -> None:
+        # Flat-concat scheme: the active group's output is a separate internal
+        # flat buffer (one contiguous tensor per group), distinct from the
+        # caller's output tensor; results are unpacked into the caller tensor
+        # after the call.
+        state = _make_state(rank=1)
+        out_tensor = torch.zeros(100)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},  # recv 100
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        out_seg = kwargs["output_tensors"][my_g]
+        self.assertEqual(out_seg.numel(), 100)
+        self.assertNotEqual(out_seg.data_ptr(), out_tensor.data_ptr())
+
+    def test_out_of_place_output_distinct_from_input(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+            in_place=False,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertNotEqual(
+            kwargs["input_tensors"][my_g].data_ptr(),
+            kwargs["output_tensors"][my_g].data_ptr(),
+        )
+
+    def test_in_place_output_aliases_input_owned_block(self) -> None:
+        # In-place: the active output is an owned-block view into the active
+        # input flat buffer at offset my_active_index * recv_count (the inverse
+        # of the out-of-place distinct-pointer assertion above).
+        state = _make_state(rank=1)  # my_active_index = 1 within group 0
+        recv_count = 100
+        inp = torch.zeros(2 * recv_count)  # nActiveRanks x recv_count
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [inp]},
+            {torch.float32: [torch.zeros(recv_count)]},
+            "test",
+            in_place=True,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_flat = kwargs["input_tensors"][my_g]
+        out_seg = kwargs["output_tensors"][my_g]
+        self.assertEqual(in_flat.numel(), 2 * recv_count)
+        self.assertEqual(out_seg.numel(), recv_count)
+        self.assertEqual(
+            out_seg.data_ptr(),
+            in_flat.data_ptr() + recv_count * in_flat.element_size(),
+        )
+
+    def test_values_written_back_to_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        out_tensor = torch.zeros(100)
+        sentinel = 7.0
+
+        def _fill(*args, **kwargs) -> None:
+            outs = kwargs["output_tensors"]
+            outs[state.my_sparse_group].fill_(sentinel)
+
+        state.fused.reduce_scatter_multi_group.side_effect = _fill
+
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        self.assertTrue(torch.all(out_tensor == sentinel))
+
+    def test_unpack_handles_multiple_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        o0 = torch.zeros(40)
+        o1 = torch.zeros(60)  # total output 100 -> input 200
+        fill_values = [1.0, 2.0]
+
+        def _fill_by_slice(*args, **kwargs) -> None:
+            # Flat-concat scheme: fill successive slices of the output flat buf.
+            flat = kwargs["output_tensors"][state.my_sparse_group]
+            flat[:40].fill_(fill_values[0])
+            flat[40:100].fill_(fill_values[1])
+
+        state.fused.reduce_scatter_multi_group.side_effect = _fill_by_slice
+
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [o0, o1]},
+            "test",
+        )
+        self.assertTrue(torch.all(o0 == fill_values[0]))
+        self.assertTrue(torch.all(o1 == fill_values[1]))
+
+    @patch("torchrec.distributed.sharded_relay_utils.dist")
+    def test_metadata_cache_skips_allgather_after_first_call(
+        self, mock_dist: MagicMock
+    ) -> None:
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for t in tensor_list:
+                t.fill_(100)  # recv_count 100 for all ranks
+
+        mock_dist.all_gather.side_effect = _allgather_side_effect
+        mock_dist.ReduceOp = dist.ReduceOp
+
+        ins = {torch.float32: [torch.zeros(200)]}
+        outs = {torch.float32: [torch.zeros(100)]}
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "other")
+        self.assertEqual(mock_dist.all_gather.call_count, 2)
+
+    def test_active_output_flat_buf_reused_across_steps(self) -> None:
+        """Out-of-place output flat buffer must be reused (grow-only)."""
+        state = _make_state(rank=0)
+        b1 = _get_active_output_flat_buf(state, 100, torch.float32, _DEVICE)
+        b2 = _get_active_output_flat_buf(state, 100, torch.float32, _DEVICE)
+        self.assertEqual(b1.data_ptr(), b2.data_ptr())
+
+
+# ---------------------------------------------------------------------------
+# Tests for FusedShardedRelayMultiGroup.reduce_scatter_multi_group validation
+# ---------------------------------------------------------------------------
+
+
+class FusedReduceScatterValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        # rcclx_comm=None -> _use_native=False; validation still runs.
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_raises_on_active_input_too_small(self) -> None:
+        """Active input must hold nActiveRanks x recv_count elements."""
+        fused = self._make_fused(rank=0)  # active for group 0
+        # recv_count 100 -> input must be 200; pass 150.
+        input_tensors = [
+            torch.zeros(150),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(100),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+                skip_validation=False,
+            )
+        self.assertIn("200", str(cm.exception))
+
+    def test_raises_on_active_output_too_small(self) -> None:
+        fused = self._make_fused(rank=0)
+        input_tensors = [
+            torch.zeros(200),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(90),  # need 100
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+                skip_validation=False,
+            )
+        self.assertIn("100", str(cm.exception))
+
+    def test_recv_count_zero_skips_validation(self) -> None:
+        """recv_count=0 group carries a placeholder and must skip validation."""
+        fused = self._make_fused(rank=0)
+        # Group 0 (this rank's active group) ran out -> recv_count=0, placeholder.
+        input_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [0, 5, 5, 5]
+
+        # Must NOT raise ValueError. RuntimeError (no native API) is expected.
+        with self.assertRaises(RuntimeError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

Add tests and a benchmark path for the sharded relay reduce-scatter
distributed utilities, mirroring the allreduce tests (D103262938):
- FlatReduceScatterTest: CPU/mock unit tests for
  reduce_scatter_tensors_with_sharded_relay covering call counts,
  recv_count = input_total / nActiveRanks, active input/output buffer sizing,
  divisibility and output-mismatch errors, passthrough-sized + distinct helper
  buffers, in-place output aliasing the input's local block at ownBlockOffset,
  out-of-place distinct output, value write-back, multi-tensor unpack, and
  metadata-cache reuse.
- FusedReduceScatterValidationTest: validation for
  FusedShardedRelayMultiGroup.reduce_scatter_multi_group (active input/output
  too-small raise ValueError; recv_count=0 groups skip validation).
- bench_reduce_scatter_flat + a [D] REDUCE-SCATTER timed path in the perf
  benchmark worker. It releases the Bench C kernel tensors first and uses
  recv_count = prod_total/2 so the input (2 x recv_count, two blocks) matches
  the allreduce active footprint and stays within GPU memory.

Reviewed By: JinghanHuang

Differential Revision: D115998394


