### PR TITLE
Add CodeQL workflow scoped to main for torchrec (#4583)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+# Scoped to the main branch so CodeQL never runs on the generated gh-pages
+# branch, which contains only built HTML and no Python source.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Summary:

The "Analyze (python)" CodeQL check on `meta-pytorch/torchrec` fails on every docs deploy. GitHub's CodeQL default setup runs on all branches, including the `gh-pages` branch that `docs.yml` publishes built Sphinx HTML to. That branch has no Python source, so CodeQL analysis fails and generates recurring CI-failure tasks.

This adds an explicit CodeQL workflow at `.github/workflows/codeql.yml` scoped to the `main` branch only (push + PR, plus a weekly schedule), analyzing `python`. Mirrors the canonical fix in [dispenso](https://github.com/facebookincubator/dispenso/commit/571d5aefe21609c8715f772051ef1c63bc74ffe5). No build step is needed since Python is interpreted.

Follow-up (manual, non-code): disable the CodeQL "default setup" in the repo's GitHub security settings so it no longer runs against `gh-pages`.

Reviewed By: micrain

Differential Revision: D116350536


