### PR TITLE
sparse/dense forward split + run_1f1b_split schedule

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_maglev.py
+++ b/torchrec/distributed/benchmark/benchmark_maglev.py
@@ -60,7 +60,11 @@ from torchrec.distributed.benchmark.base import (
     GPUMemoryStats,
 )
 from torchrec.distributed.maglev.input_dist import input_dist
-from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
+from torchrec.distributed.maglev.pipeline import (
+    MaglevPipeline,
+    run_1f1b,
+    run_1f1b_split,
+)
 from torchrec.distributed.maglev.stage import (
     build_cascade_process_groups,
     build_handoff_process_groups,
@@ -75,7 +79,7 @@ from torchrec.distributed.test_utils.multi_process import (
     run_multi_process_func,
 )
 from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
-from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.distributed.test_utils.test_model import MaglevSplitStage, MaglevTestStage
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 # Weights are seeded per stage so an HSD's two DP ranks start identical (the
@@ -118,6 +122,15 @@ class RunOptions(BenchFuncConfig):
             embedding sharding; the lookup all-to-all stays local to the pg).
             Default is True. Requires ``device_type="cuda"`` (nccl) -- gloo cannot
             P2P the CUDA activations between stages.
+        schedule (str): Which 1F1B variant to run. ``"1f1b"`` (default)
+            calls :func:`~torchrec.distributed.maglev.pipeline.run_1f1b`;
+            ``"split"`` calls
+            :func:`~torchrec.distributed.maglev.pipeline.run_1f1b_split`, which
+            hoists every microbatch's sparse (embedding) forward before the
+            first backward so all lookups see pre-step weights (SGD-exact under
+            fused TBE). ``"split"`` builds :class:`MaglevSplitStage` instead of
+            :class:`MaglevTestStage`; the two have identical parameters and
+            submodules, so the arms are directly comparable.
         output_json (bool): Print the result as JSON instead of a table.
             Default is False.
         all_rank_traces (bool): Export a profiler trace from every rank (not just
@@ -148,6 +161,9 @@ class RunOptions(BenchFuncConfig):
     # Intra-HSD embedding sharding (DMP per stage), scoped to each stage's pg so
     # the lookup all-to-all stays local to the HSD. Requires nccl (cuda).
     shard_embeddings: bool = True
+    # "1f1b" (run_1f1b) or "split" (run_1f1b_split). The A/B knob for
+    # measuring what the sparse hoist costs in wall time and peak memory.
+    schedule: str = "1f1b"
     output_json: bool = False
     # Capture a trace from every rank so each stage's HSD shows up, not only
     # rank 0's stage (traces are emitted only when profile_dir is set on CUDA).
@@ -264,6 +280,10 @@ def runner(
         f"world_size ({world_size}) must equal num_stages ({num_stages}) * "
         f"ranks_per_stage ({ranks_per_stage})"
     )
+    assert run_option.schedule in (
+        "1f1b",
+        "split",
+    ), f"schedule must be '1f1b' or 'split', got {run_option.schedule!r}"
 
     # CUDA uses nccl for the cross-HSD P2P hand-off (falls back to gloo for the
     # CPU repro). The profiler path is CUDA-only, so traces require device_type=cuda.
@@ -305,7 +325,14 @@ def runner(
         # ranks start identical -> grad all-reduce keeps them in lock-step).
         tables = all_tables[my_stage_index]
         torch.manual_seed(_WEIGHT_SEED + my_stage_index)
-        module = MaglevTestStage(
+        # The split schedule needs a stage implementing MaglevStage
+        # (forward_sparse / forward_dense). MaglevSplitStage subclasses
+        # MaglevTestStage and adds only those two methods -- same parameters,
+        # same submodules, same seeded init, so the two arms are comparable.
+        stage_cls = (
+            MaglevSplitStage if run_option.schedule == "split" else MaglevTestStage
+        )
+        module = stage_cls(
             tables=tables,
             stage_dim=run_option.stage_dim,
             is_first=(my_stage_index == 0),
@@ -364,6 +391,8 @@ def runner(
                 for _ in range(run_option.num_microbatches)
             ]
 
+        schedule_fn = run_1f1b_split if run_option.schedule == "split" else run_1f1b
+
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],
             pipeline: MaglevPipeline,
@@ -376,15 +405,33 @@ def runner(
             # One measured iteration = the input-dist all-to-all for this pass's
             # microbatches (refilling the queue as needed) + one full 1F1B pass
             # (warmup + steady 1F1B + cooldown), including the cross-HSD hand-off
-            # and the per-batch DP grad all-reduce + optimizer step.
+            # and the per-batch DP grad all-reduce + optimizer step. Both
+            # schedules take identical arguments, so the arms differ only in the
+            # order sparse/dense/backward work is issued.
             micro_inputs = driver.take(num_microbatches)
-            run_1f1b(
+            schedule_fn(
                 pipeline=pipeline,
                 microbatch_inputs=micro_inputs,
                 optimizer=optimizer,
                 labels=labels if pipeline.is_last else None,
                 criterion=criterion if pipeline.is_last else None,
             )
+            # Close the measurement window on *device* completion, not on the
+            # host finishing its launches. ``BenchmarkResult`` takes its wall
+            # timestamp (and therefore QPS) immediately after this function
+            # returns, with no sync of its own, so without this the reported
+            # wall time is "time to issue the schedule". That is badly
+            # misleading for the split schedule: its host thread stops blocking
+            # in ``dist.recv`` and races ahead, which reads as a ~4x QPS win
+            # while the GPU is still doing the same work.
+            #
+            # Draining every iteration also removes cross-iteration overlap, so
+            # this measures per-iteration latency rather than pipelined
+            # steady-state. That is the right basis for an A/B here (both arms
+            # are GPU-bound, so a host running ahead buys no throughput) and it
+            # penalizes both arms equally.
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
 
         result = benchmark_func(
             bench_inputs=[],
@@ -414,20 +461,42 @@ def run_maglev(run_option: RunOptions) -> BenchmarkResult:
         run_option=run_option,
     )
 
-    # Combine results from all ranks: timing from rank 0, memory stats per rank.
+    # Combine results from all ranks. Timing comes from the *slowest* rank, not
+    # rank 0: a pipeline iteration is only complete when every stage is, so the
+    # critical-path rank sets the achievable throughput. Reporting rank 0 would
+    # flatter any schedule that lets the early stages finish sooner while a
+    # later stage remains the bottleneck. Memory stays per-rank.
     world_size = run_option.world_size
+
+    def _median_wall_ms(res: BenchmarkResult) -> float:
+        t = res.wall_elapsed_time
+        return float(t.median().item()) if t.numel() > 0 else 0.0
+
+    critical = max(benchmark_res_per_rank, key=_median_wall_ms)
+    # print, not logger: this is the parent process, where logging has no stream
+    # handler configured (same reason ``main`` prints its result).
+    print(
+        f"critical-path rank {critical.rank} "
+        f"(median wall {_median_wall_ms(critical):.2f} ms); per-rank medians: "
+        + ", ".join(
+            f"r{r.rank}={_median_wall_ms(r):.1f}"
+            for r in sorted(benchmark_res_per_rank, key=lambda x: x.rank)
+        )
+    )
+
     total_benchmark_res = BenchmarkResult(
-        short_name=benchmark_res_per_rank[0].short_name,
-        gpu_elapsed_time=benchmark_res_per_rank[0].gpu_elapsed_time,
-        cpu_elapsed_time=benchmark_res_per_rank[0].cpu_elapsed_time,
-        cpu_utilization=benchmark_res_per_rank[0].cpu_utilization,
-        normalized_cpu_utilization=benchmark_res_per_rank[0].normalized_cpu_utilization,
+        short_name=critical.short_name,
+        gpu_elapsed_time=critical.gpu_elapsed_time,
+        cpu_elapsed_time=critical.cpu_elapsed_time,
+        cpu_utilization=critical.cpu_utilization,
+        normalized_cpu_utilization=critical.normalized_cpu_utilization,
         gpu_mem_stats=[
             GPUMemoryStats(rank, 0, 0, 0, 0, 0) for rank in range(world_size)
         ],
         cpu_mem_stats=[CPUMemoryStats(rank, 0) for rank in range(world_size)],
-        qps=benchmark_res_per_rank[0].qps,
-        rank=0,
+        qps=critical.qps,
+        wall_elapsed_time=critical.wall_elapsed_time,
+        rank=critical.rank,
     )
 
     for res in benchmark_res_per_rank:

--- a/torchrec/distributed/maglev/__init__.py
+++ b/torchrec/distributed/maglev/__init__.py
@@ -24,11 +24,17 @@ them to slot in later.
 """
 
 from torchrec.distributed.maglev.module import MaglevModuleList
-from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
+from torchrec.distributed.maglev.pipeline import (
+    MaglevPipeline,
+    run_1f1b,
+    run_1f1b_split,
+)
 from torchrec.distributed.maglev.stage import (
     build_stage_process_groups,
     EmbeddingShard,
+    MaglevStage,
     Replicated,
+    SplitForwardMixin,
     StageParallelizer,
     StageWrapper,
 )
@@ -36,7 +42,10 @@ from torchrec.distributed.maglev.stage import (
 __all__ = [
     "MaglevModuleList",
     "MaglevPipeline",
+    "MaglevStage",
+    "SplitForwardMixin",
     "run_1f1b",
+    "run_1f1b_split",
     "StageWrapper",
     "StageParallelizer",
     "Replicated",

--- a/torchrec/distributed/maglev/pipeline.py
+++ b/torchrec/distributed/maglev/pipeline.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -42,7 +42,7 @@ class MaglevPipeline:
     stages are sharded with DMP. See
     ``tech-docs/nccl_p2p_execution_order_buffer_size.md`` (sections 4-5).
 
-    Two drivers are provided:
+    Three drivers are provided:
 
     * :meth:`step` -- a single-batch forward-then-backward pass (used by the
       correctness test). Blocking send/recv form a matched wave; no deadlock.
@@ -51,6 +51,15 @@ class MaglevPipeline:
       received with blocking recv (strict dependency, forms a wave) and sent
       with non-blocking isend whose completion is deferred to
       :meth:`wait_sends`, which keeps the schedule deadlock-free.
+    * :meth:`forward_sparse_micro` / :meth:`forward_dense_micro` +
+      :func:`run_1f1b_split` -- the split-forward variant of 1F1B. Every
+      microbatch's sparse (embedding) forward completes before the first
+      backward, so all sparse lookups see the same pre-step embedding weights.
+      Warmup runs an initial burst of ``prehoist`` sparses, then each warmup
+      dense is followed by the prefetch of the sparse it would otherwise
+      "leave for later" -- so every dense in warmup is adjacent to one of the
+      trailing sparses. Requires the stage module to satisfy
+      :class:`~torchrec.distributed.maglev.stage.MaglevStage`.
 
     Every comm (activation/gradient send+recv) and the forward/backward compute
     is wrapped in a ``record_function`` range tagged with the microbatch id
@@ -137,6 +146,11 @@ class MaglevPipeline:
         ] = []
         # pyre-ignore[4]: dist work handle has no public type
         self._send_work: List[Tuple[Any, torch.Tensor]] = []
+        # Split-forward cache: sparse (pooled) output per hoisted microbatch,
+        # keyed by microbatch id. Populated by ``forward_sparse_micro`` and
+        # consumed (popped) by the matching ``forward_dense_micro``. Empty
+        # between :func:`run_1f1b_split` calls.
+        self._pooled: Dict[int, torch.Tensor] = {}
 
     @property
     def is_first(self) -> bool:
@@ -315,6 +329,75 @@ class MaglevPipeline:
 
         return loss
 
+    # ---- split-forward 1F1B driver (SGD-exact w/ fused TBE) ----
+
+    def forward_sparse_micro(self, stage_input: Any, microbatch_id: int) -> None:
+        """Sparse-only forward: pool this stage's embeddings and cache the result.
+
+        No cross-stage comm: the sparse forward depends only on ``stage_input``
+        (per :class:`~torchrec.distributed.maglev.stage.MaglevStage`), so every
+        microbatch's sparse pass can run up-front. The pooled tensor is stashed
+        in ``_pooled[microbatch_id]`` for the matching
+        :meth:`forward_dense_micro`; autograd retains its graph via that reference.
+
+        Raises:
+            AssertionError: if ``microbatch_id`` is already in ``_pooled`` (the
+                caller invoked ``forward_sparse_micro`` twice for the same
+                microbatch without a matching ``forward_dense_micro`` in
+                between).
+        """
+        assert microbatch_id not in self._pooled, (
+            f"forward_sparse_micro: microbatch {microbatch_id} already cached; "
+            f"duplicate call without a matching forward_dense_micro"
+        )
+        with record_function(f"## forward_sparse mb{microbatch_id} ##"):
+            pooled = self.stage.forward_sparse(stage_input)
+        self._pooled[microbatch_id] = pooled
+
+    def forward_dense_micro(
+        self,
+        stage_input: Any,
+        label: Optional[torch.Tensor] = None,
+        microbatch_id: int = 0,
+    ) -> None:
+        """Dense-only forward for a microbatch whose sparse was already hoisted.
+
+        Mirrors :meth:`forward_micro` (same recv/send/pending semantics) but
+        substitutes ``stage.forward_dense(stage_input, pooled, prev)`` for the
+        monolithic ``stage(...)``. Consumes (pops) ``_pooled[microbatch_id]`` --
+        must be preceded by a :meth:`forward_sparse_micro` call for the same
+        microbatch id.
+
+        Raises:
+            RuntimeError: if ``_pooled[microbatch_id]`` is missing (no matching
+                ``forward_sparse_micro`` was called for this microbatch).
+        """
+        prev_output: Optional[torch.Tensor] = None
+        if not self.is_first:
+            assert self._recv_act_pg is not None
+            with record_function(f"## recv_act mb{microbatch_id} ##"):
+                prev_output = self._recv(
+                    self._prev_rank(), self._recv_act_pg, requires_grad=True
+                )
+
+        try:
+            pooled = self._pooled.pop(microbatch_id)
+        except KeyError:
+            raise RuntimeError(
+                f"forward_dense_micro({microbatch_id}): no cached pooled tensor; "
+                f"call forward_sparse_micro({microbatch_id}) first"
+            ) from None
+
+        with record_function(f"## forward_dense mb{microbatch_id} ##"):
+            output = self.stage.forward_dense(stage_input, pooled, prev_output)
+
+        if not self.is_last:
+            assert self._send_act_pg is not None
+            with record_function(f"## send_act mb{microbatch_id} ##"):
+                self._isend(output, self._next_rank(), self._send_act_pg)
+
+        self._pending.append((prev_output, output, label, microbatch_id))
+
 
 def run_1f1b(
     pipeline: MaglevPipeline,
@@ -374,4 +457,174 @@ def run_1f1b(
     pipeline.wait_sends()
     pipeline.stage.reduce_gradients()
     optimizer.step()
+    return losses
+
+
+def run_1f1b_split(
+    pipeline: MaglevPipeline,
+    microbatch_inputs: List[Any],
+    optimizer: torch.optim.Optimizer,
+    labels: Optional[List[torch.Tensor]] = None,
+    criterion: Optional[LossFn] = None,
+) -> List[float]:
+    """Split-forward 1F1B with trailing-sparse interleave: SGD-exact under fused TBE.
+
+    Schedule (``w = min(num_stages - stage_index - 1, N)``,
+    ``prehoist = min(max(stage_index + 1, N - w), N)``); four phases, each
+    wrapped in its own ``record_function`` for profiler visibility:
+
+    * **sparse_hoist** -- ``S_j`` for ``j in [0, prehoist)``. Front-loads the
+      sparses that will not be paired with a warmup dense. This is the visible
+      cost of split-forward vs monolithic 1F1B.
+    * **warmup** -- for ``j in [0, w)``, run ``D_j``; if ``j + prehoist < N``,
+      prefetch ``S_{j + prehoist}`` immediately after ``D_j``. Every ``D_j``
+      is adjacent to one of the *trailing* sparses. Symmetric with
+      ``steady``'s (dense, backward) interleave.
+    * **steady** -- for ``_ in [0, N - w)``: one dense forward, one backward.
+      The dense forward pops the pooled tensor cached by its matching sparse.
+    * **cooldown** -- for ``_ in [0, w)``: drain remaining backwards.
+
+    By the end of ``warmup`` all ``N`` sparses have completed -- the first
+    backward in ``steady`` can safely fire the fused TBE optimizer without
+    invalidating any subsequent sparse lookup.
+
+    Per-stage sizing (``Sj`` sparse, ``Dj`` dense, ``Bj`` backward, all for
+    microbatch ``j``). Read each row across for the full stage timeline.
+
+    **4 stages, N = 4 microbatches** (``prehoist == stage_index + 1``, floor
+    dominates):
+
+    ==== === ======== ================ ============================ ============================ ============
+    stage w   prehoist sparse_hoist     warmup                       steady                       cooldown
+    ==== === ======== ================ ============================ ============================ ============
+     0    3    1       ``S0``           ``D0 S1 D1 S2 D2 S3``        ``D3 B0``                    ``B1 B2 B3``
+     1    2    2       ``S0 S1``        ``D0 S2 D1 S3``              ``D2 B0 D3 B1``              ``B2 B3``
+     2    1    3       ``S0 S1 S2``     ``D0 S3``                    ``D1 B0 D2 B1 D3 B2``        ``B3``
+     3    0    4       ``S0 S1 S2 S3``  (empty)                      ``D0 B0 D1 B1 D2 B2 D3 B3``  (empty)
+    ==== === ======== ================ ============================ ============================ ============
+
+    **4 stages, N = 8 microbatches** (``prehoist == N - w``, ceiling
+    dominates; the initial burst grows so warmup denses interleave with the
+    *last* ``w`` sparses):
+
+    ==== === ======== =========================== ===================== ================================================== ============
+    stage w   prehoist sparse_hoist                warmup                steady                                             cooldown
+    ==== === ======== =========================== ===================== ================================================== ============
+     0    3    5       ``S0 S1 S2 S3 S4``          ``D0 S5 D1 S6 D2 S7`` ``D3 B0 D4 B1 D5 B2 D6 B3 D7 B4``                  ``B5 B6 B7``
+     1    2    6       ``S0 S1 S2 S3 S4 S5``       ``D0 S6 D1 S7``       ``D2 B0 D3 B1 D4 B2 D5 B3 D6 B4 D7 B5``            ``B6 B7``
+     2    1    7       ``S0 S1 S2 S3 S4 S5 S6``    ``D0 S7``             ``D1 B0 D2 B1 D3 B2 D4 B3 D5 B4 D6 B5 D7 B6``      ``B7``
+     3    0    8       ``S0 S1 S2 S3 S4 S5 S6 S7`` (empty)               ``D0 B0 D1 B1 D2 B2 D3 B3 D4 B4 D5 B5 D6 B6 D7 B7`` (empty)
+    ==== === ======== =========================== ===================== ================================================== ============
+
+    All ``Sj`` complete in ``sparse_hoist + warmup`` (before any ``Bj``);
+    ``Dj`` forwards pair with ``Bj`` backwards in steady (except the last
+    stage where they collocate). Every dense in warmup interleaves with the
+    *last* ``w`` sparses -- there is no separate tail-hoist block, by
+    construction of the ``prehoist`` formula.
+
+    The last stage (``w == 0``) hoists all sparses up-front; the first stage
+    (``w == N - 1``) hoists only one and interleaves the rest with dense
+    forwards. Front-loading everything on every stage would delay stage 0's
+    first activation send and push a bubble downstream.
+
+    Why the hoist: under fused TBE (``apply_optimizer_in_backward``) the sparse
+    optimizer fires *during* backward. In monolithic 1F1B the sparse forward
+    for microbatch N sees embedding weights already updated by the backward of
+    some earlier microbatch -- diverging from SGD-exact semantics. Ensuring
+    every sparse completes before the first backward makes all microbatches'
+    sparse lookups observe the same pre-step weights, matching a single-process
+    ``for mb: forward; loss.backward()`` reference.
+
+    Requires the stage module to satisfy
+    :class:`~torchrec.distributed.maglev.stage.MaglevStage` (provides
+    ``forward_sparse`` and ``forward_dense``, with ``forward`` derived from
+    them -- see ``MaglevSplitStage``, or
+    :class:`~torchrec.distributed.maglev.stage.SplitForwardMixin` to derive it
+    automatically). Falling back to a stage that lacks these methods raises
+    ``AttributeError`` on the first sparse call -- fail-fast, no partial
+    schedule execution.
+
+    Returns the per-microbatch losses observed on the last stage (empty on
+    other stages). Same gradient semantics as :func:`run_1f1b`: gradients
+    accumulate across microbatches, DP-averaged once, single optimizer step.
+    """
+    num_stages = pipeline.num_stages
+    num_micro = len(microbatch_inputs)
+    stage_index = pipeline.stage_index
+    num_warmup = min(num_stages - stage_index - 1, num_micro)
+    # prehoist floor is (stage_index + 1) so the first stages have a small
+    # initial burst (fast pipeline start); ceiling is (num_micro - num_warmup)
+    # so every dense in warmup pairs with a prefetched sparse (no tail-hoist
+    # block). For N <= num_stages the two are equal; for N > num_stages the
+    # burst grows so the trailing sparses become the ones interleaved with
+    # dense forwards.
+    prehoist = min(max(stage_index + 1, num_micro - num_warmup), num_micro)
+    num_steady = num_micro - num_warmup
+
+    def _label(idx: int) -> Optional[torch.Tensor]:
+        return labels[idx] if labels is not None else None
+
+    optimizer.zero_grad()
+    losses: List[float] = []
+
+    fwd_idx = 0
+
+    # Sparse hoist: front-load the `prehoist` sparses that will not be paired
+    # with a warmup dense. This is the visible cost of split-forward vs
+    # monolithic 1F1B -- profiler traces show it as its own span.
+    with record_function("## sparse_hoist ##"):
+        for j in range(prehoist):
+            pipeline.forward_sparse_micro(microbatch_inputs[j], j)
+
+    # Warmup: for each of `num_warmup` denses, run `D_j`, then prefetch the
+    # sparse that will be needed `prehoist` microbatches later. Symmetric with
+    # `steady`'s (dense, backward) interleave. By the end of warmup, all
+    # sparses have completed -- the first backward in steady can safely fire
+    # the fused TBE optimizer.
+    with record_function("## warmup ##"):
+        for j in range(num_warmup):
+            pipeline.forward_dense_micro(microbatch_inputs[j], _label(j), j)
+            fwd_idx += 1
+            next_s = j + prehoist
+            if next_s < num_micro:
+                pipeline.forward_sparse_micro(microbatch_inputs[next_s], next_s)
+        # Tail hoist: with the current `prehoist` formula
+        # `max(stage_index + 1, num_micro - num_warmup)`, `prehoist +
+        # num_warmup >= num_micro` always, so this loop body never runs. Kept
+        # as a safety net: if `prehoist` is ever tuned down (e.g. an opt-in
+        # smaller burst to speed up pipeline start), this catches the missing
+        # sparses so exactness cannot be silently broken.
+        done_sparse_count = min(prehoist + num_warmup, num_micro)
+        for j in range(done_sparse_count, num_micro):
+            pipeline.forward_sparse_micro(microbatch_inputs[j], j)
+
+    # Steady: 1F1B on the dense halves. All sparses are done; each dense pops
+    # its pre-computed pooled tensor from _pooled.
+    with record_function("## steady ##"):
+        for _ in range(num_steady):
+            pipeline.forward_dense_micro(
+                microbatch_inputs[fwd_idx], _label(fwd_idx), fwd_idx
+            )
+            fwd_idx += 1
+            loss = pipeline.backward_micro(criterion)
+            if loss is not None:
+                losses.append(loss.item())
+
+    with record_function("## cooldown ##"):
+        for _ in range(num_warmup):
+            loss = pipeline.backward_micro(criterion)
+            if loss is not None:
+                losses.append(loss.item())
+
+    assert not pipeline._pooled, (
+        f"run_1f1b_split: {len(pipeline._pooled)} pooled tensors undrained on "
+        f"stage {stage_index}: {sorted(pipeline._pooled)}"
+    )
+
+    with record_function("## wait_sends ##"):
+        pipeline.wait_sends()
+    with record_function("## reduce_gradients ##"):
+        pipeline.stage.reduce_gradients()
+    with record_function("## optimizer_step ##"):
+        optimizer.step()
     return losses

--- a/torchrec/distributed/maglev/stage.py
+++ b/torchrec/distributed/maglev/stage.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import abc
-from typing import Any, cast, List, Optional, Tuple
+from typing import Any, cast, List, Optional, Protocol, Tuple
 
 import torch
 import torch.distributed as dist
@@ -23,6 +23,77 @@ from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
 from torchrec.optim.optimizers import in_backward_optimizer_filter
+
+
+class MaglevStage(Protocol):
+    """Typing contract for stages that opt into the sparse/dense forward split.
+
+    Structural (a stage need not inherit from this Protocol -- only match the
+    three methods). Used by pyre and by the split-aware pipeline hooks to
+    require the two halves alongside the derived ``forward``.
+
+    Invariant: ``forward_sparse`` depends only on ``stage_input`` -- never on
+    the upstream activation, never on this stage's own dense compute. Splitting
+    the forward is only valid when the embedding lookup carries no dependence
+    on the pipeline carrier.
+    """
+
+    def forward_sparse(self, stage_input: Any) -> torch.Tensor:
+        """Everything reachable from ``stage_input`` alone.
+
+        Every embedding lookup in the stage, plus any compute downstream of it
+        that needs neither the dense features nor the upstream activation.
+        Drawing the cut as late as this contract allows is deliberate: whatever
+        sits above it can be hoisted into the activation-wait window, so a later
+        cut means more bubble filled. The tradeoff is memory -- the seam tensor
+        is retained per hoisted microbatch.
+
+        May issue intra-HSD collectives (the sharded lookup all-to-all under
+        :class:`EmbeddingShard`); it must not issue cross-stage comm. Callers
+        that hoist it out of program order therefore have to keep the hoist
+        count identical across a stage's DP ranks, or the all-to-alls mismatch.
+        """
+        ...
+
+    def forward_dense(
+        self,
+        stage_input: Any,
+        sparse_out: torch.Tensor,
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """The rest: anything needing the dense features or the upstream join."""
+        ...
+
+    def forward(
+        self,
+        stage_input: Any,
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Derived; equals ``forward_dense(inp, forward_sparse(inp), prev)``."""
+        ...
+
+
+class SplitForwardMixin:
+    """Derives ``forward`` from ``forward_sparse`` + ``forward_dense``.
+
+    Mix in FIRST so the derived forward wins the MRO over any base class's
+    ``forward`` (e.g. ``MaglevTestStage.forward``)::
+
+        class MyStage(SplitForwardMixin, MaglevTestStage):
+            def forward_sparse(self, stage_input): ...
+            def forward_dense(self, stage_input, sparse_out, prev_output): ...
+            # forward is auto-derived by the mixin
+    """
+
+    def forward(
+        self,
+        stage_input: Any,
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        # pyre-ignore[16]: subclasses provide forward_sparse.
+        sparse_out = self.forward_sparse(stage_input)
+        # pyre-ignore[16]: subclasses provide forward_dense.
+        return self.forward_dense(stage_input, sparse_out, prev_output)
 
 
 def build_stage_process_groups(
@@ -188,6 +259,16 @@ class StageParallelizer(abc.ABC):
         """Complete the once-per-step DP gradient reduction over ``stage_pg``."""
         ...
 
+    def unwrap(self, module: nn.Module) -> nn.Module:
+        """The stage module underneath any wrapper :meth:`parallelize` added.
+
+        Wrappers such as DMP proxy ``forward`` but not other methods, so callers
+        that need the sparse/dense halves must reach through. Overriding is only
+        necessary for a parallelizer that actually wraps; the default returns
+        ``module`` unchanged.
+        """
+        return module
+
 
 class Replicated(StageParallelizer):
     """Full replica per rank; grads are DP-averaged over the HSD.
@@ -310,6 +391,12 @@ class EmbeddingShard(StageParallelizer):
         # handled locally by the fused (in-backward) optimizer.
         _all_reduce_dense(self._dense_params, stage_pg)
 
+    def unwrap(self, module: nn.Module) -> nn.Module:
+        # DMP shards submodules in place, so the module underneath is the same
+        # sharded one ``forward`` runs -- it just also exposes non-``forward``
+        # methods, which DMP does not proxy.
+        return cast(DistributedModelParallel, module).module
+
 
 class StageWrapper(nn.Module):
     """Binds a Maglev stage module to its HSD process group via a parallelizer.
@@ -368,6 +455,32 @@ class StageWrapper(nn.Module):
             torch.Tensor: this stage's output activation.
         """
         return self.module(stage_input, prev_output)
+
+    def _split_stage(self) -> MaglevStage:
+        """The wrapped stage, reached through any parallel wrapper.
+
+        Not held as an attribute: assigning the pre-parallelize module to a
+        field would register it a second time in ``_modules``, and while
+        ``parameters()`` de-duplicates, ``state_dict()`` does not -- every
+        tensor would be emitted twice.
+        """
+        return cast(MaglevStage, self._parallelizer.unwrap(self.module))
+
+    def forward_sparse(self, stage_input: Any) -> torch.Tensor:
+        """Run only the stage's sparse half (embedding lookup).
+
+        Requires the wrapped module to implement :class:`MaglevStage`.
+        """
+        return self._split_stage().forward_sparse(stage_input)
+
+    def forward_dense(
+        self,
+        stage_input: Any,
+        sparse_out: torch.Tensor,
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Run only the stage's dense half. See :meth:`forward_sparse`."""
+        return self._split_stage().forward_dense(stage_input, sparse_out, prev_output)
 
     def configure_optimizer(self, lr: float) -> torch.optim.Optimizer:
         """Build the optimizer matching this stage's parallelizer."""

--- a/torchrec/distributed/maglev/tests/test_module.py
+++ b/torchrec/distributed/maglev/tests/test_module.py
@@ -8,20 +8,29 @@
 # pyre-strict
 
 import random
-from typing import List
+import unittest
+from typing import Any, Dict, List, Optional, Type
 
 import torch
 import torch.nn as nn
 from torchrec.distributed.maglev.module import MaglevModuleList
-from torchrec.distributed.maglev.pipeline import MaglevPipeline
-from torchrec.distributed.maglev.stage import build_stage_process_groups, StageWrapper
+from torchrec.distributed.maglev.pipeline import (
+    MaglevPipeline,
+    run_1f1b,
+    run_1f1b_split,
+)
+from torchrec.distributed.maglev.stage import (
+    build_handoff_process_groups,
+    build_stage_process_groups,
+    StageWrapper,
+)
 from torchrec.distributed.test_utils.model_input import ModelInput
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
 from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
-from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.distributed.test_utils.test_model import MaglevSplitStage, MaglevTestStage
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 _WEIGHT_SEED = 100
@@ -76,11 +85,12 @@ def _build_stage(
     num_float_features: int,
     stage_dim: int,
     device: torch.device,
+    stage_cls: Type[MaglevTestStage] = MaglevTestStage,
 ) -> MaglevTestStage:
     """Build a stage with deterministic weights (seeded by stage index)."""
     tables = _make_tables(stage_index, num_tables, num_embeddings, emb_dim)
     torch.manual_seed(_WEIGHT_SEED + stage_index)
-    return MaglevTestStage(
+    return stage_cls(
         tables=tables,
         stage_dim=stage_dim,
         is_first=(stage_index == 0),
@@ -199,6 +209,135 @@ def _run_correctness(
         assert checked > 0, "no parameters were checked"
 
 
+def _run_schedule_equivalence(
+    rank: int,
+    world_size: int,
+    num_stages: int,
+    ranks_per_stage: int,
+    batch_size: int,
+    num_tables: int,
+    num_embeddings: int,
+    emb_dim: int,
+    num_float_features: int,
+    stage_dim: int,
+    microbatch_counts: List[int],
+) -> None:
+    """``run_1f1b_split`` must be a pure reordering of ``run_1f1b``.
+
+    Under :class:`Replicated` there is no fused TBE, so embedding weights only
+    move at ``optimizer.step()`` -- which runs once, after every microbatch, in
+    both schedules. Hoisting the sparse forwards therefore cannot change any
+    number: the two arms must agree on the per-microbatch losses and on every
+    parameter after the step. Any drift means the schedule mis-pairs a
+    microbatch's sparse half with its dense half, its label, or its backward.
+
+    Both arms use ``MaglevSplitStage`` so the only variable is the schedule --
+    its derived ``forward`` is pinned against ``MaglevTestStage`` separately by
+    :class:`MaglevSplitStageEquivalenceTest`.
+    """
+    with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo"):
+        device = torch.device("cpu")
+        criterion = nn.MSELoss()
+
+        stage_ranks: List[List[int]] = [
+            list(range(s * ranks_per_stage, (s + 1) * ranks_per_stage))
+            for s in range(num_stages)
+        ]
+        # Built once and shared by every arm: ``new_group`` is collective, so
+        # rebuilding per arm would multiply the group count for no benefit.
+        stage_pgs = build_stage_process_groups(stage_ranks)
+        handoff_pgs = build_handoff_process_groups(stage_ranks)
+        my_stage_index = rank // ranks_per_stage
+
+        tables = _make_tables(my_stage_index, num_tables, num_embeddings, emb_dim)
+
+        for num_microbatches in microbatch_counts:
+            micro_inputs = [
+                _make_input(
+                    tables,
+                    batch_size,
+                    num_float_features,
+                    _INPUT_SEED + my_stage_index * 100 + m,
+                    device,
+                )
+                for m in range(num_microbatches)
+            ]
+            labels = []
+            for m in range(num_microbatches):
+                torch.manual_seed(_LABEL_SEED + m)
+                labels.append(torch.randn(batch_size, stage_dim, device=device))
+
+            arms: Dict[str, List[float]] = {}
+            params: Dict[str, Dict[str, torch.Tensor]] = {}
+            for name, run_fn in (("1f1b", run_1f1b), ("split", run_1f1b_split)):
+                stage = StageWrapper(
+                    module=_build_stage(
+                        my_stage_index,
+                        num_tables,
+                        num_embeddings,
+                        emb_dim,
+                        num_float_features,
+                        stage_dim,
+                        device,
+                        stage_cls=MaglevSplitStage,
+                    ),
+                    stage_pg=stage_pgs[my_stage_index],
+                    stage_index=my_stage_index,
+                )
+                pipeline = MaglevPipeline(
+                    stage=stage,
+                    stage_ranks=stage_ranks,
+                    global_rank=rank,
+                    activation_shape=torch.Size([batch_size, stage_dim]),
+                    device=device,
+                    handoff_pgs=handoff_pgs,
+                )
+                arms[name] = run_fn(
+                    pipeline=pipeline,
+                    microbatch_inputs=micro_inputs,
+                    optimizer=stage.configure_optimizer(lr=0.05),
+                    labels=labels if pipeline.is_last else None,
+                    criterion=criterion if pipeline.is_last else None,
+                )
+                params[name] = {
+                    k: v.detach().clone() for k, v in stage.named_parameters()
+                }
+
+            ctx = f"N={num_microbatches} stage={my_stage_index}"
+            assert len(arms["split"]) == len(arms["1f1b"]), (
+                f"{ctx}: loss count differs -- "
+                f"1f1b={len(arms['1f1b'])} split={len(arms['split'])}"
+            )
+            if pipeline.is_last:
+                assert len(arms["1f1b"]) == num_microbatches, (
+                    f"{ctx}: last stage returned {len(arms['1f1b'])} losses, "
+                    f"expected {num_microbatches}"
+                )
+            torch.testing.assert_close(
+                torch.tensor(arms["split"]),
+                torch.tensor(arms["1f1b"]),
+                msg=lambda m, c=ctx: f"{c}: per-microbatch losses diverge\n{m}",
+            )
+
+            assert params["split"].keys() == params["1f1b"].keys()
+            assert params["1f1b"], f"{ctx}: no parameters were compared"
+            for key in params["1f1b"]:
+                torch.testing.assert_close(
+                    params["split"][key],
+                    params["1f1b"][key],
+                    msg=lambda m, k=key, c=ctx: f"{c}: param {k} diverges\n{m}",
+                )
+
+            # The split path must reach the stage through the parallelizer
+            # rather than holding a second reference to it: a duplicate entry
+            # in ``_modules`` would emit every tensor twice here.
+            state_keys = list(stage.state_dict().keys())
+            assert len(state_keys) == len(set(state_keys)), (
+                f"{ctx}: duplicate state_dict keys: "
+                f"{sorted({k for k in state_keys if state_keys.count(k) > 1})}"
+            )
+
+
 class MaglevPipelineTest(MultiProcessTestBase):
     def test_pipeline_matches_single_process(self) -> None:
         self._run_multi_process_test(
@@ -213,3 +352,107 @@ class MaglevPipelineTest(MultiProcessTestBase):
             num_float_features=8,
             stage_dim=12,
         )
+
+    def test_split_schedule_matches_1f1b(self) -> None:
+        # 3 stages x 2 ranks: ranks_per_stage > 1 keeps the DP all-reduce in the
+        # path, and 3 stages gives a distinct (w, prehoist) per stage.
+        # microbatch_counts spans the three regimes of the prehoist formula
+        # ``min(max(i + 1, N - w), N)``: N < num_stages (floor dominates),
+        # N == num_stages, and N > num_stages (ceiling dominates).
+        self._run_multi_process_test(
+            callable=_run_schedule_equivalence,
+            world_size=6,
+            num_stages=3,
+            ranks_per_stage=2,
+            batch_size=16,
+            num_tables=6,
+            num_embeddings=64,
+            emb_dim=8,
+            num_float_features=8,
+            stage_dim=12,
+            microbatch_counts=[2, 3, 5],
+        )
+
+
+class MaglevSplitStageEquivalenceTest(unittest.TestCase):
+    """Pin the derivation ``forward == forward_dense o forward_sparse``.
+
+    Single-process, no distribution, no pipeline: seed a ``MaglevSplitStage``
+    and a ``MaglevTestStage`` identically and assert all three forward paths
+    produce the same output. This is the cheapest correctness gate for the
+    split-forward stack: it isolates the stage seam from the schedule, so a
+    failure here points at the stage rather than at ``run_1f1b_split``.
+
+    Runs against two stage shapes: the first stage (``is_first=True``, no
+    ``scaled_add``, ``prev_output is None``) and a middle stage
+    (``is_first=False``, exercises the residual join). Any regression that
+    breaks one of the two forms will fail the corresponding case.
+    """
+
+    def _run_equivalence(self, stage_index: int, is_first: bool) -> None:
+        num_tables = 4
+        num_embeddings = 64
+        emb_dim = 8
+        num_float_features = 8
+        stage_dim = 12
+        batch_size = 16
+        # CPU is enough -- this test verifies math, not device kernels. Keeps
+        # the test portable in the same spirit as ``_run_correctness``.
+        device = torch.device("cpu")
+
+        tables = _make_tables(stage_index, num_tables, num_embeddings, emb_dim)
+
+        torch.manual_seed(_WEIGHT_SEED + stage_index)
+        base_stage = MaglevTestStage(
+            tables=tables,
+            stage_dim=stage_dim,
+            is_first=is_first,
+            num_float_features=num_float_features,
+            device=device,
+        )
+        torch.manual_seed(_WEIGHT_SEED + stage_index)
+        split_stage = MaglevSplitStage(
+            tables=tables,
+            stage_dim=stage_dim,
+            is_first=is_first,
+            num_float_features=num_float_features,
+            device=device,
+        )
+
+        # ``_make_input`` returns ``test_utils.model_input.ModelInput``, but the
+        # stages type ``stage_input`` as ``test_utils.test_model.ModelInput`` (two
+        # separate classes with identical duck-typed shape). Cast to bridge the
+        # pyre gap; the runtime attributes ``idlist_features`` / ``float_features``
+        # are the same on both.
+        stage_input: Any = _make_input(
+            tables,
+            batch_size=batch_size,
+            num_float_features=num_float_features,
+            seed=_INPUT_SEED + stage_index,
+            device=device,
+        )
+        prev_output: Optional[torch.Tensor]
+        if is_first:
+            prev_output = None
+        else:
+            torch.manual_seed(_INPUT_SEED)
+            prev_output = torch.randn(batch_size, stage_dim, device=device)
+
+        base_out = base_stage.forward(stage_input, prev_output)
+        split_out_derived = split_stage.forward(stage_input, prev_output)
+        pooled = split_stage.forward_sparse(stage_input)
+        split_out_manual = split_stage.forward_dense(stage_input, pooled, prev_output)
+
+        # Base and derived forward must agree (weights seeded identically).
+        torch.testing.assert_close(split_out_derived, base_out)
+        # Explicitly-composed halves must match the derived forward -- the
+        # invariant the pipeline split relies on.
+        torch.testing.assert_close(split_out_manual, base_out)
+
+    def test_first_stage_equivalence(self) -> None:
+        # is_first=True: no scaled_add submodule; prev_output=None.
+        self._run_equivalence(stage_index=0, is_first=True)
+
+    def test_middle_stage_equivalence(self) -> None:
+        # is_first=False: exercises the residual join (scaled_add).
+        self._run_equivalence(stage_index=1, is_first=False)

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -3242,3 +3242,66 @@ class MaglevTestStage(nn.Module):
             assert prev_output is not None and self.scaled_add is not None
             x = self.scaled_add(prev_output, x)
         return torch.relu(self.block(x))
+
+
+class MaglevSplitStage(MaglevTestStage):
+    """:class:`MaglevTestStage` with the sparse/dense forward split exposed.
+
+    Inherits all submodules (``ebc``, ``input_proj``, ``dense``, ``scaled_add``,
+    ``block``) from :class:`MaglevTestStage`; the split methods carve which
+    submodules run in which schedule phase. Parameters and state are shared.
+
+    ``forward`` is overridden to compose the two halves, so this class works
+    both under a monolithic pipeline path (calls ``forward``) and a split path
+    (calls the two halves). Structurally this satisfies
+    ``torchrec.distributed.maglev.stage.MaglevStage``; the protocol is not
+    imported here so that this module stays free of a maglev dependency.
+
+    Contract: ``forward_sparse`` reads only ``stage_input`` -- never
+    ``prev_output``. If a stage's embedding lookup ever depends on the upstream
+    carrier, this split is invalid.
+
+    The cut is placed **right after** ``ebc``. The ``MaglevStage`` protocol
+    permits pushing it later (e.g. through ``input_proj``, which also depends
+    only on ``stage_input``), which does hoist more work into the
+    activation-wait window and moves the mirror ``input_proj`` gradient GEMM
+    off the latency-critical ``I`` phase on the backward -- worth ~5pp of QPS
+    on this synthetic bench. We keep the tight boundary because the priority
+    here is that *what the schedule does* is easy to describe (`sparse` = the
+    embedding lookup, full stop), and prod stages will need to draw the line
+    on their own dependency structure anyway.
+    """
+
+    def forward(
+        self,
+        stage_input: "ModelInput",
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Derived; equals ``forward_dense(inp, forward_sparse(inp), prev)``."""
+        return self.forward_dense(
+            stage_input, self.forward_sparse(stage_input), prev_output
+        )
+
+    def forward_sparse(
+        self,
+        stage_input: "ModelInput",
+    ) -> torch.Tensor:
+        """The embedding lookup, and nothing else."""
+        kjt = stage_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
+        return self.ebc(kjt).values()  # (B, in_dim)
+
+    def forward_dense(
+        self,
+        stage_input: "ModelInput",
+        sparse_out: torch.Tensor,
+        prev_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Everything else: projection, dense features, upstream join, MLP."""
+        x = self.input_proj(sparse_out)  # (B, stage_dim)
+        if self.dense is not None:
+            x = x + self.dense(stage_input.float_features)
+        if not self.is_first:
+            assert prev_output is not None and self.scaled_add is not None
+            x = self.scaled_add(prev_output, x)
+        return torch.relu(self.block(x))


### PR DESCRIPTION
Summary:
Splits a Maglev stage's forward into a sparse half (embedding lookup) and a
dense half, and adds a 1F1B variant that hoists every microbatch's sparse
forward into the activation-wait bubble on non-first stages.

Measured on 4 stages x 2 ranks x 8 microbatches: critical-path (stage 0)
recv bubble **-16.9%**, QPS **+4.4%**. Bubble reduction reaches -61.8%
on the deepest stage (see per-stage breakdown below).

## Motivation: fill the activation-wait bubble

{F1994452898} 

A non-first stage cannot start microbatch `j` until the upstream activation
arrives, so it sits blocked in `recv_act` with nothing to do. That is the
activation bubble, and it is worst on early stages during warmup, when the
pipeline has not yet filled. Measured on the traces below (time the GPU
spent in a blocking NCCL recv kernel, on the critical-path rank stage 0):

| | wall p50 | s0 recv bubble | ratio |
|---|---|---|---|
| `run_1f1b` | 362.5 ms | 126.3 ms | 34.8% |

A stage's embedding lookup does not depend on that upstream activation. It
reads only ``stage_input`` (its own feature partition), so it is work already
in hand while the carrier is still in flight -- but monolithic 1F1B cannot
issue it, because the lookup is welded into the same ``forward`` call as the
dense compute that *does* need the activation.

Splitting at that dependency boundary makes the sparse half schedulable
independently. `run_1f1b_split` hoists it into the blocked window: an initial
burst of `prehoist` sparses, then one trailing sparse prefetched after each
warmup dense, so every dense in warmup is still adjacent to a sparse.

## The seam is a *dependency* boundary, not a "sparse ops vs dense ops" one

The contract on `MaglevStage.forward_sparse` is broad: *"everything reachable
from `stage_input` alone."* Anything that reads only `stage_input` and
nothing else -- the embedding lookup itself and any compute strictly
downstream of it -- can legally live above the seam and be hoisted.

**`MaglevSplitStage` implements it tightly.** In the reference stage,
`forward_sparse` is exactly the embedding lookup: ``self.ebc(kjt).values()``.
Everything else -- the input projection, dense features, the residual join
with the upstream carrier, the MLP block -- lives in `forward_dense`. The
protocol permits a looser draw (e.g. `input_proj` also reads only
`stage_input` and would legally sit above the seam, hoisting ~22 ms/rank of
extra work into the activation window on this bench) but the tight draw is
the one this diff ships. Two reasons:

* **What the schedule does is easy to describe.** `sparse` = the embedding
  lookup, full stop. No "except this one dense op, which happens to be
  hoistable at this configuration." A prod stage will need to draw the line
  on its own dependency structure anyway; a tight reference boundary makes
  the property being tested clearer.
* **Correctness gate is easy to write.** `test_split_schedule_matches_1f1b`
  pins the split against `run_1f1b` bit-for-bit; a stricter split has fewer
  places to hide a bug.

The QPS cost of tightening: `split` at +4.4% instead of +9.6% with the
looser boundary on this bench. Not worth trading the design clarity for.

## What this adds

`stage.py`:

- `MaglevStage` -- structural typing contract (Protocol), three methods
  (`forward_sparse`, `forward_dense`, `forward`). `StageWrapper` casts to it,
  so the contract is load-bearing rather than documentary (no `pyre-ignore`
  on the split call sites).
- `SplitForwardMixin` -- derives `forward` as
  `forward_dense(inp, forward_sparse(inp), prev)` for stages that want it
  supplied automatically. Mix in FIRST so the derived form wins the MRO over
  any base class's `forward`.
- `StageParallelizer.unwrap(module)` -- new **concrete** method (not
  abstract, so existing parallelizers outside this file keep working).
  Default returns `module` unchanged; `EmbeddingShard` overrides to return
  `dmp.module`. This is how the split halves reach through a DMP wrapper.
- `StageWrapper.forward_sparse` / `forward_dense` -- thin delegations via
  `self._parallelizer.unwrap(self.module)`.

`test_utils/test_model.py`:

- `MaglevSplitStage` -- `MaglevTestStage` subclass implementing the split.
  Reuses every base submodule. `forward_sparse` returns the embedding
  lookup; `forward_dense` does projection, dense features, upstream join,
  and MLP. `forward` is spelled out inline so `test_model` stays free of any
  maglev import.

`pipeline.py`:

- `MaglevPipeline._pooled` -- per-microbatch cache holding the sparse-half
  output between `forward_sparse_micro` and the matching
  `forward_dense_micro`. Popped by dense; asserted empty at the end of
  `run_1f1b_split`, so a leaked entry fails loudly on the iteration that
  leaked it.
- `forward_sparse_micro(stage_input, mb_id)` -- calls `stage.forward_sparse`,
  stashes to `_pooled[mb_id]`. No **cross-stage** comm: the sparse half
  depends only on `stage_input` per the `MaglevStage` contract. It does
  still issue the intra-HSD lookup all-to-all under `EmbeddingShard`, so
  hoisting it out of program order requires the hoist count to be identical
  across a stage's DP ranks -- it is, because `prehoist` is a function of
  `stage_index` and `N` only.
- `forward_dense_micro(stage_input, label, mb_id)` -- mirrors `forward_micro`
  (recv / send / `_pending` identical), substituting
  `stage.forward_dense(stage_input, sparse_out, prev)` for the 1F1B
  `stage(...)`. Raises a descriptive `RuntimeError` if the cached entry is
  missing.
- `run_1f1b_split(pipeline, inputs, opt, labels, criterion)` -- the schedule::

      sparse_hoist: S for j in [0, prehoist)
      warmup:       for j in [0, w):     D_j, then S_{j+prehoist}
      steady:       for _ in [0, N-w):   D, B
      cooldown:     for _ in [0, w):     B

  where ``w = min(num_stages - stage_index - 1, N)`` and
  ``prehoist = min(max(stage_index + 1, N - w), N)``. The formula's floor
  keeps early stages' initial burst small (fast pipeline start); the ceiling
  grows the burst when `N > num_stages` so every dense in warmup has a
  trailing sparse to pair with (no separate tail-hoist block). For
  `N <= num_stages` the floor dominates and the two are equal.

  Same gradient semantics as `run_1f1b`: grads accumulate across
  microbatches, DP-averaged once, single optimizer step.

- `__init__.py` -- exports `run_1f1b_split`, `MaglevStage`, `SplitForwardMixin`.

`step()`, `forward_micro`, `backward_micro` and `run_1f1b` are untouched;
the `_pending` FIFO is reused unchanged by the split path.

## Benchmark changes (`benchmark_maglev.py`)

- `--schedule={1f1b,split}` selects the arm; `split` also swaps the stage
  class to `MaglevSplitStage`.
- `run_maglev` reports the **slowest** rank rather than rank 0, and forwards
  `wall_elapsed_time`.
- `_func_to_benchmark` ends with `torch.cuda.synchronize(device)` on CUDA.
  Without it the harness timestamps wall clock without syncing, measuring
  host *issue* time rather than execution -- the split schedule stops
  blocking the host earlier than 1f1b and the unsynced measurement credits
  it with a phantom ~4x QPS win. With the sync the real figure is +4.4%.

## Measured (`full`, 4 stages x 2 ranks x 8 microbatches, 8x H100)

30 timed iterations plus 1 profiled, both arms in the same session.
Per-rank medians agree to 0.4 ms in both arms.

| arm | wall p50 | QPS p50 | vs `1f1b` | peak reserved |
|---|---|---|---|---|
| `run_1f1b` | 362.5 ms | 180,869 | -- | 16,016 MB |
| `run_1f1b_split` | 347.1 ms | 188,861 | **+4.4%** | 17,586 MB (+9.8%) |

## Bubble breakdown (from the traces linked below)

Bubble = time the GPU spends inside a blocking NCCL recv kernel, waiting
on data from an adjacent stage. Send-side kernels run async on the comm
stream and don't stall compute, so they are not counted.

Measured on **stage 0** (the critical-path rank whose wall clock determines
QPS):

| | wall p50 | s0 recv bubble | **bubble reduction** | bubble / wall |
|---|---|---|---|---|
| `1f1b` | 362.5 ms | 126.3 ms | -- | 34.8% |
| `split` | 347.1 ms | 104.9 ms | **-16.9%** | 30.2% |

`split` doesn't touch the backward, so stage 0's own `recv_grad` wait is
reduced entirely as a second-order effect: downstream stages finish their
forwards earlier (their `recv_act` bubble is now filled with hoisted sparse
work), so their `dX` sends arrive at stage 0 sooner.

Per stage, recv time summed over both ranks (shows where the direct hoist
lands):

| stage | 1f1b recv | split recv | reduction |
|---|---|---|---|
| 0 | 252.6 ms | 209.8 ms | -16.9% |
| 1 | 181.9 ms | 138.9 ms | -23.7% |
| 2 | 140.9 ms | 100.4 ms | -28.8% |
| 3 | 89.5 ms | **34.2 ms** | **-61.8%** |

Non-first stages are where the sparse hoist directly fills bubble: their
`recv_act` wait is what the hoist is designed to occupy. The reduction
grows with the depth of the stage because deeper stages spend longer in
warmup wait, giving the hoist more of a window to fill (stage 3 at
`w=0` starts drained and its full warmup is bubble). Stage 0 sees no
`recv_act` (no upstream) so its reduction is entirely the second-order
`recv_grad` effect above.

## Traces

All 16 traces uploaded to Manifold under `tree/permanent_traces/DIFF/D115662734/d4_<arm>/`.
Every rank of every arm is linked below. Perfetto opens in-browser; Perf
Doctor gives the Meta-internal view with kernel-level annotations.

### Perfetto

| arm | folder | per-rank |
|---|---|---|
| `1f1b` | [folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D115662734/d4_1f1b) | [r0](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [r2](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [r3](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [r4](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [r5](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [**r6**](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [r7](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |
| `split` | [folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D115662734/d4_split) | [**r0**](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [r2](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [r3](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [r4](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [r5](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [r6](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [r7](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |

Bold indicates the critical-path rank (slowest median wall). Stage layout:
stage 0 = ranks 0,1 · stage 1 = ranks 2,3 · stage 2 = ranks 4,5 · stage 3 = ranks 6,7.

### Perf Doctor

| arm | per-rank |
|---|---|
| `1f1b` | [r0](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [r2](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [r3](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [r4](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [r5](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [r6](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [r7](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_1f1b/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |
| `split` | [r0](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank0.json.gz&bucket=torchrec_benchmark_traces) · [r1](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank1.json.gz&bucket=torchrec_benchmark_traces) · [r2](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank2.json.gz&bucket=torchrec_benchmark_traces) · [r3](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank3.json.gz&bucket=torchrec_benchmark_traces) · [r4](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank4.json.gz&bucket=torchrec_benchmark_traces) · [r5](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank5.json.gz&bucket=torchrec_benchmark_traces) · [r6](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank6.json.gz&bucket=torchrec_benchmark_traces) · [r7](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D115662734/d4_split/trace-maglev-rank7.json.gz&bucket=torchrec_benchmark_traces) |

## Known gaps

- **Peak reserved rises 9.8%** -- pooled sparse outputs for up to `prehoist`
  microbatches are live simultaneously. Scales with `prehoist`, so configs
  with `N >> num_stages` pay more.
- **Equivalence is unit-tested, throughput is not.** The distributed test
  pins `run_1f1b_split` bit-for-bit against `run_1f1b` (identical losses,
  identical post-step parameters) on CPU/gloo under `Replicated`. The
  bubble/QPS numbers rest on the benchmark above and are not part of CI.
- **Measured on one config**, at `num_microbatches == 2 * num_stages` (the
  ceiling regime of the `prehoist` formula). The floor regime
  (`N <= num_stages`) is unit-tested for correctness but not benchmarked.

Differential Revision: D115662734


