### PR TITLE
Add A=4 single-group sharded-relay tests + fix perf-bench A=4 reduce-scatter helper sizing (#4573)

### DIFF
--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -976,11 +976,10 @@ def all_to_all_tensors_with_sharded_relay(
 
     All-to-all analogue of reduce_scatter_tensors_with_sharded_relay. For each
     dtype, the active group's input tensors are packed into a single flat send
-    buffer (holding nActiveRanks x segment_count elements:
-    input = [sendSeg[0]|sendSeg[1]]), ONE fused call all-to-alls all groups
-    simultaneously (phase-synchronized, no XGMI contention), and the transposed
-    output (output = [recvSeg[0]|recvSeg[1]]) is unpacked into the caller's
-    output tensors.
+    buffer holding nActiveRanks x segment_count elements, ONE fused call
+    all-to-alls all groups simultaneously (phase-synchronized, no XGMI
+    contention), and the transposed output is unpacked into the caller's output
+    tensors.
 
     All-to-all performs NO reduction (no op) and is OUT-OF-PLACE ONLY: a separate
     flat output buffer is always used (distinct from the input flat buffer), as
@@ -1103,10 +1102,10 @@ def all_to_all_tensors_with_sharded_relay(
                     # numHelpers + 1.
                     seg_g = per_group_segment_counts[g]
                     if sparse_group_size > 2:
-                        # Flat A>2 all-to-all is PURE-DIRECT (no helper relay),
-                        # so a helper rank does no work for this group. A tiny
-                        # placeholder satisfies the per-group tensor-list slot.
-                        helper_size_g = 1
+                        # The routed A=4 XOR path needs 3 * relayCount elements,
+                        # which is bounded by one segment. Direct routes leave
+                        # this production-sized helper buffer unused.
+                        helper_size_g = seg_g
                     else:
                         helper_size_g = _passthrough_helper_size(
                             seg_g, sparse_group_size, num_chunks
@@ -1114,7 +1113,7 @@ def all_to_all_tensors_with_sharded_relay(
                     helper_buf = _get_helper_flat_buf(
                         state, g, helper_size_g, dtype, device
                     )
-                    # Helper uses one two-slot scratch buffer for send and recv.
+                    # Helper uses one route-sized scratch buffer for send and recv.
                     input_group_tensors.append(helper_buf)
                     output_group_tensors.append(helper_buf)
 

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -761,6 +761,7 @@ def allreduce_tensors_with_sharded_relay(
     tensors_dict: dict[torch.dtype, list[torch.Tensor]],
     annotation: str,
     op: dist.ReduceOp | dist.ReduceOp.RedOpType = dist.ReduceOp.AVG,
+    output_tensors_dict: dict[torch.dtype, list[torch.Tensor]] | None = None,
 ) -> None:
     """
     Perform allreduce using the fused sharded relay algorithm.
@@ -797,6 +798,14 @@ def allreduce_tensors_with_sharded_relay(
         op: Reduction op to apply. Only ``ReduceOp.AVG`` and ``ReduceOp.SUM``
             are supported by the underlying RCCLX kernel; other values will
             be rejected by the backend.
+        output_tensors_dict: Optional destination tensors, grouped by dtype
+            and parallel to ``tensors_dict``. When ``None`` (default) the
+            allreduce is in-place — results are written back into
+            ``tensors_dict``. When provided, the active group's reduced result
+            is written out-of-place into these tensors while the inputs are
+            preserved; per dtype, ``output_tensors_dict[dtype]`` must mirror
+            ``tensors_dict[dtype]`` in per-tensor shapes and total element
+            count.
     """
     sparse_group_size = state.sparse_group_size
     my_sparse_group = state.my_sparse_group
@@ -862,11 +871,18 @@ def allreduce_tensors_with_sharded_relay(
             group_tensors: list[torch.Tensor] = []
             group_sizes: list[int] = []
 
-            # Compute num_chunks for passthrough helper size (mirrors C++).
-            num_chunks = (local_size - sparse_group_size) + 1
+            # Out-of-place: build a parallel per-group output list. The active
+            # group's output points at a separate flat destination buffer;
+            # helper groups reuse their passthrough scratch (unused by the
+            # kernel, but keeps the per-group list shape consistent). Left empty
+            # on the in-place path, where the call below passes None instead.
+            output_group_tensors: list[torch.Tensor] = []
 
             unpack_flat: torch.Tensor | None = None
             unpack_dst: list[torch.Tensor] | None = None
+
+            # Compute num_chunks for passthrough helper size (mirrors C++).
+            num_chunks = (local_size - sparse_group_size) + 1
 
             for g in range(num_sparse_groups):
                 if g == my_sparse_group:
@@ -874,9 +890,17 @@ def allreduce_tensors_with_sharded_relay(
                     _pack_into_flat(my_tensor_list, in_flat)
                     group_tensors.append(in_flat)
                     group_sizes.append(my_total)
-                    # In-place: the kernel writes back into in_flat.
-                    unpack_flat = in_flat
-                    unpack_dst = my_tensor_list
+                    if output_tensors_dict is not None:
+                        out_flat = _get_active_output_flat_buf(
+                            state, my_total, dtype, device
+                        )
+                        output_group_tensors.append(out_flat)
+                        unpack_flat = out_flat
+                        unpack_dst = output_tensors_dict[dtype]
+                    else:
+                        # In-place: the kernel writes back into in_flat.
+                        unpack_flat = in_flat
+                        unpack_dst = my_tensor_list
                 else:
                     total_g = per_group_total_counts[g]
                     if sparse_group_size > 2:
@@ -893,9 +917,10 @@ def allreduce_tensors_with_sharded_relay(
                     )
                     group_tensors.append(helper_buf)
                     group_sizes.append(total_g)  # full count goes to the kernel
+                    if output_tensors_dict is not None:
+                        output_group_tensors.append(helper_buf)
 
             # --- Step 4: ONE fused call — all groups, all data, phase-synchronized ---
-            # In-place: results are written directly into my_tensor_list.
             state.fused.allreduce_multi_group(
                 tensors=group_tensors,
                 num_groups=num_sparse_groups,
@@ -903,6 +928,9 @@ def allreduce_tensors_with_sharded_relay(
                 all_active_ranks=precomputed_active_ranks,
                 op=op,
                 skip_validation=True,
+                output_tensors=(
+                    output_group_tensors if output_tensors_dict is not None else None
+                ),
             )
 
             # --- Step 5: Unpack the active-group result into caller tensors ---

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -1229,9 +1229,12 @@ def all_gather_tensors_with_sharded_relay(
                     unpack_flat = out_flat
                 else:
                     send_g = per_group_send_counts[g]
-                    helper_size_g = _passthrough_helper_size(
-                        send_g, sparse_group_size, num_chunks
-                    )
+                    if sparse_group_size > 2:
+                        helper_size_g = sparse_group_size * send_g
+                    else:
+                        helper_size_g = _passthrough_helper_size(
+                            send_g, sparse_group_size, num_chunks
+                        )
                     helper_buf = _get_helper_flat_buf(
                         state, g, helper_size_g, dtype, device
                     )

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -120,6 +120,12 @@ class ShardedRelayState:
     # Grow-only flat buffer for the active group: dtype → tensor.
     # Packed before allreduce, unpacked after.
     _active_flat_cache: dict[torch.dtype, torch.Tensor] = field(default_factory=dict)
+    # Grow-only flat OUTPUT buffer for the active group (reduce-scatter
+    # out-of-place path): dtype → tensor. Holds recv_count elements; unused on
+    # the in-place path (where the output aliases the input's local block).
+    _active_output_flat_cache: dict[torch.dtype, torch.Tensor] = field(
+        default_factory=dict
+    )
     # Grow-only flat scratch buffer for helper groups: (group_idx, dtype) → tensor.
     # Each helper group has its own buffer (no aliasing) because phase-sync
     # processes all groups simultaneously.
@@ -452,7 +458,9 @@ def _get_helper_flat_buf(
     other across training steps.
 
     The buffer is sized to ``total``, which should be
-    _passthrough_helper_size(per_group_total_counts[g], ...).
+    _passthrough_helper_size(count_g, ...) for the count the kernel receives for
+    this group -- the group total for allreduce/reduce-scatter, the per-segment
+    count for all-to-all.
     """
     key = (group_idx, dtype)
     existing = state._helper_flat_cache.get(key)
@@ -463,30 +471,279 @@ def _get_helper_flat_buf(
 
 
 def _passthrough_helper_size(
-    total_g: int,
+    count_g: int,
     sparse_group_size: int,
     num_chunks: int,
 ) -> int:
     """Compute the passthrough helper buffer size for one group.
 
+    ``count_g`` is the per-group element count that the KERNEL receives for this
+    group, which is not always the caller's group total. Allreduce and
+    reduce-scatter hand the kernel their group total, so they pass that;
+    all-to-all hands it segmentCounts[g], so it passes the per-segment count. The
+    kernel derives its chunking from whichever count it was given, so the helper
+    size has to be derived from that same value -- passing a group total where the
+    kernel sees a segment count (or the reverse) mis-sizes the buffer.
+
+    ``num_chunks`` must equal the kernel's numHelpers + 1.
+
     Returns the allocation size (in elements) for the two-slot passthrough
     helper buffer:
 
-        min(total_g, sparse_group_size × chunk_aligned)
+        min(count_g, sparse_group_size × chunk_aligned)
 
-    where chunk_aligned = (total_g // num_chunks) rounded down to
-    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to total_g when
-    total_g < num_chunks × 128.
+    where chunk_aligned = (count_g // num_chunks) rounded down to
+    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to count_g when
+    count_g < num_chunks × 128.
 
     This is the canonical Python-side mirror of the C++ ``minRequired``
     formula in TorchCommRCCLX.cpp.
     """
     CHUNK_ALIGN_ELEMENTS = 128
-    chunk = total_g // num_chunks
+    chunk = count_g // num_chunks
     chunk_aligned = (chunk // CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS
     if chunk_aligned == 0:
-        chunk_aligned = total_g
-    return min(total_g, sparse_group_size * chunk_aligned)
+        chunk_aligned = count_g
+    return min(count_g, sparse_group_size * chunk_aligned)
+
+
+def _get_active_output_flat_buf(
+    state: ShardedRelayState,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat OUTPUT buffer for the active group.
+
+    Used by the reduce-scatter out-of-place path to receive the reduced
+    output block (recv_count elements). Separate from _active_flat_cache so
+    that the input (2 x recv_count) and output (recv_count) buffers do not
+    evict each other.
+    """
+    existing = state._active_output_flat_cache.get(dtype)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._active_output_flat_cache[dtype] = torch.empty(
+            total, dtype=dtype, device=device
+        )
+    buf = state._active_output_flat_cache[dtype]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _pack_into_flat(tensor_list: list[torch.Tensor], flat: torch.Tensor) -> None:
+    """Copy each tensor in ``tensor_list`` into successive slices of ``flat``.
+
+    Batched device-to-device pack: ``torch.cat(out=)`` writes all tensors into
+    the destination in a single fused kernel, replacing N individual copy_()
+    calls (N = number of embedding tables, ~101 for BM-FM). Each copy_() incurs
+    a separate kernel launch (~1-5us on AMD); fusing them eliminates ~100
+    launches per pack. Fills the first ``sum(numel)`` elements of ``flat``
+    (which the caller may size larger); tensors must be contiguous.
+    """
+    if not tensor_list:
+        return
+    total = sum(t.numel() for t in tensor_list)
+    dst = flat if flat.numel() == total else flat.narrow(0, 0, total)
+    torch.cat([t.flatten() for t in tensor_list], out=dst)
+
+
+def _unpack_from_flat(flat: torch.Tensor, tensor_list: list[torch.Tensor]) -> None:
+    """Scatter successive slices of ``flat`` back into each tensor.
+
+    Inverse of :func:`_pack_into_flat`. ``torch._foreach_copy_`` dispatches all
+    N copies as a single batched op; ``split()`` yields views (no allocation),
+    so this is still a pure HBM copy but with one launch instead of N.
+    """
+    if not tensor_list:
+        return
+    total = sum(t.numel() for t in tensor_list)
+    src = flat if flat.numel() == total else flat.narrow(0, 0, total)
+    slices = src.split([t.numel() for t in tensor_list])
+    torch._foreach_copy_(
+        tensor_list, [s.view(t.shape) for s, t in zip(slices, tensor_list)]
+    )
+
+
+def reduce_scatter_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    input_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+    op: dist.ReduceOp = dist.ReduceOp.SUM,
+    in_place: bool = False,
+) -> None:
+    """
+    Perform reduce-scatter using the fused sharded relay algorithm.
+
+    Reduce-scatter analogue of allreduce_tensors_with_sharded_relay. For each
+    dtype, the active group's input tensors are packed into a single flat send
+    buffer (holding nActiveRanks x recv_count elements: block[i] is the slice
+    destined for active index i), ONE fused call reduce-scatters all groups
+    simultaneously (phase-synchronized, no XGMI contention), and the reduced
+    output block (recv_count elements) is unpacked into the caller's output
+    tensors.
+
+    In-place vs out-of-place
+    ------------------------
+    ``in_place`` controls the internal flat output buffer for the active group:
+
+    - ``in_place=True``: the kernel writes the output into the input flat
+      buffer's local-contribution block (a view at ownBlockOffset). This
+      exercises the kernel's in-place path and avoids a separate output
+      allocation.
+    - ``in_place=False``: a separate grow-only flat output buffer is used,
+      exercising the kernel's out-of-place path.
+
+    Either way, results are unpacked into ``output_tensors_dict``. (Reduce-scatter
+    is inherently out-of-place at the tensor level since the input is
+    nActiveRanks x larger than the output; ``in_place`` only selects the internal
+    buffer strategy / kernel code path.)
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        input_tensors_dict: Send tensors grouped by dtype. The active group's
+            tensors for a dtype must total nActiveRanks x recv_count elements.
+        output_tensors_dict: Receive tensors grouped by dtype. The active
+            group's tensors for a dtype must total recv_count elements.
+        annotation: Profiling annotation string for record_function.
+        op: Reduction op (ReduceOp.SUM or ReduceOp.AVG).
+        in_place: Select the internal output-buffer strategy / kernel path.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    local_rank = state.local_rank
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    # This rank's index among its group's active ranks (0 or 1 for size-2).
+    my_active_index = local_rank % sparse_group_size
+
+    with record_function(f"{annotation}_fused_sharded_relay_reduce_scatter"):
+        for dtype, my_input_list in input_tensors_dict.items():
+            if not my_input_list:
+                continue
+
+            my_input_total = sum(t.numel() for t in my_input_list)
+            if my_input_total == 0:
+                continue
+
+            if my_input_total % sparse_group_size != 0:
+                raise ValueError(
+                    f"reduce_scatter_tensors_with_sharded_relay: active input total "
+                    f"({my_input_total}) for dtype {dtype} must be divisible by "
+                    f"sparse_group_size ({sparse_group_size})."
+                )
+            my_recv_count = my_input_total // sparse_group_size
+
+            my_output_list = output_tensors_dict.get(dtype, [])
+            my_output_total = sum(t.numel() for t in my_output_list)
+            if my_output_total != my_recv_count:
+                raise ValueError(
+                    f"reduce_scatter_tensors_with_sharded_relay: active output total "
+                    f"({my_output_total}) for dtype {dtype} must equal recv_count "
+                    f"({my_recv_count} = input_total/{sparse_group_size})."
+                )
+
+            device = my_input_list[0].device
+
+            # --- Step 1: Metadata (allgather recv counts once, cache forever) ---
+            meta_key = "rs_" + annotation + str(dtype)
+            per_group_recv_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_recv_tensor = torch.tensor(
+                        [my_recv_count], dtype=torch.int64, device=device
+                    )
+                    all_recv_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_recv_list,
+                        my_recv_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_recv_counts = [
+                        int(all_recv_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same recv count."
+                    )
+                    per_group_recv_counts = [my_recv_count] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_recv_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat reduce-scatter metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_recv_counts={per_group_recv_counts}"
+                )
+            else:
+                per_group_recv_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build per-group tensors ---
+            # Each group contributes ONE contiguous tensor. The active group's
+            # per-table inputs are packed into a single flat send buffer (the
+            # single-segment zero-copy fast path); helper groups pass a single
+            # passthrough scratch buffer. The reduced output block is unpacked
+            # into my_output_list after the call.
+            input_group_tensors: list[torch.Tensor] = []
+            output_group_tensors: list[torch.Tensor] = []
+
+            unpack_flat: torch.Tensor | None = None
+
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    in_flat = _get_active_flat_buf(state, my_input_total, dtype, device)
+                    _pack_into_flat(my_input_list, in_flat)
+                    input_group_tensors.append(in_flat)
+                    if in_place:
+                        # In-place: the output block is the owned-block view
+                        # inside the input flat (offset
+                        # my_active_index * recv_count), so
+                        # activeOutSegPtr == activeInSegPtr + ownBlockOffset.
+                        out_view = in_flat.narrow(
+                            0, my_active_index * my_recv_count, my_recv_count
+                        )
+                        output_group_tensors.append(out_view)
+                        unpack_flat = out_view
+                    else:
+                        out_flat = _get_active_output_flat_buf(
+                            state, my_recv_count, dtype, device
+                        )
+                        output_group_tensors.append(out_flat)
+                        unpack_flat = out_flat
+                else:
+                    recv_count_g = per_group_recv_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        recv_count_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    # Helper uses one two-slot scratch buffer for send and recv.
+                    input_group_tensors.append(helper_buf)
+                    output_group_tensors.append(helper_buf)
+
+            # --- Step 4: ONE fused call — all groups, phase-synchronized ---
+            state.fused.reduce_scatter_multi_group(
+                input_tensors=input_group_tensors,
+                output_tensors=output_group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=precomputed_active_ranks,
+                op=op,
+                skip_validation=True,
+            )
+
+            # --- Step 5: Unpack the active-group result into caller tensors ---
+            if unpack_flat is not None:
+                _unpack_from_flat(unpack_flat, my_output_list)
 
 
 def allreduce_tensors_with_sharded_relay(

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -480,6 +480,26 @@ def _get_helper_flat_buf(
     return buf if buf.numel() == total else buf.narrow(0, 0, total)
 
 
+def _relay_helper_size(
+    total_g: int,
+    sparse_group_size: int,
+) -> int:
+    """Helper scratch size (in elements) for one group when the relay reduces at
+    the helper.
+
+    The A>2 relay paths give each helper one position slice of every block and
+    have it sum the contributing sources before forwarding, which needs one chunk
+    per (owner, source) pair:
+
+        A * (A - 1) * chunk,  chunk = total_g // (A + H)
+
+    On the 8-GPU node (A == H == 4) that is 1.5 * total_g. Rather than tracking H
+    here, allocate 2 * total_g, which covers every supported (A, H) split and
+    matches the allreduce A>2 contract.
+    """
+    return 2 * total_g
+
+
 def _passthrough_helper_size(
     count_g: int,
     sparse_group_size: int,
@@ -730,9 +750,16 @@ def reduce_scatter_tensors_with_sharded_relay(
                         unpack_flat = out_flat
                 else:
                     recv_count_g = per_group_recv_counts[g]
-                    helper_size_g = _passthrough_helper_size(
-                        recv_count_g, sparse_group_size, num_chunks
-                    )
+                    if sparse_group_size > 2:
+                        # A>2 reduces at the helper, which needs one chunk per
+                        # (owner, source) pair rather than two passthrough slots.
+                        helper_size_g = _relay_helper_size(
+                            recv_count_g, sparse_group_size
+                        )
+                    else:
+                        helper_size_g = _passthrough_helper_size(
+                            recv_count_g, sparse_group_size, num_chunks
+                        )
                     helper_buf = _get_helper_flat_buf(
                         state, g, helper_size_g, dtype, device
                     )

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -815,19 +815,7 @@ def allreduce_tensors_with_sharded_relay(
 
             device = my_tensor_list[0].device
 
-            # --- Step 1: Pack ---
-            # torch.cat(out=) writes all tensors into the pre-allocated flat
-            # buffer in a single fused CUDA kernel, replacing N individual
-            # copy_() calls (N = number of embedding tables, typically 101 for
-            # BM-FM).  Each copy_() incurs a separate kernel launch (~1-5μs on
-            # AMD); fusing them into one eliminates ~100 launches for pack.
-            active_flat = _get_active_flat_buf(state, my_total, dtype, device)
-            torch.cat(
-                [t.flatten() for t in my_tensor_list],
-                out=active_flat,
-            )
-
-            # --- Step 2: Metadata (allgather once, cache forever) ---
+            # --- Step 1: Metadata (allgather once, cache forever) ---
             meta_key = annotation + str(dtype)
             per_group_total_counts: list[int]
 
@@ -865,17 +853,30 @@ def allreduce_tensors_with_sharded_relay(
             else:
                 per_group_total_counts = state._flat_metadata_cache[meta_key]
 
-            # --- Step 3: Build group tensor list ---
+            # --- Step 3: Build per-group tensors ---
+            # Each group contributes ONE contiguous tensor. The active group's
+            # per-table tensors are packed into a single flat buffer (the
+            # single-segment zero-copy fast path); helper groups pass a single
+            # passthrough scratch buffer. Results are unpacked back into the
+            # caller tensors after the call.
             group_tensors: list[torch.Tensor] = []
             group_sizes: list[int] = []
 
             # Compute num_chunks for passthrough helper size (mirrors C++).
             num_chunks = (local_size - sparse_group_size) + 1
 
+            unpack_flat: torch.Tensor | None = None
+            unpack_dst: list[torch.Tensor] | None = None
+
             for g in range(num_sparse_groups):
                 if g == my_sparse_group:
-                    group_tensors.append(active_flat)
+                    in_flat = _get_active_flat_buf(state, my_total, dtype, device)
+                    _pack_into_flat(my_tensor_list, in_flat)
+                    group_tensors.append(in_flat)
                     group_sizes.append(my_total)
+                    # In-place: the kernel writes back into in_flat.
+                    unpack_flat = in_flat
+                    unpack_dst = my_tensor_list
                 else:
                     total_g = per_group_total_counts[g]
                     if sparse_group_size > 2:
@@ -894,6 +895,7 @@ def allreduce_tensors_with_sharded_relay(
                     group_sizes.append(total_g)  # full count goes to the kernel
 
             # --- Step 4: ONE fused call — all groups, all data, phase-synchronized ---
+            # In-place: results are written directly into my_tensor_list.
             state.fused.allreduce_multi_group(
                 tensors=group_tensors,
                 num_groups=num_sparse_groups,
@@ -903,16 +905,9 @@ def allreduce_tensors_with_sharded_relay(
                 skip_validation=True,
             )
 
-            # --- Step 5: Unpack ---
-            # torch._foreach_copy_ dispatches all N copies as a single batched
-            # operation, replacing N individual copy_() calls.  The split()
-            # produces views (no allocation), so this is still a pure HBM copy
-            # but with a single kernel launch instead of N.
-            slices = active_flat.split([t.numel() for t in my_tensor_list])
-            torch._foreach_copy_(
-                my_tensor_list,
-                [s.view(t.shape) for s, t in zip(slices, my_tensor_list)],
-            )
+            # --- Step 5: Unpack the active-group result into caller tensors ---
+            if unpack_flat is not None and unpack_dst is not None:
+                _unpack_from_flat(unpack_flat, unpack_dst)
 
 
 def all_to_all_tensors_with_sharded_relay(

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -156,12 +156,22 @@ def _validate_sharded_relay_preconditions(
         )
         return False
 
-    # The RCCLX C++ kernel (buildShardedRelayRankConfig) requires exactly 2
-    # active ranks per group.  Any other sharding_group_size is unsupported.
-    if sharding_group_size != 2:
+    # The RCCLX C++ kernel (buildShardedRelayRankConfig) requires a power-of-two
+    # number of active ranks per group; 2 and 4 are supported. It also needs at
+    # least one helper (local_size > sharding_group_size).
+    if sharding_group_size != 2 and sharding_group_size != 4:
         logger.warning(
-            f"[TorchRec 2D Parallel] Sharded relay requires sharding_group_size=2, "
-            f"but got sharding_group_size={sharding_group_size}. "
+            f"[TorchRec 2D Parallel] Sharded relay requires sharding_group_size "
+            f"of 2 or 4, but got sharding_group_size={sharding_group_size}. "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    if local_size <= sharding_group_size:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Sharded relay requires at least one helper "
+            f"rank (local_size={local_size} must exceed "
+            f"sharding_group_size={sharding_group_size}). "
             "Disabling sharded relay mode."
         )
         return False
@@ -312,8 +322,8 @@ def setup_sharded_relay(
         world_size: Total number of ranks (all nodes combined).
         use_inter_host_allreduce: If True, sharded relay is not supported.
         sharding_group_size: Number of active ranks per sparse group. The
-            underlying C++ kernel requires exactly 2; any other value disables
-            sharded relay.
+            underlying C++ kernel supports 2 or 4 (power of two); any other
+            value disables sharded relay.
 
     Returns:
         ShardedRelayState on success, None to disable sharded relay.
@@ -868,9 +878,15 @@ def allreduce_tensors_with_sharded_relay(
                     group_sizes.append(my_total)
                 else:
                     total_g = per_group_total_counts[g]
-                    helper_size_g = _passthrough_helper_size(
-                        total_g, sparse_group_size, num_chunks
-                    )
+                    if sparse_group_size > 2:
+                        # Flat A>2 allreduce: helper holds A source chunks + 1
+                        # reduced chunk per offload slice ((A+1)*oChunk <=
+                        # 1.25*total_g for f<=1); 2*total_g covers it.
+                        helper_size_g = 2 * total_g
+                    else:
+                        helper_size_g = _passthrough_helper_size(
+                            total_g, sparse_group_size, num_chunks
+                        )
                     helper_buf = _get_helper_flat_buf(
                         state, g, helper_size_g, dtype, device
                     )

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -897,3 +897,165 @@ def allreduce_tensors_with_sharded_relay(
                 my_tensor_list,
                 [s.view(t.shape) for s, t in zip(slices, my_tensor_list)],
             )
+
+
+def all_to_all_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    input_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+) -> None:
+    """
+    Perform all-to-all using the fused sharded relay algorithm.
+
+    All-to-all analogue of reduce_scatter_tensors_with_sharded_relay. For each
+    dtype, the active group's input tensors are packed into a single flat send
+    buffer (holding nActiveRanks x segment_count elements:
+    input = [sendSeg[0]|sendSeg[1]]), ONE fused call all-to-alls all groups
+    simultaneously (phase-synchronized, no XGMI contention), and the transposed
+    output (output = [recvSeg[0]|recvSeg[1]]) is unpacked into the caller's
+    output tensors.
+
+    All-to-all performs NO reduction (no op) and is OUT-OF-PLACE ONLY: a separate
+    flat output buffer is always used (distinct from the input flat buffer), as
+    required by the underlying collective.
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        input_tensors_dict: Send tensors grouped by dtype. The active group's
+            tensors for a dtype must total nActiveRanks x segment_count elements.
+        output_tensors_dict: Receive tensors grouped by dtype. The active group's
+            tensors for a dtype must total the same number of elements as the
+            input (nActiveRanks x segment_count).
+        annotation: Profiling annotation string for record_function.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    with record_function(f"{annotation}_fused_sharded_relay_all_to_all"):
+        for dtype, my_input_list in input_tensors_dict.items():
+            if not my_input_list:
+                continue
+
+            my_input_total = sum(t.numel() for t in my_input_list)
+            if my_input_total == 0:
+                continue
+
+            if my_input_total % sparse_group_size != 0:
+                raise ValueError(
+                    f"all_to_all_tensors_with_sharded_relay: active input total "
+                    f"({my_input_total}) for dtype {dtype} must be divisible by "
+                    f"sparse_group_size ({sparse_group_size})."
+                )
+            my_segment_count = my_input_total // sparse_group_size
+
+            my_output_list = output_tensors_dict.get(dtype, [])
+            my_output_total = sum(t.numel() for t in my_output_list)
+            if my_output_total != my_input_total:
+                raise ValueError(
+                    f"all_to_all_tensors_with_sharded_relay: active output total "
+                    f"({my_output_total}) for dtype {dtype} must equal the input "
+                    f"total ({my_input_total})."
+                )
+
+            device = my_input_list[0].device
+
+            # --- Step 1: Metadata (allgather segment counts once, cache) ---
+            meta_key = "a2a_" + annotation + str(dtype)
+            per_group_segment_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_seg_tensor = torch.tensor(
+                        [my_segment_count], dtype=torch.int64, device=device
+                    )
+                    all_seg_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_seg_list,
+                        my_seg_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_segment_counts = [
+                        int(all_seg_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same segment count."
+                    )
+                    per_group_segment_counts = [my_segment_count] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_segment_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat all-to-all metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_segment_counts={per_group_segment_counts}"
+                )
+            else:
+                per_group_segment_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build per-group tensors ---
+            # Each group contributes ONE contiguous tensor. All-to-all is
+            # out-of-place only: the active group's per-table inputs are packed
+            # into a single flat send buffer and a separate flat output buffer
+            # receives the transposed result (single-segment fast path); helper
+            # groups pass a single passthrough scratch buffer. The output is
+            # unpacked into my_output_list after the call.
+            input_group_tensors: list[torch.Tensor] = []
+            output_group_tensors: list[torch.Tensor] = []
+
+            unpack_flat: torch.Tensor | None = None
+
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    in_flat = _get_active_flat_buf(state, my_input_total, dtype, device)
+                    _pack_into_flat(my_input_list, in_flat)
+                    out_flat = _get_active_output_flat_buf(
+                        state, my_input_total, dtype, device
+                    )
+                    input_group_tensors.append(in_flat)
+                    output_group_tensors.append(out_flat)
+                    unpack_flat = out_flat
+                else:
+                    # _passthrough_helper_size's first argument is the per-group
+                    # count the KERNEL receives, not this caller's group total.
+                    # All-to-all hands the kernel segmentCounts[g], so it derives
+                    # chunkSize = align_down(seg / numChunks, 128) from the
+                    # segment count and each helper stages nActiveRanks slots of
+                    # that -- exactly what this returns. (The allreduce path
+                    # passes its group total for the same reason: that is the
+                    # count its kernel sees.) num_chunks matches the kernel's
+                    # numHelpers + 1.
+                    seg_g = per_group_segment_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        seg_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    # Helper uses one two-slot scratch buffer for send and recv.
+                    input_group_tensors.append(helper_buf)
+                    output_group_tensors.append(helper_buf)
+
+            # --- Step 4: ONE fused call — all groups, phase-synchronized ---
+            state.fused.all_to_all_multi_group(
+                input_tensors=input_group_tensors,
+                output_tensors=output_group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=precomputed_active_ranks,
+                skip_validation=True,
+            )
+
+            # --- Step 5: Unpack the active-group result into caller tensors ---
+            if unpack_flat is not None:
+                _unpack_from_flat(unpack_flat, my_output_list)

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -1055,6 +1055,177 @@ def all_to_all_tensors_with_sharded_relay(
                 all_active_ranks=precomputed_active_ranks,
                 skip_validation=True,
             )
+            # --- Step 5: Unpack the active-group result into caller tensors ---
+            if unpack_flat is not None:
+                _unpack_from_flat(unpack_flat, my_output_list)
+
+
+def all_gather_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    input_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    output_tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+    in_place: bool = False,
+) -> None:
+    """
+    Perform all-gather using the fused sharded relay algorithm.
+
+    All-gather analogue of reduce_scatter_tensors_with_sharded_relay (its dual).
+    For each dtype, the active group's input tensors are packed into a flat send
+    buffer (send_count elements: this rank's contribution), ONE fused call
+    all-gathers all groups simultaneously (phase-synchronized, no XGMI
+    contention), and the gathered output (nActiveRanks x send_count elements,
+    output[i x send_count] from active index i) is unpacked into the caller's
+    output tensors.
+
+    All-gather performs NO reduction (no op). ``in_place`` controls the internal
+    flat input buffer for the active group:
+
+    - ``in_place=True``: the input is packed into the active rank's own slot of
+      the flat output buffer (a view at myActiveIndex x send_count), exercising
+      the kernel's in-place path (sendbuff == recvbuff + rank x send_count).
+    - ``in_place=False``: a separate flat input buffer is used.
+
+    Either way, results are unpacked into ``output_tensors_dict``.
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        input_tensors_dict: Send tensors grouped by dtype. The active group's
+            tensors for a dtype must total send_count elements.
+        output_tensors_dict: Receive tensors grouped by dtype. The active
+            group's tensors for a dtype must total nActiveRanks x send_count
+            elements.
+        annotation: Profiling annotation string for record_function.
+        in_place: Select the internal input-buffer strategy / kernel path.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    local_rank = state.local_rank
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    # This rank's index among its group's active ranks (0 or 1 for size-2).
+    my_active_index = local_rank % sparse_group_size
+
+    with record_function(f"{annotation}_fused_sharded_relay_all_gather"):
+        for dtype, my_input_list in input_tensors_dict.items():
+            if not my_input_list:
+                continue
+
+            my_send_count = sum(t.numel() for t in my_input_list)
+            if my_send_count == 0:
+                continue
+
+            my_output_list = output_tensors_dict.get(dtype, [])
+            my_output_total = sum(t.numel() for t in my_output_list)
+            if my_output_total != sparse_group_size * my_send_count:
+                raise ValueError(
+                    f"all_gather_tensors_with_sharded_relay: active output total "
+                    f"({my_output_total}) for dtype {dtype} must equal "
+                    f"sparse_group_size x send_count "
+                    f"({sparse_group_size} x {my_send_count})."
+                )
+
+            device = my_input_list[0].device
+
+            # --- Step 1: Metadata (allgather send counts once, cache) ---
+            meta_key = "ag_" + annotation + str(dtype)
+            per_group_send_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_send_tensor = torch.tensor(
+                        [my_send_count], dtype=torch.int64, device=device
+                    )
+                    all_send_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_send_list,
+                        my_send_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_send_counts = [
+                        int(all_send_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same send count."
+                    )
+                    per_group_send_counts = [my_send_count] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_send_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat all-gather metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_send_counts={per_group_send_counts}"
+                )
+            else:
+                per_group_send_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build per-group tensors ---
+            # Each group contributes ONE contiguous tensor. The active group's
+            # per-table inputs are packed into a single flat send buffer and a
+            # single flat output buffer receives the gathered result
+            # (single-segment fast path); helper groups pass a single
+            # passthrough scratch buffer. Out-of-place packs the input into a
+            # separate flat send buffer; in-place packs the input into the
+            # active rank's own slot of the output flat. The gathered output is
+            # unpacked into my_output_list after the call.
+            input_group_tensors: list[torch.Tensor] = []
+            output_group_tensors: list[torch.Tensor] = []
+
+            unpack_flat: torch.Tensor | None = None
+
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    out_flat = _get_active_output_flat_buf(
+                        state, my_output_total, dtype, device
+                    )
+                    if in_place:
+                        # In-place: input aliases the active rank's own output
+                        # slot (offset my_active_index * send_count), so
+                        # activeInSegPtr == activeOutSegPtr + m*sendCount.
+                        in_view = out_flat.narrow(
+                            0, my_active_index * my_send_count, my_send_count
+                        )
+                        _pack_into_flat(my_input_list, in_view)
+                        input_group_tensors.append(in_view)
+                    else:
+                        in_flat = _get_active_flat_buf(
+                            state, my_send_count, dtype, device
+                        )
+                        _pack_into_flat(my_input_list, in_flat)
+                        input_group_tensors.append(in_flat)
+                    output_group_tensors.append(out_flat)
+                    unpack_flat = out_flat
+                else:
+                    send_g = per_group_send_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        send_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    # Helper uses one two-slot scratch buffer for send and recv.
+                    input_group_tensors.append(helper_buf)
+                    output_group_tensors.append(helper_buf)
+
+            # --- Step 4: ONE fused call — all groups, phase-synchronized ---
+            state.fused.all_gather_multi_group(
+                input_tensors=input_group_tensors,
+                output_tensors=output_group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_send_counts=per_group_send_counts,
+                all_active_ranks=precomputed_active_ranks,
+                skip_validation=True,
+            )
 
             # --- Step 5: Unpack the active-group result into caller tensors ---
             if unpack_flat is not None:

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -1052,9 +1052,15 @@ def all_to_all_tensors_with_sharded_relay(
                     # count its kernel sees.) num_chunks matches the kernel's
                     # numHelpers + 1.
                     seg_g = per_group_segment_counts[g]
-                    helper_size_g = _passthrough_helper_size(
-                        seg_g, sparse_group_size, num_chunks
-                    )
+                    if sparse_group_size > 2:
+                        # Flat A>2 all-to-all is PURE-DIRECT (no helper relay),
+                        # so a helper rank does no work for this group. A tiny
+                        # placeholder satisfies the per-group tensor-list slot.
+                        helper_size_g = 1
+                    else:
+                        helper_size_g = _passthrough_helper_size(
+                            seg_g, sparse_group_size, num_chunks
+                        )
                     helper_buf = _get_helper_flat_buf(
                         state, g, helper_size_g, dtype, device
                     )

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -66,15 +66,18 @@ Environment variables (all optional):
     BENCH_NUM_TABLES     int              (default: 1)
     BENCH_TABLE_SIZE     int              (default: capped production total, <=1 GiB/group)
     BENCH_KERNEL_SIZE_GB float            (default: capped production total, <=1 GiB/group)
-    BENCH_WARMUP_ITERS   int              (default: 5)
+    BENCH_WARMUP_ITERS   int              (default: 10)
     BENCH_BENCH_ITERS    int              (default: 20)
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
+
+The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
+groups and prints a full report for each. The 4-active sweep covers allreduce
+only (reduce-scatter / all-to-all / all-gather are 2-active only).
 """
 
 from __future__ import annotations
 
 import os
-import time
 import unittest
 from typing import Any
 
@@ -116,6 +119,15 @@ def _env_float(key: str, default: float) -> float:
 
 def _env_str(key: str, default: str) -> str:
     return os.environ.get(key, default)
+
+
+def _want(name: str) -> bool:
+    """BENCH_ONLY optionally restricts the run to a single collective
+    (allreduce|reduce_scatter|all_to_all|all_gather) so tuning one 4-active
+    collective doesn't pay for the other three. Default "all" runs everything.
+    """
+    bo = os.environ.get("BENCH_ONLY", "all")
+    return bo == "all" or bo == name
 
 
 def _get_dtype() -> torch.dtype:
@@ -193,13 +205,17 @@ def _setup_rcclx_comm(
             os.environ["TORCHCOMM_SIZE"] = orig_size
 
 
-def _make_fused(rcclx_comm: Any, local_rank: int, local_size: int) -> Any | None:
+def _make_fused(
+    rcclx_comm: Any,
+    local_rank: int,
+    local_size: int,
+    sharding_group_size: int = 2,
+) -> Any | None:
     if FusedShardedRelayMultiGroup is None or rcclx_comm is None:
         return None
-    sparse_group_size = 2
-    num_sparse_groups = local_size // sparse_group_size
+    num_sparse_groups = local_size // sharding_group_size
     all_active_ranks = [
-        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        list(range(g * sharding_group_size, (g + 1) * sharding_group_size))
         for g in range(num_sparse_groups)
     ]
     return FusedShardedRelayMultiGroup(
@@ -279,9 +295,15 @@ def bench_fused_flat(
             group_sizes.append(my_total)
         else:
             total_g = per_group_totals[g]
-            helper_size_g = _passthrough_helper_size(
-                total_g, sparse_group_size, num_chunks
-            )
+            if sparse_group_size > 2:
+                # Flat A>2 allreduce: helper holds A source chunks + 1 reduced
+                # chunk per offload slice = (A+1)*oChunk <= 1.25*total_g for any
+                # offload fraction f<=1; 2*total_g covers it with margin.
+                helper_size_g = 2 * total_g
+            else:
+                helper_size_g = _passthrough_helper_size(
+                    total_g, sparse_group_size, num_chunks
+                )
             # Ensure the per-group helper buffer in flat_bufs is large enough.
             if flat_bufs[g].numel() < helper_size_g:
                 flat_bufs[g] = torch.empty(helper_size_g, dtype=dtype, device=device)
@@ -503,23 +525,50 @@ def bench_nccl_baseline(
 
 
 def _measure_ms(fn: Any, warmup: int, iters: int) -> tuple[float, float]:
-    """Return (mean_ms, std_ms) over 'iters' calls after 'warmup' warmup runs."""
+    """Time fn() over 'iters' runs after 'warmup' warmups.
+
+    Returns (best_ms, std_ms). The BEST (min) is the headline metric: collective
+    microbenchmarks are noise-dominated, so the mean is skewed by stray slow
+    iterations (OS jitter, DVFS, cross-rank skew). The min is the steady-state,
+    reproducible time — the same convention nccl-tests / rccl-tests use. std is
+    returned only to show the spread.
+
+    Methodology for a stable, fair measurement:
+    - A full-world barrier precedes each timed iteration so all ranks start the
+      collective aligned (rank skew otherwise inflates the measured time, and
+      differently every run). The barrier is OUTSIDE the timed region.
+    - Timing uses on-device CUDA/hipEvents, so host-side scheduling jitter is
+      excluded.
+    Note: GPU clocks should also be locked (e.g. rocm-smi) to remove DVFS
+    variance — that is operational, not done here.
+    """
+    have_dist = dist.is_available() and dist.is_initialized()
+
     torch.cuda.synchronize()
     for _ in range(warmup):
         fn()
     torch.cuda.synchronize()
+    if have_dist:
+        dist.barrier()
 
+    start_ev = torch.cuda.Event(enable_timing=True)
+    end_ev = torch.cuda.Event(enable_timing=True)
     times: list[float] = []
     for _ in range(iters):
+        if have_dist:
+            # Align all ranks' starts; excluded from the timed region below.
+            dist.barrier()
         torch.cuda.synchronize()
-        t0 = time.perf_counter()
+        start_ev.record()
         fn()
-        torch.cuda.synchronize()
-        times.append((time.perf_counter() - t0) * 1000.0)
+        end_ev.record()
+        end_ev.synchronize()
+        times.append(start_ev.elapsed_time(end_ev))
 
+    best = min(times)
     mean = sum(times) / len(times)
     std = (sum((x - mean) ** 2 for x in times) / len(times)) ** 0.5
-    return mean, std
+    return best, std
 
 
 # ---------------------------------------------------------------------------
@@ -534,15 +583,23 @@ _NCCL_PORT: int = 29500
 _TCPSTORE_PORT: int = 29502
 
 
-def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
-    """Worker for bench A: serial all_reduce on isolated 2-rank sub-group PGs.
+def _bench_a_worker(
+    rank: int,
+    world_size: int,
+    results_dict: Any,
+    sharding_group_size: int = 2,
+    port_offset: int = 0,
+) -> None:
+    """Worker for bench A: serial all_reduce on isolated sub-group PGs.
 
     Runs in its own mp.spawn with its own dist.init_process_group/destroy cycle
     (on different ports) so that NCCL sub-group communicators are fully isolated
-    from bench B/C's RCCLX communicators.
+    from bench B/C's RCCLX communicators. sharding_group_size selects the
+    active-ranks-per-group (2 or 4); port_offset isolates ports across the
+    2-rank and 4-rank sweep iterations.
     """
     os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = str(_NCCL_PORT + 10)
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT + 10 + port_offset)
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
 
@@ -551,7 +608,7 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     store = dist.TCPStore(
         host_name="localhost",
-        port=_TCPSTORE_PORT + 10,
+        port=_TCPSTORE_PORT + 10 + port_offset,
         world_size=world_size,
         is_master=is_master,
         wait_for_workers=True,
@@ -568,10 +625,10 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
     device = torch.device(f"cuda:{local_rank}")
 
     dtype = _get_dtype()
-    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 5))
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 20))
 
-    sparse_group_size = 2
+    sparse_group_size = sharding_group_size
     num_sparse_groups = world_size // sparse_group_size
     my_sparse_group = local_rank // sparse_group_size
     all_active_ranks = [
@@ -629,80 +686,93 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
         for t in my_tensors:
             t.div_(sparse_group_size)
 
-    mean_serial, std_serial = _measure_ms(run_coalesced, warmup, bench_iters)
+    mean_serial, std_serial = (
+        _measure_ms(run_coalesced, warmup, bench_iters)
+        if _want("allreduce")
+        else (0.0, 0.0)
+    )
     _store_barrier()
 
     if rank == 0:
         results_dict["A"] = (mean_serial, std_serial)
 
-    # NCCL reduce-scatter baseline on the same 2-rank sub-group PG.
-    # Free the allreduce tensors first to reclaim HBM. recv_count =
-    # prod_total // 2 so the input (2 x recv_count) matches the sharded-relay
-    # reduce-scatter benchmark's active footprint.
-    my_tensors = []
-    torch.cuda.empty_cache()
-    rs_recv = prod_totals[my_sparse_group] // 2
-    rs_in = torch.ones(2 * rs_recv, dtype=dtype, device=device)
-    rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
+    # NCCL reduce-scatter / all-to-all / all-gather baselines run on the same
+    # sub-group PG. They are 2-active only (paired with the 2-active sharded
+    # relay benches), so skip them for a 4-active allreduce sweep. All ranks
+    # share the same env-driven sparse_group_size, so the _store_barrier()
+    # calls stay balanced.
+    if sparse_group_size == 2:
+        # NCCL reduce-scatter baseline. Free the allreduce tensors first to
+        # reclaim HBM. recv_count = prod_total // 2 so the input (2 x recv_count)
+        # matches the sharded-relay reduce-scatter benchmark's active footprint.
+        my_tensors = []
+        torch.cuda.empty_cache()
+        rs_recv = prod_totals[my_sparse_group] // 2
+        rs_in = torch.ones(2 * rs_recv, dtype=dtype, device=device)
+        rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
 
-    # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
-    def run_rs_baseline() -> None:
-        rs_in.fill_(1.0)
-        dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
-        rs_out.div_(sparse_group_size)
+        # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
+        def run_rs_baseline() -> None:
+            rs_in.fill_(1.0)
+            dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
+            rs_out.div_(sparse_group_size)
 
-    mean_rs_base, std_rs_base = _measure_ms(run_rs_baseline, warmup, bench_iters)
-    _store_barrier()
+        mean_rs_base, std_rs_base = _measure_ms(run_rs_baseline, warmup, bench_iters)
+        _store_barrier()
 
-    if rank == 0:
-        results_dict["A_rs"] = (mean_rs_base, std_rs_base)
+        if rank == 0:
+            results_dict["A_rs"] = (mean_rs_base, std_rs_base)
 
-    # NCCL all-to-all baseline on the same 2-rank sub-group PG. Free the
-    # reduce-scatter baseline tensors first. segment_count = prod_total // 4 so
-    # the in/out buffers (2 x segment_count) match the sharded-relay all-to-all
-    # benchmark's footprint.
-    rs_in = torch.empty(0, dtype=dtype, device=device)
-    rs_out = torch.empty(0, dtype=dtype, device=device)
-    torch.cuda.empty_cache()
-    a2a_seg = prod_totals[my_sparse_group] // 4
-    a2a_in = torch.ones(2 * a2a_seg, dtype=dtype, device=device)
-    a2a_out = torch.empty(2 * a2a_seg, dtype=dtype, device=device)
+        # NCCL all-to-all baseline. Free the reduce-scatter baseline tensors
+        # first. segment_count = prod_total // 4 so the in/out buffers
+        # (2 x segment_count) match the sharded-relay all-to-all footprint.
+        rs_in = torch.empty(0, dtype=dtype, device=device)
+        rs_out = torch.empty(0, dtype=dtype, device=device)
+        torch.cuda.empty_cache()
+        a2a_seg = prod_totals[my_sparse_group] // 4
+        a2a_in = torch.ones(2 * a2a_seg, dtype=dtype, device=device)
+        a2a_out = torch.empty(2 * a2a_seg, dtype=dtype, device=device)
 
-    def run_a2a_baseline() -> None:
-        a2a_in.fill_(1.0)
-        dist.all_to_all_single(a2a_out, a2a_in, group=my_pg)
+        def run_a2a_baseline() -> None:
+            a2a_in.fill_(1.0)
+            dist.all_to_all_single(a2a_out, a2a_in, group=my_pg)
 
-    mean_a2a_base, std_a2a_base = _measure_ms(run_a2a_baseline, warmup, bench_iters)
-    _store_barrier()
+        mean_a2a_base, std_a2a_base = _measure_ms(run_a2a_baseline, warmup, bench_iters)
+        _store_barrier()
 
-    if rank == 0:
-        results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
+        if rank == 0:
+            results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
 
-    # NCCL all-gather baseline on the same 2-rank sub-group PG. Free the
-    # all-to-all baseline tensors first. send_count = prod_total // 4 so the
-    # output (nActiveRanks x send_count) matches the sharded-relay all-gather
-    # benchmark's footprint.
-    a2a_in = torch.empty(0, dtype=dtype, device=device)
-    a2a_out = torch.empty(0, dtype=dtype, device=device)
-    torch.cuda.empty_cache()
-    ag_send = prod_totals[my_sparse_group] // 4
-    ag_in = torch.ones(ag_send, dtype=dtype, device=device)
-    ag_out = torch.empty(sparse_group_size * ag_send, dtype=dtype, device=device)
+        # NCCL all-gather baseline. Free the all-to-all baseline tensors first.
+        # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
+        # matches the sharded-relay all-gather footprint.
+        a2a_in = torch.empty(0, dtype=dtype, device=device)
+        a2a_out = torch.empty(0, dtype=dtype, device=device)
+        torch.cuda.empty_cache()
+        ag_send = prod_totals[my_sparse_group] // 4
+        ag_in = torch.ones(ag_send, dtype=dtype, device=device)
+        ag_out = torch.empty(sparse_group_size * ag_send, dtype=dtype, device=device)
 
-    def run_ag_baseline() -> None:
-        ag_in.fill_(1.0)
-        dist.all_gather_into_tensor(ag_out, ag_in, group=my_pg)
+        def run_ag_baseline() -> None:
+            ag_in.fill_(1.0)
+            dist.all_gather_into_tensor(ag_out, ag_in, group=my_pg)
 
-    mean_ag_base, std_ag_base = _measure_ms(run_ag_baseline, warmup, bench_iters)
-    _store_barrier()
+        mean_ag_base, std_ag_base = _measure_ms(run_ag_baseline, warmup, bench_iters)
+        _store_barrier()
 
-    if rank == 0:
-        results_dict["A_ag"] = (mean_ag_base, std_ag_base)
+        if rank == 0:
+            results_dict["A_ag"] = (mean_ag_base, std_ag_base)
 
     dist.destroy_process_group()
 
 
-def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
+def _benchmark_worker(
+    rank: int,
+    world_size: int,
+    results_dict: Any,
+    sharding_group_size: int = 2,
+    port_offset: int = 0,
+) -> None:
     """
     Worker for bench B (fused flat) and C (kernel direct).
 
@@ -710,9 +780,14 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     test_sharded_relay_2d_integration.py) so that RCCLX comm creation does
     not depend on dist._get_default_store(), which can hang when called from
     spawned child processes in the Meta environment.
+
+    sharding_group_size selects the active-ranks-per-group (2 or 4). At 4 the
+    reduce-scatter / all-to-all / all-gather benches (2-active only) are
+    skipped and only the allreduce benches run. port_offset isolates ports
+    across the 2-rank and 4-rank sweep iterations.
     """
     os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = str(_NCCL_PORT)
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT + port_offset)
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
 
@@ -722,7 +797,7 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     # Explicit TCPStore — same as the integration test pattern.
     store = dist.TCPStore(
         host_name="localhost",
-        port=_TCPSTORE_PORT,
+        port=_TCPSTORE_PORT + port_offset,
         world_size=world_size,
         is_master=is_master,
         wait_for_workers=True,
@@ -743,11 +818,11 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     # Enforce minimum 1 warmup: on AMD GPUs the first RCCLX kernel call triggers
     # JIT compilation which takes several minutes.  Without warmup the timed run
     # shows compilation time, not runtime.
-    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 5))
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
     bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 20))
     log_sizes = _env_str("BENCH_LOG_SIZES", "0") == "1"
 
-    sparse_group_size = 2
+    sparse_group_size = sharding_group_size
     num_sparse_groups = world_size // sparse_group_size
     my_sparse_group = local_rank // sparse_group_size
     all_active_ranks = [
@@ -793,7 +868,7 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     # RCCLX comm — pass the explicit store directly (no _get_default_store())
     rcclx_comm = _setup_rcclx_comm(local_rank, world_size, 0, store)
-    fused = _make_fused(rcclx_comm, local_rank, world_size)
+    fused = _make_fused(rcclx_comm, local_rank, world_size, sparse_group_size)
     if fused is None:
         if rank == 0:
             print("[bench] FusedShardedRelayMultiGroup not available. Exiting.")
@@ -813,9 +888,12 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             flat_bufs.append(torch.zeros(total_my, dtype=dtype, device=device))
         else:
             helper_total_g = sum(all_tensors_sizes[g])
-            helper_size_g = _passthrough_helper_size(
-                helper_total_g, sparse_group_size, num_chunks
-            )
+            if sparse_group_size > 2:
+                helper_size_g = 2 * helper_total_g
+            else:
+                helper_size_g = _passthrough_helper_size(
+                    helper_total_g, sparse_group_size, num_chunks
+                )
             flat_bufs.append(torch.zeros(helper_size_g, dtype=dtype, device=device))
     meta_cache_b: dict[str, list[int]] = {
         "bench"
@@ -832,7 +910,9 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
         else prod_totals[my_sparse_group]
     )
     kernel_declared_sizes: list[int] = (
-        [kernel_elements] * num_sparse_groups if kernel_gb > 0 else list(prod_totals)
+        [kernel_elements] * num_sparse_groups
+        if kernel_gb > 0
+        else [prod_totals[g] for g in range(num_sparse_groups)]
     )
     kernel_tensor = torch.ones(kernel_elements, dtype=dtype, device=device)
     # For kernel bench, each helper group gets its own passthrough-sized buffer.
@@ -842,9 +922,12 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             kernel_scratch.append(kernel_tensor)
         else:
             declared_g = kernel_declared_sizes[g]
-            helper_size_g = _passthrough_helper_size(
-                declared_g, sparse_group_size, num_chunks
-            )
+            if sparse_group_size > 2:
+                helper_size_g = 2 * declared_g
+            else:
+                helper_size_g = _passthrough_helper_size(
+                    declared_g, sparse_group_size, num_chunks
+                )
             kernel_scratch.append(
                 torch.empty(helper_size_g, dtype=dtype, device=device)
             )
@@ -887,7 +970,11 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             meta_cache=meta_cache_b,
         )
 
-    mean_fused, std_fused = _measure_ms(run_fused, warmup, bench_iters)
+    mean_fused, std_fused = (
+        _measure_ms(run_fused, warmup, bench_iters)
+        if _want("allreduce")
+        else (0.0, 0.0)
+    )
 
     # -------------------------------------------------------------------------
     # Benchmark C: direct kernel call with one large tensor per group.
@@ -903,145 +990,161 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             skip_validation=True,
         )
 
-    mean_kernel, std_kernel = _measure_ms(run_kernel, warmup, bench_iters)
+    mean_kernel, std_kernel = (
+        _measure_ms(run_kernel, warmup, bench_iters)
+        if _want("allreduce")
+        else (0.0, 0.0)
+    )
 
     # Measure peak HBM usage — the whole point of this work.
-    torch.cuda.reset_peak_memory_stats()
-    run_fused()
-    torch.cuda.synchronize()
-    peak_hbm_bytes = torch.cuda.max_memory_allocated()
+    if _want("allreduce"):
+        torch.cuda.reset_peak_memory_stats()
+        run_fused()
+        torch.cuda.synchronize()
+        peak_hbm_bytes = torch.cuda.max_memory_allocated()
+    else:
+        peak_hbm_bytes = 0
 
-    # -------------------------------------------------------------------------
-    # Benchmark D: fused reduce-scatter. Release the Bench C kernel tensors
-    # first to reclaim HBM — reduce-scatter's input buffer is 2x its output
-    # (two blocks), so the active footprint is larger than allreduce's.
-    # Reassign (instead of `del`) so the run_kernel closure stays valid.
-    # -------------------------------------------------------------------------
-    kernel_tensor = torch.empty(0, dtype=dtype, device=device)
-    kernel_scratch = []
-    torch.cuda.empty_cache()
+    # The reduce-scatter / all-to-all / all-gather sharded-relay benches only
+    # support 2 active ranks today, so they are skipped during the 4-active
+    # allreduce sweep.
+    mean_rs = std_rs = mean_a2a = std_a2a = mean_ag = std_ag = 0.0
+    my_rs_recv = my_a2a_seg = my_ag_send = 0
+    if sparse_group_size == 2:
+        # ---------------------------------------------------------------------
+        # Benchmark D: fused reduce-scatter. Release the Bench C kernel tensors
+        # first to reclaim HBM — reduce-scatter's input buffer is 2x its output
+        # (two blocks), so the active footprint is larger than allreduce's.
+        # Reassign (instead of `del`) so the run_kernel closure stays valid.
+        # ---------------------------------------------------------------------
+        kernel_tensor = torch.empty(0, dtype=dtype, device=device)
+        kernel_scratch = []
+        torch.cuda.empty_cache()
 
-    # recv_count = prod_total // 2 so the input (2 x recv_count) matches the
-    # allreduce active footprint (one prod_total per group).
-    rs_recv_counts = [t // 2 for t in prod_totals]
-    my_rs_recv = rs_recv_counts[my_sparse_group]
-    rs_input = torch.ones(2 * my_rs_recv, dtype=dtype, device=device)
-    rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
-    rs_helper_bufs: list[torch.Tensor] = []
-    for g in range(num_sparse_groups):
-        if g == my_sparse_group:
-            rs_helper_bufs.append(rs_output)  # unused for the active group
-        else:
-            rs_helper_size_g = _passthrough_helper_size(
-                rs_recv_counts[g], sparse_group_size, num_chunks
+        # recv_count = prod_total // 2 so the input (2 x recv_count) matches the
+        # allreduce active footprint (one prod_total per group).
+        rs_recv_counts = [t // 2 for t in prod_totals]
+        my_rs_recv = rs_recv_counts[my_sparse_group]
+        rs_input = torch.ones(2 * my_rs_recv, dtype=dtype, device=device)
+        rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
+        rs_helper_bufs: list[torch.Tensor] = []
+        for g in range(num_sparse_groups):
+            if g == my_sparse_group:
+                rs_helper_bufs.append(rs_output)  # unused for the active group
+            else:
+                rs_helper_size_g = _passthrough_helper_size(
+                    rs_recv_counts[g], sparse_group_size, num_chunks
+                )
+                rs_helper_bufs.append(
+                    torch.empty(rs_helper_size_g, dtype=dtype, device=device)
+                )
+
+        def run_reduce_scatter() -> None:
+            rs_input.fill_(1.0)
+            bench_reduce_scatter_flat(
+                fused=fused,
+                input_flat=rs_input,
+                output_flat=rs_output,
+                num_sparse_groups=num_sparse_groups,
+                my_sparse_group=my_sparse_group,
+                all_active_ranks=all_active_ranks,
+                helper_bufs=rs_helper_bufs,
+                per_group_recv_counts=rs_recv_counts,
             )
-            rs_helper_bufs.append(
-                torch.empty(rs_helper_size_g, dtype=dtype, device=device)
+
+        mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
+
+        # ---------------------------------------------------------------------
+        # Benchmark E: fused all-to-all. Release the reduce-scatter buffers
+        # first. segment_count = prod_total // 4 so the in/out buffers
+        # (2 x segment_count) stay within HBM (all-to-all needs distinct
+        # in and out buffers).
+        # ---------------------------------------------------------------------
+        rs_input = torch.empty(0, dtype=dtype, device=device)
+        rs_output = torch.empty(0, dtype=dtype, device=device)
+        rs_helper_bufs = []
+        torch.cuda.empty_cache()
+
+        a2a_seg_counts = [t // 4 for t in prod_totals]
+        my_a2a_seg = a2a_seg_counts[my_sparse_group]
+        a2a_input = torch.ones(2 * my_a2a_seg, dtype=dtype, device=device)
+        a2a_output = torch.empty(2 * my_a2a_seg, dtype=dtype, device=device)
+        a2a_helper_bufs: list[torch.Tensor] = []
+        for g in range(num_sparse_groups):
+            if g == my_sparse_group:
+                a2a_helper_bufs.append(a2a_output)  # unused for the active group
+            else:
+                a2a_helper_size_g = _passthrough_helper_size(
+                    a2a_seg_counts[g], sparse_group_size, num_chunks
+                )
+                a2a_helper_bufs.append(
+                    torch.empty(a2a_helper_size_g, dtype=dtype, device=device)
+                )
+
+        def run_all_to_all() -> None:
+            a2a_input.fill_(1.0)
+            bench_all_to_all_flat(
+                fused=fused,
+                input_flat=a2a_input,
+                output_flat=a2a_output,
+                num_sparse_groups=num_sparse_groups,
+                my_sparse_group=my_sparse_group,
+                all_active_ranks=all_active_ranks,
+                helper_bufs=a2a_helper_bufs,
+                per_group_segment_counts=a2a_seg_counts,
             )
 
-    def run_reduce_scatter() -> None:
-        rs_input.fill_(1.0)
-        bench_reduce_scatter_flat(
-            fused=fused,
-            input_flat=rs_input,
-            output_flat=rs_output,
-            num_sparse_groups=num_sparse_groups,
-            my_sparse_group=my_sparse_group,
-            all_active_ranks=all_active_ranks,
-            helper_bufs=rs_helper_bufs,
-            per_group_recv_counts=rs_recv_counts,
+        mean_a2a, std_a2a = _measure_ms(run_all_to_all, warmup, bench_iters)
+
+        # ---------------------------------------------------------------------
+        # Benchmark F: fused all-gather. Release the all-to-all buffers first.
+        # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
+        # matches the all-to-all footprint.
+        # ---------------------------------------------------------------------
+        a2a_input = torch.empty(0, dtype=dtype, device=device)
+        a2a_output = torch.empty(0, dtype=dtype, device=device)
+        a2a_helper_bufs = []
+        torch.cuda.empty_cache()
+
+        ag_send_counts = [t // 4 for t in prod_totals]
+        my_ag_send = ag_send_counts[my_sparse_group]
+        ag_input = torch.ones(my_ag_send, dtype=dtype, device=device)
+        ag_output = torch.empty(
+            sparse_group_size * my_ag_send, dtype=dtype, device=device
         )
+        ag_helper_bufs: list[torch.Tensor] = []
+        for g in range(num_sparse_groups):
+            if g == my_sparse_group:
+                ag_helper_bufs.append(ag_output)  # unused for the active group
+            else:
+                ag_helper_size_g = _passthrough_helper_size(
+                    ag_send_counts[g], sparse_group_size, num_chunks
+                )
+                ag_helper_bufs.append(
+                    torch.empty(ag_helper_size_g, dtype=dtype, device=device)
+                )
 
-    mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
-
-    # -------------------------------------------------------------------------
-    # Benchmark E: fused all-to-all. Release the reduce-scatter buffers first.
-    # segment_count = prod_total // 4 so the in/out buffers (2 x segment_count)
-    # stay within HBM (all-to-all needs distinct in and out buffers).
-    # -------------------------------------------------------------------------
-    rs_input = torch.empty(0, dtype=dtype, device=device)
-    rs_output = torch.empty(0, dtype=dtype, device=device)
-    rs_helper_bufs = []
-    torch.cuda.empty_cache()
-
-    a2a_seg_counts = [t // 4 for t in prod_totals]
-    my_a2a_seg = a2a_seg_counts[my_sparse_group]
-    a2a_input = torch.ones(2 * my_a2a_seg, dtype=dtype, device=device)
-    a2a_output = torch.empty(2 * my_a2a_seg, dtype=dtype, device=device)
-    a2a_helper_bufs: list[torch.Tensor] = []
-    for g in range(num_sparse_groups):
-        if g == my_sparse_group:
-            a2a_helper_bufs.append(a2a_output)  # unused for the active group
-        else:
-            a2a_helper_size_g = _passthrough_helper_size(
-                a2a_seg_counts[g], sparse_group_size, num_chunks
-            )
-            a2a_helper_bufs.append(
-                torch.empty(a2a_helper_size_g, dtype=dtype, device=device)
+        def run_all_gather() -> None:
+            ag_input.fill_(1.0)
+            bench_all_gather_flat(
+                fused=fused,
+                input_flat=ag_input,
+                output_flat=ag_output,
+                num_sparse_groups=num_sparse_groups,
+                my_sparse_group=my_sparse_group,
+                all_active_ranks=all_active_ranks,
+                helper_bufs=ag_helper_bufs,
+                per_group_send_counts=ag_send_counts,
             )
 
-    def run_all_to_all() -> None:
-        a2a_input.fill_(1.0)
-        bench_all_to_all_flat(
-            fused=fused,
-            input_flat=a2a_input,
-            output_flat=a2a_output,
-            num_sparse_groups=num_sparse_groups,
-            my_sparse_group=my_sparse_group,
-            all_active_ranks=all_active_ranks,
-            helper_bufs=a2a_helper_bufs,
-            per_group_segment_counts=a2a_seg_counts,
-        )
-
-    mean_a2a, std_a2a = _measure_ms(run_all_to_all, warmup, bench_iters)
-
-    # -------------------------------------------------------------------------
-    # Benchmark F: fused all-gather. Release the all-to-all buffers first.
-    # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
-    # matches the all-to-all footprint.
-    # -------------------------------------------------------------------------
-    a2a_input = torch.empty(0, dtype=dtype, device=device)
-    a2a_output = torch.empty(0, dtype=dtype, device=device)
-    a2a_helper_bufs = []
-    torch.cuda.empty_cache()
-
-    ag_send_counts = [t // 4 for t in prod_totals]
-    my_ag_send = ag_send_counts[my_sparse_group]
-    ag_input = torch.ones(my_ag_send, dtype=dtype, device=device)
-    ag_output = torch.empty(sparse_group_size * my_ag_send, dtype=dtype, device=device)
-    ag_helper_bufs: list[torch.Tensor] = []
-    for g in range(num_sparse_groups):
-        if g == my_sparse_group:
-            ag_helper_bufs.append(ag_output)  # unused for the active group
-        else:
-            ag_helper_size_g = _passthrough_helper_size(
-                ag_send_counts[g], sparse_group_size, num_chunks
-            )
-            ag_helper_bufs.append(
-                torch.empty(ag_helper_size_g, dtype=dtype, device=device)
-            )
-
-    def run_all_gather() -> None:
-        ag_input.fill_(1.0)
-        bench_all_gather_flat(
-            fused=fused,
-            input_flat=ag_input,
-            output_flat=ag_output,
-            num_sparse_groups=num_sparse_groups,
-            my_sparse_group=my_sparse_group,
-            all_active_ranks=all_active_ranks,
-            helper_bufs=ag_helper_bufs,
-            per_group_send_counts=ag_send_counts,
-        )
-
-    mean_ag, std_ag = _measure_ms(run_all_gather, warmup, bench_iters)
+        mean_ag, std_ag = _measure_ms(run_all_gather, warmup, bench_iters)
 
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
         kernel_bytes = kernel_elements * dtype.itemsize
 
         def bw(nbytes: int, ms: float) -> float:
-            return 2 * nbytes / (ms / 1000) / 1e9
+            return 2 * nbytes / (ms / 1000) / 1e9 if ms > 0 else 0.0
 
         bench_a_mean = float(results_dict["A"][0]) if "A" in results_dict else 0.0
         bench_a_std = float(results_dict["A"][1]) if "A" in results_dict else 0.0
@@ -1075,10 +1178,15 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             )
 
         print("\n" + "=" * 72)
-        print(f"Sharded Relay Benchmark — MI350X ({world_size} GPUs)")
+        print(
+            f"Sharded Relay Benchmark — MI350X ({world_size} GPUs), "
+            f"{sparse_group_size} active ranks/group"
+        )
         print("=" * 72)
         print(f"  dtype:          {dtype}")
         print(f"  num_tables:     {num_tables}")
+        print(f"  active ranks/group: {sparse_group_size}")
+        print("  times:          best-of-N (min), barrier-aligned + hipEvent-timed")
         print(
             f"  avg table size: {table_size:,} elements "
             f"({table_size * dtype.itemsize / 1024 / 1024:.1f} MB)"
@@ -1117,100 +1225,109 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
                 f"  >> Allreduce speedup (NCCL coalesced → sharded relay): "
                 f"{speedup_ar:.2f}x"
             )
-
-        # ----- REDUCE-SCATTER -----
-        print()
-        print("-" * 72)
-        print("REDUCE-SCATTER")
-        print("-" * 72)
-        if bench_a_rs_mean > 0:
+        if bench_a_mean > 0 and mean_kernel > 0:
             print(
-                f"  [A] NCCL reduce_scatter_tensor (baseline, "
+                f"  >> Allreduce KERNEL speedup (NCCL → kernel-direct): "
+                f"{bench_a_mean / mean_kernel:.2f}x"
+            )
+
+        # ----- REDUCE-SCATTER / ALL-TO-ALL / ALL-GATHER -----
+        # These sharded-relay benches are 2-active only; skip during the
+        # 4-active allreduce sweep.
+        if sparse_group_size == 2:
+            print()
+            print("-" * 72)
+            print("REDUCE-SCATTER")
+            print("-" * 72)
+            if bench_a_rs_mean > 0:
+                print(
+                    f"  [A] NCCL reduce_scatter_tensor (baseline, "
+                    f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+                )
+                print(
+                    f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
+                    f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
+                )
+            else:
+                print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
+            print(
+                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
                 f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
             )
             print(
-                f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
-                f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
+                f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
+                f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
             )
-        else:
-            print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
-        print(
-            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
-            f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
-        )
-        print(
-            f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
-            f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
-        )
-        if bench_a_rs_mean > 0 and mean_rs > 0:
-            speedup_rs = bench_a_rs_mean / mean_rs
-            print(
-                f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
-                f"{speedup_rs:.2f}x"
-            )
+            if bench_a_rs_mean > 0 and mean_rs > 0:
+                speedup_rs = bench_a_rs_mean / mean_rs
+                print(
+                    f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
+                    f"{speedup_rs:.2f}x"
+                )
 
-        # ----- ALL-TO-ALL -----
-        a2a_seg_bytes = my_a2a_seg * dtype.itemsize
-        print()
-        print("-" * 72)
-        print("ALL-TO-ALL")
-        print("-" * 72)
-        if bench_a_a2a_mean > 0:
+            # ----- ALL-TO-ALL -----
+            a2a_seg_bytes = my_a2a_seg * dtype.itemsize
+            print()
+            print("-" * 72)
+            print("ALL-TO-ALL")
+            print("-" * 72)
+            if bench_a_a2a_mean > 0:
+                print(
+                    f"  [A] NCCL all_to_all_single (baseline, "
+                    f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
+                )
+                print(
+                    f"       {bench_a_a2a_mean:.2f} ms  ±  {bench_a_a2a_std:.2f} ms  |  "
+                    f"{rs_bw(a2a_seg_bytes, bench_a_a2a_mean):.1f} GB/s"
+                )
+            else:
+                print("  [A] NCCL all_to_all_single (baseline): N/A")
             print(
-                f"  [A] NCCL all_to_all_single (baseline, "
+                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
                 f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
             )
             print(
-                f"       {bench_a_a2a_mean:.2f} ms  ±  {bench_a_a2a_std:.2f} ms  |  "
-                f"{rs_bw(a2a_seg_bytes, bench_a_a2a_mean):.1f} GB/s"
+                f"       {mean_a2a:.2f} ms  ±  {std_a2a:.2f} ms  |  "
+                f"{rs_bw(a2a_seg_bytes, mean_a2a):.1f} GB/s"
             )
-        else:
-            print("  [A] NCCL all_to_all_single (baseline): N/A")
-        print(
-            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
-            f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
-        )
-        print(
-            f"       {mean_a2a:.2f} ms  ±  {std_a2a:.2f} ms  |  "
-            f"{rs_bw(a2a_seg_bytes, mean_a2a):.1f} GB/s"
-        )
-        if bench_a_a2a_mean > 0 and mean_a2a > 0:
-            speedup_a2a = bench_a_a2a_mean / mean_a2a
-            print(
-                f"  >> All-to-all speedup (NCCL → sharded relay): "
-                f"{speedup_a2a:.2f}x"
-            )
+            if bench_a_a2a_mean > 0 and mean_a2a > 0:
+                speedup_a2a = bench_a_a2a_mean / mean_a2a
+                print(
+                    f"  >> All-to-all speedup (NCCL → sharded relay): "
+                    f"{speedup_a2a:.2f}x"
+                )
 
-        # ----- ALL-GATHER -----
-        ag_send_bytes = my_ag_send * dtype.itemsize
-        print()
-        print("-" * 72)
-        print("ALL-GATHER")
-        print("-" * 72)
-        if bench_a_ag_mean > 0:
+            # ----- ALL-GATHER -----
+            ag_send_bytes = my_ag_send * dtype.itemsize
+            print()
+            print("-" * 72)
+            print("ALL-GATHER")
+            print("-" * 72)
+            if bench_a_ag_mean > 0:
+                print(
+                    f"  [A] NCCL all_gather_into_tensor (baseline, "
+                    f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
+                )
+                print(
+                    f"       {bench_a_ag_mean:.2f} ms  ±  {bench_a_ag_std:.2f} ms  |  "
+                    f"{rs_bw(ag_send_bytes, bench_a_ag_mean):.1f} GB/s"
+                )
+            else:
+                print("  [A] NCCL all_gather_into_tensor (baseline): N/A")
             print(
-                f"  [A] NCCL all_gather_into_tensor (baseline, "
+                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
                 f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
             )
             print(
-                f"       {bench_a_ag_mean:.2f} ms  ±  {bench_a_ag_std:.2f} ms  |  "
-                f"{rs_bw(ag_send_bytes, bench_a_ag_mean):.1f} GB/s"
+                f"       {mean_ag:.2f} ms  ±  {std_ag:.2f} ms  |  "
+                f"{rs_bw(ag_send_bytes, mean_ag):.1f} GB/s"
             )
-        else:
-            print("  [A] NCCL all_gather_into_tensor (baseline): N/A")
-        print(
-            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
-            f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
-        )
-        print(
-            f"       {mean_ag:.2f} ms  ±  {std_ag:.2f} ms  |  "
-            f"{rs_bw(ag_send_bytes, mean_ag):.1f} GB/s"
-        )
-        if bench_a_ag_mean > 0 and mean_ag > 0:
-            speedup_ag = bench_a_ag_mean / mean_ag
-            print(
-                f"  >> All-gather speedup (NCCL → sharded relay): " f"{speedup_ag:.2f}x"
-            )
+            if bench_a_ag_mean > 0 and mean_ag > 0:
+                speedup_ag = bench_a_ag_mean / mean_ag
+                print(
+                    f"  >> All-gather speedup (NCCL → sharded relay): "
+                    f"{speedup_ag:.2f}x"
+                )
         print("=" * 72)
 
     dist.barrier()
@@ -1255,21 +1372,29 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         manager = mp.Manager()
         results: Any = manager.dict()
 
-        # Phase 1: bench A — allreduce_coalesced on 2-rank NCCL sub-group PGs.
-        mp.spawn(
-            _bench_a_worker,
-            args=(NUM_GPUS, results),
-            nprocs=NUM_GPUS,
-            join=True,
-        )
+        # Sweep both 2-active and 4-active sharded relay groups, printing a full
+        # report for each. The 4-active sweep covers allreduce only (the
+        # reduce-scatter / all-to-all / all-gather benches are 2-active only and
+        # are skipped at 4). Each iteration uses a distinct port_offset so the
+        # NCCL/TCPStore endpoints don't collide across iterations.
+        for i, sharding_group_size in enumerate((2, 4)):
+            port_offset = i * 100
 
-        # Phase 2: bench B (fused flat) and C (kernel direct) via RCCLX.
-        mp.spawn(
-            _benchmark_worker,
-            args=(NUM_GPUS, results),
-            nprocs=NUM_GPUS,
-            join=True,
-        )
+            # Phase 1: bench A — NCCL allreduce_coalesced on sub-group PGs.
+            mp.spawn(
+                _bench_a_worker,
+                args=(NUM_GPUS, results, sharding_group_size, port_offset),
+                nprocs=NUM_GPUS,
+                join=True,
+            )
+
+            # Phase 2: bench B (fused flat) and C (kernel direct) via RCCLX.
+            mp.spawn(
+                _benchmark_worker,
+                args=(NUM_GPUS, results, sharding_group_size, port_offset),
+                nprocs=NUM_GPUS,
+                join=True,
+            )
 
         manager.shutdown()
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -362,6 +362,46 @@ def bench_kernel_direct(
 
 
 # ---------------------------------------------------------------------------
+# Benchmark D: fused reduce-scatter (sharded relay)
+# ---------------------------------------------------------------------------
+
+
+def bench_reduce_scatter_flat(
+    fused: Any,
+    input_flat: torch.Tensor,
+    output_flat: torch.Tensor,
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    helper_bufs: list[torch.Tensor],
+    per_group_recv_counts: list[int],
+) -> None:
+    """ONE fused reduce-scatter call across all sparse groups.
+
+    Each helper group passes its single passthrough scratch buffer.
+    """
+    input_group_tensors: list[torch.Tensor] = []
+    output_group_tensors: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            input_group_tensors.append(input_flat)
+            output_group_tensors.append(output_flat)
+        else:
+            input_group_tensors.append(helper_bufs[g])
+            output_group_tensors.append(helper_bufs[g])
+
+    fused.reduce_scatter_multi_group(
+        input_tensors=input_group_tensors,
+        output_tensors=output_group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_recv_counts=per_group_recv_counts,
+        all_active_ranks=all_active_ranks,
+        op=dist.ReduceOp.AVG,
+        skip_validation=True,
+    )
+
+
+# ---------------------------------------------------------------------------
 # NCCL baseline: 4 parallel 2-rank dist.all_reduce calls
 # ---------------------------------------------------------------------------
 
@@ -511,6 +551,28 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     if rank == 0:
         results_dict["A"] = (mean_serial, std_serial)
+
+    # NCCL reduce-scatter baseline on the same 2-rank sub-group PG.
+    # Free the allreduce tensors first to reclaim HBM. recv_count =
+    # prod_total // 2 so the input (2 x recv_count) matches the sharded-relay
+    # reduce-scatter benchmark's active footprint.
+    my_tensors = []
+    torch.cuda.empty_cache()
+    rs_recv = prod_totals[my_sparse_group] // 2
+    rs_in = torch.ones(2 * rs_recv, dtype=dtype, device=device)
+    rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
+
+    # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
+    def run_rs_baseline() -> None:
+        rs_in.fill_(1.0)
+        dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
+        rs_out.div_(sparse_group_size)
+
+    mean_rs_base, std_rs_base = _measure_ms(run_rs_baseline, warmup, bench_iters)
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_rs"] = (mean_rs_base, std_rs_base)
 
     dist.destroy_process_group()
 
@@ -724,6 +786,49 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     torch.cuda.synchronize()
     peak_hbm_bytes = torch.cuda.max_memory_allocated()
 
+    # -------------------------------------------------------------------------
+    # Benchmark D: fused reduce-scatter. Release the Bench C kernel tensors
+    # first to reclaim HBM — reduce-scatter's input buffer is 2x its output
+    # (two blocks), so the active footprint is larger than allreduce's.
+    # Reassign (instead of `del`) so the run_kernel closure stays valid.
+    # -------------------------------------------------------------------------
+    kernel_tensor = torch.empty(0, dtype=dtype, device=device)
+    kernel_scratch = []
+    torch.cuda.empty_cache()
+
+    # recv_count = prod_total // 2 so the input (2 x recv_count) matches the
+    # allreduce active footprint (one prod_total per group).
+    rs_recv_counts = [t // 2 for t in prod_totals]
+    my_rs_recv = rs_recv_counts[my_sparse_group]
+    rs_input = torch.ones(2 * my_rs_recv, dtype=dtype, device=device)
+    rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
+    rs_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            rs_helper_bufs.append(rs_output)  # unused for the active group
+        else:
+            rs_helper_size_g = _passthrough_helper_size(
+                rs_recv_counts[g], sparse_group_size, num_chunks
+            )
+            rs_helper_bufs.append(
+                torch.empty(rs_helper_size_g, dtype=dtype, device=device)
+            )
+
+    def run_reduce_scatter() -> None:
+        rs_input.fill_(1.0)
+        bench_reduce_scatter_flat(
+            fused=fused,
+            input_flat=rs_input,
+            output_flat=rs_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=rs_helper_bufs,
+            per_group_recv_counts=rs_recv_counts,
+        )
+
+    mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
+
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
         kernel_bytes = kernel_elements * dtype.itemsize
@@ -733,9 +838,25 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
         bench_a_mean = float(results_dict["A"][0]) if "A" in results_dict else 0.0
         bench_a_std = float(results_dict["A"][1]) if "A" in results_dict else 0.0
+        bench_a_rs_mean = (
+            float(results_dict["A_rs"][0]) if "A_rs" in results_dict else 0.0
+        )
+        bench_a_rs_std = (
+            float(results_dict["A_rs"][1]) if "A_rs" in results_dict else 0.0
+        )
+
+        rs_output_bytes = my_rs_recv * dtype.itemsize
+
+        def rs_bw(nbytes: int, ms: float) -> float:
+            # Reduce-scatter busBW factor for n active ranks is (n-1)/n.
+            return (
+                (sparse_group_size - 1) / sparse_group_size * nbytes / (ms / 1000) / 1e9
+                if ms > 0
+                else 0.0
+            )
 
         print("\n" + "=" * 72)
-        print(f"Sharded Relay Allreduce Benchmark — MI350X ({world_size} GPUs)")
+        print(f"Sharded Relay Benchmark — MI350X ({world_size} GPUs)")
         print("=" * 72)
         print(f"  dtype:          {dtype}")
         print(f"  num_tables:     {num_tables}")
@@ -744,23 +865,26 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             f"({table_size * dtype.itemsize / 1024 / 1024:.1f} MB)"
         )
         print(f"  total data/grp: {total_bytes / 1024 / 1024:.1f} MB")
+
+        # ----- ALLREDUCE -----
         print()
+        print("-" * 72)
+        print("ALLREDUCE")
+        print("-" * 72)
         if bench_a_mean > 0:
-            print(f"  [A] COALESCED ({num_tables} tensors, allreduce_coalesced):")
+            print(f"  [A] NCCL COALESCED (baseline, {num_tables} tensors):")
             print(
                 f"       {bench_a_mean:.2f} ms  ±  {bench_a_std:.2f} ms  |  "
                 f"{bw(total_bytes, bench_a_mean):.1f} GB/s"
             )
         else:
-            print("  [A] COALESCED: N/A")
-        print()
-        print("  [B] FUSED FLAT (1 call, passthrough helpers, phase-sync kernel):")
+            print("  [A] NCCL COALESCED (baseline): N/A")
+        print("  [B] SHARDED RELAY (1 fused call, passthrough helpers):")
         print(
             f"       {mean_fused:.2f} ms  ±  {std_fused:.2f} ms  |  "
             f"{bw(total_bytes, mean_fused):.1f} GB/s"
         )
         print(f"       Peak HBM: {peak_hbm_bytes / 1024 / 1024 / 1024:.2f} GiB")
-        print()
         print(
             f"  [C] KERNEL DIRECT (1 large tensor, {kernel_bytes / 1024 / 1024:.0f} MB):"
         )
@@ -768,10 +892,43 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             f"       {mean_kernel:.2f} ms  ±  {std_kernel:.2f} ms  |  "
             f"{bw(kernel_bytes, mean_kernel):.1f} GB/s"
         )
+        if bench_a_mean > 0 and mean_fused > 0:
+            speedup_ar = bench_a_mean / mean_fused
+            print(
+                f"  >> Allreduce speedup (NCCL coalesced → sharded relay): "
+                f"{speedup_ar:.2f}x"
+            )
+
+        # ----- REDUCE-SCATTER -----
         print()
-        if bench_a_mean > 0:
-            speedup_ab = bench_a_mean / mean_fused if mean_fused > 0 else float("inf")
-            print(f"  A→B speedup (coalesced → fused flat):  {speedup_ab:.2f}x")
+        print("-" * 72)
+        print("REDUCE-SCATTER")
+        print("-" * 72)
+        if bench_a_rs_mean > 0:
+            print(
+                f"  [A] NCCL reduce_scatter_tensor (baseline, "
+                f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+            )
+            print(
+                f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
+                f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
+            )
+        else:
+            print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+        )
+        print(
+            f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
+            f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
+        )
+        if bench_a_rs_mean > 0 and mean_rs > 0:
+            speedup_rs = bench_a_rs_mean / mean_rs
+            print(
+                f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
+                f"{speedup_rs:.2f}x"
+            )
         print("=" * 72)
 
     dist.barrier()

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -1698,6 +1698,9 @@ def _relay_helper_size(
         return _passthrough_helper_size(elements, active_ranks, num_chunks)
     if collective == "reduce_scatter":
         recv = elements // active_ranks
+        if active_ranks > 2:
+            # A>2 reduces at the helper: one chunk per (owner, source) pair.
+            return 2 * recv
         return _passthrough_helper_size(recv, active_ranks, num_chunks)
     if collective == "all_to_all":
         if active_ranks > 2:

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -71,8 +71,8 @@ Environment variables (all optional):
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
 
 The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
-groups and prints a full report for each. The 4-active sweep covers allreduce,
-reduce-scatter, and all-to-all (all-gather is still 2-active only).
+groups and prints a full report for each. The 4-active sweep covers all four
+collectives: allreduce, reduce-scatter, all-to-all, and all-gather.
 """
 
 from __future__ import annotations
@@ -483,9 +483,9 @@ def bench_all_gather_flat(
 ) -> None:
     """ONE fused all-gather call across all sparse groups.
 
-    input_flat holds send_count elements; output_flat holds nActiveRanks x
-    send_count elements. Each helper group uses its own passthrough-sized
-    scratch buffer for both send and recv.
+    Each group contributes ONE contiguous tensor: the active group passes the
+    single contiguous input_flat/output_flat; each helper group passes its
+    single passthrough scratch buffer.
     """
     input_group_tensors: list[torch.Tensor] = []
     output_group_tensors: list[torch.Tensor] = []
@@ -750,29 +750,31 @@ def _bench_a_worker(
     if rank == 0:
         results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
 
-    # NCCL all-gather baseline is 2-active only (paired with the 2-active sharded
-    # relay all-gather bench). All ranks share the same env-driven
-    # sparse_group_size, so the _store_barrier() calls stay balanced.
-    if sparse_group_size == 2:
-        # NCCL all-gather baseline. Free the all-to-all baseline tensors first.
-        # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
-        # matches the sharded-relay all-gather footprint.
-        a2a_in = torch.empty(0, dtype=dtype, device=device)
-        a2a_out = torch.empty(0, dtype=dtype, device=device)
-        torch.cuda.empty_cache()
-        ag_send = prod_totals[my_sparse_group] // 4
-        ag_in = torch.ones(ag_send, dtype=dtype, device=device)
-        ag_out = torch.empty(sparse_group_size * ag_send, dtype=dtype, device=device)
+    # NCCL all-gather baseline runs for all active-rank counts (paired with the
+    # now-4-active sharded relay all-gather bench). Free the all-to-all baseline
+    # tensors first. send_count = prod_total // (2 * sparse_group_size) so the
+    # output (A x send_count = prod_total/2) matches the sharded-relay all-gather
+    # footprint regardless of A.
+    a2a_in = torch.empty(0, dtype=dtype, device=device)
+    a2a_out = torch.empty(0, dtype=dtype, device=device)
+    torch.cuda.empty_cache()
+    ag_send = prod_totals[my_sparse_group] // (2 * sparse_group_size)
+    ag_in = torch.ones(ag_send, dtype=dtype, device=device)
+    ag_out = torch.empty(sparse_group_size * ag_send, dtype=dtype, device=device)
 
-        def run_ag_baseline() -> None:
-            ag_in.fill_(1.0)
-            dist.all_gather_into_tensor(ag_out, ag_in, group=my_pg)
+    def run_ag_baseline() -> None:
+        ag_in.fill_(1.0)
+        dist.all_gather_into_tensor(ag_out, ag_in, group=my_pg)
 
-        mean_ag_base, std_ag_base = _measure_ms(run_ag_baseline, warmup, bench_iters)
-        _store_barrier()
+    mean_ag_base, std_ag_base = (
+        _measure_ms(run_ag_baseline, warmup, bench_iters)
+        if _want("all_gather")
+        else (0.0, 0.0)
+    )
+    _store_barrier()
 
-        if rank == 0:
-            results_dict["A_ag"] = (mean_ag_base, std_ag_base)
+    if rank == 0:
+        results_dict["A_ag"] = (mean_ag_base, std_ag_base)
 
     dist.destroy_process_group()
 
@@ -792,9 +794,9 @@ def _benchmark_worker(
     not depend on dist._get_default_store(), which can hang when called from
     spawned child processes in the Meta environment.
 
-    sharding_group_size selects the active-ranks-per-group (2 or 4). At 4 the
-    all-gather bench (2-active only) is skipped; allreduce, reduce-scatter, and
-    all-to-all run at both 2 and 4. port_offset isolates ports across the
+    sharding_group_size selects the active-ranks-per-group (2 or 4). All four
+    collectives (allreduce, reduce-scatter, all-to-all, all-gather) run at both
+    2 and 4. port_offset isolates ports across the
     2-rank and 4-rank sweep iterations.
     """
     os.environ["MASTER_ADDR"] = "localhost"
@@ -1016,11 +1018,8 @@ def _benchmark_worker(
     else:
         peak_hbm_bytes = 0
 
-    # The all-gather sharded-relay bench only supports 2 active ranks today, so
-    # it is skipped during the 4-active sweep. Reduce-scatter and all-to-all
-    # support 2 or 4 and always run.
-    mean_ag = std_ag = 0.0
-    my_ag_send = 0
+    # All sharded-relay collectives (reduce-scatter, all-to-all, all-gather) run
+    # for both 2 and 4 active ranks.
 
     # -------------------------------------------------------------------------
     # Benchmark D: fused reduce-scatter (runs for all active-rank counts).
@@ -1196,49 +1195,91 @@ def _benchmark_worker(
         else (0.0, 0.0)
     )
 
-    if sparse_group_size == 2:
-        # ---------------------------------------------------------------------
-        # Benchmark F: fused all-gather. Release the all-to-all buffers first.
-        # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
-        # matches the all-to-all footprint.
-        # ---------------------------------------------------------------------
-        a2a_input = torch.empty(0, dtype=dtype, device=device)
-        a2a_output = torch.empty(0, dtype=dtype, device=device)
-        a2a_helper_bufs = []
-        torch.cuda.empty_cache()
+    # -------------------------------------------------------------------------
+    # Benchmark F: fused all-gather (runs for all active-rank counts). Release
+    # the all-to-all buffers first. send_count = prod_total // (2*sparse_group_size)
+    # so the output (A x send_count = prod_total/2) stays within HBM. Indexed by
+    # range(num_sparse_groups) (NOT `for t in prod_totals`) so the send-count list
+    # length matches num_sparse_groups (2 at 4-active).
+    # -------------------------------------------------------------------------
+    a2a_input = torch.empty(0, dtype=dtype, device=device)
+    a2a_output = torch.empty(0, dtype=dtype, device=device)
+    a2a_helper_bufs = []
+    a2a_in_model = [torch.empty(0, dtype=dtype, device=device)]
+    a2a_out_model = [torch.empty(0, dtype=dtype, device=device)]
+    torch.cuda.empty_cache()
 
-        ag_send_counts = [t // 4 for t in prod_totals]
-        my_ag_send = ag_send_counts[my_sparse_group]
-        ag_input = torch.ones(my_ag_send, dtype=dtype, device=device)
-        ag_output = torch.empty(
-            sparse_group_size * my_ag_send, dtype=dtype, device=device
-        )
-        ag_helper_bufs: list[torch.Tensor] = []
-        for g in range(num_sparse_groups):
-            if g == my_sparse_group:
-                ag_helper_bufs.append(ag_output)  # unused for the active group
+    ag_send_counts = [
+        prod_totals[g] // (2 * sparse_group_size) for g in range(num_sparse_groups)
+    ]
+    my_ag_send = ag_send_counts[my_sparse_group]
+    ag_input = torch.ones(my_ag_send, dtype=dtype, device=device)
+    ag_output = torch.empty(sparse_group_size * my_ag_send, dtype=dtype, device=device)
+    ag_in_model = [torch.ones(my_ag_send, dtype=dtype, device=device)]
+    ag_out_model = [
+        torch.empty(sparse_group_size * my_ag_send, dtype=dtype, device=device)
+    ]
+    ag_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            ag_helper_bufs.append(ag_output)  # unused for the active group
+        else:
+            if sparse_group_size > 2:
+                # Flat A>2 path: each helper stores one offload chunk per active
+                # source (A*cs <= send_count). A*send_count safely covers that
+                # (and matches the C++ tests).
+                ag_helper_size_g = sparse_group_size * ag_send_counts[g]
             else:
                 ag_helper_size_g = _passthrough_helper_size(
                     ag_send_counts[g], sparse_group_size, num_chunks
                 )
-                ag_helper_bufs.append(
-                    torch.empty(ag_helper_size_g, dtype=dtype, device=device)
-                )
-
-        def run_all_gather() -> None:
-            ag_input.fill_(1.0)
-            bench_all_gather_flat(
-                fused=fused,
-                input_flat=ag_input,
-                output_flat=ag_output,
-                num_sparse_groups=num_sparse_groups,
-                my_sparse_group=my_sparse_group,
-                all_active_ranks=all_active_ranks,
-                helper_bufs=ag_helper_bufs,
-                per_group_send_counts=ag_send_counts,
+            ag_helper_bufs.append(
+                torch.empty(ag_helper_size_g, dtype=dtype, device=device)
             )
 
-        mean_ag, std_ag = _measure_ms(run_all_gather, warmup, bench_iters)
+    def run_all_gather() -> None:
+        # Production path: pack the per-table model input into the contiguous
+        # flat send buffer, run the fused call, then unpack into the model output.
+        for t in ag_in_model:
+            t.fill_(1.0)
+        ag_input.copy_(ag_in_model[0].reshape(-1))
+        bench_all_gather_flat(
+            fused=fused,
+            input_flat=ag_input,
+            output_flat=ag_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=ag_helper_bufs,
+            per_group_send_counts=ag_send_counts,
+        )
+        ag_out_model[0].reshape(-1).copy_(ag_output)
+
+    mean_ag, std_ag = (
+        _measure_ms(run_all_gather, warmup, bench_iters)
+        if _want("all_gather")
+        else (0.0, 0.0)
+    )
+
+    def run_all_gather_kernel() -> None:
+        # Kernel-direct: raw kernel on the contiguous flat buffers, no pack/copy.
+        ag_input.fill_(1.0)
+        bench_all_gather_flat(
+            fused=fused,
+            input_flat=ag_input,
+            output_flat=ag_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=ag_helper_bufs,
+            per_group_send_counts=ag_send_counts,
+        )
+
+    mean_ag_kernel, std_ag_kernel = (
+        _measure_ms(run_all_gather_kernel, warmup, bench_iters)
+        if _want("all_gather")
+        else (0.0, 0.0)
+    )
 
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
@@ -1421,39 +1462,49 @@ def _benchmark_worker(
                 f"{bench_a_a2a_mean / mean_a2a_kernel:.2f}x"
             )
 
-        # ----- ALL-GATHER (2-active only) -----
-        if sparse_group_size == 2:
-            # ----- ALL-GATHER -----
-            ag_send_bytes = my_ag_send * dtype.itemsize
-            print()
-            print("-" * 72)
-            print("ALL-GATHER")
-            print("-" * 72)
-            if bench_a_ag_mean > 0:
-                print(
-                    f"  [A] NCCL all_gather_into_tensor (baseline, "
-                    f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
-                )
-                print(
-                    f"       {bench_a_ag_mean:.2f} ms  ±  {bench_a_ag_std:.2f} ms  |  "
-                    f"{rs_bw(ag_send_bytes, bench_a_ag_mean):.1f} GB/s"
-                )
-            else:
-                print("  [A] NCCL all_gather_into_tensor (baseline): N/A")
+        # ----- ALL-GATHER (runs for 2 or 4 active ranks) -----
+        ag_send_bytes = my_ag_send * dtype.itemsize
+        print()
+        print("-" * 72)
+        print("ALL-GATHER")
+        print("-" * 72)
+        if bench_a_ag_mean > 0:
             print(
-                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+                f"  [A] NCCL all_gather_into_tensor (baseline, "
                 f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
             )
             print(
-                f"       {mean_ag:.2f} ms  ±  {std_ag:.2f} ms  |  "
-                f"{rs_bw(ag_send_bytes, mean_ag):.1f} GB/s"
+                f"       {bench_a_ag_mean:.2f} ms  ±  {bench_a_ag_std:.2f} ms  |  "
+                f"{rs_bw(ag_send_bytes, bench_a_ag_mean):.1f} GB/s"
             )
-            if bench_a_ag_mean > 0 and mean_ag > 0:
-                speedup_ag = bench_a_ag_mean / mean_ag
-                print(
-                    f"  >> All-gather speedup (NCCL → sharded relay): "
-                    f"{speedup_ag:.2f}x"
-                )
+        else:
+            print("  [A] NCCL all_gather_into_tensor (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
+        )
+        print(
+            f"       {mean_ag:.2f} ms  ±  {std_ag:.2f} ms  |  "
+            f"{rs_bw(ag_send_bytes, mean_ag):.1f} GB/s"
+        )
+        print(
+            f"  [C] KERNEL DIRECT (no pack/copy, "
+            f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
+        )
+        print(
+            f"       {mean_ag_kernel:.2f} ms  ±  {std_ag_kernel:.2f} ms  |  "
+            f"{rs_bw(ag_send_bytes, mean_ag_kernel):.1f} GB/s"
+        )
+        if bench_a_ag_mean > 0 and mean_ag > 0:
+            speedup_ag = bench_a_ag_mean / mean_ag
+            print(
+                f"  >> All-gather speedup (NCCL → sharded relay): " f"{speedup_ag:.2f}x"
+            )
+        if bench_a_ag_mean > 0 and mean_ag_kernel > 0:
+            print(
+                f"  >> All-gather KERNEL speedup (NCCL → kernel-direct): "
+                f"{bench_a_ag_mean / mean_ag_kernel:.2f}x"
+            )
         print("=" * 72)
 
     dist.barrier()
@@ -1499,10 +1550,10 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         results: Any = manager.dict()
 
         # Sweep both 2-active and 4-active sharded relay groups, printing a full
-        # report for each. The 4-active sweep covers allreduce, reduce-scatter,
-        # and all-to-all (the all-gather bench is 2-active only and is skipped at
-        # 4). Each iteration uses a distinct port_offset so the NCCL/TCPStore
-        # endpoints don't collide across iterations.
+        # report for each. The 4-active sweep covers all four collectives
+        # (allreduce, reduce-scatter, all-to-all, all-gather). Each iteration
+        # uses a distinct port_offset so the NCCL/TCPStore endpoints don't
+        # collide across iterations.
         for i, sharding_group_size in enumerate((2, 4)):
             port_offset = i * 100
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -73,12 +73,29 @@ Environment variables (all optional):
 The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
 groups and prints a full report for each. The 4-active sweep covers all four
 collectives: allreduce, reduce-scatter, all-to-all, and all-gather.
+
+Message-size sweep (all collectives, 2- & 4-rank, bf16):
+    A separate test method, test_collectives_msg_size_sweep, sweeps a fixed list
+    of message sizes (4 KB .. 1 GB) for every collective (allreduce,
+    reduce-scatter, all-to-all, all-gather) at both 2 and 4 active ranks, and
+    reports the sharded-relay speedup over NCCL in the FUSED scenario:
+    (NUM_GPUS // A) concurrent A-rank groups in one multi-group relay kernel vs
+    the matching NCCL baseline run in parallel on each rank's A-rank sub-group.
+    It prints one table per (collective, active-rank-count). The swept size is the
+    per-active-rank input tensor byte size, so sizes stay comparable across
+    collectives. The single-group scenario is benchmarked separately (see
+    test_parallel_2rank_allreduce_sweep). Run it selectively so the production
+    test above does not also run:
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+            //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
+            torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_collectives_msg_size_sweep
 """
 
 from __future__ import annotations
 
 import os
 import unittest
+from functools import partial
 from typing import Any
 
 import torch
@@ -166,6 +183,52 @@ def _default_totals(dtype: torch.dtype) -> list[int]:
     totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
     cap = _DEFAULT_MAX_BYTES_PER_GROUP // dtype.itemsize
     return [min(total, cap) for total in totals]
+
+
+# ---------------------------------------------------------------------------
+# Message-size sweep (test_allreduce_msg_size_sweep)
+# ---------------------------------------------------------------------------
+
+_KIB: int = 1024
+_MIB: int = 1024 * 1024
+
+# (human label, bytes) for each swept allreduce message size. Each value is the
+# byte size of the input tensor a single active rank contributes to the
+# allreduce; element count = bytes // dtype.itemsize.
+_MSG_SWEEP_SIZES: list[tuple[str, int]] = [
+    ("4 KB", 4 * _KIB),
+    ("9 KB", 9 * _KIB),
+    ("18 KB", 18 * _KIB),
+    ("36 KB", 36 * _KIB),
+    ("72 KB", 72 * _KIB),
+    ("144 KB", 144 * _KIB),
+    ("288 KB", 288 * _KIB),
+    ("576 KB", 576 * _KIB),
+    ("4.5 MB", int(4.5 * _MIB)),
+    ("9 MB", 9 * _MIB),
+    ("13.5 MB", int(13.5 * _MIB)),
+    ("27 MB", 27 * _MIB),
+    ("31.5 MB", int(31.5 * _MIB)),
+    ("36 MB", 36 * _MIB),
+    ("63 MB", 63 * _MIB),
+    ("67.5 MB", int(67.5 * _MIB)),
+    ("72 MB", 72 * _MIB),
+    ("135 MB", 135 * _MIB),
+    ("144 MB", 144 * _MIB),
+    ("256 MB", 256 * _MIB),
+    ("512 MB", 512 * _MIB),
+    ("1 GB", 1024 * _MIB),
+]
+
+# Active-rank counts and collectives swept by test_collectives_msg_size_sweep.
+# The sweep prints one table per (collective, active-rank-count) = 8 tables.
+_MSG_SWEEP_ACTIVE_RANKS: tuple[int, ...] = (2, 4)
+_MSG_SWEEP_COLLECTIVES: tuple[str, ...] = (
+    "allreduce",
+    "reduce_scatter",
+    "all_to_all",
+    "all_gather",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1512,6 +1575,652 @@ def _benchmark_worker(
 
 
 # ---------------------------------------------------------------------------
+# Message-size sweep workers (test_collectives_msg_size_sweep)
+#
+# Sweeps every collective (allreduce, reduce-scatter, all-to-all, all-gather) at
+# both 2 and 4 active ranks over a fixed list of message sizes and reports, per
+# size, the sharded-relay speedup over NCCL for the FUSED scenario:
+#   FUSED — (NUM_GPUS // A) concurrent A-rank groups in one multi-group kernel
+#           call, vs the NCCL baseline run in parallel on each rank's A-rank
+#           sub-group.
+# The single-group scenario is benchmarked separately (see the parallel
+# independent-comm sweep, test_parallel_2rank_allreduce_sweep).
+# Fixed at bf16. NCCL allreduce/reduce-scatter baselines use SUM + manual divide
+# (RCCL on MI350X lacks the AVG kernel); the relay path uses AVG in the kernel.
+# all-to-all / all-gather do no reduction. The swept nbytes is the per-active-rank
+# input tensor byte size, so sizes stay comparable across collectives.
+# ---------------------------------------------------------------------------
+
+# Data type for the message-size sweep comparison.
+_MSG_SWEEP_DTYPE: torch.dtype = torch.bfloat16
+
+
+# ----- Per-collective buffer/shape helpers (shared by NCCL + relay) ---------
+
+
+def _active_io(
+    collective: str,
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """(input, output) tensors an ACTIVE rank contributes for one collective.
+
+    `elements` is the per-active-rank input size (the swept size axis).
+    """
+    if collective == "allreduce":
+        t = torch.ones(elements, dtype=dtype, device=device)
+        return t, t  # in place
+    if collective == "reduce_scatter":
+        recv = elements // active_ranks
+        return (
+            torch.ones(elements, dtype=dtype, device=device),  # A * recv
+            torch.empty(recv, dtype=dtype, device=device),
+        )
+    if collective == "all_to_all":
+        return (
+            torch.ones(elements, dtype=dtype, device=device),  # A * seg
+            torch.empty(elements, dtype=dtype, device=device),
+        )
+    if collective == "all_gather":
+        return (
+            torch.ones(elements, dtype=dtype, device=device),  # send
+            torch.empty(active_ranks * elements, dtype=dtype, device=device),
+        )
+    raise ValueError(f"unknown collective {collective!r}")
+
+
+def _relay_helper_size(
+    collective: str, active_ranks: int, elements: int, num_chunks: int
+) -> int:
+    """Helper-buffer element count for a single helper group's relay tensor.
+
+    Mirrors the per-collective helper sizing _benchmark_worker uses for A=2 vs A>2.
+    """
+    if collective == "allreduce":
+        if active_ranks > 2:
+            return 2 * elements
+        return _passthrough_helper_size(elements, active_ranks, num_chunks)
+    if collective == "reduce_scatter":
+        recv = elements // active_ranks
+        return _passthrough_helper_size(recv, active_ranks, num_chunks)
+    if collective == "all_to_all":
+        if active_ranks > 2:
+            return 1  # pure-direct A>2 all-to-all: helper does no relay work
+        seg = elements // active_ranks
+        return _passthrough_helper_size(seg, active_ranks, num_chunks)
+    if collective == "all_gather":
+        if active_ranks > 2:
+            return active_ranks * elements
+        return _passthrough_helper_size(elements, active_ranks, num_chunks)
+    raise ValueError(f"unknown collective {collective!r}")
+
+
+def _relay_counts(
+    collective: str, active_ranks: int, elements: int, num_groups: int
+) -> list[int]:
+    """Per-group declared count vector passed to the fused relay call."""
+    if collective in ("allreduce", "all_gather"):
+        return [elements] * num_groups
+    if collective in ("reduce_scatter", "all_to_all"):
+        return [elements // active_ranks] * num_groups
+    raise ValueError(f"unknown collective {collective!r}")
+
+
+def _build_relay_bufs(
+    collective: str,
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    num_groups: int,
+    my_sparse_group: int,
+    num_chunks: int,
+) -> tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]:
+    """Build (active_in, active_out, per_group_helper_bufs) for one FUSED relay
+    call. Every rank is active in exactly one of the num_groups groups; the
+    helper slot for the active group is a placeholder (unused by the kernel)."""
+    active_in, active_out = _active_io(
+        collective, active_ranks, elements, dtype, device
+    )
+    helper_size = _relay_helper_size(collective, active_ranks, elements, num_chunks)
+    bufs: list[torch.Tensor] = []
+    for g in range(num_groups):
+        if g == my_sparse_group:
+            bufs.append(active_out)  # active group slot — unused by the kernel
+        else:
+            bufs.append(torch.empty(helper_size, dtype=dtype, device=device))
+    return active_in, active_out, bufs
+
+
+def _build_relay_group_lists(
+    active_in: torch.Tensor,
+    active_out: torch.Tensor,
+    bufs: list[torch.Tensor],
+    num_groups: int,
+    my_sparse_group: int,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Per-group (input, output) tensor lists for a FUSED relay call, built ONCE
+    outside the timed loop: the active group slot holds this rank's real
+    tensors; every other (helper) slot holds that group's passthrough scratch.
+    For allreduce (in-place) out_list mirrors in_list and is otherwise unused."""
+    in_list: list[torch.Tensor] = []
+    out_list: list[torch.Tensor] = []
+    for g in range(num_groups):
+        if g == my_sparse_group:
+            in_list.append(active_in)
+            out_list.append(active_out)
+        else:
+            in_list.append(bufs[g])
+            out_list.append(bufs[g])
+    return in_list, out_list
+
+
+def _run_relay_once(
+    collective: str,
+    relay: Any,
+    in_list: list[torch.Tensor],
+    out_list: list[torch.Tensor],
+    counts: list[int],
+    num_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+) -> None:
+    """One sharded-relay collective call with PRE-BUILT per-group tensor lists.
+
+    The per-group input/output lists (and inputs) are constructed once outside
+    the timed loop, so the timed region is just the wrapper dispatch — on par
+    with the NCCL baseline's single call. Inputs stay ones (AVG of ones = ones;
+    the non-allreduce collectives are out-of-place), so no per-call refill."""
+    if collective == "allreduce":
+        relay.allreduce_multi_group(
+            tensors=in_list,
+            num_groups=num_groups,
+            per_group_sizes=counts,
+            all_active_ranks=all_active_ranks,
+            op=dist.ReduceOp.AVG,
+            skip_validation=True,
+        )
+    elif collective == "reduce_scatter":
+        relay.reduce_scatter_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=num_groups,
+            per_group_recv_counts=counts,
+            all_active_ranks=all_active_ranks,
+            op=dist.ReduceOp.AVG,
+            skip_validation=True,
+        )
+    elif collective == "all_to_all":
+        relay.all_to_all_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=num_groups,
+            per_group_segment_counts=counts,
+            all_active_ranks=all_active_ranks,
+            skip_validation=True,
+        )
+    elif collective == "all_gather":
+        relay.all_gather_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=num_groups,
+            per_group_send_counts=counts,
+            all_active_ranks=all_active_ranks,
+            skip_validation=True,
+        )
+    else:
+        raise ValueError(f"unknown collective {collective!r}")
+
+
+# ----- NCCL baseline op builders (one per collective) ----------------------
+
+
+def _nccl_ops_allreduce(
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fused_pg: dist.ProcessGroup,
+    ar_opts: Any,
+) -> Any:
+    ft = torch.ones(elements, dtype=dtype, device=device)
+
+    def run_fused() -> None:
+        fused_pg.allreduce_coalesced([ft], opts=ar_opts).wait()
+        ft.div_(active_ranks)
+
+    return run_fused
+
+
+def _nccl_ops_reduce_scatter(
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fused_pg: dist.ProcessGroup,
+    _ar_opts: Any,
+) -> Any:
+    recv = elements // active_ranks
+    fin = torch.ones(elements, dtype=dtype, device=device)  # A * recv
+    fout = torch.empty(recv, dtype=dtype, device=device)
+
+    def run_fused() -> None:
+        dist.reduce_scatter_tensor(fout, fin, op=dist.ReduceOp.SUM, group=fused_pg)
+        fout.div_(active_ranks)
+
+    return run_fused
+
+
+def _nccl_ops_all_to_all(
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fused_pg: dist.ProcessGroup,
+    _ar_opts: Any,
+) -> Any:
+    fin = torch.ones(elements, dtype=dtype, device=device)  # A * seg
+    fout = torch.empty(elements, dtype=dtype, device=device)
+
+    def run_fused() -> None:
+        dist.all_to_all_single(fout, fin, group=fused_pg, async_op=True).wait()
+
+    return run_fused
+
+
+def _nccl_ops_all_gather(
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fused_pg: dist.ProcessGroup,
+    _ar_opts: Any,
+) -> Any:
+    fin = torch.ones(elements, dtype=dtype, device=device)  # send
+    fout = torch.empty(active_ranks * elements, dtype=dtype, device=device)
+
+    def run_fused() -> None:
+        dist.all_gather_into_tensor(fout, fin, group=fused_pg, async_op=True).wait()
+
+    return run_fused
+
+
+def _nccl_baseline_op(
+    collective: str,
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    fused_pg: dist.ProcessGroup,
+    ar_opts: Any,
+) -> Any:
+    """Return the FUSED NCCL baseline closure for one size (runs on this rank's
+    A-rank sub-group)."""
+    builders = {
+        "allreduce": _nccl_ops_allreduce,
+        "reduce_scatter": _nccl_ops_reduce_scatter,
+        "all_to_all": _nccl_ops_all_to_all,
+        "all_gather": _nccl_ops_all_gather,
+    }
+    return builders[collective](
+        active_ranks, elements, dtype, device, fused_pg, ar_opts
+    )
+
+
+def _msg_sweep_nccl_worker(
+    rank: int,
+    world_size: int,
+    results_dict: Any,
+    port_offset: int = 0,
+) -> None:
+    """NCCL FUSED baselines for the message-size sweep.
+
+    Writes, for each (collective, active-rank-count A, size index i) (rank 0 only):
+      results_dict["nccl_{collective}_a{A}_fused_{i}"] = (best_ms, std_ms)
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT + 200 + port_offset)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    local_rank = rank
+    is_master = rank == 0
+
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=_TCPSTORE_PORT + 200 + port_offset,
+        world_size=world_size,
+        is_master=is_master,
+        wait_for_workers=True,
+    )
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size, store=store
+    )
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    dtype = _MSG_SWEEP_DTYPE
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
+
+    # Build the A-rank sub-group PGs once per A (all ranks call new_group for
+    # every group collectively). pgs_by_a[A][rank // A] is this rank's FUSED
+    # sub-group.
+    pgs_by_a: dict[int, list[dist.ProcessGroup]] = {}
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        num_groups = world_size // active_ranks
+        groups = [
+            list(range(g * active_ranks, (g + 1) * active_ranks))
+            for g in range(num_groups)
+        ]
+        pgs_by_a[active_ranks] = [dist.new_group(ranks=grp) for grp in groups]
+
+    # SUM + manual divide (RCCL on MI350X lacks the AVG kernel).
+    _ar_opts = dist.AllreduceCoalescedOptions()
+    _ar_opts.reduceOp = dist.ReduceOp.SUM
+
+    # Warm up each FUSED sub-group communicator.
+    _wt = torch.ones(1, dtype=dtype, device=device)
+    for active_ranks, pgs in pgs_by_a.items():
+        dist.all_reduce(_wt, op=dist.ReduceOp.SUM, group=pgs[rank // active_ranks])
+    torch.cuda.synchronize()
+    del _wt
+
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        pgs = pgs_by_a[active_ranks]
+        fused_pg = pgs[rank // active_ranks]
+        for collective in _MSG_SWEEP_COLLECTIVES:
+            for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+                elements = nbytes // dtype.itemsize
+                if elements % active_ranks != 0:
+                    continue
+                run_fused_base = _nccl_baseline_op(
+                    collective,
+                    active_ranks,
+                    elements,
+                    dtype,
+                    device,
+                    fused_pg,
+                    _ar_opts,
+                )
+                best_f, std_f = _measure_ms(run_fused_base, warmup, bench_iters)
+                # Drop the per-size tensors held by the closure before the next
+                # (larger) size.
+                del run_fused_base
+                torch.cuda.empty_cache()
+
+                if rank == 0:
+                    key = f"{collective}_a{active_ranks}"
+                    results_dict[f"nccl_{key}_fused_{i}"] = (best_f, std_f)
+
+    # Match the relay worker: let every rank finish its collectives before any
+    # rank tears the process group down.
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _measure_relay_for(
+    collective: str,
+    active_ranks: int,
+    relay_fused: Any,
+    nbytes: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+    warmup: int,
+    bench_iters: int,
+) -> tuple[float, float]:
+    """Time the FUSED (num_groups = world // A) relay collective for one message
+    size. Returns (best_ms, std_ms)."""
+    elements = nbytes // dtype.itemsize
+    if active_ranks == 0 or elements % active_ranks != 0:
+        return 0.0, 0.0
+    num_chunks = (world_size - active_ranks) + 1
+
+    num_groups = world_size // active_ranks
+    my_sparse_group = rank // active_ranks
+    fused_active_ranks = [
+        list(range(g * active_ranks, (g + 1) * active_ranks)) for g in range(num_groups)
+    ]
+    active_in, active_out, bufs = _build_relay_bufs(
+        collective,
+        active_ranks,
+        elements,
+        dtype,
+        device,
+        num_groups,
+        my_sparse_group,
+        num_chunks,
+    )
+    counts = _relay_counts(collective, active_ranks, elements, num_groups)
+    in_list, out_list = _build_relay_group_lists(
+        active_in, active_out, bufs, num_groups, my_sparse_group
+    )
+    best_f, std_f = _measure_ms(
+        partial(
+            _run_relay_once,
+            collective,
+            relay_fused,
+            in_list,
+            out_list,
+            counts,
+            num_groups,
+            my_sparse_group,
+            fused_active_ranks,
+        ),
+        warmup,
+        bench_iters,
+    )
+    del active_in, active_out, bufs, in_list, out_list
+    torch.cuda.empty_cache()
+    return best_f, std_f
+
+
+def _msg_sweep_relay_warmup(
+    fused_by_a: dict[int, Any],
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Tiny FUSED relay calls for every (A, collective) so each distinct HIP
+    kernel config JIT-compiles before timing."""
+    torch.cuda.synchronize()
+    dist.barrier()
+    # The A=2 reduce-scatter/all-to-all 2-active relay path requires the chunked
+    # quantity Q = elements // A >= 128 * numChunks (= 128 * (world - A + 1)); for
+    # 8 ranks, A=2 that is Q >= 896, i.e. elements >= A * 896 = 1792. Use 2048 so
+    # every (collective, A) warmup config clears the floor (the real sweep starts
+    # at 4 KB = 2048 elements, so it is always valid too).
+    warm_elems = 2048
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        num_chunks = (world_size - active_ranks) + 1
+        num_groups = world_size // active_ranks
+        my_sparse_group = rank // active_ranks
+        fused_active_ranks = [
+            list(range(g * active_ranks, (g + 1) * active_ranks))
+            for g in range(num_groups)
+        ]
+        for collective in _MSG_SWEEP_COLLECTIVES:
+            a_in, a_out, bufs = _build_relay_bufs(
+                collective,
+                active_ranks,
+                warm_elems,
+                dtype,
+                device,
+                num_groups,
+                my_sparse_group,
+                num_chunks,
+            )
+            counts = _relay_counts(collective, active_ranks, warm_elems, num_groups)
+            in_list, out_list = _build_relay_group_lists(
+                a_in, a_out, bufs, num_groups, my_sparse_group
+            )
+            for _ in range(3):
+                _run_relay_once(
+                    collective,
+                    fused_by_a[active_ranks],
+                    in_list,
+                    out_list,
+                    counts,
+                    num_groups,
+                    my_sparse_group,
+                    fused_active_ranks,
+                )
+            del a_in, a_out, bufs, in_list, out_list
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+
+def _msg_sweep_relay_worker(
+    rank: int,
+    world_size: int,
+    results_dict: Any,
+    port_offset: int = 0,
+) -> None:
+    """Sharded-relay FUSED collectives for the message-size sweep.
+
+    Writes, for each (collective, active-rank-count A, size index i) (rank 0 only):
+      results_dict["relay_{collective}_a{A}_fused_{i}"] = (best_ms, std_ms)
+
+    Rank 0 prints the final summary tables using both the relay results and the
+    NCCL results written earlier by _msg_sweep_nccl_worker.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT + 300 + port_offset)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    local_rank = rank
+    is_master = rank == 0
+
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=_TCPSTORE_PORT + 300 + port_offset,
+        world_size=world_size,
+        is_master=is_master,
+        wait_for_workers=True,
+    )
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size, store=store
+    )
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    dtype = _MSG_SWEEP_DTYPE
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
+
+    # One shared intra-node RCCLX comm, then a FUSED (num_groups = world // A)
+    # relay object per active-rank count. Every rank constructs all objects
+    # collectively.
+    rcclx_comm = _setup_rcclx_comm(local_rank, world_size, 0, store)
+    fused_by_a: dict[int, Any] = {}
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        fused_by_a[active_ranks] = _make_fused(
+            rcclx_comm, local_rank, world_size, active_ranks
+        )
+    if rcclx_comm is None or any(v is None for v in fused_by_a.values()):
+        if rank == 0:
+            print("[bench] FusedShardedRelayMultiGroup not available. Exiting.")
+        dist.destroy_process_group()
+        return
+
+    # Pre-compile every distinct HIP kernel config before timing.
+    _msg_sweep_relay_warmup(fused_by_a, rank, world_size, dtype, device)
+
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        relay_fused = fused_by_a[active_ranks]
+        for collective in _MSG_SWEEP_COLLECTIVES:
+            for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+                best_f, std_f = _measure_relay_for(
+                    collective=collective,
+                    active_ranks=active_ranks,
+                    relay_fused=relay_fused,
+                    nbytes=nbytes,
+                    dtype=dtype,
+                    device=device,
+                    rank=rank,
+                    world_size=world_size,
+                    warmup=warmup,
+                    bench_iters=bench_iters,
+                )
+                if rank == 0:
+                    key = f"{collective}_a{active_ranks}"
+                    results_dict[f"relay_{key}_fused_{i}"] = (best_f, std_f)
+
+    if rank == 0:
+        _print_msg_sweep_report(results_dict, dtype)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _sweep_get_ms(results_dict: Any, key: str) -> float:
+    v = results_dict.get(key)
+    return float(v[0]) if v is not None else 0.0
+
+
+def _sweep_fmt_ms(v: float) -> str:
+    return f"{v:.3f}" if v > 0 else "N/A"
+
+
+def _sweep_fmt_speedup(nccl: float, relay: float) -> str:
+    return f"{nccl / relay:.2f}x" if nccl > 0 and relay > 0 else "N/A"
+
+
+def _print_sweep_table(
+    results_dict: Any, dtype: torch.dtype, collective: str, active_ranks: int
+) -> None:
+    """Print one (collective, active-rank-count) FUSED message-size sweep table."""
+    num_groups = NUM_GPUS // active_ranks
+    key = f"{collective}_a{active_ranks}"
+    title = collective.replace("_", "-").upper()
+    width = 55
+    line = "=" * width
+    print("\n" + line)
+    print(
+        f"Sharded Relay {title} — Message-Size Sweep "
+        f"(MI350X, {NUM_GPUS} GPUs, {dtype})"
+    )
+    print(
+        f"  {active_ranks} active ranks/group; times = best-of-N (min), "
+        "barrier-aligned + hipEvent-timed"
+    )
+    print(
+        f"  FUSED = {num_groups}-group sharded relay  vs  "
+        f"NCCL baseline ({num_groups} concurrent {active_ranks}-rank groups)"
+    )
+    print(line)
+    print(f"{'':>10} | {f'FUSED ({num_groups} groups)':^33}")
+    print(f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}")
+    print("-" * width)
+    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+        elements = nbytes // dtype.itemsize
+        if elements % active_ranks != 0:
+            continue
+        nf = _sweep_get_ms(results_dict, f"nccl_{key}_fused_{i}")
+        rf = _sweep_get_ms(results_dict, f"relay_{key}_fused_{i}")
+        print(
+            f"{label:>10} | {_sweep_fmt_ms(nf):>10} {_sweep_fmt_ms(rf):>10} "
+            f"{_sweep_fmt_speedup(nf, rf):>9}"
+        )
+    print(line)
+
+
+def _print_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
+    """Print one FUSED message-size sweep table per (collective, active-rank-count)."""
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+            _print_sweep_table(results_dict, dtype, collective, active_ranks)
+
+
+# ---------------------------------------------------------------------------
 # TestCase — works with both "buck2 test" and "buck2 run" (same as the old
 # test_sharded_relay_2d_integration.py pattern).
 # ---------------------------------------------------------------------------
@@ -1572,6 +2281,55 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
                 nprocs=NUM_GPUS,
                 join=True,
             )
+
+        manager.shutdown()
+
+    def test_collectives_msg_size_sweep(self) -> None:
+        """All-collective, 2- & 4-rank sharded relay message-size sweep (bf16).
+
+        Sweeps the fixed message sizes in _MSG_SWEEP_SIZES for every collective
+        (allreduce, reduce-scatter, all-to-all, all-gather) at both 2 and 4
+        active ranks and, per size, reports the sharded-relay FUSED speedup over
+        NCCL (one table per (collective, active-rank-count)):
+          FUSED — (NUM_GPUS // A) concurrent A-rank groups in one multi-group
+                  kernel call vs the matching NCCL baseline on each rank's A-rank
+                  sub-group.
+        The single-group scenario is benchmarked separately (see
+        test_parallel_2rank_allreduce_sweep).
+
+        Run selectively (so the production test_benchmark does not also run).
+        The buck2 test runner imports the module, so the selector must be the
+        fully-qualified module.Class.method path:
+            buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+                //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
+                torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_collectives_msg_size_sweep
+        """
+        manager = mp.Manager()
+        results: Any = manager.dict()
+
+        # Pin the GPU HW-queue count to the production regime: BM-FM runs with
+        # GPU_MAX_HW_QUEUES=2. Set before mp.spawn so the spawned workers inherit
+        # it before the HIP runtime initializes. Fused is queue-insensitive (one
+        # comm, one multi-group launch), so this only aligns it with the parallel
+        # sweep, which needs =2 to avoid uncoordinated multi-comm XGMI contention.
+        os.environ["GPU_MAX_HW_QUEUES"] = "2"
+
+        # Phase 1: NCCL FUSED baselines per collective and A.
+        mp.spawn(
+            _msg_sweep_nccl_worker,
+            args=(NUM_GPUS, results, 0),
+            nprocs=NUM_GPUS,
+            join=True,
+        )
+
+        # Phase 2: sharded relay FUSED per collective and A via RCCLX;
+        # rank 0 prints all 8 summary tables.
+        mp.spawn(
+            _msg_sweep_relay_worker,
+            args=(NUM_GPUS, results, 0),
+            nprocs=NUM_GPUS,
+            join=True,
+        )
 
         manager.shutdown()
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -444,6 +444,47 @@ def bench_all_to_all_flat(
 
 
 # ---------------------------------------------------------------------------
+# Benchmark F: fused all-gather (sharded relay)
+# ---------------------------------------------------------------------------
+
+
+def bench_all_gather_flat(
+    fused: Any,
+    input_flat: torch.Tensor,
+    output_flat: torch.Tensor,
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    helper_bufs: list[torch.Tensor],
+    per_group_send_counts: list[int],
+) -> None:
+    """ONE fused all-gather call across all sparse groups.
+
+    input_flat holds send_count elements; output_flat holds nActiveRanks x
+    send_count elements. Each helper group uses its own passthrough-sized
+    scratch buffer for both send and recv.
+    """
+    input_group_tensors: list[torch.Tensor] = []
+    output_group_tensors: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            input_group_tensors.append(input_flat)
+            output_group_tensors.append(output_flat)
+        else:
+            input_group_tensors.append(helper_bufs[g])
+            output_group_tensors.append(helper_bufs[g])
+
+    fused.all_gather_multi_group(
+        input_tensors=input_group_tensors,
+        output_tensors=output_group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_send_counts=per_group_send_counts,
+        all_active_ranks=all_active_ranks,
+        skip_validation=True,
+    )
+
+
+# ---------------------------------------------------------------------------
 # NCCL baseline: 4 parallel 2-rank dist.all_reduce calls
 # ---------------------------------------------------------------------------
 
@@ -636,6 +677,27 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     if rank == 0:
         results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
+
+    # NCCL all-gather baseline on the same 2-rank sub-group PG. Free the
+    # all-to-all baseline tensors first. send_count = prod_total // 4 so the
+    # output (nActiveRanks x send_count) matches the sharded-relay all-gather
+    # benchmark's footprint.
+    a2a_in = torch.empty(0, dtype=dtype, device=device)
+    a2a_out = torch.empty(0, dtype=dtype, device=device)
+    torch.cuda.empty_cache()
+    ag_send = prod_totals[my_sparse_group] // 4
+    ag_in = torch.ones(ag_send, dtype=dtype, device=device)
+    ag_out = torch.empty(sparse_group_size * ag_send, dtype=dtype, device=device)
+
+    def run_ag_baseline() -> None:
+        ag_in.fill_(1.0)
+        dist.all_gather_into_tensor(ag_out, ag_in, group=my_pg)
+
+    mean_ag_base, std_ag_base = _measure_ms(run_ag_baseline, warmup, bench_iters)
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_ag"] = (mean_ag_base, std_ag_base)
 
     dist.destroy_process_group()
 
@@ -933,6 +995,47 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     mean_a2a, std_a2a = _measure_ms(run_all_to_all, warmup, bench_iters)
 
+    # -------------------------------------------------------------------------
+    # Benchmark F: fused all-gather. Release the all-to-all buffers first.
+    # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
+    # matches the all-to-all footprint.
+    # -------------------------------------------------------------------------
+    a2a_input = torch.empty(0, dtype=dtype, device=device)
+    a2a_output = torch.empty(0, dtype=dtype, device=device)
+    a2a_helper_bufs = []
+    torch.cuda.empty_cache()
+
+    ag_send_counts = [t // 4 for t in prod_totals]
+    my_ag_send = ag_send_counts[my_sparse_group]
+    ag_input = torch.ones(my_ag_send, dtype=dtype, device=device)
+    ag_output = torch.empty(sparse_group_size * my_ag_send, dtype=dtype, device=device)
+    ag_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            ag_helper_bufs.append(ag_output)  # unused for the active group
+        else:
+            ag_helper_size_g = _passthrough_helper_size(
+                ag_send_counts[g], sparse_group_size, num_chunks
+            )
+            ag_helper_bufs.append(
+                torch.empty(ag_helper_size_g, dtype=dtype, device=device)
+            )
+
+    def run_all_gather() -> None:
+        ag_input.fill_(1.0)
+        bench_all_gather_flat(
+            fused=fused,
+            input_flat=ag_input,
+            output_flat=ag_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=ag_helper_bufs,
+            per_group_send_counts=ag_send_counts,
+        )
+
+    mean_ag, std_ag = _measure_ms(run_all_gather, warmup, bench_iters)
+
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
         kernel_bytes = kernel_elements * dtype.itemsize
@@ -953,6 +1056,12 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
         )
         bench_a_a2a_std = (
             float(results_dict["A_a2a"][1]) if "A_a2a" in results_dict else 0.0
+        )
+        bench_a_ag_mean = (
+            float(results_dict["A_ag"][0]) if "A_ag" in results_dict else 0.0
+        )
+        bench_a_ag_std = (
+            float(results_dict["A_ag"][1]) if "A_ag" in results_dict else 0.0
         )
 
         rs_output_bytes = my_rs_recv * dtype.itemsize
@@ -1070,6 +1179,37 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             print(
                 f"  >> All-to-all speedup (NCCL → sharded relay): "
                 f"{speedup_a2a:.2f}x"
+            )
+
+        # ----- ALL-GATHER -----
+        ag_send_bytes = my_ag_send * dtype.itemsize
+        print()
+        print("-" * 72)
+        print("ALL-GATHER")
+        print("-" * 72)
+        if bench_a_ag_mean > 0:
+            print(
+                f"  [A] NCCL all_gather_into_tensor (baseline, "
+                f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
+            )
+            print(
+                f"       {bench_a_ag_mean:.2f} ms  ±  {bench_a_ag_std:.2f} ms  |  "
+                f"{rs_bw(ag_send_bytes, bench_a_ag_mean):.1f} GB/s"
+            )
+        else:
+            print("  [A] NCCL all_gather_into_tensor (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{ag_send_bytes / 1024 / 1024:.0f} MB send/group):"
+        )
+        print(
+            f"       {mean_ag:.2f} ms  ±  {std_ag:.2f} ms  |  "
+            f"{rs_bw(ag_send_bytes, mean_ag):.1f} GB/s"
+        )
+        if bench_a_ag_mean > 0 and mean_ag > 0:
+            speedup_ag = bench_a_ag_mean / mean_ag
+            print(
+                f"  >> All-gather speedup (NCCL → sharded relay): " f"{speedup_ag:.2f}x"
             )
         print("=" * 72)
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -84,16 +84,41 @@ Message-size sweep (all collectives, 2- & 4-rank, bf16):
     It prints one table per (collective, active-rank-count). The swept size is the
     per-active-rank input tensor byte size, so sizes stay comparable across
     collectives. The single-group scenario is benchmarked separately (see
-    test_parallel_2rank_allreduce_sweep). Run it selectively so the production
+    test_parallel_collectives_msg_size_sweep). Run it selectively so the production
     test above does not also run:
         buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
             //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
             torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_collectives_msg_size_sweep
+
+Parallel separate-job sweep (all collectives, 2- & 4-rank, bf16):
+    A separate test method, test_parallel_collectives_msg_size_sweep, sweeps the
+    same fixed message sizes for every collective (allreduce, reduce-scatter,
+    all-to-all, all-gather) at both 2 and 4 active ranks. It models N = NUM_GPUS
+    // A independent workloads the way production runs them: as N SEPARATE
+    co-resident jobs on one 8-GPU node, each owning its OWN full 8-rank
+    communicator and issuing exactly ONE single-group A-rank sharded relay call
+    (its own process, CUDA context, and GPU_MAX_HW_QUEUES budget). For each A it
+    spawns N * NUM_GPUS processes (process p → job = p // NUM_GPUS,
+    rank_in_job = p % NUM_GPUS on cuda:rank_in_job), so the N jobs are
+    co-resident (N processes per GPU); a gloo PG across all processes overlaps
+    the jobs and the reported time is the max across jobs. This is the
+    production-faithful counterpart to the FUSED scenario: because each workload
+    owns a separate communicator the multi-group fused kernel cannot be used, so
+    it measures single-group A-rank relay performance under real inter-process
+    XGMI contention. The NCCL baseline is N disjoint A-rank NCCL collectives run
+    as separate processes (one per GPU), overlapped, max across jobs. It prints
+    one table per (collective, active-rank-count). Run it selectively:
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+            //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
+            torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_parallel_collectives_msg_size_sweep
 """
 
 from __future__ import annotations
 
 import os
+import socket
+import sys
+import tempfile
 import unittest
 from functools import partial
 from typing import Any
@@ -128,6 +153,18 @@ except ImportError:
 
 def _env_int(key: str, default: int) -> int:
     return int(os.environ.get(key, str(default)))
+
+
+def _find_free_port() -> int:
+    """Return a currently-free localhost TCP port.
+
+    Chosen at runtime (in the parent process, before mp.spawn) and passed to the
+    workers so rank 0's TCPStore never collides with a hardcoded port left in
+    TIME_WAIT by a prior run or by another phase of the same test.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
 
 
 def _env_float(key: str, default: float) -> float:
@@ -588,7 +625,12 @@ def bench_nccl_baseline(
 # ---------------------------------------------------------------------------
 
 
-def _measure_ms(fn: Any, warmup: int, iters: int) -> tuple[float, float]:
+def _measure_ms(
+    fn: Any,
+    warmup: int,
+    iters: int,
+    device_barrier_group: Any = None,
+) -> tuple[float, float]:
     """Time fn() over 'iters' runs after 'warmup' warmups.
 
     Returns (best_ms, std_ms). The BEST (min) is the headline metric: collective
@@ -601,6 +643,13 @@ def _measure_ms(fn: Any, warmup: int, iters: int) -> tuple[float, float]:
     - A full-world barrier precedes each timed iteration so all ranks start the
       collective aligned (rank skew otherwise inflates the measured time, and
       differently every run). The barrier is OUTSIDE the timed region.
+    - device_barrier_group (optional): an additional barrier on this group is
+      issued after the default barrier. The parallel sweep passes a per-job NCCL
+      group so each job's participants are aligned ON-DEVICE (removing P2P
+      partner skew that inflates latency-bound relay times), while the default
+      barrier (a global CPU/gloo group there) deterministically overlaps all
+      co-resident jobs each iteration. Both baselines pass the same pair, so the
+      comparison is apples-to-apples.
     - Timing uses on-device CUDA/hipEvents, so host-side scheduling jitter is
       excluded.
     Note: GPU clocks should also be locked (e.g. rocm-smi) to remove DVFS
@@ -608,20 +657,25 @@ def _measure_ms(fn: Any, warmup: int, iters: int) -> tuple[float, float]:
     """
     have_dist = dist.is_available() and dist.is_initialized()
 
+    def _align() -> None:
+        if not have_dist:
+            return
+        dist.barrier()
+        if device_barrier_group is not None:
+            dist.barrier(group=device_barrier_group)
+
     torch.cuda.synchronize()
     for _ in range(warmup):
         fn()
     torch.cuda.synchronize()
-    if have_dist:
-        dist.barrier()
+    _align()
 
     start_ev = torch.cuda.Event(enable_timing=True)
     end_ev = torch.cuda.Event(enable_timing=True)
     times: list[float] = []
     for _ in range(iters):
-        if have_dist:
-            # Align all ranks' starts; excluded from the timed region below.
-            dist.barrier()
+        # Align all ranks' starts; excluded from the timed region below.
+        _align()
         torch.cuda.synchronize()
         start_ev.record()
         fn()
@@ -1584,7 +1638,7 @@ def _benchmark_worker(
 #           call, vs the NCCL baseline run in parallel on each rank's A-rank
 #           sub-group.
 # The single-group scenario is benchmarked separately (see the parallel
-# independent-comm sweep, test_parallel_2rank_allreduce_sweep).
+# independent-comm sweep, test_parallel_collectives_msg_size_sweep).
 # Fixed at bf16. NCCL allreduce/reduce-scatter baselines use SUM + manual divide
 # (RCCL on MI350X lacks the AVG kernel); the relay path uses AVG in the kernel.
 # all-to-all / all-gather do no reduction. The swept nbytes is the per-active-rank
@@ -2154,9 +2208,6 @@ def _msg_sweep_relay_worker(
                     key = f"{collective}_a{active_ranks}"
                     results_dict[f"relay_{key}_fused_{i}"] = (best_f, std_f)
 
-    if rank == 0:
-        _print_msg_sweep_report(results_dict, dtype)
-
     dist.barrier()
     dist.destroy_process_group()
 
@@ -2174,50 +2225,682 @@ def _sweep_fmt_speedup(nccl: float, relay: float) -> str:
     return f"{nccl / relay:.2f}x" if nccl > 0 and relay > 0 else "N/A"
 
 
-def _print_sweep_table(
+def _emit_report(lines: list[str], default_basename: str) -> None:
+    """Write the assembled results tables to a dedicated file AND to stdout as a
+    single atomic write.
+
+    The sweep spawns up to N * NUM_GPUS worker processes, each emitting glog /
+    thrift / RCCLX C++ init logging to the shared stdout/stderr. Interleaving
+    that firehose with per-line print() mangles the tables (a stray token can
+    land mid-row). Assembling the whole report as one string and writing it once
+    — and also to an isolated file no other process touches — keeps the results
+    clean and diffable. BENCH_RESULTS_FILE overrides the file path.
+    """
+    report = "\n".join(lines) + "\n"
+    path = os.environ.get(
+        "BENCH_RESULTS_FILE",
+        os.path.join(tempfile.gettempdir(), default_basename),
+    )
+    try:
+        with open(path, "w") as f:
+            f.write(report)
+    except OSError:
+        path = ""
+    banner = "#" * 55
+    header = "# BENCH RESULTS" + (f" (also written to {path})" if path else "")
+    sys.stdout.write(f"\n{banner}\n{header}\n{banner}\n{report}{banner}\n")
+    sys.stdout.flush()
+
+
+def _format_sweep_table(
     results_dict: Any, dtype: torch.dtype, collective: str, active_ranks: int
-) -> None:
-    """Print one (collective, active-rank-count) FUSED message-size sweep table."""
+) -> list[str]:
+    """Build the lines for one (collective, A) FUSED message-size sweep table."""
     num_groups = NUM_GPUS // active_ranks
     key = f"{collective}_a{active_ranks}"
     title = collective.replace("_", "-").upper()
     width = 55
     line = "=" * width
-    print("\n" + line)
-    print(
+    out: list[str] = [
+        "",
+        line,
         f"Sharded Relay {title} — Message-Size Sweep "
-        f"(MI350X, {NUM_GPUS} GPUs, {dtype})"
-    )
-    print(
+        f"(MI350X, {NUM_GPUS} GPUs, {dtype})",
         f"  {active_ranks} active ranks/group; times = best-of-N (min), "
-        "barrier-aligned + hipEvent-timed"
-    )
-    print(
+        "barrier-aligned + hipEvent-timed",
         f"  FUSED = {num_groups}-group sharded relay  vs  "
-        f"NCCL baseline ({num_groups} concurrent {active_ranks}-rank groups)"
-    )
-    print(line)
-    print(f"{'':>10} | {f'FUSED ({num_groups} groups)':^33}")
-    print(f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}")
-    print("-" * width)
+        f"NCCL baseline ({num_groups} concurrent {active_ranks}-rank groups)",
+        line,
+        f"{'':>10} | {f'FUSED ({num_groups} groups)':^33}",
+        f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
+        "-" * width,
+    ]
     for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
         elements = nbytes // dtype.itemsize
         if elements % active_ranks != 0:
             continue
         nf = _sweep_get_ms(results_dict, f"nccl_{key}_fused_{i}")
         rf = _sweep_get_ms(results_dict, f"relay_{key}_fused_{i}")
-        print(
+        out.append(
             f"{label:>10} | {_sweep_fmt_ms(nf):>10} {_sweep_fmt_ms(rf):>10} "
             f"{_sweep_fmt_speedup(nf, rf):>9}"
         )
-    print(line)
+    out.append(line)
+    return out
 
 
 def _print_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
-    """Print one FUSED message-size sweep table per (collective, active-rank-count)."""
+    """Emit one FUSED message-size sweep table per (collective, active-rank-count)
+    as a single clean, diffable block (file + atomic stdout write)."""
+    lines: list[str] = []
     for collective in _MSG_SWEEP_COLLECTIVES:
         for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
-            _print_sweep_table(results_dict, dtype, collective, active_ranks)
+            lines.extend(
+                _format_sweep_table(results_dict, dtype, collective, active_ranks)
+            )
+    _emit_report(lines, "bench_sharded_relay_fused_sweep_results.txt")
+
+
+# ---------------------------------------------------------------------------
+# Parallel independent-comm sweep workers (test_parallel_collectives_msg_size_sweep)
+#
+# Models N = NUM_GPUS // A independent workloads, each with its OWN 8-rank
+# communicator and a disjoint active rank group, all launching a SINGLE-GROUP
+# A-rank sharded relay collective IN PARALLEL (async, one per comm). Unlike the
+# fused multi-group kernel (which coordinates all groups in lockstep phases to
+# remove XGMI link contention), these calls cannot be fused — each workload owns
+# a separate communicator — so this measures single-group A-rank relay collective
+# performance under the link contention of several overlapping independent
+# relays. Covers all four collectives (allreduce, reduce-scatter, all-to-all,
+# all-gather) at both 2 and 4 active ranks → one table per (collective, A).
+#
+# Topology (8 GPUs, A active ranks/group); each comm spans ALL 8 ranks, e.g. A=2:
+#   comm 0: active [0,1], helpers [2,3,4,5,6,7]
+#   comm 1: active [2,3], helpers [0,1,4,5,6,7]  ... (N=4 comms)
+# Each rank is active in exactly one comm and a helper in the others.
+#
+# Fixed at bf16. NCCL baseline: N disjoint A-rank NCCL collectives running
+# concurrently (identical to the FUSED sweep's baseline; reuses _nccl_baseline_op).
+# NCCL allreduce/reduce-scatter use SUM + manual divide (RCCL on MI350X lacks the
+# AVG kernel); the relay path uses AVG in the RCCLX kernel.
+# ---------------------------------------------------------------------------
+
+
+def _build_per_job_nccl_group(total_procs: int, my_job: int) -> Any:
+    """Collectively build each job's NUM_GPUS-rank NCCL group (over global ranks
+    [j*NUM_GPUS .. j*NUM_GPUS+NUM_GPUS-1]); return this proc's own job group.
+
+    Called with a global (gloo) default PG so dist.barrier(group=...) on the
+    returned group is an on-device NCCL barrier that aligns the job's NUM_GPUS
+    participants — matching how the NCCL baseline aligns its participants."""
+    my_group = None
+    num_jobs = total_procs // NUM_GPUS
+    for j in range(num_jobs):
+        ranks = list(range(j * NUM_GPUS, (j + 1) * NUM_GPUS))
+        g = dist.new_group(ranks=ranks, backend="nccl")
+        if j == my_job:
+            my_group = g
+    return my_group
+
+
+def _build_per_job_active_subgroup(
+    total_procs: int, my_job: int, active_ranks: int
+) -> Any:
+    """Collectively build each job's A-rank NCCL sub-group used for the NCCL
+    baseline collective. Job j's active ranks are rank_in_job [j*A .. j*A+A-1]
+    (device j*A..), i.e. global ranks [j*NUM_GPUS + r]. Returns this proc's own
+    job sub-group (a non-member handle if this proc is a helper)."""
+    my_sub = None
+    num_jobs = total_procs // NUM_GPUS
+    for j in range(num_jobs):
+        active_in_job = range(j * active_ranks, (j + 1) * active_ranks)
+        ranks = [j * NUM_GPUS + r for r in active_in_job]
+        g = dist.new_group(ranks=ranks, backend="nccl")
+        if j == my_job:
+            my_sub = g
+    return my_sub
+
+
+def _noop_fn() -> None:
+    """Timed no-op for idle co-resident ranks in the parallel NCCL baseline."""
+    return None
+
+
+def _parallel_msg_sweep_nccl_worker(
+    p: int,
+    total_procs: int,
+    active_ranks: int,
+    results_dict: Any,
+    store_port: int,
+) -> None:
+    """NCCL baseline under the SAME topology/co-residency as the relay sweep.
+
+    To compare the collective ALGORITHMS apples-to-apples (not the deployment
+    topology), this mirrors the relay worker exactly: N = NUM_GPUS // A separate
+    8-rank jobs are spawned as N * NUM_GPUS processes (N per GPU); process p is
+    (job = p // NUM_GPUS, rank_in_job = p % NUM_GPUS) on cuda:rank_in_job. Each
+    job builds its OWN 8-rank NCCL world (per-job PrefixStore, 1 rank/GPU) and,
+    within it, an A-rank sub-group [job*A .. job*A+A-1]. The A active ranks run
+    the A-rank NCCL collective on that sub-group; the other ranks are idle
+    co-resident processes (exactly like the relay's helper ranks). Alignment uses
+    the same per-job 8-rank NCCL device barrier (_measure_ms's dist.barrier), so
+    both baselines pay identical co-residency and get identical device-side
+    alignment. Records per job's rank-0 (rank_in_job == job*A):
+      results_dict["nccl_parallel_{collective}_a{A}_{i}_job{job}"] = (best, std)
+    """
+    job = p // NUM_GPUS
+    rank_in_job = p % NUM_GPUS
+    device_idx = rank_in_job
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(store_port)
+    os.environ["RANK"] = str(p)
+    os.environ["WORLD_SIZE"] = str(total_procs)
+
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=store_port,
+        world_size=total_procs,
+        is_master=(p == 0),
+        wait_for_workers=True,
+    )
+    torch.cuda.set_device(device_idx)
+    device = torch.device(f"cuda:{device_idx}")
+
+    # Global (gloo) default PG across ALL N * NUM_GPUS procs: its dist.barrier
+    # deterministically overlaps every co-resident job each iteration (identical
+    # worst-case contention for both baselines). A per-job NUM_GPUS-rank NCCL
+    # group provides the on-device within-job alignment (passed to _measure_ms).
+    dist.init_process_group(
+        backend="gloo",
+        rank=p,
+        world_size=total_procs,
+        store=dist.PrefixStore("parallel_global", store),
+    )
+    job_device_group = _build_per_job_nccl_group(total_procs, job)
+
+    dtype = _MSG_SWEEP_DTYPE
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
+
+    # A-rank sub-group (global ranks) for this job's NCCL collective.
+    active_group = list(range(job * active_ranks, (job + 1) * active_ranks))
+    subgroup = _build_per_job_active_subgroup(total_procs, job, active_ranks)
+    is_active = rank_in_job in active_group
+    is_job_rank0 = rank_in_job == active_group[0]
+
+    # SUM + manual divide (RCCL on MI350X lacks the AVG kernel).
+    _ar_opts = dist.AllreduceCoalescedOptions()
+    _ar_opts.reduceOp = dist.ReduceOp.SUM
+
+    # Warm up the sub-group communicator (active ranks only).
+    if is_active:
+        _wt = torch.ones(1, dtype=dtype, device=device)
+        dist.all_reduce(_wt, op=dist.ReduceOp.SUM, group=subgroup)
+        del _wt
+    torch.cuda.synchronize()
+
+    key = f"a{active_ranks}"
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+            elements = nbytes // dtype.itemsize
+            if elements % active_ranks != 0:
+                continue
+            if is_active:
+                fn = _nccl_baseline_op(
+                    collective,
+                    active_ranks,
+                    elements,
+                    dtype,
+                    device,
+                    subgroup,
+                    _ar_opts,
+                )
+            else:
+                # Idle co-resident process (mirrors a relay helper rank); still
+                # participates in the alignment barriers.
+                fn = _noop_fn
+            best, std = _measure_ms(
+                fn, warmup, bench_iters, device_barrier_group=job_device_group
+            )
+            del fn
+            torch.cuda.empty_cache()
+            if is_job_rank0:
+                results_dict[f"nccl_parallel_{collective}_{key}_{i}_job{job}"] = (
+                    best,
+                    std,
+                )
+
+    # Match the relay worker: let every rank finish its collectives before any
+    # rank tears the process group down.
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _issue_relay_async(
+    collective: str,
+    comm: Any,
+    in_list: list[torch.Tensor],
+    out_list: list[torch.Tensor],
+    count_list: list[int],
+    all_active_ranks: list[list[int]],
+) -> Any:
+    """Issue ONE single-group (num_groups=1) sharded relay collective on a comm
+    with async_op=True; returns its work handle."""
+    if collective == "allreduce":
+        return comm.allreduce_multi_group(
+            tensors=in_list,
+            num_groups=1,
+            per_group_sizes=count_list,
+            all_active_ranks=all_active_ranks,
+            op=dist.ReduceOp.AVG,
+            skip_validation=True,
+            async_op=True,
+        )
+    if collective == "reduce_scatter":
+        return comm.reduce_scatter_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=1,
+            per_group_recv_counts=count_list,
+            all_active_ranks=all_active_ranks,
+            op=dist.ReduceOp.AVG,
+            skip_validation=True,
+            async_op=True,
+        )
+    if collective == "all_to_all":
+        return comm.all_to_all_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=1,
+            per_group_segment_counts=count_list,
+            all_active_ranks=all_active_ranks,
+            skip_validation=True,
+            async_op=True,
+        )
+    if collective == "all_gather":
+        return comm.all_gather_multi_group(
+            input_tensors=in_list,
+            output_tensors=out_list,
+            num_groups=1,
+            per_group_send_counts=count_list,
+            all_active_ranks=all_active_ranks,
+            skip_validation=True,
+            async_op=True,
+        )
+    raise ValueError(f"unknown collective {collective!r}")
+
+
+def _run_parallel_relay_once(
+    collective: str,
+    comms: list[Any],
+    in_tensors: list[list[torch.Tensor]],
+    out_tensors: list[list[torch.Tensor]],
+    count_list: list[int],
+    active_ranks_per_comm: list[list[list[int]]],
+    num_parallel: int,
+) -> None:
+    """Issue N single-group relay collectives (one per comm) in parallel.
+
+    Each call is async_op=True so it runs on its communicator's dedicated stream;
+    the N calls therefore overlap. The wait() calls only enqueue device-side
+    stream-waits on the current stream (non host-blocking), so the following
+    end-event captures the LAST (max) completion across the N comms — i.e. the
+    overlapped wall-time. Inputs are pre-filled with ones at buffer construction
+    and stay ones, so no per-call refill is done inside the timed region.
+    """
+    works: list[Any] = []
+    for k in range(num_parallel):
+        works.append(
+            _issue_relay_async(
+                collective,
+                comms[k],
+                in_tensors[k],
+                out_tensors[k],
+                count_list,
+                active_ranks_per_comm[k],
+            )
+        )
+    for work in works:
+        if work is not None:
+            work.wait()
+
+
+def _parallel_relay_single_call(
+    collective: str,
+    comm: Any,
+    active_group: list[int],
+    rank_in_job: int,
+    active_ranks: int,
+    elements: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Any:
+    """Zero-arg closure that issues this process's ONE single-group relay call.
+
+    Active ranks (rank_in_job in active_group) pass real message buffers; helper
+    ranks pass a 1-element placeholder (the kernel stages helpers into its own
+    internal scratch and never reads the caller's buffer). Reuses
+    _run_parallel_relay_once with num_parallel=1 so exactly one async relay
+    collective is issued and waited on per call.
+    """
+    count_list = _relay_counts(collective, active_ranks, elements, 1)
+    if rank_in_job in active_group:
+        a_in, a_out = _active_io(collective, active_ranks, elements, dtype, device)
+        in_list = [a_in]
+        out_list = [a_out]
+    else:
+        # Helper slots are ignored by the kernel (it stages into internal
+        # scratch), so a 1-element placeholder suffices for every collective.
+        ph = torch.empty(1, dtype=dtype, device=device)
+        in_list = [ph]
+        out_list = [ph]
+    return partial(
+        _run_parallel_relay_once,
+        collective,
+        [comm],
+        [in_list],
+        [out_list],
+        count_list,
+        [[active_group]],
+        1,
+    )
+
+
+def _parallel_relay_warmup_single(
+    comm: Any,
+    active_group: list[int],
+    rank_in_job: int,
+    active_ranks: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Tiny relay call per collective so each distinct single-group HIP kernel
+    config JIT-compiles before timing. warm_elems=2048 clears the A=2
+    reduce-scatter/all-to-all 2-active chunk floor (elements>=1792)."""
+    torch.cuda.synchronize()
+    dist.barrier()
+    warm_elems = 2048
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        fn = _parallel_relay_single_call(
+            collective,
+            comm,
+            active_group,
+            rank_in_job,
+            active_ranks,
+            warm_elems,
+            dtype,
+            device,
+        )
+        for _ in range(3):
+            fn()
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+
+def _parallel_msg_sweep_relay_worker(
+    p: int,
+    total_procs: int,
+    active_ranks: int,
+    results_dict: Any,
+    store_port: int,
+) -> None:
+    """One production job's rank in the reconciled parallel relay sweep.
+
+    Models N = NUM_GPUS // A independent relay jobs co-resident on one 8-GPU
+    node (the production topology: N separate processes/jobs, each owning its own
+    full 8-rank communicator, each issuing exactly ONE relay call). This spawn
+    launches N * NUM_GPUS processes; process p maps to
+    (job = p // NUM_GPUS, rank_in_job = p % NUM_GPUS) and runs on
+    cuda:rank_in_job, so the N jobs are co-resident (N processes per GPU) with
+    per-process CUDA contexts and their own GPU_MAX_HW_QUEUES=2 budget.
+
+    Each process creates exactly ONE 8-rank RCCLX comm for its job (a per-job
+    PrefixStore namespace via node_idx=job) and issues exactly ONE single-group
+    A-rank relay call per timed iteration: active if rank_in_job is in the job's
+    A-rank group [job*A .. job*A+A-1], helper otherwise. A gloo process group
+    spanning all N * NUM_GPUS processes provides the cross-job barrier in
+    _measure_ms so every job's timed region overlaps (true inter-process XGMI
+    contention is the measurement target). Writes, per (collective, size index
+    i), for each job's rank-0 (rank_in_job == job*A):
+      results_dict["relay_parallel_{collective}_a{A}_{i}_job{job}"] = (best, std)
+    The parent reduces max across jobs (overlapped wall-time).
+    """
+    job = p // NUM_GPUS
+    rank_in_job = p % NUM_GPUS
+    device_idx = rank_in_job
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(store_port)
+    os.environ["RANK"] = str(p)
+    os.environ["WORLD_SIZE"] = str(total_procs)
+
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=store_port,
+        world_size=total_procs,
+        is_master=(p == 0),
+        wait_for_workers=True,
+    )
+    torch.cuda.set_device(device_idx)
+    device = torch.device(f"cuda:{device_idx}")
+
+    # Global (gloo) default PG across ALL N * NUM_GPUS procs: its dist.barrier
+    # deterministically overlaps every co-resident job each iteration (same
+    # worst-case contention every iter). A per-job NUM_GPUS-rank NCCL group gives
+    # on-device within-job alignment (passed to _measure_ms as
+    # device_barrier_group) so the P2P partner skew that would otherwise inflate
+    # latency-bound small-size times is removed — identical treatment to the NCCL
+    # baseline. This exactly matches the NCCL baseline's alignment, so relay vs
+    # NCCL isolates the collective algorithm, not the harness.
+    dist.init_process_group(
+        backend="gloo",
+        rank=p,
+        world_size=total_procs,
+        store=dist.PrefixStore("parallel_global", store),
+    )
+    job_device_group = _build_per_job_nccl_group(total_procs, job)
+
+    dtype = _MSG_SWEEP_DTYPE
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 10))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 100))
+
+    # This job owns ONE full 8-rank RCCLX comm in its own store namespace.
+    raw_comm = _setup_rcclx_comm(
+        rank_in_job,
+        NUM_GPUS,
+        job,
+        dist.PrefixStore("parallel_relay_rcclx", store),
+    )
+    if FusedShardedRelayMultiGroup is None or raw_comm is None:
+        if p == 0:
+            print("[bench] FusedShardedRelayMultiGroup not available. Exiting.")
+        dist.destroy_process_group()
+        return
+
+    # Job j's single active group is [j*A .. j*A+A-1], spreading the N jobs'
+    # active ranks evenly across the 8 GPUs (each GPU is active for one job and a
+    # helper for the other N-1) — matching production's balanced co-residency.
+    active_group = list(range(job * active_ranks, (job + 1) * active_ranks))
+    comm = FusedShardedRelayMultiGroup(
+        rcclx_comm=raw_comm,
+        world_size=NUM_GPUS,
+        rank=rank_in_job,
+        all_active_ranks=[active_group],
+    )
+
+    _parallel_relay_warmup_single(
+        comm, active_group, rank_in_job, active_ranks, dtype, device
+    )
+
+    is_job_rank0 = rank_in_job == active_group[0]
+    key = f"a{active_ranks}"
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+            elements = nbytes // dtype.itemsize
+            if elements % active_ranks != 0:
+                continue
+            fn = _parallel_relay_single_call(
+                collective,
+                comm,
+                active_group,
+                rank_in_job,
+                active_ranks,
+                elements,
+                dtype,
+                device,
+            )
+            best, std = _measure_ms(
+                fn, warmup, bench_iters, device_barrier_group=job_device_group
+            )
+            del fn
+            torch.cuda.empty_cache()
+            if is_job_rank0:
+                results_dict[f"relay_parallel_{collective}_{key}_{i}_job{job}"] = (
+                    best,
+                    std,
+                )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _reduce_parallel_jobs_max(results_dict: Any) -> None:
+    """Collapse per-job parallel-sweep entries to the max across jobs.
+
+    Each job writes its own best-of-N under ..._job{j}; the overlapped wall-time
+    is the slowest (max) job, so reduce both the relay and NCCL per-job entries
+    into the base keys the print/report helpers read.
+    """
+    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        num_jobs = NUM_GPUS // active_ranks
+        for collective in _MSG_SWEEP_COLLECTIVES:
+            key = f"{collective}_a{active_ranks}"
+            for i, (_label, _nbytes) in enumerate(_MSG_SWEEP_SIZES):
+                for prefix in ("relay_parallel", "nccl_parallel"):
+                    vals = [
+                        results_dict.get(f"{prefix}_{key}_{i}_job{j}")
+                        for j in range(num_jobs)
+                    ]
+                    present = [v for v in vals if v is not None]
+                    if present:
+                        results_dict[f"{prefix}_{key}_{i}"] = max(
+                            present, key=lambda v: v[0]
+                        )
+
+
+def _format_parallel_sweep_table(
+    results_dict: Any, dtype: torch.dtype, collective: str, active_ranks: int
+) -> list[str]:
+    """Build the lines for one (collective, A) parallel separate-job table."""
+    num_parallel = NUM_GPUS // active_ranks
+    key = f"{collective}_a{active_ranks}"
+    title = collective.replace("_", "-").upper()
+    width = 55
+    line = "=" * width
+    out: list[str] = [
+        "",
+        line,
+        f"Sharded Relay {title} — {num_parallel}x Parallel Separate-Job "
+        f"Sweep (MI350X, {NUM_GPUS} GPUs, {dtype})",
+        f"  {active_ranks} active ranks/group; times = best-of-N (min), "
+        "barrier-aligned + hipEvent-timed; max across jobs",
+        f"  PARALLEL = {num_parallel} co-resident jobs, each a separate 8-rank "
+        f"comm issuing one {active_ranks}-rank relay (max across jobs)",
+        f"  NCCL baseline = {num_parallel} concurrent {active_ranks}-rank NCCL "
+        "collectives as separate processes (max across jobs)",
+        line,
+        f"{'':>10} | {f'PARALLEL ({num_parallel} jobs)':^33}",
+        f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
+        "-" * width,
+    ]
+    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+        elements = nbytes // dtype.itemsize
+        if elements % active_ranks != 0:
+            continue
+        n = _sweep_get_ms(results_dict, f"nccl_parallel_{key}_{i}")
+        r = _sweep_get_ms(results_dict, f"relay_parallel_{key}_{i}")
+        out.append(
+            f"{label:>10} | {_sweep_fmt_ms(n):>10} {_sweep_fmt_ms(r):>10} "
+            f"{_sweep_fmt_speedup(n, r):>9}"
+        )
+    out.append(line)
+    return out
+
+
+def _print_parallel_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
+    """Emit one parallel separate-job table per (collective, active-rank-count) as
+    a single clean, diffable block (file + atomic stdout write)."""
+    lines: list[str] = []
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+            lines.extend(
+                _format_parallel_sweep_table(
+                    results_dict, dtype, collective, active_ranks
+                )
+            )
+    _emit_report(lines, "bench_sharded_relay_parallel_sweep_results.txt")
+
+
+def _format_single_group_sweep_table(
+    results_dict: Any, dtype: torch.dtype, collective: str, active_ranks: int
+) -> list[str]:
+    """Build the lines for one (collective, A) SINGLE-GROUP best-case table.
+
+    Best case = exactly ONE A-rank relay group on the 8-GPU host with no other
+    co-resident job competing for XGMI bandwidth or HW queues (num_jobs == 1).
+    The relay still spans the full 8-rank comm (A active + 8-A helpers); the
+    NCCL baseline runs the A-rank collective with the remaining ranks idle. The
+    alignment (global barrier + per-job device barrier) matches the parallel
+    sweep, so this is that sweep's num_jobs=1 point — the contention-free upper
+    bound. Reads the same reduced base keys the parallel report reads.
+    """
+    key = f"{collective}_a{active_ranks}"
+    title = collective.replace("_", "-").upper()
+    width = 55
+    line = "=" * width
+    out: list[str] = [
+        "",
+        line,
+        f"Sharded Relay {title} — Single-Group Best-Case Sweep "
+        f"(MI350X, {NUM_GPUS} GPUs, {dtype})",
+        f"  {active_ranks} active ranks/group; times = best-of-N (min), "
+        "barrier-aligned + hipEvent-timed",
+        f"  SINGLE GROUP = one {active_ranks}-rank relay on a full "
+        f"{NUM_GPUS}-rank comm, no co-resident jobs (best case)",
+        f"  NCCL baseline = one {active_ranks}-rank NCCL collective, "
+        f"other {NUM_GPUS - active_ranks} ranks idle",
+        line,
+        f"{'':>10} | {'SINGLE GROUP (1 job)':^33}",
+        f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
+        "-" * width,
+    ]
+    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+        elements = nbytes // dtype.itemsize
+        if elements % active_ranks != 0:
+            continue
+        n = _sweep_get_ms(results_dict, f"nccl_parallel_{key}_{i}")
+        r = _sweep_get_ms(results_dict, f"relay_parallel_{key}_{i}")
+        out.append(
+            f"{label:>10} | {_sweep_fmt_ms(n):>10} {_sweep_fmt_ms(r):>10} "
+            f"{_sweep_fmt_speedup(n, r):>9}"
+        )
+    out.append(line)
+    return out
+
+
+def _print_single_group_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
+    """Emit one single-group best-case table per (collective, active-rank-count)
+    as a single clean, diffable block (file + atomic stdout write)."""
+    lines: list[str] = []
+    for collective in _MSG_SWEEP_COLLECTIVES:
+        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+            lines.extend(
+                _format_single_group_sweep_table(
+                    results_dict, dtype, collective, active_ranks
+                )
+            )
+    _emit_report(lines, "bench_sharded_relay_single_group_sweep_results.txt")
 
 
 # ---------------------------------------------------------------------------
@@ -2295,7 +2978,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
                   kernel call vs the matching NCCL baseline on each rank's A-rank
                   sub-group.
         The single-group scenario is benchmarked separately (see
-        test_parallel_2rank_allreduce_sweep).
+        test_parallel_collectives_msg_size_sweep).
 
         Run selectively (so the production test_benchmark does not also run).
         The buck2 test runner imports the module, so the selector must be the
@@ -2322,14 +3005,146 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
             join=True,
         )
 
-        # Phase 2: sharded relay FUSED per collective and A via RCCLX;
-        # rank 0 prints all 8 summary tables.
+        # Phase 2: sharded relay FUSED per collective and A via RCCLX; the
+        # parent emits all tables after the workers join (clean, un-interleaved).
         mp.spawn(
             _msg_sweep_relay_worker,
             args=(NUM_GPUS, results, 0),
             nprocs=NUM_GPUS,
             join=True,
         )
+
+        _print_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
+
+        manager.shutdown()
+
+    def test_parallel_collectives_msg_size_sweep(self) -> None:
+        """N independent single-group A-rank relay JOBS in parallel (bf16).
+
+        Production-faithful reconciliation: models N = NUM_GPUS // A independent
+        relay workloads as SEPARATE co-resident jobs on one 8-GPU node (not one
+        shared process issuing N calls). For each A, one mp.spawn launches
+        N * NUM_GPUS processes — process p is (job = p // NUM_GPUS,
+        rank_in_job = p % NUM_GPUS) on cuda:rank_in_job — so the N jobs are
+        co-resident (N processes per GPU). Each process owns exactly ONE 8-rank
+        RCCLX communicator for its job and issues exactly ONE single-group
+        A-rank relay call per iteration, with its own CUDA context and
+        GPU_MAX_HW_QUEUES=2 budget. A gloo PG spanning all N * NUM_GPUS
+        processes overlaps every job's timed region; the reported time is the max
+        across jobs (overlapped wall-time).
+
+        The NCCL baseline is N disjoint A-rank NCCL collectives run as separate
+        processes (A ranks/job → NUM_GPUS processes total, one per GPU),
+        overlapped under the same barrier, max across jobs. The relay's 8-rank
+        comm vs NCCL's A-rank comm asymmetry is exactly the production contrast.
+        Prints one table per (collective, active-rank-count).
+
+        Run selectively (so the production test_benchmark does not also run).
+        The buck2 test runner imports the module, so the selector must be the
+        fully-qualified module.Class.method path:
+            buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+                //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
+                torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_parallel_collectives_msg_size_sweep
+        """
+        manager = mp.Manager()
+        results: Any = manager.dict()
+
+        # Production regime: BM-FM runs with GPU_MAX_HW_QUEUES=2. Each spawned
+        # process now inherits its OWN budget (N separate co-resident jobs), so
+        # this reproduces the per-process queue budget of production rather than
+        # one shared budget split across N calls. Set before mp.spawn so the
+        # workers inherit it before HIP init.
+        os.environ["GPU_MAX_HW_QUEUES"] = "2"
+
+        # Each process builds several co-resident NCCL groups (a per-job device
+        # group + the baseline's A-rank sub-group). The NCCL flight recorder /
+        # heartbeat monitor names its dump pipe /tmp/nccl_trace_<sec>_rank_<r>.pipe
+        # by (second, rank), so groups created in the same second with the same
+        # rank number collide ("File exists" -> SIGABRT). Disable the monitor /
+        # trace buffer for the benchmark (a debugging aid, not needed here).
+        os.environ["TORCH_NCCL_ENABLE_MONITORING"] = "0"
+        os.environ["TORCH_NCCL_TRACE_BUFFER_SIZE"] = "0"
+
+        # Both baselines use the SAME separate-job topology (N * NUM_GPUS procs
+        # per A, N co-resident jobs each a full 8-rank world) and the SAME
+        # alignment (global gloo cross-job barrier for deterministic overlap +
+        # per-job NCCL device barrier for on-device within-job alignment), so
+        # relay vs NCCL isolates the collective algorithm rather than the
+        # deployment topology or the measurement harness. Per A, run the NCCL
+        # baseline then the relay.
+        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+            num_jobs = NUM_GPUS // active_ranks
+            total_procs = num_jobs * NUM_GPUS
+            mp.spawn(
+                _parallel_msg_sweep_nccl_worker,
+                args=(total_procs, active_ranks, results, _find_free_port()),
+                nprocs=total_procs,
+                join=True,
+            )
+            mp.spawn(
+                _parallel_msg_sweep_relay_worker,
+                args=(total_procs, active_ranks, results, _find_free_port()),
+                nprocs=total_procs,
+                join=True,
+            )
+
+        # Reduce per-job entries to max-across-jobs, then print the tables.
+        _reduce_parallel_jobs_max(results)
+        _print_parallel_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
+
+        manager.shutdown()
+
+    def test_single_group_collectives_msg_size_sweep(self) -> None:
+        """Best-case SINGLE-GROUP A-rank relay sweep (bf16): exactly ONE group.
+
+        Uses the same workers and harness as
+        test_parallel_collectives_msg_size_sweep, but forces num_jobs == 1 for
+        every A (total_procs = NUM_GPUS), so only ONE A-rank relay group runs on
+        the 8-GPU host with no co-resident job competing for XGMI bandwidth or HW
+        queues. This is the parallel sweep's num_jobs=1 point — the
+        contention-free upper bound on both relay and NCCL. The relay still uses
+        the full 8-rank comm (A active ranks [0..A-1] + 8-A helpers); the NCCL
+        baseline runs the A-rank collective with the remaining ranks idle. Same
+        alignment (global gloo barrier + per-job NCCL device barrier) as the
+        parallel sweep. Prints one table per (collective, active-rank-count).
+
+        Run selectively (so the production test_benchmark does not also run).
+        The buck2 test runner imports the module, so the selector must be the
+        fully-qualified module.Class.method path:
+            buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+                //torchrec/distributed/tests:bench_sharded_relay_perf -- \\
+                torchrec.distributed.tests.bench_sharded_relay_perf.BenchShardedRelayPerfTest.test_single_group_collectives_msg_size_sweep
+        """
+        manager = mp.Manager()
+        results: Any = manager.dict()
+
+        # Same production regime + NCCL flight-recorder disable as the parallel
+        # sweep (see test_parallel_collectives_msg_size_sweep for the rationale).
+        os.environ["GPU_MAX_HW_QUEUES"] = "2"
+        os.environ["TORCH_NCCL_ENABLE_MONITORING"] = "0"
+        os.environ["TORCH_NCCL_TRACE_BUFFER_SIZE"] = "0"
+
+        # One job only: total_procs = NUM_GPUS -> num_jobs = 1 in both workers,
+        # so the single A-rank group [0..A-1] is the only workload on the host
+        # (the other 8-A ranks are helpers/idle). Per A, run NCCL then relay.
+        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+            total_procs = NUM_GPUS
+            mp.spawn(
+                _parallel_msg_sweep_nccl_worker,
+                args=(total_procs, active_ranks, results, _find_free_port()),
+                nprocs=total_procs,
+                join=True,
+            )
+            mp.spawn(
+                _parallel_msg_sweep_relay_worker,
+                args=(total_procs, active_ranks, results, _find_free_port()),
+                nprocs=total_procs,
+                join=True,
+            )
+
+        # Collapse the single job's per-job entries to the base keys, then print.
+        _reduce_parallel_jobs_max(results)
+        _print_single_group_msg_sweep_report(results, _MSG_SWEEP_DTYPE)
 
         manager.shutdown()
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -72,7 +72,7 @@ Environment variables (all optional):
 
 The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
 groups and prints a full report for each. The 4-active sweep covers allreduce
-only (reduce-scatter / all-to-all / all-gather are 2-active only).
+and reduce-scatter (all-to-all / all-gather are still 2-active only).
 """
 
 from __future__ import annotations
@@ -400,7 +400,9 @@ def bench_reduce_scatter_flat(
 ) -> None:
     """ONE fused reduce-scatter call across all sparse groups.
 
-    Each helper group passes its single passthrough scratch buffer.
+    Each group contributes ONE contiguous tensor: the active group passes the
+    single contiguous input_flat/output_flat; each helper group passes its
+    single passthrough scratch buffer.
     """
     input_group_tensors: list[torch.Tensor] = []
     output_group_tensors: list[torch.Tensor] = []
@@ -696,33 +698,38 @@ def _bench_a_worker(
     if rank == 0:
         results_dict["A"] = (mean_serial, std_serial)
 
-    # NCCL reduce-scatter / all-to-all / all-gather baselines run on the same
-    # sub-group PG. They are 2-active only (paired with the 2-active sharded
-    # relay benches), so skip them for a 4-active allreduce sweep. All ranks
-    # share the same env-driven sparse_group_size, so the _store_barrier()
-    # calls stay balanced.
+    # NCCL reduce-scatter baseline runs for all active-rank counts (paired with
+    # the now-4-active sharded relay reduce-scatter bench). recv_count =
+    # prod_total // sparse_group_size so the input (A x recv_count) matches the
+    # sharded-relay reduce-scatter benchmark's active footprint. Free the
+    # allreduce tensors first to reclaim HBM.
+    my_tensors = []
+    torch.cuda.empty_cache()
+    rs_recv = prod_totals[my_sparse_group] // sparse_group_size
+    rs_in = torch.ones(sparse_group_size * rs_recv, dtype=dtype, device=device)
+    rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
+
+    # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
+    def run_rs_baseline() -> None:
+        rs_in.fill_(1.0)
+        dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
+        rs_out.div_(sparse_group_size)
+
+    mean_rs_base, std_rs_base = (
+        _measure_ms(run_rs_baseline, warmup, bench_iters)
+        if _want("reduce_scatter")
+        else (0.0, 0.0)
+    )
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_rs"] = (mean_rs_base, std_rs_base)
+
+    # NCCL all-to-all / all-gather baselines are 2-active only (paired with the
+    # 2-active sharded relay A2A/AG benches), so skip them for a 4-active sweep.
+    # All ranks share the same env-driven sparse_group_size, so the
+    # _store_barrier() calls stay balanced.
     if sparse_group_size == 2:
-        # NCCL reduce-scatter baseline. Free the allreduce tensors first to
-        # reclaim HBM. recv_count = prod_total // 2 so the input (2 x recv_count)
-        # matches the sharded-relay reduce-scatter benchmark's active footprint.
-        my_tensors = []
-        torch.cuda.empty_cache()
-        rs_recv = prod_totals[my_sparse_group] // 2
-        rs_in = torch.ones(2 * rs_recv, dtype=dtype, device=device)
-        rs_out = torch.empty(rs_recv, dtype=dtype, device=device)
-
-        # Use SUM + manual divide (RCCL on MI350X lacks the AVG+fp16 kernel).
-        def run_rs_baseline() -> None:
-            rs_in.fill_(1.0)
-            dist.reduce_scatter_tensor(rs_out, rs_in, op=dist.ReduceOp.SUM, group=my_pg)
-            rs_out.div_(sparse_group_size)
-
-        mean_rs_base, std_rs_base = _measure_ms(run_rs_baseline, warmup, bench_iters)
-        _store_barrier()
-
-        if rank == 0:
-            results_dict["A_rs"] = (mean_rs_base, std_rs_base)
-
         # NCCL all-to-all baseline. Free the reduce-scatter baseline tensors
         # first. segment_count = prod_total // 4 so the in/out buffers
         # (2 x segment_count) match the sharded-relay all-to-all footprint.
@@ -782,9 +789,9 @@ def _benchmark_worker(
     spawned child processes in the Meta environment.
 
     sharding_group_size selects the active-ranks-per-group (2 or 4). At 4 the
-    reduce-scatter / all-to-all / all-gather benches (2-active only) are
-    skipped and only the allreduce benches run. port_offset isolates ports
-    across the 2-rank and 4-rank sweep iterations.
+    all-to-all / all-gather benches (2-active only) are skipped; allreduce and
+    reduce-scatter run at both 2 and 4. port_offset isolates ports across the
+    2-rank and 4-rank sweep iterations.
     """
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(_NCCL_PORT + port_offset)
@@ -1005,55 +1012,98 @@ def _benchmark_worker(
     else:
         peak_hbm_bytes = 0
 
-    # The reduce-scatter / all-to-all / all-gather sharded-relay benches only
-    # support 2 active ranks today, so they are skipped during the 4-active
-    # allreduce sweep.
-    mean_rs = std_rs = mean_a2a = std_a2a = mean_ag = std_ag = 0.0
-    my_rs_recv = my_a2a_seg = my_ag_send = 0
-    if sparse_group_size == 2:
-        # ---------------------------------------------------------------------
-        # Benchmark D: fused reduce-scatter. Release the Bench C kernel tensors
-        # first to reclaim HBM — reduce-scatter's input buffer is 2x its output
-        # (two blocks), so the active footprint is larger than allreduce's.
-        # Reassign (instead of `del`) so the run_kernel closure stays valid.
-        # ---------------------------------------------------------------------
-        kernel_tensor = torch.empty(0, dtype=dtype, device=device)
-        kernel_scratch = []
-        torch.cuda.empty_cache()
+    # The all-to-all / all-gather sharded-relay benches only support 2 active
+    # ranks today, so they are skipped during the 4-active sweep. Reduce-scatter
+    # supports 2 or 4 and always runs.
+    mean_a2a = std_a2a = mean_ag = std_ag = 0.0
+    my_a2a_seg = my_ag_send = 0
 
-        # recv_count = prod_total // 2 so the input (2 x recv_count) matches the
-        # allreduce active footprint (one prod_total per group).
-        rs_recv_counts = [t // 2 for t in prod_totals]
-        my_rs_recv = rs_recv_counts[my_sparse_group]
-        rs_input = torch.ones(2 * my_rs_recv, dtype=dtype, device=device)
-        rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
-        rs_helper_bufs: list[torch.Tensor] = []
-        for g in range(num_sparse_groups):
-            if g == my_sparse_group:
-                rs_helper_bufs.append(rs_output)  # unused for the active group
-            else:
-                rs_helper_size_g = _passthrough_helper_size(
-                    rs_recv_counts[g], sparse_group_size, num_chunks
-                )
-                rs_helper_bufs.append(
-                    torch.empty(rs_helper_size_g, dtype=dtype, device=device)
-                )
+    # -------------------------------------------------------------------------
+    # Benchmark D: fused reduce-scatter (runs for all active-rank counts).
+    # Release the Bench C kernel tensors first to reclaim HBM — reduce-scatter's
+    # input buffer is A x its output (A blocks), so the active footprint is
+    # larger than allreduce's. Reassign (instead of `del`) so the run_kernel
+    # closure stays valid.
+    # -------------------------------------------------------------------------
+    kernel_tensor = torch.empty(0, dtype=dtype, device=device)
+    kernel_scratch = []
+    torch.cuda.empty_cache()
 
-        def run_reduce_scatter() -> None:
-            rs_input.fill_(1.0)
-            bench_reduce_scatter_flat(
-                fused=fused,
-                input_flat=rs_input,
-                output_flat=rs_output,
-                num_sparse_groups=num_sparse_groups,
-                my_sparse_group=my_sparse_group,
-                all_active_ranks=all_active_ranks,
-                helper_bufs=rs_helper_bufs,
-                per_group_recv_counts=rs_recv_counts,
+    # recv_count = prod_total // sparse_group_size so the input (A x recv_count)
+    # matches the allreduce active footprint (one prod_total per group). Index by
+    # range(num_sparse_groups) — NOT `for t in prod_totals` — because prod_totals
+    # always has 4 entries while num_sparse_groups = local_size // sparse_group_size
+    # (2 at 4-active), and per_group_recv_counts must match input_tensors length.
+    rs_recv_counts = [
+        prod_totals[g] // sparse_group_size for g in range(num_sparse_groups)
+    ]
+    my_rs_recv = rs_recv_counts[my_sparse_group]
+    rs_input = torch.ones(sparse_group_size * my_rs_recv, dtype=dtype, device=device)
+    rs_output = torch.empty(my_rs_recv, dtype=dtype, device=device)
+    # Production per-table model tensors: packed into / unpacked from the flat
+    # buffers so the measured cost includes the cat/copy the production util
+    # (reduce_scatter_tensors_with_sharded_relay) performs.
+    rs_in_model = [
+        torch.ones(sparse_group_size * my_rs_recv, dtype=dtype, device=device)
+    ]
+    rs_out_model = [torch.empty(my_rs_recv, dtype=dtype, device=device)]
+    rs_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            rs_helper_bufs.append(rs_output)  # unused for the active group
+        else:
+            rs_helper_size_g = _passthrough_helper_size(
+                rs_recv_counts[g], sparse_group_size, num_chunks
+            )
+            rs_helper_bufs.append(
+                torch.empty(rs_helper_size_g, dtype=dtype, device=device)
             )
 
-        mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
+    def run_reduce_scatter() -> None:
+        # Production path: pack the per-table model input into the contiguous
+        # flat send buffer, run the fused call, then unpack into the model output.
+        for t in rs_in_model:
+            t.fill_(1.0)
+        rs_input.copy_(rs_in_model[0].reshape(-1))
+        bench_reduce_scatter_flat(
+            fused=fused,
+            input_flat=rs_input,
+            output_flat=rs_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=rs_helper_bufs,
+            per_group_recv_counts=rs_recv_counts,
+        )
+        rs_out_model[0].reshape(-1).copy_(rs_output)
 
+    mean_rs, std_rs = (
+        _measure_ms(run_reduce_scatter, warmup, bench_iters)
+        if _want("reduce_scatter")
+        else (0.0, 0.0)
+    )
+
+    def run_reduce_scatter_kernel() -> None:
+        # Kernel-direct: raw kernel on the contiguous flat buffers, no pack/copy.
+        rs_input.fill_(1.0)
+        bench_reduce_scatter_flat(
+            fused=fused,
+            input_flat=rs_input,
+            output_flat=rs_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=rs_helper_bufs,
+            per_group_recv_counts=rs_recv_counts,
+        )
+
+    mean_rs_kernel, std_rs_kernel = (
+        _measure_ms(run_reduce_scatter_kernel, warmup, bench_iters)
+        if _want("reduce_scatter")
+        else (0.0, 0.0)
+    )
+
+    if sparse_group_size == 2:
         # ---------------------------------------------------------------------
         # Benchmark E: fused all-to-all. Release the reduce-scatter buffers
         # first. segment_count = prod_total // 4 so the in/out buffers
@@ -1063,6 +1113,8 @@ def _benchmark_worker(
         rs_input = torch.empty(0, dtype=dtype, device=device)
         rs_output = torch.empty(0, dtype=dtype, device=device)
         rs_helper_bufs = []
+        rs_in_model = [torch.empty(0, dtype=dtype, device=device)]
+        rs_out_model = [torch.empty(0, dtype=dtype, device=device)]
         torch.cuda.empty_cache()
 
         a2a_seg_counts = [t // 4 for t in prod_totals]
@@ -1231,40 +1283,52 @@ def _benchmark_worker(
                 f"{bench_a_mean / mean_kernel:.2f}x"
             )
 
-        # ----- REDUCE-SCATTER / ALL-TO-ALL / ALL-GATHER -----
-        # These sharded-relay benches are 2-active only; skip during the
-        # 4-active allreduce sweep.
-        if sparse_group_size == 2:
-            print()
-            print("-" * 72)
-            print("REDUCE-SCATTER")
-            print("-" * 72)
-            if bench_a_rs_mean > 0:
-                print(
-                    f"  [A] NCCL reduce_scatter_tensor (baseline, "
-                    f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
-                )
-                print(
-                    f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
-                    f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
-                )
-            else:
-                print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
+        # ----- REDUCE-SCATTER (runs for 2 or 4 active ranks) -----
+        print()
+        print("-" * 72)
+        print("REDUCE-SCATTER")
+        print("-" * 72)
+        if bench_a_rs_mean > 0:
             print(
-                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+                f"  [A] NCCL reduce_scatter_tensor (baseline, "
                 f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
             )
             print(
-                f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
-                f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
+                f"       {bench_a_rs_mean:.2f} ms  ±  {bench_a_rs_std:.2f} ms  |  "
+                f"{rs_bw(rs_output_bytes, bench_a_rs_mean):.1f} GB/s"
             )
-            if bench_a_rs_mean > 0 and mean_rs > 0:
-                speedup_rs = bench_a_rs_mean / mean_rs
-                print(
-                    f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
-                    f"{speedup_rs:.2f}x"
-                )
+        else:
+            print("  [A] NCCL reduce_scatter_tensor (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+        )
+        print(
+            f"       {mean_rs:.2f} ms  ±  {std_rs:.2f} ms  |  "
+            f"{rs_bw(rs_output_bytes, mean_rs):.1f} GB/s"
+        )
+        print(
+            f"  [C] KERNEL DIRECT (no pack/copy, "
+            f"{rs_output_bytes / 1024 / 1024:.0f} MB output/group):"
+        )
+        print(
+            f"       {mean_rs_kernel:.2f} ms  ±  {std_rs_kernel:.2f} ms  |  "
+            f"{rs_bw(rs_output_bytes, mean_rs_kernel):.1f} GB/s"
+        )
+        if bench_a_rs_mean > 0 and mean_rs > 0:
+            speedup_rs = bench_a_rs_mean / mean_rs
+            print(
+                f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
+                f"{speedup_rs:.2f}x"
+            )
+        if bench_a_rs_mean > 0 and mean_rs_kernel > 0:
+            print(
+                f"  >> Reduce-scatter KERNEL speedup (NCCL → kernel-direct): "
+                f"{bench_a_rs_mean / mean_rs_kernel:.2f}x"
+            )
 
+        # ----- ALL-TO-ALL / ALL-GATHER (2-active only) -----
+        if sparse_group_size == 2:
             # ----- ALL-TO-ALL -----
             a2a_seg_bytes = my_a2a_seg * dtype.itemsize
             print()

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -41,8 +41,15 @@ BM-FM production numbers (from aps-bm_fm_amd_srinathb_20260420_200640-ea51247ebd
       [479_250_475, 553_440_942, 634_386_550, 560_128_334]
       ≈ 1.8–2.4 GiB per group (fp32)
 
-The production per-group totals above are the defaults.  Run with no extra flags:
+The production per-group totals above are capped to a 1 GiB-per-group default so
+the benchmark fits alongside other work on a shared GPU host and in CI.  Run with
+no extra flags:
     buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+        //torchrec/distributed/tests:bench_sharded_relay_perf
+
+Production scale (uncapped, needs an otherwise-idle host):
+    BENCH_TABLE_SIZE=12002982488 BENCH_KERNEL_SIZE_GB=22.4 \\
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
         //torchrec/distributed/tests:bench_sharded_relay_perf
 
 Optimizer-sync scale (fp32):
@@ -57,8 +64,8 @@ Small-scale smoke run (101 tables × 1M elements ≈ 100M per group):
 Environment variables (all optional):
     BENCH_DTYPE          bf16|fp16|fp32   (default: fp16)
     BENCH_NUM_TABLES     int              (default: 1)
-    BENCH_TABLE_SIZE     int              (default: production total for active group)
-    BENCH_KERNEL_SIZE_GB float            (default: production total for active group)
+    BENCH_TABLE_SIZE     int              (default: capped production total, <=1 GiB/group)
+    BENCH_KERNEL_SIZE_GB float            (default: capped production total, <=1 GiB/group)
     BENCH_WARMUP_ITERS   int              (default: 5)
     BENCH_BENCH_ITERS    int              (default: 20)
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
@@ -135,6 +142,18 @@ _PROD_TOTALS_FP32: list[int] = [
     634_386_550,  # group 2
     560_128_334,  # group 3
 ]
+
+# The production totals above are ~22 GiB per group, which needs ~69 GiB per rank
+# once helper and scratch buffers are included and OOMs whenever the host is
+# shared (or in CI). Cap the per-group default and use BENCH_TABLE_SIZE /
+# BENCH_KERNEL_SIZE_GB to measure at production scale on an idle host.
+_DEFAULT_MAX_BYTES_PER_GROUP: int = 1024**3  # 1 GiB
+
+
+def _default_totals(dtype: torch.dtype) -> list[int]:
+    totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    cap = _DEFAULT_MAX_BYTES_PER_GROUP // dtype.itemsize
+    return [min(total, cap) for total in totals]
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +456,7 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
         for g in range(num_sparse_groups)
     ]
 
-    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    prod_totals = _default_totals(dtype)
 
     num_tables = _env_int("BENCH_NUM_TABLES", 1)
     table_sizes_all = [
@@ -550,7 +569,7 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
     ]
 
     # Production per-group totals: groups have heterogeneous sizes matching BM-FM.
-    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+    prod_totals = _default_totals(dtype)
 
     # Tensors for Benchmark B.
     # Default: one flat tensor per group at the production total for this rank's

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -1256,10 +1256,9 @@ def _benchmark_worker(
             a2a_helper_bufs.append(a2a_output)  # unused for the active group
         else:
             if sparse_group_size > 2:
-                # Flat A>2 all-to-all is pure-direct (no helper relay), so the
-                # helper does no work for this group -- a tiny placeholder is
-                # all the per-group tensor-list slot needs.
-                a2a_helper_size_g = 1
+                # Match production: one segment bounds the A=4 XOR path's
+                # three compact relay slots and is unused on direct routes.
+                a2a_helper_size_g = a2a_seg_counts[g]
             else:
                 a2a_helper_size_g = _passthrough_helper_size(
                     a2a_seg_counts[g], sparse_group_size, num_chunks
@@ -1704,7 +1703,7 @@ def _relay_helper_size(
         return _passthrough_helper_size(recv, active_ranks, num_chunks)
     if collective == "all_to_all":
         if active_ranks > 2:
-            return 1  # pure-direct A>2 all-to-all: helper does no relay work
+            return elements // active_ranks
         seg = elements // active_ranks
         return _passthrough_helper_size(seg, active_ranks, num_chunks)
     if collective == "all_gather":

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -402,6 +402,48 @@ def bench_reduce_scatter_flat(
 
 
 # ---------------------------------------------------------------------------
+# Benchmark E: fused all-to-all (sharded relay)
+# ---------------------------------------------------------------------------
+
+
+def bench_all_to_all_flat(
+    fused: Any,
+    input_flat: torch.Tensor,
+    output_flat: torch.Tensor,
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    helper_bufs: list[torch.Tensor],
+    per_group_segment_counts: list[int],
+) -> None:
+    """ONE fused all-to-all call across all sparse groups.
+
+    input_flat and output_flat each hold nActiveRanks x segment_count elements
+    (two segments for sparse_group_size=2) and must be distinct buffers
+    (all-to-all is out-of-place only). Each helper group uses its own
+    passthrough-sized scratch buffer for both send and recv.
+    """
+    input_group_tensors: list[torch.Tensor] = []
+    output_group_tensors: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            input_group_tensors.append(input_flat)
+            output_group_tensors.append(output_flat)
+        else:
+            input_group_tensors.append(helper_bufs[g])
+            output_group_tensors.append(helper_bufs[g])
+
+    fused.all_to_all_multi_group(
+        input_tensors=input_group_tensors,
+        output_tensors=output_group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_segment_counts=per_group_segment_counts,
+        all_active_ranks=all_active_ranks,
+        skip_validation=True,
+    )
+
+
+# ---------------------------------------------------------------------------
 # NCCL baseline: 4 parallel 2-rank dist.all_reduce calls
 # ---------------------------------------------------------------------------
 
@@ -573,6 +615,27 @@ def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     if rank == 0:
         results_dict["A_rs"] = (mean_rs_base, std_rs_base)
+
+    # NCCL all-to-all baseline on the same 2-rank sub-group PG. Free the
+    # reduce-scatter baseline tensors first. segment_count = prod_total // 4 so
+    # the in/out buffers (2 x segment_count) match the sharded-relay all-to-all
+    # benchmark's footprint.
+    rs_in = torch.empty(0, dtype=dtype, device=device)
+    rs_out = torch.empty(0, dtype=dtype, device=device)
+    torch.cuda.empty_cache()
+    a2a_seg = prod_totals[my_sparse_group] // 4
+    a2a_in = torch.ones(2 * a2a_seg, dtype=dtype, device=device)
+    a2a_out = torch.empty(2 * a2a_seg, dtype=dtype, device=device)
+
+    def run_a2a_baseline() -> None:
+        a2a_in.fill_(1.0)
+        dist.all_to_all_single(a2a_out, a2a_in, group=my_pg)
+
+    mean_a2a_base, std_a2a_base = _measure_ms(run_a2a_baseline, warmup, bench_iters)
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
 
     dist.destroy_process_group()
 
@@ -829,6 +892,47 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
 
     mean_rs, std_rs = _measure_ms(run_reduce_scatter, warmup, bench_iters)
 
+    # -------------------------------------------------------------------------
+    # Benchmark E: fused all-to-all. Release the reduce-scatter buffers first.
+    # segment_count = prod_total // 4 so the in/out buffers (2 x segment_count)
+    # stay within HBM (all-to-all needs distinct in and out buffers).
+    # -------------------------------------------------------------------------
+    rs_input = torch.empty(0, dtype=dtype, device=device)
+    rs_output = torch.empty(0, dtype=dtype, device=device)
+    rs_helper_bufs = []
+    torch.cuda.empty_cache()
+
+    a2a_seg_counts = [t // 4 for t in prod_totals]
+    my_a2a_seg = a2a_seg_counts[my_sparse_group]
+    a2a_input = torch.ones(2 * my_a2a_seg, dtype=dtype, device=device)
+    a2a_output = torch.empty(2 * my_a2a_seg, dtype=dtype, device=device)
+    a2a_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            a2a_helper_bufs.append(a2a_output)  # unused for the active group
+        else:
+            a2a_helper_size_g = _passthrough_helper_size(
+                a2a_seg_counts[g], sparse_group_size, num_chunks
+            )
+            a2a_helper_bufs.append(
+                torch.empty(a2a_helper_size_g, dtype=dtype, device=device)
+            )
+
+    def run_all_to_all() -> None:
+        a2a_input.fill_(1.0)
+        bench_all_to_all_flat(
+            fused=fused,
+            input_flat=a2a_input,
+            output_flat=a2a_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=a2a_helper_bufs,
+            per_group_segment_counts=a2a_seg_counts,
+        )
+
+    mean_a2a, std_a2a = _measure_ms(run_all_to_all, warmup, bench_iters)
+
     if rank == 0:
         total_bytes = sum(sz * dtype.itemsize for sz in sizes)
         kernel_bytes = kernel_elements * dtype.itemsize
@@ -843,6 +947,12 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
         )
         bench_a_rs_std = (
             float(results_dict["A_rs"][1]) if "A_rs" in results_dict else 0.0
+        )
+        bench_a_a2a_mean = (
+            float(results_dict["A_a2a"][0]) if "A_a2a" in results_dict else 0.0
+        )
+        bench_a_a2a_std = (
+            float(results_dict["A_a2a"][1]) if "A_a2a" in results_dict else 0.0
         )
 
         rs_output_bytes = my_rs_recv * dtype.itemsize
@@ -928,6 +1038,38 @@ def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
             print(
                 f"  >> Reduce-scatter speedup (NCCL → sharded relay): "
                 f"{speedup_rs:.2f}x"
+            )
+
+        # ----- ALL-TO-ALL -----
+        a2a_seg_bytes = my_a2a_seg * dtype.itemsize
+        print()
+        print("-" * 72)
+        print("ALL-TO-ALL")
+        print("-" * 72)
+        if bench_a_a2a_mean > 0:
+            print(
+                f"  [A] NCCL all_to_all_single (baseline, "
+                f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
+            )
+            print(
+                f"       {bench_a_a2a_mean:.2f} ms  ±  {bench_a_a2a_std:.2f} ms  |  "
+                f"{rs_bw(a2a_seg_bytes, bench_a_a2a_mean):.1f} GB/s"
+            )
+        else:
+            print("  [A] NCCL all_to_all_single (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
+        )
+        print(
+            f"       {mean_a2a:.2f} ms  ±  {std_a2a:.2f} ms  |  "
+            f"{rs_bw(a2a_seg_bytes, mean_a2a):.1f} GB/s"
+        )
+        if bench_a_a2a_mean > 0 and mean_a2a > 0:
+            speedup_a2a = bench_a_a2a_mean / mean_a2a
+            print(
+                f"  >> All-to-all speedup (NCCL → sharded relay): "
+                f"{speedup_a2a:.2f}x"
             )
         print("=" * 72)
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -71,8 +71,8 @@ Environment variables (all optional):
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
 
 The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
-groups and prints a full report for each. The 4-active sweep covers allreduce
-and reduce-scatter (all-to-all / all-gather are still 2-active only).
+groups and prints a full report for each. The 4-active sweep covers allreduce,
+reduce-scatter, and all-to-all (all-gather is still 2-active only).
 """
 
 from __future__ import annotations
@@ -442,10 +442,9 @@ def bench_all_to_all_flat(
 ) -> None:
     """ONE fused all-to-all call across all sparse groups.
 
-    input_flat and output_flat each hold nActiveRanks x segment_count elements
-    (two segments for sparse_group_size=2) and must be distinct buffers
-    (all-to-all is out-of-place only). Each helper group uses its own
-    passthrough-sized scratch buffer for both send and recv.
+    Each group contributes ONE contiguous tensor: the active group passes the
+    single contiguous input_flat/output_flat; each helper group passes its
+    single passthrough scratch buffer.
     """
     input_group_tensors: list[torch.Tensor] = []
     output_group_tensors: list[torch.Tensor] = []
@@ -725,31 +724,36 @@ def _bench_a_worker(
     if rank == 0:
         results_dict["A_rs"] = (mean_rs_base, std_rs_base)
 
-    # NCCL all-to-all / all-gather baselines are 2-active only (paired with the
-    # 2-active sharded relay A2A/AG benches), so skip them for a 4-active sweep.
-    # All ranks share the same env-driven sparse_group_size, so the
-    # _store_barrier() calls stay balanced.
+    # NCCL all-to-all baseline runs for all active-rank counts (paired with the
+    # now-4-active sharded relay all-to-all bench). Free the reduce-scatter
+    # baseline tensors first. segment_count = prod_total // (2*sparse_group_size)
+    # so the out-of-place in/out buffers (each A x segment_count = prod_total/2)
+    # match the sharded-relay all-to-all footprint regardless of A.
+    rs_in = torch.empty(0, dtype=dtype, device=device)
+    rs_out = torch.empty(0, dtype=dtype, device=device)
+    torch.cuda.empty_cache()
+    a2a_seg = prod_totals[my_sparse_group] // (2 * sparse_group_size)
+    a2a_in = torch.ones(sparse_group_size * a2a_seg, dtype=dtype, device=device)
+    a2a_out = torch.empty(sparse_group_size * a2a_seg, dtype=dtype, device=device)
+
+    def run_a2a_baseline() -> None:
+        a2a_in.fill_(1.0)
+        dist.all_to_all_single(a2a_out, a2a_in, group=my_pg)
+
+    mean_a2a_base, std_a2a_base = (
+        _measure_ms(run_a2a_baseline, warmup, bench_iters)
+        if _want("all_to_all")
+        else (0.0, 0.0)
+    )
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
+
+    # NCCL all-gather baseline is 2-active only (paired with the 2-active sharded
+    # relay all-gather bench). All ranks share the same env-driven
+    # sparse_group_size, so the _store_barrier() calls stay balanced.
     if sparse_group_size == 2:
-        # NCCL all-to-all baseline. Free the reduce-scatter baseline tensors
-        # first. segment_count = prod_total // 4 so the in/out buffers
-        # (2 x segment_count) match the sharded-relay all-to-all footprint.
-        rs_in = torch.empty(0, dtype=dtype, device=device)
-        rs_out = torch.empty(0, dtype=dtype, device=device)
-        torch.cuda.empty_cache()
-        a2a_seg = prod_totals[my_sparse_group] // 4
-        a2a_in = torch.ones(2 * a2a_seg, dtype=dtype, device=device)
-        a2a_out = torch.empty(2 * a2a_seg, dtype=dtype, device=device)
-
-        def run_a2a_baseline() -> None:
-            a2a_in.fill_(1.0)
-            dist.all_to_all_single(a2a_out, a2a_in, group=my_pg)
-
-        mean_a2a_base, std_a2a_base = _measure_ms(run_a2a_baseline, warmup, bench_iters)
-        _store_barrier()
-
-        if rank == 0:
-            results_dict["A_a2a"] = (mean_a2a_base, std_a2a_base)
-
         # NCCL all-gather baseline. Free the all-to-all baseline tensors first.
         # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
         # matches the sharded-relay all-gather footprint.
@@ -789,8 +793,8 @@ def _benchmark_worker(
     spawned child processes in the Meta environment.
 
     sharding_group_size selects the active-ranks-per-group (2 or 4). At 4 the
-    all-to-all / all-gather benches (2-active only) are skipped; allreduce and
-    reduce-scatter run at both 2 and 4. port_offset isolates ports across the
+    all-gather bench (2-active only) is skipped; allreduce, reduce-scatter, and
+    all-to-all run at both 2 and 4. port_offset isolates ports across the
     2-rank and 4-rank sweep iterations.
     """
     os.environ["MASTER_ADDR"] = "localhost"
@@ -1012,11 +1016,11 @@ def _benchmark_worker(
     else:
         peak_hbm_bytes = 0
 
-    # The all-to-all / all-gather sharded-relay benches only support 2 active
-    # ranks today, so they are skipped during the 4-active sweep. Reduce-scatter
-    # supports 2 or 4 and always runs.
-    mean_a2a = std_a2a = mean_ag = std_ag = 0.0
-    my_a2a_seg = my_ag_send = 0
+    # The all-gather sharded-relay bench only supports 2 active ranks today, so
+    # it is skipped during the 4-active sweep. Reduce-scatter and all-to-all
+    # support 2 or 4 and always run.
+    mean_ag = std_ag = 0.0
+    my_ag_send = 0
 
     # -------------------------------------------------------------------------
     # Benchmark D: fused reduce-scatter (runs for all active-rank counts).
@@ -1103,51 +1107,96 @@ def _benchmark_worker(
         else (0.0, 0.0)
     )
 
-    if sparse_group_size == 2:
-        # ---------------------------------------------------------------------
-        # Benchmark E: fused all-to-all. Release the reduce-scatter buffers
-        # first. segment_count = prod_total // 4 so the in/out buffers
-        # (2 x segment_count) stay within HBM (all-to-all needs distinct
-        # in and out buffers).
-        # ---------------------------------------------------------------------
-        rs_input = torch.empty(0, dtype=dtype, device=device)
-        rs_output = torch.empty(0, dtype=dtype, device=device)
-        rs_helper_bufs = []
-        rs_in_model = [torch.empty(0, dtype=dtype, device=device)]
-        rs_out_model = [torch.empty(0, dtype=dtype, device=device)]
-        torch.cuda.empty_cache()
+    # -------------------------------------------------------------------------
+    # Benchmark E: fused all-to-all (runs for all active-rank counts). Release
+    # the reduce-scatter buffers first. segment_count =
+    # prod_total // (2 * sparse_group_size) so the out-of-place in/out buffers
+    # (each A x segment_count = prod_total/2) stay within HBM. Indexed by
+    # range(num_sparse_groups) (NOT `for t in prod_totals`) so the segment-count
+    # list length matches num_sparse_groups (2 at 4-active).
+    # -------------------------------------------------------------------------
+    rs_input = torch.empty(0, dtype=dtype, device=device)
+    rs_output = torch.empty(0, dtype=dtype, device=device)
+    rs_helper_bufs = []
+    rs_in_model = [torch.empty(0, dtype=dtype, device=device)]
+    rs_out_model = [torch.empty(0, dtype=dtype, device=device)]
+    torch.cuda.empty_cache()
 
-        a2a_seg_counts = [t // 4 for t in prod_totals]
-        my_a2a_seg = a2a_seg_counts[my_sparse_group]
-        a2a_input = torch.ones(2 * my_a2a_seg, dtype=dtype, device=device)
-        a2a_output = torch.empty(2 * my_a2a_seg, dtype=dtype, device=device)
-        a2a_helper_bufs: list[torch.Tensor] = []
-        for g in range(num_sparse_groups):
-            if g == my_sparse_group:
-                a2a_helper_bufs.append(a2a_output)  # unused for the active group
+    a2a_seg_counts = [
+        prod_totals[g] // (2 * sparse_group_size) for g in range(num_sparse_groups)
+    ]
+    my_a2a_seg = a2a_seg_counts[my_sparse_group]
+    a2a_input = torch.ones(sparse_group_size * my_a2a_seg, dtype=dtype, device=device)
+    a2a_output = torch.empty(sparse_group_size * my_a2a_seg, dtype=dtype, device=device)
+    a2a_in_model = [
+        torch.ones(sparse_group_size * my_a2a_seg, dtype=dtype, device=device)
+    ]
+    a2a_out_model = [
+        torch.empty(sparse_group_size * my_a2a_seg, dtype=dtype, device=device)
+    ]
+    a2a_helper_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            a2a_helper_bufs.append(a2a_output)  # unused for the active group
+        else:
+            if sparse_group_size > 2:
+                # Flat A>2 all-to-all is pure-direct (no helper relay), so the
+                # helper does no work for this group -- a tiny placeholder is
+                # all the per-group tensor-list slot needs.
+                a2a_helper_size_g = 1
             else:
                 a2a_helper_size_g = _passthrough_helper_size(
                     a2a_seg_counts[g], sparse_group_size, num_chunks
                 )
-                a2a_helper_bufs.append(
-                    torch.empty(a2a_helper_size_g, dtype=dtype, device=device)
-                )
-
-        def run_all_to_all() -> None:
-            a2a_input.fill_(1.0)
-            bench_all_to_all_flat(
-                fused=fused,
-                input_flat=a2a_input,
-                output_flat=a2a_output,
-                num_sparse_groups=num_sparse_groups,
-                my_sparse_group=my_sparse_group,
-                all_active_ranks=all_active_ranks,
-                helper_bufs=a2a_helper_bufs,
-                per_group_segment_counts=a2a_seg_counts,
+            a2a_helper_bufs.append(
+                torch.empty(a2a_helper_size_g, dtype=dtype, device=device)
             )
 
-        mean_a2a, std_a2a = _measure_ms(run_all_to_all, warmup, bench_iters)
+    def run_all_to_all() -> None:
+        # Production path: pack the per-table model input into the contiguous
+        # flat send buffer, run the fused call, then unpack into the model output.
+        for t in a2a_in_model:
+            t.fill_(1.0)
+        a2a_input.copy_(a2a_in_model[0].reshape(-1))
+        bench_all_to_all_flat(
+            fused=fused,
+            input_flat=a2a_input,
+            output_flat=a2a_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=a2a_helper_bufs,
+            per_group_segment_counts=a2a_seg_counts,
+        )
+        a2a_out_model[0].reshape(-1).copy_(a2a_output)
 
+    mean_a2a, std_a2a = (
+        _measure_ms(run_all_to_all, warmup, bench_iters)
+        if _want("all_to_all")
+        else (0.0, 0.0)
+    )
+
+    def run_all_to_all_kernel() -> None:
+        # Kernel-direct: raw kernel on the contiguous flat buffers, no pack/copy.
+        a2a_input.fill_(1.0)
+        bench_all_to_all_flat(
+            fused=fused,
+            input_flat=a2a_input,
+            output_flat=a2a_output,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            helper_bufs=a2a_helper_bufs,
+            per_group_segment_counts=a2a_seg_counts,
+        )
+
+    mean_a2a_kernel, std_a2a_kernel = (
+        _measure_ms(run_all_to_all_kernel, warmup, bench_iters)
+        if _want("all_to_all")
+        else (0.0, 0.0)
+    )
+
+    if sparse_group_size == 2:
         # ---------------------------------------------------------------------
         # Benchmark F: fused all-gather. Release the all-to-all buffers first.
         # send_count = prod_total // 4 so the output (nActiveRanks x send_count)
@@ -1327,40 +1376,53 @@ def _benchmark_worker(
                 f"{bench_a_rs_mean / mean_rs_kernel:.2f}x"
             )
 
-        # ----- ALL-TO-ALL / ALL-GATHER (2-active only) -----
-        if sparse_group_size == 2:
-            # ----- ALL-TO-ALL -----
-            a2a_seg_bytes = my_a2a_seg * dtype.itemsize
-            print()
-            print("-" * 72)
-            print("ALL-TO-ALL")
-            print("-" * 72)
-            if bench_a_a2a_mean > 0:
-                print(
-                    f"  [A] NCCL all_to_all_single (baseline, "
-                    f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
-                )
-                print(
-                    f"       {bench_a_a2a_mean:.2f} ms  ±  {bench_a_a2a_std:.2f} ms  |  "
-                    f"{rs_bw(a2a_seg_bytes, bench_a_a2a_mean):.1f} GB/s"
-                )
-            else:
-                print("  [A] NCCL all_to_all_single (baseline): N/A")
+        # ----- ALL-TO-ALL (runs for 2 or 4 active ranks) -----
+        a2a_seg_bytes = my_a2a_seg * dtype.itemsize
+        print()
+        print("-" * 72)
+        print("ALL-TO-ALL")
+        print("-" * 72)
+        if bench_a_a2a_mean > 0:
             print(
-                f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+                f"  [A] NCCL all_to_all_single (baseline, "
                 f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
             )
             print(
-                f"       {mean_a2a:.2f} ms  ±  {std_a2a:.2f} ms  |  "
-                f"{rs_bw(a2a_seg_bytes, mean_a2a):.1f} GB/s"
+                f"       {bench_a_a2a_mean:.2f} ms  ±  {bench_a_a2a_std:.2f} ms  |  "
+                f"{rs_bw(a2a_seg_bytes, bench_a_a2a_mean):.1f} GB/s"
             )
-            if bench_a_a2a_mean > 0 and mean_a2a > 0:
-                speedup_a2a = bench_a_a2a_mean / mean_a2a
-                print(
-                    f"  >> All-to-all speedup (NCCL → sharded relay): "
-                    f"{speedup_a2a:.2f}x"
-                )
+        else:
+            print("  [A] NCCL all_to_all_single (baseline): N/A")
+        print(
+            f"  [B] SHARDED RELAY (1 fused call, passthrough helpers, "
+            f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
+        )
+        print(
+            f"       {mean_a2a:.2f} ms  ±  {std_a2a:.2f} ms  |  "
+            f"{rs_bw(a2a_seg_bytes, mean_a2a):.1f} GB/s"
+        )
+        print(
+            f"  [C] KERNEL DIRECT (no pack/copy, "
+            f"{a2a_seg_bytes / 1024 / 1024:.0f} MB segment/group):"
+        )
+        print(
+            f"       {mean_a2a_kernel:.2f} ms  ±  {std_a2a_kernel:.2f} ms  |  "
+            f"{rs_bw(a2a_seg_bytes, mean_a2a_kernel):.1f} GB/s"
+        )
+        if bench_a_a2a_mean > 0 and mean_a2a > 0:
+            speedup_a2a = bench_a_a2a_mean / mean_a2a
+            print(
+                f"  >> All-to-all speedup (NCCL → sharded relay): "
+                f"{speedup_a2a:.2f}x"
+            )
+        if bench_a_a2a_mean > 0 and mean_a2a_kernel > 0:
+            print(
+                f"  >> All-to-all KERNEL speedup (NCCL → kernel-direct): "
+                f"{bench_a_a2a_mean / mean_a2a_kernel:.2f}x"
+            )
 
+        # ----- ALL-GATHER (2-active only) -----
+        if sparse_group_size == 2:
             # ----- ALL-GATHER -----
             ag_send_bytes = my_ag_send * dtype.itemsize
             print()
@@ -1437,10 +1499,10 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         results: Any = manager.dict()
 
         # Sweep both 2-active and 4-active sharded relay groups, printing a full
-        # report for each. The 4-active sweep covers allreduce only (the
-        # reduce-scatter / all-to-all / all-gather benches are 2-active only and
-        # are skipped at 4). Each iteration uses a distinct port_offset so the
-        # NCCL/TCPStore endpoints don't collide across iterations.
+        # report for each. The 4-active sweep covers allreduce, reduce-scatter,
+        # and all-to-all (the all-gather bench is 2-active only and is skipped at
+        # 4). Each iteration uses a distinct port_offset so the NCCL/TCPStore
+        # endpoints don't collide across iterations.
         for i, sharding_group_size in enumerate((2, 4)):
             port_offset = i * 100
 

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -1172,9 +1172,16 @@ def _benchmark_worker(
         if g == my_sparse_group:
             rs_helper_bufs.append(rs_output)  # unused for the active group
         else:
-            rs_helper_size_g = _passthrough_helper_size(
-                rs_recv_counts[g], sparse_group_size, num_chunks
-            )
+            if sparse_group_size > 2:
+                # A>2 reduces at the helper and needs 2 x recv_count (mirrors
+                # the allreduce benches and _relay_helper_size's reduce_scatter
+                # case). The A=2 passthrough size under-allocates for A=4, so the
+                # kernel writes past the helper buffer -> GPU memory access fault.
+                rs_helper_size_g = 2 * rs_recv_counts[g]
+            else:
+                rs_helper_size_g = _passthrough_helper_size(
+                    rs_recv_counts[g], sparse_group_size, num_chunks
+                )
             rs_helper_bufs.append(
                 torch.empty(rs_helper_size_g, dtype=dtype, device=device)
             )

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -2090,5 +2090,147 @@ class FusedReduceScatter4ActiveValidationTest(unittest.TestCase):
         self.assertNotIsInstance(cm.exception, ValueError)
 
 
+class FlatAllToAll4ActiveTest(unittest.TestCase):
+    """all_to_all_tensors_with_sharded_relay with sparse_group_size=4.
+
+    8-rank node -> 2 groups of 4 active ranks. The active group's input/output
+    each hold nActiveRanks x segment_count elements (out-of-place). Verifies the
+    flat-concat path is generic over the active-rank count.
+    """
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.all_to_all_multi_group.call_args_list
+
+    def test_single_call_two_groups(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # input total 400 -> segment_count 100 (sparse_group_size=4)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        self.assertEqual(state.fused.all_to_all_multi_group.call_count, 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["num_groups"], 2)
+        self.assertEqual(kwargs["per_group_segment_counts"][state.my_sparse_group], 100)
+        self.assertEqual(
+            kwargs["input_tensors"][state.my_sparse_group].numel(),
+            400,
+        )
+        self.assertEqual(
+            kwargs["output_tensors"][state.my_sparse_group].numel(),
+            400,
+        )
+
+    def test_output_flat_distinct_from_input_flat_4active(self) -> None:
+        """All-to-all is out-of-place: active output flat must differ from input."""
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertNotEqual(
+            kwargs["input_tensors"][my_g].data_ptr(),
+            kwargs["output_tensors"][my_g].data_ptr(),
+        )
+
+    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # input total 800 -> segment_count 200
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(800)]},
+            {torch.float32: [torch.zeros(800)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                self.assertEqual(in_tensors[g].numel(), 800)
+                self.assertEqual(out_tensors[g].numel(), 800)
+                continue
+            # Flat A>2 all-to-all is pure-direct: helpers do no work, so the
+            # util passes a tiny placeholder (size 1), not a full helper buffer.
+            self.assertEqual(in_tensors[g].numel(), 1)
+            # Helper uses one scratch buffer for both send and recv.
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_group_is_group_zero_for_rank0(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        self.assertEqual(state.my_sparse_group, 0)
+        self.assertEqual(state.num_sparse_groups, 2)
+        self.assertEqual(state.precomputed_active_ranks, [[0, 1, 2, 3], [4, 5, 6, 7]])
+
+
+class FusedAllToAll4ActiveValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_4active_validation_accepts(self) -> None:
+        """all_to_all_multi_group must accept 4 active ranks (no ValueError);
+        without a native comm it falls through to RuntimeError. The active
+        input/output each hold nActiveRanks x segment_count = 4 x 100, distinct
+        (out-of-place)."""
+        fused = self._make_fused(rank=0)
+        input_tensors = [torch.zeros(400), torch.zeros(400)]
+        output_tensors = [torch.zeros(400), torch.zeros(400)]
+        per_group_segment_counts = [100, 100]
+
+        with self.assertRaises(RuntimeError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=2,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1, 2, 3], [4, 5, 6, 7]],
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+    def test_4active_in_place_rejected(self) -> None:
+        """In-place (input aliases output) for the active group must raise at 4
+        active ranks too."""
+        fused = self._make_fused(rank=0)
+        shared = torch.zeros(400)
+        input_tensors = [shared, torch.zeros(400)]
+        output_tensors = [shared, torch.zeros(400)]  # aliases input for group 0
+        per_group_segment_counts = [100, 100]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=2,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1, 2, 3], [4, 5, 6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("in-place", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -40,9 +40,11 @@ import torch
 import torch.distributed as dist
 from torchrec.distributed.sharded_relay_utils import (
     _get_active_flat_buf,
+    _get_active_output_flat_buf,
     _get_helper_flat_buf,
     _passthrough_helper_size,
     allreduce_tensors_with_sharded_relay,
+    reduce_scatter_tensors_with_sharded_relay,
     ShardedRelayState,
 )
 
@@ -704,17 +706,19 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
 
     def test_passthrough_size_matches_2x_chunkSize_for_realistic_totals(self) -> None:
         """BM-FM fp16: ~12B elements per group, 8 ranks, 2 active → numChunks=7."""
-        total_g = 12_002_982_488
-        sparse_group_size = 2
-        num_chunks = 7  # (8 - 2) + 1
-        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
-        chunk = total_g // num_chunks
-        chunk_aligned = (chunk // 128) * 128
-        expected = sparse_group_size * chunk_aligned
-        self.assertEqual(result, expected)
-        # Sanity: result should be ~2/7 of total, much less than total
-        self.assertLess(result, total_g)
-        self.assertGreater(result, 0)
+        # Worked out by hand from the contract rather than re-derived with the
+        # implementation's own expression -- recomputing
+        # sparse_group_size * align_down(total_g // num_chunks, 128) here would
+        # move both sides of the assertion together and could never fail:
+        #
+        #   12_002_982_488 // 7 = 1_714_711_784   (remainder 0)
+        #   align_down(.., 128) = 1_714_711_680   (trims 104 elements)
+        #   2 * 1_714_711_680   = 3_429_423_360   (< total_g, so no clamp)
+        result = _passthrough_helper_size(12_002_982_488, 2, 7)
+        self.assertEqual(result, 3_429_423_360)
+        # Each of the 2 slots is a whole number of 128-element chunks, which is
+        # the property the alignment exists for.
+        self.assertEqual(result % (2 * 128), 0)
 
     def test_passthrough_size_falls_back_to_total_for_tiny_counts(self) -> None:
         """When total_g < num_chunks * CACHE_LINE_SIZE, chunkSize falls back to total_g."""
@@ -737,16 +741,10 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
 
     def test_python_meets_cpp_min_required_at_alignment_boundary(self) -> None:
         """At exact alignment boundaries, Python and C++ formulas agree."""
-        # total_g = 7 * 128 * k for some k → exact alignment, no remainder
-        total_g = 7 * 128 * 1000  # 896_000
-        sparse_group_size = 2
-        num_chunks = 7
-        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
-        chunk = total_g // num_chunks  # 128_000
-        chunk_aligned = (chunk // 128) * 128  # 128_000
-        expected = min(total_g, sparse_group_size * chunk_aligned)
-        self.assertEqual(result, expected)
-        self.assertEqual(result, 256_000)
+        # total_g = 7 * 128 * 1000 = 896_000 divides evenly by num_chunks * 128,
+        # so nothing is lost to alignment: 896_000 // 7 = 128_000, which is
+        # already 128-aligned, and 2 * 128_000 = 256_000 stays under total_g.
+        self.assertEqual(_passthrough_helper_size(7 * 128 * 1000, 2, 7), 256_000)
 
     def test_total_per_rank_helper_memory_is_6x_chunkSize(self) -> None:
         """
@@ -759,12 +757,380 @@ class _PassthroughHelperSizePolicyTest(unittest.TestCase):
         helper_per_group = _passthrough_helper_size(
             total_g, sparse_group_size, num_chunks
         )
-        chunk = total_g // num_chunks
-        chunk_aligned = (chunk // 128) * 128
-        self.assertEqual(helper_per_group, sparse_group_size * chunk_aligned)
-        # 3 helper groups per rank
-        total_helper = 3 * helper_per_group
-        self.assertEqual(total_helper, 6 * chunk_aligned)
+        # Literals rather than a re-derivation of the implementation's own
+        # expression, which would make these assertions unfalsifiable:
+        # align_down(12_002_982_488 // 7, 128) = 1_714_711_680, and the helper
+        # buffer holds 2 of those chunks.
+        self.assertEqual(helper_per_group, 3_429_423_360)
+        # 3 helper groups per rank, so 3 x 2 = 6 aligned chunks in total:
+        # 6 * 1_714_711_680.
+        self.assertEqual(3 * helper_per_group, 10_288_270_080)
+
+
+# ---------------------------------------------------------------------------
+# Tests for reduce_scatter_tensors_with_sharded_relay (flat-concat approach)
+# ---------------------------------------------------------------------------
+
+
+class FlatReduceScatterTest(unittest.TestCase):
+    """Tests for the reduce-scatter flat-concat helper.
+
+    The active group's input is packed into ONE contiguous flat buffer holding
+    nActiveRanks x recv_count elements (two blocks for sparse_group_size=2);
+    the output holds recv_count elements.  fused.reduce_scatter_multi_group is
+    a MagicMock that records every call (one tensor per group).
+    """
+
+    def _call_count(self, state: ShardedRelayState) -> int:
+        return state.fused.reduce_scatter_multi_group.call_count
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.reduce_scatter_multi_group.call_args_list
+
+    def test_returns_immediately_when_no_tensors(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(state, {}, {}, "test")
+        self.assertEqual(self._call_count(state), 0)
+
+    def test_single_call_recv_count_is_half_input_total(self) -> None:
+        state = _make_state(rank=0)
+        # input total 200 -> recv_count 100 (sparse_group_size=2)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["per_group_recv_counts"][state.my_sparse_group], 100)
+
+    def test_single_call_per_dtype(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {
+                torch.float16: [torch.zeros(40, dtype=torch.float16)],
+                torch.float32: [torch.zeros(40, dtype=torch.float32)],
+            },
+            {
+                torch.float16: [torch.zeros(20, dtype=torch.float16)],
+                torch.float32: [torch.zeros(20, dtype=torch.float32)],
+            },
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 2)
+
+    def test_active_input_and_output_buffer_sizes(self) -> None:
+        state = _make_state(rank=0)
+        in_sizes = [100, 200, 300]  # total 600 -> recv 300
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(s) for s in in_sizes]},
+            {torch.float32: [torch.zeros(300)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertEqual(kwargs["per_group_recv_counts"][my_g], 300)
+        # Active group's inputs are packed into ONE contiguous flat buffer.
+        self.assertEqual(kwargs["input_tensors"][my_g].numel(), 600)
+        self.assertEqual(kwargs["output_tensors"][my_g].numel(), 300)
+
+    def test_raises_when_input_total_not_divisible_by_group_size(self) -> None:
+        state = _make_state(rank=0)  # sparse_group_size=2
+        with self.assertRaises(ValueError):
+            reduce_scatter_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(101)]},  # odd
+                {torch.float32: [torch.zeros(50)]},
+                "test",
+            )
+
+    def test_raises_when_output_total_mismatches_recv_count(self) -> None:
+        state = _make_state(rank=0)
+        with self.assertRaises(ValueError):
+            reduce_scatter_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(200)]},  # recv 100
+                {torch.float32: [torch.zeros(90)]},  # wrong
+                "test",
+            )
+
+    def test_helper_buffers_passthrough_sized_and_distinct(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},  # recv 200
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        recv = kwargs["per_group_recv_counts"]
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            expected = _passthrough_helper_size(
+                recv[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(in_tensors[g].numel(), expected)
+            # Helper uses one scratch buffer for both send and recv.
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_output_is_separate_flat_buffer(self) -> None:
+        # Flat-concat scheme: the active group's output is a separate internal
+        # flat buffer (one contiguous tensor per group), distinct from the
+        # caller's output tensor; results are unpacked into the caller tensor
+        # after the call.
+        state = _make_state(rank=1)
+        out_tensor = torch.zeros(100)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},  # recv 100
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        out_seg = kwargs["output_tensors"][my_g]
+        self.assertEqual(out_seg.numel(), 100)
+        self.assertNotEqual(out_seg.data_ptr(), out_tensor.data_ptr())
+
+    def test_out_of_place_output_distinct_from_input(self) -> None:
+        state = _make_state(rank=0)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+            in_place=False,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertNotEqual(
+            kwargs["input_tensors"][my_g].data_ptr(),
+            kwargs["output_tensors"][my_g].data_ptr(),
+        )
+
+    def test_in_place_output_aliases_input_owned_block(self) -> None:
+        # In-place: the active output is an owned-block view into the active
+        # input flat buffer at offset my_active_index * recv_count (the inverse
+        # of the out-of-place distinct-pointer assertion above).
+        state = _make_state(rank=1)  # my_active_index = 1 within group 0
+        recv_count = 100
+        inp = torch.zeros(2 * recv_count)  # nActiveRanks x recv_count
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [inp]},
+            {torch.float32: [torch.zeros(recv_count)]},
+            "test",
+            in_place=True,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_flat = kwargs["input_tensors"][my_g]
+        out_seg = kwargs["output_tensors"][my_g]
+        self.assertEqual(in_flat.numel(), 2 * recv_count)
+        self.assertEqual(out_seg.numel(), recv_count)
+        self.assertEqual(
+            out_seg.data_ptr(),
+            in_flat.data_ptr() + recv_count * in_flat.element_size(),
+        )
+
+    def test_values_written_back_to_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        out_tensor = torch.zeros(100)
+        sentinel = 7.0
+
+        def _fill(*args, **kwargs) -> None:
+            outs = kwargs["output_tensors"]
+            outs[state.my_sparse_group].fill_(sentinel)
+
+        state.fused.reduce_scatter_multi_group.side_effect = _fill
+
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        self.assertTrue(torch.all(out_tensor == sentinel))
+
+    def test_unpack_handles_multiple_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        o0 = torch.zeros(40)
+        o1 = torch.zeros(60)  # total output 100 -> input 200
+        fill_values = [1.0, 2.0]
+
+        def _fill_by_slice(*args, **kwargs) -> None:
+            # Flat-concat scheme: fill successive slices of the output flat buf.
+            flat = kwargs["output_tensors"][state.my_sparse_group]
+            flat[:40].fill_(fill_values[0])
+            flat[40:100].fill_(fill_values[1])
+
+        state.fused.reduce_scatter_multi_group.side_effect = _fill_by_slice
+
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [o0, o1]},
+            "test",
+        )
+        self.assertTrue(torch.all(o0 == fill_values[0]))
+        self.assertTrue(torch.all(o1 == fill_values[1]))
+
+    @patch("torchrec.distributed.sharded_relay_utils.dist")
+    def test_metadata_cache_skips_allgather_after_first_call(
+        self, mock_dist: MagicMock
+    ) -> None:
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for t in tensor_list:
+                t.fill_(100)  # recv_count 100 for all ranks
+
+        mock_dist.all_gather.side_effect = _allgather_side_effect
+        mock_dist.ReduceOp = dist.ReduceOp
+
+        ins = {torch.float32: [torch.zeros(200)]}
+        outs = {torch.float32: [torch.zeros(100)]}
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        reduce_scatter_tensors_with_sharded_relay(state, ins, outs, "other")
+        self.assertEqual(mock_dist.all_gather.call_count, 2)
+
+    def test_active_output_flat_buf_reused_across_steps(self) -> None:
+        """Out-of-place output flat buffer must be reused (grow-only)."""
+        state = _make_state(rank=0)
+        b1 = _get_active_output_flat_buf(state, 100, torch.float32, _DEVICE)
+        b2 = _get_active_output_flat_buf(state, 100, torch.float32, _DEVICE)
+        self.assertEqual(b1.data_ptr(), b2.data_ptr())
+
+
+# ---------------------------------------------------------------------------
+# Tests for FusedShardedRelayMultiGroup.reduce_scatter_multi_group validation
+# ---------------------------------------------------------------------------
+
+
+class FusedReduceScatterValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        # rcclx_comm=None -> _use_native=False; validation still runs.
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_raises_on_active_input_too_small(self) -> None:
+        """Active input must hold nActiveRanks x recv_count elements."""
+        fused = self._make_fused(rank=0)  # active for group 0
+        # recv_count 100 -> input must be 200; pass 150.
+        input_tensors = [
+            torch.zeros(150),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(100),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+                skip_validation=False,
+            )
+        self.assertIn("200", str(cm.exception))
+
+    def test_raises_on_active_output_too_small(self) -> None:
+        fused = self._make_fused(rank=0)
+        input_tensors = [
+            torch.zeros(200),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(90),  # need 100
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+                skip_validation=False,
+            )
+        self.assertIn("100", str(cm.exception))
+
+    def test_recv_count_zero_skips_validation(self) -> None:
+        """recv_count=0 group carries a placeholder and must skip validation."""
+        fused = self._make_fused(rank=0)
+        # Group 0 (this rank's active group) ran out -> recv_count=0, placeholder.
+        input_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_recv_counts = [0, 5, 5, 5]
+
+        # Must NOT raise ValueError. RuntimeError (no native API) is expected.
+        with self.assertRaises(RuntimeError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
 
 
 if __name__ == "__main__":

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -223,6 +223,59 @@ class FlatAllreduceTest(unittest.TestCase):
         self.assertEqual(self._call_count(state), 1)
 
     # ------------------------------------------------------------------
+    # Out-of-place vs in-place wiring
+    # ------------------------------------------------------------------
+
+    def test_out_of_place_active_output_wired_distinctly(self) -> None:
+        """output_tensors_dict routes the active group's reduced result to a
+        separate destination (out-of-place). The active input and output are
+        distinct internal flat buffers; the caller's out buffer receives the
+        result via the unpack step while the caller's input is preserved."""
+        state = _make_state(rank=0)  # active for group 0
+        inp = torch.ones(100)
+        out = torch.zeros(100)
+
+        sentinel = 42.0
+
+        def _fill_active_output(*args, **kwargs) -> None:
+            # Simulate the reduced result landing in the active output flat buf.
+            outs = kwargs["output_tensors"]
+            outs[state.my_sparse_group].fill_(sentinel)
+
+        state.fused.allreduce_multi_group.side_effect = _fill_active_output
+
+        allreduce_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [inp]},
+            "test",
+            output_tensors_dict={torch.float32: [out]},
+        )
+
+        call_kwargs = self._all_calls(state)[0].kwargs
+        self.assertIn("output_tensors", call_kwargs)
+        output_tensors = call_kwargs["output_tensors"]
+        self.assertIsNotNone(output_tensors)
+
+        active = state.my_sparse_group
+        active_input = call_kwargs["tensors"][active]
+        active_output = output_tensors[active]
+        # Active input and output are distinct flat buffers (out-of-place).
+        self.assertNotEqual(active_output.data_ptr(), active_input.data_ptr())
+        # The result is unpacked into the caller's out buffer...
+        self.assertTrue(torch.all(out == sentinel))
+        # ...while the caller's input buffer is preserved.
+        self.assertTrue(torch.all(inp == 1.0))
+
+    def test_in_place_passes_no_output_tensors(self) -> None:
+        """Default (no output_tensors_dict) → in-place: output_tensors is None."""
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100)]}, "test"
+        )
+        call_kwargs = self._all_calls(state)[0].kwargs
+        self.assertIsNone(call_kwargs.get("output_tensors"))
+
+    # ------------------------------------------------------------------
     # Flat buffer sizing passed to allreduce_multi_group
     # ------------------------------------------------------------------
 
@@ -651,6 +704,7 @@ class FusedShardedRelayValidationTest(unittest.TestCase):
                 per_group_sizes=per_group_sizes,
                 all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
                 op=dist.ReduceOp.SUM,
+                skip_validation=False,
             )
 
         err = str(cm.exception)

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -1808,5 +1808,151 @@ class FusedAllGatherValidationTest(unittest.TestCase):
         self.assertNotIsInstance(cm.exception, ValueError)
 
 
+# ---------------------------------------------------------------------------
+# Tests for the 4-active-rank allreduce path (2 groups x 4 active per group)
+# ---------------------------------------------------------------------------
+
+
+class FlatAllreduce4ActiveTest(unittest.TestCase):
+    """allreduce_tensors_with_sharded_relay with sparse_group_size=4.
+
+    8-rank node -> 2 groups of 4 active ranks; each rank is helper for the 1
+    other group. Verifies the flat-concat path is generic over the active-rank
+    count.
+    """
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.allreduce_multi_group.call_args_list
+
+    def test_single_call_two_groups(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(400)]}, "test"
+        )
+        self.assertEqual(state.fused.allreduce_multi_group.call_count, 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["num_groups"], 2)
+        self.assertEqual(kwargs["per_group_sizes"][state.my_sparse_group], 400)
+
+    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(800)]}, "test"
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        iter_tensors = kwargs["tensors"]
+        iter_sizes = kwargs["per_group_sizes"]
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                self.assertEqual(iter_tensors[g].numel(), 800)
+                continue
+            # Flat A>2 allreduce: the util sizes the helper 2*total_g
+            # ((A+1)*oChunk <= 1.25*total_g), not the recursive _passthrough.
+            expected = 2 * iter_sizes[g]
+            self.assertEqual(iter_tensors[g].numel(), expected)
+            helper_ptrs.add(iter_tensors[g].data_ptr())
+
+        # Each rank is helper for exactly num_sparse_groups - 1 == 1 group.
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_group_is_group_zero_for_rank0(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        self.assertEqual(state.my_sparse_group, 0)
+        self.assertEqual(state.num_sparse_groups, 2)
+        self.assertEqual(state.precomputed_active_ranks, [[0, 1, 2, 3], [4, 5, 6, 7]])
+
+
+class FusedAllreduce4ActiveValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_4active_validation_accepts(self) -> None:
+        """allreduce_multi_group must accept 4 active ranks (no ValueError);
+        without a native comm it falls through to RuntimeError."""
+        fused = self._make_fused(rank=0)
+        tensors = [torch.zeros(400), torch.zeros(400)]
+        per_group_sizes = [400, 400]
+
+        with self.assertRaises(RuntimeError) as cm:
+            fused.allreduce_multi_group(
+                tensors=tensors,
+                num_groups=2,
+                per_group_sizes=per_group_sizes,
+                all_active_ranks=[[0, 1, 2, 3], [4, 5, 6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
+class _PassthroughHelperSize4ActivePolicyTest(unittest.TestCase):
+    """_passthrough_helper_size against hand-computed sizes, not the formula.
+
+    Every expected value below is worked out by hand from the documented
+    contract and written in as a literal. Re-deriving it with the same
+    ``min(total_g, A * align_down(total_g // num_chunks, 128))`` expression the
+    implementation uses would make the assertion unfalsifiable: any change to
+    the formula would move both sides together and the test would still pass.
+    The three branches of that contract are covered -- ordinary alignment loss,
+    the ``min()`` clamp, and the ``chunk_aligned == 0`` fallback.
+    """
+
+    def test_passthrough_size_4active(self) -> None:
+        # 4-active on an 8-rank node: num_chunks = (8 - 4) + 1 = 5.
+        #
+        # 12_002_982_488 // 5      = 2_400_596_497   (remainder 3)
+        # align_down(.., 128)      = 2_400_596_480   (trims 17 elements)
+        # 4 * 2_400_596_480        = 9_602_385_920   (< total_g, so no clamp)
+        self.assertEqual(_passthrough_helper_size(12_002_982_488, 4, 5), 9_602_385_920)
+        # A total that is already a multiple of num_chunks * 128 loses nothing to
+        # alignment, and lands on the same size because the case above only had a
+        # sub-128 remainder to trim.
+        self.assertEqual(_passthrough_helper_size(12_002_982_400, 4, 5), 9_602_385_920)
+
+    def test_passthrough_size_per_slot_is_chunk_aligned(self) -> None:
+        # The buffer holds sparse_group_size slots, so whenever min() has not
+        # clamped, each slot must be a whole number of 128-element chunks. This
+        # is the property the 128-alignment exists for.
+        for total_g, sparse_group_size, num_chunks in (
+            (12_002_982_488, 4, 5),
+            (12_002_982_488, 2, 7),
+            (1_000_000, 4, 5),
+        ):
+            with self.subTest(total_g=total_g, A=sparse_group_size):
+                result = _passthrough_helper_size(
+                    total_g, sparse_group_size, num_chunks
+                )
+                self.assertLess(result, total_g, "expected no min() clamp here")
+                self.assertEqual(result % (sparse_group_size * 128), 0)
+
+    def test_passthrough_size_clamps_to_total(self) -> None:
+        # sparse_group_size >= num_chunks makes A * chunk_aligned exceed total_g,
+        # so min() clamps: 10_000 // 2 = 5_000 -> 4_992 -> 4 * 4_992 = 19_968,
+        # which is larger than total_g.
+        self.assertEqual(_passthrough_helper_size(10_000, 4, 2), 10_000)
+
+    def test_passthrough_size_falls_back_below_one_chunk(self) -> None:
+        # 500 // 5 = 100, and align_down(100, 128) == 0, so the fallback replaces
+        # chunk_aligned with total_g; min() then clamps the product back to 500.
+        self.assertEqual(_passthrough_helper_size(500, 4, 5), 500)
+        # 2-active production shape, for contrast: num_chunks = (8 - 2) + 1 = 7,
+        # 12_002_982_488 // 7 = 1_714_711_784 -> 1_714_711_680 -> x2.
+        self.assertEqual(_passthrough_helper_size(12_002_982_488, 2, 7), 3_429_423_360)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -1954,5 +1954,141 @@ class _PassthroughHelperSize4ActivePolicyTest(unittest.TestCase):
         self.assertEqual(_passthrough_helper_size(12_002_982_488, 2, 7), 3_429_423_360)
 
 
+class FlatReduceScatter4ActiveTest(unittest.TestCase):
+    """reduce_scatter_tensors_with_sharded_relay with sparse_group_size=4.
+
+    8-rank node -> 2 groups of 4 active ranks; each rank is helper for the 1
+    other group. The active group's input holds nActiveRanks x recv_count
+    elements; the output holds recv_count. Verifies the flat-concat path is
+    generic over the active-rank count.
+    """
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.reduce_scatter_multi_group.call_args_list
+
+    def test_single_call_two_groups(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # input total 400 -> recv_count 100 (sparse_group_size=4)
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},
+            {torch.float32: [torch.zeros(100)]},
+            "test",
+        )
+        self.assertEqual(state.fused.reduce_scatter_multi_group.call_count, 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["num_groups"], 2)
+        self.assertEqual(kwargs["per_group_recv_counts"][state.my_sparse_group], 100)
+        self.assertEqual(
+            kwargs["input_tensors"][state.my_sparse_group].numel(),
+            400,
+        )
+        self.assertEqual(
+            kwargs["output_tensors"][state.my_sparse_group].numel(),
+            100,
+        )
+
+    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # input total 800 -> recv_count 200
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(800)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        recv = kwargs["per_group_recv_counts"]
+        # num_chunks = local_size - sparse_group_size + 1 = 8 - 4 + 1 = 5
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                self.assertEqual(in_tensors[g].numel(), 800)
+                self.assertEqual(out_tensors[g].numel(), 200)
+                continue
+            expected = _passthrough_helper_size(
+                recv[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(in_tensors[g].numel(), expected)
+            # Helper uses one scratch buffer for both send and recv.
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        # Each rank is helper for exactly num_sparse_groups - 1 == 1 group.
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_in_place_output_aliases_input_owned_block(self) -> None:
+        # 4-active in-place: the active output is an owned-block view into the
+        # active input flat buffer at offset my_active_index * recv_count.
+        state = _make_state(rank=2, sparse_group_size=4, local_size=8)
+        recv_count = 100
+        inp = torch.zeros(4 * recv_count)  # nActiveRanks x recv_count
+        reduce_scatter_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [inp]},
+            {torch.float32: [torch.zeros(recv_count)]},
+            "test",
+            in_place=True,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_flat = kwargs["input_tensors"][my_g]
+        out_seg = kwargs["output_tensors"][my_g]
+        self.assertEqual(out_seg.numel(), recv_count)
+        # rank=2 -> my_active_index = 2 within its group.
+        self.assertEqual(
+            out_seg.data_ptr(),
+            in_flat.data_ptr() + 2 * recv_count * in_flat.element_size(),
+        )
+
+    def test_active_group_is_group_zero_for_rank0(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        self.assertEqual(state.my_sparse_group, 0)
+        self.assertEqual(state.num_sparse_groups, 2)
+        self.assertEqual(state.precomputed_active_ranks, [[0, 1, 2, 3], [4, 5, 6, 7]])
+
+
+class FusedReduceScatter4ActiveValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_4active_validation_accepts(self) -> None:
+        """reduce_scatter_multi_group must accept 4 active ranks (no
+        ValueError); without a native comm it falls through to RuntimeError.
+        The active input holds nActiveRanks x recv_count = 4 x 100."""
+        fused = self._make_fused(rank=0)
+        input_tensors = [torch.zeros(400), torch.zeros(400)]
+        output_tensors = [torch.zeros(100), torch.zeros(100)]
+        per_group_recv_counts = [100, 100]
+
+        with self.assertRaises(RuntimeError) as cm:
+            fused.reduce_scatter_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=2,
+                per_group_recv_counts=per_group_recv_counts,
+                all_active_ranks=[[0, 1, 2, 3], [4, 5, 6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -2042,7 +2042,7 @@ class FlatReduceScatter4ActiveTest(unittest.TestCase):
             100,
         )
 
-    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+    def test_helper_buffers_sized_to_2x_recv_count_4active(self) -> None:
         state = _make_state(rank=0, sparse_group_size=4, local_size=8)
         # input total 800 -> recv_count 200
         reduce_scatter_tensors_with_sharded_relay(
@@ -2055,8 +2055,6 @@ class FlatReduceScatter4ActiveTest(unittest.TestCase):
         in_tensors = kwargs["input_tensors"]
         out_tensors = kwargs["output_tensors"]
         recv = kwargs["per_group_recv_counts"]
-        # num_chunks = local_size - sparse_group_size + 1 = 8 - 4 + 1 = 5
-        num_chunks = (state.local_size - state.sparse_group_size) + 1
 
         helper_ptrs = set()
         for g in range(state.num_sparse_groups):
@@ -2064,9 +2062,9 @@ class FlatReduceScatter4ActiveTest(unittest.TestCase):
                 self.assertEqual(in_tensors[g].numel(), 800)
                 self.assertEqual(out_tensors[g].numel(), 200)
                 continue
-            expected = _passthrough_helper_size(
-                recv[g], state.sparse_group_size, num_chunks
-            )
+            # A>2 reduce-scatter reduces at the helper and retains the
+            # 2 * recvCount helper-buffer contract.
+            expected = 2 * recv[g]
             self.assertEqual(in_tensors[g].numel(), expected)
             # Helper uses one scratch buffer for both send and recv.
             self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -2191,7 +2191,7 @@ class FlatAllToAll4ActiveTest(unittest.TestCase):
             kwargs["output_tensors"][my_g].data_ptr(),
         )
 
-    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+    def test_helper_buffers_one_segment_sized_4active(self) -> None:
         state = _make_state(rank=0, sparse_group_size=4, local_size=8)
         # input total 800 -> segment_count 200
         all_to_all_tensors_with_sharded_relay(
@@ -2210,9 +2210,9 @@ class FlatAllToAll4ActiveTest(unittest.TestCase):
                 self.assertEqual(in_tensors[g].numel(), 800)
                 self.assertEqual(out_tensors[g].numel(), 800)
                 continue
-            # Flat A>2 all-to-all is pure-direct: helpers do no work, so the
-            # util passes a tiny placeholder (size 1), not a full helper buffer.
-            self.assertEqual(in_tensors[g].numel(), 1)
+            # One segment bounds the routed A=4 XOR helper scratch; direct
+            # routes keep the same production allocation unused.
+            self.assertEqual(in_tensors[g].numel(), 200)
             # Helper uses one scratch buffer for both send and recv.
             self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
             helper_ptrs.add(in_tensors[g].data_ptr())

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -43,6 +43,7 @@ from torchrec.distributed.sharded_relay_utils import (
     _get_active_output_flat_buf,
     _get_helper_flat_buf,
     _passthrough_helper_size,
+    all_to_all_tensors_with_sharded_relay,
     allreduce_tensors_with_sharded_relay,
     reduce_scatter_tensors_with_sharded_relay,
     ShardedRelayState,
@@ -1129,6 +1130,341 @@ class FusedReduceScatterValidationTest(unittest.TestCase):
                 per_group_recv_counts=per_group_recv_counts,
                 all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
                 op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Tests for all_to_all_tensors_with_sharded_relay (flat-concat approach)
+# ---------------------------------------------------------------------------
+
+
+class FlatAllToAllTest(unittest.TestCase):
+    """Tests for the all-to-all flat-concat helper (out-of-place only).
+
+    The active group's input/output each hold nActiveRanks x segment_count
+    elements (two segments for sparse_group_size=2).
+    fused.all_to_all_multi_group is a MagicMock that records every call.
+    """
+
+    def _call_count(self, state: ShardedRelayState) -> int:
+        return state.fused.all_to_all_multi_group.call_count
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.all_to_all_multi_group.call_args_list
+
+    def test_returns_immediately_when_no_tensors(self) -> None:
+        state = _make_state(rank=0)
+        all_to_all_tensors_with_sharded_relay(state, {}, {}, "test")
+        self.assertEqual(self._call_count(state), 0)
+
+    def test_single_call_segment_count_is_half_input_total(self) -> None:
+        state = _make_state(rank=0)
+        # input total 200 -> segment_count 100; output total 200
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["per_group_segment_counts"][state.my_sparse_group], 100)
+
+    def test_single_call_per_dtype(self) -> None:
+        state = _make_state(rank=0)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {
+                torch.float16: [torch.zeros(40, dtype=torch.float16)],
+                torch.float32: [torch.zeros(40, dtype=torch.float32)],
+            },
+            {
+                torch.float16: [torch.zeros(40, dtype=torch.float16)],
+                torch.float32: [torch.zeros(40, dtype=torch.float32)],
+            },
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 2)
+
+    def test_active_input_and_output_buffer_sizes(self) -> None:
+        state = _make_state(rank=0)
+        in_sizes = [100, 200, 300]  # total 600 -> segment 300
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(s) for s in in_sizes]},
+            {torch.float32: [torch.zeros(600)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertEqual(kwargs["per_group_segment_counts"][my_g], 300)
+        self.assertEqual(kwargs["input_tensors"][my_g].numel(), 600)
+        self.assertEqual(kwargs["output_tensors"][my_g].numel(), 600)
+
+    def test_raises_when_input_total_not_divisible_by_group_size(self) -> None:
+        state = _make_state(rank=0)  # sparse_group_size=2
+        with self.assertRaises(ValueError):
+            all_to_all_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(101)]},  # odd
+                {torch.float32: [torch.zeros(101)]},
+                "test",
+            )
+
+    def test_raises_when_output_total_mismatches_input_total(self) -> None:
+        state = _make_state(rank=0)
+        with self.assertRaises(ValueError):
+            all_to_all_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(200)]},
+                {torch.float32: [torch.zeros(100)]},  # must equal input total
+                "test",
+            )
+
+    def test_helper_buffers_passthrough_sized_and_distinct(self) -> None:
+        state = _make_state(rank=0)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(400)]},  # segment 200
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        seg = kwargs["per_group_segment_counts"]
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            expected = _passthrough_helper_size(
+                seg[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(in_tensors[g].numel(), expected)
+            # Helper uses one scratch buffer for both send and recv.
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_output_flat_distinct_from_input_flat(self) -> None:
+        """All-to-all is out-of-place: active output flat must differ from input."""
+        state = _make_state(rank=0)
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertNotEqual(
+            kwargs["input_tensors"][my_g].data_ptr(),
+            kwargs["output_tensors"][my_g].data_ptr(),
+        )
+
+    def test_values_written_back_to_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        out_tensor = torch.zeros(200)
+        sentinel = 9.0
+
+        def _fill(*args, **kwargs) -> None:
+            outs = kwargs["output_tensors"]
+            outs[state.my_sparse_group].fill_(sentinel)
+
+        state.fused.all_to_all_multi_group.side_effect = _fill
+
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        self.assertTrue(torch.all(out_tensor == sentinel))
+
+    def test_unpack_handles_multiple_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        o0 = torch.zeros(80)
+        o1 = torch.zeros(120)  # total 200 == input 200
+        fill_values = [3.0, 4.0]
+
+        def _fill_by_slice(*args, **kwargs) -> None:
+            flat = kwargs["output_tensors"][state.my_sparse_group]
+            flat[:80].fill_(fill_values[0])
+            flat[80:200].fill_(fill_values[1])
+
+        state.fused.all_to_all_multi_group.side_effect = _fill_by_slice
+
+        all_to_all_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [o0, o1]},
+            "test",
+        )
+        self.assertTrue(torch.all(o0 == fill_values[0]))
+        self.assertTrue(torch.all(o1 == fill_values[1]))
+
+    @patch("torchrec.distributed.sharded_relay_utils.dist")
+    def test_metadata_cache_skips_allgather_after_first_call(
+        self, mock_dist: MagicMock
+    ) -> None:
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for t in tensor_list:
+                t.fill_(100)  # segment_count 100 for all ranks
+
+        mock_dist.all_gather.side_effect = _allgather_side_effect
+        mock_dist.ReduceOp = dist.ReduceOp
+
+        ins = {torch.float32: [torch.zeros(200)]}
+        outs = {torch.float32: [torch.zeros(200)]}
+
+        all_to_all_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        all_to_all_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        all_to_all_tensors_with_sharded_relay(state, ins, outs, "other")
+        self.assertEqual(mock_dist.all_gather.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for FusedShardedRelayMultiGroup.all_to_all_multi_group validation
+# ---------------------------------------------------------------------------
+
+
+class FusedAllToAllValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_raises_on_active_input_too_small(self) -> None:
+        fused = self._make_fused(rank=0)  # active for group 0
+        # segment_count 100 -> input/output must be 200; pass input 150.
+        input_tensors = [
+            torch.zeros(150),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(200),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_segment_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("200", str(cm.exception))
+
+    def test_raises_on_active_output_too_small(self) -> None:
+        fused = self._make_fused(rank=0)
+        input_tensors = [
+            torch.zeros(200),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(150),  # need 200
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_segment_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("200", str(cm.exception))
+
+    def test_raises_on_in_place(self) -> None:
+        """In-place (input aliases output) for the active group must raise."""
+        fused = self._make_fused(rank=0)
+        shared = torch.zeros(200)
+        input_tensors = [
+            shared,
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            shared,  # aliases input for active group 0
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_segment_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("in-place", str(cm.exception))
+
+    def test_segment_count_zero_skips_validation(self) -> None:
+        """segment_count=0 group carries a placeholder and must skip validation."""
+        fused = self._make_fused(rank=0)
+        input_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_segment_counts = [0, 5, 5, 5]
+
+        # Must NOT raise ValueError. RuntimeError (no native API) is expected.
+        with self.assertRaises(RuntimeError) as cm:
+            fused.all_to_all_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
             )
         self.assertNotIsInstance(cm.exception, ValueError)
 

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -43,6 +43,7 @@ from torchrec.distributed.sharded_relay_utils import (
     _get_active_output_flat_buf,
     _get_helper_flat_buf,
     _passthrough_helper_size,
+    all_gather_tensors_with_sharded_relay,
     all_to_all_tensors_with_sharded_relay,
     allreduce_tensors_with_sharded_relay,
     reduce_scatter_tensors_with_sharded_relay,
@@ -1464,6 +1465,344 @@ class FusedAllToAllValidationTest(unittest.TestCase):
                 output_tensors=output_tensors,
                 num_groups=4,
                 per_group_segment_counts=per_group_segment_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Tests for all_gather_tensors_with_sharded_relay (flat-concat approach)
+# ---------------------------------------------------------------------------
+
+
+class FlatAllGatherTest(unittest.TestCase):
+    """Tests for the all-gather flat-concat helper (in-place + out-of-place).
+
+    The active group's input holds send_count elements (this rank's
+    contribution); its output holds nActiveRanks x send_count elements.
+    fused.all_gather_multi_group is a MagicMock that records every call.
+    """
+
+    def _call_count(self, state: ShardedRelayState) -> int:
+        return state.fused.all_gather_multi_group.call_count
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.all_gather_multi_group.call_args_list
+
+    def test_returns_immediately_when_no_tensors(self) -> None:
+        state = _make_state(rank=0)
+        all_gather_tensors_with_sharded_relay(state, {}, {}, "test")
+        self.assertEqual(self._call_count(state), 0)
+
+    def test_single_call_output_is_group_size_times_input(self) -> None:
+        state = _make_state(rank=0)
+        # input total 100 (send_count); output total 200 (2 x send_count)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["per_group_send_counts"][state.my_sparse_group], 100)
+
+    def test_single_call_per_dtype(self) -> None:
+        state = _make_state(rank=0)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {
+                torch.float16: [torch.zeros(20, dtype=torch.float16)],
+                torch.float32: [torch.zeros(20, dtype=torch.float32)],
+            },
+            {
+                torch.float16: [torch.zeros(40, dtype=torch.float16)],
+                torch.float32: [torch.zeros(40, dtype=torch.float32)],
+            },
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 2)
+
+    def test_active_input_and_output_buffer_sizes(self) -> None:
+        state = _make_state(rank=0)
+        in_sizes = [100, 200]  # send_count 300
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(s) for s in in_sizes]},
+            {torch.float32: [torch.zeros(600)]},  # 2 x 300
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertEqual(kwargs["per_group_send_counts"][my_g], 300)
+        self.assertEqual(kwargs["input_tensors"][my_g].numel(), 300)
+        self.assertEqual(kwargs["output_tensors"][my_g].numel(), 600)
+
+    def test_raises_when_output_total_mismatches(self) -> None:
+        state = _make_state(rank=0)
+        with self.assertRaises(ValueError):
+            all_gather_tensors_with_sharded_relay(
+                state,
+                {torch.float32: [torch.zeros(100)]},  # send 100 -> output 200
+                {torch.float32: [torch.zeros(150)]},  # wrong
+                "test",
+            )
+
+    def test_helper_buffers_passthrough_sized_and_distinct(self) -> None:
+        state = _make_state(rank=0)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},  # send 200
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        send = kwargs["per_group_send_counts"]
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            expected = _passthrough_helper_size(
+                send[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(in_tensors[g].numel(), expected)
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_input_is_separate_flat_buffer(self) -> None:
+        # Flat-concat scheme: the active group's input is a separate internal
+        # flat send buffer (one contiguous tensor per group), distinct from the
+        # caller's input tensor (packed into it before the call).
+        state = _make_state(rank=1)
+        in_tensor = torch.zeros(100)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [in_tensor]},  # send 100
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_seg = kwargs["input_tensors"][my_g]
+        self.assertEqual(in_seg.numel(), 100)
+        self.assertNotEqual(in_seg.data_ptr(), in_tensor.data_ptr())
+
+    def test_out_of_place_input_distinct_from_output(self) -> None:
+        state = _make_state(rank=0)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [torch.zeros(200)]},
+            "test",
+            in_place=False,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        self.assertNotEqual(
+            kwargs["input_tensors"][my_g].data_ptr(),
+            kwargs["output_tensors"][my_g].data_ptr(),
+        )
+
+    def test_in_place_input_aliases_output_own_slot(self) -> None:
+        # In-place: the active input is an owned-slot view into the active
+        # output flat buffer at offset my_active_index * send_count (the
+        # inverse of the out-of-place distinct-pointer assertion above).
+        state = _make_state(rank=1)  # my_active_index = 1 within group 0
+        send_count = 100
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(send_count)]},
+            {torch.float32: [torch.zeros(2 * send_count)]},
+            "test",
+            in_place=True,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_seg = kwargs["input_tensors"][my_g]
+        out_flat = kwargs["output_tensors"][my_g]
+        self.assertEqual(out_flat.numel(), 2 * send_count)
+        self.assertEqual(in_seg.numel(), send_count)
+        self.assertEqual(
+            in_seg.data_ptr(),
+            out_flat.data_ptr() + send_count * out_flat.element_size(),
+        )
+
+    def test_values_written_back_to_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        out_tensor = torch.zeros(200)
+        sentinel = 5.0
+
+        def _fill(*args, **kwargs) -> None:
+            outs = kwargs["output_tensors"]
+            outs[state.my_sparse_group].fill_(sentinel)
+
+        state.fused.all_gather_multi_group.side_effect = _fill
+
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [out_tensor]},
+            "test",
+        )
+        self.assertTrue(torch.all(out_tensor == sentinel))
+
+    def test_unpack_handles_multiple_output_tensors(self) -> None:
+        state = _make_state(rank=0)
+        o0 = torch.zeros(80)
+        o1 = torch.zeros(120)  # total 200 == 2 x send 100
+        fill_values = [6.0, 7.0]
+
+        def _fill_by_slice(*args, **kwargs) -> None:
+            flat = kwargs["output_tensors"][state.my_sparse_group]
+            flat[:80].fill_(fill_values[0])
+            flat[80:200].fill_(fill_values[1])
+
+        state.fused.all_gather_multi_group.side_effect = _fill_by_slice
+
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [o0, o1]},
+            "test",
+        )
+        self.assertTrue(torch.all(o0 == fill_values[0]))
+        self.assertTrue(torch.all(o1 == fill_values[1]))
+
+    @patch("torchrec.distributed.sharded_relay_utils.dist")
+    def test_metadata_cache_skips_allgather_after_first_call(
+        self, mock_dist: MagicMock
+    ) -> None:
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for t in tensor_list:
+                t.fill_(100)  # send_count 100 for all ranks
+
+        mock_dist.all_gather.side_effect = _allgather_side_effect
+        mock_dist.ReduceOp = dist.ReduceOp
+
+        ins = {torch.float32: [torch.zeros(100)]}
+        outs = {torch.float32: [torch.zeros(200)]}
+
+        all_gather_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        all_gather_tensors_with_sharded_relay(state, ins, outs, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        all_gather_tensors_with_sharded_relay(state, ins, outs, "other")
+        self.assertEqual(mock_dist.all_gather.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for FusedShardedRelayMultiGroup.all_gather_multi_group validation
+# ---------------------------------------------------------------------------
+
+
+class FusedAllGatherValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_raises_on_active_input_too_small(self) -> None:
+        fused = self._make_fused(rank=0)  # active for group 0
+        # send_count 100 -> input must be >= 100; pass 90.
+        input_tensors = [
+            torch.zeros(90),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(200),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_send_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_gather_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_send_counts=per_group_send_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("100", str(cm.exception))
+
+    def test_raises_on_active_output_too_small(self) -> None:
+        fused = self._make_fused(rank=0)
+        # send_count 100 -> output must be >= 200; pass 150.
+        input_tensors = [
+            torch.zeros(100),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(150),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_send_counts = [100, 5, 5, 5]
+
+        with self.assertRaises(ValueError) as cm:
+            fused.all_gather_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_send_counts=per_group_send_counts,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                skip_validation=False,
+            )
+        self.assertIn("200", str(cm.exception))
+
+    def test_send_count_zero_skips_validation(self) -> None:
+        """send_count=0 group carries a placeholder and must skip validation."""
+        fused = self._make_fused(rank=0)
+        input_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        output_tensors = [
+            torch.zeros(1),
+            torch.zeros(10),
+            torch.zeros(10),
+            torch.zeros(10),
+        ]
+        per_group_send_counts = [0, 5, 5, 5]
+
+        # Must NOT raise ValueError. RuntimeError (no native API) is expected.
+        with self.assertRaises(RuntimeError) as cm:
+            fused.all_gather_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=4,
+                per_group_send_counts=per_group_send_counts,
                 all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
             )
         self.assertNotIsInstance(cm.exception, ValueError)

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -2232,5 +2232,154 @@ class FusedAllToAll4ActiveValidationTest(unittest.TestCase):
         self.assertIn("in-place", str(cm.exception))
 
 
+class FlatAllGather4ActiveTest(unittest.TestCase):
+    """all_gather_tensors_with_sharded_relay with sparse_group_size=4.
+
+    8-rank node -> 2 groups of 4 active ranks. The active group's input holds
+    send_count elements and the output holds nActiveRanks x send_count. Verifies
+    the flat-concat path is generic over the active-rank count, in both in-place
+    and out-of-place modes.
+    """
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.all_gather_multi_group.call_args_list
+
+    def test_single_call_two_groups(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # input total 100 (send_count); output total 400 (4 x send_count)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(100)]},
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        self.assertEqual(state.fused.all_gather_multi_group.call_count, 1)
+        kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(kwargs["num_groups"], 2)
+        self.assertEqual(kwargs["per_group_send_counts"][state.my_sparse_group], 100)
+        self.assertEqual(
+            kwargs["input_tensors"][state.my_sparse_group].numel(),
+            100,
+        )
+        self.assertEqual(
+            kwargs["output_tensors"][state.my_sparse_group].numel(),
+            400,
+        )
+
+    def test_helper_buffers_passthrough_sized_4active(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        # send_count 200 -> output 800
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(200)]},
+            {torch.float32: [torch.zeros(800)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        in_tensors = kwargs["input_tensors"]
+        out_tensors = kwargs["output_tensors"]
+        send = kwargs["per_group_send_counts"]
+
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                self.assertEqual(in_tensors[g].numel(), 200)
+                self.assertEqual(out_tensors[g].numel(), 800)
+                continue
+            # Flat A>2 all-gather: the util sizes the helper A*send_count
+            # (matches the kernel's A*cs broadcast scratch), not _passthrough.
+            expected = state.sparse_group_size * send[g]
+            self.assertEqual(in_tensors[g].numel(), expected)
+            self.assertEqual(in_tensors[g].data_ptr(), out_tensors[g].data_ptr())
+            helper_ptrs.add(in_tensors[g].data_ptr())
+
+        self.assertEqual(len(helper_ptrs), state.num_sparse_groups - 1)
+
+    def test_active_input_is_separate_flat_buffer_4active(self) -> None:
+        # Flat-concat scheme: the active group's input is a separate internal
+        # flat send buffer (one contiguous tensor per group), distinct from the
+        # caller's input tensor (packed into it before the call).
+        state = _make_state(rank=1, sparse_group_size=4, local_size=8)
+        in_tensor = torch.zeros(100)
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [in_tensor]},  # send 100
+            {torch.float32: [torch.zeros(400)]},
+            "test",
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_seg = kwargs["input_tensors"][my_g]
+        self.assertEqual(in_seg.numel(), 100)
+        self.assertNotEqual(in_seg.data_ptr(), in_tensor.data_ptr())
+
+    def test_in_place_input_aliases_output_own_slot(self) -> None:
+        # 4-active in-place: the active input is an owned-slot view into the
+        # active output flat buffer at offset my_active_index * send_count.
+        state = _make_state(rank=2, sparse_group_size=4, local_size=8)
+        send_count = 100
+        all_gather_tensors_with_sharded_relay(
+            state,
+            {torch.float32: [torch.zeros(send_count)]},
+            {torch.float32: [torch.zeros(4 * send_count)]},
+            "test",
+            in_place=True,
+        )
+        kwargs = self._all_calls(state)[0].kwargs
+        my_g = state.my_sparse_group
+        in_seg = kwargs["input_tensors"][my_g]
+        out_flat = kwargs["output_tensors"][my_g]
+        self.assertEqual(in_seg.numel(), send_count)
+        # rank=2 -> my_active_index = 2 within its group.
+        self.assertEqual(
+            in_seg.data_ptr(),
+            out_flat.data_ptr() + 2 * send_count * out_flat.element_size(),
+        )
+
+    def test_active_group_is_group_zero_for_rank0(self) -> None:
+        state = _make_state(rank=0, sparse_group_size=4, local_size=8)
+        self.assertEqual(state.my_sparse_group, 0)
+        self.assertEqual(state.num_sparse_groups, 2)
+        self.assertEqual(state.precomputed_active_ranks, [[0, 1, 2, 3], [4, 5, 6, 7]])
+
+
+class FusedAllGather4ActiveValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_4active_validation_accepts(self) -> None:
+        """all_gather_multi_group must accept 4 active ranks (no ValueError);
+        without a native comm it falls through to RuntimeError. The active input
+        holds send_count = 100 and the output holds nActiveRanks x send_count =
+        400."""
+        fused = self._make_fused(rank=0)
+        input_tensors = [torch.zeros(100), torch.zeros(100)]
+        output_tensors = [torch.zeros(400), torch.zeros(400)]
+        per_group_send_counts = [100, 100]
+
+        with self.assertRaises(RuntimeError) as cm:
+            fused.all_gather_multi_group(
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
+                num_groups=2,
+                per_group_send_counts=per_group_send_counts,
+                all_active_ranks=[[0, 1, 2, 3], [4, 5, 6, 7]],
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:

X-link: https://github.com/meta-pytorch/torchcomms/pull/3683

The sharded-relay collective suites covered the single-group (nGroups=1) path
well for A=2, and the fused multi-group path for both A=2 and A=4, but A=4 with
a single group (nGroups=1) was under-tested: all-gather had it, allreduce only
exercised it for bf16 SUM, and reduce-scatter and all-to-all had no A=4
single-group coverage at all. nGroups=1 removes the cross-group lockstep and
A=4 selects the separate direct+offload kernels, so "A=4, single group" is a
distinct, supported configuration (ranks {0,1,2,3} active, {4,5,6,7} helpers)
that a caller can pass.

Add A=4 single-group correctness tests, modeled on all-gather's existing
Correctness_SingleGroup_A4 test and the sibling 4Active_2Groups tests:

- ReduceScatter: Correctness_4Active_SingleGroup_{InPlace, OutOfPlace, Avg} via
  a new runReduceScatterA4SingleGroup(op, inPlace) helper.
- AllToAll: Correctness_4Active_SingleGroup_{Routed_63MiB,
  DirectBelowLowerBoundary, RoutedUnalignedTail} via a new
  runA4SingleGroupCorrectnessCase(...) helper (the existing runA4CorrectnessCase
  is intrinsically 2-group). Verifies active-rank output at the region
  boundaries and that helpers never write past their scratch contract.
- AllReduce: Correctness_4Active_SingleGroup_{InPlace (SUM), Avg} via a new
  runAllReduceA4SingleGroup(op) helper, complementing the existing bf16 A=4
  single-group boundary test with int32 SUM/AVG.

Also fix a crash in the Python perf benchmark (bench_sharded_relay_perf.py) at
A=4. _benchmark_worker sized the reduce-scatter helper buffer with the A=2
_passthrough_helper_size() formula regardless of active-rank count. For A>2 the
reduce-scatter reduces at the helper and needs 2 x recv_count (as the allreduce
benches and _relay_helper_size already do); the A=2 size under-allocates for
A=4, so the kernel writes past the helper buffer and the run dies with a GPU
"Memory access fault". The bug is independent of message size and dtype (it
reproduced at 64 MiB and 24 GiB, in both fp16 and bf16), which is why the
fixed-size msg-size sweep -- which sizes A=4 helpers correctly -- was
unaffected. Size the reduce-scatter helper to 2 x recv_count for A>2, matching
the other benches.

Reviewed By: JinghanHuang

Differential Revision: D115998374
