### PR TITLE
Make external-dependency failures visible instead of silent (#4553)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 from torchrec.distributed.planner.protocols import PlannerExecutor
 from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
 from torchrec.distributed.planner.types import (
+    PlannerErrorType,
     PlannerSessionContext,
     ShardingPlanRequest,
     ShardingPlanResult,
@@ -215,6 +216,10 @@ class ShardingPlannerAPI(abc.ABC):
             success=False,
             sharding_plan=None,
             planner_failure_reason=f"{type(error).__name__}: {error}",
+            # Classify these isolated non-PlannerError failures as OTHER instead of
+            # leaving planner_error_type NULL, so the failure taxonomy panel counts
+            # them rather than dropping them.
+            planner_error_type=PlannerErrorType.OTHER,
             estimated_max_hbm_bytes=0,
             estimated_max_ddr_bytes=0,
             request_hash=ctx.request.request_hash,

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -78,6 +78,9 @@ _BYTES_PER_GB: int = 1024**3
 # Matches EmbeddingShardingPlanner's own heuristical default, so an unset
 # percentage reserves the same fraction the OSS planner would by default.
 _DEFAULT_RESERVATION_PERCENTAGE: float = 0.15
+# Mirrors HeuristicalStorageReservation's own default; used when the config leaves
+# parameter_multiplier unset so the reserved dense footprint is unchanged.
+_DEFAULT_PARAMETER_MULTIPLIER: float = 6.0
 
 # OSS proposer_type selectors -> factory (legacy simple selection path; the
 # richer proposer_config path is handled in _build_proposer).
@@ -209,6 +212,11 @@ class DefaultPlannerProvider(PlannerProvider):
         ):
             return HeuristicalStorageReservation(
                 percentage=percentage,
+                parameter_multiplier=(
+                    cfg.parameter_multiplier
+                    if cfg.parameter_multiplier is not None
+                    else _DEFAULT_PARAMETER_MULTIPLIER
+                ),
                 dense_tensor_estimate=cfg.dense_tensor_estimate,
             )
         if policy == StorageReservationPolicy.FIXED_PERCENTAGE:

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -1995,6 +1995,46 @@ class ShardingPlanRequestTest(unittest.TestCase):
         self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
         self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
 
+    def test_request_hash_includes_parameter_multiplier(self) -> None:
+        """parameter_multiplier sizes the reserved dense HBM, so two requests that
+        differ only in it are different requests and must not share a hash."""
+        base = self._create_request().request_hash
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=8.0)
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=8.0)
+            ).request_hash,
+            self._create_request(
+                planner_config=PlannerConfig(parameter_multiplier=4.0)
+            ).request_hash,
+        )
+
+    def test_parameter_multiplier_rejects_negative_and_non_finite(self) -> None:
+        for bad in (-1.0, float("nan"), float("inf")):
+            with self.assertRaisesRegex(ValueError, "parameter_multiplier"):
+                PlannerConfig(parameter_multiplier=bad)
+        # 0.0 is a legitimate "reserve no dense footprint" request.
+        self.assertEqual(
+            PlannerConfig(parameter_multiplier=0.0).parameter_multiplier, 0.0
+        )
+
+    def test_planner_config_positional_construction_is_stable(self) -> None:
+        """PlannerConfig is not kw_only, so new fields must be appended, never
+        inserted -- inserting silently rebinds existing positional arguments."""
+        cfg = PlannerConfig(
+            PlannerVariant.OSS,
+            StorageReservationPolicy.HEURISTICAL,
+            0.15,
+            "greedy",
+        )
+        self.assertEqual(cfg.proposer_type, "greedy")
+        self.assertIsNone(cfg.parameter_multiplier)
+
     def test_request_hash_includes_planner_config(self) -> None:
         # planner_config is plan-affecting, so it participates in the content hash.
         base = self._create_request().request_hash

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2830,6 +2830,14 @@ class PlannerSessionContext:
     # capture_search_space is set (SKU -> url); surfaced as search_space_url on the
     # planner_runs Scuba row. Empty when capture is off.
     search_space_urls: Dict[str, str] = field(default_factory=dict)
+    # Planner-input context hash per SKU (SKU -> hash as str), recorded by the
+    # Manifold sink that computes it. This is the key the Manifold plan cache is
+    # addressed by ({job_name}-planner_input_context_hash_{hash}/...), so persisting
+    # it is what lets a later run find a reusable plan. Distinct from
+    # request_hash: it is computed post reserve()+enumerate() and covers the
+    # resolved topology + enumerated search space, not just the request params.
+    # Empty when the sink could not compute it (missing enumerator/reservation).
+    input_context_hash: Dict[str, str] = field(default_factory=dict)
     # External trace / job identifier (the MAST job name) this planning session
     # corresponds to. Links the request/session to the launching job for
     # cross-system correlation. Populated by the caller/adapter (None off-MAST,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2766,6 +2766,13 @@ class ModelArch:
     sharders: Tuple[SharderArch, ...] = ()
 
 
+# Marker prefix on session warnings that record an external-dependency failure
+# (see PlannerSessionContext.record_external_failure). Kept as a constant so
+# consumers can separate "a dependency was down" from the ordinary planning
+# diagnostics that share the warnings list.
+_EXTERNAL_FAILURE_PREFIX = "external_failure"
+
+
 @dataclass
 class PlannerSessionContext:
     """Mutable context accumulating state during a planner session.
@@ -2822,8 +2829,11 @@ class PlannerSessionContext:
     # Caller-provided session metadata (e.g. training_framework, model_type,
     # entitlement). Populated by the caller/adapter at context construction.
     client_metadata: Dict[str, str] = field(default_factory=dict)
-    # Whether each SKU's result came from cache — per SKU (SKU -> hit). Scaffolding:
-    # empty until a plan-level cache exists (see ``cached_plans``).
+    # Whether each SKU's result came from cache — per SKU (SKU -> hit). Set by the
+    # planner when it consults its plan cache; left unset when that path did not
+    # run, so "did not attempt" stays distinct from a miss. Note this tracks the
+    # planner's own cache, not the request-keyed ``cached_plans`` scaffolding below,
+    # which is still unused.
     cache_hit: Dict[str, bool] = field(default_factory=dict)
     # Source of resolved hardware-capability data per SKU (SKU -> source label).
     # Populated by the provider's build_topology: OSS records "request_caps"; fb
@@ -2893,6 +2903,29 @@ class PlannerSessionContext:
     # Empty when persistence is disabled or upload failed; observability only, so
     # the caller/CLI can surface where the run's artifacts live.
     content_urls: Dict[str, str] = field(default_factory=dict)
+
+    def record_external_failure(
+        self, system: str, operation: str, exc: BaseException
+    ) -> None:
+        """Note that a best-effort call to an external system failed.
+
+        Blob upload and run persistence must never fail a plan, so those call
+        sites swallow their exceptions. Swallowing silently makes an outage
+        indistinguishable from "there was nothing to do" -- the artifact URL is
+        simply absent either way. Recording it here puts the failure on the
+        session warnings, where the reporter surfaces it, so a dependency being
+        down is a queryable fact rather than a log line.
+
+        Observability only, and itself best-effort: never raises, so a failure to
+        record a failure cannot escalate into a planning failure.
+        """
+        try:
+            self.warnings.append(
+                f"{_EXTERNAL_FAILURE_PREFIX} {system}:{operation}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+        except Exception:
+            pass
 
 
 # ---- Types Utils ---- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -10,6 +10,7 @@
 import abc
 import hashlib
 import logging
+import math
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -2173,6 +2174,13 @@ class PlannerConfig:
     # ignored by every other policy. (Appended last to preserve positional
     # construction of the pre-existing fields.)
     model_base_bytes: Optional[int] = None
+    # Dense-footprint multiplier for the Heuristical and SKU-aware reservations;
+    # None = the reservation's own default (6.0). Plan-affecting (it sizes the
+    # reserved dense HBM), so it is carried here to stay in request_hash -- a
+    # framework that overrides it (e.g. MVAI) must not silently fall back to 6.0.
+    # (Appended last, like model_base_bytes: this dataclass is not kw_only, so
+    # inserting mid-list would silently rebind existing positional arguments.)
+    parameter_multiplier: Optional[float] = None
 
     def request_hash_extension(self) -> Optional[Tuple[object, ...]]:
         """Return package-specific planner config data for the request hash."""
@@ -2204,6 +2212,19 @@ class PlannerConfig:
             raise ValueError(
                 "bwd_compute_multiplier must be non-negative, got "
                 f"{self.bwd_compute_multiplier}"
+            )
+        # Validated here rather than in the provider: the provider resolves this
+        # per-SKU, so a bad value would otherwise surface N times mid-sweep (or as
+        # a nonsensical reservation) instead of once at config construction. NaN is
+        # rejected explicitly -- every comparison against it is False, so a bare
+        # "< 0" check would let it through and silently poison the reserved HBM.
+        if self.parameter_multiplier is not None and (
+            not math.isfinite(self.parameter_multiplier)
+            or self.parameter_multiplier < 0
+        ):
+            raise ValueError(
+                "parameter_multiplier must be a finite non-negative number, got "
+                f"{self.parameter_multiplier}"
             )
 
 
@@ -2375,6 +2396,7 @@ class ShardingPlanRequest:
                     self.planner_config.planner_variant.value,
                     self.planner_config.storage_reservation_policy.value,
                     self.planner_config.storage_reservation_percentage,
+                    self.planner_config.parameter_multiplier,
                     self.planner_config.proposer_type,
                     self.planner_config.partitioner_type,
                     self.planner_config.use_hardware_based_compute,


### PR DESCRIPTION
Summary:

Every external call the planner makes is best-effort: Manifold blob upload, the
XDB reproduction registry, the Manifold plan-cache read, and the MAST runtime
environment all swallow their exceptions so that a dependency being down can
never fail a plan. That part is right and does not change here.

The problem is that swallowing them silently makes an outage indistinguishable
from there being nothing to do. A blob that failed to upload and a blob that was
never needed both leave the URL empty. A cache read that failed and a genuine
cache miss both return None. An entitlement that could not be resolved and a run
that is legitimately off-MAST both yield None. In every case the only trace is a
log line, so from the dashboard a broken sink and a quiet one read identically --
you cannot tell a healthy system from a silently failing one.

`PlannerSessionContext.warnings` already existed for exactly this class of
session-scoped diagnostic, was already populated (dropped SKUs), and was never
emitted to any sink. So:

- `PlannerSessionContext.record_external_failure(system, operation, exc)` notes a
  failure on the session under an `external_failure` prefix, so a query can
  separate "a dependency was down" from ordinary planning diagnostics. It is
  itself best-effort and cannot raise -- failing to record a failure must not
  escalate into a planning failure.
- `planner_runs_logger` emits `ctx.warnings` as the `session_warnings`
  normvector, on every row of the session (these facts have no single SKU to
  attach to). Absent entirely on a clean run, so presence is the signal.
- Wired at the two sites that hold both the context and the exception: the XDB
  registry transaction (which rolls back as a unit, so an outage drops every row
  for the session) and the Manifold content-blob uploads (per blob kind).
- The runtime-environment resolvers now log when the pybind *throws*, which is
  not the same as running off-MAST and returning cleanly. Both still yield None,
  but only one is a problem, and a silent None makes the MVAI cohort coverage
  hole unmeasurable.
- The LP plan-cache read logs a failed read distinctly from a miss. Both still
  fall back to a fresh solve, but they mean opposite things, and collapsing them
  makes a Manifold outage read as "plan reuse is not working". Documented the
  contract on both Manifold read paths: the cache read is fail-open by design,
  ManifoldPlanner's explicit load re-raises because there the plan IS the
  requested output rather than an optimization.

No behaviour changes: every path still fails open, and no call site gained a way
to raise. `jk_check` already logged with exc_info and needed nothing.

Chose the session context over a shared helper module because a helper in
`adapter.py` would have closed a cycle (registry -> adapter -> api -> registry),
and the data being mutated lives on the context anyway. `session_warnings` needs
no schema migration -- Scuba infers columns on first write.

Reviewed By: Frederick-Zhu

Differential Revision: D116050403


