### PR TITLE
MLPerf DLRM-v2 train-perf benchmark on torch_tpu (#4587)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -4801,3 +4801,136 @@ class BatchedTPUEmbedding(BaseBatchedEmbedding[torch.Tensor]):
                 self._emb_modules[self._feature_table_map[feature_idx]](feature_values)
             )
         return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+
+
+class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
+    """Pooled TPU compute kernel (`UNFUSED_TPU`).
+
+    Pooled sibling of `BatchedTPUEmbedding`, and a drop-in alongside
+    `BatchedDenseEmbeddingBag` in the pooled dispatch
+    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`). Backs the lookup with one
+    `TPUEmbeddingUnfused` table per table in the group; `forward` routes each feature to
+    its table, gathers its ids, and pools per sample (SUM or MEAN per `config.pooling`).
+
+    Pooling is done in torch (scatter-add over per-id sample indices) on top of the
+    unfused gather, so no dedicated pooled kernel is required and the backward flows
+    through the gather op's autograd.
+
+    Args:
+        config (GroupedEmbeddingConfig): grouped table config (one or more tables).
+        pg (Optional[dist.ProcessGroup]): process group (unused locally).
+        device (Optional[torch.device]): compute device (e.g. ``"tpu"``).
+        sharding_type (Optional[ShardingType]): sharding type (for the pooling mode).
+
+    Example::
+
+        kernel = BatchedTPUEmbeddingBag(grouped_config, device="tpu")
+        out = kernel(features)  # [batch, sum(embedding_dim over features)]
+    """
+
+    def __init__(
+        self,
+        config: GroupedEmbeddingConfig,
+        pg: Optional[dist.ProcessGroup] = None,
+        device: Optional[torch.device] = None,
+        sharding_type: Optional[ShardingType] = None,
+    ) -> None:
+        super().__init__(config, pg, device, sharding_type)
+        # Lazy import to avoid pulling in experimental TPU code at module load time.
+        from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+            TPUEmbeddingUnfused,
+        )
+
+        dtype = data_type_to_sparse_type(config.data_type).as_dtype()
+        # One TPUEmbeddingUnfused per table in the group (mirrors BatchedTPUEmbedding);
+        # the base class fills _local_rows / _local_cols / _feature_table_map.
+        self._emb_modules: nn.ModuleList = nn.ModuleList()
+        for local_rows, local_cols in zip(self._local_rows, self._local_cols):
+            self._emb_modules.append(
+                TPUEmbeddingUnfused(
+                    num_embeddings=local_rows,
+                    embedding_dim=local_cols,
+                    device=device,
+                    dtype=dtype,
+                )
+            )
+        self.init_parameters()
+
+    @property
+    # pyrefly: ignore [bad-override]  # TPUEmbeddingUnfused is not one of the
+    # fbgemm codegen types the base class enumerates (same as the Triton kernel).
+    def emb_module(self) -> "TPUEmbeddingUnfused":  # noqa: F821
+        # pyre-ignore[16]: ModuleList returns Module, pyre thinks Union
+        return self._emb_modules[0]
+
+    def split_embedding_weights(self) -> List[torch.Tensor]:
+        # pyre-ignore[16]
+        return [emb_module.weight for emb_module in self._emb_modules]
+
+    def named_split_embedding_weights(
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        assert (
+            remove_duplicate
+        ), "remove_duplicate=False not supported in named_split_embedding_weights"
+        for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
+            # pyre-ignore[16]
+            yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
+
+    def named_parameters(
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ) -> Iterator[Tuple[str, nn.Parameter]]:
+        for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
+            # pyre-ignore[7]
+            yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
+
+    def _pool(
+        self, gathered: torch.Tensor, lengths: torch.Tensor, batch_size: int
+    ) -> torch.Tensor:
+        """Pool a feature's per-id embeddings [L, dim] into [batch, dim].
+
+        Sum-pool by scatter-adding each id's row into its sample slot; MEAN divides by
+        the bag length. `lengths` are this feature's per-sample bag sizes (may be jagged
+        after the row-wise all2all), summing to L. Uses only arange / repeat_interleave /
+        index_add_ / div, so it lowers on TPU without a bespoke pooled kernel.
+        """
+        dim = gathered.shape[1]
+        device = gathered.device
+        pooled = torch.zeros(batch_size, dim, dtype=gathered.dtype, device=device)
+        # sample index for each gathered row: sample b repeated lengths[b] times.
+        sample_idx = torch.repeat_interleave(
+            torch.arange(batch_size, device=device), lengths
+        )
+        pooled.index_add_(0, sample_idx, gathered)
+        if self._pooling == PoolingMode.MEAN:
+            denom = lengths.clamp(min=1).unsqueeze(1).to(pooled.dtype)
+            pooled = pooled / denom
+        return pooled
+
+    # pyrefly: ignore [bad-override]  # same signature shape as the sequence kernel
+    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
+        batch_size = features.stride()
+        length_per_key = features.length_per_key()
+        # KJT lengths are feature-major: feature i's per-sample bag sizes are the
+        # i-th block of batch_size entries.
+        all_lengths = features.lengths()
+        per_feature_values = (
+            torch.split(features.values(), length_per_key)
+            if len(length_per_key) > 1
+            else [features.values()]
+        )
+        outputs: List[torch.Tensor] = []
+        for feature_idx, feature_values in enumerate(per_feature_values):
+            emb_module = self._emb_modules[self._feature_table_map[feature_idx]]
+            # pyre-ignore[9, 16]: ModuleList returns Module, pyre thinks Union;
+            # the table's `weight` is a Tensor so `.device` is a torch.device.
+            device: torch.device = emb_module.weight.device
+            gathered = emb_module(
+                feature_values.to(device=device, dtype=torch.int32)
+            )  # [L_i, dim]
+            lengths_i = all_lengths[
+                feature_idx * batch_size : (feature_idx + 1) * batch_size
+            ].to(device)
+            outputs.append(self._pool(gathered, lengths_i, batch_size))
+        # Pooled features concatenate along the embedding dim -> [batch, sum(dim)].
+        return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=1)

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -49,6 +49,7 @@ from torchrec.distributed.batched_embedding_kernel import (
     BatchedFusedEmbedding,
     BatchedFusedEmbeddingBag,
     BatchedTPUEmbedding,
+    BatchedTPUEmbeddingBag,
     KeyValueEmbedding,
     KeyValueEmbeddingBag,
     ShardedBatchedFusedEmbedding,
@@ -730,6 +731,13 @@ class GroupedPooledEmbeddingsLookup(
                 config=config,
                 pg=pg,
                 device=device,
+            )
+        elif config.compute_kernel == EmbeddingComputeKernel.UNFUSED_TPU:
+            return BatchedTPUEmbeddingBag(
+                config=config,
+                pg=pg,
+                device=device,
+                sharding_type=sharding_type,
             )
         elif config.compute_kernel in {
             EmbeddingComputeKernel.KEY_VALUE,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1381,6 +1381,15 @@ class ShardedEmbeddingBagCollection(
                                 self._table_name_to_config[table_name].data_type
                             )
                         ),
+                        # Set grad-ness so ShardedTensor init does not reject an
+                        # unfused (autograd-trained) kernel whose shard is a
+                        # grad-requiring nn.Parameter.
+                        requires_grad=(
+                            _model_parallel_name_to_compute_kernel[table_name]
+                            in {
+                                EmbeddingComputeKernel.UNFUSED_TPU.value,
+                            }
+                        ),
                     )
 
                     sharded_tensor_metadata = sharding_spec.build_metadata(

--- a/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
@@ -17,6 +17,8 @@ import time
 from typing import List
 
 import torch
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
 from torch_tpu._internal import profiler, sync
 from torchrec.distributed.batched_embedding_kernel import BatchedTPUEmbedding
 from torchrec.distributed.embedding_types import (
@@ -135,6 +137,7 @@ def main() -> None:
     # Copy weights from reference into the TPU tables so outputs are comparable.
     # split_embedding_weights() returns one weight per table, in table order.
     for weight, config in zip(tpu_kernel.split_embedding_weights(), embedding_configs):
+        # pyre-ignore[6]: EmbeddingCollection.embeddings is a ModuleDict, so indexing it types as Module.
         weight.data.copy_(ref_module.embeddings[config.name].weight.data)
 
     # --- Accuracy test: compare outputs across different batch sizes ---
@@ -153,6 +156,7 @@ def main() -> None:
         )
         # CPU embedding needs int64 on torch 2.13
         kjt = model_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
         # Convert to int32/TPU outside the forward, before ref_module caches a CPU _jt_dict on kjt.
         kjt_tpu = KeyedJaggedTensor(
             keys=kjt.keys(),
@@ -180,6 +184,7 @@ def main() -> None:
         print("\nTRACE_DIR unset, skipping the profiled step")
     else:
         print(f"Profiler Start, traces printed to {traces_dir}")
+        tpu_output: torch.Tensor | None = None
         with profiler.profile(
             activities=[
                 profiler.ProfilerActivity.CPU,
@@ -199,6 +204,7 @@ def main() -> None:
                 )
                 # CPU embedding needs int64
                 kjt = model_input.idlist_features
+                assert isinstance(kjt, KeyedJaggedTensor)
 
                 # Convert to int32/TPU outside the forward.
                 kjt_tpu = KeyedJaggedTensor(
@@ -208,6 +214,9 @@ def main() -> None:
                 )
                 tpu_output = tpu_kernel(kjt_tpu)
 
+        assert (
+            tpu_output is not None
+        ), "profiled step never ran; PROFILE_NUMBER_TIMES must be > 0"
         print("Profiled TPU output shape:", tuple(tpu_output.shape))
 
     # --- Benchmark here -------
@@ -243,6 +252,7 @@ def main() -> None:
         )
         # CPU embedding needs int64
         kjt = model_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
         # Convert to int32/TPU
         kjt_tpu = KeyedJaggedTensor(
             keys=kjt.keys(),
@@ -267,6 +277,7 @@ def main() -> None:
             )
             # CPU embedding needs int64
             kjt = model_input.idlist_features
+            assert isinstance(kjt, KeyedJaggedTensor)
             # Convert to int32/TPU
             kjt_tpu = KeyedJaggedTensor(
                 keys=kjt.keys(),

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Steady-state training-throughput benchmark for the MLPerf DLRM-v2 model on the
+torch_tpu stack (torch side only -- no JAX).
+
+Same model as the reference JAX MLPerf DLRM benchmark: torchrec `DLRM_DCN`
+(DCNv2 cross net) over a multi-hot `EmbeddingBagCollection` (pool sum = 214),
+embedding_dim 128, dense arch [512,256,128], over arch [1024,1024,512,256,1],
+per-element Adagrad. Cardinalities are the MLPerf-v2 `shrunk` (sum 30M, any
+value >4M capped at 4M) or `canonical` (sum 228M) sets, selectable via
+--cardinality. This is the third comparison point for the GPU<->TPU per-chip
+gap-closure work: B200 GPU (MAST) vs v7x jte (JAX) vs **v7x torch_tpu (here)**.
+
+The embeddings are ROW_WISE-sharded on the `UNFUSED_TPU` compute kernel under
+`DistributedModelParallel` over the `tpu_dist` backend; the dense DCN/MLP path
+runs on TPU via torch_tpu. Reports steady-state ms/step and K samples/s/chip
+(per_chip_batch / step_time), the same metric as
+`mlperf_dlrm_tpu/EXPERIMENT_LOG.md`.
+
+NOTE (faithful-model caveat): the full MLPerf model uses POOLED, MULTI-HOT
+embeddings, which produce an UNEVEN row-wise all2all. The torch_tpu RW path was
+first brought up for `EmbeddingCollection`, 1-hot, EVEN splits only (see
+`dlrm_bench_rw_tpu.py`). Running this faithful config may require torch_tpu
+support for pooled multi-hot / uneven all2all that is still landing; that is an
+intentional choice (measure the real model, surface the gap).
+
+Run on the TPU pod via run_pod.sh (pushes torchrec, launches via run_dist_file.sh):
+
+    ./run_pod.sh run train_dlrm_mlperf_tpu.py --cardinality shrunk --steps 50
+    ./run_pod.sh run train_dlrm_mlperf_tpu.py --cardinality canonical
+"""
+
+import argparse
+import logging
+import time
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+import torch_tpu  # noqa: F401  (registers the "tpu" device + "tpu_dist" backend)
+from torch import nn
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.sharding_plan import construct_module_sharding_plan, row_wise
+from torchrec.distributed.types import ShardingEnv, ShardingPlan
+from torchrec.models.dlrm import DLRM_DCN
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+# ── MLPerf DLRM-v2 config (matches the reference JAX benchmark) ───────────────
+EMBEDDING_DIM = 128
+NUM_DENSE = 13
+NUM_SPARSE = 26
+DENSE_ARCH_LAYER_SIZES = [512, 256, 128]  # last must == EMBEDDING_DIM
+OVER_ARCH_LAYER_SIZES = [1024, 1024, 512, 256, 1]
+DCN_NUM_LAYERS = 3
+DCN_LOW_RANK_DIM = 512
+LR = 0.01
+DENSE_DTYPE: torch.dtype = torch.float32
+
+# Multi-hot pool sizes per feature (sum = 214). MLPerf-v2 `_MHS`.
+MULTI_HOT_SIZES = [
+    3,
+    2,
+    1,
+    2,
+    6,
+    1,
+    1,
+    1,
+    1,
+    7,
+    3,
+    8,
+    1,
+    6,
+    9,
+    5,
+    1,
+    1,
+    1,
+    12,
+    100,
+    27,
+    10,
+    3,
+    1,
+    1,
+]
+
+# Shrunk Criteo cardinalities (any value >4M capped at 4M). Sum 30M.
+NEPF_SHRUNK = [
+    4000000,
+    4000000,
+    17295,
+    7424,
+    20265,
+    3,
+    7122,
+    1543,
+    63,
+    4000000,
+    3067956,
+    405282,
+    10,
+    2209,
+    11938,
+    155,
+    4,
+    976,
+    14,
+    4000000,
+    4000000,
+    4000000,
+    585935,
+    12972,
+    108,
+    36,
+]
+# Canonical MLPerf-v2 cardinalities. Sum 228,487,552.
+NEPF_CANONICAL = [
+    40000000,
+    39060192,
+    17295,
+    7424,
+    20265,
+    3,
+    7122,
+    1543,
+    63,
+    40000000,
+    3067956,
+    405282,
+    10,
+    2209,
+    11938,
+    155,
+    4,
+    976,
+    14,
+    39979771,
+    25641295,
+    39664984,
+    585935,
+    12972,
+    108,
+    36,
+]
+
+
+# torch_tpu materialization (force lazy ops to execute, optionally blocking) --
+# same primitive dlrm_bench_rw_tpu.py uses to make wall-clock timing meaningful.
+try:
+    from torch_tpu._internal import sync as _tpu_sync  # type: ignore[import-not-found]
+
+    def _materialize(tensor: torch.Tensor | None = None) -> None:
+        if tensor is None:
+            _tpu_sync.synchronize(wait=True)
+        else:
+            _tpu_sync.synchronize(tensor, wait=True)
+
+except Exception:  # noqa: BLE001
+    # Warn loudly: this is a timing harness, so a silent fallback risks publishing
+    # numbers that only measure dispatch. The fallback below still blocks, but say so.
+    logging.warning(
+        "torch_tpu._internal.sync unavailable; falling back to torch.tpu.synchronize() "
+        "for step-boundary flushes. Verify reported ms/step before trusting it."
+    )
+
+    def _materialize(tensor: torch.Tensor | None = None) -> None:
+        # Must still FLUSH on the no-tensor call: run_step()/warmup call _materialize()
+        # with no argument purely to drain pending TPU work before the clock is read,
+        # so a no-op here would silently report meaningless step times.
+        if tensor is None:
+            # pyre-ignore[16]: torch.tpu is registered at runtime by torch_tpu, which
+            # is a pod-only dependency and so is invisible to the type checker.
+            torch.tpu.synchronize()
+        else:
+            tensor.detach().to("cpu")
+
+
+def _round_up_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _build_tables(nepf: list[int], world_size: int) -> list[EmbeddingBagConfig]:
+    """One EmbeddingBagConfig per sparse feature. num_embeddings is rounded up to a
+    multiple of world_size so the RW shards are even-sized."""
+    tables = []
+    for i, rows in enumerate(nepf):
+        padded = _round_up_div(rows, world_size) * world_size
+        tables.append(
+            EmbeddingBagConfig(
+                name=f"table{i}",
+                embedding_dim=EMBEDDING_DIM,
+                num_embeddings=padded,
+                feature_names=[f"feature{i}"],
+            )
+        )
+    return tables
+
+
+def _build_sharded(
+    tables: list[EmbeddingBagConfig],
+    device: torch.device,
+    pg: dist.ProcessGroup,
+    world_size: int,
+    dcn_num_layers: int,
+    dcn_low_rank_dim: int,
+) -> nn.Module:
+    """Faithful MLPerf DLRM_DCN with a RW / UNFUSED_TPU EmbeddingBagCollection under DMP."""
+    ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
+    model = DLRM_DCN(
+        embedding_bag_collection=ebc,
+        dense_in_features=NUM_DENSE,
+        dense_arch_layer_sizes=DENSE_ARCH_LAYER_SIZES,
+        over_arch_layer_sizes=OVER_ARCH_LAYER_SIZES,
+        dcn_num_layers=dcn_num_layers,
+        dcn_low_rank_dim=dcn_low_rank_dim,
+        dense_device=device,
+    )
+    plan = ShardingPlan(
+        {
+            # fqn of the EBC inside DLRM_DCN: sparse_arch.embedding_bag_collection
+            "sparse_arch.embedding_bag_collection": construct_module_sharding_plan(
+                model.sparse_arch.embedding_bag_collection,
+                per_param_sharding={
+                    t.name: row_wise(
+                        compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU.value
+                    )
+                    for t in tables
+                },
+                # pyre-ignore[6]: ModuleSharder is invariant; the EBC sharder is
+                # the correct sharder for this module type.
+                sharder=EmbeddingBagCollectionSharder(),
+                local_size=1,
+                world_size=world_size,
+                device_type="tpu",
+            )
+        }
+    )
+    return DistributedModelParallel(
+        module=model,
+        env=ShardingEnv.from_process_group(pg),
+        device=device,
+        plan=plan,
+        # pyre-ignore[6]: see note above on ModuleSharder invariance.
+        sharders=[EmbeddingBagCollectionSharder()],
+    )
+
+
+def make_multihot_kjt(
+    features: list[str],
+    nepf: list[int],
+    per_chip_batch: int,
+    generator: torch.Generator,
+) -> KeyedJaggedTensor:
+    """A realistic multi-hot KJT: feature i has MULTI_HOT_SIZES[i] random ids per sample.
+
+    Values span each table's full cardinality, so the RW bucketize routes them across
+    all ranks (an UNEVEN all2all -- the faithful MLPerf regime). Values vary per call
+    (seed per step) so the looked-up rows change every step.
+
+    Citrine C3 exception (deliberate): these ids are built on CPU and moved to the TPU by
+    the caller, rather than created directly on device. `generator` is a CPU
+    `torch.Generator` -- passing it to a device-side `torch.randint` is not allowed, and
+    the per-step reseeding is what makes each step look up different rows. This also
+    mirrors a real input pipeline, where sparse ids arrive from the host. The resulting
+    host->device copy is done OUTSIDE the timed region in `run_step` (before `t0`), so it
+    does not inflate the reported ms/step.
+    """
+    values_list: list[torch.Tensor] = []
+    lengths_list: list[torch.Tensor] = []
+    for i in range(len(features)):
+        pool = MULTI_HOT_SIZES[i]
+        n = per_chip_batch * pool
+        values_list.append(
+            torch.randint(0, nepf[i], (n,), generator=generator, dtype=torch.int32)
+        )
+        lengths_list.append(torch.full((per_chip_batch,), pool, dtype=torch.int32))
+    return KeyedJaggedTensor.from_lengths_sync(
+        keys=features,
+        values=torch.cat(values_list),
+        lengths=torch.cat(lengths_list),
+    )
+
+
+def _median(xs: list[float]) -> float:
+    s = sorted(xs)
+    n = len(s)
+    return s[n // 2] if n % 2 else 0.5 * (s[n // 2 - 1] + s[n // 2])
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="MLPerf DLRM-v2 torch_tpu train-perf benchmark"
+    )
+    p.add_argument(
+        "--cardinality",
+        choices=["shrunk", "canonical"],
+        default="shrunk",
+        help="Embedding table cardinalities: shrunk (sum 30M) or canonical (sum 228M).",
+    )
+    p.add_argument(
+        "--per-chip-batch",
+        type=int,
+        default=4096,
+        help="Local batch per rank/chip. Global batch = world_size * this.",
+    )
+    p.add_argument("--steps", type=int, default=50, help="Timed steps.")
+    p.add_argument(
+        "--warmup", type=int, default=10, help="Warmup steps (compile/autotune)."
+    )
+    p.add_argument("--dcn-num-layers", type=int, default=DCN_NUM_LAYERS)
+    p.add_argument("--dcn-low-rank", type=int, default=DCN_LOW_RANK_DIM)
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dist.init_process_group(backend="tpu_dist")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device("tpu")
+    pg = dist.group.WORLD
+    assert pg is not None, "default process group missing after init_process_group"
+    assert world_size > 1, "benchmark needs WORLD_SIZE > 1 for RW sharding"
+    # Guard the timed loop: with --steps 0 the stats below divide by len(step_ms) == 0.
+    assert args.steps > 0, "--steps must be > 0 to report timing statistics"
+    assert args.warmup >= 0, "--warmup cannot be negative"
+
+    nepf = NEPF_CANONICAL if args.cardinality == "canonical" else NEPF_SHRUNK
+    tables = _build_tables(nepf, world_size)
+    padded_nepf = [t.num_embeddings for t in tables]
+    features = [t.feature_names[0] for t in tables]
+    per_chip_batch = args.per_chip_batch
+
+    sharded_model = _build_sharded(
+        tables, device, pg, world_size, args.dcn_num_layers, args.dcn_low_rank
+    )
+
+    # Fixed dense inputs + labels (constant across steps); only sparse ids vary.
+    dense_x = torch.randn(per_chip_batch, NUM_DENSE, dtype=DENSE_DTYPE, device=device)
+    # Citrine C3: create directly on device rather than building on CPU and moving.
+    labels = (torch.rand(per_chip_batch, 1, device=device) > 0.5).to(DENSE_DTYPE)
+
+    # Per-element (D=128 momenta/row) Adagrad over all params (dense + unfused
+    # embeddings), matching MLPerf's EXACT_ADAGRAD (see EXPERIMENT_LOG A.1).
+    # Citrine C2: foreach=True for multi-tensor execution. Safe here -- the UNFUSED_TPU
+    # kernel's backward is a dense scatter-add, so no sparse grads are involved.
+    opt = torch.optim.Adagrad(sharded_model.parameters(), lr=LR, foreach=True)
+
+    kjt_gen = torch.Generator()
+
+    def run_step(step: int, timed: bool) -> float:
+        # The KJT must already be on the TPU: the sharded EBC input_dist bucketizes (RW)
+        # and all2alls it over the `tpu_dist` process group, which has no CPU backend
+        # ("No backend type associated with device type cpu" if the ids stay on host).
+        kjt_gen.manual_seed(args.seed + 1 + step)
+        kjt = make_multihot_kjt(features, padded_nepf, per_chip_batch, kjt_gen).to(
+            device
+        )
+        opt.zero_grad()
+        t0 = time.perf_counter()
+        logits = sharded_model(dense_x, kjt)
+        loss = F.binary_cross_entropy_with_logits(logits, labels)
+        loss.backward()
+        opt.step()
+        if timed:
+            _materialize()  # flush fwd+bwd+opt for this step
+        return time.perf_counter() - t0
+
+    for w in range(args.warmup):
+        run_step(w, timed=False)
+    _materialize()
+
+    step_ms: list[float] = []
+    for s in range(args.steps):
+        step_ms.append(run_step(args.warmup + s, timed=True) * 1e3)
+
+    # Aggregate across ranks: MAX = straggler-bound wall-clock, SUM/world = avg rank.
+    local_mean = torch.tensor([sum(step_ms) / len(step_ms)], device=device)
+    xmax = local_mean.clone()
+    dist.all_reduce(xmax, op=dist.ReduceOp.MAX)
+    xsum = local_mean.clone()
+    dist.all_reduce(xsum, op=dist.ReduceOp.SUM)
+    xrank_max = xmax.cpu().item()
+    xrank_mean = (xsum / world_size).cpu().item()
+
+    if rank == 0:
+        # K samples/s/chip = per_chip_batch / step_time_s / 1000 (straggler-bound).
+        kspc = per_chip_batch / (xrank_max / 1e3) / 1e3
+        print("=" * 72, flush=True)
+        print(
+            f"MLPerf DLRM-v2 torch_tpu train-perf  (world={world_size}, "
+            f"per_chip_batch={per_chip_batch}, global_bs={world_size * per_chip_batch}, "
+            f"cardinality={args.cardinality} sum={sum(nepf):,}, "
+            f"tables={NUM_SPARSE}, dim={EMBEDDING_DIM}, pool_sum={sum(MULTI_HOT_SIZES)}, "
+            f"DCN[{args.dcn_num_layers}x{args.dcn_low_rank}])",
+            flush=True,
+        )
+        print(
+            f"{args.steps} timed steps after {args.warmup} warmup:",
+            flush=True,
+        )
+        print(
+            f"  ms/step   xrank-mean={xrank_mean:.3f}  xrank-max={xrank_max:.3f}  "
+            f"r0-p50={_median(step_ms):.3f}",
+            flush=True,
+        )
+        print(f"  K samples/s/chip (straggler-bound) = {kspc:.1f}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

Adds `train_perf_mlperf_tpu.py`, a steady-state training-throughput benchmark for the faithful MLPerf DLRM-v2 model on the torch_tpu stack (torch side only, no JAX). Same model as the GPU `mlperf_dlrm` runner in D110238830: torchrec `DLRM_DCN` (DCNv2, 3 layers / low-rank 512) over a multi-hot `EmbeddingBagCollection` (pool sum 214), `embedding_dim` 128, dense arch `[512,256,128]`, over arch `[1024,1024,512,256,1]`, per-element Adagrad. Cardinalities selectable via `--cardinality` (`shrunk` sum 30M / `canonical` sum 228M).

Embeddings are row-wise sharded on the `UNFUSED_TPU` compute kernel under `DistributedModelParallel` over `tpu_dist`; the dense DCN/MLP path runs on TPU via torch_tpu. Reports steady-state ms/step and K samples/s/chip, the same metric as the jte TPU side, so it is a direct third comparison point for the GPU vs TPU per-chip gap-closure work (B200 GPU vs v7x jte-JAX vs v7x torch_tpu).

Faithful-model caveat: the full MLPerf model uses pooled, multi-hot embeddings, which produce an uneven row-wise all2all. The torch_tpu RW path was first brought up for `EmbeddingCollection` / 1-hot / even-split only, so running this faithful config may require pooled-multi-hot / uneven-all2all support that is still landing.

Differential Revision: D110794150


