### PR TITLE
Reland device-aware export and CPU-safe runtime buffers

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -126,13 +126,16 @@ def _safe_tolist(tensor: torch.Tensor) -> List[int]:
     if tensor.numel() == 0:
         return []
 
-    # During torch.compile tracing, skip the JK check and _cuda_to_cpu_safe
-    # and fall back to plain .tolist(). justknobs_check calls pyjk.check()
+    # During PT2 compilation/export, skip the JK check and _cuda_to_cpu_safe
+    # and fall back to plain .tolist(). Non-strict export can present a
+    # FakeTensor whose reported device is CUDA even on a CPU-only host; calling
+    # torch.cuda.current_stream() for that tensor would initialize real CUDA.
+    # justknobs_check calls pyjk.check()
     # (a Cython function) which can raise SystemError in sandbox/RE
     # environments. The resulting exception captures a reference to the pyjk
     # module that cannot be pickled by the multiprocessing pool used in
     # distributed tests, masking the real error behind MaybeEncodingError.
-    if is_torchdynamo_compiling() or not torch._utils_internal.justknobs_check(
+    if is_pt2_compiling() or not torch._utils_internal.justknobs_check(
         "pytorch/torchrec:killswitch_safe_tolist"
     ):
         return tensor.tolist()

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -9,6 +9,7 @@
 
 
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.utils._pytree as pytree
@@ -1432,6 +1433,25 @@ class TestJaggedTensorTracing(unittest.TestCase):
     def test_cuda_tolist_cpu_tensor(self) -> None:
         tensor = torch.tensor([3, 5, 7, 2])
         result = _safe_tolist(tensor)
+        self.assertEqual(result, [3, 5, 7, 2])
+
+    def test_cuda_tolist_fake_cuda_tensor_during_pt2_export(self) -> None:
+        fake_mode = torch._subclasses.FakeTensorMode()
+        tensor = fake_mode.fake_tensor_converter.from_real_tensor(
+            fake_mode,
+            torch.tensor([3, 5, 7, 2]),
+            make_constant=True,
+        )
+        tensor.fake_device = torch.device("cuda")
+
+        with patch(
+            "torchrec.sparse.jagged_tensor.is_pt2_compiling", return_value=True
+        ), patch(
+            "torchrec.sparse.jagged_tensor._cuda_to_cpu_safe",
+            side_effect=AssertionError("fake tensors must not use a real CUDA stream"),
+        ):
+            result = _safe_tolist(tensor)
+
         self.assertEqual(result, [3, 5, 7, 2])
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
Reland both D115880297 and D115927354. They were reverted by adjacent commits fa4a734fb500 and 317e02a100f3 after T285442709 identified deterministic inference-model FQN baseline drift in the D115880297 portion.

Restore trace-safe, device-aware PT2/Sigmoid export while keeping CPU-host publishing safe and preserving the packaged runtime format.

The D115880297 portion assigns local and local_request_only partitions to their configured devices, preserves deterministic allocation ordering, and stores selector/Sigrid indices as relocatable non-persistent buffers. Dense one-hot, Box-Cox, and Sigrid authoring avoid trace-visible tensor .to(device) operations.

To preserve the frozen production-model contract, the multi-entity float-feature index buffer remains unset during ordinary model construction and is omitted from named_buffers(). The final Sigmoid pre-export hook materializes it only beneath an explicit non-CPU allocation, captures it with the requested fake device, restores its exact CPU value into the ExportedProgram, and resets the source module afterward. Therefore neither the frozen v0 FQN baseline nor the launch-candidate FQN baseline changes. The baseline updater skips frozen v0 by default and requires an explicit --include-frozen-v0 flag for approved exceptional updates.

The D115927354 portion records real runtime buffer values before final export, substitutes value-backed fake constants on the requested device for export-time inspection, bypasses TorchRec's real-CUDA stream-scoped tolist helper during PT2 export, and restores ordinary real tensors with their exact values into the ExportedProgram constants or state_dict before packaging. This preserves CUDA device metadata for fake-mode capture without requiring a physical CUDA device or a separate runtime loader.

Reviewed By: georgiaphillips

Differential Revision: D116657418


