### PR TITLE
Register PECEmbeddingCollectionSharder in default sharders

### DIFF
--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -28,6 +28,7 @@ from torchrec.distributed.mc_embeddingbag import (
     ManagedCollisionEmbeddingBagCollectionSharder,
 )
 from torchrec.distributed.mc_modules import InferManagedCollisionCollectionSharder
+from torchrec.distributed.pec_embedding import PECEmbeddingCollectionSharder
 from torchrec.distributed.planner.constants import MIN_CW_DIM
 from torchrec.distributed.quant_embedding import (
     QuantEmbeddingCollectionSharder,
@@ -50,6 +51,7 @@ def get_default_sharders() -> List[ModuleSharder[nn.Module]]:
         cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], FeatureProcessedEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], EmbeddingCollectionSharder()),
+        cast(ModuleSharder[nn.Module], PECEmbeddingCollectionSharder()),
         cast(ModuleSharder[nn.Module], FusedEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingBagCollectionSharder()),
         cast(ModuleSharder[nn.Module], QuantEmbeddingCollectionSharder()),

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -15,6 +15,7 @@ import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings, Verbosity
 from torchrec import distributed as trec_dist
+from torchrec.distributed.pec_embedding import PECEmbeddingCollectionSharder
 from torchrec.distributed.quant_embedding import (
     QuantManagedCollisionEmbeddingCollectionSharder,
 )
@@ -65,6 +66,7 @@ from torchrec.modules.mc_embedding_modules import (
     ManagedCollisionEmbeddingBagCollection,
     ManagedCollisionEmbeddingCollection,
 )
+from torchrec.modules.pec_embedding_modules import PECEmbeddingCollection
 from torchrec.quant.embedding_modules import (
     EmbeddingBagCollection as QuantEmbeddingBagCollection,
     EmbeddingCollection as QuantEmbeddingCollection,
@@ -1195,6 +1197,7 @@ movie_id | [2048, 0]     | [2048, 32]  | rank:0/cuda:1
                 EmbeddingBagCollection,
                 FeatureProcessedEmbeddingBagCollection,
                 EmbeddingCollection,
+                PECEmbeddingCollection,
                 FusedEmbeddingBagCollection,
                 QuantEmbeddingBagCollection,
                 QuantEmbeddingCollection,
@@ -1205,6 +1208,9 @@ movie_id | [2048, 0]     | [2048, 32]  | rank:0/cuda:1
         )
         self.assertIsInstance(
             default_sharder_map[EmbeddingBagCollection], EmbeddingBagCollectionSharder
+        )
+        self.assertIsInstance(
+            default_sharder_map[PECEmbeddingCollection], PECEmbeddingCollectionSharder
         )
         self.assertIsInstance(
             default_sharder_map[FeatureProcessedEmbeddingBagCollection],


### PR DESCRIPTION
Summary:
## Context

`PECEmbeddingCollection` could not be sharded by `DistributedModelParallel` / the planner out of the box -- callers had to pass the PEC sharder explicitly.

## Approach

- Add `PECEmbeddingCollectionSharder` to `get_default_sharders`, keyed under `PECEmbeddingCollection` in `get_module_to_default_sharders` (distinct from `EmbeddingCollection`), so it only matches PEC modules and leaves other models unaffected.
- Declare the `pec_embedding` dep on the `sharding_plan` BUCK target (the new import).
- Update `test_module_to_default_sharders` to expect `PECEmbeddingCollection` in the default sharder map and assert its sharder type.

Reviewed By: TroyGarden

Differential Revision: D110148596


