### PR TITLE
Don't crash the no-plan diagnostic on a non-percentage storage reservation (#4595)

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -40,6 +40,7 @@ from torchrec.distributed.planner.stats import EmbeddingStats
 from torchrec.distributed.planner.storage_reservations import (
     FixedAbsoluteStorageReservation,
     HeuristicalStorageReservation,
+    SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import (
     Enumerator,
@@ -1133,9 +1134,35 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
                 )
             elif isinstance(self._storage_reservation, FixedAbsoluteStorageReservation):
                 storage_reservation_solution = f"\n\t  Storage reservation: {round(bytes_to_gb(self._storage_reservation._hbm_reserved_bytes), 3)} GB per device, "
+            elif isinstance(self._storage_reservation, SKUAwareStorageReservation):
+                reservation = self._storage_reservation
+                # No percentage is reported: the static base is anchored to a fixed
+                # home SKU and does not scale with the device being planned, so a
+                # fraction of THIS device would differ per SKU for one unchanged
+                # config -- a plausible-looking value that no one configured.
+                # model_base_bytes REPLACES margin and dense when set, so naming it
+                # a margin would report a number the reservation never used.
+                static_base = (
+                    f"Measured model base: {round(bytes_to_gb(reservation._model_base_bytes), 3)} GB"
+                    if reservation._model_base_bytes is not None
+                    else f"Home-anchored margin: {round(bytes_to_gb(reservation._margin_bytes), 3)} GB"
+                )
+                storage_reservation_solution = (
+                    f"\n\t  {static_base}, "
+                    f"\n\t  Per rank reservation for dense storage: {storage_repr_in_gb(reservation._dense_storage)}, "
+                    f"\n\t  Per rank reservation for kjt storage: {storage_repr_in_gb(reservation._kjt_storage)}, "
+                    f"\n\t  Runtime overhead: {round(bytes_to_gb(reservation._runtime_overhead_bytes), 3)} GB"
+                )
             else:
-                # pyrefly: ignore[missing-attribute]
-                storage_reservation_solution = f"\n\t  Storage reservation percentage: {self._storage_reservation._percentage}, "
+                # Not every reservation is percentage-based, and the no-plan path
+                # must never fail: raising here replaces a real planner diagnostic
+                # with an unrelated AttributeError and hides the actual error type.
+                percentage = getattr(self._storage_reservation, "_percentage", None)
+                storage_reservation_solution = (
+                    f"\n\t  Storage reservation percentage: {percentage}, "
+                    if percentage is not None
+                    else f"\n\t  Storage reservation: {type(self._storage_reservation).__name__}, "
+                )
             no_plan_solution = (
                 f"Planner evaluated {self._num_proposals} proposals."
                 "\nPossible solutions:"

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -31,6 +31,7 @@ from torchrec.distributed.planner.stats import EmbeddingStats
 from torchrec.distributed.planner.storage_reservations import (
     FixedAbsoluteStorageReservation,
     HeuristicalStorageReservation,
+    SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import (
     ParameterConstraints,
@@ -224,6 +225,45 @@ class TestEmbeddingShardingPlanner(unittest.TestCase):
         sharding_plan = self.planner.plan(module=model, sharders=[])
 
         self.assertEqual(sharding_plan, ShardingPlan({}))
+
+
+class TestNoPlanDiagnostic(unittest.TestCase):
+    """The no-plan diagnostic must never fail on a non-percentage reservation.
+
+    The message is built only when planning has ALREADY failed, so raising inside
+    it replaces a real PlannerError with an unrelated AttributeError and hides the
+    error type the caller needs. `SKUAwareStorageReservation` has no `_percentage`.
+    """
+
+    def test_sku_aware_reports_planner_error_not_attribute_error(self) -> None:
+        # The reservation must SUCCEED and planning must then fail, so execution
+        # reaches the no-plan diagnostic. Tables large enough to fail reserve()
+        # would raise INSUFFICIENT_STORAGE first and never exercise the branch --
+        # which is how the first version of this test passed against the bug.
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=10000000,
+                embedding_dim=256,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(2)
+        ]
+        model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+        planner = EmbeddingShardingPlanner(
+            topology=Topology(
+                world_size=2, hbm_cap=1024 * 1024 * 1024, compute_device="cuda"
+            ),
+            storage_reservation=SKUAwareStorageReservation(margin_bytes=0),
+        )
+        with self.assertRaises(PlannerError) as context:
+            # pyrefly: ignore[bad-argument-type, missing-argument]
+            planner.plan(module=model, sharders=[TWvsRWSharder()])
+        # The specific type matters: an AttributeError escaping the diagnostic
+        # would surface as a non-PlannerError and mask the real cause.
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
 
 
 class TestEmbeddingShardingPlannerWithConstraints(unittest.TestCase):


### PR DESCRIPTION
Summary:

When the planner finds no valid plan, it builds a "no plan found" message that
tells the user global storage, per-rank memory, the reservation breakdown and how
to fix it. The `else` branch of that message builder read
`self._storage_reservation._percentage` unguarded.

`_percentage` is defined by exactly three classes --
`HeuristicalStorageReservation`, `FixedPercentageStorageReservation` and
`InferenceStorageReservation`. `SKUAwareStorageReservation` never defines it, and
the `else` catches every type that is not `Heuristical` or `FixedAbsolute`. So a
genuine `INSUFFICIENT_STORAGE` failure surfaced instead as:

  AttributeError: 'SKUAwareStorageReservation' object has no attribute '_percentage'

This is a defect in the error-reporting path, which is what makes it easy to
miss: planning had ALREADY failed legitimately, and the bug replaced an
actionable diagnostic with an unrelated stack trace. Three consequences:

- The failure taxonomy undercounts `INSUFFICIENT_STORAGE`. A non-`PlannerError`
  exception is classified `OTHER`, so these land in an unclassified bucket. 45
  occurrences in 90 days on `torchrec_planner_runs`, growing as SKUAware ramps.
- The diagnosis the user needs is exactly what is destroyed.
- Reservation-band reporting extracts the band from the
  "Storage reservation percentage" substring, which is never produced when the
  crash fires, so affected failures disappear rather than showing up in a band.

A `# pyrefly: ignore[missing-attribute]` was suppressing the type checker on the
exact line that crashed; it is removed here.

This adds an explicit `SKUAwareStorageReservation` branch reporting the
home-anchored static base, runtime overhead, dense and kjt, plus the equivalent
fraction of the current device so band reporting keeps working. The remaining
`else` uses a defensive `getattr` -- mirroring the accessor already used
elsewhere in this file -- so no future reservation type can reintroduce the
crash.

The same pattern in the LP planner was fixed separately.

Differential Revision: D116844407


