### PR TITLE
Add configurable `uvm_host_mapped` to `TableBatchedEmbeddingConfig` for publish (#4590)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -2565,6 +2565,9 @@ class BatchedFusedEmbedding(BaseBatchedEmbedding[torch.Tensor], FusedOptimizerMo
 
         enable_res, res_params = _populate_res_params(config)
         fused_params[ENABLE_RAW_EMBEDDING_STREAMING_STR] = enable_res
+        logger.info(
+            f"BatchedFusedEmbedding: uvm_host_mapped={fused_params.get('uvm_host_mapped', False)}"
+        )
 
         self._emb_module: SplitTableBatchedEmbeddingBagsCodegen = (
             SplitTableBatchedEmbeddingBagsCodegen(
@@ -3764,6 +3767,9 @@ class BatchedFusedEmbeddingBag(
 
         enable_res, res_params = _populate_res_params(config)
         fused_params[ENABLE_RAW_EMBEDDING_STREAMING_STR] = enable_res
+        logger.info(
+            f"BatchedFusedEmbeddingBag: uvm_host_mapped={fused_params.get('uvm_host_mapped', False)}"
+        )
 
         self._emb_module: SplitTableBatchedEmbeddingBagsCodegen = (
             SplitTableBatchedEmbeddingBagsCodegen(


### PR DESCRIPTION
Summary:

Plumb a configurable `uvm_host_mapped` through `TableBatchedEmbeddingConfig` (torchrec `batched_embedding_kernel`) and the MVAI `model_family_api` configs so the OneFlow publish path can place large embedding tables in host-mapped UVM. Wires the flag through the blue_reels_oneflow config providers (base + cotrain). General publish infra graft.

Reviewed By: mengyuehang

Differential Revision: D116165774


