### PR TITLE
[detailed][memory] study of HBM fragmentation during stashing

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_data_transfer.py
+++ b/torchrec/distributed/benchmark/benchmark_data_transfer.py
@@ -81,6 +81,156 @@ def _validate(x: torch.Tensor, ctx: MultiProcessContext) -> torch.Tensor:
     return torch.all(checks)
 
 
+_GIB: int = 1024**3
+
+
+def _stats(device: torch.device) -> str:
+    """Allocated / reserved / driver-free, for a record_function label."""
+    free_hbm, _ = torch.cuda.mem_get_info(device)
+    return (
+        f"alloc {torch.cuda.memory_allocated(device) / _GIB:.0f}GiB, "
+        f"reserve {torch.cuda.memory_reserved(device) / _GIB:.0f}GiB, "
+        f"free {free_hbm / _GIB:.0f}GiB"
+    )
+
+
+def _fragment_hbm(
+    ctx: MultiProcessContext,  # used for device
+    sparse_size: int,  # stashed in B, restored in E; the hole everything turns on
+    dense_size: int,  # stays resident, so reserved never drops below it
+    fragment_size: int,  # one activation; must be < sparse_size to carve the hole
+    fragment_count: int,  # overfilling the hole is fine, the excess grows reserved
+    restore_at: int,  # activations still live at restore time; 0 = no fragmentation
+    size_in_byte: int = _GIB,
+    empty_cache: bool = False,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """
+    Reproduce what EMS (see ``torchrec/distributed/memory_stashing.py``) does to the
+    caching allocator over one training step, and the fragmentation the restore can
+    run into. Returns the block lists, which the caller must keep alive.
+
+    EMS frees HBM with ``storage.resize_(0)`` after copying the tensor to pinned
+    host memory, and takes it back with ``resize_(orig_size)``. To the allocator
+    those are an ordinary free and an ordinary allocation, so the stashed block goes
+    onto the pool's free list like any other. The D2H/H2D copies are left out here:
+    they move bytes, not the allocator state this is about.
+
+    The step:
+      A: sparse + dense weights resident, one segment each
+      B: stash the sparse weights -- a sparse_size hole opens in the pool
+      C: forward activations. The first sparse_size // fragment_size of them are
+         served from that hole, which is what the stash makes room for; once it is
+         used up the rest come from the driver and reserved grows
+      D: backward frees activations from the tail. The remaining ones,
+         activations[:restore_at], are the oldest -- so while restore_at is at most
+         sparse_size // fragment_size they are the ones the hole served, and they
+         sit inside what used to be the sparse segment
+      E: restore. Freed blocks inside that segment coalesce, but not across one that
+         is still live, so whether the sparse_size block fits depends on where the
+         remaining activations sit. When it does not fit the allocator takes a fresh
+         segment from the driver and the old region stays free but unused
+
+    So the cost is a property of the layout at restore time, not of stashing itself.
+    restore_at stands for how deep in the backward the restore hook sits: at 0
+    nothing is left in the region, it coalesces whole and the restore lands back in
+    it. At 2 with the sizes below it does not fit -- measured on a 96GiB card with
+    16 / 33 / 4 x 11, reserved ends at 93GiB against a peak allocated of 77GiB, one
+    sparse_size above the largest footprint the step needed.
+
+    empty_cache in D is one way to avoid that; an arena preallocated by the caller
+    (see hbm_fragmentation) is another. empty_cache releases every segment that is
+    entirely free, and whatever outgrew the hole in C is in a segment of its own, so
+    at the sizes above it recovers the full 16GiB. It cannot release a segment that
+    still holds a live activation. It costs a device sync plus re-mallocing what E and the
+    next cycle ask for.
+    """
+    device = ctx.device
+    assert restore_at <= fragment_count
+    sparse_bytes = sparse_size * size_in_byte
+
+    with record_function(f"## A: model weights (start: {_stats(device)}) ##"):
+        sparse_weights = torch.empty(sparse_bytes, dtype=torch.int8, device=device)
+        dense_weights = torch.empty(
+            dense_size * size_in_byte, dtype=torch.int8, device=device
+        )
+
+    with record_function(f"## B: stash the sparse weights ({_stats(device)}) ##"):
+        # resize_(0) frees the block back to the pool but keeps the tensor -- and
+        # its storage -- alive, which is what lets E restore into the same tensor
+        sparse_weights.untyped_storage().resize_(0)
+
+    with record_function(f"## C: forward activations ({_stats(device)}) ##"):
+        # each is smaller than the hole B just opened, so the allocator splits that
+        # free segment instead of going to the driver -- until the hole runs out and
+        # the remainder is cudaMalloc'd after all
+        activations = [
+            torch.empty(fragment_size * size_in_byte, dtype=torch.int8, device=device)
+            for _ in range(fragment_count)
+        ]
+
+    with record_function(f"## D: backward frees activations ({_stats(device)}) ##"):
+        # backward releases them newest-first, so what remains is the head of the
+        # list -- and that is what keeps the old sparse region from coalescing
+        activations = activations[:restore_at]
+
+        if empty_cache:
+            torch.cuda.empty_cache()
+
+    with record_function(f"## E: restore the sparse weights ({_stats(device)}) ##"):
+        reserved_before = torch.cuda.memory_reserved(device)
+        sparse_weights.untyped_storage().resize_(sparse_bytes)
+
+    with record_function(f"### exit memory ({_stats(device)}) ###"):
+        grown = torch.cuda.memory_reserved(device) - reserved_before
+        logger.warning(
+            f"[rank-{ctx.rank}] restore_at={restore_at}: the restore grew reserved "
+            f"by {grown / size_in_byte:.0f} units, stranding "
+            f"{(torch.cuda.memory_reserved(device) - torch.cuda.memory_allocated(device)) / size_in_byte:.0f} "
+            f"in the pool; {_stats(device)}"
+        )
+
+    return activations, [sparse_weights, dense_weights]
+
+
+def _bring_up_nccl_comms(ctx: MultiProcessContext, probes: list[torch.Tensor]) -> None:
+    """
+    Bring up one fresh NCCL communicator per probe, or die trying. Each
+    ``new_group`` is only bootstrapped over the store; the tiny collective after it
+    is what forces ncclCommInitRank, and with it the cudaMalloc of the ring buffers
+    -- outside the caching allocator, so out of reach of every byte the pool holds.
+
+    The failure is left to propagate: no group timeout, no recovery. Whatever the
+    starved ncclCommInitRank does -- throw, or wedge the ranks against each other
+    -- is the outcome being reproduced. Returning at all means it never OOM'd.
+    """
+    for i, probe in enumerate(probes):
+        try:
+            pg = dist.new_group(ranks=list(range(ctx.world_size)), backend="nccl")
+            # new_group returns the NON_GROUP_MEMBER sentinel for ranks left out of
+            # the group; every rank is in this one, so it is always a real pg
+            assert isinstance(pg, dist.ProcessGroup)
+            dist.all_reduce(probe, group=pg)
+            torch.cuda.synchronize(ctx.device)
+        except RuntimeError as e:
+            # NCCL surfaces the failed cudaMalloc as DistBackendError (unhandled
+            # cuda error / ncclSystemError); a torch-side allocation on the same
+            # path would raise OutOfMemoryError. Both are RuntimeError subclasses.
+            # Log the memory state and the error, then let the rank die on it --
+            # the message goes out at fatal level because the traceback that
+            # follows may be truncated, interleaved across ranks, or lost entirely
+            # if a peer wedges instead of throwing.
+            driver_free, total = torch.cuda.mem_get_info(ctx.device)
+            logger.fatal(
+                f"[rank-{ctx.rank}] NCCL could not allocate its buffers outside the "
+                f"torch pool for communicator {i}, with "
+                f"{torch.cuda.memory_allocated(ctx.device) / _GIB:.1f}GiB allocated / "
+                f"{torch.cuda.memory_reserved(ctx.device) / _GIB:.1f}GiB reserved of "
+                f"{total / _GIB:.1f}GiB and {driver_free / _GIB:.2f}GiB left on the "
+                f"driver: {type(e).__name__}: {e}"
+            )
+            raise
+
+
 ################################# framework components #################################
 @dataclass
 class DataCopyConfig(BenchFuncConfig):
@@ -1093,6 +1243,133 @@ def a2a_d2h_contention(
     with record_function("## assert ##"):
         assert checks_a2a.item()
         assert d2h_correct, f"D2H copy validation failed on rank {ctx.rank}"
+
+
+@dataclass
+class HbmFragmentationConfig(DataCopyConfig):
+    """
+    run commands:
+    1. default: one stash/restore cycle per iteration, no NCCL
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer hbm_fragmentation
+
+    2. preallocate an arena first, so every block is split out of one segment
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer hbm_fragmentation \
+        --name=preallocation \
+        --preallocation=77
+
+    3. release what the allocator can before the restore
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer hbm_fragmentation \
+        --name=empty_cache \
+        --empty_cache=True
+
+    4. probe the leftover with NCCL, which allocates outside the pool
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer hbm_fragmentation \
+        --name=nccl \
+        --run_nccl=True
+
+    use case:
+        measure what EMS-style stashing does to the caching allocator, and the
+        conditions under which the restore has to grow reserved. _fragment_hbm walks
+        one training step (see its A-E plan): the sparse weights are stashed with
+        resize_(0), the forward's activations are served from the hole that opens,
+        and the restore fits back into it only if nothing the forward allocated is
+        still in the way. When it does not fit, the allocator takes a fresh segment
+        and the old region stays free but unused, so reserved ends above allocated.
+        Block sizes are GiB-scale and few, to keep the layout readable in the memory
+        snapshot. --preallocation and --empty_cache are the two mitigations to
+        compare against the default.
+
+        Reserved is the number of interest: it is what the card is holding, whether
+        or not tensors are in it. --run_nccl=True exercises one consequence of that
+        -- NCCL allocates its buffers outside the caching allocator, so it sees only
+        the driver's free list and can fail to bring up a communicator while
+        torch.cuda.memory_allocated() still reports room. Anything else allocating
+        outside the pool (cuBLAS workspaces, profiler buffers) is in the same
+        position. It is off by default: the failure is unguarded, so the rank either
+        raises DistBackendError or hangs when the ranks fail at different points
+        inside the init, and neither outcome writes a trace or a memory snapshot.
+    """
+
+    # how many fresh communicators to try before declaring that NCCL survived
+    max_nccl_comms: int = 4
+    # stash/restore cycles per iteration; each one leaves reserved a little higher
+    num_concat: int = 10
+
+    # GiB allocated and dropped up front, leaving one arena for every later block to
+    # be split out of -- neighbours within a segment coalesce, so the restore fits
+    preallocation: int = 0
+    # release the fully-free segments in D, before the restore
+    empty_cache: bool = False
+    # true adds the NCCL probe, which is expected to kill the rank -- see the
+    # docstring above for why it is off by default
+    run_nccl: bool = False
+
+    world_size: int = 2
+    # each iteration re-fragments the whole card, so keep the iteration counts at 1;
+    # the profiled run doubles as the memory-snapshot capture
+    num_benchmarks: int = 0
+    num_profiles: int = 1
+
+    memory_snapshot: bool = True
+    expandable_segments: bool = True
+
+
+@register_benchmark(HbmFragmentationConfig)
+def hbm_fragmentation(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    max_nccl_comms: int,
+    preallocation: int,
+    empty_cache: bool,
+    run_nccl: bool,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Fragment the caching allocator the way an EMS stash/restore cycle does, then
+    optionally probe what is left with NCCL, which allocates outside the pool.
+
+    When the probe reproduces, it ends the run: the NCCL failure propagates out of
+    this function and takes the rank down with it.
+    """
+    device = ctx.device
+    assert device.type == "cuda", "hbm_fragmentation requires a CUDA device"
+
+    with record_function("## setup ##"):
+        # Everything needed after the fragmentation has to exist before it: with the
+        # driver's free list empty, opening a new small-pool segment would fail its
+        # cudaMalloc, and the allocator's recovery (release cached segments, retry)
+        # would dissolve the fragmented pool this benchmark is built to hold.
+        probes = [torch.zeros(1, device=device) for _ in range(max_nccl_comms)]
+        # bring ctx.pg's own communicator up here so its NCCL buffers land in the
+        # baseline rather than looking like part of the fragmentation
+        dist.barrier(group=ctx.pg)
+        torch.cuda.synchronize(device)
+
+    if preallocation > 0:
+        torch.empty(preallocation * _GIB, dtype=torch.int8, device=ctx.device)
+
+    # each cycle leaves reserved a little higher than the last, so repeating one
+    # step's stash/restore is what walks the card towards full
+    for i in range(num_concat):
+        _fragment_hbm(
+            ctx,
+            sparse_size=16,
+            dense_size=33,
+            fragment_size=4,
+            fragment_count=11,
+            restore_at=2,
+            empty_cache=(empty_cache and (i == 0)),
+        )
+
+    if run_nccl:
+        with record_function("## NCCL communicator bring-up ##"):
+            # the expected exit point of this benchmark -- the starved
+            # ncclCommInitRank throws (or wedges the ranks) and the failure is left
+            # to propagate
+            _bring_up_nccl_comms(ctx, probes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
# Study of HBM Fragmentation with Memory Stashing

## TL;DR

- Reserved memory can sit far above peak allocated while the live set stays flat. EMS gets there by freeing a large block mid-step and taking it back later in the same step, and any step that repeatedly frees and re-takes large blocks can do the same.
- That gap has three distinct causes, and they are not equally fixable: **hard** fragmentation, where live blocks are interleaved with the free ones; **soft**, where the free space is spread across segments that are never merged with one another; and **stream**, where idle segments are tagged to a stream the main one cannot allocate from.
- Soft is the common case and the one general approaches reach. Preallocating a single large arena, or calling `empty_cache()` once, each collapses the scattered segments and closes the gap.
- Neither is free: `empty_cache()` costs a device-wide sync, and preallocation needs the steady-state peak known up front. The cycle studied here is simplified, so the mechanism generalizes but the measurements do not.

## 1. Motivation

HBM pressure keeps rising as models scale ([Memory Bottlenecks in Ads Model Sequence Scaling: Symptoms and Techniques](https://fb.workplace.com/groups/527654686243695/permalink/1336397825369373/)). Under that pressure the two memory readings diverge: jobs run at 98%+ device usage while PyTorch reports allocated 10+ GB below it.

The usage is the real number. Jobs at that level die with NCCL OOM ([NCCL OOM vs. Reserved–Allocated Gap](nccl_oom_reserved_allocated_gap.md)), because NCCL allocates its buffers outside the caching allocator and cannot reuse what the pool is holding. That report named fragmentation as the root cause, but we have no systematic way to avoid it yet.

We observed a similar discrepancy with EMS: stashing the embedding tables drops allocated HBM by 10+ GB against the baseline, but reserved memory does not fall with it.

This study reproduces that behavior and looks for a mitigation. EMS is the case to model, because its design is to free a large block now and take it back later in the same step. It is one instance of a general pattern: any step that repeatedly allocates and frees large blocks can strand memory the same way.

## 2. Background: HBM Usage vs. PyTorch Reserved vs. PyTorch Allocated

Three different numbers describe the memory on a GPU. Zoomer's GPU memory page reports all three for the same job, here on a 95.07 GiB card:

<img width="4356" height="2644" alt="image" src="https://github.com/user-attachments/assets/9f082479-76e1-4959-aede-4959da635ad6" />

**HBM usage** is the total memory in use on the device. It covers PyTorch's memory pool plus everything else the process loads: the NCCL buffers, the CUDA context and the CUDA libraries. This is the number the system metrics report.

**PyTorch reserved** is the part the caching allocator has taken from the driver. The allocator requests memory in segments and keeps them after the tensors inside are freed, so reserved covers both live tensors and cached blocks waiting to be reused.

**PyTorch allocated** is the memory currently held by live tensors, which is what `torch.cuda.memory_allocated()` reports.

<img width="2520" height="1600" alt="image" src="https://github.com/user-attachments/assets/28e172c6-4b8d-4510-a287-444f2fb74855" />

The three nest, allocated inside reserved and reserved inside usage, which leaves two kinds of free space. Inside the pool, the difference between reserved and allocated is memory PyTorch holds but no tensor is using; the allocator can hand it to the next tensor, and nothing outside PyTorch can touch it. Outside the pool, whatever the device has left after usage is what everything else works with.

That second kind is why a job can OOM in NCCL while PyTorch still reports memory to spare. NCCL takes its communication buffers from the driver rather than from the pool, so a large reserved but unallocated region keeps usage high and leaves too little behind for them.

Most of the non-PyTorch usage is outside our direct control, so this study stays inside the reserved pool. Allocated memory holds the real data and we take it as fixed here. That leaves the gap between allocated and reserved as the thing to close.

## 3. Types of HBM Fragmentation

During our investigation of the HBM fragmentation issue in EMS (see more details in the benchmark section), we've identified three types of fragmentation, all showing reserved memory higher than peak allocated memory.

### 3.1. Hard Fragmentation

The most straightforward case is a comb-shaped pattern of allocations and frees. The freed blocks are not adjacent, and the allocator only merges free blocks that sit next to each other inside the same segment. So when it needs one contiguous block larger than any of the scattered gaps, none of them can take it and it requests a new segment from the driver.

<img width="3616" height="1760" alt="image" src="https://github.com/user-attachments/assets/cb822b38-3f03-4544-ac3b-ef178de87d5c" />

The hard fragmentation run ([snapshot](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation_hard_conflict-rank0.pickle)): the reserved segments in the lower left are combed with empty blocks. Allocated peaks at 75 GiB and reserved peaks at 91 GiB, and the two peaks are not the same moment. When reserved is at its peak, allocated is only 67 GiB, so the pool is holding 24 GiB it cannot hand out, and a whole segment is sitting empty while the allocator keeps taking new ones from the driver.

Once the pool is in this layout there is not much left to do about it. The gaps are real free memory, but turning them into the contiguous 9 GiB the request asks for means moving the live blocks out of the way, and the caching allocator never relocates a live tensor. Without that move the only way to serve the request is a new segment from the driver, which is the reserved growth itself.

Calling `empty_cache()` to give the interleaved empty blocks back is not a good option either. It only releases segments that are entirely free, so the gaps inside the comb stay where they are. The segments it does release come out of the middle of the pool, leaving holes between the ones that remain and a reserved space that is disjointed.

### 3.2. Soft Fragmentation

The situation is not as bad as hard fragmentation, which only happens when the activations are freed in an interleaved order. The usual pattern is more like a pyramid: backpropagation walks the graph in reverse, so the earlier activations last longer than the later ones. What is left in the pool late in the backward is a handful of the oldest blocks rather than a comb.

Let's look into an over-simplified case where the sparse weights (embedding tables) and the dense weights are allocated during model init, then the embedding tables are stashed at the beginning of the forward and brought back toward the end of the backward.

<img width="3592" height="1908" alt="image" src="https://github.com/user-attachments/assets/d60281b7-72e9-4ab3-ae7c-b1e7e58f122a" />

The baseline run ([snapshot](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation-rank0.pickle)): allocated peaks at 77 GiB and reserved at 93 GiB, and at the reserved peak allocated is only 57 GiB.

What makes this case soft is the reason the restore does not fit. The free memory is not carved up by live blocks in an interleaved pattern, it is just spread across separate segments. Two segments are never merged, however much free space each of them holds: `try_merge_blocks` joins only blocks that neighbor each other inside one segment, a point the [PyTorch devlog on the caching allocator](https://docs.pytorch.org/devlogs/eager/2026-06-01-cuda-caching-allocator/) makes as well. Nothing has to move here, and nothing prevents the smaller segments from being reused, which section 4 comes back to.

### 3.3. Stream Fragmentation

The caching allocator keeps its free blocks partitioned by stream, and every segment carries the stream it was allocated on. A request can only be served from blocks tagged with its own stream, so an allocation on one stream cannot reuse an empty segment that belongs to another, however much of it is free. [CUDA Stream Memory Footprint](../torchrec-designs/cuda_stream_memory_footprint.md) goes through what this costs in multi-stream memory usage.

<img width="3592" height="1702" alt="image" src="https://github.com/user-attachments/assets/5ecbbdbe-096a-445c-ae9c-ff39bff438a0" />

A production snapshot at the allocated peak ([snapshot](https://www.internalfb.com/pytorch_memory_visualizer/aps_traces/tree/gpu_snapshot/aps-V4_0427tk_256B2_FBonly_datafm_arch_infra_fixes-1819c510eb/0/rank-27-from-4009-to-4010.May_14_00_55_41.7499.snapshot.pickle)): the empty segments belong to stream 3 and the main stream cannot touch them. A segment tagged to another stream is only a problem when it is idle, which is why the fully occupied one beside them does not count.

## 4. Approaches

There are not many good methods for hard fragmentation. What we have seen so far, across a few production models, is that it stays mild as long as the activations, or any other memory whose lifespan is within one training iteration, are under about 1 GB. Please reach out to us if you have a use case where it is severe.

For stream fragmentation, the idle segments can usually be recovered by preallocating the block on the main stream and copying into it in place, which is what [Inplace Copy Batch to GPU](../torchrec-designs/inplace_copy_batch_to_gpu.md) does for the input batch. The occupied ones are worth a second look too: whether that memory has to be live right when the peak happens. If it does not, re-aligning the work across streams moves the allocation off the peak.

The rest of this section is about soft fragmentation, which we believe is the more common case and the one that general approaches can reach.

### 4.1. Release the Idle Segments

In soft fragmentation the idle segments are each large enough on their own, they just cannot be combined to serve one large request. Calling `torch.cuda.empty_cache()` hands them back to the driver, and the next allocation takes a segment of the shape it actually needs.

For the same benchmark, reserved peaks at 77 GiB while the allocated profile is identical to the baseline.

<img width="3726" height="1620" alt="image" src="https://github.com/user-attachments/assets/db48bc8b-3877-484a-8869-268a189a9449" />

The cost is a device-wide sync, plus a round of fresh driver allocations behind it. In this cycle it is paid once: after the release the restore takes a new 16 GiB segment, and later iterations reuse the two 16 GiB segments instead of growing reserved again.

[**not verified**] The allocator can also do this on its own, with no explicit call: set both `per_process_memory_fraction` and `garbage_collection_threshold` in `PYTORCH_ALLOC_CONF`. Setting the threshold alone does nothing, because collection measures itself against the fraction cap and stays disabled while that cap is unset. Collection is the cheaper of the two, since it never synchronizes on outstanding events, but it is also narrower: it sweeps only the large pool, and releases the segments that have gone longest without a hit rather than everything idle.

### 4.2. Pre-allocate a Large, Contiguous Segment

What `empty_cache()` effectively does is release the separate smaller segments so a larger one can take their place. The natural next idea is to arrange for that larger segment up front, before anything has had a chance to fragment. A single `torch.empty` call is enough:

```python
torch.empty(preallocation_bytes, dtype=torch.int8, device=device)
```

The tensor is released immediately, but the segment behind it stays in the pool, and every later allocation is served out of that one arena instead of taking fresh segments from the driver. Since we already know the allocated peak is 77 GiB, that is the size to ask for.

<img width="3616" height="1766" alt="image" src="https://github.com/user-attachments/assets/92815669-1de0-4d9e-abde-cec3895554c9" />

Reserved peaks at 77 GiB with nothing stranded, the same result as `empty_cache()` but with no sync on the step. The catch is that it only works when the peak is known ahead of time, and it reserves that peak whether or not the step ever reaches it.

## 5. Benchmark

**Setup**

The benchmark models one training step with a stash in it and nothing else. `_fragment_hbm` in `benchmark_data_transfer.py` walks that step in five phases, each wrapped in a `record_function` whose label carries allocated, reserved and driver-free at entry, so the whole walk is readable in the trace with no extra instrumentation:

| | phase | effect on the pool |
|---|---|---|
| A | sparse and dense weights resident | one segment each |
| B | stash the sparse weights | a hole the size of the sparse weights opens |
| C | forward allocates activations | the first `sparse_size // fragment_size` come out of that hole, the rest from the driver |
| D | backward frees activations from the tail | `activations[:restore_at]` are left behind, the oldest ones |
| E | restore the sparse weights | the activations still alive split the old region, so a fresh segment comes from the driver |

Phase C is the win the stash is after, since the freed region gets reused instead of sitting idle. Phase D decides whether that win holds: the activations left behind are the oldest, so while `restore_at <= sparse_size // fragment_size` they are exactly the ones the hole served, and they sit inside the old sparse region. In phase E the freed blocks inside that segment coalesce, but not across a block that is still live, so the restore no longer fits and the allocator goes to the driver.

`restore_at` is the knob, and it stands for how deep in the backward the restore hook sits. At **0** every activation is already freed, the old region coalesces whole, the restore lands back in it and reserved never moves. **Above 0** what remains splits the region, and reserved grows by the size of the stash. The fragmentation is not caused by the stash, it is caused by restoring while something the forward allocated is still alive.

The D2H/H2D copies EMS performs are deliberately left out: they move bytes, not allocator state.

**Repro**

```bash
# baseline -- the stash/restore cycle on an otherwise empty card
python -m torchrec.distributed.benchmark.benchmark_data_transfer hbm_fragmentation

# preallocation -- take a 77 GiB arena and drop it, so every later block is split out of that one segment
python -m torchrec.distributed.benchmark.benchmark_data_transfer \
    hbm_fragmentation --preallocation=77 --name=preallocation

# empty_cache -- release what the allocator can before the restore, on the first cycle only
python -m torchrec.distributed.benchmark.benchmark_data_transfer \
    hbm_fragmentation --empty_cache=True --name=empty_cache
```

**Results**
[HBM fragmentation study.zip](https://github.com/user-attachments/files/31159860/HBM.fragmentation.study.zip)

96 GiB card, 10 cycles of sparse 16 / dense 33 / 11 × 4 GiB activations, `restore_at=2`. All four runs had `--run_nccl` off.

| run | peak allocated | reserved | stranded | rank0 links |
|---|---|---|---|---|
| baseline | 77 GiB | 93 GiB | 16 GiB | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation-rank0.json.gz&bucket=torchrec_benchmark_traces) · [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation-rank0.pickle) |
| `--preallocation=77` | 77 GiB | 77 GiB | 0 | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_preallocation-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_preallocation-rank0.json.gz&bucket=torchrec_benchmark_traces) · [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation_preallocation-rank0.pickle) |
| `--empty_cache=True` | 77 GiB | 77 GiB | 0 | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_empty_cache-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_empty_cache-rank0.json.gz&bucket=torchrec_benchmark_traces) · [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation_empty_cache-rank0.pickle) |
| hard fragmentation | 75 GiB | 93 GiB | 18 GiB | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_hard_conflict-rank0.json.gz&bucket=torchrec_benchmark_traces) · [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D114921496/trace-hbm_fragmentation_hard_conflict-rank0.json.gz&bucket=torchrec_benchmark_traces) · [memory](https://www.internalfb.com/pytorch_memory_visualizer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496/memory-hbm_fragmentation_hard_conflict-rank0.pickle) |

Full set in the [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D114921496). The hard fragmentation row uses a hand-edited block plan that the current CLI flags do not reach.


## 6. Discussion

### 6.1. The Cycle Is Over-Simplified

The cycle here is deliberately simple: a handful of round GiB blocks, one stash and one restore per iteration, and no other allocation traffic to speak of. Real steps are messier. There is a long tail of small tensors, more than one stash can be in flight, and the activations do not unwind in a clean pyramid. All of it changes the packing. The mechanism this study isolates is real, but the numbers attached to it are the numbers for this cycle on this card, and there is no reason to expect them to carry over unchanged.

### 6.2. `empty_cache()` Is Expensive

`empty_cache()` is the more general of the two mitigations and the more expensive one: a device-wide sync, plus a round of fresh driver allocations to rebuild what it released. Here that cost is paid once, on the first cycle, and the segments left behind serve every cycle after it. A step that called it every iteration would pay the sync every iteration, which is why it belongs in an occasional release valve rather than in the step itself.

### 6.3. Preallocation Needs the Steady-State Peak

Preallocation avoids the sync entirely, but it needs a number: the peak the step settles at in steady state. Ask for too little and the arena fills up and the step fragments anyway; ask for too much and the excess sits reserved, out of reach of anything allocating outside the pool. That number is easy here because the block plan is fixed. In a real model it has to come from a profile of a warmed-up run, not from the first few iterations.

## 7. References

- [D114921496](https://www.internalfb.com/diff/D114921496) — the `hbm_fragmentation` benchmark and traces
- [`memory_stashing.py`](https://www.internalfb.com/code/fbsource/fbcode/torchrec/distributed/memory_stashing.py) — `MemoryStashingManager`, the resize-to-0 / resize-back pair
- [NCCL OOM vs. Reserved–Allocated Gap](nccl_oom_reserved_allocated_gap.md) — the production symptom this reproduces
- [Record Stream NaN in EMS](record_stream_nan_ems.md) — a different EMS/allocator interaction
- [CUDA caching allocator](https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDACachingAllocator.cpp) — `try_merge_blocks` (same-segment coalescing only), `release_cached_blocks` (what `empty_cache` calls)
- [PyTorch devlog: When does fragmentation occur in the CUDA caching allocator?](https://docs.pytorch.org/devlogs/eager/2026-06-01-cuda-caching-allocator/) — segments are never merged with one another

Reviewed By: spmex

Differential Revision: D114921496


