### PR TITLE
Wire TrainPipelinePEC into the train-pipeline benchmark

### DIFF
--- a/torchrec/distributed/benchmark/yaml/pec_overlap.yml
+++ b/torchrec/distributed/benchmark/yaml/pec_overlap.yml
@@ -1,0 +1,61 @@
+# PEC (Pipelined Embedding Collection) benchmark config.
+# Mixed EBC + PEC-EC model run through TrainPipelinePEC with controlled
+# batch-to-batch index overlap on the EC tables (where PEC overlap helps).
+# EC/PEC tables use row_wise sharding (PECEmbeddingCollectionSharder enforces RW).
+RunOptions:
+  world_size: 4
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "pec_overlap"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "pec"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+  overlap_ratio: 0.3
+  overlap_tables: ["ec_table_0", "ec_table_1"]
+ModelSelectionConfig:
+  model_name: "pec_mixed_embedding"
+  model_config:
+    num_float_features: 100
+EmbeddingTablesConfig:
+  num_unweighted_features: 70
+  num_weighted_features: 70
+  embedding_feature_dim: 256
+  additional_tables:
+    # First list: unweighted tables (EBC + PEC-EC mixed)
+    - - name: ebc_table_0
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["ebc_feature_0"]
+      - name: ebc_table_1
+        embedding_dim: 256
+        num_embeddings: 200_000
+        feature_names: ["ebc_feature_1"]
+      # EC tables - use config_class to specify EmbeddingConfig; wrapped in
+      # PECEmbeddingCollection by the pec_mixed_embedding model.
+      - name: ec_table_0
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["ec_feature_0"]
+        config_class: EmbeddingConfig
+      - name: ec_table_1
+        embedding_dim: 1024
+        num_embeddings: 2_000_000
+        feature_names: ["ec_feature_1"]
+        config_class: EmbeddingConfig
+    # Second list: weighted tables (empty for this config)
+    - []
+PlannerConfig:
+  pooling_factors: [30.0]
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB
+  additional_constraints:
+    ec_table_0:
+      sharding_types: [row_wise]
+    ec_table_1:
+      sharding_types: [row_wise]

--- a/torchrec/distributed/test_utils/model_config.py
+++ b/torchrec/distributed/test_utils/model_config.py
@@ -31,6 +31,7 @@ from torchrec.distributed.test_utils.test_model import (
     TestOverArch,
     TestOverArchLarge,
     TestOverArchRegroupModule,
+    TestPECMixedEmbeddingSparseArch,
     TestSparseNN,
     TestTowerCollectionSparseNN,
     TestTowerSparseNN,
@@ -275,6 +276,33 @@ class MixedEmbeddingConfig(BaseModelConfig):
 
 
 @dataclass
+class PECMixedEmbeddingConfig(MixedEmbeddingConfig):
+    """Configuration for mixed EBC + PEC-EC model using TestPECMixedEmbeddingSparseArch.
+
+    Same as MixedEmbeddingConfig but wraps the EmbeddingCollection tables in a
+    PECEmbeddingCollection so the model exercises the PEC train pipeline.
+    """
+
+    def generate_model(
+        self,
+        tables: Union[List[EmbeddingBagConfig], List[EmbeddingConfig]],
+        weighted_tables: Optional[List[EmbeddingBagConfig]] = None,
+        dense_device: Optional[torch.device] = None,
+        **kwargs: Any,
+    ) -> nn.Module:
+        return TestPECMixedEmbeddingSparseArch(
+            tables=tables,
+            num_float_features=self.num_float_features,
+            weighted_tables=weighted_tables,
+            embedding_groups=self.embedding_groups,
+            dense_device=dense_device,
+            sparse_device=torch.device("meta"),
+            over_arch_clazz=self.over_arch_clazz,
+            dense_arch_hidden_sizes=self.dense_arch_hidden_sizes,
+        )
+
+
+@dataclass
 class TestModelWithPreprocConfig(BaseModelConfig):
     """Configuration for TestModelWithPreproc model (model with postproc modules)."""
 
@@ -309,6 +337,7 @@ def create_model_config(model_name: str, **kwargs: Any) -> BaseModelConfig:
         "deepfm": DeepFMConfig,
         "dlrm": DLRMConfig,
         "mixed_embedding": MixedEmbeddingConfig,
+        "pec_mixed_embedding": PECMixedEmbeddingConfig,
         "test_model_with_preproc": TestModelWithPreprocConfig,
     }
 
@@ -344,6 +373,8 @@ class ModelSelectionConfig:
                 return DLRMConfig
             case "mixed_embedding":
                 return MixedEmbeddingConfig
+            case "pec_mixed_embedding":
+                return PECMixedEmbeddingConfig
             case "test_model_with_preproc":
                 return TestModelWithPreprocConfig
             case _:

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -26,6 +26,7 @@ from torchrec.distributed.train_pipeline.experimental_pipelines import (
     TrainPipelineSparseDistOptStash,
     TrainPipelineSparseDistT,
 )
+from torchrec.distributed.train_pipeline.pec_train_pipeline import TrainPipelinePEC
 from torchrec.distributed.train_pipeline.train_pipelines import (
     EvalPipelineFusedSparseDist,
     EvalPipelineSparseDist,
@@ -78,13 +79,13 @@ class PipelineConfig:
             kwargs["pipeline_postproc"] = True
         if "sharding_type" in kwargs:
             kwargs["sharding_type"] = ShardingType(kwargs["sharding_type"])
-        if self.pipeline in ("base", "sparse", "sparse_lite", "prefetch"):
+        if self.pipeline in ("base", "sparse", "sparse_lite", "prefetch", "pec"):
             for key in ("site_fqn", "sharding_type"):
                 if key in kwargs:
                     kwargs.pop(key)
         if self.pipeline in ("sparse-emb-stash", "prefetch-ems"):
             kwargs.pop("sharding_type", None)
-        if self.pipeline in ("base", "eval-sdd"):
+        if self.pipeline in ("base", "eval-sdd", "pec"):
             kwargs.pop("pipeline_postproc", None)
         return kwargs
 
@@ -142,6 +143,7 @@ class PipelineConfig:
             "sparse-emb-stash": TrainPipelineSparseDistEmbStash,
             "prefetch-ems": TrainPipelinePrefetchEMS,
             "eval-cpu-sparse": EvalPipelineCPUSparse,
+            "pec": TrainPipelinePEC,
         }
 
         match self.pipeline:
@@ -183,6 +185,15 @@ class PipelineConfig:
                     clear_data_dist_inputs=self.clear_data_dist_inputs,
                     enable_embedding_lookup_prefetch=self.enable_embedding_lookup_prefetch,
                     **self.get_kwargs(emb_lookup_stream=self.emb_lookup_stream),
+                )
+            case "pec":
+                # TrainPipelinePEC owns its full progress and does not accept the
+                # inplace-copy / free-features / clear-data-dist knobs.
+                return TrainPipelinePEC(
+                    model=model,
+                    optimizer=opt,
+                    device=device,
+                    **self.get_kwargs(),
                 )
             case _:
                 Pipeline = _pipeline_cls[self.pipeline]

--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -35,6 +35,7 @@ from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.model_parallel import HybridEvalDMP
+from torchrec.distributed.pec_embedding import PECEmbeddingCollectionSharder
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.planner.constants import POOLING_FACTOR
 from torchrec.distributed.planner.storage_reservations import (
@@ -321,6 +322,12 @@ def _get_sharders_with_fused_params(
         cast(
             ModuleSharder[nn.Module],
             EmbeddingCollectionSharder(fused_params=fused_params),
+        ),
+        cast(
+            ModuleSharder[nn.Module],
+            PECEmbeddingCollectionSharder(
+                EmbeddingCollectionSharder(fused_params=fused_params)
+            ),
         ),
     ]
 


### PR DESCRIPTION
Summary:
## Context

`TrainPipelinePEC` and the PEC test model existed but were not reachable from the standard train-pipeline benchmark, so PEC could not be benchmarked alongside the other pipelines.

## Approach

- `pipeline_config`: add the `pec` pipeline -> `TrainPipelinePEC`, in a dedicated case (PEC owns its full `progress` and does not take the inplace-copy / free-features / clear-data-dist knobs), with the same `site_fqn` / `sharding_type` / `pipeline_postproc` kwarg filtering as the other plain pipelines.
- `model_config`: add `PECMixedEmbeddingConfig` + model name `pec_mixed_embedding`, which builds `TestPECMixedEmbeddingSparseArch` so the EC tables are wrapped in `PECEmbeddingCollection` (and thus sharded as PEC).
- `sharding_config`: include `PECEmbeddingCollectionSharder` in the fused-params sharder branch (the no-fused branch already uses `get_default_sharders`, which now registers it).
- `yaml/pec_overlap.yml`: mixed EBC + PEC-EC config running through the `pec` pipeline with `overlap_ratio=0.3` on the row_wise EC tables.

Differential Revision: D110148593


