### PR TITLE
Fix Pyre type error on torch.tpu access

### DIFF
--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -361,7 +361,7 @@ def _skip_ddp_shape_verify_on_tpu() -> None:
     unaffected (the check already passes there). The durable fix belongs in torch_tpu's
     device->CPU lowering; this unblocks the multi-host benchmark run.
     """
-    if not torch.tpu.is_available():
+    if not (hasattr(torch, "tpu") and torch.tpu.is_available()):
         return
     import torch.nn.parallel.distributed as _ddp
 


### PR DESCRIPTION
Summary:
The MLPerf TPU benchmark calls `torch.tpu.is_available()`. The `tpu` submodule is registered on `torch` at runtime by `torch_tpu`, which is not a build dependency, so the type checker cannot see it. The benchmark's type-check target fails on every run with ``No attribute `tpu` in module `torch` ``.

Guard the access with `hasattr(torch, "tpu")`, matching the pattern already used in `torchrec/distributed/utils.py`. Behavior on a TPU pod is unchanged: when the attribute exists the guard short-circuits to the original check.

Differential Revision: D116948710


