### PR TITLE
Suppress Pyrefly constexpr false-positives in triton_permute_2d

### DIFF
--- a/torchrec/sparse/triton_permute_2d.py
+++ b/torchrec/sparse/triton_permute_2d.py
@@ -221,7 +221,9 @@ def triton_permute_2d_sparse_data(
             permute,
             B,
             n_seg,
+            # pyrefly: ignore[bad-argument-type]
             HAS_W=has_w,
+            # pyrefly: ignore[bad-argument-type]
             BLOCK=block,
         )
     else:
@@ -240,7 +242,9 @@ def triton_permute_2d_sparse_data(
             torch.searchsorted(out_off, ends, right=True) - 1,
             B,
             n_out,
+            # pyrefly: ignore[bad-argument-type]
             HAS_W=has_w,
+            # pyrefly: ignore[bad-argument-type]
             BLOCK=block,
         )
 


### PR DESCRIPTION
Summary:
https://www.internalfb.com/monitoring/oncall_operator?board=1631883755168032&workItem=1210133724614425

---

The `fbcode//torchrec/sparse:jagged_tensor-type-checking` target started failing
after D115082056 added `torchrec/sparse/triton_permute_2d.py`. Pyrefly reports
four `bad-argument-type` errors on the two `triton.jit` kernel launches:

  triton_permute_2d.py:224 Argument `bool` is not assignable to parameter `HAS_W` with type `constexpr`
  triton_permute_2d.py:225 Argument `int` is not assignable to parameter `BLOCK` with type `constexpr`
  triton_permute_2d.py:243 Argument `bool` is not assignable to parameter `HAS_W` with type `constexpr`
  triton_permute_2d.py:244 Argument `int` is not assignable to parameter `BLOCK` with type `constexpr`

These are the acknowledged Triton `tl.constexpr` false positives: the Triton stub
promotion D115081437 (`[triton][stable] Promote 3.8.0+fb`, upstream Triton PR #10048)
gave `JITFunction.__call__` a `ParamSpec` bound to the wrapped kernel signature, so
the standard idiom of passing a plain `bool`/`int` into a `tl.constexpr` parameter is
now flagged. A mechanical suppression sweep remediated the rest of the fleet, but
`triton_permute_2d.py` landed just after that sweep and was never covered.

Apply the same per-argument `# pyrefly: ignore[bad-argument-type]` suppression already
used throughout the sibling file `torchrec/sparse/jagged_tensor.py` (e.g. lines 1226,
1237, 2359). No behavior change — `constexpr`-ness is a Triton JIT concept the type
checker cannot model.

Differential Revision: D116013061


