### PR TITLE
On-device SparseCore/TensorCore recat for CW input dist

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -4801,3 +4801,136 @@ class BatchedTPUEmbedding(BaseBatchedEmbedding[torch.Tensor]):
                 self._emb_modules[self._feature_table_map[feature_idx]](feature_values)
             )
         return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+
+
+class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
+    """Pooled TPU compute kernel (`UNFUSED_TPU`).
+
+    Pooled sibling of `BatchedTPUEmbedding`, and a drop-in alongside
+    `BatchedDenseEmbeddingBag` in the pooled dispatch
+    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`). Backs the lookup with one
+    `TPUEmbeddingUnfused` table per table in the group; `forward` routes each feature to
+    its table, gathers its ids, and pools per sample (SUM or MEAN per `config.pooling`).
+
+    Pooling is done in torch (scatter-add over per-id sample indices) on top of the
+    unfused gather, so no dedicated pooled kernel is required and the backward flows
+    through the gather op's autograd.
+
+    Args:
+        config (GroupedEmbeddingConfig): grouped table config (one or more tables).
+        pg (Optional[dist.ProcessGroup]): process group (unused locally).
+        device (Optional[torch.device]): compute device (e.g. ``"tpu"``).
+        sharding_type (Optional[ShardingType]): sharding type (for the pooling mode).
+
+    Example::
+
+        kernel = BatchedTPUEmbeddingBag(grouped_config, device="tpu")
+        out = kernel(features)  # [batch, sum(embedding_dim over features)]
+    """
+
+    def __init__(
+        self,
+        config: GroupedEmbeddingConfig,
+        pg: Optional[dist.ProcessGroup] = None,
+        device: Optional[torch.device] = None,
+        sharding_type: Optional[ShardingType] = None,
+    ) -> None:
+        super().__init__(config, pg, device, sharding_type)
+        # Lazy import to avoid pulling in experimental TPU code at module load time.
+        from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+            TPUEmbeddingUnfused,
+        )
+
+        dtype = data_type_to_sparse_type(config.data_type).as_dtype()
+        # One TPUEmbeddingUnfused per table in the group (mirrors BatchedTPUEmbedding);
+        # the base class fills _local_rows / _local_cols / _feature_table_map.
+        self._emb_modules: nn.ModuleList = nn.ModuleList()
+        for local_rows, local_cols in zip(self._local_rows, self._local_cols):
+            self._emb_modules.append(
+                TPUEmbeddingUnfused(
+                    num_embeddings=local_rows,
+                    embedding_dim=local_cols,
+                    device=device,
+                    dtype=dtype,
+                )
+            )
+        self.init_parameters()
+
+    @property
+    # pyrefly: ignore [bad-override]  # TPUEmbeddingUnfused is not one of the
+    # fbgemm codegen types the base class enumerates (same as the Triton kernel).
+    def emb_module(self) -> "TPUEmbeddingUnfused":  # noqa: F821
+        # pyre-ignore[16]: ModuleList returns Module, pyre thinks Union
+        return self._emb_modules[0]
+
+    def split_embedding_weights(self) -> List[torch.Tensor]:
+        # pyre-ignore[16]
+        return [emb_module.weight for emb_module in self._emb_modules]
+
+    def named_split_embedding_weights(
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        assert (
+            remove_duplicate
+        ), "remove_duplicate=False not supported in named_split_embedding_weights"
+        for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
+            # pyre-ignore[16]
+            yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
+
+    def named_parameters(
+        self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
+    ) -> Iterator[Tuple[str, nn.Parameter]]:
+        for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
+            # pyre-ignore[7]
+            yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
+
+    def _pool(
+        self, gathered: torch.Tensor, lengths: torch.Tensor, batch_size: int
+    ) -> torch.Tensor:
+        """Pool a feature's per-id embeddings [L, dim] into [batch, dim].
+
+        Sum-pool by scatter-adding each id's row into its sample slot; MEAN divides by
+        the bag length. `lengths` are this feature's per-sample bag sizes (may be jagged
+        after the row-wise all2all), summing to L. Uses only arange / repeat_interleave /
+        index_add_ / div, so it lowers on TPU without a bespoke pooled kernel.
+        """
+        dim = gathered.shape[1]
+        device = gathered.device
+        pooled = torch.zeros(batch_size, dim, dtype=gathered.dtype, device=device)
+        # sample index for each gathered row: sample b repeated lengths[b] times.
+        sample_idx = torch.repeat_interleave(
+            torch.arange(batch_size, device=device), lengths
+        )
+        pooled.index_add_(0, sample_idx, gathered)
+        if self._pooling == PoolingMode.MEAN:
+            denom = lengths.clamp(min=1).unsqueeze(1).to(pooled.dtype)
+            pooled = pooled / denom
+        return pooled
+
+    # pyrefly: ignore [bad-override]  # same signature shape as the sequence kernel
+    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
+        batch_size = features.stride()
+        length_per_key = features.length_per_key()
+        # KJT lengths are feature-major: feature i's per-sample bag sizes are the
+        # i-th block of batch_size entries.
+        all_lengths = features.lengths()
+        per_feature_values = (
+            torch.split(features.values(), length_per_key)
+            if len(length_per_key) > 1
+            else [features.values()]
+        )
+        outputs: List[torch.Tensor] = []
+        for feature_idx, feature_values in enumerate(per_feature_values):
+            emb_module = self._emb_modules[self._feature_table_map[feature_idx]]
+            # pyre-ignore[9, 16]: ModuleList returns Module, pyre thinks Union;
+            # the table's `weight` is a Tensor so `.device` is a torch.device.
+            device: torch.device = emb_module.weight.device
+            gathered = emb_module(
+                feature_values.to(device=device, dtype=torch.int32)
+            )  # [L_i, dim]
+            lengths_i = all_lengths[
+                feature_idx * batch_size : (feature_idx + 1) * batch_size
+            ].to(device)
+            outputs.append(self._pool(gathered, lengths_i, batch_size))
+        # Pooled features concatenate along the embedding dim -> [batch, sum(dim)].
+        return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=1)

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -49,6 +49,7 @@ from torchrec.distributed.batched_embedding_kernel import (
     BatchedFusedEmbedding,
     BatchedFusedEmbeddingBag,
     BatchedTPUEmbedding,
+    BatchedTPUEmbeddingBag,
     KeyValueEmbedding,
     KeyValueEmbeddingBag,
     ShardedBatchedFusedEmbedding,
@@ -730,6 +731,13 @@ class GroupedPooledEmbeddingsLookup(
                 config=config,
                 pg=pg,
                 device=device,
+            )
+        elif config.compute_kernel == EmbeddingComputeKernel.UNFUSED_TPU:
+            return BatchedTPUEmbeddingBag(
+                config=config,
+                pg=pg,
+                device=device,
+                sharding_type=sharding_type,
             )
         elif config.compute_kernel in {
             EmbeddingComputeKernel.KEY_VALUE,

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1381,6 +1381,15 @@ class ShardedEmbeddingBagCollection(
                                 self._table_name_to_config[table_name].data_type
                             )
                         ),
+                        # Set grad-ness so ShardedTensor init does not reject an
+                        # unfused (autograd-trained) kernel whose shard is a
+                        # grad-requiring nn.Parameter.
+                        requires_grad=(
+                            _model_parallel_name_to_compute_kernel[table_name]
+                            in {
+                                EmbeddingComputeKernel.UNFUSED_TPU.value,
+                            }
+                        ),
                     )
 
                     sharded_tensor_metadata = sharding_spec.build_metadata(

--- a/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
@@ -17,6 +17,8 @@ import time
 from typing import List
 
 import torch
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
 from torch_tpu._internal import profiler, sync
 from torchrec.distributed.batched_embedding_kernel import BatchedTPUEmbedding
 from torchrec.distributed.embedding_types import (
@@ -135,6 +137,7 @@ def main() -> None:
     # Copy weights from reference into the TPU tables so outputs are comparable.
     # split_embedding_weights() returns one weight per table, in table order.
     for weight, config in zip(tpu_kernel.split_embedding_weights(), embedding_configs):
+        # pyre-ignore[6]: EmbeddingCollection.embeddings is a ModuleDict, so indexing it types as Module.
         weight.data.copy_(ref_module.embeddings[config.name].weight.data)
 
     # --- Accuracy test: compare outputs across different batch sizes ---
@@ -153,6 +156,7 @@ def main() -> None:
         )
         # CPU embedding needs int64 on torch 2.13
         kjt = model_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
         # Convert to int32/TPU outside the forward, before ref_module caches a CPU _jt_dict on kjt.
         kjt_tpu = KeyedJaggedTensor(
             keys=kjt.keys(),
@@ -180,6 +184,7 @@ def main() -> None:
         print("\nTRACE_DIR unset, skipping the profiled step")
     else:
         print(f"Profiler Start, traces printed to {traces_dir}")
+        tpu_output: torch.Tensor | None = None
         with profiler.profile(
             activities=[
                 profiler.ProfilerActivity.CPU,
@@ -199,6 +204,7 @@ def main() -> None:
                 )
                 # CPU embedding needs int64
                 kjt = model_input.idlist_features
+                assert isinstance(kjt, KeyedJaggedTensor)
 
                 # Convert to int32/TPU outside the forward.
                 kjt_tpu = KeyedJaggedTensor(
@@ -208,6 +214,9 @@ def main() -> None:
                 )
                 tpu_output = tpu_kernel(kjt_tpu)
 
+        assert (
+            tpu_output is not None
+        ), "profiled step never ran; PROFILE_NUMBER_TIMES must be > 0"
         print("Profiled TPU output shape:", tuple(tpu_output.shape))
 
     # --- Benchmark here -------
@@ -243,6 +252,7 @@ def main() -> None:
         )
         # CPU embedding needs int64
         kjt = model_input.idlist_features
+        assert isinstance(kjt, KeyedJaggedTensor)
         # Convert to int32/TPU
         kjt_tpu = KeyedJaggedTensor(
             keys=kjt.keys(),
@@ -267,6 +277,7 @@ def main() -> None:
             )
             # CPU embedding needs int64
             kjt = model_input.idlist_features
+            assert isinstance(kjt, KeyedJaggedTensor)
             # Convert to int32/TPU
             kjt_tpu = KeyedJaggedTensor(
                 keys=kjt.keys(),

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -16,18 +16,25 @@ value >4M capped at 4M) or `canonical` (sum 228M) sets, selectable via
 --cardinality. This is the third comparison point for the GPU<->TPU per-chip
 gap-closure work: B200 GPU (MAST) vs v7x jte (JAX) vs **v7x torch_tpu (here)**.
 
-The embeddings are ROW_WISE-sharded on the `UNFUSED_TPU` compute kernel under
+The embeddings are COLUMN_WISE-sharded on the `UNFUSED_TPU` compute kernel under
 `DistributedModelParallel` over the `tpu_dist` backend; the dense DCN/MLP path
-runs on TPU via torch_tpu. Reports steady-state ms/step and K samples/s/chip
+runs on TPU via torch_tpu. The embedding lookup (forward gather) runs on the
+SparseCore (`LOOKUP_MODE=v1_sc`, set in `main`); its unfused backward runs on the
+TensorCore. Reports steady-state ms/step and K samples/s/chip
 (per_chip_batch / step_time), the same metric as
 `mlperf_dlrm_tpu/EXPERIMENT_LOG.md`.
 
-NOTE (faithful-model caveat): the full MLPerf model uses POOLED, MULTI-HOT
-embeddings, which produce an UNEVEN row-wise all2all. The torch_tpu RW path was
-first brought up for `EmbeddingCollection`, 1-hot, EVEN splits only (see
-`dlrm_bench_rw_tpu.py`). Running this faithful config may require torch_tpu
-support for pooled multi-hot / uneven all2all that is still landing; that is an
-intentional choice (measure the real model, surface the gap).
+WHY COLUMN_WISE (not row_wise): the `tpu_dist` backend only implements EVEN
+`all_to_all_single`. Row-wise bucketizes ids across ranks by row, giving
+data-dependent, uneven per-partition counts -> uneven all2all (unsupported).
+Column-wise reuses the table-wise input dist (`KJTAllToAll`, no bucketization):
+each table's `embedding_dim` is split across all ranks, so every rank owns every
+feature and each destination receives exactly `per_chip_batch * sum(MULTI_HOT_SIZES)`
+ids -> an EVEN all2all, with no id-dropping. Requires `EMBEDDING_DIM % world_size
+== 0` AND `(EMBEDDING_DIM // world_size) % 4 == 0` -- CW rounds each shard's column
+width up to a multiple of 4, so a narrower split would place fewer, wider shards on a
+subset of ranks and the all2all would go uneven again. With dim=128 that caps the
+benchmark at world_size <= 32.
 
 Run on the TPU pod via run_pod.sh (pushes torchrec, launches via run_dist_file.sh):
 
@@ -37,6 +44,7 @@ Run on the TPU pod via run_pod.sh (pushes torchrec, launches via run_dist_file.s
 
 import argparse
 import logging
+import os
 import time
 
 import torch
@@ -45,12 +53,20 @@ import torch.nn.functional as F
 
 # pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
 import torch_tpu  # noqa: F401  (registers the "tpu" device + "tpu_dist" backend)
+import torchrec.experimental.torch_tpu.pallas.dispatcher  # noqa: F401  registers fbgemm  TPU kernels
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.model_parallel import DistributedModelParallel
-from torchrec.distributed.sharding_plan import construct_module_sharding_plan, row_wise
+from torchrec.distributed.sharding_plan import (
+    column_wise,
+    construct_module_sharding_plan,
+)
 from torchrec.distributed.types import ShardingEnv, ShardingPlan
+
+# Registers the TPU (SparseCore) impls of torchrec::embedding_lookup{,_backward};
+# pallas/ops.py only registers the CPU ones, so the UNFUSED_TPU lookup needs this.
+from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
 from torchrec.models.dlrm import DLRM_DCN
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
@@ -188,21 +204,17 @@ except Exception:  # noqa: BLE001
             tensor.detach().to("cpu")
 
 
-def _round_up_div(a: int, b: int) -> int:
-    return (a + b - 1) // b
-
-
-def _build_tables(nepf: list[int], world_size: int) -> list[EmbeddingBagConfig]:
-    """One EmbeddingBagConfig per sparse feature. num_embeddings is rounded up to a
-    multiple of world_size so the RW shards are even-sized."""
+def _build_tables(nepf: list[int]) -> list[EmbeddingBagConfig]:
+    """One EmbeddingBagConfig per sparse feature. Column-wise sharding keeps every
+    row on every rank (only the embedding_dim is split), so num_embeddings needs no
+    world_size padding (unlike row-wise)."""
     tables = []
     for i, rows in enumerate(nepf):
-        padded = _round_up_div(rows, world_size) * world_size
         tables.append(
             EmbeddingBagConfig(
                 name=f"table{i}",
                 embedding_dim=EMBEDDING_DIM,
-                num_embeddings=padded,
+                num_embeddings=rows,
                 feature_names=[f"feature{i}"],
             )
         )
@@ -217,7 +229,7 @@ def _build_sharded(
     dcn_num_layers: int,
     dcn_low_rank_dim: int,
 ) -> nn.Module:
-    """Faithful MLPerf DLRM_DCN with a RW / UNFUSED_TPU EmbeddingBagCollection under DMP."""
+    """Faithful MLPerf DLRM_DCN with a CW / UNFUSED_TPU EmbeddingBagCollection under DMP."""
     ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
     model = DLRM_DCN(
         embedding_bag_collection=ebc,
@@ -228,14 +240,18 @@ def _build_sharded(
         dcn_low_rank_dim=dcn_low_rank_dim,
         dense_device=device,
     )
+    # Split each table's embedding_dim across ALL ranks (one column shard per rank),
+    # so every rank owns every feature -> the sparse input all2all is EVEN.
+    ranks = list(range(world_size))
     plan = ShardingPlan(
         {
             # fqn of the EBC inside DLRM_DCN: sparse_arch.embedding_bag_collection
             "sparse_arch.embedding_bag_collection": construct_module_sharding_plan(
                 model.sparse_arch.embedding_bag_collection,
                 per_param_sharding={
-                    t.name: row_wise(
-                        compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU.value
+                    t.name: column_wise(
+                        ranks=ranks,
+                        compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU.value,
                     )
                     for t in tables
                 },
@@ -263,15 +279,17 @@ def make_multihot_kjt(
     nepf: list[int],
     per_chip_batch: int,
     generator: torch.Generator,
+    device: torch.device,
 ) -> KeyedJaggedTensor:
     """A realistic multi-hot KJT: feature i has MULTI_HOT_SIZES[i] random ids per sample.
 
-    Values span each table's full cardinality, so the RW bucketize routes them across
-    all ranks (an UNEVEN all2all -- the faithful MLPerf regime). Values vary per call
-    (seed per step) so the looked-up rows change every step.
+    Values span each table's full cardinality. Under column-wise sharding the KJT is
+    routed feature-wise (no bucketize) and, since every rank owns every feature, the
+    all2all is EVEN. Values vary per call (seed per step) so looked-up rows change
+    every step.
 
-    Citrine C3 exception (deliberate): these ids are built on CPU and moved to the TPU by
-    the caller, rather than created directly on device. `generator` is a CPU
+    Citrine C3 exception (deliberate): these ids are built on CPU and moved to the TPU
+    at the end of this function, rather than created directly on device. `generator` is a CPU
     `torch.Generator` -- passing it to a device-side `torch.randint` is not allowed, and
     the per-step reseeding is what makes each step look up different rows. This also
     mirrors a real input pipeline, where sparse ids arrive from the host. The resulting
@@ -291,7 +309,7 @@ def make_multihot_kjt(
         keys=features,
         values=torch.cat(values_list),
         lengths=torch.cat(lengths_list),
-    )
+    ).to(device)
 
 
 def _median(xs: list[float]) -> float:
@@ -328,20 +346,31 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+    # Run the embedding lookup (forward gather) on the SparseCore. Set before the
+    # first lookup; single_lookup._lookup_mode() reads LOOKUP_MODE at call time.
+    # The unfused backward always runs on the TensorCore.
+    os.environ["LOOKUP_MODE"] = "v1_sc"
     dist.init_process_group(backend="tpu_dist")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     device = torch.device("tpu")
     pg = dist.group.WORLD
     assert pg is not None, "default process group missing after init_process_group"
-    assert world_size > 1, "benchmark needs WORLD_SIZE > 1 for RW sharding"
+    assert world_size > 1, "benchmark needs WORLD_SIZE > 1 for CW sharding"
+    # CW rounds each shard's column width up to a multiple of 4 (sharding_plan
+    # _find_base_dim); dim//world_size must be a multiple of 4 so CW places exactly
+    # one shard per rank (every rank owns every feature -> even input all2all).
+    assert EMBEDDING_DIM % world_size == 0 and (EMBEDDING_DIM // world_size) % 4 == 0, (
+        f"column_wise across all ranks needs EMBEDDING_DIM ({EMBEDDING_DIM}) "
+        f"// world_size ({world_size}) to be a multiple of 4"
+    )
     # Guard the timed loop: with --steps 0 the stats below divide by len(step_ms) == 0.
     assert args.steps > 0, "--steps must be > 0 to report timing statistics"
     assert args.warmup >= 0, "--warmup cannot be negative"
 
     nepf = NEPF_CANONICAL if args.cardinality == "canonical" else NEPF_SHRUNK
-    tables = _build_tables(nepf, world_size)
-    padded_nepf = [t.num_embeddings for t in tables]
+    tables = _build_tables(nepf)
+    table_rows = [t.num_embeddings for t in tables]
     features = [t.feature_names[0] for t in tables]
     per_chip_batch = args.per_chip_batch
 
@@ -363,13 +392,11 @@ def main() -> None:
     kjt_gen = torch.Generator()
 
     def run_step(step: int, timed: bool) -> float:
-        # The KJT must already be on the TPU: the sharded EBC input_dist bucketizes (RW)
-        # and all2alls it over the `tpu_dist` process group, which has no CPU backend
-        # ("No backend type associated with device type cpu" if the ids stay on host).
+        # KJT is built on host then moved to device; the sharded EBC input_dist
+        # all2alls it feature-wise (CW: even). It must already be on device -- the
+        # splits all2all inside KJTAllToAll runs on the KJT's device.
         kjt_gen.manual_seed(args.seed + 1 + step)
-        kjt = make_multihot_kjt(features, padded_nepf, per_chip_batch, kjt_gen).to(
-            device
-        )
+        kjt = make_multihot_kjt(features, table_rows, per_chip_batch, kjt_gen, device)
         opt.zero_grad()
         t0 = time.perf_counter()
         logits = sharded_model(dense_x, kjt)

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -338,6 +338,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--warmup", type=int, default=10, help="Warmup steps (compile/autotune)."
     )
+    p.add_argument(
+        "--profile-dir",
+        type=str,
+        default="",
+        help="If set, capture an xprof xplane trace of the timed steps to this dir ",
+    )
     p.add_argument("--dcn-num-layers", type=int, default=DCN_NUM_LAYERS)
     p.add_argument("--dcn-low-rank", type=int, default=DCN_LOW_RANK_DIM)
     p.add_argument("--seed", type=int, default=0)
@@ -411,9 +417,24 @@ def main() -> None:
         run_step(w, timed=False)
     _materialize()
 
+    # Optional xprof capture of the timed steps. jax.profiler records the TPU device
+    # timeline (SC/TC ops) via libtpu regardless of framework; rank 0 captures.
+    profiling = bool(args.profile_dir) and rank == 0
+    if profiling:
+        import jax
+
+        os.makedirs(args.profile_dir, exist_ok=True)
+        jax.profiler.start_trace(args.profile_dir)
+
     step_ms: list[float] = []
     for s in range(args.steps):
         step_ms.append(run_step(args.warmup + s, timed=True) * 1e3)
+
+    if profiling:
+        _materialize()  # flush pending TPU work into the trace window
+        # pyre-ignore[18]: jax imported above under the same guard
+        jax.profiler.stop_trace()
+        print(f"xprof trace written to {args.profile_dir}", flush=True)
 
     # Aggregate across ranks: MAX = straggler-bound wall-clock, SUM/world = avg rank.
     local_mean = torch.tensor([sum(step_ms) / len(step_ms)], device=device)

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Steady-state training-throughput benchmark for the MLPerf DLRM-v2 model on the
+torch_tpu stack (torch side only -- no JAX).
+
+Same model as the reference JAX MLPerf DLRM benchmark: torchrec `DLRM_DCN`
+(DCNv2 cross net) over a multi-hot `EmbeddingBagCollection` (pool sum = 214),
+embedding_dim 128, dense arch [512,256,128], over arch [1024,1024,512,256,1],
+per-element Adagrad. Cardinalities are the MLPerf-v2 `shrunk` (sum 30M, any
+value >4M capped at 4M) or `canonical` (sum 228M) sets, selectable via
+--cardinality. This is the third comparison point for the GPU<->TPU per-chip
+gap-closure work: B200 GPU (MAST) vs v7x jte (JAX) vs **v7x torch_tpu (here)**.
+
+The embeddings are ROW_WISE-sharded on the `UNFUSED_TPU` compute kernel under
+`DistributedModelParallel` over the `tpu_dist` backend; the dense DCN/MLP path
+runs on TPU via torch_tpu. Reports steady-state ms/step and K samples/s/chip
+(per_chip_batch / step_time), the same metric as
+`mlperf_dlrm_tpu/EXPERIMENT_LOG.md`.
+
+NOTE (faithful-model caveat): the full MLPerf model uses POOLED, MULTI-HOT
+embeddings, which produce an UNEVEN row-wise all2all. The torch_tpu RW path was
+first brought up for `EmbeddingCollection`, 1-hot, EVEN splits only (see
+`dlrm_bench_rw_tpu.py`). Running this faithful config may require torch_tpu
+support for pooled multi-hot / uneven all2all that is still landing; that is an
+intentional choice (measure the real model, surface the gap).
+
+Run on the TPU pod via run_pod.sh (pushes torchrec, launches via run_dist_file.sh):
+
+    ./run_pod.sh run train_dlrm_mlperf_tpu.py --cardinality shrunk --steps 50
+    ./run_pod.sh run train_dlrm_mlperf_tpu.py --cardinality canonical
+"""
+
+import argparse
+import logging
+import time
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+import torch_tpu  # noqa: F401  (registers the "tpu" device + "tpu_dist" backend)
+from torch import nn
+from torchrec.distributed.embedding_types import EmbeddingComputeKernel
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.sharding_plan import construct_module_sharding_plan, row_wise
+from torchrec.distributed.types import ShardingEnv, ShardingPlan
+from torchrec.models.dlrm import DLRM_DCN
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+# ── MLPerf DLRM-v2 config (matches the reference JAX benchmark) ───────────────
+EMBEDDING_DIM = 128
+NUM_DENSE = 13
+NUM_SPARSE = 26
+DENSE_ARCH_LAYER_SIZES = [512, 256, 128]  # last must == EMBEDDING_DIM
+OVER_ARCH_LAYER_SIZES = [1024, 1024, 512, 256, 1]
+DCN_NUM_LAYERS = 3
+DCN_LOW_RANK_DIM = 512
+LR = 0.01
+DENSE_DTYPE: torch.dtype = torch.float32
+
+# Multi-hot pool sizes per feature (sum = 214). MLPerf-v2 `_MHS`.
+MULTI_HOT_SIZES = [
+    3,
+    2,
+    1,
+    2,
+    6,
+    1,
+    1,
+    1,
+    1,
+    7,
+    3,
+    8,
+    1,
+    6,
+    9,
+    5,
+    1,
+    1,
+    1,
+    12,
+    100,
+    27,
+    10,
+    3,
+    1,
+    1,
+]
+
+# Shrunk Criteo cardinalities (any value >4M capped at 4M). Sum 30M.
+NEPF_SHRUNK = [
+    4000000,
+    4000000,
+    17295,
+    7424,
+    20265,
+    3,
+    7122,
+    1543,
+    63,
+    4000000,
+    3067956,
+    405282,
+    10,
+    2209,
+    11938,
+    155,
+    4,
+    976,
+    14,
+    4000000,
+    4000000,
+    4000000,
+    585935,
+    12972,
+    108,
+    36,
+]
+# Canonical MLPerf-v2 cardinalities. Sum 228,487,552.
+NEPF_CANONICAL = [
+    40000000,
+    39060192,
+    17295,
+    7424,
+    20265,
+    3,
+    7122,
+    1543,
+    63,
+    40000000,
+    3067956,
+    405282,
+    10,
+    2209,
+    11938,
+    155,
+    4,
+    976,
+    14,
+    39979771,
+    25641295,
+    39664984,
+    585935,
+    12972,
+    108,
+    36,
+]
+
+
+# torch_tpu materialization (force lazy ops to execute, optionally blocking) --
+# same primitive dlrm_bench_rw_tpu.py uses to make wall-clock timing meaningful.
+try:
+    from torch_tpu._internal import sync as _tpu_sync  # type: ignore[import-not-found]
+
+    def _materialize(tensor: torch.Tensor | None = None) -> None:
+        if tensor is None:
+            _tpu_sync.synchronize(wait=True)
+        else:
+            _tpu_sync.synchronize(tensor, wait=True)
+
+except Exception:  # noqa: BLE001
+    # Warn loudly: this is a timing harness, so a silent fallback risks publishing
+    # numbers that only measure dispatch. The fallback below still blocks, but say so.
+    logging.warning(
+        "torch_tpu._internal.sync unavailable; falling back to torch.tpu.synchronize() "
+        "for step-boundary flushes. Verify reported ms/step before trusting it."
+    )
+
+    def _materialize(tensor: torch.Tensor | None = None) -> None:
+        # Must still FLUSH on the no-tensor call: run_step()/warmup call _materialize()
+        # with no argument purely to drain pending TPU work before the clock is read,
+        # so a no-op here would silently report meaningless step times.
+        if tensor is None:
+            # pyre-ignore[16]: torch.tpu is registered at runtime by torch_tpu, which
+            # is a pod-only dependency and so is invisible to the type checker.
+            torch.tpu.synchronize()
+        else:
+            tensor.detach().to("cpu")
+
+
+def _round_up_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _build_tables(nepf: list[int], world_size: int) -> list[EmbeddingBagConfig]:
+    """One EmbeddingBagConfig per sparse feature. num_embeddings is rounded up to a
+    multiple of world_size so the RW shards are even-sized."""
+    tables = []
+    for i, rows in enumerate(nepf):
+        padded = _round_up_div(rows, world_size) * world_size
+        tables.append(
+            EmbeddingBagConfig(
+                name=f"table{i}",
+                embedding_dim=EMBEDDING_DIM,
+                num_embeddings=padded,
+                feature_names=[f"feature{i}"],
+            )
+        )
+    return tables
+
+
+def _build_sharded(
+    tables: list[EmbeddingBagConfig],
+    device: torch.device,
+    pg: dist.ProcessGroup,
+    world_size: int,
+    dcn_num_layers: int,
+    dcn_low_rank_dim: int,
+) -> nn.Module:
+    """Faithful MLPerf DLRM_DCN with a RW / UNFUSED_TPU EmbeddingBagCollection under DMP."""
+    ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
+    model = DLRM_DCN(
+        embedding_bag_collection=ebc,
+        dense_in_features=NUM_DENSE,
+        dense_arch_layer_sizes=DENSE_ARCH_LAYER_SIZES,
+        over_arch_layer_sizes=OVER_ARCH_LAYER_SIZES,
+        dcn_num_layers=dcn_num_layers,
+        dcn_low_rank_dim=dcn_low_rank_dim,
+        dense_device=device,
+    )
+    plan = ShardingPlan(
+        {
+            # fqn of the EBC inside DLRM_DCN: sparse_arch.embedding_bag_collection
+            "sparse_arch.embedding_bag_collection": construct_module_sharding_plan(
+                model.sparse_arch.embedding_bag_collection,
+                per_param_sharding={
+                    t.name: row_wise(
+                        compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU.value
+                    )
+                    for t in tables
+                },
+                # pyre-ignore[6]: ModuleSharder is invariant; the EBC sharder is
+                # the correct sharder for this module type.
+                sharder=EmbeddingBagCollectionSharder(),
+                local_size=1,
+                world_size=world_size,
+                device_type="tpu",
+            )
+        }
+    )
+    return DistributedModelParallel(
+        module=model,
+        env=ShardingEnv.from_process_group(pg),
+        device=device,
+        plan=plan,
+        # pyre-ignore[6]: see note above on ModuleSharder invariance.
+        sharders=[EmbeddingBagCollectionSharder()],
+    )
+
+
+def make_multihot_kjt(
+    features: list[str],
+    nepf: list[int],
+    per_chip_batch: int,
+    generator: torch.Generator,
+) -> KeyedJaggedTensor:
+    """A realistic multi-hot KJT: feature i has MULTI_HOT_SIZES[i] random ids per sample.
+
+    Values span each table's full cardinality, so the RW bucketize routes them across
+    all ranks (an UNEVEN all2all -- the faithful MLPerf regime). Values vary per call
+    (seed per step) so the looked-up rows change every step.
+
+    Citrine C3 exception (deliberate): these ids are built on CPU and moved to the TPU by
+    the caller, rather than created directly on device. `generator` is a CPU
+    `torch.Generator` -- passing it to a device-side `torch.randint` is not allowed, and
+    the per-step reseeding is what makes each step look up different rows. This also
+    mirrors a real input pipeline, where sparse ids arrive from the host. The resulting
+    host->device copy is done OUTSIDE the timed region in `run_step` (before `t0`), so it
+    does not inflate the reported ms/step.
+    """
+    values_list: list[torch.Tensor] = []
+    lengths_list: list[torch.Tensor] = []
+    for i in range(len(features)):
+        pool = MULTI_HOT_SIZES[i]
+        n = per_chip_batch * pool
+        values_list.append(
+            torch.randint(0, nepf[i], (n,), generator=generator, dtype=torch.int32)
+        )
+        lengths_list.append(torch.full((per_chip_batch,), pool, dtype=torch.int32))
+    return KeyedJaggedTensor.from_lengths_sync(
+        keys=features,
+        values=torch.cat(values_list),
+        lengths=torch.cat(lengths_list),
+    )
+
+
+def _median(xs: list[float]) -> float:
+    s = sorted(xs)
+    n = len(s)
+    return s[n // 2] if n % 2 else 0.5 * (s[n // 2 - 1] + s[n // 2])
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="MLPerf DLRM-v2 torch_tpu train-perf benchmark"
+    )
+    p.add_argument(
+        "--cardinality",
+        choices=["shrunk", "canonical"],
+        default="shrunk",
+        help="Embedding table cardinalities: shrunk (sum 30M) or canonical (sum 228M).",
+    )
+    p.add_argument(
+        "--per-chip-batch",
+        type=int,
+        default=4096,
+        help="Local batch per rank/chip. Global batch = world_size * this.",
+    )
+    p.add_argument("--steps", type=int, default=50, help="Timed steps.")
+    p.add_argument(
+        "--warmup", type=int, default=10, help="Warmup steps (compile/autotune)."
+    )
+    p.add_argument("--dcn-num-layers", type=int, default=DCN_NUM_LAYERS)
+    p.add_argument("--dcn-low-rank", type=int, default=DCN_LOW_RANK_DIM)
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dist.init_process_group(backend="tpu_dist")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device("tpu")
+    pg = dist.group.WORLD
+    assert pg is not None, "default process group missing after init_process_group"
+    assert world_size > 1, "benchmark needs WORLD_SIZE > 1 for RW sharding"
+    # Guard the timed loop: with --steps 0 the stats below divide by len(step_ms) == 0.
+    assert args.steps > 0, "--steps must be > 0 to report timing statistics"
+    assert args.warmup >= 0, "--warmup cannot be negative"
+
+    nepf = NEPF_CANONICAL if args.cardinality == "canonical" else NEPF_SHRUNK
+    tables = _build_tables(nepf, world_size)
+    padded_nepf = [t.num_embeddings for t in tables]
+    features = [t.feature_names[0] for t in tables]
+    per_chip_batch = args.per_chip_batch
+
+    sharded_model = _build_sharded(
+        tables, device, pg, world_size, args.dcn_num_layers, args.dcn_low_rank
+    )
+
+    # Fixed dense inputs + labels (constant across steps); only sparse ids vary.
+    dense_x = torch.randn(per_chip_batch, NUM_DENSE, dtype=DENSE_DTYPE, device=device)
+    # Citrine C3: create directly on device rather than building on CPU and moving.
+    labels = (torch.rand(per_chip_batch, 1, device=device) > 0.5).to(DENSE_DTYPE)
+
+    # Per-element (D=128 momenta/row) Adagrad over all params (dense + unfused
+    # embeddings), matching MLPerf's EXACT_ADAGRAD (see EXPERIMENT_LOG A.1).
+    # Citrine C2: foreach=True for multi-tensor execution. Safe here -- the UNFUSED_TPU
+    # kernel's backward is a dense scatter-add, so no sparse grads are involved.
+    opt = torch.optim.Adagrad(sharded_model.parameters(), lr=LR, foreach=True)
+
+    kjt_gen = torch.Generator()
+
+    def run_step(step: int, timed: bool) -> float:
+        # The KJT must already be on the TPU: the sharded EBC input_dist bucketizes (RW)
+        # and all2alls it over the `tpu_dist` process group, which has no CPU backend
+        # ("No backend type associated with device type cpu" if the ids stay on host).
+        kjt_gen.manual_seed(args.seed + 1 + step)
+        kjt = make_multihot_kjt(features, padded_nepf, per_chip_batch, kjt_gen).to(
+            device
+        )
+        opt.zero_grad()
+        t0 = time.perf_counter()
+        logits = sharded_model(dense_x, kjt)
+        loss = F.binary_cross_entropy_with_logits(logits, labels)
+        loss.backward()
+        opt.step()
+        if timed:
+            _materialize()  # flush fwd+bwd+opt for this step
+        return time.perf_counter() - t0
+
+    for w in range(args.warmup):
+        run_step(w, timed=False)
+    _materialize()
+
+    step_ms: list[float] = []
+    for s in range(args.steps):
+        step_ms.append(run_step(args.warmup + s, timed=True) * 1e3)
+
+    # Aggregate across ranks: MAX = straggler-bound wall-clock, SUM/world = avg rank.
+    local_mean = torch.tensor([sum(step_ms) / len(step_ms)], device=device)
+    xmax = local_mean.clone()
+    dist.all_reduce(xmax, op=dist.ReduceOp.MAX)
+    xsum = local_mean.clone()
+    dist.all_reduce(xsum, op=dist.ReduceOp.SUM)
+    xrank_max = xmax.cpu().item()
+    xrank_mean = (xsum / world_size).cpu().item()
+
+    if rank == 0:
+        # K samples/s/chip = per_chip_batch / step_time_s / 1000 (straggler-bound).
+        kspc = per_chip_batch / (xrank_max / 1e3) / 1e3
+        print("=" * 72, flush=True)
+        print(
+            f"MLPerf DLRM-v2 torch_tpu train-perf  (world={world_size}, "
+            f"per_chip_batch={per_chip_batch}, global_bs={world_size * per_chip_batch}, "
+            f"cardinality={args.cardinality} sum={sum(nepf):,}, "
+            f"tables={NUM_SPARSE}, dim={EMBEDDING_DIM}, pool_sum={sum(MULTI_HOT_SIZES)}, "
+            f"DCN[{args.dcn_num_layers}x{args.dcn_low_rank}])",
+            flush=True,
+        )
+        print(
+            f"{args.steps} timed steps after {args.warmup} warmup:",
+            flush=True,
+        )
+        print(
+            f"  ms/step   xrank-mean={xrank_mean:.3f}  xrank-max={xrank_max:.3f}  "
+            f"r0-p50={_median(step_ms):.3f}",
+            flush=True,
+        )
+        print(f"  K samples/s/chip (straggler-bound) = {kspc:.1f}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -347,6 +347,13 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--dcn-num-layers", type=int, default=DCN_NUM_LAYERS)
     p.add_argument("--dcn-low-rank", type=int, default=DCN_LOW_RANK_DIM)
     p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--recat-mode",
+        choices=["sc", "tc", "cpu"],
+        default="sc",
+        help="Post-a2a recat engine: sc (SparseCore), tc (TensorCore), "
+        "or cpu (FBGEMM CPU round-trip).",
+    )
     return p.parse_args()
 
 
@@ -378,6 +385,11 @@ def main() -> None:
     # first lookup; single_lookup._lookup_mode() reads LOOKUP_MODE at call time.
     # The unfused backward always runs on the TensorCore.
     os.environ["LOOKUP_MODE"] = "v1_sc"
+    # Recat (post-a2a KJT reconstruction) on-device instead of the CPU FBGEMM
+    # permute round-trip. --recat-mode sc|tc selects the engine (see dist_data
+    # _wait_impl); cpu leaves TPU_RECAT_MODE unset -> CPU fallback.
+    if args.recat_mode in ("sc", "tc"):
+        os.environ["TPU_RECAT_MODE"] = args.recat_mode
     dist.init_process_group(backend="tpu_dist")
     rank = dist.get_rank()
     world_size = dist.get_world_size()

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -350,6 +350,28 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _skip_ddp_shape_verify_on_tpu() -> None:
+    """No-op DDP's startup param-shape verification on TPU (multi-host workaround).
+
+    `DistributedDataParallel.__init__` calls `_verify_param_shape_across_processes`,
+    which does a device->CPU transfer whose StableHLO lowering fails on the torch_tpu
+    multi-host runtime (32 ranks): "transfer to 'cpu' device failed ... StableHLO
+    failed". The check is only a sanity guard, and DMP's dense arch is deterministically
+    replicated (identical shapes on every rank), so skipping it is safe. Single-host is
+    unaffected (the check already passes there). The durable fix belongs in torch_tpu's
+    device->CPU lowering; this unblocks the multi-host benchmark run.
+    """
+    if not torch.tpu.is_available():
+        return
+    import torch.nn.parallel.distributed as _ddp
+
+    def _noop(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    # DDP resolves the name in its own module namespace, so patch it there.
+    _ddp._verify_param_shape_across_processes = _noop
+
+
 def main() -> None:
     args = parse_args()
     # Run the embedding lookup (forward gather) on the SparseCore. Set before the
@@ -379,6 +401,10 @@ def main() -> None:
     table_rows = [t.num_embeddings for t in tables]
     features = [t.feature_names[0] for t in tables]
     per_chip_batch = args.per_chip_batch
+
+    # torch_tpu multi-host workaround: DDP's startup shape-verify can't lower its
+    # device->CPU transfer at 32 ranks; skip it (dense arch shapes are replicated).
+    _skip_ddp_shape_verify_on_tpu()
 
     sharded_model = _build_sharded(
         tables, device, pg, world_size, args.dcn_num_layers, args.dcn_low_rank

--- a/torchrec/experimental/torch_tpu/pallas/dispatcher.py
+++ b/torchrec/experimental/torch_tpu/pallas/dispatcher.py
@@ -127,8 +127,36 @@ def invert_permute(permute):
     return torch.ops.fbgemm.invert_permute(permute.to("cpu")).to("tpu")
 
 
+def permute_pooled_embs_auto_grad_split(
+    pooled_embs,
+    offset_dim_list,
+    permute_list,
+    inv_offset_dim_list,
+    inv_permute_list,
+):
+    """CPU fallback for the CW output-dist feature-order permute.
+
+    Restores feature order after the column-wise PooledEmbeddingsAllToAll. The fbgemm
+    kernel has no TPU implementation, so round-trip through CPU like the sparse-side
+    permutes above. Autograd flows through the `.to()` calls, so the op's backward runs
+    on CPU as well.
+    """
+    return torch.ops.fbgemm.permute_pooled_embs_auto_grad_split(
+        pooled_embs.to("cpu"),
+        offset_dim_list.to("cpu"),
+        permute_list.to("cpu"),
+        inv_offset_dim_list.to("cpu"),
+        inv_permute_list.to("cpu"),
+    ).to("tpu")
+
+
 # Register these functions to dispatcher with key 'TPU'
 lib.impl("permute_2D_sparse_data", permute_2D_sparse_data, "TPU")
 lib.impl("permute_1D_sparse_data", permute_1D_sparse_data, "TPU")
 lib.impl("block_bucketize_sparse_features", block_bucketize_sparse_features, "TPU")
 lib.impl("invert_permute", invert_permute, "TPU")
+lib.impl(
+    "permute_pooled_embs_auto_grad_split",
+    permute_pooled_embs_auto_grad_split,
+    "TPU",
+)

--- a/torchrec/experimental/torch_tpu/pallas/recat_sc.py
+++ b/torchrec/experimental/torch_tpu/pallas/recat_sc.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SparseCore recat kernel for the KJT post-all2all reconstruction.
+
+After the TW/CW input all2all, `KeyedJaggedTensor.dist_init` reorders the received
+tensors from rank-major `[T_local*W, B]` to feature-major `[T_local, W*B]` via
+`fbgemm.permute_2D_sparse_data` (a variable-length segment gather). That op has no
+TPU kernel, so today it runs on CPU (values round-trip TPU->CPU->TPU every step —
+~100MB/rank at MLPerf-16chip scale).
+
+This replaces the values (and weights) segment-gather with a **SparseCore** flat
+gather, keeping the id payload on-device. The gather index and permuted lengths are
+compile-time constant for FIXED multi-hot sizes (the MLPerf regime), so they are
+computed once (from the first batch's lengths), moved to the device, and cached; per
+step only the SparseCore value gather runs.
+
+Public entry point: `sc_recat_tensors(output_tensors, recat, stride_per_rank)` ->
+the feature-major `[lengths, values, (weights)]` to hand to `dist_init(recat=None)`.
+"""
+
+from typing import Dict, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import torch
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu, tpu_sc as plsc
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+from torch_tpu._internal import pallas
+
+# Cache: signature -> (gather_idx on device, permuted_lengths on device). The recat
+# permutation and per-segment sizes are static for fixed multi-hot, so a plan
+# computed from the first batch is reused for every subsequent step.
+_PLAN_CACHE: Dict[Tuple[object, ...], Tuple[torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_params_sc(n: int, num_subcores: int) -> Tuple[int, int, int]:
+    """Chunk/grid sizing for a width-1 SparseCore gather.
+
+    A width-1 output row is padded to the SC vector lane width (LANE) in tile_spmem,
+    so an `(chunk, 1)` VMEM tile actually costs `chunk*LANE` words. Budget the chunk
+    against the ~131071-word SPMEM limit with double-buffering (idx + out) and margin,
+    else the pipeline hits CompileTimeSparseCoreAllocationFailure.
+    """
+    TILE = 8
+    LANE = 16
+    SPMEM_WORDS = 131072
+    # 4x = double-buffered (2x) idx+out tiles, each padded to LANE, plus headroom.
+    max_chunk = SPMEM_WORDS // (4 * (LANE + 1))
+    indices_chunk = min(max(n, 1), max_chunk)
+    indices_chunk = max((indices_chunk // TILE) * TILE, TILE)
+    grid_size = (n + indices_chunk - 1) // indices_chunk
+    grid_size = ((grid_size + num_subcores - 1) // num_subcores) * num_subcores
+    return indices_chunk, grid_size, grid_size * indices_chunk
+
+
+@jax.jit
+def _run_sc_gather(values: jax.Array, indices: jax.Array) -> jax.Array:
+    """Gather rows of ``values`` ([N, LANE]) by ``indices`` ([M]) on the SparseCore.
+
+    Returns [M, LANE] of ``values.dtype``. ``out[k] = values[indices[k]]``. Rows must
+    be the SC vector-lane width (a width-1 gather silently returns zeros).
+    """
+    # pyre-ignore[16]: the buck-pinned jax stubs predate the SparseCore Pallas
+    # API that the pod's jax exposes.
+    assert (sc_info := pltpu.get_tpu_info().sparse_core)
+    # pyre-ignore[20]: `num_cores` is defaulted in the pod's jax, not in the stubs.
+    vector_mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="core", subcore_axis_name="subcore"
+    )
+    sc_num_subcores = sc_info.num_subcores
+
+    n = indices.shape[0]
+    width = values.shape[1]
+    indices_chunk, grid_size, padded_n = _get_params_sc(n, sc_num_subcores)
+    if padded_n > n:
+        indices = jnp.pad(indices, (0, padded_n - n), constant_values=0)
+
+    # pyre-ignore[16]: `pl.kernel` exists in the pod's jax, not in the stubs.
+    @pl.kernel(
+        out_type=jax.ShapeDtypeStruct((padded_n, width), values.dtype),
+        mesh=vector_mesh,
+    )
+    def _kernel(values_hbm, indices_hbm, out_hbm):
+        def body(idx_smem, out_vmem):
+            pltpu.sync_copy(values_hbm.at[idx_smem], out_vmem)
+
+        pltpu.emit_pipeline(
+            body,
+            grid=(grid_size,),
+            in_specs=[
+                pl.BlockSpec((indices_chunk,), lambda i: (i,), memory_space=pltpu.VMEM)
+            ],
+            out_specs=[pl.BlockSpec((indices_chunk, width), lambda i: (i, 0))],
+            core_axis_name="subcore",
+            dimension_semantics=(pltpu.PARALLEL,),
+        )(indices_hbm, out_hbm)
+
+    return _kernel(values, indices)[:n, :]
+
+
+# torch op over the SparseCore gather (no autograd: recat runs on ids under no_grad).
+_recat_gather_fn = pallas.jax_op("pallas::recat_gather", _run_sc_gather)
+
+
+def _sc_gather_1d(values: torch.Tensor, gather_idx: torch.Tensor) -> torch.Tensor:
+    """``values[gather_idx]`` on the SparseCore, restoring the input dtype.
+
+    The gather runs in int32 (SparseCore ids are int32, matching the unfused lookup
+    kernel), so the op has a single, stable specialization regardless of whether the
+    KJT ships int32 or int64 ids. Ids exceed int32 only above ~2.1B rows.
+    """
+    orig_dtype = values.dtype
+    # A width-1 SparseCore gather silently returns zeros, so pad each id to the
+    # 16-wide SC vector lane (value in column 0) and take column 0 back. Gather in
+    # float32 (the proven run_sc_lookup dtype); exact for ids < 2**24 (shrunk).
+    lane = 16
+    n = values.numel()
+    padded = torch.zeros(n, lane, dtype=torch.float32, device=values.device)
+    padded[:, 0] = values.view(-1).to(torch.float32)
+    out = _recat_gather_fn(
+        values=padded,
+        indices=gather_idx.to(dtype=torch.int32, device=values.device),
+    )
+    return out[:, 0].round().to(orig_dtype)
+
+
+def _tc_gather_1d(values: torch.Tensor, gather_idx: torch.Tensor) -> torch.Tensor:
+    """``values[gather_idx]`` on the TensorCore via a native width-1 gather.
+
+    A plain `index_select` lowers to an optimized TensorCore gather — width-1
+    native, so (unlike the SparseCore path) there is no 16-lane padding / 16x
+    bandwidth waste. Keeps the id payload on-device (no CPU round-trip).
+    """
+    return values.view(-1).index_select(
+        0, gather_idx.to(dtype=torch.int64, device=values.device)
+    )
+
+
+def _compute_recat_plan(
+    lengths: torch.Tensor, recat: torch.Tensor, stride: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute the value gather-index and permuted (feature-major) lengths on CPU.
+
+    Mirrors `permute_2D_sparse_data(recat, lengths.view(T*W, stride), values)`:
+    rows are reordered by ``recat`` and each row carries its contiguous value block.
+    Done once per signature (static for fixed multi-hot), so CPU cost is amortized.
+    """
+    lengths_cpu = lengths.detach().to("cpu")
+    recat_cpu = recat.detach().to("cpu").to(torch.int64)
+    tw = recat_cpu.numel()
+    lengths_2d = lengths_cpu.view(tw, stride)
+
+    # Feature-major lengths: rows reordered by recat, flattened back.
+    permuted_lengths = lengths_2d[recat_cpu].reshape(-1).to(lengths.dtype)
+
+    # Per-source-row value block sizes and start offsets (rank-major layout).
+    row_size = lengths_2d.sum(dim=1).to(torch.int64)  # [T*W]
+    src_off = torch.zeros(tw + 1, dtype=torch.int64)
+    torch.cumsum(row_size, dim=0, out=src_off[1:])
+
+    # For each output row k (feature-major), its block gathers source row recat[k].
+    psize = row_size[recat_cpu]  # [T*W]
+    starts = src_off[recat_cpu]  # [T*W]
+    total = int(psize.sum().item())
+    out_row = torch.repeat_interleave(torch.arange(tw), psize)  # [total]
+    block_start = torch.cumsum(psize, dim=0) - psize  # exclusive prefix in output order
+    within = torch.arange(total) - block_start[out_row]  # position within block
+    gather_idx = (starts[out_row] + within).to(torch.int32)
+
+    device = lengths.device
+    return gather_idx.to(device), permuted_lengths.to(device)
+
+
+def recat_tensors(
+    output_tensors: List[torch.Tensor],
+    recat: torch.Tensor,
+    stride_per_rank: List[int],
+    mode: str = "sc",
+) -> List[torch.Tensor]:
+    """Feature-major `[lengths, values, (weights)]` via an on-device value gather.
+
+    Drop-in for the CPU `permute_2D_sparse_data` recat on the fixed-stride TW/CW TPU
+    path: pass the result to `dist_init(..., recat=None)` (already permuted). Only
+    supports single (equal) stride per rank — the fixed-batch case. Both backends
+    keep the id payload on-device (no CPU round-trip); they differ only in engine.
+
+    Args:
+        output_tensors: post-all2all `[lengths, values]` or `[lengths, values, weights]`.
+        recat: rank-major -> feature-major segment permutation (`_get_recat`).
+        stride_per_rank: per-rank batch sizes; all equal on this path.
+        mode: "sc" (SparseCore gather) or "tc" (TensorCore native gather).
+
+    Returns:
+        `[permuted_lengths, permuted_values, (permuted_weights)]`, all on-device.
+    """
+    lengths = output_tensors[0]
+    values = output_tensors[1]
+    weights = output_tensors[2] if len(output_tensors) == 3 else None
+    stride = stride_per_rank[0]
+
+    sig = (
+        str(values.device),
+        int(recat.numel()),
+        int(stride),
+        int(lengths.numel()),
+        int(values.numel()),
+    )
+    plan = _PLAN_CACHE.get(sig)
+    if plan is None:
+        plan = _compute_recat_plan(lengths, recat, stride)
+        _PLAN_CACHE[sig] = plan
+    gather_idx, permuted_lengths = plan
+
+    gather = _tc_gather_1d if mode == "tc" else _sc_gather_1d
+    permuted = [permuted_lengths, gather(values, gather_idx)]
+    if weights is not None:
+        permuted.append(gather(weights, gather_idx))
+    return permuted

--- a/torchrec/experimental/torch_tpu/pallas/single_pooled_lookup.py
+++ b/torchrec/experimental/torch_tpu/pallas/single_pooled_lookup.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused pooled (gather + sum) TPU embedding lookup on the SparseCore.
+
+`embedding_pooled_lookup_fn(indices, offsets, dev_weights, emb_dim)` gathers each
+bag's rows and sum-pools them, returning the pooled `[B, emb_dim]` output. The pooling
+reduction runs entirely inside a fused SparseCore Pallas kernel (adapted from the torus
+`bench_tpu_gather_pool_pallas_sc` fused gather-sum kernel): it gathers `RBLK*K` rows
+into VMEM via the `plsc.Indices` indirect gather, reduces over the pool dim in VMEM in
+16-lane column slices, and writes only the pooled `[nbag, dim]` output -- the
+`[nbag*pool, dim]` gather intermediate never touches HBM.
+
+The fused kernel pools a FIXED number `K` of ids per bag. Jagged (offset-driven) bags
+are supported by a host-side repack in `embedding_pooled_lookup_fn`: each bag is padded
+to `K = round_up(max_bag_len, 8)` ids, and the pad slots point at an appended zero row
+so they contribute nothing to the sum. This keeps the reduction on the SparseCore (which
+cannot cheaply read per-bag offset scalars on the vector subcore) at the cost of padding
+every bag to the batch's max length.
+
+Forward only (no autograd backward yet).
+"""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import torch
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu, tpu_sc as plsc
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+from torch_tpu._internal import pallas
+
+# SparseCore vector lane width (NL) and the number of partial accumulators (NACC)
+# used to break the pool-dim reduction into independent chains.
+NL, NACC = 16, 16
+
+
+def _rblk(K, D):
+    """Rows-per-block: largest power-of-two (<=4) bag block whose double-buffered
+    gather buffer stays under the ~500 KiB VMEM budget."""
+    r = 1
+    while 2 * (r * 2) * K * D * 4 <= 500 * 1024 and r * 2 <= 4:
+        r *= 2
+    return r
+
+
+# ─── Fused SparseCore gather-sum kernel (from torus bench_tpu_gather_pool_pallas_sc) ──
+def _kernel(idx_hbm, table_hbm, out_hbm, idx_v, buf, ov, sem, *, RBLK, K):
+    sc = pltpu.get_tpu_info().sparse_core
+    num_sub = sc.num_cores * sc.num_subcores
+    B, D, TILE = out_hbm.shape[0], buf.shape[-1], RBLK * K
+    nb = pl.cdiv(B, RBLK * num_sub)
+
+    @functools.partial(
+        pltpu.emit_pipeline,
+        grid=(nb + 1, num_sub),
+        core_axis_name=("c", "s"),
+        dimension_semantics=(pltpu.ARBITRARY, pltpu.PARALLEL),
+    )
+    def _inner():
+        blk, core = pl.program_id(0), pl.program_id(1)
+
+        @pl.when(blk < nb)  # gather block blk
+        def _():
+            p = jax.lax.rem(blk, 2)
+            o0 = (blk * num_sub + core) * RBLK
+            pltpu.sync_copy(idx_hbm.at[pl.ds(o0 * K, TILE)], idx_v.at[p])
+            pltpu.make_async_copy(
+                table_hbm.at[plsc.Indices(idx_v.at[p])], buf.at[p], sem.at[p]
+            ).start()
+
+        @pl.when(blk > 0)  # reduce block blk-1 (overlaps gather)
+        def _():
+            q = jax.lax.rem(blk - 1, 2)
+            o0 = ((blk - 1) * num_sub + core) * RBLK
+            pltpu.make_async_copy(
+                table_hbm.at[plsc.Indices(idx_v.at[q])], buf.at[q], sem.at[q]
+            ).wait()
+            for r in range(RBLK):
+                base = r * K
+
+                @plsc.parallel_loop(0, D, step=NL)
+                def _cols(c0, base=base, r=r):  # bind loop vars (flake8 B023)
+                    cs = pl.ds(c0, NL)
+                    accs = [buf[q, base + a, cs] for a in range(NACC)]
+                    for k in range(NACC, K):
+                        accs[k % NACC] = accs[k % NACC] + buf[q, base + k, cs]
+                    acc = accs[0]
+                    for a in range(1, NACC):
+                        acc = acc + accs[a]
+                    ov[r, cs] = acc
+
+            pltpu.sync_copy(ov, out_hbm.at[pl.ds(o0, RBLK)])
+
+    _inner()
+
+
+def build(B, K, D):
+    """f(table[V, D] f32, idx[B*K] i32) -> out[B, D] f32 (fused gather + sum-pool).
+
+    Returns the plain JAX function (not jitted) so ``jax_op`` can trace/export it.
+    """
+    RBLK = _rblk(K, D)
+    sc = pltpu.get_tpu_info().sparse_core
+    num_sub = sc.num_cores * sc.num_subcores
+    Bpad = pl.cdiv(B, RBLK * num_sub) * RBLK * num_sub
+    mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="c",
+        subcore_axis_name="s",
+        num_cores=sc.num_cores,
+        num_subcores=sc.num_subcores,
+    )
+    ker = pl.kernel(
+        functools.partial(_kernel, RBLK=RBLK, K=K),
+        out_type=jax.ShapeDtypeStruct((Bpad, D), jnp.float32),
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            use_tc_tiling_on_sc=False,
+            needs_layout_passes=False,
+        ),
+        scratch_types=[
+            pltpu.VMEM((2, RBLK * K), jnp.int32),
+            pltpu.VMEM((2, RBLK * K, D), jnp.float32),
+            pltpu.VMEM((RBLK, D), jnp.float32),
+            pltpu.SemaphoreType.DMA((2,)),
+        ],
+        mesh=mesh,
+    )
+
+    def run(table, idx):
+        idxp = idx if Bpad == B else jnp.pad(idx, (0, (Bpad - B) * K))
+        return ker(idxp, table)[:B]
+
+    return run
+
+
+def _pooled_gather_jax(idx: jax.Array, table: jax.Array, pool: int) -> jax.Array:
+    """Fused uniform gather + sum-pool: idx[B*pool] i32, table[V, D] f32 -> [B, D]."""
+    B = idx.shape[0] // pool
+    D = table.shape[1]
+    return build(B, pool, D)(table, idx)
+
+
+_pooled_gather_fn = pallas.jax_op("pallas::embedding_pooled_gather", _pooled_gather_jax)
+
+
+# ─── Backward: gradient w.r.t. the embedding table ───────────────────────────
+# The forward is out[b] = sum_{k} table[idx[b*pool + k]], so the gradient scatter-adds
+# each bag's grad back onto every row it gathered: grad_table[idx[j]] += grad_out[j//pool].
+# Runs on the TensorCore (dense scatter-add via .at[].add), mirroring single_lookup.
+def _pooled_gather_bwd_jax(
+    grad_out: jax.Array, idx: jax.Array, pool: int, num_rows: int, emb_dim: int
+) -> jax.Array:
+    grad_expanded = jnp.repeat(
+        grad_out, pool, axis=0
+    )  # [B*pool, D]; row j -> grad_out[j//pool]
+    return (
+        jnp.zeros((num_rows, emb_dim), dtype=grad_out.dtype).at[idx].add(grad_expanded)
+    )
+
+
+_pooled_gather_bwd_fn = pallas.jax_op(
+    "pallas::embedding_pooled_gather_bwd", _pooled_gather_bwd_jax
+)
+
+
+def _pooled_gather_backward(ctx, grad_out):
+    (idx,) = ctx.saved_tensors
+    grad_table = _pooled_gather_bwd_fn(
+        grad_out=grad_out.contiguous(),
+        idx=idx,
+        pool=ctx.pool,
+        num_rows=ctx.num_rows,
+        emb_dim=ctx.emb_dim,
+    )
+    # One grad per forward input: (idx, table, pool).
+    return None, grad_table, None
+
+
+def _pooled_gather_setup_context(ctx, inputs, output):
+    idx, table, pool = inputs
+    ctx.save_for_backward(idx)
+    ctx.pool = pool
+    ctx.num_rows = table.shape[0]
+    ctx.emb_dim = table.shape[1]
+
+
+torch.library.register_autograd(
+    "pallas::embedding_pooled_gather",
+    _pooled_gather_backward,
+    setup_context=_pooled_gather_setup_context,
+)
+
+
+def embedding_pooled_lookup_fn(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    dev_weights: torch.Tensor,
+    emb_dim: int,
+    pooling_mode: str = "sum",
+) -> torch.Tensor:
+    """Jagged sum/mean-pool via the fused SparseCore kernel (pad-to-max + zero-row sentinel).
+
+    Differentiable w.r.t. ``dev_weights`` (the grad flows through the pad/cat back to the
+    table). Any ``emb_dim`` is accepted -- it is padded up to a multiple of the SparseCore
+    lane width internally.
+
+    Args:
+        indices: 1-D int32 flat ids for all bags, concatenated.
+        offsets: 1-D int32 [B + 1] bag boundaries into ``indices``.
+        dev_weights: [V, emb_dim] embedding table (on the TPU).
+        emb_dim: embedding width.
+        pooling_mode: "sum" or "mean".
+
+    Returns:
+        [B, emb_dim] pooled output.
+    """
+    device = dev_weights.device
+    V, D = dev_weights.shape
+    # The kernel reduces the dim in NL-wide lanes, so pad emb_dim up to a multiple of NL.
+    D_pad = ((D + NL - 1) // NL) * NL
+
+    # Repack on-device (no host round trip): only the pool size K needs a host value.
+    off = offsets.to(device=device, dtype=torch.int64)
+    lengths = off[1:] - off[:-1]
+    B = int(lengths.numel())
+    total = int(off[-1].item())  # one scalar sync
+    max_len = int(lengths.max().item()) if B > 0 else 0  # one scalar sync
+    # K rounded up to the SparseCore id tile (8) so RBLK*K stays tile-aligned, and
+    # clamped to >= NACC: the kernel's reduction seeds NACC accumulators unconditionally,
+    # so a smaller pool would read past the bag into the next bag's rows.
+    K = max(((max_len + 7) // 8) * 8, NACC)
+
+    # [B, K] index matrix, pad slots -> sentinel row V (an appended zero row -> adds 0).
+    idx_mat = torch.full((B, K), V, dtype=torch.int32, device=device)
+    if total > 0:
+        sample_idx = torch.repeat_interleave(torch.arange(B, device=device), lengths)
+        within = torch.arange(total, device=device) - off[:-1][sample_idx]
+        idx_mat[sample_idx, within] = indices.to(device=device, dtype=torch.int32)
+    idx_flat = idx_mat.reshape(-1)
+
+    # Pad columns to D_pad and append a zero sentinel row; both extensions are zero so
+    # they don't affect the pooled sum, and autograd carries the grad back to dev_weights.
+    table = dev_weights
+    if D_pad != D:
+        table = torch.nn.functional.pad(table, (0, D_pad - D))
+    zero_row = torch.zeros(1, D_pad, dtype=table.dtype, device=device)
+    table_p = torch.cat([table, zero_row], dim=0)  # sentinel row index == V
+
+    out = _pooled_gather_fn(idx=idx_flat, table=table_p, pool=K)[:, :D]  # [B, D]
+    if pooling_mode == "mean":
+        denom = lengths.clamp(min=1).unsqueeze(1).to(out.dtype)
+        out = out / denom
+    return out
+
+
+if __name__ == "__main__":
+    # Correctness check vs torch CPU embedding_bag. Run with:
+    #   ./run_pod.sh run single_pooled_lookup.py
+    import torch.distributed as dist
+    import torch.nn.functional as F
+
+    # pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+    import torch_tpu  # noqa: F401  (registers the "tpu" device + "tpu_dist" backend)
+
+    # run_dist_file.sh launches one process per TPU. Set up the process group so all
+    # ranks stay in lockstep; each rank runs the same check independently on its own
+    # device (the kernel does no collectives), then barrier + destroy for a clean exit
+    # (early-exiting non-zero ranks wedges the distributed runtime teardown -> hang).
+    dist.init_process_group(backend="tpu_dist")
+    rank = dist.get_rank()
+
+    torch.manual_seed(0)
+
+    NUM_ROWS = 10000
+    EMB_DIM = 32
+    BATCH_SIZES = [1, 8, 64, 512]
+    POOLING_AVG = 5  # average ids per bag
+
+    weight_cpu = torch.randn(NUM_ROWS, EMB_DIM, dtype=torch.float32)
+    weight_tpu = weight_cpu.to("tpu")
+
+    for mode in ("sum", "mean"):
+        for batch_size in BATCH_SIZES:
+            lengths = torch.randint(1, 2 * POOLING_AVG, (batch_size,))
+            total_ids = int(lengths.sum().item())
+            indices = torch.randint(0, NUM_ROWS, (total_ids,), dtype=torch.int32)
+            offsets = torch.cat(
+                [torch.zeros(1, dtype=torch.int32), lengths.cumsum(0).to(torch.int32)]
+            )
+
+            # --- forward ---
+            ref_out = F.embedding_bag(
+                input=indices.to(torch.int64),
+                weight=weight_cpu,
+                offsets=offsets[:-1].to(torch.int64),
+                mode=mode,
+            )
+            tpu_out = embedding_pooled_lookup_fn(
+                indices=indices.to("tpu"),
+                offsets=offsets.to("tpu"),
+                dev_weights=weight_tpu,
+                emb_dim=EMB_DIM,
+                pooling_mode=mode,
+            ).to("cpu")
+            fwd_err = (ref_out - tpu_out).abs().max().item()
+            assert torch.allclose(
+                ref_out, tpu_out, atol=1e-4
+            ), f"{mode} fwd B={batch_size}: max abs diff = {fwd_err}"
+
+            # --- backward (grad w.r.t. the table) ---
+            grad_seed = torch.randn(batch_size, EMB_DIM, dtype=torch.float32)
+            w_ref = weight_cpu.clone().requires_grad_(True)
+            F.embedding_bag(
+                input=indices.to(torch.int64),
+                weight=w_ref,
+                offsets=offsets[:-1].to(torch.int64),
+                mode=mode,
+            ).backward(grad_seed)
+            w_dev = weight_cpu.clone().to("tpu")
+            w_dev.requires_grad_(True)
+            embedding_pooled_lookup_fn(
+                indices=indices.to("tpu"),
+                offsets=offsets.to("tpu"),
+                dev_weights=w_dev,
+                emb_dim=EMB_DIM,
+                pooling_mode=mode,
+            ).backward(grad_seed.to("tpu"))
+            assert w_ref.grad is not None and w_dev.grad is not None
+            bwd_err = (w_ref.grad - w_dev.grad.to("cpu")).abs().max().item()
+            assert torch.allclose(
+                w_ref.grad, w_dev.grad.to("cpu"), atol=1e-3
+            ), f"{mode} bwd B={batch_size}: max abs diff = {bwd_err}"
+
+            if rank == 0:
+                print(
+                    f"OK  {mode:>4}  B={batch_size:>4}  "
+                    f"fwd_err={fwd_err:.2e}  bwd_err={bwd_err:.2e}",
+                    flush=True,
+                )
+
+    if rank == 0:
+        print("All pooled-lookup fwd+bwd correctness checks passed.", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()

--- a/torchrec/experimental/torch_tpu/pallas/tests/test_sc_gather.py
+++ b/torchrec/experimental/torch_tpu/pallas/tests/test_sc_gather.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Isolated correctness check for the SparseCore recat gather (`_sc_gather_1d`).
+
+Gathers a known permutation on the SparseCore and compares to a plain torch gather.
+Run: ./run_pod.sh run test_sc_gather.py
+"""
+
+import torch
+import torch.distributed as dist
+
+# pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
+import torch_tpu  # noqa: F401
+from torchrec.experimental.torch_tpu.pallas.recat_sc import _sc_gather_1d
+
+
+def main() -> None:
+    dist.init_process_group(backend="tpu_dist")
+    rank = dist.get_rank()
+    dev = torch.device("tpu")
+
+    n = 1024
+    gen = torch.Generator().manual_seed(0)
+    values_cpu = (torch.arange(n, dtype=torch.int64) * 7) % 997
+    idx_cpu = torch.randperm(n, generator=gen)  # a full permutation
+
+    values = values_cpu.to(dev)
+    got = _sc_gather_1d(values, idx_cpu.to(torch.int32).to(dev)).cpu()
+    expected = values_cpu[idx_cpu]  # reference: values[idx]
+
+    ok = torch.equal(got, expected)
+    if rank == 0:
+        print(f"SC_GATHER_MATCH: {ok}", flush=True)
+        if not ok:
+            nmis = int((got != expected).sum())
+            print(f"  mismatched {nmis}/{n}", flush=True)
+            print(f"  idx[:12]      {idx_cpu[:12].tolist()}", flush=True)
+            print(f"  got[:12]      {got[:12].tolist()}", flush=True)
+            print(f"  expected[:12] {expected[:12].tolist()}", flush=True)
+            print(f"  values[:12]   {values_cpu[:12].tolist()}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
The post-all2all KJT reconstruction ("recat", `permute_2D_sparse_data`) has no TPU kernel, so on TPU it ran on CPU — the received id payload round-tripped device->CPU->device every step (~100MB/rank at 16-chip). This adds two on-device recat backends that keep the payload on-device and wires them into `KJTAllToAllTensorsAwaitable._wait_impl` behind `TPU_RECAT_MODE`:

- SparseCore (`recat_sc.py` `_sc_gather_1d`): a Pallas SC gather. A scalar (width-1) gather returns zeros on the SC, so each id is padded to the 16-wide vector lane and column 0 is taken (16x bandwidth waste, inherent to a scalar permute on the SC).
- TensorCore (`_tc_gather_1d`): a native width-1 `index_select` — no lane padding.

Both share one cached plan (the recat gather-index and permuted lengths are compile-time constant for fixed multi-hot), so per step only the value gather runs. `dist_init` is then called with `recat=None` (already permuted). Selectable via the benchmark `--recat-mode {sc,tc,cpu}`; default sc.

Perf finding (16-chip 2x2x4, per_chip_batch=4096, shrunk): recat engine does not matter — it is not the bottleneck.

| Recat engine | ms/step |
| CPU FBGEMM (round-trip) | 39,627 |
| SparseCore (on-device) | 39,598 |
| TensorCore (on-device) | 39,488 |

All within noise; the ~100MB round-trip is negligible against a ~39.6s step dominated by the unfused dense full-table gradient + per-element Adagrad + cross-host all2all. The real lever remains a fused embedding backward with a sparse (touched-rows-only) gradient + optimizer. EXPERIMENT_LOG.md updated with the multi-host table and this A/B.

Differential Revision: D111092421


