### PR TITLE
Preserve runtime buffer values through CPU export (#4588)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -126,13 +126,16 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     if tensor.numel() == 0:
         return []
 
-    # During torch.compile tracing, skip the JK check and _cuda_to_cpu_safe
-    # and fall back to plain .tolist(). justknobs_check calls pyjk.check()
+    # During PT2 compilation/export, skip the JK check and _cuda_to_cpu_safe
+    # and fall back to plain .tolist(). Non-strict export can present a
+    # FakeTensor whose reported device is CUDA even on a CPU-only host; calling
+    # torch.cuda.current_stream() for that tensor would initialize real CUDA.
+    # justknobs_check calls pyjk.check()
     # (a Cython function) which can raise SystemError in sandbox/RE
     # environments. The resulting exception captures a reference to the pyjk
     # module that cannot be pickled by the multiprocessing pool used in
     # distributed tests, masking the real error behind MaybeEncodingError.
-    if is_torchdynamo_compiling() or not torch._utils_internal.justknobs_check(
+    if is_pt2_compiling() or not torch._utils_internal.justknobs_check(
         "pytorch/torchrec:killswitch_safe_tolist"
     ):
         return tensor.tolist()

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -9,6 +9,7 @@
 
 
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.utils._pytree as pytree
@@ -1432,6 +1433,25 @@ class TestJaggedTensorTracing(unittest.TestCase):
     def test_cuda_tolist_cpu_tensor(self) -> None:
         tensor = torch.tensor([3, 5, 7, 2])
         result = _safe_tolist(tensor)
+        self.assertEqual(result, [3, 5, 7, 2])
+
+    def test_cuda_tolist_fake_cuda_tensor_during_pt2_export(self) -> None:
+        fake_mode = torch._subclasses.FakeTensorMode()
+        tensor = fake_mode.fake_tensor_converter.from_real_tensor(
+            fake_mode,
+            torch.tensor([3, 5, 7, 2]),
+            make_constant=True,
+        )
+        tensor.fake_device = torch.device("cuda")
+
+        with patch(
+            "torchrec.sparse.jagged_tensor.is_pt2_compiling", return_value=True
+        ), patch(
+            "torchrec.sparse.jagged_tensor._cuda_to_cpu_safe",
+            side_effect=AssertionError("fake tensors must not use a real CUDA stream"),
+        ):
+            result = _safe_tolist(tensor)
+
         self.assertEqual(result, [3, 5, 7, 2])
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:

Make final Sigmoid PT2 capture safe on a CPU publishing host without changing the packaged runtime format.

Before export, record the real runtime buffer values and replace only export-visible runtime buffers with value-backed fake constants on the requested device. Value backing preserves metadata that export-time TorchRec paths inspect through tolist(). During PT2 compilation/export, TorchRec bypasses its real-CUDA stream-scoped tolist helper so a fake CUDA tensor never initializes a physical CUDA stream. After torch.export completes, restore ordinary real tensors with the exact values into the ExportedProgram constants or state_dict before packaging. This keeps CUDA device metadata available to fake-mode capture, preserves buffer data, and avoids requiring a separate xl_weights-style runtime loader.

Reviewed By: georgiaphillips

Differential Revision: D115927354


