### PR TITLE
Carry APF plan-stats projections on PlanReportMetadata for the unified reporter

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2679,8 +2679,10 @@ class PlanReportMetadata:
     sinks — data our layer cannot derive from the plan/topology/request. It is
     observability-only and does NOT affect the plan, so it is deliberately kept
     off ``PlannerConfig`` and excluded from ``request_hash``. Optional; absent ->
-    the reporter falls back to console stats only. (``feature_stats_summary`` and
-    similar summary objects are not projected here yet — a follow-up.)
+    the reporter falls back to console stats only. Framework-specific summary
+    objects that the OSS layer cannot type (e.g. the feature-stats summary) are
+    carried as pre-projected scalars (``feature_stats_summary_str``,
+    ``resgen_config_json``) rather than as the objects themselves.
 
     One instance describes a single plan (one model), so model-specific fields
     such as ``proposer_types``, ``embedding_hash`` and the size fields vary across
@@ -2697,6 +2699,18 @@ class PlanReportMetadata:
     # would raise TypeError when an instance carrying proposer types is hashed.
     proposer_types: Optional[Tuple[str, ...]] = None
     num_parallel_worlds: Optional[int] = None
+    # UVM/embedding stats source path, surfaced as the Scuba column of the same
+    # name so downstream stats-attribution tooling sees it on this path too.
+    embedding_stats_source: Optional[str] = None
+    # str() projection of the framework's feature-stats summary. The OSS layer
+    # cannot carry the framework-specific summary object, so the fb caller projects
+    # it to a string; the reporter forwards it to the Scuba logger.
+    feature_stats_summary_str: Optional[str] = None
+    # JSON-encoded resgen config (``asdict`` of the tbe_input_multiplexer). Stored
+    # as a string, not a dict, so this frozen dataclass stays hashable -- a dict
+    # field would raise TypeError on hash, the same reason ``proposer_types`` is a
+    # Tuple. The reporter decodes it before handing the dict to the Scuba logger.
+    resgen_config_json: Optional[str] = None
     log_plan: bool = True
     # Optional override for the Manifold upload directory (relative to the
     # sharding_analysis bucket, e.g. "tree/sharding_plan/my_dry_run"). None ->


### PR DESCRIPTION
Summary:
The unified sharding-plan reporter (`FbPlanReporter`) builds the same `ShardingPlanScubaLogger` (-> `ai_training_sharding_stats`) as the legacy APF path, but `PlanReportMetadata` could not carry three framework-specific stats the legacy logger populates, so the unified path left those Scuba columns blank: `embedding_stats_source`, `feature_stats_summary`, and the resgen config (`resgen_stats_lookup` / `resgen_stats_match`). Downstream stats-attribution tooling reads these columns, so on the unified path they regress to empty.

This adds the plumbing (inert until a caller populates the fields):
- `PlanReportMetadata` gains `embedding_stats_source`, `feature_stats_summary_str`, and `resgen_config_json`. The framework-typed feature-stats summary and the resgen dict cannot ride on this OSS dataclass, so they are carried as pre-projected scalars; resgen is a JSON string (not a dict) so the frozen dataclass stays hashable -- the same reason `proposer_types` is a `Tuple`.
- `FbPlanReporter` forwards them to `ShardingPlanScubaLogger`, decoding `resgen_config_json` back to the dict the logger expects.
- `ShardingPlanScubaLogger` accepts a pre-projected `feature_stats_summary_str`, used as a fallback when no `FeatureStatsSummary` object is passed (the unified path has only the projection).

All three fields default to `None`, so this is inert until the APF adapter's `build_report_metadata` sets them (follow-up). Observability-only; no plan/topology/solve change.

Differential Revision: D116531800


