### PR TITLE
Report SKUAware storage reservation in planner stats

### DIFF
--- a/torchrec/distributed/planner/stats.py
+++ b/torchrec/distributed/planner/stats.py
@@ -40,6 +40,7 @@ from torchrec.distributed.planner.storage_reservations import (
     FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
     InferenceStorageReservation,
+    SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import (
     CriticalPathEstimate,
@@ -691,6 +692,7 @@ class EmbeddingStats(Stats):
                 HeuristicalStorageReservation,
                 InferenceStorageReservation,
                 FixedPercentageStorageReservation,
+                SKUAwareStorageReservation,
             ),
         ):
             dense_hbm = round(bytes_to_gb(dense_storage.hbm), 3)
@@ -1074,6 +1076,23 @@ def _compute_storage(
         reserved_hbm_percent = (
             storage_reservation._hbm_reserved_bytes / topology.devices[0].storage.hbm
         )
+    elif (
+        isinstance(storage_reservation, SKUAwareStorageReservation)
+        and topology is not None
+        and topology.devices[0].storage.hbm > 0
+    ):
+        # SKUAware reserves absolute bytes anchored to a fixed home SKU, so there is
+        # no percentage to read off it. Report the STATIC base only: dense and kjt
+        # are rendered as their own blocks below, and folding them in here would
+        # count them twice.
+        static_base = (
+            storage_reservation._model_base_bytes
+            if storage_reservation._model_base_bytes is not None
+            else storage_reservation._margin_bytes
+        )
+        reserved_hbm_percent = (
+            static_base + storage_reservation._runtime_overhead_bytes
+        ) / topology.devices[0].storage.hbm
     elif isinstance(
         storage_reservation,
         (
@@ -1090,7 +1109,11 @@ def _compute_storage(
         storage_reservation._dense_storage
         if isinstance(
             storage_reservation,
-            (HeuristicalStorageReservation, InferenceStorageReservation),
+            (
+                HeuristicalStorageReservation,
+                InferenceStorageReservation,
+                SKUAwareStorageReservation,
+            ),
         )
         and storage_reservation._dense_storage is not None
         else Storage(0, 0, 0)
@@ -1104,6 +1127,7 @@ def _compute_storage(
                 HeuristicalStorageReservation,
                 InferenceStorageReservation,
                 FixedPercentageStorageReservation,
+                SKUAwareStorageReservation,
             ),
         )
         and storage_reservation._kjt_storage

--- a/torchrec/distributed/planner/tests/test_stats.py
+++ b/torchrec/distributed/planner/tests/test_stats.py
@@ -9,11 +9,12 @@
 
 import math
 import unittest
-from typing import List
+from typing import cast, List
 
 import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings
+from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.planners import EmbeddingShardingPlanner
@@ -21,6 +22,7 @@ from torchrec.distributed.planner.stats import (
     _calc_max_chi_sq_divergence,
     _calc_max_kl_divergence,
     _chi_sq_divergence,
+    _compute_storage,
     _kl_divergence,
     _normalize_float,
     _normalize_int,
@@ -29,9 +31,13 @@ from torchrec.distributed.planner.stats import (
     EmbeddingStats,
     NoopEmbeddingStats,
 )
-from torchrec.distributed.planner.types import Topology
+from torchrec.distributed.planner.storage_reservations import (
+    HeuristicalStorageReservation,
+    SKUAwareStorageReservation,
+)
+from torchrec.distributed.planner.types import StorageReservation, Topology
 from torchrec.distributed.test_utils.test_model import TestSparseNN
-from torchrec.distributed.types import ShardingType
+from torchrec.distributed.types import ModuleSharder, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 
@@ -190,3 +196,102 @@ class TestEmbeddingStats(unittest.TestCase):
                 abs_tol=1e-10,
             )
         )
+
+
+class TestComputeStorage(unittest.TestCase):
+    """`_compute_storage` must report SKUAware's reservation rather than zeroing it.
+
+    SKUAware reserves absolute bytes instead of a percentage of the device, so it
+    fell through to the catch-all branch and every stat derived from
+    `reserved_hbm_percent` -- reserved memory, planning memory, and the per-rank
+    utilization denominator -- reported a reservation of zero.
+    """
+
+    def setUp(self) -> None:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name="table_" + str(i),
+                feature_names=["feature_" + str(i)],
+            )
+            for i in range(4)
+        ]
+        self.model = TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+        self.sharders: List[ModuleSharder[nn.Module]] = cast(
+            List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()]
+        )
+        self.hbm_cap = 8 * 1024 * 1024 * 1024
+
+    def _topology(self) -> Topology:
+        return Topology(world_size=2, compute_device="cuda", hbm_cap=self.hbm_cap)
+
+    def _reserve(self, reservation: StorageReservation) -> Topology:
+        topology = self._topology()
+        # reserve() works on a deep copy, so `topology` stays at full capacity and
+        # remains the correct denominator to hand to _compute_storage.
+        reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=self.model,
+            sharders=self.sharders,
+        )
+        return topology
+
+    def test_sku_aware_reports_static_base(self) -> None:
+        margin = 2 * 1024 * 1024 * 1024
+        overhead = 512 * 1024 * 1024
+        reservation = SKUAwareStorageReservation(
+            margin_bytes=margin, runtime_overhead_bytes=overhead
+        )
+        topology = self._reserve(reservation)
+
+        reserved_hbm_percent, dense_storage, kjt_storage = _compute_storage(
+            reservation, topology
+        )
+
+        self.assertAlmostEqual(
+            reserved_hbm_percent * self.hbm_cap, margin + overhead, delta=1
+        )
+        self.assertGreater(dense_storage.hbm, 0)
+        self.assertGreater(kjt_storage.hbm, 0)
+
+    def test_sku_aware_model_base_bytes_replaces_margin_and_dense(self) -> None:
+        model_base_bytes = 3 * 1024 * 1024 * 1024
+        reservation = SKUAwareStorageReservation(
+            margin_bytes=2 * 1024 * 1024 * 1024,
+            model_base_bytes=model_base_bytes,
+        )
+        topology = self._reserve(reservation)
+
+        reserved_hbm_percent, dense_storage, kjt_storage = _compute_storage(
+            reservation, topology
+        )
+
+        self.assertAlmostEqual(
+            reserved_hbm_percent * self.hbm_cap, model_base_bytes, delta=1
+        )
+        # Dense is subsumed into the explicit base, so it is not reported twice.
+        self.assertEqual(dense_storage.hbm, 0)
+        self.assertGreater(kjt_storage.hbm, 0)
+
+    def test_sku_aware_matches_heuristical_on_home_sku(self) -> None:
+        # The stats-layer expression of SKUAware's documented no-op invariant: with
+        # overhead 0 and margin == percentage * hbm[home], the two policies report
+        # the same reservation on the home SKU.
+        percentage = 0.25
+        heuristical = HeuristicalStorageReservation(percentage=percentage)
+        sku_aware = SKUAwareStorageReservation(
+            margin_bytes=int(percentage * self.hbm_cap), runtime_overhead_bytes=0
+        )
+
+        heuristical_percent, heuristical_dense, heuristical_kjt = _compute_storage(
+            heuristical, self._reserve(heuristical)
+        )
+        sku_aware_percent, sku_aware_dense, sku_aware_kjt = _compute_storage(
+            sku_aware, self._reserve(sku_aware)
+        )
+
+        self.assertAlmostEqual(heuristical_percent, sku_aware_percent, places=6)
+        self.assertEqual(heuristical_dense.hbm, sku_aware_dense.hbm)
+        self.assertEqual(heuristical_kjt.hbm, sku_aware_kjt.hbm)


### PR DESCRIPTION
Summary:
`_compute_storage` recognises `FixedPercentageStorageReservation`,
`HeuristicalStorageReservation` and `InferenceStorageReservation`, and falls
through to `reserved_hbm_percent = 0.0` for anything else.
`SKUAwareStorageReservation` was not imported into `stats.py` at all, so every
successful SKUAware plan reported a reservation of zero.

Three things were wrong on each such plan:

- `Reserved Memory: HBM: 0.0 GB / 0%` and `Planning Memory: 100%`, regardless of
  what was actually reserved.
- The `Dense Storage (per rank)` and `KJT Storage (per rank)` blocks were
  suppressed entirely, because the same `isinstance` gate guards their rendering.
- Per-rank utilization was computed against `(1 - 0.0) * hbm`, overstating the
  headroom the planner really had.

Observed on a dry run of an APS model: the `HeuristicalStorageReservation(25%)`
arm reported `23.751 GB / 25%` while the SKUAware arm of the same model reported
`0.0 GB / 0%`.

SKUAware reserves absolute bytes anchored to a fixed home SKU, so there is no
percentage to read off it. This reports the STATIC base --
`model_base_bytes` when set, otherwise `margin_bytes`, plus
`runtime_overhead_bytes` -- expressed as a fraction of per-rank HBM, mirroring
the existing `FixedAbsoluteStorageReservation` branch. Dense and kjt are
deliberately excluded: they render as their own blocks, and including them here
would count them twice.

Differential Revision: D116706171


