### PR TITLE
Preserve metric construction in offloaded clones (#4582)

### DIFF
--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -127,26 +127,7 @@ class CPUCommsRecMetricModule(RecMetricModule):
         cloned_metrics = []
         for metric in self.rec_metrics.rec_metrics:
             metric = cast(RecMetric, metric)
-            # pyrefly: ignore [bad-instantiation]
-            cloned_metric = type(metric)(
-                world_size=metric._world_size,
-                my_rank=metric._my_rank,
-                batch_size=metric._batch_size,
-                tasks=metric._tasks,
-                compute_mode=metric._compute_mode,
-                # Standard initialization passes in the global window size. A RecMetric's
-                # window size is set as the local window size.
-                window_size=metric._window_size * metric._world_size,
-                fused_update_limit=metric._fused_update_limit,
-                # pyrefly: ignore[bad-argument-type]
-                compute_on_all_ranks=metric._metrics_computations[
-                    0
-                ]._compute_on_all_ranks,
-                should_validate_update=metric._should_validate_update,
-                # Process group should be none to prevent unwanted distributed syncs.
-                # This is handled manually via RecMetricModule.get_pre_compute_states()
-                process_group=None,
-            )
+            cloned_metric = metric._new_like(process_group=None)
             cloned_metrics.append(cloned_metric)
 
         return RecMetricList(cloned_metrics)

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import abc
+import copy
 import inspect
 import itertools
 import math
@@ -85,6 +86,48 @@ DefaultValueT = TypeVar("DefaultValueT")
 ComputeIterType = Iterator[
     Tuple[RecTaskInfo, MetricNameBase, torch.Tensor, MetricPrefix, str]
 ]
+
+
+def _snapshot_init_value(value: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
+    if memo is None:
+        memo = {}
+    value_id = id(value)
+    if value_id in memo:
+        return memo[value_id]
+    if isinstance(value, torch.Tensor):
+        snapshot = value.detach().clone()
+        memo[value_id] = snapshot
+        return snapshot
+    if type(value) is dict:
+        snapshot_dict: Dict[Any, Any] = {}
+        memo[value_id] = snapshot_dict
+        snapshot_dict.update(
+            {
+                _snapshot_init_value(key, memo): _snapshot_init_value(item, memo)
+                for key, item in value.items()
+            }
+        )
+        return snapshot_dict
+    if type(value) is list:
+        snapshot_list: List[Any] = []
+        memo[value_id] = snapshot_list
+        snapshot_list.extend(_snapshot_init_value(item, memo) for item in value)
+        return snapshot_list
+    if type(value) is tuple:
+        snapshot_tuple = tuple(_snapshot_init_value(item, memo) for item in value)
+        memo[value_id] = snapshot_tuple
+        return snapshot_tuple
+    if type(value) is set:
+        snapshot_set = {_snapshot_init_value(item, memo) for item in value}
+        memo[value_id] = snapshot_set
+        return snapshot_set
+    return copy.deepcopy(value, memo)
+
+
+def _snapshot_init_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
+    memo: Dict[int, Any] = {}
+    return {key: _snapshot_init_value(value, memo) for key, value in kwargs.items()}
+
 
 MAX_BUFFER_COUNT = 1000
 _WINDOW_BUFFER_REGISTRY: weakref.WeakValueDictionary[int, Any] = (
@@ -413,7 +456,7 @@ class RecMetric(nn.Module, abc.ABC):
         compute_on_all_ranks: bool = False,
         should_validate_update: bool = False,
         process_group: Optional[dist.ProcessGroup] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         torch._C._log_api_usage_once(
             f"torchrec.metrics.rec_metric.{self.__class__.__name__}"
@@ -441,6 +484,8 @@ class RecMetric(nn.Module, abc.ABC):
         self._compute_mode = compute_mode
         self._fused_update_limit = fused_update_limit
         self._should_validate_update = should_validate_update
+        self._global_window_size = window_size
+        self._compute_on_all_ranks = compute_on_all_ranks
         self._default_weights = {}
         self._required_inputs = set()
         self._update_buffers = {
@@ -449,25 +494,17 @@ class RecMetric(nn.Module, abc.ABC):
             self.WEIGHTS: [],
         }
         self._fused_update_log_tensors: List[bool] = []
-        #  Dict[str, Any]]`.
-        # pyrefly: ignore[bad-assignment]
-        self.enable_pt2_compile: bool = kwargs.get("enable_pt2_compile", False)
-        # we need to remove the enable_pt2_compile from kwargs to avoid Metric object being initialized with it
-        if "enable_pt2_compile" in kwargs:
-            del kwargs["enable_pt2_compile"]
-
-        #  Dict[str, Any]]`.
-        # pyrefly: ignore[bad-assignment]
-        self._should_clone_update_inputs: bool = kwargs.get(
+        self.enable_pt2_compile: bool = kwargs.pop("enable_pt2_compile", False)
+        self._should_clone_update_inputs: bool = kwargs.pop(
             "should_clone_update_inputs", False
         )
-        if "should_clone_update_inputs" in kwargs:
-            del kwargs["should_clone_update_inputs"]
-
-        # Pop batch_size_stages from kwargs so it doesn't cause type conflicts
-        # when subclasses pass **kwargs: Dict[str, Any] to super().__init__().
-        # TowerQPSMetric declares its own explicit batch_size_stages parameter.
         kwargs.pop("batch_size_stages", None)
+        metric_init_kwargs = _snapshot_init_kwargs(kwargs)
+        self._init_kwargs: Dict[str, Any] = {
+            **metric_init_kwargs,
+            "enable_pt2_compile": self.enable_pt2_compile,
+            "should_clone_update_inputs": self._should_clone_update_inputs,
+        }
 
         if self._window_size < self._batch_size:
             raise ValueError(
@@ -493,8 +530,6 @@ class RecMetric(nn.Module, abc.ABC):
             ]
             else self._tasks
         ):
-            # pyrefly: ignore[unsupported-operation]
-            kwargs["fused_update_limit"] = fused_update_limit
             # This Pyre error seems to be Pyre's bug as it can be inferred by mypy
             # according to https://github.com/python/mypy/issues/3048.
             metric_computation = self._computation_class(
@@ -506,9 +541,10 @@ class RecMetric(nn.Module, abc.ABC):
                 should_validate_update=self._should_validate_update,
                 compute_mode=compute_mode,
                 process_group=process_group,
+                fused_update_limit=fused_update_limit,
                 # pyrefly: ignore[bad-argument-type]
                 **{
-                    **kwargs,
+                    **metric_init_kwargs,
                     **self._get_task_kwargs(task_config),
                     "enable_pt2_compile": self.enable_pt2_compile,
                 },
@@ -517,6 +553,25 @@ class RecMetric(nn.Module, abc.ABC):
 
             self._metrics_computations.append(metric_computation)
             self._required_inputs.update(required_inputs)
+
+    def _get_new_like_kwargs(self) -> Dict[str, Any]:
+        """Return constructor kwargs for a new metric instance."""
+        return dict(self._init_kwargs)
+
+    def _new_like(self, process_group: Optional[dist.ProcessGroup]) -> "RecMetric":
+        return type(self)(
+            world_size=self._world_size,
+            my_rank=self._my_rank,
+            batch_size=self._batch_size,
+            tasks=self._tasks,
+            compute_mode=self._compute_mode,
+            window_size=self._global_window_size,
+            fused_update_limit=self._fused_update_limit,
+            compute_on_all_ranks=self._compute_on_all_ranks,
+            should_validate_update=self._should_validate_update,
+            process_group=process_group,
+            **self._get_new_like_kwargs(),
+        )
 
     def _get_task_kwargs(
         self, task_config: Union[RecTaskInfo, List[RecTaskInfo]]

--- a/torchrec/metrics/tests/test_cpu_comms_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_comms_metric_module.py
@@ -8,12 +8,15 @@
 # pyre-strict
 
 import unittest
-from typing import cast, List
+from collections import defaultdict
+from typing import cast, DefaultDict, List
 
 import torch
 from torchrec.metrics.auc import _state_reduction
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+from torchrec.metrics.metrics_config import BatchSizeStage
+from torchrec.metrics.ne import NEMetric, NEMetricComputation
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
 from torchrec.metrics.test_utils import gen_test_tasks
 from torchrec.metrics.test_utils.mock_metrics import (
@@ -22,6 +25,7 @@ from torchrec.metrics.test_utils.mock_metrics import (
     create_tensor_states,
     MockRecMetric,
 )
+from torchrec.metrics.tower_qps import TowerQPSMetric
 
 
 class CPUCommsRecMetricModuleTest(unittest.TestCase):
@@ -86,6 +90,111 @@ class CPUCommsRecMetricModuleTest(unittest.TestCase):
             # Cloned metric should have torchmetric.Metric's sync() disabled to prevent
             # unwanted distributed syncs. All syncs will be called via cpu_comms_module.
             self.assertTrue(cloned_metric.verify_sync_disabled())
+
+    def test_clone_rec_metrics_preserves_metric_specific_kwargs(self) -> None:
+        ne_metric = NEMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            allow_missing_label_with_zero_weight=True,
+            enable_pt2_compile=False,
+            should_clone_update_inputs=True,
+        )
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([ne_metric]),
+        )
+
+        original_computation = cast(
+            NEMetricComputation, ne_metric._metrics_computations[0]
+        )
+        cloned_metric = cast(NEMetric, cpu_comms_module.rec_metrics.rec_metrics[0])
+        cloned_computation = cast(
+            NEMetricComputation, cloned_metric._metrics_computations[0]
+        )
+
+        self.assertTrue(original_computation._allow_missing_label_with_zero_weight)
+        self.assertTrue(cloned_computation._allow_missing_label_with_zero_weight)
+        self.assertTrue(cloned_metric._should_clone_update_inputs)
+        self.assertFalse(cloned_metric.enable_pt2_compile)
+        cloned_value = cloned_computation._compute()[0].value
+        self.assertTrue(torch.isfinite(cloned_value).all())
+        torch.testing.assert_close(
+            cloned_value,
+            original_computation._compute()[0].value,
+        )
+
+    def test_clone_rec_metrics_snapshots_subclass_init_kwargs(self) -> None:
+        batch_size_stages = [
+            BatchSizeStage(batch_size=4, max_iters=1),
+            BatchSizeStage(batch_size=8, max_iters=None),
+        ]
+        tower_qps_metric = TowerQPSMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            batch_size_stages=batch_size_stages,
+        )
+        batch_size_stages.append(BatchSizeStage(batch_size=16, max_iters=None))
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([tower_qps_metric]),
+        )
+
+        cloned_metric = cast(
+            TowerQPSMetric, cpu_comms_module.rec_metrics.rec_metrics[0]
+        )
+        cloned_metric.update(
+            predictions=None,
+            labels={"test_task": torch.ones(4)},
+            weights=None,
+        )
+        cloned_metric.update(
+            predictions=None,
+            labels={"test_task": torch.ones(8)},
+            weights=None,
+        )
+
+        self.assertEqual(
+            cloned_metric.compute()["qps-test_task|total_examples"],
+            12,
+        )
+
+    def test_clone_rec_metrics_snapshots_container_kwargs(self) -> None:
+        initial_states: DefaultDict[str, torch.Tensor] = defaultdict(
+            lambda: torch.tensor(0.0),
+            {"state": torch.tensor(1.0)},
+        )
+        metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+        )
+        initial_states["late_state"] = torch.tensor(2.0)
+        initial_states["state"].add_(1.0)
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([metric]),
+        )
+
+        cloned_metric = cpu_comms_module.rec_metrics.rec_metrics[0]
+        # pyrefly: ignore[not-callable]
+        cloned_states = cloned_metric.get_computation_states()
+        self.assertNotIn("late_state", cloned_states)
+        torch.testing.assert_close(cloned_states["state"], torch.tensor(1.0))
 
     def test_load_metric_states(self) -> None:
         """
@@ -209,6 +318,11 @@ class CPUCommsRecMetricModuleTest(unittest.TestCase):
         cloned_metric = cpu_comms_module.rec_metrics.rec_metrics[0]
         # pyrefly: ignore[bad-index]
         cloned_computation = cloned_metric._metrics_computations[0]
+        cloned_states_before_load = {
+            name: value.clone()
+            # pyrefly: ignore[not-callable]
+            for name, value in cloned_metric.get_computation_states().items()
+        }
 
         cpu_comms_module._load_metric_states(
             "test_prefix",
@@ -222,19 +336,15 @@ class CPUCommsRecMetricModuleTest(unittest.TestCase):
             cloned_metric.get_computation_states()["state_1"],
             torch.tensor(5.0),
         )
-        self.assertFalse(
-            torch.allclose(
-                # pyrefly: ignore[not-callable]
-                cloned_metric.get_computation_states()["state_2"],
-                torch.tensor(2.0),
-            )
+        torch.testing.assert_close(
+            # pyrefly: ignore[not-callable]
+            cloned_metric.get_computation_states()["state_2"],
+            cloned_states_before_load["state_2"],
         )
-        self.assertFalse(
-            torch.allclose(
-                # pyrefly: ignore[not-callable]
-                cloned_metric.get_computation_states()["state_2"],
-                torch.tensor(3.0),
-            )
+        torch.testing.assert_close(
+            # pyrefly: ignore[not-callable]
+            cloned_metric.get_computation_states()["state_3"],
+            cloned_states_before_load["state_3"],
         )
 
     def test_load_multiple_metrics_unfused(self) -> None:

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -8,7 +8,8 @@
 # pyre-strict
 
 import unittest
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, cast, Dict
 from unittest.mock import patch
 
 import torch
@@ -16,11 +17,21 @@ from torchrec.metrics.metrics_config import BatchSizeStage, DefaultTaskInfo, Rec
 from torchrec.metrics.model_utils import parse_task_model_outputs
 from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.ne import NEMetric
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
+from torchrec.metrics.rec_metric import (
+    _snapshot_init_kwargs,
+    RecComputeMode,
+    RecMetric,
+    RecMetricList,
+)
 from torchrec.metrics.test_utils import gen_test_batch, gen_test_tasks
 
 
 _CUDA_UNAVAILABLE: bool = not torch.cuda.is_available()
+
+
+@dataclass
+class _MutableInitConfig:
+    values: list[int]
 
 
 class RecMetricTest(unittest.TestCase):
@@ -30,6 +41,29 @@ class RecMetricTest(unittest.TestCase):
         self.labels, self.predictions, self.weights, _ = parse_task_model_outputs(
             [DefaultTaskInfo], model_output
         )
+
+    def test_init_kwargs_snapshot_isolates_nested_mutable_values(self) -> None:
+        tensor = torch.tensor([1.0], requires_grad=True)
+        custom = _MutableInitConfig(values=[1])
+
+        snapshot = _snapshot_init_kwargs(
+            {
+                "nested": [{"tensor": tensor}],
+                "custom": custom,
+            }
+        )
+        nested = cast(list[dict[str, Any]], snapshot["nested"])
+        snapshot_tensor = cast(torch.Tensor, nested[0]["tensor"])
+        snapshot_custom = cast(_MutableInitConfig, snapshot["custom"])
+
+        self.assertIsNot(snapshot_tensor, tensor)
+        self.assertFalse(snapshot_tensor.requires_grad)
+        self.assertIsNot(snapshot_custom, custom)
+        with torch.no_grad():
+            tensor.fill_(2.0)
+        custom.values.append(2)
+        torch.testing.assert_close(snapshot_tensor, torch.tensor([1.0]))
+        self.assertEqual(snapshot_custom.values, [1])
 
     def test_optional_weights(self) -> None:
         ne1 = NEMetric(
@@ -301,34 +335,25 @@ class RecMetricTest(unittest.TestCase):
         )
         self.assertEqual(required_inputs["session_id"].device, torch.device("cuda:0"))
 
-    def test_batch_size_stages_kwargs_stripped(self) -> None:
-        """Verify RecMetric.__init__ strips batch_size_stages from kwargs
-        so non-TowerQPS metrics can be constructed with it in kwargs."""
-        batch_size_stages = [
-            BatchSizeStage(256, 100),
-            BatchSizeStage(512, None),
-        ]
-        # NEMetric does NOT declare batch_size_stages as an explicit param.
-        # This should succeed because RecMetric.__init__ strips it from kwargs.
-        extra_kwargs: dict[str, Any] = {"batch_size_stages": batch_size_stages}
+    def test_batch_size_stages_kwargs_are_ignored(self) -> None:
         ne = NEMetric(
             world_size=1,
             my_rank=0,
             batch_size=64,
             tasks=[DefaultTaskInfo],
-            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
-            window_size=100,
-            fused_update_limit=0,
-            **extra_kwargs,
+            window_size=128,
+            batch_size_stages=[
+                BatchSizeStage(batch_size=64, max_iters=None),
+            ],
         )
-        # Verify the metric initialized and can compute
+
         ne.update(
             predictions=self.predictions,
             labels=self.labels,
             weights=self.weights,
         )
-        res = ne.compute()
-        self.assertIn("ne-DefaultTask|lifetime_ne", res)
+
+        self.assertIn("ne-DefaultTask|lifetime_ne", ne.compute())
 
 
 class RecMetricTensorSizeLoggingTest(unittest.TestCase):

--- a/torchrec/metrics/tests/test_tower_qps.py
+++ b/torchrec/metrics/tests/test_tower_qps.py
@@ -11,7 +11,7 @@
 import unittest
 from collections import OrderedDict
 from functools import partial, update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type, Union
 from unittest.mock import Mock, patch
 
 import torch
@@ -32,7 +32,7 @@ from torchrec.metrics.test_utils import (
     rec_metric_value_test_launcher,
     TestMetric,
 )
-from torchrec.metrics.tower_qps import TowerQPSMetric
+from torchrec.metrics.tower_qps import TowerQPSMetric, TowerQPSMetricComputation
 
 WORLD_SIZE = 4
 WARMUP_STEPS = 100
@@ -176,6 +176,35 @@ class TowerQPSMetricTest(unittest.TestCase):
 
     target_clazz: Type[RecMetric] = TowerQPSMetric
     task_names: str = "qps"
+
+    def test_new_like_preserves_tower_qps_kwargs(self) -> None:
+        warmup_steps = 7
+        batch_size_stages = [
+            BatchSizeStage(256, 1),
+            BatchSizeStage(512, None),
+        ]
+        metric = TowerQPSMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=256,
+            tasks=[DefaultTaskInfo],
+            window_size=1000,
+            warmup_steps=warmup_steps,
+            batch_size_stages=batch_size_stages,
+        )
+
+        cloned = cast(TowerQPSMetric, metric._new_like(process_group=None))
+        cloned_computation = cast(
+            TowerQPSMetricComputation, cloned._metrics_computations[0]
+        )
+
+        self.assertEqual(cloned_computation._warmup_steps, warmup_steps)
+        self.assertEqual(cloned._batch_size_stages_config, batch_size_stages)
+        self.assertIsNot(
+            cloned._batch_size_stages_config, metric._batch_size_stages_config
+        )
+        metric._batch_size_stages_config = [BatchSizeStage(1024, None)]
+        self.assertEqual(cloned._batch_size_stages_config, batch_size_stages)
 
     def test_tower_qps_during_warmup_unfused(self) -> None:
         rec_metric_value_test_launcher(

--- a/torchrec/metrics/tower_qps.py
+++ b/torchrec/metrics/tower_qps.py
@@ -219,8 +219,11 @@ class TowerQPSMetric(RecMetric):
 
         self._batch_size = batch_size
         self._world_size = world_size
-        self._batch_size_stages: Optional[List[BatchSizeStage]] = copy.deepcopy(
+        self._batch_size_stages_config: Optional[List[BatchSizeStage]] = copy.deepcopy(
             batch_size_stages
+        )
+        self._batch_size_stages: Optional[List[BatchSizeStage]] = copy.deepcopy(
+            self._batch_size_stages_config
         )
 
         if self._batch_size_stages is not None:
@@ -228,6 +231,12 @@ class TowerQPSMetric(RecMetric):
 
         self._register_load_state_dict_pre_hook(self.load_state_dict_hook)
         self.register_state_dict_post_hook(self.state_dict_hook)
+
+    def _get_new_like_kwargs(self) -> Dict[str, Any]:
+        return {
+            **super()._get_new_like_kwargs(),
+            "batch_size_stages": self._batch_size_stages_config,
+        }
 
     def update(
         self,


### PR DESCRIPTION
Summary:

Preserve metric-specific construction semantics when creating an offloaded reporting copy. This prevents valid metric options from silently reverting to defaults.

Reviewed By: TroyGarden

Differential Revision: D115919787


