### PR TITLE
Wire overlap ratio into the train-pipeline benchmark

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -202,6 +202,8 @@ def runner(
         bench_inputs = input_config.generate_batches(
             tables=tables,
             weighted_tables=weighted_tables,
+            world_size=world_size,
+            rank=rank,
         )
 
         total_bytes = 0

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq_overlap.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq_overlap.yml
@@ -1,0 +1,58 @@
+# Mixed EBC + EC benchmark config with overlap ratio for controlled index overlap
+# EC tables use row_wise sharding
+RunOptions:
+  world_size: 4
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_seq_overlap"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+  overlap_ratio: 0.3
+  overlap_tables: ["ec_table_0", "ec_table_1"]
+ModelSelectionConfig:
+  model_name: "mixed_embedding"
+  model_config:
+    num_float_features: 100
+EmbeddingTablesConfig:
+  num_unweighted_features: 70
+  num_weighted_features: 70
+  embedding_feature_dim: 256
+  additional_tables:
+    # First list: unweighted tables (EBC + EC mixed)
+    - - name: ebc_table_0
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["ebc_feature_0"]
+      - name: ebc_table_1
+        embedding_dim: 256
+        num_embeddings: 200_000
+        feature_names: ["ebc_feature_1"]
+      # EC tables - use config_class to specify EmbeddingConfig
+      - name: ec_table_0
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["ec_feature_0"]
+        config_class: EmbeddingConfig
+      - name: ec_table_1
+        embedding_dim: 1024
+        num_embeddings: 2_000_000
+        feature_names: ["ec_feature_1"]
+        config_class: EmbeddingConfig
+    # Second list: weighted tables (empty for this config)
+    - []
+PlannerConfig:
+  pooling_factors: [30.0]
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    ec_table_0:
+      sharding_types: [row_wise]
+    ec_table_1:
+      sharding_types: [row_wise]

--- a/torchrec/distributed/test_utils/input_config.py
+++ b/torchrec/distributed/test_utils/input_config.py
@@ -13,7 +13,11 @@ from typing import List, Optional
 import torch
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
-from .model_input import ModelInput, VariableBatchModelInput
+from .model_input import (
+    generate_overlapping_batches,
+    ModelInput,
+    VariableBatchModelInput,
+)
 
 
 @dataclass
@@ -35,6 +39,12 @@ class ModelInputConfig:
     power_law_alpha: Optional[float] = (
         None  # If set, use power-law distribution for indices
     )
+    overlap_ratio: Optional[float] = (
+        None  # If set, generate batches with controlled index overlap
+    )
+    overlap_tables: Optional[List[str]] = (
+        None  # If set, only apply overlap to these table names
+    )
 
     def __post_init__(self):
         assert self.num_batches is not MISSING, "--num_batches must be specified"
@@ -50,17 +60,49 @@ class ModelInputConfig:
         self,
         tables: List[EmbeddingBagConfig],
         weighted_tables: List[EmbeddingBagConfig],
+        world_size: int = 1,
+        rank: int = 0,
     ) -> List[ModelInput]:
         """
         Generate model input data for benchmarking.
 
         Args:
             tables: List of embedding tables
+            weighted_tables: List of weighted embedding tables
+            world_size: Number of ranks (used with overlap_ratio)
+            rank: Current rank (used with overlap_ratio)
 
         Returns:
             A list of ModelInput objects representing the generated batches
         """
         device = torch.device(self.device) if self.device is not None else None
+
+        if self.overlap_ratio is not None:
+            # generate_overlapping_batches produces batches for ALL ranks at
+            # once, but each rank calls this method independently. We seed the
+            # RNG deterministically so every rank produces the same global
+            # batches, then each rank picks its own slice. The original RNG
+            # state is saved and restored so the seeding does not affect
+            # subsequent random operations (e.g. weight init, dropout).
+            rng_state = torch.random.get_rng_state()
+            torch.manual_seed(42)
+            all_batches = generate_overlapping_batches(
+                tables=tables,
+                batch_size=self.batch_size,
+                world_size=world_size,
+                num_batches=self.num_batches,
+                overlap_ratio=self.overlap_ratio,
+                weighted_tables=weighted_tables,
+                num_float_features=self.num_float_features,
+                pooling_avg=self.feature_pooling_avg,
+                device=device or torch.device("cpu"),
+                indices_dtype=(torch.int64 if self.long_kjt_indices else torch.int32),
+                lengths_dtype=(torch.int64 if self.long_kjt_lengths else torch.int32),
+                overlap_tables=self.overlap_tables,
+                pin_memory=self.pin_memory,
+            )
+            torch.random.set_rng_state(rng_state)
+            return [all_batches[b][rank] for b in range(self.num_batches)]
 
         if self.use_variable_batch:
             return [

--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -9,7 +9,7 @@
 
 import random
 from dataclasses import dataclass, field
-from typing import cast, List, Optional, Tuple, Union
+from typing import cast, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from tensordict import TensorDict
@@ -1062,3 +1062,307 @@ class VariableBatchModelInput(ModelInput):
 class TdModelInput(ModelInput):
     # pyrefly: ignore[bad-override]
     idlist_features: TensorDict
+
+
+def _generate_overlap_indices(
+    total_indices: int,
+    index_range: int,
+    overlap_ratio: float,
+    prev_unique_indices: Optional[torch.Tensor],
+    device: torch.device,
+    dtype: torch.dtype = torch.int64,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Generates indices in [0, index_range) with controlled overlap vs the prev batch.
+
+    Overlap ratio is defined as |S_t intersect S_{t+1}| / |S_t|. Fresh indices are
+    drawn exclusively from the complement of prev_unique_indices (via a boolean
+    mask) to avoid accidental overlap.
+
+    Args:
+        total_indices: number of indices to generate.
+        index_range: exclusive upper bound of the index range.
+        overlap_ratio: target fraction of prev unique indices to reuse.
+        prev_unique_indices: unique indices from the previous batch, or None.
+        device: device for the output tensors.
+        dtype: dtype for the output tensors.
+
+    Returns:
+        (generated indices, unique indices in the new batch).
+    """
+    if total_indices == 0:
+        empty = torch.empty(0, dtype=dtype, device=device)
+        return empty, empty
+
+    if prev_unique_indices is None or prev_unique_indices.numel() == 0:
+        indices = torch.randint(
+            0, index_range, (total_indices,), dtype=dtype, device=device
+        )
+        return indices, indices.unique()
+
+    num_prev = len(prev_unique_indices)
+    num_reuse = min(round(overlap_ratio * num_prev), total_indices)
+    num_fresh = total_indices - num_reuse
+
+    # Reuse: sample num_reuse indices from prev_unique_indices.
+    reuse = prev_unique_indices[torch.randperm(num_prev, device=device)[:num_reuse]]
+
+    # Fresh: sample from [0, index_range) excluding prev_unique_indices.
+    if num_fresh > 0 and num_prev < index_range:
+        mask = torch.ones(index_range, dtype=torch.bool, device=device)
+        mask[prev_unique_indices.long()] = False
+        available = mask.nonzero(as_tuple=False).squeeze(1).to(dtype)
+        fresh = available[torch.randint(0, len(available), (num_fresh,), device=device)]
+    elif num_fresh > 0:
+        # index_range exhausted by prev; fall back to sampling from prev.
+        fresh = prev_unique_indices[
+            torch.randint(0, num_prev, (num_fresh,), device=device)
+        ]
+    else:
+        fresh = torch.empty(0, dtype=dtype, device=device)
+
+    indices = torch.cat([reuse, fresh])
+    indices = indices[torch.randperm(total_indices, device=device)]
+    return indices, indices.unique()
+
+
+def _generate_global_kjt_with_overlap(
+    tables: List[EmbeddingBagConfig],
+    batch_size: int,
+    overlap_ratio: float,
+    prev_unique_per_feature: Dict[str, torch.Tensor],
+    device: torch.device,
+    pooling_avg: int = 10,
+    indices_dtype: torch.dtype = torch.int64,
+    lengths_dtype: torch.dtype = torch.int32,
+    weighted: bool = False,
+    overlap_tables: Optional[Set[str]] = None,
+) -> Tuple[KeyedJaggedTensor, Dict[str, torch.Tensor]]:
+    """Generates a global KJT with controlled per-feature index overlap vs the prev batch.
+
+    Args:
+        tables: embedding table configs defining features and num_embeddings.
+        batch_size: global batch size (typically B * W).
+        overlap_ratio: target overlap ratio for unique indices across batches.
+        prev_unique_per_feature: previous batch's unique indices per feature name.
+        pooling_avg: average pooling factor (number of indices per sample).
+        device: device for the output tensors.
+        indices_dtype: dtype for index tensors.
+        lengths_dtype: dtype for length tensors.
+        weighted: if True, generate random weights via _assemble_kjt.
+        overlap_tables: if provided, only apply overlap control to features of
+            tables whose names are in this set; other features use plain random
+            indices.
+
+    Returns:
+        (global KJT, the new batch's unique indices per overlap feature).
+    """
+    features: List[str] = []
+    lengths_per_feature: List[torch.Tensor] = []
+    indices_per_feature: List[torch.Tensor] = []
+    new_prev_unique: Dict[str, torch.Tensor] = {}
+
+    for table in tables:
+        num_embeddings = table.num_embeddings_post_pruning or table.num_embeddings
+        use_overlap = overlap_tables is None or table.name in overlap_tables
+
+        for feature_name in table.feature_names:
+            features.append(feature_name)
+
+            lengths = torch.max(
+                torch.normal(
+                    float(pooling_avg),
+                    float(pooling_avg) / 10.0,
+                    [batch_size],
+                    device=device,
+                ),
+                torch.tensor(1.0, device=device),
+            ).to(lengths_dtype)
+            lengths_per_feature.append(lengths)
+
+            total_indices = cast(int, lengths.sum().item())
+            if use_overlap:
+                prev = prev_unique_per_feature.get(feature_name, None)
+                indices, new_unique = _generate_overlap_indices(
+                    total_indices=total_indices,
+                    index_range=num_embeddings,
+                    overlap_ratio=overlap_ratio,
+                    prev_unique_indices=prev,
+                    device=device,
+                    dtype=indices_dtype,
+                )
+                new_prev_unique[feature_name] = new_unique
+            else:
+                indices = torch.randint(
+                    0,
+                    num_embeddings,
+                    (total_indices,),
+                    device=device,
+                    dtype=indices_dtype,
+                )
+            indices_per_feature.append(indices)
+
+    kjt = ModelInput._assemble_kjt(
+        features=features,
+        lengths_per_feature=lengths_per_feature,
+        indices_per_feature=indices_per_feature,
+        weighted=weighted,
+        device=device,
+    )
+    return kjt, new_prev_unique
+
+
+def _split_kjt(
+    global_kjt: KeyedJaggedTensor,
+    world_size: int,
+) -> List[KeyedJaggedTensor]:
+    """Splits a global KJT into world_size per-rank KJTs along the batch dimension.
+
+    Reshapes lengths from [F, B*W] to [F*W, B] and uses a single
+    permute_2D_sparse_data call to regroup from feature-major to rank-major
+    order, then slices the result.
+
+    Args:
+        global_kjt: KJT with stride = B * W.
+        world_size: number of ranks to split into.
+
+    Returns:
+        A list of world_size KJTs, each with stride = B.
+    """
+    total_batch = global_kjt.stride()
+    local_batch = total_batch // world_size
+    keys = global_kjt.keys()
+    num_features = len(keys)
+    values = global_kjt.values()
+    weights = global_kjt.weights_or_none()
+    device = values.device
+
+    # Reshape [F, B*W] -> [F*W, B]: each row is one (feature, chunk) pair.
+    lengths_fw_b = global_kjt.lengths().view(num_features * world_size, local_batch)
+
+    # Single permutation feature-major -> rank-major: input row (f, r) at index
+    # f*W+r, output row (r, f) at index r*F+f, so permute[r*F + f] = f*W + r.
+    r_idx = torch.arange(world_size, device=device).unsqueeze(1)
+    f_idx = torch.arange(num_features, device=device).unsqueeze(0)
+    permute = (f_idx * world_size + r_idx).reshape(-1).int()
+
+    out_lengths, out_values, out_weights = torch.ops.fbgemm.permute_2D_sparse_data(
+        permute, lengths_fw_b, values, weights, values.numel()
+    )
+
+    # Slice into W rank chunks.
+    out_lengths_per_rank = out_lengths.view(world_size, num_features * local_batch)
+    value_splits = out_lengths_per_rank.sum(dim=1).tolist()
+    value_chunks = out_values.split(value_splits)
+    weight_chunks = (
+        out_weights.split(value_splits) if weights is not None else [None] * world_size
+    )
+
+    return [
+        KeyedJaggedTensor(
+            keys=list(keys),
+            values=value_chunks[r],
+            lengths=out_lengths_per_rank[r],
+            weights=weight_chunks[r],
+        )
+        for r in range(world_size)
+    ]
+
+
+def generate_overlapping_batches(
+    tables: List[EmbeddingBagConfig],
+    batch_size: int,
+    world_size: int,
+    num_batches: int,
+    overlap_ratio: float = 0.5,
+    weighted_tables: Optional[List[EmbeddingBagConfig]] = None,
+    num_float_features: int = 16,
+    pooling_avg: int = 10,
+    device: Optional[torch.device] = None,
+    indices_dtype: torch.dtype = torch.int64,
+    lengths_dtype: torch.dtype = torch.int32,
+    overlap_tables: Optional[List[str]] = None,
+    pin_memory: bool = False,
+) -> List[List[ModelInput]]:
+    """Generates batches of ModelInput with controlled post-A2A index overlap.
+
+    Intended for PEC RW-sharding training benchmarks/tests. Generates a global
+    KJT (batch size B * W) with per-feature overlap control, then splits it into
+    per-rank KJTs; under a uniform index distribution, per-rank post-A2A overlap
+    approximates the global overlap.
+
+    Args:
+        tables: embedding table configs for unweighted (idlist) features.
+        batch_size: per-rank batch size (B).
+        world_size: number of ranks (W).
+        num_batches: number of batches to generate.
+        overlap_ratio: target |S_t intersect S_{t+1}| / |S_t| for unique indices
+            across consecutive batches (0.0 to 1.0).
+        weighted_tables: optional embedding table configs for weighted features.
+        num_float_features: number of dense float features.
+        pooling_avg: average pooling factor per feature.
+        device: device for the output tensors.
+        indices_dtype: dtype for index tensors.
+        lengths_dtype: dtype for length tensors.
+        overlap_tables: if provided, only apply overlap control to tables whose
+            names are in this list; other tables use plain random indices.
+        pin_memory: if True, pin each ModelInput's tensors for fast async H2D
+            copy in the pipeline (matches ModelInput.generate).
+
+    Returns:
+        batches[b][r]: ModelInput for batch b, rank r (pre-A2A format).
+    """
+    device = device if device is not None else torch.device("cpu")
+    global_batch_size = batch_size * world_size
+    prev_unique_idlist: Dict[str, torch.Tensor] = {}
+    prev_unique_idscore: Dict[str, torch.Tensor] = {}
+    all_batches: List[List[ModelInput]] = []
+    overlap_set: Optional[Set[str]] = (
+        set(overlap_tables) if overlap_tables is not None else None
+    )
+
+    for _ in range(num_batches):
+        global_idlist_kjt, prev_unique_idlist = _generate_global_kjt_with_overlap(
+            tables=tables,
+            batch_size=global_batch_size,
+            overlap_ratio=overlap_ratio,
+            prev_unique_per_feature=prev_unique_idlist,
+            pooling_avg=pooling_avg,
+            device=device,
+            indices_dtype=indices_dtype,
+            lengths_dtype=lengths_dtype,
+            overlap_tables=overlap_set,
+        )
+        per_rank_idlist = _split_kjt(global_idlist_kjt, world_size)
+
+        per_rank_idscore: Optional[List[KeyedJaggedTensor]] = None
+        if weighted_tables:
+            global_idscore_kjt, prev_unique_idscore = _generate_global_kjt_with_overlap(
+                tables=weighted_tables,
+                batch_size=global_batch_size,
+                overlap_ratio=overlap_ratio,
+                prev_unique_per_feature=prev_unique_idscore,
+                pooling_avg=pooling_avg,
+                device=device,
+                indices_dtype=indices_dtype,
+                lengths_dtype=lengths_dtype,
+                weighted=True,
+                overlap_tables=overlap_set,
+            )
+            per_rank_idscore = _split_kjt(global_idscore_kjt, world_size)
+
+        batch: List[ModelInput] = []
+        for r in range(world_size):
+            float_features = torch.rand(batch_size, num_float_features, device=device)
+            label = torch.rand(batch_size, device=device)
+            idlist = per_rank_idlist[r]
+            idscore = per_rank_idscore[r] if per_rank_idscore is not None else None
+            if pin_memory:
+                # Pin so the pipeline's H2D copy can be truly async, matching the
+                # standard ModelInput.generate path.
+                float_features, idlist, idscore, label, _ = ModelInput._pin_memory(
+                    float_features, idlist, idscore, label
+                )
+            batch.append(ModelInput(float_features, idlist, idscore, label))
+        all_batches.append(batch)
+
+    return all_batches

--- a/torchrec/distributed/tests/test_model_input.py
+++ b/torchrec/distributed/tests/test_model_input.py
@@ -8,13 +8,17 @@
 
 # pyre-strict
 
+import math
 import unittest
 from collections import Counter
-from typing import List
+from typing import Dict, List
 
 import numpy as np
 import torch
-from torchrec.distributed.test_utils.model_input import ModelInput
+from torchrec.distributed.test_utils.model_input import (
+    generate_overlapping_batches,
+    ModelInput,
+)
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
@@ -687,6 +691,301 @@ class TestModelInput(unittest.TestCase):
                 device=None,
             )
         self.assertIn("num_embeddings must be >= 1", str(context.exception))
+
+
+class TestGenerateOverlappingBatches(unittest.TestCase):
+    """Tests for generate_overlapping_batches."""
+
+    def setUp(self) -> None:
+        torch.manual_seed(42)
+        self.tables: List[EmbeddingBagConfig] = [
+            EmbeddingBagConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=64,
+                num_embeddings=10000,
+            ),
+            EmbeddingBagConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=32,
+                num_embeddings=5000,
+            ),
+        ]
+        self.batch_size = 32
+        self.world_size = 4
+        self.pooling_avg = 10
+
+    def _get_global_unique_per_feature(
+        self,
+        batches: List[List[ModelInput]],
+        batch_idx: int,
+    ) -> Dict[str, torch.Tensor]:
+        """Collect unique indices per feature across all ranks for a given batch."""
+        per_feature: Dict[str, List[torch.Tensor]] = {}
+        for r in range(len(batches[batch_idx])):
+            kjt = batches[batch_idx][r].idlist_features
+            assert kjt is not None
+            keys = kjt.keys()
+            lengths = kjt.lengths()
+            values = kjt.values()
+            num_features = len(keys)
+            stride = lengths.numel() // num_features
+            lengths_2d = lengths.view(num_features, stride)
+            offset = 0
+            for f_idx, key in enumerate(keys):
+                n = int(lengths_2d[f_idx].sum().item())
+                if key not in per_feature:
+                    per_feature[key] = []
+                per_feature[key].append(values[offset : offset + n])
+                offset += n
+        return {k: torch.cat(v).unique() for k, v in per_feature.items()}
+
+    def test_structure(self) -> None:
+        """Output should have correct shape and types."""
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=3,
+            overlap_ratio=0.5,
+            pooling_avg=self.pooling_avg,
+        )
+
+        self.assertEqual(len(batches), 3)
+        for batch in batches:
+            self.assertEqual(len(batch), self.world_size)
+            for mi in batch:
+                self.assertIsInstance(mi, ModelInput)
+                self.assertEqual(mi.float_features.shape[0], self.batch_size)
+                self.assertEqual(mi.label.shape[0], self.batch_size)
+                kjt = mi.idlist_features
+                self.assertIsNotNone(kjt)
+                assert kjt is not None
+                self.assertEqual(kjt.keys(), ["feature_0", "feature_1"])
+
+    def test_kjt_validity(self) -> None:
+        """KJT lengths sum should match values length, indices in valid range."""
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=2,
+            overlap_ratio=0.5,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for batch in batches:
+            for mi in batch:
+                kjt = mi.idlist_features
+                assert kjt is not None
+                self.assertEqual(int(kjt.lengths().sum().item()), kjt.values().numel())
+                self.assertTrue(torch.all(kjt.values() >= 0))
+                num_features = len(kjt.keys())
+                stride = kjt.lengths().numel() // num_features
+                lengths_2d = kjt.lengths().view(num_features, stride)
+                offset = 0
+                for f_idx, table in enumerate(self.tables):
+                    n = int(lengths_2d[f_idx].sum().item())
+                    f_values = kjt.values()[offset : offset + n]
+                    self.assertTrue(
+                        torch.all(f_values < table.num_embeddings),
+                        f"feature {f_idx} has values >= {table.num_embeddings}",
+                    )
+                    offset += n
+
+    def test_global_overlap_accuracy(self) -> None:
+        """Global overlap ratio should approximate the target."""
+        target = 0.7
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=5,
+            overlap_ratio=target,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for b in range(1, len(batches)):
+            prev_unique = self._get_global_unique_per_feature(batches, b - 1)
+            curr_unique = self._get_global_unique_per_feature(batches, b)
+
+            for key in prev_unique:
+                prev_set = set(prev_unique[key].tolist())
+                curr_set = set(curr_unique[key].tolist())
+                if len(prev_set) == 0:
+                    continue
+                overlap = len(prev_set & curr_set) / len(prev_set)
+                self.assertAlmostEqual(
+                    overlap,
+                    target,
+                    delta=0.1,
+                    msg=f"batch {b}, feature {key}: overlap={overlap:.3f}",
+                )
+
+    def test_per_rank_overlap(self) -> None:
+        """Per-rank post-A2A overlap should approximate the global target."""
+        target = 0.7
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=3,
+            overlap_ratio=target,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for table in self.tables:
+            block_size = math.ceil(table.num_embeddings / self.world_size)
+            feature_name = table.feature_names[0]
+
+            for rank in range(self.world_size):
+                post_a2a_unique_per_batch: List[set] = []
+                for b in range(len(batches)):
+                    global_unique = self._get_global_unique_per_feature(batches, b)
+                    indices = global_unique[feature_name]
+                    rank_mask = (indices // block_size) == rank
+                    post_a2a_unique_per_batch.append(set(indices[rank_mask].tolist()))
+
+                for b in range(1, len(batches)):
+                    prev_set = post_a2a_unique_per_batch[b - 1]
+                    curr_set = post_a2a_unique_per_batch[b]
+                    if len(prev_set) == 0:
+                        continue
+                    overlap = len(prev_set & curr_set) / len(prev_set)
+                    self.assertAlmostEqual(
+                        overlap,
+                        target,
+                        delta=0.15,
+                        msg=(
+                            f"rank {rank}, batch {b}, feature {feature_name}: "
+                            f"overlap={overlap:.3f}"
+                        ),
+                    )
+
+    def test_overlap_zero(self) -> None:
+        """With overlap_ratio=0.0, consecutive batches should have minimal overlap."""
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=3,
+            overlap_ratio=0.0,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for b in range(1, len(batches)):
+            prev_unique = self._get_global_unique_per_feature(batches, b - 1)
+            curr_unique = self._get_global_unique_per_feature(batches, b)
+
+            for key in prev_unique:
+                prev_set = set(prev_unique[key].tolist())
+                curr_set = set(curr_unique[key].tolist())
+                if len(prev_set) == 0:
+                    continue
+                overlap = len(prev_set & curr_set) / len(prev_set)
+                self.assertLess(overlap, 0.15)
+
+    def test_overlap_one(self) -> None:
+        """With overlap_ratio=1.0, all previous indices should reappear."""
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=3,
+            overlap_ratio=1.0,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for b in range(1, len(batches)):
+            prev_unique = self._get_global_unique_per_feature(batches, b - 1)
+            curr_unique = self._get_global_unique_per_feature(batches, b)
+
+            for key in prev_unique:
+                prev_set = set(prev_unique[key].tolist())
+                curr_set = set(curr_unique[key].tolist())
+                if len(prev_set) == 0:
+                    continue
+                overlap = len(prev_set & curr_set) / len(prev_set)
+                self.assertGreater(overlap, 0.85)
+
+    def test_with_weighted_tables(self) -> None:
+        """Weighted tables should produce valid idscore KJTs with weights."""
+        weighted_tables = [
+            EmbeddingBagConfig(
+                name="weighted_table_0",
+                feature_names=["weighted_feature_0"],
+                embedding_dim=64,
+                num_embeddings=5000,
+            ),
+        ]
+
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=2,
+            overlap_ratio=0.5,
+            weighted_tables=weighted_tables,
+            pooling_avg=self.pooling_avg,
+        )
+
+        for batch in batches:
+            for mi in batch:
+                self.assertIsNotNone(mi.idscore_features)
+                idscore = mi.idscore_features
+                assert idscore is not None
+                self.assertIsNotNone(idscore.weights_or_none())
+                self.assertEqual(idscore.weights().numel(), idscore.values().numel())
+
+    def test_overlap_tables_filter(self) -> None:
+        """Only tables in overlap_tables should get controlled overlap."""
+        target = 0.9
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            num_batches=4,
+            overlap_ratio=target,
+            pooling_avg=self.pooling_avg,
+            overlap_tables=["table_0"],
+        )
+
+        overlapped = []
+        plain = []
+        for b in range(1, len(batches)):
+            prev_unique = self._get_global_unique_per_feature(batches, b - 1)
+            curr_unique = self._get_global_unique_per_feature(batches, b)
+            for key, samples in (("feature_0", overlapped), ("feature_1", plain)):
+                prev_set = set(prev_unique[key].tolist())
+                curr_set = set(curr_unique[key].tolist())
+                if len(prev_set) == 0:
+                    continue
+                samples.append(len(prev_set & curr_set) / len(prev_set))
+
+        # table_0 (overlapped) tracks the target; table_1 (plain random) is well
+        # below it -- only accidental overlap, which is sizeable for a small
+        # index range but far under the controlled 0.9 target.
+        self.assertAlmostEqual(sum(overlapped) / len(overlapped), target, delta=0.1)
+        self.assertLess(sum(plain) / len(plain), 0.5)
+
+    def test_single_rank(self) -> None:
+        """Should work with world_size=1."""
+        batches = generate_overlapping_batches(
+            tables=self.tables,
+            batch_size=self.batch_size,
+            world_size=1,
+            num_batches=2,
+            overlap_ratio=0.5,
+            pooling_avg=self.pooling_avg,
+        )
+
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 1)
+            kjt = batch[0].idlist_features
+            assert kjt is not None
+            self.assertEqual(int(kjt.lengths().sum().item()), kjt.values().numel())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
## Context

The PEC benefit scales with batch-to-batch index overlap, but the benchmark input config could not produce overlapped batches, so PEC pipelines could not be benchmarked at a chosen overlap.

## Approach

- `ModelInputConfig` gains `overlap_ratio` and `overlap_tables`. When `overlap_ratio` is set, `generate_batches` seeds the RNG deterministically (saving/restoring global RNG state so weight init etc. are unaffected), calls `generate_overlapping_batches` to build the same global batches on every rank, and returns this rank slice. `overlap_tables` restricts overlap to specific tables (e.g. the EC/PEC tables) while others stay plain random.
- `generate_batches` takes `world_size` / `rank`; `benchmark_train_pipeline` passes them from the runner.
- Add `yaml/sparse_data_dist_seq_overlap.yml`: a mixed EBC + EC config (EC tables row_wise) with `overlap_ratio=0.3` applied only to the EC tables.

Reviewed By: TroyGarden

Differential Revision: D110148603


