### PR TITLE
Use group-local rank when broadcasting in collective_utils (#4601)

### DIFF
--- a/torchrec/distributed/collective_utils.py
+++ b/torchrec/distributed/collective_utils.py
@@ -55,6 +55,8 @@ def invoke_on_rank_and_broadcast_result(
     Invokes a function on the designated rank and broadcasts the result to all
     members within the group.
 
+    ``rank`` is a rank within ``pg``, not a global rank.
+
     Example::
 
         id = invoke_on_rank_and_broadcast_result(pg, 0, allocate_id)
@@ -66,7 +68,10 @@ def invoke_on_rank_and_broadcast_result(
     else:
         object_list = [None]
     if pg.size() > 1:
-        dist.broadcast_object_list(object_list, rank, group=pg)
+        # broadcast_object_list's positional `src` is a global rank, while the
+        # leader above is picked with pg.rank(). Pass group_src so both halves
+        # use group-local numbering; they only coincide for the default group.
+        dist.broadcast_object_list(object_list, group_src=rank, group=pg)
     return cast(T, object_list[0])
 
 
@@ -180,7 +185,10 @@ def create_on_rank_and_share_result(
         object_list = [None]
 
     if pg.size() > 1:
-        dist.broadcast_object_list(object_list, rank, group=pg)
+        # group_src, not src: `rank` is group-local here too. This matters more
+        # for this helper, whose intended intra-node groups exclude global rank
+        # 0 on every host but the first.
+        dist.broadcast_object_list(object_list, group_src=rank, group=pg)
 
     if res is not None:
         return res

--- a/torchrec/distributed/tests/test_collective_utils.py
+++ b/torchrec/distributed/tests/test_collective_utils.py
@@ -150,6 +150,60 @@ class CollectiveUtilsTest(unittest.TestCase):
         )
 
     @classmethod
+    def _test_invoke_on_rank_and_broadcast_result_subgroup(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        if backend == "nccl":
+            torch.cuda.set_device(rank)
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        # Every rank has to call new_group, including the one left out of it.
+        pg = dist.new_group(ranks=[1, 2], backend=backend)
+        if rank != 0:
+            assert isinstance(pg, dist.ProcessGroup)
+            # Group-local rank 0 is global rank 1 for this group.
+            res = invoke_on_rank_and_broadcast_result(pg=pg, rank=0, func=lambda: 42)
+            assert res == 42, f"Expect res to be 42 (got {res})"
+        dist.destroy_process_group()
+
+    def test_invoke_on_rank_and_broadcast_result_subgroup(self) -> None:
+        self._run_multi_process_test(
+            world_size=3,
+            backend="gloo",
+            # pyrefly: ignore[bad-argument-type]
+            callable=self._test_invoke_on_rank_and_broadcast_result_subgroup,
+        )
+
+    @classmethod
+    def _test_invoke_on_rank_and_broadcast_result_unsorted_subgroup(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        if backend == "nccl":
+            torch.cuda.set_device(rank)
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        # sort_ranks=False leaves global rank 0 at group-local index 1, so the
+        # two rank spaces disagree for every member of the group.
+        pg = dist.new_group(ranks=[1, 0], backend=backend, sort_ranks=False)
+        assert isinstance(pg, dist.ProcessGroup)
+        # Group-local rank 0 is global rank 1, so it is the one that runs func.
+        res = invoke_on_rank_and_broadcast_result(pg=pg, rank=0, func=lambda: pg.rank())
+        assert res == 0, f"Expect res to be 0 (got {res})"
+        dist.destroy_process_group()
+
+    def test_invoke_on_rank_and_broadcast_result_unsorted_subgroup(self) -> None:
+        self._run_multi_process_test(
+            world_size=2,
+            backend="gloo",
+            # pyrefly: ignore[bad-argument-type]
+            callable=self._test_invoke_on_rank_and_broadcast_result_unsorted_subgroup,
+        )
+
+    @classmethod
     def _test_run_on_leader_decorator(
         cls,
         rank: int,
@@ -227,6 +281,42 @@ class CollectiveUtilsTest(unittest.TestCase):
             backend="gloo",
             # pyrefly: ignore[bad-argument-type]
             callable=self._test_create_on_rank_and_share_result_single_tensor,
+        )
+
+    @classmethod
+    def _test_create_on_rank_and_share_result_subgroup(
+        cls,
+        rank: int,
+        world_size: int,
+        backend: str,
+    ) -> None:
+        dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        # Every rank has to call new_group, including the one left out of it.
+        pg = dist.new_group(ranks=[1, 2], backend=backend)
+        if rank != 0:
+            assert isinstance(pg, dist.ProcessGroup)
+            shape = (8, 4)
+            fill_value = 7.0
+            # Group-local rank 0 is global rank 1 for this group.
+            result = create_on_rank_and_share_result(
+                pg,
+                0,
+                creator=lambda: torch.full(
+                    shape, fill_value=fill_value, dtype=torch.float32
+                ),
+                extractor=lambda t: [t],
+                constructor=lambda ts: ts[0],  # pyrefly: ignore[bad-argument-type]
+            )
+            assert result.shape == shape, f"Expected shape {shape}, got {result.shape}"
+            assert torch.all(result == fill_value).item(), "Shared tensor data mismatch"
+        dist.destroy_process_group()
+
+    def test_create_on_rank_and_share_result_subgroup(self) -> None:
+        self._run_multi_process_test(
+            world_size=3,
+            backend="gloo",
+            # pyrefly: ignore[bad-argument-type]
+            callable=self._test_create_on_rank_and_share_result_subgroup,
         )
 
     @classmethod


### PR DESCRIPTION
Summary:

Two helpers in `collective_utils` pick their leader with a group-local rank but broadcast from a global rank.

`invoke_on_rank_and_broadcast_result` and `create_on_rank_and_share_result` both compare `pg.rank()` against the `rank` argument to choose which process runs the callback. `pg.rank()` returns a group-local rank. Both then pass that same `rank` to `broadcast_object_list` as the positional `src`, which PyTorch documents as a global rank. The two rank spaces coincide for the default process group, so no caller has hit this. They diverge for a subgroup. A subgroup that excludes global rank 0 raises `ValueError: Global rank 0 is not part of group`. `create_on_rank_and_share_result` is the more exposed of the two. Its docstring directs callers to intra-node groups, and those exclude global rank 0 on every host but the first.

This diff passes the rank as `group_src` instead. `group_src` is group-local, which matches how the leader is selected. The change is a no-op for the default process group, where `get_group_rank` and `get_global_rank` both return the identity. It is also a no-op for a subgroup built by `new_group`, which sorts its ranks by default and so places global rank 0 at group index 0 whenever it is a member.

Reviewed By: TroyGarden

Differential Revision: D116906900


