### PR TITLE
INT4 publish: log merge NaN check, zero-copy quint4x2 reinterpret (#4577)

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -75,6 +75,15 @@ from torchrec.sparse.jagged_tensor import (
 from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
 from torchrec.types import ModuleNoCopyMixin
 
+try:
+    # Zero-copy quint4x2 -> uint8 reinterpret (torch.ops.gr.quantized_to_uint8_view)
+    # on the Meta-internal TGIF inference path. Falls back to the portable
+    # int_repr()-based copy above in OSS builds. Same fx op name either way, which
+    # downstream graph passes detect.
+    from torchrec.fb.modules.utils import _maybe_quint4x2_to_int8  # noqa: F811
+except ImportError:
+    pass
+
 torch.fx.wrap("_get_batching_hinted_output")
 torch.fx.wrap("len")
 torch.fx.wrap("_maybe_quint4x2_to_int8")


### PR DESCRIPTION
Summary:

## Context
Stacked on the diff that sets `sparse_output_dtype="int4"` / `skip_tgif_quantization=False` for `IFR_ESR_PROD_BASE`. Turning `skip_tgif_quantization` off makes TGIF's `DenseQuantizationPass` run against this model for the first time, which exposed two problems in the INT4 publish path. This diff addresses both.

## Change 1: merge-net NaN check raises on a false positive
`publish_prospector_model_gpu.py` — `DEFAULT_VARIFICATION_CONFIG.validate_no_nan_in_merge`: `EXECUTE_RAISE` -> `EXECUTE`.

`_check_merge_net_nan_or_inf` lives inside `DenseQuantizationPass`, so it had never run for this model before. It now raises `TGIFAssertError("Found NaN/Infs in merge")`, ~1 hour into the publish.

The NaN is not real. 15 nodes are flagged, all from two op families — `_triton_cc_group_layer_norm_empty_version*` (12) and `_triton_cc_gln_mul_dropout_empty_version*` (3). Each returns a 3-tuple `(y, scale, y_quantized)`. Output 0 (`y`) holds finite values; outputs 1 and 2 are 100% NaN, and there are zero Inf values anywhere in the report — not the signature of the FP16 weight explosion the check's error message assumes.

Cause: these kernels allocate `scale` and `y_quantized` with `torch.empty(...)` and pass `QUANTIZE_OUTPUT=quantize_output` as a Triton `constexpr`. With `quantize_output=False` (which is what the traced graph bakes in — the literal `False` is the 6th positional arg on every call site), the kernel's stores to `Scale` and `Y_QUANTIZED` are compiled out (`hammer/v2/ops/triton/triton_group_layer_norm.py:306`, guarded by `if QUANTIZE_OUTPUT:`), while the store to `Y` still happens (line 295, `if TRAINING or (not QUANTIZE_OUTPUT):`). So those two buffers are returned as never-written memory. The public wrapper then discards them: `triton_cc_group_layer_norm.py:402-405` returns `result[0]` when `quantize_output` is false.

They are provably dead in the merge graph: all 15 nodes are `[num_users=1]`, the single consumer of each is a `getitem` at index `0`, and index `0` is the only index taken from these nodes anywhere in the graph. The checker still flags them because `model_nan_or_inf_check_and_log_paste` (`tgif/lib/utils.py:211-265`) records every node's full result via `RecordInterpreter.run_node` and flattens it with `torch.fx.node.map_aggregate`, with no filter for consumer count.

Control: `_triton_cc_swish_layer_norm_empty_version` is called 12 times in the same merge graph on the same TritonCC `""`-version path, and was not flagged — it returns only `y` (`hammer/ops/triton/cc/swish_layer_norm/triton_cc_swish_layer_norm.py:94-138`), so it has no dead buffers in its return value. The discriminator is exactly "does the node's return value carry unwritten buffers", not "is there NaN in the computation".

`EXECUTE` keeps the check running and downgrades it to `logger.warning` (`dense_quantization_pass.py:861-870` raises only on `EXECUTE_RAISE`). Note `TGIFExecutionType` has only `SKIP` / `EXECUTE` / `EXECUTE_RAISE` — there is no `EXECUTE_LOG` despite the docstring naming one.

## Change 2: INT4 reinterpret uses the copying OSS variant
`torchrec/quant/embedding_modules.py` — add a guarded import of the Meta-internal zero-copy `_maybe_quint4x2_to_int8`.

The published graph for the resulting model had `target=torchrec.modules.utils._maybe_quint4x2_to_int8` on the TBE output of `_ranking_model.mot._sparse_arch._embedding_collection.tbes.0`. That is the OSS variant, which calls `embedding.int_repr()` and copies the packed 4-bit payload on every forward. The Meta-internal counterpart `torchrec.fb.modules.utils._maybe_quint4x2_to_int8` does the same reinterpret with `torch.ops.gr.quantized_to_uint8_view` and no copy. Both deliberately share the function name because downstream fx passes detect the op by name.

## Known constraints
- Change 2 makes OSS `torchrec/quant/` import from `torchrec/fb/`, which violates the torchrec public/internal boundary. The import is `try/except ImportError` guarded so OSS builds fall back to `int_repr()`, but this is not the intended mechanism.
- The intended mechanism is the "overridable seam" at `torchrec/quant/embedding_modules.py:917-921`, taken by `QuantNoShardEmbeddingCollection` (`torchrec/fb/inference/noshard_ebc.py:87`). This model gets the base `QuantEmbeddingCollection` because it declares a plain `EmbeddingCollection`, which `EmbeddingQuantizationPass`'s swap map sends to the base class (`tgif/lib/embedding_quantization_pass.py:107-109`). `EmbeddingQuantizationPass` also has a gated `_replace_with_noshard_emb` path (line 271-275) whose two call sites only handle embedding *bag* collections — extending it to `EmbeddingCollection` is likely the correct long-term fix.
- Change 1 is also global: it downgrades the NaN check for every prospector publish, not just ESR. The narrower fix is to make the checker skip node outputs with no users.

Both changes are for debugging and perf measurement of the INT4 path and should not land in this form.

Differential Revision: D115237216


