### PR TITLE
[detailed][maglev] Maglev API Refactoring for Stage and Sharding (#4605)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_maglev.py
+++ b/torchrec/distributed/benchmark/benchmark_maglev.py
@@ -10,22 +10,16 @@
 """
 Benchmark for the Maglev staged pipeline (MVP).
 
-Measures the microbatched 1F1B schedule
-(:func:`~torchrec.distributed.maglev.pipeline.run_1f1b`) of a K-stage Maglev
-model across per-stage process groups (one hardware scale-up domain, HSD, each),
-including the input distribution and the cross-HSD activation / gradient
-hand-off. Each stage is an ``EmbeddingBagCollection`` feature partition plus
-dense compute
-(:class:`~torchrec.distributed.test_utils.test_model.MaglevTestStage`, shared
-with the correctness test).
-
-Input distribution: every rank holds a full per-stage input set and all-to-alls
-it over its "cascade" (one rank per stage) via
-:func:`~torchrec.distributed.maglev.input_dist.input_dist`, so each rank ends up
-with ``num_stages`` microbatches for its own stage. A queue driver decouples the
-microbatch count from the stage count (more microbatches -> several rounds per
-pass; fewer -> drained a pass at a time). One measured iteration is this
-input-dist plus one full 1F1B pass over ``num_microbatches`` microbatches.
+Measures a microbatched 1F1B schedule, selected by ``--pipeline``:
+``1f1b-recv-ahead`` posts each receive a microbatch ahead of the compute it feeds
+(:class:`~torchrec.distributed.maglev.pipeline.Maglev1F1BRecvAhead`, the default)
+and ``1f1b`` posts it immediately before its wait
+(:class:`~torchrec.distributed.maglev.pipeline.Maglev1F1B`). The model is a
+``sum(layers_per_stage)``-layer model authored on ``meta`` and cut across
+per-stage process groups (one hardware scale-up domain, HSD, each). One measured
+iteration is the input-dist all-to-all plus one full 1F1B pass over
+``num_microbatches`` microbatches, including the cross-HSD activation / gradient
+hand-off and the DP grad all-reduce + optimizer step.
 
 Runs on GPU + nccl by default (the cross-HSD P2P hand-off and the profiler path
 are CUDA-only); `all_rank_traces` defaults on so every stage's HSD shows up in
@@ -41,16 +35,20 @@ OSS (external):
     python -m torchrec.distributed.benchmark.benchmark_maglev --profile_dir=/tmp/maglev_traces
 """
 
+import itertools
 import json
 import logging
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import cast, Dict, Iterator, List, Optional, Type
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 import torch
 import torch.distributed as dist
-from torch import nn
+import torch.nn as nn
+from torch.distributed.optim import (
+    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+)
 from torchrec.distributed.benchmark.base import (
     BenchFuncConfig,
     benchmark_func,
@@ -59,29 +57,113 @@ from torchrec.distributed.benchmark.base import (
     CPUMemoryStats,
     GPUMemoryStats,
 )
-from torchrec.distributed.maglev.input_dist import input_dist
-from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
-from torchrec.distributed.maglev.stage import (
-    build_cascade_process_groups,
-    build_handoff_process_groups,
-    build_stage_process_groups,
-    EmbeddingShard,
-    Replicated,
-    StageWrapper,
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.maglev.module import MaglevLayer
+from torchrec.distributed.maglev.pipeline import (
+    Maglev1F1B,
+    Maglev1F1BRecvAhead,
+    MaglevPipelineBase,
 )
+from torchrec.distributed.maglev.stage import remap_plan_to_process_group, StageWrapper
+from torchrec.distributed.model_parallel import (
+    DefaultDataParallelWrapper,
+    DistributedModelParallel,
+)
+from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.test_utils.model_input import ModelInput
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     run_multi_process_func,
 )
 from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
-from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.distributed.test_utils.test_model import MaglevTestLayer, MaglevTestModel
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.optim.optimizers import in_backward_optimizer_filter
 
-# Weights are seeded per stage so an HSD's two DP ranks start identical (the
-# sharded path builds DMP with init_parameters=False, so it relies on this).
+# Weights are seeded per stage, just before the stage materializes, so an HSD's
+# DP ranks start identical -- nothing syncs them afterwards.
 # Inputs are left unseeded -- values don't affect a throughput benchmark.
 _WEIGHT_SEED = 100
+
+# Selectable schedules, by --pipeline. "base" runs one microbatch per pass and
+# so is the un-pipelined reference the 1F1B variants are worth measuring against;
+# the two 1F1B entries move identical data and differ only in where the receives
+# are posted. sample_count is taken from the pipeline's microbatches_per_pass, so
+# throughput stays comparable across all three.
+_PIPELINE_CLS: Dict[str, Type[MaglevPipelineBase]] = {
+    "base": MaglevPipelineBase,
+    "1f1b": Maglev1F1B,
+    "1f1b-recv-ahead": Maglev1F1BRecvAhead,
+}
+
+
+def _shard_embeddings_in_hsd(
+    module: nn.Module,
+    stage_pg: dist.ProcessGroup,
+    device: torch.device,
+    embedding_lr: float,
+) -> nn.Module:
+    """Shard a stage's ``EmbeddingBagCollection`` within its HSD, via DMP.
+
+    Plain TorchRec, scoped to a sub-process-group -- nothing here is Maglev's, and
+    a caller is free to use any other wrapper (FSDP, none) instead. It lives in
+    the benchmark rather than the library for exactly that reason.
+
+    The tables are sharded over ``stage_pg``, so the lookup all-to-all stays local
+    to the HSD with no global cross-HSD exchange, and the embedding optimizer is
+    fused into the TBE backward. Dense params are replicated in DDP over the same
+    group and reduced once per pass, the schedule having suppressed DDP's sync on
+    every backward but the last.
+    """
+    sharders: List[ModuleSharder[nn.Module]] = [
+        cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder())
+    ]
+    # Fuse the embedding optimizer into the TBE backward *before* DMP so the
+    # sharder builds it into the kernel (sparse params train in backward).
+    emb_params = [
+        p
+        for m in module.modules()
+        if isinstance(m, EmbeddingBagCollection)
+        for p in m.parameters()
+    ]
+    apply_optimizer_in_backward(torch.optim.SGD, emb_params, {"lr": embedding_lr})
+
+    env = ShardingEnv.from_process_group(stage_pg)
+    planner = EmbeddingShardingPlanner(
+        topology=Topology(world_size=stage_pg.size(), compute_device=device.type)
+    )
+    # NOTE: not planner.collective_plan(): it broadcasts from group-local rank 0
+    # but passes it as a *global* broadcast src, which deadlocks for any stage
+    # whose pg does not contain global rank 0 (stages 1..N-1). Compute the plan on
+    # the pg's leader and broadcast with the correct global src.
+    if stage_pg.rank() == 0:
+        plan_holder: List[Optional[ShardingPlan]] = [planner.plan(module, sharders)]
+    else:
+        plan_holder = [None]
+    if stage_pg.size() > 1:
+        dist.broadcast_object_list(
+            plan_holder, src=dist.get_global_rank(stage_pg, 0), group=stage_pg
+        )
+    plan = plan_holder[0]
+    assert plan is not None
+    remap_plan_to_process_group(plan, stage_pg, device)
+    return DistributedModelParallel(
+        module=module,
+        env=env,
+        device=device,
+        plan=plan,
+        sharders=sharders,
+        # Dense params go into DDP over the stage pg; the schedule suppresses its
+        # sync around every forward but the pass's last, so one all-reduce lands
+        # per pass. static_graph is off: it requires the reducer to be armed on
+        # the first backward, which cannot hold when the first microbatch's
+        # forward is deliberately inside no_sync.
+        init_data_parallel=True,
+        data_parallel_wrapper=DefaultDataParallelWrapper(static_graph=False),
+        init_parameters=True,
+    )
 
 
 @dataclass
@@ -92,25 +174,40 @@ class RunOptions(BenchFuncConfig):
         name (str): Human-readable benchmark name. Default is "maglev".
         world_size (int): Total number of ranks. Must equal
             ``num_stages * ranks_per_stage``. Default is 8.
-        num_benchmarks (int): Number of measured iterations (each one full 1F1B
-            pass). Default is 12.
+        num_benchmarks (int): Number of measured iterations (each one full pass).
+            Default is 0 -- a plain run only profiles, emitting traces and no
+            timings. Pass e.g. ``--num_benchmarks=12`` to measure.
         num_profiles (int): Number of profiling iterations (CUDA only; unused on
             the CPU path). Default is 2.
-        num_stages (int): Number of Maglev stages (one HSD each). Default is 4.
+        layers_per_stage (List[int]): How the model's layers are cut across the
+            pipeline -- one entry per stage, so this also sets the stage count
+            (one HSD each) and the model depth (its sum). Default is
+            ``[2, 3, 4, 3]``: 12 layers over 4 stages, deliberately uneven, since
+            only stage boundaries cross the network and a real cut is rarely
+            uniform.
         ranks_per_stage (int): Ranks per stage's HSD (intra-HSD data
             parallelism). Default is 2.
         batch_size (int): Per-microbatch batch size ``B``. Default is 8192, which
-            with ``stage_dim`` gives a 128 MiB cross-stage activation (past NCCL's
+            with ``layer_dim`` gives a 128 MiB cross-stage activation (past NCCL's
             ~64 MiB P2P buffer cliff).
         num_microbatches (int): Number of microbatches per 1F1B pass.
             Default is 8.
-        num_tables (int): Embedding tables per stage (one feature each). Default is 8.
+        pipeline (str): Which schedule to measure. Options:
+            - "base": one microbatch per pass, no pipelining -- the reference the
+              1F1B variants are worth measuring against
+            - "1f1b": each receive posted immediately before its wait
+            - "1f1b-recv-ahead": each receive posted a microbatch ahead of the
+              compute it feeds
+            The two 1F1B variants move identical data; only the receive placement
+            differs. Default is "1f1b-recv-ahead".
+        num_tables (int): Embedding tables per layer (one feature each). Default is 8.
         num_embeddings (int): Rows per embedding table. Default is 1000000.
         emb_dim (int): Embedding dimension ``D``. Default is 256.
         num_float_features (int): Width of each stage's dense/float feature input.
             Default is 64.
-        stage_dim (int): Width of the activation carried between stages.
-            Default is 4096 (128 MiB activation with the default batch size).
+        layer_dim (int): Width of the activation carried between layers (and so
+            between stages). Default is 4096 (128 MiB activation with the default
+            batch size).
         lr (float): Learning rate for the per-stage SGD optimizer.
             Default is 0.05.
         shard_embeddings (bool): Shard each stage's embedding tables within its
@@ -120,6 +217,9 @@ class RunOptions(BenchFuncConfig):
             P2P the CUDA activations between stages.
         output_json (bool): Print the result as JSON instead of a table.
             Default is False.
+        debug_mode (bool): Attach a debugger before running. Every rank attaches,
+            so pair it with a small ``world_size`` unless you want eight
+            simultaneous sessions. Default is False.
         all_rank_traces (bool): Export a profiler trace from every rank (not just
             rank 0) so each stage's HSD is captured. Default is True. Traces are
             only emitted when ``profile_dir`` is set and ``device_type`` is
@@ -128,27 +228,32 @@ class RunOptions(BenchFuncConfig):
 
     name: str = "maglev"
     world_size: int = 8
-    num_benchmarks: int = 12
+    num_benchmarks: int = 1
     num_profiles: int = 2
-    num_stages: int = 4
+    layers_per_stage: List[int] = field(default_factory=lambda: [2, 3, 4, 3])
     ranks_per_stage: int = 2
-    # Heavy default: batch_size * stage_dim * 4B = 8192 * 4096 * 4 = 128 MiB
+    # Heavy default: batch_size * layer_dim * 4B = 8192 * 4096 * 4 = 128 MiB
     # cross-stage activation, past NCCL's ~64 MiB P2P buffer cliff, so the
     # hand-off exercises the large-payload (rendezvous) path -- see the parity
     # handoff pgs in stage.py and tech-docs/nccl_p2p_execution_order_buffer_size.md.
     batch_size: int = 8192
     num_microbatches: int = 8
-    # Heavier embedding tables: 1M rows * 256 dim * 8 tables per stage.
+    # Which schedule to measure; see _PIPELINE_CLS. The two move identical data
+    # and differ only in where the receives are posted, so this is the knob that
+    # isolates what running the receives ahead is worth.
+    pipeline: str = "1f1b-recv-ahead"
+    # Heavier embedding tables: 1M rows * 256 dim * 8 tables per layer.
     num_tables: int = 8
     num_embeddings: int = 1_000_000
     emb_dim: int = 256
     num_float_features: int = 64
-    stage_dim: int = 4096
+    layer_dim: int = 4096
     lr: float = 0.05
     # Intra-HSD embedding sharding (DMP per stage), scoped to each stage's pg so
     # the lookup all-to-all stays local to the HSD. Requires nccl (cuda).
     shard_embeddings: bool = True
     output_json: bool = False
+    debug_mode: bool = False
     # Capture a trace from every rank so each stage's HSD shows up, not only
     # rank 0's stage (traces are emitted only when profile_dir is set on CUDA).
     all_rank_traces: bool = True
@@ -158,24 +263,51 @@ class RunOptions(BenchFuncConfig):
     device_type: str = "cuda"
     profile_dir: str = "."
 
+    def generate_pipeline(
+        self, stage: StageWrapper, optimizer: torch.optim.Optimizer
+    ) -> MaglevPipelineBase:
+        """Build the schedule named by :attr:`pipeline`.
+
+        Raises:
+            ValueError: if :attr:`pipeline` is not a known schedule.
+        """
+        if self.pipeline not in _PIPELINE_CLS:
+            raise ValueError(
+                f"unknown pipeline {self.pipeline!r}; expected one of "
+                f"{sorted(_PIPELINE_CLS)}"
+            )
+        match self.pipeline:
+            case "base":
+                # One microbatch per pass; takes no microbatch count.
+                return MaglevPipelineBase(stage=stage, optimizer=optimizer)
+            case _:
+                # Every non-"base" entry is a Maglev1F1B subclass, which is what
+                # makes num_microbatches a valid argument.
+                Pipeline = cast(Type[Maglev1F1B], _PIPELINE_CLS[self.pipeline])
+                return Pipeline(
+                    stage=stage,
+                    optimizer=optimizer,
+                    num_microbatches=self.num_microbatches,
+                )
+
 
 def _make_tables(
-    stage_index: int,
+    layer_index: int,
     num_tables: int,
     num_embeddings: int,
     emb_dim: int,
 ) -> List[EmbeddingBagConfig]:
-    """This stage's feature partition: ``num_tables`` disjoint 1-feature tables.
+    """This layer's feature partition: ``num_tables`` disjoint 1-feature tables.
 
     Reuses the shared :class:`EmbeddingTablesConfig` generator, namespaced per
-    stage via ``name_prefix`` so each stage's tables/features are disjoint.
+    layer via ``name_prefix`` so each layer's tables/features are disjoint.
     """
     return EmbeddingTablesConfig(
         num_unweighted_features=num_tables,
         num_weighted_features=0,
         embedding_feature_dim=emb_dim,
         base_row_size=num_embeddings,
-    ).generate_tables(name_prefix=f"s{stage_index}_")[0]
+    ).generate_tables(name_prefix=f"l{layer_index}_")[0]
 
 
 def _make_input(
@@ -194,75 +326,29 @@ def _make_input(
     )
 
 
-class _InputDistDriver:
-    """Feeds the 1F1B schedule with microbatches produced by ``input_dist``.
-
-    Each rank holds a *full set* of inputs (one ``ModelInput`` per stage); one
-    :func:`input_dist` round over the rank's cascade all-to-alls that set so the
-    rank receives ``num_stages`` inputs for its own stage -- i.e. ``num_stages``
-    microbatches per round. :meth:`take` refills a FIFO queue with whole rounds
-    until it holds at least ``n`` microbatches, then hands back ``n`` and keeps
-    the remainder, decoupling the microbatch count from the stage count:
-
-    * more microbatches than stages (e.g. 8 wanted, 4 stages) -> 2 rounds/pass;
-    * fewer (e.g. 8 wanted, 16 stages) -> one round every other pass, drained
-      ``n`` at a time from the queue.
-
-    The refill count is a deterministic function of ``(queue length, n)`` and the
-    queue starts empty on every rank, so all ranks in a cascade call
-    :func:`input_dist` the same number of times and stay in lock-step.
-
-    Args:
-        send: this rank's full input set; ``send[s]`` is destined for stage ``s``.
-        example: template carrier for reconstruction (a local-stage ModelInput).
-        cascade_pg: the cascade process group (size == num stages) to exchange over.
-    """
-
-    def __init__(
-        self,
-        send: List[ModelInput],
-        example: ModelInput,
-        cascade_pg: dist.ProcessGroup,
-    ) -> None:
-        self._send = send
-        self._example = example
-        self._pg = cascade_pg
-        self._queue: List[ModelInput] = []
-        # Monotonic input-dist round counter, tags the profiler ranges.
-        self._batch_id = 0
-
-    def take(self, n: int) -> List[ModelInput]:
-        while len(self._queue) < n:
-            # Same handle drives both phases: CPU/gloo sizes, CUDA/nccl data.
-            # input_dist returns a LazyAwaitable; wait() completes the exchange.
-            self._queue.extend(
-                input_dist(
-                    self._send,
-                    self._example,
-                    pg_gloo=self._pg,
-                    pg_nccl=self._pg,
-                    batch_id=self._batch_id,
-                ).wait()
-            )
-            self._batch_id += 1
-        out = self._queue[:n]
-        self._queue = self._queue[n:]
-        return out
-
-
 # single-rank runner
 def runner(
     rank: int,
     world_size: int,
     run_option: RunOptions,
 ) -> BenchmarkResult:
+    # debug mode only works with vscode for now.
+    if run_option.debug_mode:
+        # pyrefly: ignore[missing-module-attribute]
+        from fbvscode import attach_debugger
+
+        attach_debugger()
+
     run_option.set_log_level()
 
-    num_stages = run_option.num_stages
+    # The cut is the source of truth: it fixes the stage count and the depth.
+    layers_per_stage = list(run_option.layers_per_stage)
+    num_stages = len(layers_per_stage)
+    num_layers = sum(layers_per_stage)
     ranks_per_stage = run_option.ranks_per_stage
     assert world_size == num_stages * ranks_per_stage, (
-        f"world_size ({world_size}) must equal num_stages ({num_stages}) * "
-        f"ranks_per_stage ({ranks_per_stage})"
+        f"world_size ({world_size}) must equal len(layers_per_stage) "
+        f"({num_stages}) * ranks_per_stage ({ranks_per_stage})"
     )
 
     # CUDA uses nccl for the cross-HSD P2P hand-off (falls back to gloo for the
@@ -270,121 +356,104 @@ def runner(
     backend = "cpu:gloo,cuda:nccl" if run_option.device_type == "cuda" else "gloo"
     with MultiProcessContext(rank=rank, world_size=world_size, backend=backend) as ctx:
         device = ctx.device
-        criterion = nn.MSELoss()
 
-        # HSD layout: contiguous rank groups, one stage per HSD.
-        stage_ranks: List[List[int]] = [
-            list(range(s * ranks_per_stage, (s + 1) * ranks_per_stage))
-            for s in range(num_stages)
-        ]
+        # HSD layout is implicit in stage_size: stage i is the contiguous rank
+        # block starting at i * ranks_per_stage. StageWrapper builds every process
+        # group (stage / hand-off / cascade) itself, before it shards.
+        my_stage_index, position = StageWrapper.locate_rank(ranks_per_stage, rank)
 
-        # Collective: every rank builds every stage's process group.
-        stage_pgs = build_stage_process_groups(stage_ranks)
-        # Build hand-off + cascade pgs up front (before any DMP sharding) so all
-        # new_group collectives stay contiguous and cannot deadlock against
-        # sharding comms. Cascade pgs (one rank per stage) carry the input-dist
-        # all-to-all; every rank builds all of them in the same order.
-        handoff_pgs = build_handoff_process_groups(stage_ranks)
-        cascade_pgs = build_cascade_process_groups(stage_ranks)
-        my_stage_index = rank // ranks_per_stage
-        position = rank - my_stage_index * ranks_per_stage
-        cascade_pg = cascade_pgs[position]
-
-        # All stages' table configs (identical on every rank) so each rank can
+        # All layers' table configs (identical on every rank) so each rank can
         # generate a full per-stage input set for the input-dist all-to-all.
         all_tables = [
             _make_tables(
-                s,
+                l,
                 run_option.num_tables,
                 run_option.num_embeddings,
                 run_option.emb_dim,
             )
-            for s in range(num_stages)
+            for l in range(num_layers)
         ]
-        # This rank's stage (weights seeded by stage index so an HSD's two DP
-        # ranks start identical -> grad all-reduce keeps them in lock-step).
-        tables = all_tables[my_stage_index]
+        # Every rank authors the whole model and lets StageWrapper keep its own
+        # stage. Layers this rank does not own are built on the ``meta`` device:
+        # StageWrapper drops them, and meta tensors have no storage, so they cost
+        # nothing -- which matters here because a materialized layer is 1M x 256 x
+        # 8 tables. Weights are seeded by layer index so an HSD's two DP ranks
+        # start identical -> the grad all-reduce keeps them in lock-step.
+        # Author the whole model on meta -- no storage, so holding every layer
+        # costs nothing -- then let StageWrapper keep this rank's stage and
+        # materialize only those layers on the device.
+        meta_device = torch.device("meta")
+        layers: List[MaglevLayer] = [
+            MaglevTestLayer(
+                tables=all_tables[layer_index],
+                layer_dim=run_option.layer_dim,
+                is_first=(layer_index == 0),
+                batch_size=run_option.batch_size,
+                num_float_features=run_option.num_float_features,
+                device=meta_device,
+            )
+            for layer_index in range(num_layers)
+        ]
+        model = MaglevTestModel(layers)
+        # Meta construction consumes no randomness, so the weights are drawn when
+        # the stage materializes: seed here, per stage, so an HSD's ranks start
+        # identical (the sharded path relies on that -- it does not sync weights).
         torch.manual_seed(_WEIGHT_SEED + my_stage_index)
-        module = MaglevTestStage(
-            tables=tables,
-            stage_dim=run_option.stage_dim,
-            is_first=(my_stage_index == 0),
-            num_float_features=run_option.num_float_features,
-            device=device,
-        )
-        parallelizer = (
-            EmbeddingShard(embedding_lr=run_option.lr)
-            if run_option.shard_embeddings
-            else Replicated()
-        )
         stage = StageWrapper(
-            module=module,
-            stage_pg=stage_pgs[my_stage_index],
-            stage_index=my_stage_index,
-            parallelizer=parallelizer,
+            model=model,
+            layers_per_stage=layers_per_stage,
+            stage_size=ranks_per_stage,
         )
-        pipeline = MaglevPipeline(
-            stage=stage,
-            stage_ranks=stage_ranks,
-            global_rank=rank,
-            activation_shape=torch.Size([run_option.batch_size, run_option.stage_dim]),
-            device=device,
-            handoff_pgs=handoff_pgs,
+        # Parallelism is the caller's: shard the embeddings within the HSD, then
+        # materialize. Wrapping before to() is what keeps a meta-authored stage
+        # from allocating full-size tables the sharder is about to cut up.
+        if run_option.shard_embeddings:
+            stage.module = _shard_embeddings_in_hsd(
+                stage.module, stage.stage_pg, device, run_option.lr
+            )
+        stage.to(device)
+        # Dense params only, as benchmark_train_pipeline does: when the stage is
+        # sharded the embeddings train in backward via the fused TBE optimizer, so
+        # they neither need nor belong in the outer step.
+        # (Citrine C2: foreach=True for multi-tensor execution.)
+        optimizer = torch.optim.SGD(
+            [
+                p
+                for _, p in in_backward_optimizer_filter(
+                    stage.module.named_parameters()
+                )
+            ],
+            lr=run_option.lr,
+            foreach=True,
         )
+        pipeline = run_option.generate_pipeline(stage=stage, optimizer=optimizer)
 
-        # Sharded: CombinedOptimizer(fused embedding + dense SGD). Replicated:
-        # a plain SGD. (Citrine C2: foreach=True in the dense/replicated SGD.)
-        optimizer = stage.configure_optimizer(run_option.lr)
-
-        # Full per-stage input set for this rank (send[s] is destined for stage
-        # s's rank in the cascade). Generated once, outside the measured region --
-        # data loading is not what we benchmark; the input-dist all-to-all itself
-        # runs inside _func_to_benchmark via the driver.
-        send_set: List[ModelInput] = [
+        # One batch, replayed forever: data loading is not what we benchmark, so
+        # the dataloader hands back the same pre-built batch every round and only
+        # the input-dist all-to-all inside progress() is measured. A batch here is
+        # one ModelInput per layer of the whole model, which is what the model's
+        # (passthrough) preproc consumes.
+        model_input = [
             _make_input(
-                all_tables[s],
+                all_tables[l],
                 run_option.batch_size,
                 run_option.num_float_features,
                 device,
             )
-            for s in range(num_stages)
+            for l in range(num_layers)
         ]
-        # Reconstruction template: a local-stage input (== the item this rank
-        # sends to itself at cascade index my_stage_index).
-        driver = _InputDistDriver(
-            send=send_set,
-            example=send_set[my_stage_index],
-            cascade_pg=cascade_pg,
-        )
-
-        labels: List[torch.Tensor] = []
-        if pipeline.is_last:
-            labels = [
-                torch.randn(run_option.batch_size, run_option.stage_dim, device=device)
-                for _ in range(run_option.num_microbatches)
-            ]
+        dataloader_iter: Iterator[List[ModelInput]] = itertools.repeat(model_input)
 
         def _func_to_benchmark(
             bench_inputs: List[ModelInput],
-            pipeline: MaglevPipeline,
-            optimizer: torch.optim.Optimizer,
-            driver: _InputDistDriver,
-            num_microbatches: int,
-            labels: List[torch.Tensor],
-            criterion: nn.Module,
+            pipeline: MaglevPipelineBase,
+            dataloader_iter: Iterator[List[ModelInput]],
         ) -> None:
             # One measured iteration = the input-dist all-to-all for this pass's
-            # microbatches (refilling the queue as needed) + one full 1F1B pass
-            # (warmup + steady 1F1B + cooldown), including the cross-HSD hand-off
-            # and the per-batch DP grad all-reduce + optimizer step.
-            micro_inputs = driver.take(num_microbatches)
-            run_1f1b(
-                pipeline=pipeline,
-                microbatch_inputs=micro_inputs,
-                optimizer=optimizer,
-                labels=labels if pipeline.is_last else None,
-                criterion=criterion if pipeline.is_last else None,
-            )
+            # microbatches (refilling the queue as needed) + one full pass,
+            # including the cross-HSD hand-off and the per-batch DP grad
+            # all-reduce + optimizer step.
+            pipeline.progress(dataloader_iter)
 
         result = benchmark_func(
             bench_inputs=[],
@@ -392,14 +461,12 @@ def runner(
             func_to_benchmark=_func_to_benchmark,
             benchmark_func_kwargs={
                 "pipeline": pipeline,
-                "optimizer": optimizer,
-                "driver": driver,
-                "num_microbatches": run_option.num_microbatches,
-                "labels": labels,
-                "criterion": criterion,
+                "dataloader_iter": dataloader_iter,
             },
-            # One 1F1B pass consumes num_microbatches per-rank batches.
-            sample_count=run_option.batch_size * run_option.num_microbatches,
+            # A pass consumes microbatches_per_pass per-rank batches -- which is
+            # num_microbatches for 1F1B but 1 for the base schedule, so this has
+            # to come from the pipeline, not the config.
+            sample_count=run_option.batch_size * pipeline.microbatches_per_pass,
             **run_option.benchmark_func_kwargs(rank=rank),
         )
 
@@ -443,6 +510,12 @@ def run_maglev(run_option: RunOptions) -> BenchmarkResult:
 # command-line interface
 @cmd_conf
 def main(run_option: RunOptions) -> None:
+    if run_option.debug_mode:
+        # pyrefly: ignore[missing-module-attribute]
+        from fbvscode import attach_debugger
+
+        attach_debugger()
+
     result = run_maglev(run_option=run_option)
 
     # Print from the parent process so the result is always visible (rank-0

--- a/torchrec/distributed/maglev/__init__.py
+++ b/torchrec/distributed/maglev/__init__.py
@@ -9,37 +9,17 @@
 
 """Maglev: staged, HSD-aligned recommender execution for TorchRec (MVP).
 
-This package holds the systems skeleton of Maglev:
+A **layer** is the unit of compute; a **stage** is one or more consecutive layers
+and the unit of parallelism, one per hardware scale-up domain (HSD). A model is
+authored as a :class:`~torchrec.distributed.maglev.module.MaglevModuleList` of
+layers and runs either standalone in one process or pipeline-parallel: each rank
+hands the whole model to a
+:class:`~torchrec.distributed.maglev.stage.StageWrapper`, which keeps the one
+stage that rank owns, and a
+:class:`~torchrec.distributed.maglev.pipeline.MaglevPipelineBase` schedule drives
+it.
 
-* :class:`~torchrec.distributed.maglev.module.MaglevModuleList` -- the
-  ``ModuleList``-like API where each entry is a stage.
-* :class:`~torchrec.distributed.maglev.stage.StageWrapper` -- binds a stage to
-  its process group (one hardware scale-up domain, HSD).
-* :class:`~torchrec.distributed.maglev.pipeline.MaglevPipeline` -- hooks the
-  stages together across HSDs (forward activation + backward gradient hand-off).
-
-Modeling components (Maglev Indexers / Induct) and the zero-bubble Maglev Rail
-schedule are intentionally out of scope for the MVP; the API leaves room for
-them to slot in later.
+Import from the submodules directly (``maglev.module``, ``maglev.stage``,
+``maglev.pipeline``); nothing is re-exported here, so there is no second list of
+names to keep in step with the code.
 """
-
-from torchrec.distributed.maglev.module import MaglevModuleList
-from torchrec.distributed.maglev.pipeline import MaglevPipeline, run_1f1b
-from torchrec.distributed.maglev.stage import (
-    build_stage_process_groups,
-    EmbeddingShard,
-    Replicated,
-    StageParallelizer,
-    StageWrapper,
-)
-
-__all__ = [
-    "MaglevModuleList",
-    "MaglevPipeline",
-    "run_1f1b",
-    "StageWrapper",
-    "StageParallelizer",
-    "Replicated",
-    "EmbeddingShard",
-    "build_stage_process_groups",
-]

--- a/torchrec/distributed/maglev/input_dist.py
+++ b/torchrec/distributed/maglev/input_dist.py
@@ -9,29 +9,18 @@
 
 """Flatten structured data to a list of tensors, rebuild it, and all-to-all it.
 
-Used to move structured cross-stage "carriers" across HSD boundaries. A carrier
-(dataclass of tensors / ``KeyedJaggedTensor`` / nested containers) is flattened to
-a flat list of tensors on the sender and rebuilt on the receiver from a known
-*example* (template) instance. Only tensors cross the wire; every non-tensor part
--- dataclass field values that are scalars/strings, container shapes, dict keys,
-and a ``KeyedJaggedTensor``'s feature keys -- is supplied by the example.
-
-Supported structure: ``torch.Tensor``, ``KeyedJaggedTensor``, dataclasses, and
-nested ``list`` / ``tuple`` / ``dict``; any other value is a non-tensor leaf
-(carried by the example, not transferred).
-
-On top of flatten/unflatten this module provides a two-phase all-to-all of a list
-of carriers (:func:`input_dist`): :func:`input_size_dist` exchanges the small
-tensor-size metadata over a cheap CPU/gloo group, then :func:`input_data_dist`
-moves the bulk tensors over an nccl group with the sizes learned in phase one.
-Both phases issue their collectives with ``async_op=True`` and return a
-:class:`~torchrec.distributed.types.LazyAwaitable`, so the caller can overlap
-other work and ``wait()`` only when the result is needed.
+A "carrier" (dataclass of tensors / ``KeyedJaggedTensor`` / nested containers) is
+flattened on the sender and rebuilt on the receiver from a known *example*
+instance: only tensors cross the wire, and every non-tensor part comes from the
+example. :func:`input_dist` all-to-alls a list of carriers in two phases -- sizes
+over CPU/gloo, then bulk tensors over nccl -- both async, returning a
+:class:`~torchrec.distributed.types.LazyAwaitable`.
 """
 
 import math
+from collections import deque
 from dataclasses import fields, is_dataclass
-from typing import Any, Dict, Iterator, List, Tuple, TypeVar
+from typing import Any, Callable, Deque, Dict, Generic, Iterator, List, Tuple, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -186,7 +175,8 @@ class _InputSizeAwaitable(
     ``wait()`` completes the async exchange and returns ``(flat_send, recv_sizes)``:
     the flattened send tensors (available immediately, threaded through so phase two
     need not re-flatten) and ``recv_sizes[i][k]`` -- the dim-0 size of slot ``k`` of
-    the carrier rank ``i`` is sending to this rank.
+    the carrier rank ``i`` is sending to this rank. The sizes arrive flat and are
+    reshaped to ``[world_size, recv_slots]`` here.
     """
 
     def __init__(
@@ -195,19 +185,22 @@ class _InputSizeAwaitable(
         work: Any,
         flat_send: List[List[torch.Tensor]],
         recv_sizes: torch.Tensor,
+        recv_slots: int,
         batch_id: int,
     ) -> None:
         super().__init__()
         self._work = work
         self._flat_send = flat_send
         self._recv_sizes = recv_sizes
+        self._recv_slots = recv_slots
         self._batch_id = batch_id
 
     def _wait_impl(self) -> Tuple[List[List[torch.Tensor]], List[List[int]]]:
         with record_function(f"## input_size_dist wait batch{self._batch_id} ##"):
             if self._work is not None:
                 self._work.wait()
-            return self._flat_send, self._recv_sizes.tolist()
+            # Flat on the wire, [source rank][slot] to the caller.
+            return self._flat_send, self._recv_sizes.view(-1, self._recv_slots).tolist()
 
 
 class _InputDataAwaitable(LazyAwaitable[List[T]]):
@@ -275,21 +268,32 @@ class _InputDataAwaitable(LazyAwaitable[List[T]]):
 
 def input_size_dist(
     send: List[T],
+    example: T,
     pg_gloo: dist.ProcessGroup,
     batch_id: int = 0,
 ) -> LazyAwaitable[Tuple[List[List[torch.Tensor]], List[List[int]]]]:
     """Phase one: flatten each carrier and async all-to-all the tensor-size metadata.
 
     ``send`` must have one carrier per rank in ``pg_gloo`` (``send[j]`` is destined
-    for rank ``j``). Each carrier is flattened to the same number ``K`` of tensors
-    (the homogeneity assumption), and only each tensor's dim-0 size varies between
-    carriers -- trailing dims and dtype are fixed per slot and recovered from the
-    example in phase two. This issues an async all-to-all of a small ``[W, K]``
-    integer matrix of dim-0 sizes over the (cheap, CPU) gloo group so every rank
-    learns the sizes of the tensors it is about to receive.
+    for rank ``j``), and each must have the structure *that destination* expects --
+    which is what ``example`` describes locally. Carriers may therefore differ in
+    tensor count between destinations: a rank sending a 2-slot carrier to one peer
+    and a 3-slot carrier to another is fine, as long as each peer's own example
+    agrees. What is *received* is always homogeneous, since every incoming carrier
+    is built for this rank.
+
+    Only each tensor's dim-0 size varies; trailing dims and dtype are fixed per
+    slot and recovered from the example in phase two. This issues an async
+    all-to-all of the dim-0 sizes over the (cheap, CPU) gloo group -- ragged on the
+    way out (``input_split_sizes`` is each carrier's tensor count) and rectangular
+    on the way back (every peer sends this rank ``K`` sizes, ``K`` taken from
+    ``example``) -- so every rank learns the sizes of the tensors it is about to
+    receive.
 
     Args:
         send: one carrier per destination rank; ``send[j]`` goes to rank ``j``.
+        example: template carrier for what this rank *receives*; its tensor count
+            fixes how many sizes to expect from each peer.
         pg_gloo: a gloo process group used only for the tiny size exchange.
         batch_id: identifier for this input batch, used only to tag the profiler
             ranges (``## input_size_dist batch{batch_id} ##``).
@@ -301,8 +305,7 @@ def input_size_dist(
         slot ``k`` of the carrier rank ``i`` is sending to this rank.
 
     Raises:
-        ValueError: if ``len(send)`` does not match the group size, or the carriers
-            do not all flatten to the same number of tensors.
+        ValueError: if ``len(send)`` does not match the group size.
     """
     world_size = dist.get_world_size(pg_gloo)
     if len(send) != world_size:
@@ -311,24 +314,28 @@ def input_size_dist(
             f"{world_size}"
         )
     flat_send: List[List[torch.Tensor]] = [flatten_to_tensors(item) for item in send]
-    num_tensors = len(flat_send[0])
-    for j, tensors in enumerate(flat_send):
-        if len(tensors) != num_tensors:
-            raise ValueError(
-                f"carriers must flatten to the same tensor count: send[0] has "
-                f"{num_tensors}, send[{j}] has {len(tensors)}"
-            )
+    # Every carrier this rank receives is built for this rank, so they all have the
+    # example's slot count -- the receive side stays rectangular even when the send
+    # side is ragged.
+    recv_slots = len(flatten_to_tensors(example))
 
     with record_function(f"## input_size_dist batch{batch_id} ##"):
         send_sizes = torch.tensor(
-            [[t.shape[0] for t in tensors] for tensors in flat_send],
+            [t.shape[0] for tensors in flat_send for t in tensors],
             dtype=torch.int64,
         )
-        recv_sizes = torch.empty_like(send_sizes)
+        in_splits = [len(tensors) for tensors in flat_send]
+        out_splits = [recv_slots] * world_size
+        recv_sizes = torch.empty(recv_slots * world_size, dtype=torch.int64)
         work = dist.all_to_all_single(
-            recv_sizes, send_sizes, group=pg_gloo, async_op=True
+            recv_sizes,
+            send_sizes,
+            out_splits,
+            in_splits,
+            group=pg_gloo,
+            async_op=True,
         )
-    return _InputSizeAwaitable(work, flat_send, recv_sizes, batch_id)
+    return _InputSizeAwaitable(work, flat_send, recv_sizes, recv_slots, batch_id)
 
 
 def input_data_dist(
@@ -363,10 +370,12 @@ def input_data_dist(
         the carrier received from rank ``i``.
     """
     world_size = len(flat_send)
-    num_tensors = len(flat_send[0])
     example_flat = flatten_to_tensors(example)
+    num_tensors = len(example_flat)
     # Per-slot layout from the example: elements per dim-0 row and the trailing shape
-    # (only dim-0 varies between carriers, so these are fixed per slot).
+    # (only dim-0 varies between carriers, so these are fixed per slot). This is the
+    # *receive* side, which is homogeneous -- every incoming carrier is built for
+    # this rank.
     row_elems = [math.prod(t.shape[1:]) for t in example_flat]
     trailing = [tuple(t.shape[1:]) for t in example_flat]
     # Bucket slots by dtype in first-seen order. The example is a shared template, so
@@ -374,6 +383,23 @@ def input_data_dist(
     buckets: Dict[torch.dtype, List[int]] = {}
     for k in range(num_tensors):
         buckets.setdefault(example_flat[k].dtype, []).append(k)
+
+    # The *send* side may be ragged: a carrier built for a destination with more
+    # layers has more slots than this rank's own example. So bucket each
+    # destination's slots by its own dtypes rather than reusing the example's slot
+    # indices, which describe a different carrier.
+    send_slots: List[Dict[torch.dtype, List[int]]] = []
+    for j in range(world_size):
+        by_dtype: Dict[torch.dtype, List[int]] = {}
+        for k, tensor in enumerate(flat_send[j]):
+            if tensor.dtype not in buckets:
+                raise ValueError(
+                    f"send[{j}] slot {k} has dtype {tensor.dtype}, which the example "
+                    "does not have; a carrier may differ from the example in slot "
+                    "count, not in the dtypes it carries"
+                )
+            by_dtype.setdefault(tensor.dtype, []).append(k)
+        send_slots.append(by_dtype)
 
     device = flat_send[0][0].device
     # pyre-ignore[33]: dist work handles have no public type
@@ -385,11 +411,22 @@ def input_data_dist(
         for dtype, slots in buckets.items():
             # Destination-major, then slot-major: chunk j (-> rank j) is this rank's
             # slots for j laid end to end; input_split_sizes marks the j boundaries.
+            # Each destination contributes its *own* slots of this dtype, in slot
+            # order -- which lines up with how that peer's example slices them out,
+            # since the carrier was built to its structure.
             in_splits = [
-                sum(flat_send[j][k].numel() for k in slots) for j in range(world_size)
+                sum(flat_send[j][k].numel() for k in send_slots[j].get(dtype, []))
+                for j in range(world_size)
             ]
-            in_buf = torch.cat(
-                [flat_send[j][k].reshape(-1) for j in range(world_size) for k in slots]
+            parts = [
+                flat_send[j][k].reshape(-1)
+                for j in range(world_size)
+                for k in send_slots[j].get(dtype, [])
+            ]
+            in_buf = (
+                torch.cat(parts)
+                if parts
+                else torch.empty(0, dtype=dtype, device=device)
             )
             out_splits = [
                 sum(recv_sizes[i][k] * row_elems[k] for k in slots)
@@ -450,5 +487,101 @@ def input_dist(
         A :class:`LazyAwaitable` whose ``wait()`` yields ``recv`` with ``recv[i]``
         the carrier received from rank ``i``.
     """
-    flat_send, recv_sizes = input_size_dist(send, pg_gloo, batch_id).wait()
+    flat_send, recv_sizes = input_size_dist(send, example, pg_gloo, batch_id).wait()
     return input_data_dist(flat_send, recv_sizes, example, pg_nccl, batch_id)
+
+
+class InputDistDriver(Generic[T]):
+    """Feeds a pipeline schedule with microbatches produced by :func:`input_dist`.
+
+    One :func:`input_dist` round over a cascade yields one carrier per stage --
+    i.e. as many microbatches as there are stages, all destined for the calling
+    rank. A schedule asks for ``n`` microbatches per pass, which need not match.
+    This buffers whole rounds in a FIFO and hands out ``n`` at a time,
+    decoupling the two:
+
+    * more microbatches than stages (8 wanted, 4 stages) -> 2 rounds per pass;
+    * fewer (8 wanted, 16 stages) -> one round every other pass, drained ``n``
+      at a time.
+
+    .. warning::
+        :func:`input_dist` is a collective over the cascade, so **every rank in
+        that cascade must run the same number of rounds**. The refill count here
+        is a deterministic function of ``(queue length, n)`` and the queue starts
+        empty everywhere, which is what keeps them in lock-step. Never make a
+        refill depend on rank-local data -- a stage that decides to fetch one
+        extra round hangs the whole cascade.
+
+    Args:
+        pg_gloo: group for the size-metadata exchange.
+        pg_nccl: group for the tensor-data exchange. Usually the same handle: a
+            group created on a ``cpu:gloo,cuda:nccl`` job dispatches by tensor
+            device, so one handle drives both phases.
+        self_index: this rank's own position in the cascade -- the entry it sends
+            to itself, used as the reconstruction template since everything it
+            receives has that same structure.
+
+    Example::
+
+        driver = InputDistDriver(pg, pg, self_index=stage_index)
+        microbatches = driver.take(lambda: send_set(next(dataloader_iter)), n=8)
+    """
+
+    def __init__(
+        self,
+        pg_gloo: dist.ProcessGroup,
+        pg_nccl: dist.ProcessGroup,
+        self_index: int,
+    ) -> None:
+        self._pg_gloo = pg_gloo
+        self._pg_nccl = pg_nccl
+        self._self_index = self_index
+        self._queue: Deque[T] = deque()
+        # Monotonic round counter, tagging the profiler ranges.
+        self._batch_id = 0
+
+    @property
+    def pending(self) -> int:
+        """Microbatches already received and not yet handed out."""
+        return len(self._queue)
+
+    def exchange(self, send: List[T]) -> LazyAwaitable[List[T]]:
+        """Run one all-to-all round, unwaited.
+
+        Args:
+            send: one carrier per rank of the cascade; ``send[j]`` goes to rank
+                ``j``.
+
+        Returns:
+            LazyAwaitable[List[T]]: ``wait()`` yields one carrier from each rank,
+            all destined here. Returned unwaited so the caller can overlap work.
+        """
+        batch_id = self._batch_id
+        self._batch_id += 1
+        return input_dist(
+            send,
+            send[self._self_index],
+            pg_gloo=self._pg_gloo,
+            pg_nccl=self._pg_nccl,
+            batch_id=batch_id,
+        )
+
+    def take(self, next_send: Callable[[], List[T]], n: int) -> List[T]:
+        """Hand out ``n`` microbatches, running whole rounds as needed.
+
+        Args:
+            next_send: produces one round's send set (one carrier per rank of the
+                cascade). Called once per round, and only when the queue runs
+                dry, so a caller reading a dataloader consumes exactly one batch
+                per round.
+            n: how many microbatches to return.
+
+        Returns:
+            List[T]: ``n`` carriers for this rank; the remainder of the last
+            round stays queued for the next call.
+        """
+        while len(self._queue) < n:
+            self._queue.extend(self.exchange(next_send()).wait())
+        # Oldest first: the remainder of the last round stays queued for the
+        # next call.
+        return [self._queue.popleft() for _ in range(n)]

--- a/torchrec/distributed/maglev/module.py
+++ b/torchrec/distributed/maglev/module.py
@@ -7,83 +7,327 @@
 
 # pyre-strict
 
-from typing import Any, List
+"""The Maglev authoring API: layers and the model that chains them.
+
+Everything here is parallelism-free -- a model built from these runs end to end
+in a single process. Cutting a model into pipeline stages, binding those stages
+to process groups, and sharding them lives in
+:mod:`torchrec.distributed.maglev.stage`.
+"""
+
+import abc
+from dataclasses import dataclass
+from typing import Any, List, Sequence, Tuple
 
 import torch
 import torch.nn as nn
 
+# The carrier between Maglev layers: always a tuple of tensors, empty for a
+# layer with no incoming activation (the first layer of a model).
+Activations = Tuple[torch.Tensor, ...]
 
-class MaglevModuleList(nn.ModuleList):
-    """An ordered ``ModuleList`` of Maglev stages that chains them in ``forward``.
 
-    ``forward`` runs the stages in order, threading each stage's output into the
-    next::
+@dataclass(frozen=True)
+class ActivationSpec:
+    """Static description of one tensor in an inter-layer activation tuple.
 
-        out_i = stage_i(stage_inputs[i], out_{i-1})   with   out_{-1} = None
+    A layer declares the activations it consumes and produces as specs
+    (:meth:`MaglevLayer.in_activation_specs` /
+    :meth:`MaglevLayer.out_activation_specs`) so the pipeline-parallel connector
+    can allocate receive buffers -- and match send/recv order -- without running
+    a shape-inference forward pass.
 
-    This is the single-process reference execution -- the in-process analogue of
-    the pipeline-parallel ``MaglevPipeline`` (which runs only the stage a given
-    rank owns and transfers the activation across HSD boundaries). Both must
-    produce identical numerics; that equivalence is what the correctness test
-    checks. Container behavior (``len``, indexing, iteration) is inherited from
-    ``nn.ModuleList``.
+    ``shape`` is the full per-microbatch shape, including the batch dimension.
 
     Args:
-        stages: the ordered stage modules. Each stage's ``forward`` takes
-            ``(stage_input, prev_output)`` and returns its output activation
-            (``prev_output=None`` for the first stage).
+        shape: full shape of the tensor, batch dimension included.
+        dtype: dtype of the tensor. Default is ``torch.float32``.
 
     Example::
 
-        model = MaglevModuleList([stage0, stage1])
-        out = model([stage_input0, stage_input1])
+        ActivationSpec(torch.Size([1024, 512]))
     """
 
-    def __init__(self, stages: List[nn.Module]) -> None:
-        if len(stages) == 0:
-            raise ValueError("MaglevModuleList requires at least one stage")
-        super().__init__(stages)
+    shape: torch.Size
+    dtype: torch.dtype = torch.float32
+
+    @property
+    def requires_grad(self) -> bool:
+        """Whether this activation carries a gradient back to the producer.
+
+        Only floating-point activations are differentiable, so integer carriers
+        (ids, lengths, offsets) are skipped by the backward hand-off.
+        """
+        return self.dtype.is_floating_point
+
+
+def check_activations(
+    specs: Sequence[ActivationSpec], activations: Activations, what: str
+) -> None:
+    """Validate an activation tuple against the specs that describe it.
+
+    Args:
+        specs: the declared specs.
+        activations: the tensors to check, index-aligned with ``specs``.
+        what: label used in the error message (e.g. ``"layer 2 input"``).
+
+    Raises:
+        ValueError: if the count, a shape, or a dtype does not match.
+    """
+    if len(activations) != len(specs):
+        raise ValueError(
+            f"{what}: expected {len(specs)} activation tensors, got {len(activations)}"
+        )
+    for i, (spec, tensor) in enumerate(zip(specs, activations)):
+        if tuple(tensor.shape) != tuple(spec.shape):
+            raise ValueError(
+                f"{what}[{i}]: expected shape {tuple(spec.shape)}, got "
+                f"{tuple(tensor.shape)}"
+            )
+        if tensor.dtype != spec.dtype:
+            raise ValueError(
+                f"{what}[{i}]: expected dtype {spec.dtype}, got {tensor.dtype}"
+            )
+
+
+class MaglevLayer(abc.ABC, nn.Module):
+    """Base class for a Maglev layer -- the unit of compute in a Maglev model.
+
+    A layer consumes two things and produces one:
+
+    * ``layer_input`` -- its own slice of the batch (its feature partition), of
+      whatever type the layer defines (e.g. a ``ModelInput``);
+    * ``in_activations`` -- the previous layer's output, always a **tuple of
+      tensors** (empty for the first layer of a model);
+    * and returns its own output activation, again a tuple of tensors.
+
+    The activation tuples are declared statically by
+    :meth:`in_activation_specs` and :meth:`out_activation_specs`. The
+    pipeline-parallel connector reads those specs to size its receive buffers and
+    to order the per-tensor send/recv pairs, so a layer's declared specs must
+    match what its ``forward`` actually consumes and produces
+    (:func:`check_activations` asserts this).
+
+    A *stage* -- the unit of pipeline parallelism, one per hardware scale-up
+    domain (HSD) -- is one or more consecutive layers bound to a process group by
+    :class:`~torchrec.distributed.maglev.stage.StageWrapper`, which takes the
+    layer list directly. There is no separate stage type: a stage is just a run
+    of layers plus the wrapper that distributes it.
+
+    Args:
+        None. The base class holds no state; subclasses declare their own
+        constructor arguments and must implement :meth:`in_activation_specs`,
+        :meth:`out_activation_specs`, and :meth:`forward`.
+
+    Example::
+
+        class Block(MaglevLayer):
+            def __init__(self, batch_size: int, dim: int, is_first: bool) -> None:
+                super().__init__()
+                self._batch_size = batch_size
+                self._dim = dim
+                self._is_first = is_first
+                self.lin: nn.Linear = nn.Linear(dim, dim)
+
+            def in_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+                if self._is_first:
+                    return ()
+                return (ActivationSpec(torch.Size([self._batch_size, self._dim])),)
+
+            def out_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+                return (ActivationSpec(torch.Size([self._batch_size, self._dim])),)
+
+            def forward(self, layer_input, in_activations=()):
+                x = self.lin(layer_input)
+                if in_activations:
+                    x = x + in_activations[0]
+                return (x,)
+    """
+
+    @abc.abstractmethod
+    def in_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """The activation tuple this layer consumes; ``()`` if it consumes none."""
+        ...
+
+    @abc.abstractmethod
+    def out_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """The activation tuple this layer produces."""
+        ...
+
+    @abc.abstractmethod
+    def forward(
+        self, layer_input: Any, in_activations: Activations = ()
+    ) -> Activations:
+        """Run the layer over its own input and the previous layer's activation.
+
+        Args:
+            layer_input: this layer's own input (its feature partition).
+            in_activations: the previous layer's output activation, matching
+                :meth:`in_activation_specs`. Default is ``()`` (no incoming
+                activation), which is what the first layer of a model receives.
+
+        Returns:
+            Activations: this layer's output activation, matching
+            :meth:`out_activation_specs`.
+        """
+        ...
+
+
+def check_layers_chain(layers: Sequence[MaglevLayer], what: str) -> None:
+    """Validate that consecutive layers agree on the activation they exchange.
+
+    Args:
+        layers: the layers, in execution order.
+        what: label used in the error message (e.g. ``"stage"``).
+
+    Raises:
+        ValueError: if layer ``i``'s output specs differ from layer ``i+1``'s
+            input specs.
+    """
+    for i in range(len(layers) - 1):
+        out_specs = layers[i].out_activation_specs()
+        in_specs = layers[i + 1].in_activation_specs()
+        if tuple(out_specs) != tuple(in_specs):
+            raise ValueError(
+                f"{what}: layer {i} produces {tuple(out_specs)} but layer {i + 1} "
+                f"consumes {tuple(in_specs)}"
+            )
+
+
+class MaglevModuleList(nn.ModuleList):
+    """An ordered ``ModuleList`` of Maglev layers that chains them in ``forward``.
+
+    This is the authoring API for a Maglev model, and the single-process
+    reference execution::
+
+        acts_i = layer_i(layer_inputs[i], acts_{i-1})   with   acts_{-1} = ()
+
+    The same authored model runs two ways:
+
+    * **standalone** -- call it; :meth:`forward` runs every layer in one process.
+      That is all this class does; it knows nothing about parallelism.
+    * **pipeline-parallel** -- hand the whole model to a
+      :class:`~torchrec.distributed.maglev.stage.StageWrapper`, which keeps the
+      one stage a rank owns (the *same* layer modules, not copies) and is driven
+      by :class:`~torchrec.distributed.maglev.pipeline.MaglevPipelineBase`.
+
+    Both must produce identical numerics; that equivalence is what the
+    correctness test checks. Container behavior (``len``, indexing, iteration) is
+    inherited from ``nn.ModuleList``.
+
+    Args:
+        layers: the ordered layers, each following the :class:`MaglevLayer`
+            contract.
+
+    Raises:
+        ValueError: if ``layers`` is empty, or consecutive layers disagree on the
+            activation they exchange.
+
+    Example::
+
+        model = MaglevModuleList([layer0, layer1, layer2, layer3])
+        (out,) = model([in0, in1, in2, in3])
+    """
+
+    def __init__(self, layers: Sequence[MaglevLayer]) -> None:
+        if len(layers) == 0:
+            raise ValueError("MaglevModuleList requires at least one layer")
+        check_layers_chain(layers, "MaglevModuleList")
+        super().__init__(layers)
 
     def preproc(self, model_input: Any) -> List[Any]:
-        """Split the raw model input into one input per stage.
+        """Split the raw model input into one input per layer.
 
         This is the seam where feature partitioning / indexing lives (the Maglev
         Indexer). The MVP is a passthrough: ``model_input`` is already the list of
-        per-stage inputs. Runs under ``torch.no_grad()`` (see :meth:`forward`).
+        per-layer inputs. Runs under ``torch.no_grad()`` (see :meth:`forward`).
 
         Args:
-            model_input: the raw batch to partition across stages.
+            model_input: the raw batch to partition across layers.
 
         Returns:
-            List[Any]: one input per stage, index-aligned with the stage list.
+            List[Any]: one input per layer, index-aligned with the layer list.
         """
         return model_input
 
-    def forward(self, model_input: Any) -> Any:
-        """Chain the stages, threading each stage's output into the next.
+    def postproc(
+        self, activations: Activations, layer_input: Any
+    ) -> Tuple[torch.Tensor, Any]:
+        """Turn the last layer's activation into ``(losses, output)``.
+
+        The mirror of :meth:`preproc`: where that seam splits the raw batch into
+        per-layer inputs, this one closes the model -- it applies whatever head
+        the architecture ends with, scores it, and returns the pair every
+        TorchRec model returns::
+
+            losses, output = model(batch)
+
+        ``layer_input`` is the *last layer's* input, which is where the target
+        lives (``ModelInput.label``, by convention). Taking the label from the
+        batch rather than from a separate argument is what lets the pipeline drop
+        label plumbing entirely: the last stage already holds the input it needs
+        to score itself.
+
+        Unlike :meth:`preproc`, this runs **inside** the autograd graph -- it
+        computes the very loss that is backpropagated, so everything here is
+        differentiated. It also runs on the last pipeline stage, inside the
+        parallelized module, so a head with parameters shards with that stage.
+
+        There is no meaningful default: a model has to say how it scores itself.
+        Subclass and override.
+
+        Args:
+            activations: the last layer's output activation.
+            layer_input: the last layer's input, carrying the target.
+
+        Returns:
+            Tuple[torch.Tensor, Any]: ``(losses, output)``. ``losses`` is a tensor
+            the pipeline calls ``.backward()`` on, so it must be a scalar (or
+            already reduced). ``output`` is whatever the model predicts -- a
+            tensor for a single head, a dict or tuple for several.
+
+        Raises:
+            NotImplementedError: unless overridden.
+
+        Example::
+
+            class MyModel(MaglevModuleList):
+                def postproc(self, activations, layer_input):
+                    output = self.head(activations[0])
+                    return F.mse_loss(output, layer_input.label), output
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must override postproc() to return "
+            "(losses, output); see MaglevModuleList.postproc"
+        )
+
+    def forward(self, model_input: Any) -> Tuple[torch.Tensor, Any]:
+        """Chain the layers, threading each layer's activation into the next.
 
         :meth:`preproc` (run under ``torch.no_grad()``) splits ``model_input``
-        into one input per stage; each stage's output feeds the next as
-        ``prev_output`` (``None`` for the first stage).
+        into one input per layer; each layer's output activation feeds the next
+        (``()`` for the first layer); :meth:`postproc` closes the model, scoring
+        the last activation against the target in the last layer's input.
 
         Args:
             model_input: the raw batch; ``preproc`` partitions it into one input
-                per stage. Inputs may be of any (per-stage) type.
+                per layer. Inputs may be of any (per-layer) type.
 
         Returns:
-            Any: the last stage's output (e.g. the final prediction). The
-            inter-stage carrier type may differ from the final output type, so
-            both input and output are typed ``Any``.
+            Tuple[torch.Tensor, Any]: ``(losses, output)``, from
+            :meth:`postproc`.
+
+        Raises:
+            ValueError: if ``preproc`` does not yield one input per layer.
         """
         with torch.no_grad():
-            stage_inputs = self.preproc(model_input)
+            layer_inputs = self.preproc(model_input)
 
-        if len(stage_inputs) != len(self):
+        if len(layer_inputs) != len(self):
             raise ValueError(
-                f"expected {len(self)} stage inputs, got {len(stage_inputs)}"
+                f"expected {len(self)} layer inputs, got {len(layer_inputs)}"
             )
-        prev_output: Any = None
-        for stage, stage_input in zip(self, stage_inputs):
-            prev_output = stage(stage_input, prev_output)
-        assert prev_output is not None  # guaranteed: at least one stage
-        return prev_output
+        activations: Activations = ()
+        for layer, layer_input in zip(self, layer_inputs):
+            activations = layer(layer_input, activations)
+        return self.postproc(activations, layer_inputs[-1])

--- a/torchrec/distributed/maglev/pipeline.py
+++ b/torchrec/distributed/maglev/pipeline.py
@@ -7,371 +7,377 @@
 
 # pyre-strict
 
-from typing import Any, Callable, List, Optional, Tuple
+"""Schedules that drive a staged Maglev model across per-stage HSDs.
+
+A schedule reads raw batches from a dataloader and decides *when* to forward,
+backward, and hand off; the :class:`StageWrapper` it holds owns everything about
+how (the wire, the process groups, the input distribution).
+"""
+
+import contextlib
+from typing import Any, Callable, ContextManager, Iterator, List, Optional, Sequence
 
 import torch
-import torch.distributed as dist
-from torch.autograd.profiler import record_function
-from torchrec.distributed.maglev.stage import build_handoff_process_groups, StageWrapper
-
-LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+from torchrec.distributed.maglev.stage import StageWrapper
 
 
-class MaglevPipeline:
-    """Drives a staged Maglev model across per-stage HSDs.
+def _no_sync_modules(module: nn.Module) -> List[nn.Module]:
+    """The parallel wrappers in ``module``'s tree whose gradient sync to suppress.
 
-    This is the pipeline-parallel analogue of the sequential loop in
-    ``WukongMaglev.forward`` (legokit/backbones/maglev_prototype.py): instead of
-    iterating stages in one process, each stage lives on a disjoint set of ranks
-    (its HSD) and the activation is handed between HSDs over the network.
+    Two-tier, following ``GradientAccumulationWrapper._get_ddp_modules``: the root
+    counts if it merely *has* ``no_sync``, which covers DDP, FSDP and custom
+    wrappers alike, while descendants must be ``DistributedDataParallel``
+    instances. The asymmetry is deliberate -- the root is known to be the parallel
+    wrapper, whereas a descendant is an arbitrary submodule and a nested FSDP's
+    ``no_sync`` does not mean the same thing.
 
-    A rank owns exactly one stage. The hand-off is **by position**: the rank at
-    position ``p`` in HSD ``i`` exchanges with the rank at position ``p`` in HSD
-    ``i ± 1``. Forward activations flow ``i -> i+1``; backward gradients flow
-    ``i+1 -> i``. The two ranks of an HSD are data-parallel lanes; gradients are
-    averaged across them (:meth:`StageWrapper.reduce_gradients`).
+    Descendants matter because a sharded submodule can hold its own inner DDP for
+    data-parallel lookups; suppressing only the outer wrapper leaves those
+    all-reducing on every backward.
 
-    The hand-off runs over **two direction-split process groups** (``act_pg`` for
-    forward activations, ``grad_pg`` for backward gradients, built by
-    :func:`build_handoff_process_groups`) rather than P2P over the default (world)
-    group. A boundary's forward activation and backward gradient thus land on
-    *different* communicators (separate NCCL streams instead of serializing), and
-    each communicator carries a single flow direction (recv-then-send per rank,
-    never send-first). Both are separate from each stage's intra-HSD sharded
-    all-to-all; interleaving P2P with that on the world group deadlocks once the
-    stages are sharded with DMP. See
-    ``tech-docs/nccl_p2p_execution_order_buffer_size.md`` (sections 4-5).
+    ``DistributedModelParallel`` is unwrapped first: it defines no ``no_sync`` of
+    its own, so the wrapper worth entering is the module it holds.
+    """
+    found: List[nn.Module] = []
+    root = module
+    wrapped = getattr(module, "_dmp_wrapped_module", None)
+    if isinstance(wrapped, nn.Module):
+        root = wrapped
+    if hasattr(root, "no_sync"):
+        found.append(root)
+    found.extend(
+        m
+        for m in root.modules()
+        if m is not root and isinstance(m, DistributedDataParallel)
+    )
+    return found
 
-    Two drivers are provided:
 
-    * :meth:`step` -- a single-batch forward-then-backward pass (used by the
-      correctness test). Blocking send/recv form a matched wave; no deadlock.
-    * :meth:`forward_micro` / :meth:`backward_micro` + :func:`run_1f1b` -- a
-      microbatched 1F1B schedule (used by the benchmark). Activations are
-      received with blocking recv (strict dependency, forms a wave) and sent
-      with non-blocking isend whose completion is deferred to
-      :meth:`wait_sends`, which keeps the schedule deadlock-free.
+@contextlib.contextmanager
+def _no_sync(modules: Sequence[nn.Module]) -> Iterator[None]:
+    """Enter every wrapper's ``no_sync`` at once; a no-op when there are none."""
+    with contextlib.ExitStack() as stack:
+        for module in modules:
+            # pyre-ignore[16]: presence of no_sync is what put it in this list
+            stack.enter_context(module.no_sync())
+        yield
 
-    Every comm (activation/gradient send+recv) and the forward/backward compute
-    is wrapped in a ``record_function`` range tagged with the microbatch id
-    (``## recv_act mb3 ##`` etc.), so profiler traces show which microbatch each
-    operation belongs to.
+
+class MaglevPipelineBase:
+    """The trivial schedule -- one forward, one backward, one step -- and the base
+    every other schedule extends.
+
+    With a single microbatch every stage runs the same forward-then-backward
+    wave, so the sends drain before the gradients are reduced and no interleaving
+    is needed. Used directly by the correctness test. This is *not* 1F1B with
+    ``num_microbatches=1``: that schedule needs at least one microbatch per stage
+    to fill (see :class:`Maglev1F1B`).
+
+    Subclasses override :meth:`progress` with their own ordering; what they
+    inherit is the stage and optimizer, the boundary-contract check, and
+    :meth:`_forward_context`, which every schedule uses to place the single
+    gradient sync of a pass.
 
     Args:
-        stage: this rank's :class:`StageWrapper`.
-        stage_ranks: ``stage_ranks[i]`` is the global ranks of stage ``i``'s HSD.
-            Every stage must have the same number of ranks (same position layout).
-        global_rank: this process's global rank.
-        activation_shape: shape of the activation handed between stages.
-        device: device the stage runs on.
-        dtype: dtype of the activation / gradient tensors.
+        stage: this rank's :class:`StageWrapper`. Everything about where this
+            rank sits -- its stage, its position in that stage's HSD, the
+            neighbouring ranks, the hand-off process groups -- is read off the
+            wrapper rather than derived a second time here.
+        optimizer: the stage's optimizer. Gradients accumulate across a pass and
+            are applied with a single step.
+        no_sync: returns a context that suppresses the DP wrapper's gradient
+            sync, entered around every forward but the pass's last. Defaults to
+            suppressing whatever wrappers :func:`_no_sync_modules` finds on
+            ``stage.module``, so an unwrapped stage needs nothing and a
+            DDP/FSDP/DMP one works unconfigured. Pass your own only if that
+            derivation is wrong for your setup.
+
+    Raises:
+        ValueError: if a boundary stage declares an activation it cannot have (an
+            incoming one on the first stage, or none on any later stage).
     """
 
     def __init__(
         self,
         stage: StageWrapper,
-        stage_ranks: List[List[int]],
-        global_rank: int,
-        activation_shape: torch.Size,
-        device: torch.device,
-        dtype: torch.dtype = torch.float32,
-        handoff_pgs: Optional[Tuple[dist.ProcessGroup, dist.ProcessGroup]] = None,
+        optimizer: torch.optim.Optimizer,
+        no_sync: Optional[Callable[[], ContextManager[None]]] = None,
     ) -> None:
         self.stage = stage
-        self.stage_ranks = stage_ranks
-        self.global_rank = global_rank
-        self.num_stages: int = len(stage_ranks)
-        self.activation_shape = activation_shape
-        self.device = device
-        self.dtype = dtype
+        self.optimizer = optimizer
+        # Read once: the module tree is static after wrapping, and the
+        # pipeline is built after it.
+        modules = _no_sync_modules(stage.module)
+        self._no_sync: Callable[[], ContextManager[None]] = no_sync or (
+            lambda: _no_sync(modules)
+        )
 
-        # Locate this rank's stage and its position within that stage's HSD.
-        stage_index = -1
-        position = -1
-        for s_idx, ranks in enumerate(stage_ranks):
-            if global_rank in ranks:
-                stage_index = s_idx
-                position = ranks.index(global_rank)
-                break
-        if stage_index < 0:
+        in_specs = stage.in_activation_specs()
+        if stage.is_first and in_specs:
             raise ValueError(
-                f"rank {global_rank} not found in stage_ranks {stage_ranks}"
+                f"stage 0 declares an incoming activation {in_specs} but has "
+                "no previous stage to receive it from"
             )
-        if stage_index != stage.stage_index:
+        if not stage.is_first and not in_specs:
             raise ValueError(
-                f"rank {global_rank} owns stage {stage_index} but the StageWrapper "
-                f"is for stage {stage.stage_index}"
+                f"stage {stage.stage_index} declares no incoming activation; only "
+                "stage 0 may start the chain"
             )
-        self.stage_index: int = stage_index
-        self.position: int = position
-
-        # Two direction-split P2P communicators (see build_handoff_process_groups):
-        # forward activations go on ``act_pg``, backward gradients on ``grad_pg``,
-        # so a boundary's two directions land on different communicators (separate
-        # streams) and each carries a single flow direction (recv-then-send, never
-        # send-first). When sharding, pass ``handoff_pgs`` built *before* any DMP so
-        # the two ``new_group`` collectives stay contiguous; otherwise built here.
-        if handoff_pgs is None:
-            handoff_pgs = build_handoff_process_groups(stage_ranks)
-        self._act_pg, self._grad_pg = handoff_pgs
-
-        # Per-direction pg for this stage: activations on act_pg, gradients on
-        # grad_pg (None where this stage has no neighbor on that side).
-        self._recv_act_pg: Optional[dist.ProcessGroup] = (
-            None if self.is_first else self._act_pg
-        )
-        self._send_act_pg: Optional[dist.ProcessGroup] = (
-            None if self.is_last else self._act_pg
-        )
-        self._recv_grad_pg: Optional[dist.ProcessGroup] = (
-            None if self.is_last else self._grad_pg
-        )
-        self._send_grad_pg: Optional[dist.ProcessGroup] = (
-            None if self.is_first else self._grad_pg
-        )
-
-        # 1F1B state: FIFO of in-flight microbatches (with their microbatch id,
-        # for profiler labels) and deferred send handles.
-        self._pending: List[
-            Tuple[Optional[torch.Tensor], torch.Tensor, Optional[torch.Tensor], int]
-        ] = []
-        # pyre-ignore[4]: dist work handle has no public type
-        self._send_work: List[Tuple[Any, torch.Tensor]] = []
 
     @property
     def is_first(self) -> bool:
-        return self.stage_index == 0
+        return self.stage.is_first
 
     @property
     def is_last(self) -> bool:
-        return self.stage_index == self.num_stages - 1
+        return self.stage.is_last
 
-    def _prev_rank(self) -> int:
-        """Global rank at this position in the previous HSD."""
-        return self.stage_ranks[self.stage_index - 1][self.position]
+    @property
+    def microbatches_per_pass(self) -> int:
+        """Microbatches one :meth:`progress` call consumes.
 
-    def _next_rank(self) -> int:
-        """Global rank at this position in the next HSD."""
-        return self.stage_ranks[self.stage_index + 1][self.position]
-
-    def _recv(
-        self, src: int, pg: dist.ProcessGroup, requires_grad: bool
-    ) -> torch.Tensor:
-        tensor = torch.empty(
-            self.activation_shape, device=self.device, dtype=self.dtype
-        )
-        dist.recv(tensor, src=src, group=pg)
-        if requires_grad:
-            # Make it a leaf that requires grad so backward yields its grad to
-            # hand back to the previous stage.
-            tensor.requires_grad_(True)
-        return tensor
-
-    def _isend(self, tensor: torch.Tensor, dst: int, pg: dist.ProcessGroup) -> None:
-        # Non-blocking send; the buffer is kept alive until wait_sends().
-        buf = tensor.detach().contiguous()
-        work = dist.isend(buf, dst=dst, group=pg)
-        self._send_work.append((work, buf))
-
-    def wait_sends(self) -> None:
-        """Complete all deferred non-blocking sends."""
-        for work, _buf in self._send_work:
-            work.wait()
-        self._send_work.clear()
-
-    # ---- single-batch driver (correctness) ----
-
-    def step(
-        self,
-        stage_input: Any,
-        optimizer: torch.optim.Optimizer,
-        label: Optional[torch.Tensor] = None,
-        criterion: Optional[LossFn] = None,
-    ) -> Optional[torch.Tensor]:
-        """Run one forward + backward + optimizer step for a single batch.
-
-        Returns the loss on the last stage, ``None`` on every other stage.
-        ``label`` and ``criterion`` are required on (and only used by) the last
-        stage.
+        What a caller measuring throughput has to divide by; schedules differ.
         """
-        optimizer.zero_grad()
+        return 1
 
-        prev_output: Optional[torch.Tensor] = None
-        if not self.is_first:
-            assert self._recv_act_pg is not None
-            with record_function("## recv_act mb0 ##"):
-                prev_output = self._recv(
-                    self._prev_rank(), self._recv_act_pg, requires_grad=True
-                )
+    def progress(self, dataloader_iter: Iterator[Any]) -> Optional[torch.Tensor]:
+        """Run one microbatch and apply the gradients.
 
-        with record_function("## forward mb0 ##"):
-            output = self.stage(stage_input, prev_output)
+        Args:
+            dataloader_iter: yields raw batches -- whatever the model's
+                :meth:`~torchrec.distributed.maglev.module.MaglevModuleList.preproc`
+                consumes. The stage pulls from it, partitions each batch into
+                per-layer inputs, and all-to-alls them over its cascade, so a
+                rank never has to know which layers it owns to feed it.
 
-        if not self.is_last:
-            assert self._send_act_pg is not None
-            with record_function("## send_act mb0 ##"):
-                dist.send(
-                    output.detach().contiguous(),
-                    dst=self._next_rank(),
-                    group=self._send_act_pg,
-                )
+        Returns:
+            Optional[torch.Tensor]: the loss on the last stage, ``None`` on every
+            other stage. The last stage's model scored itself in ``postproc``, so
+            no label or criterion is passed in.
+        """
+        (stage_input,) = self.stage.take_inputs(dataloader_iter, 1)
 
-        loss: Optional[torch.Tensor] = None
-        if self.is_last:
-            if criterion is None or label is None:
-                raise ValueError("last stage requires both `criterion` and `label`")
-            with record_function("## backward mb0 ##"):
-                loss = criterion(output, label)
-                loss.backward()
-        else:
-            assert self._recv_grad_pg is not None
-            grad_output = torch.empty(
-                output.shape, device=self.device, dtype=self.dtype
-            )
-            with record_function("## recv_grad mb0 ##"):
-                dist.recv(grad_output, src=self._next_rank(), group=self._recv_grad_pg)
-            with record_function("## backward mb0 ##"):
-                output.backward(grad_output)
-
-        if not self.is_first:
-            assert prev_output is not None and prev_output.grad is not None
-            assert self._send_grad_pg is not None
-            with record_function("## send_grad mb0 ##"):
-                dist.send(
-                    prev_output.grad.contiguous(),
-                    dst=self._prev_rank(),
-                    group=self._send_grad_pg,
-                )
-
-        self.stage.reduce_gradients()
-        optimizer.step()
+        self.optimizer.zero_grad()
+        self.stage.start_recv_act()
+        self.stage.forward_micro(stage_input, microbatch_id=0)
+        # Immediately before the backward, never earlier -- see Maglev1F1B.
+        self.stage.start_recv_grad()
+        loss = self.stage.backward_micro()
+        self.stage.drain_sends()
+        self.optimizer.step()
         return loss
 
-    # ---- microbatched 1F1B driver (benchmark) ----
+    def _forward_context(self, fwd_idx: int, num_forwards: int) -> ContextManager[None]:
+        """Suppress gradient sync for every microbatch but the pass's last.
 
-    def forward_micro(
-        self,
-        stage_input: Any,
-        label: Optional[torch.Tensor] = None,
-        microbatch_id: int = 0,
-    ) -> None:
-        """One microbatch forward: recv activation, compute, send activation.
+        Wraps the **forward**, not the backward. ``DistributedDataParallel``
+        reads ``require_backward_grad_sync`` in ``_pre_forward`` /
+        ``_post_forward`` -- that is where the reducer is armed for the coming
+        backward -- so a ``no_sync`` placed around ``backward()`` alone has no
+        effect and every microbatch all-reduces. PyTorch documents the same:
+        "The forward pass should be included inside the context manager, or else
+        gradients will still be synchronized."
 
-        ``microbatch_id`` tags the profiler ranges (and is carried on the pending
-        FIFO to the matching backward) so a trace shows which microbatch each
-        comm/compute belongs to.
+        The last microbatch forwards outside the context, so its backward carries
+        the one reduction for the whole pass, over gradients every earlier
+        microbatch accumulated locally.
+
+        Args:
+            fwd_idx: index of this forward within the pass.
+            num_forwards: forwards this pass will run.
         """
-        prev_output: Optional[torch.Tensor] = None
-        if not self.is_first:
-            assert self._recv_act_pg is not None
-            with record_function(f"## recv_act mb{microbatch_id} ##"):
-                prev_output = self._recv(
-                    self._prev_rank(), self._recv_act_pg, requires_grad=True
-                )
-
-        with record_function(f"## forward mb{microbatch_id} ##"):
-            output = self.stage(stage_input, prev_output)
-
-        if not self.is_last:
-            assert self._send_act_pg is not None
-            with record_function(f"## send_act mb{microbatch_id} ##"):
-                self._isend(output, self._next_rank(), self._send_act_pg)
-
-        self._pending.append((prev_output, output, label, microbatch_id))
-
-    def backward_micro(
-        self, criterion: Optional[LossFn] = None
-    ) -> Optional[torch.Tensor]:
-        """One microbatch backward: recv grad, backward, send input grad.
-
-        Gradients accumulate across microbatches (no ``zero_grad`` here); the
-        caller runs the DP all-reduce and optimizer step once per batch. Profiler
-        ranges are tagged with the ``microbatch_id`` recorded at forward time.
-        """
-        prev_output, output, label, microbatch_id = self._pending.pop(0)
-
-        loss: Optional[torch.Tensor] = None
-        if self.is_last:
-            if criterion is None or label is None:
-                raise ValueError("last stage requires both `criterion` and `label`")
-            with record_function(f"## backward mb{microbatch_id} ##"):
-                loss = criterion(output, label)
-                loss.backward()
-        else:
-            assert self._recv_grad_pg is not None
-            grad_output = torch.empty(
-                output.shape, device=self.device, dtype=self.dtype
-            )
-            with record_function(f"## recv_grad mb{microbatch_id} ##"):
-                dist.recv(grad_output, src=self._next_rank(), group=self._recv_grad_pg)
-            with record_function(f"## backward mb{microbatch_id} ##"):
-                output.backward(grad_output)
-
-        if not self.is_first:
-            assert prev_output is not None and prev_output.grad is not None
-            assert self._send_grad_pg is not None
-            with record_function(f"## send_grad mb{microbatch_id} ##"):
-                self._isend(prev_output.grad, self._prev_rank(), self._send_grad_pg)
-
-        return loss
+        if fwd_idx == num_forwards - 1:
+            return contextlib.nullcontext()
+        return self._no_sync()
 
 
-def run_1f1b(
-    pipeline: MaglevPipeline,
-    microbatch_inputs: List[Any],
-    optimizer: torch.optim.Optimizer,
-    labels: Optional[List[torch.Tensor]] = None,
-    criterion: Optional[LossFn] = None,
-) -> List[float]:
-    """Run one 1F1B (one-forward-one-backward) pass over ``microbatch_inputs``.
+class Maglev1F1B(MaglevPipelineBase):
+    """The 1F1B (one-forward-one-backward) schedule, with plain P2P.
 
-    Standard PipeDream-flush schedule: each stage runs ``num_warmup`` forwards,
-    then interleaves 1 forward / 1 backward in steady state, then drains the
-    remaining backwards in cooldown. ``num_warmup = num_stages - stage_index - 1``
-    (clamped to the microbatch count), so deeper stages warm up less and the
-    send/recv pairs line up across ranks.
+    Standard PipeDream-flush: each stage runs ``num_warmup`` forwards, then
+    interleaves 1 forward / 1 backward in steady state, then drains the remaining
+    backwards in cooldown. ``num_warmup = num_stages - stage_index - 1`` (clamped
+    to the microbatch count), so deeper stages warm up less and the send/recv
+    pairs line up across ranks.
 
-    Returns the per-microbatch losses observed on the last stage (empty on
-    other stages). Gradients are accumulated across all microbatches, then
-    DP-averaged and applied with a single optimizer step.
+    Each receive is posted immediately before the operation that consumes it, so
+    a transfer is issued and then waited on with nothing in between: the stage
+    stalls for the whole latency of every hand-off. That is the straightforward
+    ordering, and the baseline that :class:`Maglev1F1BRecvAhead` is measured
+    against.
+
+    Sends are still asynchronous -- ``forward_micro`` / ``backward_micro`` start
+    one and finish it on the next call -- so only the receive side blocks.
+
+    Args:
+        stage: this rank's :class:`StageWrapper`.
+        optimizer: the stage's optimizer.
+        num_microbatches: microbatches per pass. Fixed for the pipeline's life,
+            so the schedule's shape is computed once here rather than per pass.
+
+    Raises:
+        ValueError: if there are fewer microbatches than stages. That leaves the
+            early stages with no steady phase at all, and it is the steady phase
+            that seeds the gradient receives -- so those ranks would fail in
+            cooldown while the later ones ran on, hanging the job
+            asymmetrically. It is also a pointless schedule: the pipeline never
+            fills, so it is all bubble.
     """
-    num_stages = pipeline.num_stages
-    num_micro = len(microbatch_inputs)
-    stage_index = pipeline.stage_index
-    num_warmup = min(num_stages - stage_index - 1, num_micro)
-    num_steady = num_micro - num_warmup
 
-    def _label(idx: int) -> Optional[torch.Tensor]:
-        return labels[idx] if labels is not None else None
+    def __init__(
+        self,
+        stage: StageWrapper,
+        optimizer: torch.optim.Optimizer,
+        num_microbatches: int,
+        no_sync: Optional[Callable[[], ContextManager[None]]] = None,
+    ) -> None:
+        super().__init__(stage, optimizer, no_sync)
+        if num_microbatches < stage.num_stages:
+            raise ValueError(
+                f"1F1B needs at least one microbatch per stage: got "
+                f"{num_microbatches} for {stage.num_stages} stages"
+            )
+        self.num_microbatches: int = num_microbatches
+        self.num_warmup: int = min(
+            stage.num_stages - stage.stage_index - 1, num_microbatches
+        )
+        self.num_steady: int = num_microbatches - self.num_warmup
 
-    optimizer.zero_grad()
-    losses: List[float] = []
+    @property
+    def microbatches_per_pass(self) -> int:
+        return self.num_microbatches
 
-    fwd_idx = 0
-    bwd_idx = 0
+    def progress(self, dataloader_iter: Iterator[Any]) -> Optional[torch.Tensor]:
+        """Run one 1F1B pass.
 
-    # Warmup: fill the pipeline.
-    for _ in range(num_warmup):
-        pipeline.forward_micro(microbatch_inputs[fwd_idx], _label(fwd_idx), fwd_idx)
-        fwd_idx += 1
+        Gradients are accumulated across all microbatches, then DP-averaged and
+        applied with a single optimizer step.
 
-    # Steady state: one forward, one backward.
-    for _ in range(num_steady):
-        pipeline.forward_micro(microbatch_inputs[fwd_idx], _label(fwd_idx), fwd_idx)
-        fwd_idx += 1
-        loss = pipeline.backward_micro(criterion)
-        bwd_idx += 1
-        if loss is not None:
-            losses.append(loss.item())
+        Args:
+            dataloader_iter: yields raw batches, as in
+                :meth:`MaglevPipelineBase.progress`. One pass consumes as many as
+                the input distribution needs to produce ``num_microbatches``.
 
-    # Cooldown: drain remaining backwards.
-    for _ in range(num_warmup):
-        loss = pipeline.backward_micro(criterion)
-        bwd_idx += 1
-        if loss is not None:
-            losses.append(loss.item())
+        Returns:
+            Optional[torch.Tensor]: always ``None``. Reading a per-microbatch
+            loss means ``loss.item()``, which is a device-to-host sync in the
+            middle of the schedule -- it would stall the pipeline it is meant to
+            be measuring. Use :class:`MaglevPipelineBase` when a value is
+            actually needed.
+        """
+        stage = self.stage
+        microbatch_inputs = stage.take_inputs(dataloader_iter, self.num_microbatches)
 
-    pipeline.wait_sends()
-    pipeline.stage.reduce_gradients()
-    optimizer.step()
-    return losses
+        self.optimizer.zero_grad()
+
+        fwd_idx = 0
+
+        def _forward() -> None:
+            nonlocal fwd_idx
+            stage.start_recv_act()
+            with self._forward_context(fwd_idx, self.num_microbatches):
+                stage.forward_micro(microbatch_inputs[fwd_idx], fwd_idx)
+            fwd_idx += 1
+
+        def _backward() -> None:
+            stage.start_recv_grad()
+            stage.backward_micro()
+
+        # Warmup: fill the pipeline.
+        for _ in range(self.num_warmup):
+            _forward()
+
+        # Steady state: one forward, one backward.
+        for _ in range(self.num_steady):
+            _forward()
+            _backward()
+
+        # Cooldown: drain remaining backwards.
+        for _ in range(self.num_warmup):
+            _backward()
+
+        stage.drain_sends()
+        self.optimizer.step()
+        return None
+
+
+class Maglev1F1BRecvAhead(Maglev1F1B):
+    """1F1B that posts each receive a microbatch ahead of the compute it feeds.
+
+    Same warmup / steady / cooldown structure and the same number of transfers as
+    :class:`Maglev1F1B`; only the *placement* of the receives differs. The
+    transfer for microbatch ``k+1`` is posted before ``k`` is computed, so it
+    lands during that compute instead of being waited on the moment it is issued.
+    That hides the hand-off latency behind the neighbouring stage's work, which is
+    the whole point of splitting the P2P into start/wait.
+
+    .. note::
+        Gradient receives cannot run as far ahead as activation receives. The
+        first one on a rank creates the pair's NCCL communicator and blocks until
+        the peer's matching send, and a peer only touches the gradient direction
+        in its own backward -- so posting one during the forward phase parks this
+        rank mid-wave and deadlocks the pipeline. The first gradient receive
+        therefore waits until warmup is over; from then on running a microbatch
+        ahead is free.
+    """
+
+    def progress(self, dataloader_iter: Iterator[Any]) -> Optional[torch.Tensor]:
+        """Run one 1F1B pass, keeping both receive directions one microbatch ahead.
+
+        Returns:
+            Optional[torch.Tensor]: always ``None``, as
+            :meth:`Maglev1F1B.progress`.
+        """
+        stage = self.stage
+        microbatch_inputs = stage.take_inputs(dataloader_iter, self.num_microbatches)
+
+        self.optimizer.zero_grad()
+
+        fwd_idx = 0
+
+        def _forward() -> None:
+            """Run one forward, consuming the activation receive posted before it."""
+            nonlocal fwd_idx
+            with self._forward_context(fwd_idx, self.num_microbatches):
+                stage.forward_micro(microbatch_inputs[fwd_idx], fwd_idx)
+            fwd_idx += 1
+
+        # Two receives outstanding before the first forward: this seed plus the
+        # one the first warmup iteration posts.
+        stage.start_recv_act()
+
+        # Warmup: fill the pipeline.
+        for _ in range(self.num_warmup):
+            stage.start_recv_act()
+            _forward()
+
+        def _backward() -> None:
+            """Run one backward."""
+            stage.backward_micro()
+
+        # Steady state: one forward, one backward.
+        for i in range(self.num_steady):
+            # Warmup is over by now, so the stages below have every activation
+            # they need to reach their own first backward -- see the note on the
+            # class about why this cannot move earlier.
+            stage.start_recv_grad()
+            _forward()
+            if i < self.num_steady - 1:
+                stage.start_recv_act()
+            else:
+                # No more forwards to run ahead for; keep the gradient side one
+                # ahead for cooldown instead.
+                stage.start_recv_grad()
+            _backward()
+
+        # Cooldown: drain remaining backwards.
+        for i in range(self.num_warmup):
+            if i < self.num_warmup - 1:
+                stage.start_recv_grad()
+            _backward()
+
+        stage.drain_sends()
+        self.optimizer.step()
+        return None

--- a/torchrec/distributed/maglev/stage.py
+++ b/torchrec/distributed/maglev/stage.py
@@ -7,22 +7,33 @@
 
 # pyre-strict
 
+"""Distributing a Maglev model: cutting it into stages and parallelizing them.
+
+Everything that knows about ranks lives here -- process-group builders, the
+layers-to-stages partitioning, the parallelism strategies, and
+:class:`StageWrapper`, which binds one stage's layers to its HSD and owns the
+wire between stages. The authoring side is in
+:mod:`torchrec.distributed.maglev.module`.
+"""
+
 import abc
-from typing import Any, cast, List, Optional, Tuple
+from collections import deque
+from typing import Any, Callable, cast, Deque, Iterator, List, Optional, Sequence, Tuple
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.distributed.optim import (
-    _apply_optimizer_in_backward as apply_optimizer_in_backward,
+from torch.autograd.profiler import record_function
+from torchrec.distributed.maglev.input_dist import InputDistDriver
+from torchrec.distributed.maglev.module import (
+    Activations,
+    ActivationSpec,
+    check_layers_chain,
+    MaglevLayer,
+    MaglevModuleList,
 )
-from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
-from torchrec.distributed.model_parallel import DistributedModelParallel
-from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
-from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
-from torchrec.modules.embedding_modules import EmbeddingBagCollection
-from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizerWrapper
-from torchrec.optim.optimizers import in_backward_optimizer_filter
+from torchrec.distributed.types import LazyAwaitable, ShardingPlan
+from torchrec.distributed.utils import init_parameters
 
 
 def build_stage_process_groups(
@@ -47,40 +58,6 @@ def build_stage_process_groups(
         pg = cast(dist.ProcessGroup, dist.new_group(ranks=ranks))
         pgs.append(pg)
     return pgs
-
-
-def _remap_plan_to_pg_devices(
-    plan: ShardingPlan, stage_pg: dist.ProcessGroup, device: torch.device
-) -> None:
-    """Rewrite each shard's placement device to the sub-pg rank's actual device.
-
-    The planner builds the plan over a size-``N`` topology, so it emits
-    *group-local* ranks/devices: ``rank:0/cuda:0``, ``rank:1/cuda:1`` for a 2-rank
-    stage. But shard placements are interpreted against the *global* rank space
-    (DMP maps ``placement.rank()`` back through the pg, and the shard tensor lives
-    on the process's actual device). For a stage whose ranks are global ``{2,3}``
-    on ``cuda:{2,3}`` the group-local plan is wrong twice over -- rank 0 is not in
-    the pg, and the device is cuda:0 not cuda:2. Remap group-local rank ``r`` to
-    global rank ``g = get_global_rank(stage_pg, r)`` on ``cuda:{g % device_count}``
-    (single-host assumption). Deterministic given ``(plan, stage_pg)``, so every
-    rank in the pg produces the same result.
-    """
-    if device.type != "cuda":
-        return
-    device_count = torch.cuda.device_count()
-    for module_plan in plan.plan.values():
-        # ModuleShardingPlan is dict-like at runtime (param name -> ParameterSharding).
-        # pyrefly: ignore[missing-attribute]
-        for param_sharding in module_plan.values():
-            spec = getattr(param_sharding, "sharding_spec", None)
-            if spec is None:
-                continue
-            for shard in spec.shards:
-                g = dist.get_global_rank(stage_pg, shard.placement.rank())
-                dev = g % device_count if device_count else 0
-                shard.placement = torch.distributed._remote_device(
-                    f"rank:{g}/cuda:{dev}"
-                )
 
 
 def build_handoff_process_groups(
@@ -145,234 +122,966 @@ def build_cascade_process_groups(
     return pgs
 
 
-def _all_reduce_dense(params: List[nn.Parameter], stage_pg: dist.ProcessGroup) -> None:
-    """DP-average the given params' grads across the HSD's ranks (once per step)."""
-    world_size = stage_pg.size()
-    if world_size == 1:
+def pg_init(stage_size: int, num_stages: int) -> Tuple[
+    List[dist.ProcessGroup],
+    Tuple[dist.ProcessGroup, dist.ProcessGroup],
+    List[dist.ProcessGroup],
+]:
+    """Build the three sets of process groups a Maglev pipeline needs.
+
+    Returns ``(stage_pgs, handoff_pgs, cascade_pgs)``:
+
+    1. **stage** -- one per stage, joined only by that stage's own ranks; what the
+       parallelizer shards over (:func:`build_stage_process_groups`).
+    2. **cascade** -- one per position, holding one rank from each stage; what the
+       input distribution all-to-alls over
+       (:func:`build_cascade_process_groups`).
+    3. **hand-off** -- exactly two, full-membership, one carrying forward
+       activations and one carrying backward gradients
+       (:func:`build_handoff_process_groups`).
+
+    Their memberships overlap -- a cascade contains the very ranks the hand-off
+    walks at that position -- but they must stay distinct communicators: the
+    cascade carries a collective, the hand-off carries P2P, and mixing the two on
+    one communicator is the documented NCCL hang. The hand-off is two groups so a
+    boundary's forward and backward run on separate streams rather than
+    serializing.
+
+    This function exists for the *ordering*, which is the part that is easy to get
+    wrong: ``dist.new_group`` is a collective, so every rank must create every
+    group in the same order, and interleaving those calls with DMP's sharding
+    collectives deadlocks. Building all three sets here, in a fixed order, before
+    any parallelizer runs, makes both properties hold by construction --
+    :class:`StageWrapper` calls this before it shards.
+
+    The stage layout is implicit in ``stage_size``: stage ``i`` is the contiguous
+    rank block starting at ``i * stage_size``. This is the one place that table is
+    materialized; the builders take it explicitly.
+
+    Args:
+        stage_size: ranks per stage (one HSD); also the number of cascades.
+        num_stages: how many stages the job holds; also each cascade's size.
+
+    Returns:
+        The stage groups (indexed by stage), the ``(act_pg, grad_pg)`` hand-off
+        pair, and the cascade groups (indexed by position).
+    """
+    stage_ranks: List[List[int]] = [
+        list(range(s * stage_size, (s + 1) * stage_size)) for s in range(num_stages)
+    ]
+    stage_pgs = build_stage_process_groups(stage_ranks)
+    handoff_pgs = build_handoff_process_groups(stage_ranks)
+    cascade_pgs = build_cascade_process_groups(stage_ranks)
+    return stage_pgs, handoff_pgs, cascade_pgs
+
+
+def remap_plan_to_process_group(
+    plan: ShardingPlan, pg: dist.ProcessGroup, device: torch.device
+) -> None:
+    """Rewrite a plan's shard placements from group-local to global, in place.
+
+    A planner built over a sub-process-group topology emits *group-local* ranks
+    and devices -- ``rank:0/cuda:0``, ``rank:1/cuda:1`` for a 2-rank group. Shard
+    placements are interpreted against the *global* rank space, though:
+    ``DistributedModelParallel`` maps ``placement.rank()`` back through the
+    process group, and the shard tensor lives on the process's actual device. For
+    a group whose ranks are global ``{2, 3}`` on ``cuda:{2, 3}`` the group-local
+    plan is wrong twice over -- rank 0 is not in the group at all, and the device
+    is ``cuda:0`` rather than ``cuda:2``.
+
+    Call this on a plan produced by a planner whose ``Topology`` was sized to
+    ``pg`` rather than to the world, before handing it to
+    ``DistributedModelParallel``. Group-local rank ``r`` is remapped to global
+    rank ``g = get_global_rank(pg, r)``, placed on ``cuda:{g % device_count}``.
+    Deterministic given ``(plan, pg)``, so every rank in the group produces the
+    same result.
+
+    A no-op for non-CUDA devices, which carry no ordinal to correct.
+
+    Args:
+        plan: the sharding plan to rewrite, modified in place.
+        pg: the process group the plan was planned over.
+        device: the compute device; only ``cuda`` placements are remapped.
+
+    .. note::
+        Assumes one host -- global rank ``g`` is taken to be on local device
+        ``g % torch.cuda.device_count()``.
+    """
+    if device.type != "cuda":
         return
-    for param in params:
-        if param.grad is not None:
-            dist.all_reduce(param.grad, group=stage_pg)
-            param.grad /= world_size
+    device_count = torch.cuda.device_count()
+    for module_plan in plan.plan.values():
+        # ModuleShardingPlan is dict-like at runtime (param name -> ParameterSharding).
+        # pyrefly: ignore[missing-attribute]
+        for param_sharding in module_plan.values():
+            spec = getattr(param_sharding, "sharding_spec", None)
+            if spec is None:
+                continue
+            for shard in spec.shards:
+                g = dist.get_global_rank(pg, shard.placement.rank())
+                dev = g % device_count if device_count else 0
+                shard.placement = torch.distributed._remote_device(
+                    f"rank:{g}/cuda:{dev}"
+                )
 
 
-class StageParallelizer(abc.ABC):
-    """Strategy for mapping a stage module onto its HSD process group.
+class _LayerChain(nn.Module):
+    """Runs a stage's layers back to back, threading the activation through.
 
-    Encapsulates the three things that vary by parallelism scheme: how the module
-    is transformed (:meth:`parallelize`), how its optimizer is built
-    (:meth:`build_optimizer`), and how its gradients are reduced
-    (:meth:`reduce_gradients`).
+    Not part of the Maglev API -- it exists only because the parallelizers need a
+    single callable ``nn.Module`` to own the stage's layers:
+    ``DistributedModelParallel`` shards exactly one module, and a bare
+    ``nn.ModuleList`` has no ``forward``. :class:`StageWrapper` builds one from
+    the layer list it is given and exposes it as :attr:`StageWrapper.module`.
 
-    **Invariant:** implementations must configure any data-parallelism so
-    gradients are NOT reduced during backward. The pipeline accumulates across
-    microbatches and reduces once, via :meth:`reduce_gradients`, after all
-    microbatch backwards (see ``run_1f1b``). This keeps the 1F1B schedule
-    decoupled from per-backward DP collectives.
-    """
+    The stage holding the model's *final* layer is also given the model's
+    :meth:`~torchrec.distributed.maglev.module.MaglevModuleList.postproc`, and
+    applies it to the last activation, returning ``(losses, output)``. That is
+    what keeps the two execution modes equivalent: ``MaglevModuleList.forward``
+    ends with ``postproc``, so a pipelined run has to end with it too, or the
+    model's head and loss would simply not run. It happens here, inside the
+    parallelized module, so it stays in the autograd graph and a head with
+    parameters shards with the rest of the stage.
 
-    @abc.abstractmethod
-    def parallelize(
-        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
-    ) -> nn.Module:
-        """Transform ``module`` for ``stage_pg`` (shard/wrap) and return it."""
-        ...
-
-    @abc.abstractmethod
-    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
-        """Build the optimizer for the parallelized ``module``."""
-        ...
-
-    @abc.abstractmethod
-    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
-        """Complete the once-per-step DP gradient reduction over ``stage_pg``."""
-        ...
-
-
-class Replicated(StageParallelizer):
-    """Full replica per rank; grads are DP-averaged over the HSD.
-
-    The numerics-transparent path the correctness test compares against a
-    single-process reference.
-
-    Example::
-
-        stage = StageWrapper(module, stage_pg, stage_index, Replicated())
-    """
-
-    def parallelize(
-        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
-    ) -> nn.Module:
-        return module
-
-    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
-        return torch.optim.SGD(module.parameters(), lr=lr, foreach=True)
-
-    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
-        _all_reduce_dense(list(module.parameters()), stage_pg)
-
-
-class EmbeddingShard(StageParallelizer):
-    """Shard the stage's ``EmbeddingBagCollection`` within its HSD via DMP.
-
-    The EBC tables are sharded over ``stage_pg`` (the lookup all-to-all stays
-    local to the HSD -- no global cross-HSD embedding exchange), and the embedding
-    optimizer is fused into the TBE backward (``apply_optimizer_in_backward``).
-    Dense params stay replicated and are DP-averaged by :meth:`reduce_gradients`;
-    ``init_data_parallel=False`` keeps them out of DDP so the pipeline's manual
-    1F1B backward drives them (the pipeline-safe dense-DP mode). See
-    :func:`_remap_plan_to_pg_devices` for the sub-pg placement fix.
+    ``postproc`` is handed the last layer's *input* as well as its activation,
+    because that is where the target lives -- which is why the pipeline never has
+    to carry labels.
 
     Args:
-        embedding_lr: learning rate for the fused (in-backward) embedding
-            optimizer.
+        layers: the stage's layers, in execution order.
+        postproc: the model's output seam, on the stage that owns the final
+            layer; ``None`` on every other stage, which must hand a plain
+            activation tuple to the next HSD. Called as
+            ``postproc(activations, layer_inputs[-1])``.
 
     Example::
 
-        stage = StageWrapper(module, stage_pg, stage_index, EmbeddingShard())
-    """
-
-    def __init__(self, embedding_lr: float = 0.05) -> None:
-        self._embedding_lr = embedding_lr
-        # Dense (non-sharded) params to DP-average once per step.
-        self._dense_params: List[nn.Parameter] = []
-
-    def parallelize(
-        self, module: nn.Module, stage_pg: dist.ProcessGroup, device: torch.device
-    ) -> nn.Module:
-        sharders: List[ModuleSharder[nn.Module]] = [
-            cast(ModuleSharder[nn.Module], EmbeddingBagCollectionSharder())
-        ]
-
-        # Fuse the embedding optimizer into the TBE backward *before* DMP so the
-        # sharder builds it into the kernel (sparse params train in backward).
-        emb_params = [
-            p
-            for m in module.modules()
-            if isinstance(m, EmbeddingBagCollection)
-            for p in m.parameters()
-        ]
-        if not emb_params:
-            raise ValueError(
-                "EmbeddingShard requires an EmbeddingBagCollection in the stage"
-            )
-        apply_optimizer_in_backward(
-            torch.optim.SGD, emb_params, {"lr": self._embedding_lr}
-        )
-
-        # Plan + shard scoped to this stage's HSD; the embedding all-to-all runs
-        # only over ``stage_pg`` (world_size == the HSD's rank count).
-        env = ShardingEnv.from_process_group(stage_pg)
-        planner = EmbeddingShardingPlanner(
-            topology=Topology(world_size=stage_pg.size(), compute_device=device.type)
-        )
-        # NOTE: not planner.collective_plan(): it broadcasts from group-local rank
-        # 0 but passes it as a *global* broadcast src, which deadlocks for any
-        # stage whose pg does not contain global rank 0 (stages 1..N-1). Compute
-        # the plan on the pg's leader and broadcast with the correct global src.
-        if stage_pg.rank() == 0:
-            plan_holder: List[Optional[ShardingPlan]] = [planner.plan(module, sharders)]
-        else:
-            plan_holder = [None]
-        if stage_pg.size() > 1:
-            dist.broadcast_object_list(
-                plan_holder, src=dist.get_global_rank(stage_pg, 0), group=stage_pg
-            )
-        plan = plan_holder[0]
-        assert plan is not None
-        # The planner places shards on cuda:{group-local-rank}; remap to this
-        # stage's actual device ordinals (cuda:2/3 for stage 1, etc.).
-        _remap_plan_to_pg_devices(plan, stage_pg, device)
-        dmp = DistributedModelParallel(
-            module=module,
-            env=env,
-            device=device,
-            plan=plan,
-            sharders=sharders,
-            init_data_parallel=False,
-            init_parameters=False,
-        )
-        self._dense_params = [
-            p for _, p in in_backward_optimizer_filter(dmp.named_parameters())
-        ]
-        return dmp
-
-    def build_optimizer(self, module: nn.Module, lr: float) -> torch.optim.Optimizer:
-        dense_optim = KeyedOptimizerWrapper(
-            dict(in_backward_optimizer_filter(module.named_parameters())),
-            lambda params: torch.optim.SGD(params, lr=lr, foreach=True),
-        )
-        dmp = cast(DistributedModelParallel, module)
-        return CombinedOptimizer([dmp.fused_optimizer, dense_optim])
-
-    def reduce_gradients(self, module: nn.Module, stage_pg: dist.ProcessGroup) -> None:
-        # Only the dense params need DP averaging; the sharded embedding grads are
-        # handled locally by the fused (in-backward) optimizer.
-        _all_reduce_dense(self._dense_params, stage_pg)
-
-
-class StageWrapper(nn.Module):
-    """Binds a Maglev stage module to its HSD process group via a parallelizer.
-
-    The :class:`StageParallelizer` decides how the stage is mapped onto
-    ``stage_pg`` -- replicated, embedding-sharded, etc. -- and owns optimizer
-    construction and the once-per-step gradient reduction. The wrapper itself is a
-    thin delegator, so new parallelism schemes (FSDP/TP on the dense sub-arch) are
-    added as new parallelizers without changing the wrapper or the pipeline.
-
-    Args:
-        module: the stage module, following the ``forward(stage_input,
-            prev_output)`` contract.
-        stage_pg: the process group for this stage's HSD.
-        stage_index: this stage's position in the pipeline.
-        parallelizer: the parallelization strategy. Defaults to
-            :class:`Replicated`.
-
-    Example::
-
-        stage = StageWrapper(module, stage_pg, stage_index, EmbeddingShard())
-        opt = stage.configure_optimizer(lr=0.05)
+        chain = _LayerChain([layer0, layer1])
+        (out,) = chain([layer_input0, layer_input1])
     """
 
     def __init__(
         self,
-        module: nn.Module,
-        stage_pg: dist.ProcessGroup,
-        stage_index: int,
-        parallelizer: Optional[StageParallelizer] = None,
+        layers: Sequence[MaglevLayer],
+        postproc: Optional[Callable[[Activations, Any], Any]] = None,
     ) -> None:
         super().__init__()
-        self._stage_pg: dist.ProcessGroup = stage_pg
-        self.stage_index: int = stage_index
-        self._parallelizer: StageParallelizer = parallelizer or Replicated()
-        device: torch.device = next(module.parameters()).device
-        self.module: nn.Module = self._parallelizer.parallelize(
-            module, stage_pg, device
+        self.layers: nn.ModuleList = nn.ModuleList(layers)
+        # Plain attribute, not a submodule: postproc is a bound method of the
+        # authored model, whose parameters are already owned by ``layers``.
+        self._postproc = postproc
+
+    def forward(
+        self, layer_inputs: Sequence[Any], in_activations: Activations = ()
+    ) -> Any:
+        """Chain the layers, threading each layer's activation into the next.
+
+        Args:
+            layer_inputs: one input per layer, index-aligned with :attr:`layers`.
+            in_activations: the activation entering the stage. Default is ``()``.
+
+        Returns:
+            Any: a plain ``Activations`` tuple, except on the stage owning the
+            final layer, where the model's ``postproc`` has produced
+            ``(losses, output)``.
+
+        Raises:
+            ValueError: if the input count does not match the layer count.
+        """
+        if len(layer_inputs) != len(self.layers):
+            raise ValueError(
+                f"expected {len(self.layers)} layer inputs, got {len(layer_inputs)}"
+            )
+        activations = in_activations
+        for layer, layer_input in zip(self.layers, layer_inputs):
+            activations = layer(layer_input, activations)
+        if self._postproc is not None:
+            # The last layer's input carries the target postproc scores against.
+            return self._postproc(activations, layer_inputs[-1])
+        return activations
+
+
+class StageWrapper(nn.Module):
+    """Takes a whole Maglev model and keeps the one stage this rank owns.
+
+    Every rank passes the same ``model`` and ``layers_per_stage``; only
+    ``dist.get_rank()`` differs. The wrapper derives which stage this rank owns
+    (:meth:`locate_rank` -- HSDs are contiguous blocks of ``stage_size`` ranks, so
+    no rank-to-stage table is carried), keeps that contiguous run of layers, and
+    drops the rest. The kept layers are the model's *own* modules, not copies, so
+    the standalone and pipelined executions share parameters.
+
+    It builds its own process groups: :attr:`stage_pg` (intra-HSD),
+    :attr:`handoff_pgs` (the two direction-split P2P communicators), and
+    :attr:`cascade_pg` (input distribution). ``dist.new_group`` is a collective,
+    so every rank must create every group in the same order; doing it in the
+    constructor makes that ordering unmissable.
+
+    **Parallelism is the caller's job.** The wrapper cuts the model, builds the
+    groups, and reads the boundary contract; it does not shard. Wrap
+    :attr:`module` however you like, assign it back, then :meth:`to` to
+    materialize whatever is still on ``meta``::
+
+        stage = StageWrapper(model, layers_per_stage, stage_size)
+        stage.module = DistributedModelParallel(
+            stage.module, env=ShardingEnv.from_process_group(stage.stage_pg), ...
         )
+        stage.to(device)
+
+    Wrap before materializing, so a sharder places the tables rather than
+    resharding ones already allocated at full size.
+
+    The stage reduces no gradients. They accumulate across a pass, and the
+    schedule runs every backward but the last inside a caller-supplied
+    ``no_sync`` context so the DP wrapper's own reducer fires once (see
+    :class:`~torchrec.distributed.maglev.pipeline.MaglevPipelineBase`).
+
+    The activation specs are captured in the constructor, before any wrapping,
+    since a wrapped module may no longer re-expose the
+    :class:`~torchrec.distributed.maglev.module.MaglevLayer` API.
+
+    Args:
+        model: the authored model, in full.
+        layers_per_stage: how many layers each pipeline stage owns; must sum to
+            ``len(model)``, with one entry per stage.
+        stage_size: ranks per stage -- the size of one hardware scale-up domain
+            (HSD). Stage ``i`` is the contiguous rank block starting at
+            ``i * stage_size``.
+
+    Raises:
+        ValueError: if ``layers_per_stage`` does not describe ``model``, the
+            number of stages implied by ``stage_size`` does not match
+            ``layers_per_stage``, or the kept layers disagree on the activation
+            they exchange.
+
+    Example::
+
+        # Authored on meta: no storage anywhere yet.
+        model = MaglevModuleList([l0, l1, l2, l3])
+        # World size 4, so two stages of two ranks. On rank 3: position 1 of
+        # stage 1, so layers l2 and l3 -- and only those are materialized.
+        stage = StageWrapper(model, [2, 2], stage_size=2)
+        stage.to(device)
+        (out,) = stage([layer_inputs[i] for i in stage.layer_indices])
+    """
+
+    @classmethod
+    def count_stages(cls, stage_size: int, world_size: Optional[int] = None) -> int:
+        """How many pipeline stages a job of ``world_size`` ranks holds.
+
+        The layout is implicit: stage ``i`` is the contiguous block of
+        ``stage_size`` ranks starting at ``i * stage_size``.
+
+        Args:
+            stage_size: ranks per stage (one HSD).
+            world_size: total ranks in the job. Defaults to
+                ``dist.get_world_size()``.
+
+        Returns:
+            int: the number of stages.
+
+        Raises:
+            ValueError: if ``stage_size`` is not positive, or ``world_size`` is
+                not a whole number of stages.
+
+        Example::
+
+            StageWrapper.count_stages(2, world_size=8)   # 4
+        """
+        if world_size is None:
+            world_size = dist.get_world_size()
+        if stage_size <= 0:
+            raise ValueError(f"stage_size must be positive, got {stage_size}")
+        if world_size % stage_size:
+            raise ValueError(
+                f"world_size {world_size} is not a whole number of stages of "
+                f"{stage_size} ranks"
+            )
+        return world_size // stage_size
+
+    @classmethod
+    def locate_rank(cls, stage_size: int, global_rank: int) -> Tuple[int, int]:
+        """Find which stage a rank belongs to, and where in that stage's HSD.
+
+        With HSDs laid out as contiguous blocks of ``stage_size`` ranks, a rank's
+        whole role is one ``divmod``: the stage it owns, and its *position* within
+        that stage, which is what pairs it with the corresponding rank of the
+        neighbouring HSDs for the hand-off.
+
+        Args:
+            stage_size: ranks per stage.
+            global_rank: the rank to locate.
+
+        Returns:
+            Tuple[int, int]: ``(stage_index, position)``.
+
+        Raises:
+            ValueError: if ``stage_size`` is not positive, or ``global_rank`` is
+                negative.
+
+        Example::
+
+            StageWrapper.locate_rank(2, 3)   # (1, 1)
+        """
+        if stage_size <= 0:
+            raise ValueError(f"stage_size must be positive, got {stage_size}")
+        if global_rank < 0:
+            raise ValueError(f"global_rank must not be negative, got {global_rank}")
+        stage_index, position = divmod(global_rank, stage_size)
+        return stage_index, position
+
+    def __init__(
+        self,
+        model: MaglevModuleList,
+        layers_per_stage: Sequence[int],
+        stage_size: int,  # number of ranks for each stage
+    ) -> None:
+        super().__init__()
+        num_stages = self.count_stages(stage_size)
+        if len(layers_per_stage) != num_stages:
+            raise ValueError(
+                f"layers_per_stage describes {len(layers_per_stage)} stages, but "
+                f"stage_size {stage_size} gives {num_stages}"
+            )
+        if sum(layers_per_stage) != len(model):
+            raise ValueError(
+                f"layers_per_stage sums to {sum(layers_per_stage)}, but the model "
+                f"has {len(model)} layers"
+            )
+        for s, count in enumerate(layers_per_stage):
+            if count <= 0:
+                raise ValueError(f"stage {s} must own at least one layer, got {count}")
+        # This rank's own role: the wrapper shards collectively, so it can only
+        # ever be built for the calling rank.
+        stage_index, position = self.locate_rank(stage_size, dist.get_rank())
+        self.stage_index: int = stage_index
+        self.position: int = position
+        self.stage_size: int = stage_size
+        self.num_stages: int = num_stages
+        # How the model is cut is the source of truth; which layers this stage
+        # owns is derived from it (see layer_indices), never stored twice.
+        self.layers_per_stage: List[int] = list(layers_per_stage)
+        layers: List[MaglevLayer] = [
+            cast(MaglevLayer, model[i]) for i in self.layer_indices
+        ]
+        check_layers_chain(layers, f"stage {stage_index}")
+        # Every group the pipeline needs, built in one contiguous run before the
+        # parallelizer issues a single sharding collective (see pg_init).
+        stage_pgs, handoff_pgs, cascade_pgs = pg_init(stage_size, num_stages)
+        self._stage_pg: dist.ProcessGroup = stage_pgs[stage_index]
+        self._handoff_pgs: Tuple[dist.ProcessGroup, dist.ProcessGroup] = handoff_pgs
+        self._cascade_pg: dist.ProcessGroup = cascade_pgs[position]
+        # Posted receives, oldest first: each entry is one transfer's work
+        # handles and the buffers landing into them.
+        # pyre-ignore[4]: dist work handles have no public type
+        self._recv_act: Deque[Tuple[List[Any], List[torch.Tensor]]] = deque()
+        # pyre-ignore[4]
+        self._recv_grad: Deque[Tuple[List[Any], List[torch.Tensor]]] = deque()
+        # The one send in flight per direction: one (work, buffer) per tensor,
+        # the buffer keeping the send open.
+        # pyre-ignore[4]
+        self._send_act: List[Tuple[Any, torch.Tensor]] = []
+        # pyre-ignore[4]
+        self._send_grad: List[Tuple[Any, torch.Tensor]] = []
+        # The model's own input seam. Kept as the bound method, not the model:
+        # holding the model would register every other stage's layers as
+        # submodules of this wrapper.
+        self._preproc: Callable[[Any], List[Any]] = model.preproc
+        # Holds this stage's inputs between all-to-all rounds and the schedule
+        # asking for microbatches.
+        self._input_driver: InputDistDriver[List[Any]] = InputDistDriver(
+            pg_gloo=self._cascade_pg,
+            pg_nccl=self._cascade_pg,
+            self_index=stage_index,
+        )
+        # Microbatches forwarded but not yet backwarded, oldest first:
+        # (incoming activation, this stage's output, microbatch id).
+        self._pending: List[Tuple[Activations, Any, int]] = []
+        # Read the boundary contract off the authored layers; parallelize() may
+        # return a wrapper that hides it.
+        self._in_specs: Tuple[ActivationSpec, ...] = layers[0].in_activation_specs()
+        self._out_specs: Tuple[ActivationSpec, ...] = layers[-1].out_activation_specs()
+        # The stage owning the model's final layer also owns its output seam, so
+        # the pipelined run ends exactly where MaglevModuleList.forward does.
+        self.is_last_stage: bool = stage_index == num_stages - 1
+        # Public and reassignable: wrap it in DMP/FSDP/nothing and assign back.
+        self.module: nn.Module = _LayerChain(
+            layers, model.postproc if self.is_last_stage else None
+        )
+        # Set by to(): a meta-authored model has no device to infer, which is the
+        # whole point of authoring it there.
+        self.device: Optional[torch.device] = None
+
+    @property
+    def num_layers(self) -> int:
+        """How many layers this stage owns (== how many inputs it takes)."""
+        return self.layers_per_stage[self.stage_index]
+
+    @property
+    def layer_indices(self) -> range:
+        """Which of the model's layers this stage owns, in model order.
+
+        Derived from :attr:`layers_per_stage` rather than stored: this stage's
+        layers are the ones following every earlier stage's.
+
+        Example::
+
+            (out,) = stage([layer_inputs[i] for i in stage.layer_indices])
+        """
+        start = sum(self.layers_per_stage[: self.stage_index])
+        return range(start, start + self.num_layers)
+
+    @property
+    def handoff_pgs(self) -> Tuple[dist.ProcessGroup, dist.ProcessGroup]:
+        """The ``(act_pg, grad_pg)`` pair the pipeline hands activations over."""
+        return self._handoff_pgs
+
+    @property
+    def cascade_pg(self) -> dist.ProcessGroup:
+        """This rank's input-distribution group (one rank per stage)."""
+        return self._cascade_pg
+
+    def neighbor_rank(self, offset: int) -> int:
+        """The global rank at this position in the HSD ``offset`` stages away.
+
+        The hand-off is by position: ``neighbor_rank(-1)`` and
+        ``neighbor_rank(+1)`` are the ranks this one exchanges activations and
+        gradients with.
+
+        Args:
+            offset: stages to move, e.g. ``-1`` for the previous HSD.
+
+        Returns:
+            int: the neighbouring rank.
+
+        Raises:
+            ValueError: if the offset lands outside the pipeline.
+
+        Example::
+
+            prev_rank = stage.neighbor_rank(-1)
+        """
+        stage_index = self.stage_index + offset
+        if not 0 <= stage_index < self.num_stages:
+            raise ValueError(
+                f"stage {self.stage_index} has no neighbor at offset {offset}: "
+                f"the pipeline has {self.num_stages} stages"
+            )
+        return stage_index * self.stage_size + self.position
 
     @property
     def stage_pg(self) -> dist.ProcessGroup:
         return self._stage_pg
 
-    def forward(
-        self, stage_input: Any, prev_output: Optional[torch.Tensor]
-    ) -> torch.Tensor:
-        """Run the wrapped stage.
+    # pyre-ignore[14]: narrower than nn.Module.to by design -- this one
+    # materializes meta parameters, which nn.Module.to cannot.
+    def to(self, device: torch.device) -> "StageWrapper":
+        """Place this stage on ``device``, materializing anything still on ``meta``.
+
+        Call after wrapping :attr:`module`, not before: a meta-authored stage
+        materialized first allocates full-size embedding tables a sharder is
+        about to cut up. Idempotent, and a no-op for parameters a wrapper
+        (``DistributedModelParallel``) already placed.
 
         Args:
-            stage_input: this stage's own input (its feature partition).
-            prev_output: the previous stage's activation, or ``None`` for the
-                first stage.
+            device: where this stage runs. Also where the hand-off allocates its
+                receive buffers, so it must be set before the pipeline runs.
+        """
+        init_parameters(self.module, device)
+        self.device = device
+        return self
+
+    @property
+    def _placed_device(self) -> torch.device:
+        """:attr:`device`, or a clear error if :meth:`to` was never called."""
+        device = self.device
+        if device is None:
+            raise ValueError(
+                f"stage {self.stage_index}: no device; call stage.to(device) after "
+                "wrapping stage.module and before running the pipeline"
+            )
+        return device
+
+    def in_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """The activation this stage receives from the previous HSD."""
+        return self._in_specs
+
+    def out_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """The activation this stage sends to the next HSD."""
+        return self._out_specs
+
+    def forward(
+        self, stage_input: Sequence[Any], in_activations: Activations = ()
+    ) -> Any:
+        """Run this stage's layers.
+
+        Args:
+            stage_input: one input per layer this stage owns.
+            in_activations: the previous stage's activation, ``()`` for the first
+                stage.
 
         Returns:
-            torch.Tensor: this stage's output activation.
+            Any: a plain ``Activations`` tuple, except on the last stage, where
+            the model's ``postproc`` has produced ``(losses, output)``.
+
+        Raises:
+            ValueError: if the input count does not match the layers this stage
+                owns.
+
+        .. note::
+            The incoming activation is deliberately *not* validated here. On the
+            pipeline path it cannot be wrong: the connector allocates each buffer
+            as ``torch.empty(spec.shape, dtype=spec.dtype)`` from these very
+            specs, so a per-microbatch check would only restate its own premise
+            while running on the host's critical path. Call
+            :func:`~torchrec.distributed.maglev.module.check_activations`
+            explicitly when feeding a stage hand-built activations.
         """
-        return self.module(stage_input, prev_output)
+        return self.module(stage_input, in_activations)
 
-    def configure_optimizer(self, lr: float) -> torch.optim.Optimizer:
-        """Build the optimizer matching this stage's parallelizer."""
-        return self._parallelizer.build_optimizer(self.module, lr)
+    # ---- cross-HSD hand-off ----
+    #
+    # The stage owns the wire, not just the compute: it knows its neighbours
+    # (:meth:`neighbor_rank`), the two direction-split communicators
+    # (:attr:`handoff_pgs`), and the specs that fix the wire layout. A schedule
+    # (see :mod:`torchrec.distributed.maglev.pipeline`) decides
+    # *when* to call these; it does not need to know how a boundary is wired.
+    # This mirrors ``torch.distributed.pipelining``, where ``PipelineStage`` owns
+    # the send/recv ops and the schedule only orders them.
+    #
+    # Every transfer is split into a start and a wait, and every one is
+    # non-blocking underneath. Issuing is therefore free of ordering constraints,
+    # and a schedule chooses how much work to slide between the two halves --
+    # posting a receive well before the data is needed is what lets a zero-bubble
+    # schedule hide the hand-off behind compute. Each direction keeps its own
+    # queue. Receives queue: each start posts another, and the matching wait
+    # dequeues in issue order, so a schedule can run several boundaries ahead of
+    # the compute. Sends do not queue -- one per direction is in flight at a time,
+    # and the schedule must finish it before starting the next. No start ever
+    # blocks, so where the wait falls is the schedule's choice, not a side effect
+    # buried in the send.
 
-    def reduce_gradients(self) -> None:
-        """Complete the once-per-step DP gradient reduction for this stage."""
-        self._parallelizer.reduce_gradients(self.module, self._stage_pg)
+    @property
+    def is_first(self) -> bool:
+        """Whether this stage starts the pipeline (nothing to receive)."""
+        return self.stage_index == 0
+
+    @property
+    def is_last(self) -> bool:
+        """Whether this stage ends the pipeline (nothing to send)."""
+        return self.stage_index == self.num_stages - 1
+
+    def start_recv_act(self) -> None:
+        """Ensure a receive is posted for the previous HSD's activation.
+
+        Allocates one buffer per incoming spec and issues the receives in spec
+        order, so both sides of the boundary agree without exchanging metadata.
+        Collect them with :meth:`wait_for_act`.
+
+        No-op on the first stage. Otherwise each call posts another receive and
+        queues it, so a schedule can run several boundaries ahead of the compute;
+        :meth:`wait_for_act` dequeues them in issue order.
+        """
+        if self.is_first:
+            return
+        act_pg, _ = self._handoff_pgs
+        src = self.neighbor_rank(-1)
+        works: List[Any] = []
+        tensors: List[torch.Tensor] = []
+        for spec in self._in_specs:
+            tensor = torch.empty(
+                spec.shape, device=self._placed_device, dtype=spec.dtype
+            )
+            works.append(dist.irecv(tensor, src=src, group=act_pg))
+            tensors.append(tensor)
+        self._recv_act.append((works, tensors))
+
+    def wait_for_act(self) -> Activations:
+        """Dequeue the oldest receive posted by :meth:`start_recv_act`.
+
+        Returns:
+            Activations: the received activation; ``()`` on the first stage.
+
+        Raises:
+            ValueError: if no receive is queued.
+        """
+        if self.is_first:
+            return ()
+        if not self._recv_act:
+            raise ValueError(
+                f"stage {self.stage_index}: wait_for_act() with no activation "
+                "receive in flight; call start_recv_act() first"
+            )
+        works, tensors = self._recv_act.popleft()
+        for work in works:
+            work.wait()
+        for spec, tensor in zip(self._in_specs, tensors):
+            if spec.requires_grad:
+                # Only now the receive has landed: making it a leaf that requires
+                # grad any earlier would make the incoming write an in-place op on
+                # a grad-requiring leaf. As a leaf it collects the gradient this
+                # stage hands back to the previous one.
+                tensor.requires_grad_(True)
+        return tuple(tensors)
+
+    def start_send_act(self, outputs: Activations) -> None:
+        """Send this stage's activation to the next HSD; no-op if last.
+
+        Never blocks. One activation send is in flight at a time, so the caller
+        must :meth:`finish_send_act` the previous one first -- keeping the wait
+        where the schedule put it, and bounding the buffers held open to a single
+        transfer.
+
+        Args:
+            outputs: this stage's output activation.
+
+        Raises:
+            ValueError: if an activation send is still in flight.
+        """
+        if self.is_last:
+            return
+        if self._send_act:
+            raise ValueError(
+                f"stage {self.stage_index}: an activation send is still in "
+                "flight; call finish_send_act() before starting the next"
+            )
+        act_pg, _ = self._handoff_pgs
+        self._send_act = self._isend(outputs, self.neighbor_rank(1), act_pg)
+
+    def finish_send_act(self) -> None:
+        """Complete the activation send in flight, if any."""
+        self._drain(self._send_act)
+
+    def start_recv_grad(self) -> None:
+        """Ensure a receive is posted for the next HSD's output gradients.
+
+        One receive per grad-carrying output slot. No-op on the last stage, which
+        takes its gradient from the loss its own ``postproc`` computed. Otherwise
+        each call queues another, as :meth:`start_recv_act`.
+        """
+        if self.is_last:
+            return
+        _, grad_pg = self._handoff_pgs
+        src = self.neighbor_rank(1)
+        works: List[Any] = []
+        tensors: List[torch.Tensor] = []
+        for spec in self._out_specs:
+            if not spec.requires_grad:
+                continue
+            grad = torch.empty(spec.shape, device=self._placed_device, dtype=spec.dtype)
+            works.append(dist.irecv(grad, src=src, group=grad_pg))
+            tensors.append(grad)
+        self._recv_grad.append((works, tensors))
+
+    def wait_for_grad(self) -> List[torch.Tensor]:
+        """Dequeue the oldest receive posted by :meth:`start_recv_grad`.
+
+        Returns:
+            List[torch.Tensor]: the gradients, in spec order; empty on the last
+            stage.
+
+        Raises:
+            ValueError: if no receive is queued.
+        """
+        if self.is_last:
+            return []
+        if not self._recv_grad:
+            raise ValueError(
+                f"stage {self.stage_index}: wait_for_grad() with no gradient "
+                "receive in flight; call start_recv_grad() first"
+            )
+        works, tensors = self._recv_grad.popleft()
+        for work in works:
+            work.wait()
+        return tensors
+
+    def start_send_grad(self, in_activations: Activations) -> None:
+        """Send this stage's input gradients upstream; no-op if first.
+
+        A slot unused by the stage's graph has no ``.grad``; zeros are sent so the
+        previous stage's receive still matches -- the wire layout is fixed by the
+        specs, not by graph connectivity. As with :meth:`start_send_act`, never
+        blocks: the previous gradient send must already have been finished.
+
+        Args:
+            in_activations: the activation this stage received.
+
+        Raises:
+            ValueError: if a gradient send is still in flight.
+        """
+        if self.is_first:
+            return
+        if self._send_grad:
+            raise ValueError(
+                f"stage {self.stage_index}: a gradient send is still in flight; "
+                "call finish_send_grad() before starting the next"
+            )
+        _, grad_pg = self._handoff_pgs
+        grads: List[torch.Tensor] = []
+        for tensor, spec in zip(in_activations, self._in_specs):
+            if not spec.requires_grad:
+                continue
+            grads.append(
+                tensor.grad if tensor.grad is not None else torch.zeros_like(tensor)
+            )
+        self._send_grad = self._isend(grads, self.neighbor_rank(-1), grad_pg)
+
+    def finish_send_grad(self) -> None:
+        """Complete the gradient send in flight, if any."""
+        self._drain(self._send_grad)
+
+    def group_by_stage(self, layer_inputs: Sequence[Any]) -> List[List[Any]]:
+        """Regroup a full per-layer input list into one carrier per stage.
+
+        The inverse of :attr:`layer_indices`, and the form :meth:`input_dist`
+        needs: ``result[s]`` holds the inputs for stage ``s``'s layers, so it is
+        what that stage's rank in the cascade should receive.
+
+        Derived from :attr:`layers_per_stage`, so a non-uniform cut like
+        ``[1, 3]`` groups correctly -- which hand-slicing by a single
+        layers-per-stage number does not.
+
+        Args:
+            layer_inputs: one input per layer of the whole model, in model order.
+
+        Returns:
+            List[List[Any]]: one carrier per stage, index-aligned with the
+            pipeline.
+
+        Raises:
+            ValueError: if there is not exactly one input per model layer.
+
+        Example::
+
+            send_set = stage.group_by_stage(layer_inputs)
+            microbatches = stage.input_dist(send_set, send_set[stage.stage_index]).wait()
+        """
+        grouped: List[List[Any]] = []
+        offset = 0
+        for count in self.layers_per_stage:
+            grouped.append(list(layer_inputs[offset : offset + count]))
+            offset += count
+        return grouped
+
+    def input_dist(self, layer_inputs: Sequence[Any]) -> LazyAwaitable[List[List[Any]]]:
+        """All-to-all a full per-layer input set over this rank's cascade.
+
+        A *cascade* holds one rank from every stage (see :attr:`cascade_pg`), so
+        this is the exchange that turns "the whole batch, held by every rank" into
+        "this stage's inputs, delivered here". The inputs are grouped per stage
+        (:meth:`group_by_stage`), each group is sent to that stage's rank in the
+        cascade, and what comes back is one group from every stage's rank -- i.e.
+        ``num_stages`` microbatches, all of them for *this* stage.
+
+        One round, unwaited. Use :meth:`take_inputs` when the schedule wants a
+        microbatch count that does not divide evenly into rounds.
+
+        The cascade group inherits the job's backend (``cpu:gloo,cuda:nccl``), so
+        the one handle drives both phases of
+        :func:`~torchrec.distributed.maglev.input_dist.input_dist`: the small size
+        exchange on CPU/gloo and the bulk tensor exchange on CUDA/nccl.
+
+        Args:
+            layer_inputs: one input per layer of the whole model, in model order
+                -- what
+                :meth:`~torchrec.distributed.maglev.module.MaglevModuleList.preproc`
+                produces.
+
+        Returns:
+            LazyAwaitable[List[List[Any]]]: ``wait()`` yields ``num_stages``
+            microbatches for this stage, each one input per layer this stage
+            owns. Returned unwaited so the caller can overlap other work with the
+            exchange.
+
+        Raises:
+            ValueError: if there is not exactly one input per model layer.
+
+        Example::
+
+            microbatches = stage.input_dist(layer_inputs).wait()
+            stage.forward_micro(microbatches[0])
+        """
+        return self._input_driver.exchange(self.group_by_stage(layer_inputs))
+
+    def send_set(self, model_input: Any) -> List[List[Any]]:
+        """Turn one raw batch into the cascade send set: one carrier per stage.
+
+        The model's own :meth:`preproc` seam splits the batch into one input per
+        layer (under ``no_grad``, as in
+        :meth:`~torchrec.distributed.maglev.module.MaglevModuleList.forward`),
+        then :meth:`group_by_stage` regroups those by destination stage.
+
+        Args:
+            model_input: the raw batch, as the dataloader yields it.
+
+        Returns:
+            List[List[Any]]: ``result[s]`` is the input list destined for stage
+            ``s``'s rank in this cascade.
+        """
+        with torch.no_grad():
+            layer_inputs = self._preproc(model_input)
+        return self.group_by_stage(layer_inputs)
+
+    def take_inputs(self, dataloader_iter: Iterator[Any], n: int) -> List[List[Any]]:
+        """Hand the schedule ``n`` microbatches for this stage.
+
+        Pulls raw batches from ``dataloader_iter`` and runs as many
+        :meth:`input_dist` rounds as it takes, keeping the remainder queued -- so
+        the microbatch count a schedule wants need not equal the ``num_stages`` a
+        round produces, and a batch is consumed only when a round actually runs.
+        Every rank in the cascade runs the same number of rounds, so every rank
+        advances its dataloader in lock-step -- see
+        :class:`~torchrec.distributed.maglev.input_dist.InputDistDriver`.
+
+        Args:
+            dataloader_iter: yields raw batches, one per round.
+            n: how many microbatches the schedule wants.
+
+        Returns:
+            List[List[Any]]: ``n`` microbatches, each one input per layer this
+            stage owns.
+        """
+        return self._input_driver.take(lambda: self.send_set(next(dataloader_iter)), n)
+
+    def backward(self, outputs: Activations, grads: Sequence[torch.Tensor]) -> None:
+        """Backward through this stage from the gradients its outputs received.
+
+        Args:
+            outputs: this stage's output activation.
+            grads: the matching gradients, from :meth:`wait_for_grad`.
+        """
+        grad_carrying = [
+            t for t, spec in zip(outputs, self._out_specs) if spec.requires_grad
+        ]
+        pairs = [
+            (out, grad) for out, grad in zip(grad_carrying, grads) if out.requires_grad
+        ]
+        if pairs:
+            torch.autograd.backward([o for o, _ in pairs], [g for _, g in pairs])
+
+    # pyre-ignore[3]: dist work handle has no public type
+    def _isend(
+        self, tensors: Sequence[torch.Tensor], dst: int, pg: dist.ProcessGroup
+    ) -> List[Tuple[Any, torch.Tensor]]:
+        """Issue non-blocking sends, in order, for a later drain.
+
+        The detached buffer is returned alongside the work handle so it stays
+        alive until the send completes. ``.contiguous()`` is a no-op for an
+        already contiguous tensor, so this aliases the activation rather than
+        copying it.
+        """
+        out: List[Tuple[Any, torch.Tensor]] = []
+        for tensor in tensors:
+            buf = tensor.detach().contiguous()
+            out.append((dist.isend(buf, dst=dst, group=pg), buf))
+        return out
+
+    # pyre-ignore[2]: dist work handle has no public type
+    def _drain(self, sends: List[Tuple[Any, torch.Tensor]]) -> None:
+        """Wait every send in ``sends`` and release the buffers holding it open."""
+        for work, _buf in sends:
+            work.wait()
+        sends.clear()
+
+    # ---- one microbatch of this stage's work ----
+
+    def forward_micro(
+        self,
+        stage_input: Sequence[Any],
+        microbatch_id: int = 0,
+    ) -> None:
+        """One microbatch forward: recv activation, compute, send activation.
+
+        The result is parked on an internal FIFO for the matching
+        :meth:`backward_micro`, so a schedule can run several forwards before the
+        first backward without tracking in-flight state itself.
+
+        Does *not* post its own activation receive: the schedule starts that
+        ahead of time (:meth:`start_recv_act`) so the transfer overlaps earlier
+        work, and this dequeues it.
+
+        Neither receive is posted here -- the schedule owns both (see the
+        warning on :meth:`backward_micro` for the constraint the gradient one
+        carries).
+
+        Args:
+            stage_input: one input per layer this stage owns.
+            microbatch_id: tags the profiler ranges (and is carried to the
+                matching backward) so a trace shows which microbatch each
+                comm/compute belongs to.
+        """
+        # Posted by the schedule ahead of this call, so the transfer has already
+        # been in flight; wait_for_act raises if it was never started.
+        with record_function(f"## recv_act mb{microbatch_id} ##"):
+            in_activations = self.wait_for_act()
+
+        with record_function(f"## forward mb{microbatch_id} ##"):
+            outputs = self.forward(stage_input, in_activations)
+
+        # The previous microbatch's send, drained before this one is issued.
+        with record_function(f"## finish_send_act mb{microbatch_id} ##"):
+            self.finish_send_act()
+        with record_function(f"## send_act mb{microbatch_id} ##"):
+            self.start_send_act(outputs)
+
+        self._pending.append((in_activations, outputs, microbatch_id))
+
+    def backward_micro(self) -> Optional[torch.Tensor]:
+        """One microbatch backward: recv grad, backward, send input grad.
+
+        Pops the oldest microbatch parked by :meth:`forward_micro`. Gradients
+        accumulate across microbatches (no ``zero_grad`` here); the schedule runs
+        the DP all-reduce and optimizer step once per batch. Profiler ranges are
+        tagged with the ``microbatch_id`` recorded at forward time.
+
+        The last stage takes its gradient from the loss its own ``postproc``
+        computed; every other stage collects the receive the schedule posted, and
+        :meth:`wait_for_grad` raises if it did not.
+
+        .. warning::
+            The schedule must not post that receive during the forward phase. The
+            hand-off groups are full-membership, so the *first* P2P on a pair
+            lazily creates a 2-rank communicator and **blocks until both ranks
+            touch the pair** -- and a peer only touches the gradient direction in
+            its own backward. Posted too early, this rank parks mid-wave and the
+            pipeline deadlocks: the peer is left waiting for the next activation
+            this rank can no longer send. Once that communicator exists, posting
+            a microbatch ahead is free, which is what
+            :class:`~torchrec.distributed.maglev.pipeline.MaglevPipeline1F1B` does.
+
+        Returns:
+            Optional[torch.Tensor]: the microbatch loss on the last stage,
+            ``None`` on every other stage.
+        """
+        in_activations, outputs, microbatch_id = self._pending.pop(0)
+
+        loss: Optional[torch.Tensor] = None
+        if self.is_last:
+            with record_function(f"## backward mb{microbatch_id} ##"):
+                loss = outputs[0]
+                loss.backward()
+        else:
+            with record_function(f"## recv_grad mb{microbatch_id} ##"):
+                grads = self.wait_for_grad()
+            with record_function(f"## backward mb{microbatch_id} ##"):
+                self.backward(outputs, grads)
+
+        with record_function(f"## finish_send_grad mb{microbatch_id} ##"):
+            self.finish_send_grad()
+        with record_function(f"## send_grad mb{microbatch_id} ##"):
+            self.start_send_grad(in_activations)
+
+        return loss
+
+    def drain_sends(self) -> None:
+        """Complete the in-flight send in each direction, if any.
+
+        ``forward_micro`` / ``backward_micro`` each finish the *previous* send
+        before starting the next, so at the end of a pass exactly one send per
+        direction is still outstanding. Left unwaited, its work handle leaks and
+        its buffer stays pinned while NCCL may still be reading it -- and
+        :meth:`start_send_act` refuses to start another while one is in flight.
+        A schedule therefore ends every pass here.
+        """
+        self.finish_send_act()
+        self.finish_send_grad()

--- a/torchrec/distributed/maglev/tests/test_input_dist.py
+++ b/torchrec/distributed/maglev/tests/test_input_dist.py
@@ -275,13 +275,57 @@ class InputDistInProcessTest(unittest.TestCase):
         torch.testing.assert_close(got.features.lengths(), send[0].features.lengths())
         self.assertEqual(got.tag, "from_example")
 
+    def test_ragged_carriers(self) -> None:
+        """A carrier may have more slots than the example, if its peer expects them.
+
+        The maglev case: with a non-uniform cut like ``[2, 3]``, the carrier a rank
+        sends to a 3-layer stage flattens to more tensors than the one it sends to a
+        2-layer stage. Only what this rank *receives* has to match its example.
+        """
+        pg = dist.group.WORLD
+        assert pg is not None
+        # world_size == 1, so this rank sends to itself: the carrier it sends must
+        # match its own example. Make both two carriers deep to prove the flat
+        # (rather than rectangular) size exchange round-trips a multi-slot carrier.
+        send = [[_make_carrier(src=0, dst=0), _make_carrier(src=0, dst=1)]]
+        example = [_make_carrier(src=0, dst=0), _make_carrier(src=0, dst=1)]
+
+        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
+        # Sizes come back reshaped to [source rank][slot], covering both carriers.
+        self.assertEqual(len(recv_sizes), 1)
+        self.assertEqual(len(recv_sizes[0]), len(flat_send[0]))
+        self.assertEqual(recv_sizes[0], [t.shape[0] for t in flat_send[0]])
+
+        recv = input_data_dist(flat_send, recv_sizes, example, pg).wait()
+        self.assertEqual(len(recv), 1)
+        self.assertEqual(len(recv[0]), 2)
+        for got, expected in zip(recv[0], send[0]):
+            torch.testing.assert_close(got.dense, expected.dense)
+            torch.testing.assert_close(got.ids, expected.ids)
+            torch.testing.assert_close(
+                got.features.values(), expected.features.values()
+            )
+
+    def test_send_dtype_absent_from_example_is_rejected(self) -> None:
+        """A carrier may differ from the example in slot count, not in dtypes."""
+        pg = dist.group.WORLD
+        assert pg is not None
+        send = [_make_carrier(src=0, dst=0)]
+        example = _make_carrier(src=0, dst=0)
+        # float64 appears in no bucket the example defines.
+        send[0].extras = [t.to(torch.float64) for t in send[0].extras]
+
+        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
+        with self.assertRaisesRegex(ValueError, "which the example does not have"):
+            input_data_dist(flat_send, recv_sizes, example, pg)
+
     def test_size_then_data_phase(self) -> None:
         pg = dist.group.WORLD
         assert pg is not None
         send = [_make_carrier(src=0, dst=0)]
         example = _make_carrier(src=0, dst=0)
 
-        flat_send, recv_sizes = input_size_dist(send, pg).wait()
+        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
         # One carrier -> one row; sizes match the flattened tensors' dim-0.
         self.assertEqual(len(recv_sizes), 1)
         self.assertEqual(recv_sizes[0], [t.shape[0] for t in flat_send[0]])

--- a/torchrec/distributed/maglev/tests/test_module.py
+++ b/torchrec/distributed/maglev/tests/test_module.py
@@ -8,40 +8,39 @@
 # pyre-strict
 
 import random
-from typing import List
+import unittest
+from typing import Any, List, Tuple
 
 import torch
-import torch.nn as nn
 from torchrec.distributed.maglev.module import MaglevModuleList
-from torchrec.distributed.maglev.pipeline import MaglevPipeline
-from torchrec.distributed.maglev.stage import build_stage_process_groups, StageWrapper
+from torchrec.distributed.maglev.pipeline import MaglevPipelineBase
+from torchrec.distributed.maglev.stage import StageWrapper
 from torchrec.distributed.test_utils.model_input import ModelInput
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
 from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
-from torchrec.distributed.test_utils.test_model import MaglevTestStage
+from torchrec.distributed.test_utils.test_model import MaglevTestLayer, MaglevTestModel
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 
 _WEIGHT_SEED = 100
 _INPUT_SEED = 500
-_LABEL_SEED = 900
 
 
 def _make_tables(
-    stage_index: int,
+    layer_index: int,
     num_tables: int,
     num_embeddings: int,
     emb_dim: int,
 ) -> List[EmbeddingBagConfig]:
-    """This stage's feature partition: disjoint 1-feature tables, namespaced per stage."""
+    """This layer's feature partition: disjoint 1-feature tables, namespaced per layer."""
     return EmbeddingTablesConfig(
         num_unweighted_features=num_tables,
         num_weighted_features=0,
         embedding_feature_dim=emb_dim,
         base_row_size=num_embeddings,
-    ).generate_tables(name_prefix=f"s{stage_index}_")[0]
+    ).generate_tables(name_prefix=f"l{layer_index}_")[0]
 
 
 def _make_input(
@@ -68,116 +67,114 @@ def _make_input(
     )
 
 
-def _build_stage(
-    stage_index: int,
+def _build_model(
+    num_layers: int,
+    batch_size: int,
     num_tables: int,
     num_embeddings: int,
     emb_dim: int,
     num_float_features: int,
-    stage_dim: int,
+    layer_dim: int,
     device: torch.device,
-) -> MaglevTestStage:
-    """Build a stage with deterministic weights (seeded by stage index)."""
-    tables = _make_tables(stage_index, num_tables, num_embeddings, emb_dim)
-    torch.manual_seed(_WEIGHT_SEED + stage_index)
-    return MaglevTestStage(
-        tables=tables,
-        stage_dim=stage_dim,
-        is_first=(stage_index == 0),
-        num_float_features=num_float_features,
-        device=device,
-    )
+) -> MaglevTestModel:
+    """Author the model as a list of layers, with weights seeded by layer index."""
+    layers: List[MaglevTestLayer] = []
+    for layer_index in range(num_layers):
+        tables = _make_tables(layer_index, num_tables, num_embeddings, emb_dim)
+        torch.manual_seed(_WEIGHT_SEED + layer_index)
+        layers.append(
+            MaglevTestLayer(
+                tables=tables,
+                layer_dim=layer_dim,
+                is_first=(layer_index == 0),
+                batch_size=batch_size,
+                num_float_features=num_float_features,
+                device=device,
+            )
+        )
+    return MaglevTestModel(layers)
 
 
 def _run_correctness(
     rank: int,
     world_size: int,
     num_stages: int,
+    layers_per_stage: int,
     ranks_per_stage: int,
     batch_size: int,
     num_tables: int,
     num_embeddings: int,
     emb_dim: int,
     num_float_features: int,
-    stage_dim: int,
+    layer_dim: int,
 ) -> None:
     # CPU + gloo keeps the 8-rank repro portable (no 8-GPU requirement).
     with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo"):
         device = torch.device("cpu")
-        criterion = nn.MSELoss()
+        num_layers = num_stages * layers_per_stage
+        partition = [layers_per_stage] * num_stages
 
-        stage_ranks: List[List[int]] = [
-            list(range(s * ranks_per_stage, (s + 1) * ranks_per_stage))
-            for s in range(num_stages)
-        ]
-        # Collective: every rank builds every stage's process group.
-        stage_pgs = build_stage_process_groups(stage_ranks)
-        my_stage_index = rank // ranks_per_stage
+        my_stage_index, _position = StageWrapper.locate_rank(ranks_per_stage, rank)
 
-        # Deterministic per-stage inputs / label, identical on every rank (so the
+        # Deterministic per-layer inputs / label, identical on every rank (so the
         # two DP lanes of an HSD see the same data and the DP all-reduce is an
         # identity -- keeping the distributed grads exactly comparable to the
         # single-process reference).
         all_tables = [
-            _make_tables(s, num_tables, num_embeddings, emb_dim)
-            for s in range(num_stages)
+            _make_tables(l, num_tables, num_embeddings, emb_dim)
+            for l in range(num_layers)
         ]
-        stage_inputs = [
+        layer_inputs: List[Any] = [
             _make_input(
-                all_tables[s], batch_size, num_float_features, _INPUT_SEED + s, device
+                all_tables[l], batch_size, num_float_features, _INPUT_SEED + l, device
             )
-            for s in range(num_stages)
+            for l in range(num_layers)
         ]
-        torch.manual_seed(_LABEL_SEED)
-        label = torch.randn(batch_size, stage_dim, device=device)
-
         # ---- distributed pipeline: forward + backward for this rank's stage ----
-        stage_module = _build_stage(
-            my_stage_index,
+        # Every rank authors the same full model and hands it to StageWrapper,
+        # which keeps only this rank's stage; the kept layers are the model's own
+        # modules.
+        dist_model = _build_model(
+            num_layers,
+            batch_size,
             num_tables,
             num_embeddings,
             emb_dim,
             num_float_features,
-            stage_dim,
+            layer_dim,
             device,
         )
+        # The wrapper derives this rank's stage from stage_size and builds
+        # every process group it and the pipeline need.
         stage = StageWrapper(
-            module=stage_module,
-            stage_pg=stage_pgs[my_stage_index],
-            stage_index=my_stage_index,
+            model=dist_model,
+            layers_per_stage=partition,
+            stage_size=ranks_per_stage,
         )
-        pipeline = MaglevPipeline(
-            stage=stage,
-            stage_ranks=stage_ranks,
-            global_rank=rank,
-            activation_shape=torch.Size([batch_size, stage_dim]),
-            device=device,
-        )
+        # Unwrapped: the numerics-transparent path this test compares against a
+        # single-process reference. to() materializes the meta-authored layers.
+        stage.to(device)
         # lr=0: weights are unchanged, grads remain populated for comparison.
         optimizer = torch.optim.SGD(stage.parameters(), lr=0.0, foreach=True)
-        dist_loss = pipeline.step(
-            stage_input=stage_inputs[my_stage_index],
-            optimizer=optimizer,
-            label=label if pipeline.is_last else None,
-            criterion=criterion if pipeline.is_last else None,
-        )
+        pipeline = MaglevPipelineBase(stage=stage, optimizer=optimizer)
+        # One batch, the whole model's per-layer inputs; the stage pulls it,
+        # partitions it and all-to-alls it to get its own. No label or criterion:
+        # the model scores itself in postproc, against the target carried by the
+        # last layer's own ModelInput.
+        dist_loss = pipeline.progress(iter([layer_inputs]))
 
         # ---- single-process reference: the whole MaglevModuleList in-process ----
-        ref_stages: List[nn.Module] = [
-            _build_stage(
-                s,
-                num_tables,
-                num_embeddings,
-                emb_dim,
-                num_float_features,
-                stage_dim,
-                device,
-            )
-            for s in range(num_stages)
-        ]
-        ref_model = MaglevModuleList(ref_stages)
-        ref_out = ref_model(stage_inputs)
-        ref_loss = criterion(ref_out, label)
+        ref_model = _build_model(
+            num_layers,
+            batch_size,
+            num_tables,
+            num_embeddings,
+            emb_dim,
+            num_float_features,
+            layer_dim,
+            device,
+        )
+        ref_loss, _ref_output = ref_model(layer_inputs)
         ref_loss.backward()
 
         # 1. Last-stage loss matches the reference.
@@ -186,30 +183,109 @@ def _run_correctness(
             torch.testing.assert_close(dist_loss, ref_loss)
 
         # 2. This stage's gradients (after DP all-reduce) match the reference
-        #    stage's gradients => forward + backward numerics of the pipeline
-        #    wrapper match the hand-written single-process model.
-        ref_params = dict(ref_stages[my_stage_index].named_parameters())
+        #    model's gradients for the same layers => forward + backward numerics
+        #    of the pipelined execution match the standalone model.
         checked = 0
-        for name, param in stage.module.named_parameters():
-            assert param.grad is not None, f"no grad for {name}"
-            ref_grad = ref_params[name].grad
-            assert ref_grad is not None, f"no reference grad for {name}"
-            torch.testing.assert_close(param.grad, ref_grad)
-            checked += 1
+        for offset in range(layers_per_stage):
+            layer_index = my_stage_index * layers_per_stage + offset
+            ref_params = dict(ref_model[layer_index].named_parameters())
+            for name, param in dist_model[layer_index].named_parameters():
+                assert param.grad is not None, f"no grad for layer{layer_index}.{name}"
+                ref_grad = ref_params[name].grad
+                assert (
+                    ref_grad is not None
+                ), f"no reference grad for layer{layer_index}.{name}"
+                torch.testing.assert_close(param.grad, ref_grad)
+                checked += 1
         assert checked > 0, "no parameters were checked"
 
 
 class MaglevPipelineTest(MultiProcessTestBase):
     def test_pipeline_matches_single_process(self) -> None:
+        """Multi-layer stages: 8 layers partitioned into 4 stages of 2 layers each."""
         self._run_multi_process_test(
             callable=_run_correctness,
             world_size=8,
             num_stages=4,
+            layers_per_stage=2,
             ranks_per_stage=2,
             batch_size=16,
             num_tables=6,
             num_embeddings=64,
             emb_dim=8,
             num_float_features=8,
-            stage_dim=12,
+            layer_dim=12,
         )
+
+
+class MaglevModuleListTest(unittest.TestCase):
+    """Single-process checks of the authoring API (no distributed setup needed)."""
+
+    def _model(self, num_layers: int = 4, batch_size: int = 4) -> MaglevTestModel:
+        return _build_model(
+            num_layers=num_layers,
+            batch_size=batch_size,
+            num_tables=2,
+            num_embeddings=16,
+            emb_dim=4,
+            num_float_features=4,
+            layer_dim=6,
+            device=torch.device("cpu"),
+        )
+
+    def _inputs(self, num_layers: int = 4, batch_size: int = 4) -> List[Any]:
+        return [
+            _make_input(
+                _make_tables(l, 2, 16, 4),
+                batch_size,
+                4,
+                _INPUT_SEED + l,
+                torch.device("cpu"),
+            )
+            for l in range(num_layers)
+        ]
+
+    def test_standalone_matches_stage_by_stage(self) -> None:
+        """Running the model one stage's layers at a time reproduces its forward."""
+        model = self._model()
+        inputs = self._inputs()
+
+        losses, output = model(inputs)
+
+        # [1, 3]: stage 0 owns layer 0, stage 1 owns layers 1..3.
+        activations: Tuple[torch.Tensor, ...] = ()
+        for stage_layers in ([0], [1, 2, 3]):
+            for i in stage_layers:
+                activations = model[i](inputs[i], activations)
+        staged_losses, staged_output = model.postproc(activations, inputs[-1])
+
+        torch.testing.assert_close(output, staged_output)
+        torch.testing.assert_close(losses, staged_losses)
+
+    def test_postproc_returns_losses_and_output(self) -> None:
+        """The model returns the usual (losses, output) pair."""
+        model = self._model(batch_size=4)
+        losses, output = model(self._inputs(batch_size=4))
+        self.assertEqual(losses.shape, torch.Size([]))  # scalar, backward-able
+        self.assertEqual(output.shape, torch.Size([4]))  # one prediction per row
+
+    def test_base_postproc_must_be_overridden(self) -> None:
+        """MaglevModuleList itself cannot score a model."""
+        with self.assertRaises(NotImplementedError):
+            MaglevModuleList.postproc(self._model(), (), None)
+
+    def test_locate_rank_maps_every_rank_to_a_stage_slot(self) -> None:
+        """Each rank resolves to its stage and its position within that HSD."""
+        located = [StageWrapper.locate_rank(2, r) for r in range(6)]
+        self.assertEqual(located, [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)])
+
+    def test_count_stages_requires_whole_stages(self) -> None:
+        self.assertEqual(StageWrapper.count_stages(2, world_size=8), 4)
+        with self.assertRaises(ValueError):
+            StageWrapper.count_stages(3, world_size=8)
+        with self.assertRaises(ValueError):
+            StageWrapper.count_stages(0, world_size=8)
+
+    def test_empty_model_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            MaglevModuleList([])

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -16,6 +16,11 @@ import torch
 import torch.nn as nn
 from tensordict import TensorDict
 from torchrec.distributed.embedding_types import EmbeddingTableConfig
+from torchrec.distributed.maglev.module import (
+    ActivationSpec,
+    MaglevLayer,
+    MaglevModuleList,
+)
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.utils import CopyableMixin
 from torchrec.modules.activation import SwishLayerNorm
@@ -3122,8 +3127,8 @@ class MaglevScaledAdd(nn.Module):
     """Per-feature scaled residual sum ``a * (1 + alpha) + b * (1 + beta)``.
 
     Lightweight analogue of ``ScaledAdd`` in the Maglev reference
-    (legokit/backbones/maglev_prototype.py), used by :class:`MaglevTestStage` to
-    fold the previous stage's activation into the current stage.
+    (legokit/backbones/maglev_prototype.py), used by :class:`MaglevTestLayer` to
+    fold the previous layer's activation into the current layer.
 
     Args:
         dim: width of the per-element learned scales.
@@ -3153,32 +3158,37 @@ class MaglevScaledAdd(nn.Module):
         return a * (1 + self.alpha) + b * (1 + self.beta)
 
 
-class MaglevTestStage(nn.Module):
-    """One Maglev stage for tests and benchmarks.
+class MaglevTestLayer(MaglevLayer):
+    """One Maglev layer for tests and benchmarks.
 
-    A self-contained stage that owns its feature partition (sparse + dense) and
-    consumes a :class:`ModelInput`:
+    A self-contained :class:`~torchrec.distributed.maglev.module.MaglevLayer` that
+    owns its feature partition (sparse + dense) and consumes a
+    :class:`ModelInput`:
 
-    * ``ebc`` pools this stage's sparse features (``stage_input.idlist_features``)
-      into ``(B, sum(F_t * D_t))``; ``input_proj`` projects that to ``stage_dim``.
-      (Unsharded here; sharding within the HSD is a follow-up.)
-    * ``dense`` projects this stage's float features
-      (``stage_input.float_features``, ``(B, num_float_features)``) to
-      ``stage_dim`` and adds them in (disabled when ``num_float_features == 0``).
-    * non-first stages fold in the previous stage's activation via
+    * ``ebc`` pools this layer's sparse features (``layer_input.idlist_features``)
+      into ``(B, sum(F_t * D_t))``; ``input_proj`` projects that to ``layer_dim``.
+      (Unsharded here; sharding within the HSD is applied by
+      :class:`~torchrec.distributed.maglev.stage.EmbeddingShard`.)
+    * ``dense`` projects this layer's float features
+      (``layer_input.float_features``, ``(B, num_float_features)``) to
+      ``layer_dim`` and adds them in (disabled when ``num_float_features == 0``).
+    * non-first layers fold in the previous layer's activation via
       :class:`MaglevScaledAdd` (the Induct-style residual hand-off),
-    * ``block`` is the stage's dense compute.
+    * ``block`` is the layer's dense compute.
 
-    The first stage (``is_first=True``) takes no incoming activation. The output
-    is a ``(B, stage_dim)`` tensor -- the activation handed to the next stage.
+    The first layer (``is_first=True``) takes no incoming activation, i.e. its
+    :meth:`in_activation_specs` is empty. The output activation is a 1-tuple
+    holding a ``(batch_size, layer_dim)`` tensor.
 
     Args:
-        tables: this stage's embedding tables (its sparse feature partition).
-        stage_dim: width of the stage activation carried between stages.
-        is_first: whether this is the first stage (no incoming activation).
-        num_float_features: width of this stage's float feature input. 0 disables
+        tables: this layer's embedding tables (its sparse feature partition).
+        layer_dim: width of the activation carried between layers.
+        is_first: whether this is the first layer (no incoming activation).
+        batch_size: per-microbatch batch size ``B``; only used to declare the
+            activation specs.
+        num_float_features: width of this layer's float feature input. 0 disables
             the dense path.
-        device: device to build the stage on.
+        device: device to build the layer on.
 
     Example::
 
@@ -3186,59 +3196,114 @@ class MaglevTestStage(nn.Module):
 
         tables = [EmbeddingBagConfig(name="t", embedding_dim=8, num_embeddings=16,
                                      feature_names=["f"])]
-        stage = MaglevTestStage(tables, stage_dim=12, is_first=True, num_float_features=4)
+        layer = MaglevTestLayer(tables, layer_dim=12, is_first=True, batch_size=2,
+                                num_float_features=4)
         mi = ModelInput.generate(batch_size=2, tables=tables, weighted_tables=[],
                                  num_float_features=4)
-        out = stage(mi, None)
+        (out,) = layer(mi)
     """
 
     def __init__(
         self,
         tables: List[EmbeddingBagConfig],
-        stage_dim: int,
+        layer_dim: int,
         is_first: bool,
+        batch_size: int,
         num_float_features: int = 0,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
         self.is_first = is_first
+        self._spec: ActivationSpec = ActivationSpec(
+            torch.Size([batch_size, layer_dim]), torch.float32
+        )
         self.ebc: EmbeddingBagCollection = EmbeddingBagCollection(
             tables=tables, device=device
         )
         in_dim = sum(t.embedding_dim * len(t.feature_names) for t in tables)
-        self.input_proj: nn.Linear = nn.Linear(in_dim, stage_dim, device=device)
+        self.input_proj: nn.Linear = nn.Linear(in_dim, layer_dim, device=device)
         self.dense: Optional[nn.Linear] = (
-            nn.Linear(num_float_features, stage_dim, device=device)
+            nn.Linear(num_float_features, layer_dim, device=device)
             if num_float_features > 0
             else None
         )
         self.scaled_add: Optional[MaglevScaledAdd] = (
-            None if is_first else MaglevScaledAdd(stage_dim, device=device)
+            None if is_first else MaglevScaledAdd(layer_dim, device=device)
         )
-        self.block: nn.Linear = nn.Linear(stage_dim, stage_dim, device=device)
+        self.block: nn.Linear = nn.Linear(layer_dim, layer_dim, device=device)
+
+    def in_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """``()`` for the first layer, else the ``(B, layer_dim)`` residual input."""
+        return () if self.is_first else (self._spec,)
+
+    def out_activation_specs(self) -> Tuple[ActivationSpec, ...]:
+        """The ``(B, layer_dim)`` activation handed to the next layer."""
+        return (self._spec,)
 
     def forward(
         self,
-        stage_input: "ModelInput",
-        prev_output: Optional[torch.Tensor],
-    ) -> torch.Tensor:
-        """Run this stage over its ``ModelInput`` and the previous activation.
+        layer_input: "ModelInput",
+        in_activations: Tuple[torch.Tensor, ...] = (),
+    ) -> Tuple[torch.Tensor, ...]:
+        """Run this layer over its ``ModelInput`` and the previous activation.
 
         Args:
-            stage_input: this stage's ``ModelInput`` (float + sparse features).
-            prev_output: the previous stage's ``(B, stage_dim)`` activation, or
-                ``None`` for the first stage.
+            layer_input: this layer's ``ModelInput`` (float + sparse features).
+            in_activations: 1-tuple holding the previous layer's
+                ``(B, layer_dim)`` activation, or ``()`` for the first layer.
 
         Returns:
-            torch.Tensor: this stage's ``(B, stage_dim)`` output activation.
+            Tuple[torch.Tensor, ...]: 1-tuple holding this layer's
+            ``(B, layer_dim)`` output activation.
         """
-        kjt = stage_input.idlist_features
+        kjt = layer_input.idlist_features
         assert isinstance(kjt, KeyedJaggedTensor)
         pooled = self.ebc(kjt).values()  # (B, in_dim)
-        x = self.input_proj(pooled)  # (B, stage_dim)
+        x = self.input_proj(pooled)  # (B, layer_dim)
         if self.dense is not None:
-            x = x + self.dense(stage_input.float_features)  # add dense features
+            x = x + self.dense(layer_input.float_features)  # add dense features
         if not self.is_first:
-            assert prev_output is not None and self.scaled_add is not None
-            x = self.scaled_add(prev_output, x)
-        return torch.relu(self.block(x))
+            assert len(in_activations) == 1 and self.scaled_add is not None
+            x = self.scaled_add(in_activations[0], x)
+        return (torch.relu(self.block(x)),)
+
+
+class MaglevTestModel(MaglevModuleList):
+    """A Maglev model of :class:`MaglevTestLayer` s, closed with a head and loss.
+
+    Supplies the :meth:`~torchrec.distributed.maglev.module.MaglevModuleList.postproc`
+    the base class leaves abstract: the last layer's ``(B, layer_dim)`` activation
+    is summed to a ``(B,)`` prediction and scored against ``ModelInput.label``
+    with MSE, so the model returns the usual ``(losses, output)`` pair.
+
+    Shared by the Maglev correctness test and benchmark, which is what makes the
+    standalone and pipelined runs comparable: both end in this same head.
+
+    Args:
+        layers: the model's layers, in execution order.
+
+    Example::
+
+        model = MaglevTestModel([layer0, layer1])
+        losses, output = model([layer_input0, layer_input1])
+    """
+
+    def postproc(
+        self,
+        activations: Tuple[torch.Tensor, ...],
+        layer_input: "ModelInput",
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Score the final activation against the last layer's label.
+
+        Args:
+            activations: 1-tuple holding the last layer's ``(B, layer_dim)``
+                activation.
+            layer_input: the last layer's ``ModelInput``, carrying ``label``.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: ``(losses, output)`` -- a scalar
+            MSE and the ``(B,)`` prediction.
+        """
+        output = activations[0].sum(dim=1)  # (B, layer_dim) -> (B,)
+        losses = torch.nn.functional.mse_loss(output, layer_input.label)
+        return losses, output


### PR DESCRIPTION
Summary:
# Maglev Layer/Stage API — Design

## 1. Context

The [Maglev MVP](https://github.com/meta-pytorch/torchrec/pull/4465) had one concept doing three jobs: a "stage" was simultaneously the unit of authoring, the unit of compute, and the unit of pipeline parallelism. That conflation had four consequences:

1. A stage could hold only one block of compute, forcing the model's depth to equal the number of HSDs.
2. The inter-stage carrier was a bare `torch.Tensor`, so a stage could not hand more than one tensor forward — no auxiliary carriers, no mixed dtypes.
3. The connector had no way to ask a stage what crossed its boundary. `MaglevPipeline` took an `activation_shape` the caller had to keep in sync with the model by hand, plus a single `dtype` for everything.
4. The loss lived outside the model: the pipeline carried `label` and `criterion` per microbatch, so the model could not score itself the way every other TorchRec model does.

This design separates the two, and defines the API surface by which stages are formed, sharded, and connected.

## 2. Two concepts

A **layer** (`MaglevLayer`) is the unit of *compute*. It takes its own input plus the previous layer's activation, and produces the next activation.

A **stage** is the unit of *parallelism*: one or more consecutive layers, one HSD. A stage is deliberately **not a class**. It is whichever layers a `StageWrapper` decides to keep, plus the parallelism applied to them.

That separation is what lets `layers_per_stage` be a per-stage list. A 12-layer model can be cut `[2, 3, 4, 3]` over 4 HSDs; depth is a modeling decision, not a consequence of the hardware topology.

## 3. Authoring: a model becomes a `MaglevModuleList`

<img width="2638" height="1350" alt="image" src="https://github.com/user-attachments/assets/f89b9e8a-0480-41cb-8744-b39210a26e42" />

*Left: the original architecture — one `sparse_arch + indexer` feeding a chain of dense blocks, then a task arch. Right: the same model as a `MaglevModuleList`, where each maglev layer owns its own feature partition.*

Five steps turn an existing model into a pipelineable one:

1. **Break the batch down in `preproc`.** One raw `model_input` in, one input per layer out. This is the seam where feature partitioning / indexing lives; the MVP's is a passthrough.
2. **Split `sparse_arch`.** Each layer carries its own sparse modules with its own feature definitions and embedding configs, so a layer holds exactly the tables for its feature partition.
3. **Wrap each block in a `MaglevLayer`.**
4. **Declare activation specs** — what crosses the layer's boundaries.
5. **Implement `postproc`** so the model returns the standard `(losses, output)`.

The resulting `forward` is the single-process reference execution, and it is the definition every parallel path must match:

```python
def forward(self, model_input):
    with torch.no_grad():
        layer_inputs = self.preproc(model_input)
    activations = ()
    for layer, layer_input in zip(self, layer_inputs):
        activations = layer(layer_input, activations)
    return self.postproc(activations, layer_inputs[-1])
```

Nothing in `module.py` knows about ranks. It is dep-free beyond torch and lives in its own Buck target, so authoring a model cannot accidentally pull in a distributed dependency.

### 3.1 The layer contract

```python
class MaglevLayer(abc.ABC, nn.Module):
    def in_activation_specs(self) -> Tuple[ActivationSpec, ...]: ...
    def out_activation_specs(self) -> Tuple[ActivationSpec, ...]: ...
    def forward(self, layer_input: Any, in_activations: Activations = ()) -> Activations: ...
```

`Activations = Tuple[torch.Tensor, ...]` is the only inter-layer type. The first layer receives `()` rather than `None`, which removes the `Optional` special case from every signature.

`postproc` is the mirror of `preproc`: it applies the head, scores it, and returns `(losses, output)`. The target rides in the *last layer's own input* (`ModelInput.label` by convention), which is what lets every schedule drop label and criterion plumbing entirely — the last stage already holds what it needs to score itself.

## 4. The boundary contract: `ActivationSpec`

```python
@dataclass(frozen=True)
class ActivationSpec:
    shape: torch.Size          # full per-microbatch shape, batch dim included
    dtype: torch.dtype = torch.float32

    @property
    def requires_grad(self) -> bool:
        return self.dtype.is_floating_point
```

This is the hinge of the whole design. Because every layer *declares* what crosses its boundaries, the connector can:

- **size receive buffers** without running a shape-inference forward pass,
- **order per-tensor send/recv pairs** identically on both sides of a boundary, with no metadata exchange,
- **skip integer carriers in the backward** automatically — ids, lengths and offsets are not differentiable, and `requires_grad` falls out of the dtype rather than being configured.

`check_layers_chain` validates at construction that layer `i`'s output specs equal layer `i+1`'s input specs, so a mismatched chain fails at authoring time rather than as a shape error inside a collective.

### 4.1 Batch size lives in the spec

`batch_size` appears nowhere in the maglev package outside `ActivationSpec.shape` — `module.py`, `stage.py` and `pipeline.py` never name it. The layer author bakes it in at construction:

```python
self._spec = ActivationSpec(torch.Size([batch_size, layer_dim]), torch.float32)
```

and it flows from there into buffer allocation — `start_recv_act` and `start_recv_grad` both allocate `torch.empty(spec.shape, dtype=spec.dtype)`. That is what let `activation_shape` disappear as a pipeline argument: the schedule reads the batch dimension off the model rather than being told it separately.

The batch size is assumed **constant** for now, which is what keeps the boundary contract fully static. Since a receive buffer is sized from the spec, any batch of a different size mismatches the receive its peer already posted, so batching must be fixed-size (`drop_last=True`).

The planned relaxation is to make batch size a **model parameter** and derive the specs from it. `in_activation_specs()` / `out_activation_specs()` are already methods rather than stored values, so they can become functions of it instead of constants fixed when a layer is built.

## 5. Creating a sharded stage: `StageWrapper`

<img width="3404" height="1480" alt="image" src="https://github.com/user-attachments/assets/956d8170-e938-4f9b-b4aa-e29f052b0bee" />

*The same `MaglevModuleList` exists on every device, each layer holding its own sparse module and dense block with the activation chained through them. `StageWrapper` cuts it by `layers_per_stage`, so each HSD keeps only its own layers ("maglev layers are sharded") and the chain is severed at the stage boundary — that severed link is the only thing that crosses the network. The caller then shards each stage's embedding tables within that HSD ("emb tables are sharded"), giving the two orthogonal axes: pipeline-parallel across HSDs, embedding-sharded within one.*

```python
stage = StageWrapper(
    model=model,                      # the WHOLE model
    layers_per_stage=[2, 3, 4, 3],
    stage_size=2,                     # ranks per HSD
)
stage.module = <wrap however you like>   # DMP scoped to stage.stage_pg, FSDP, nothing
stage.to(device)                         # materialize whatever is still on meta
```

`StageWrapper` is framework-provided and is never subclassed — a stage is created by constructing one, not by writing one. The constructor cuts the model, locates the rank, and builds the process groups; **it does not shard**. Parallelism is applied by the caller, between construction and `to()`.

### 5.1 Every rank passes the same arguments

The wrapper takes the **whole** model and keeps only this rank's layers — the same shape as `DistributedModelParallel`, which takes the whole module and keeps this rank's shards. Every rank passes byte-identical arguments; the only thing that differs is `dist.get_rank()`.

### 5.2 The rank locates itself

```python
stage_index, position = divmod(global_rank, stage_size)
```

`stage_index` is which HSD this rank belongs to; `position` is its lane within that HSD. **Nothing carries an explicit rank-to-stage table.** With HSDs laid out as contiguous blocks of `stage_size` ranks, the layout is implied by two integers, so there is no description that can drift out of step with the ranks actually running. `layer_indices` is likewise derived from `layers_per_stage` rather than stored, so the cut has exactly one source of truth.

### 5.3 The wrapper builds its own process groups

Three families, all created up front in `pg_init` before any sharding collective, because `dist.new_group` is itself a collective and every rank must call it for every group in the same order:

| group | membership | carries |
|---|---|---|
| **stage** | the `stage_size` ranks of one HSD | intra-HSD sharded embedding all-to-all, DP gradient all-reduce |
| **cascade** | one rank per stage, same `position` | input distribution |
| **hand-off** | `act_pg` and `grad_pg` | forward activations / backward gradients between HSDs |

The hand-off is **direction-split**: a boundary's forward activation and backward gradient land on *different* communicators, so they run on separate NCCL streams instead of serializing, and each communicator carries a single flow direction (recv-then-send per rank, never send-first). Both are separate from the stage group, so P2P never interleaves with the sharding collectives — which deadlocks once stages are sharded with DMP. See the [NCCL P2P study](https://github.com/meta-pytorch/torchrec/pull/4472).

### 5.4 Wrap, then materialize — the caller's two steps

The constructor leaves two things on the stage, and they are the entire handshake:

| attribute | what it is |
|---|---|
| `stage.module` | an `nn.Module` holding **this rank's layers only**, still on `meta`. Reassignable. |
| `stage.stage_pg` | the intra-HSD process group — the world any wrapper should be scoped to. |

`stage.module` is a single module rather than the layer list because `DistributedModelParallel` shards exactly one module and a bare `nn.ModuleList` has no `forward`. Read it, wrap it, assign the result back:

```python
stage = StageWrapper(model, layers_per_stage, stage_size)
stage.module = <wrapper>(stage.module, ...scoped to stage.stage_pg...)
stage.to(device)
```

**The wrapper is yours to choose, and yours to get right.** Maglev ships no parallelism strategy, no base class to implement, and nothing in `stage.py` that knows how to shard:

```python
# nothing — full replica per rank
stage.to(device)

# embedding-sharded within the HSD (what the benchmark does)
planner = EmbeddingShardingPlanner(
    topology=Topology(world_size=stage.stage_pg.size(), compute_device=device.type)
)
plan = planner.plan(stage.module, sharders)          # sized to the HSD, not the world
remap_plan_to_process_group(plan, stage.stage_pg, device)   # <-- REQUIRED, see below
stage.module = DistributedModelParallel(
    module=stage.module,
    env=ShardingEnv.from_process_group(stage.stage_pg),
    device=device,
    plan=plan,
    sharders=[EmbeddingBagCollectionSharder()],
    init_data_parallel=True,         # dense params into DDP over the same group
)
stage.to(device)

# FSDP over the HSD
stage.module = FullyShardedDataParallel(
    stage.module, process_group=stage.stage_pg, device_id=device
)
stage.to(device)
```

Two things a caller has to know:

**Wrap before `to()`.** `to()` materializes whatever is still on `meta`; do it first and a sharder ends up resharding tables already allocated at full size. (A rank never allocates *another* stage's parameters either way — those layers were dropped in the constructor.)

**Remap the plan, or the shards land on the wrong ranks.** This is the one step that has no analogue in ordinary whole-world DMP, and it fails confusingly if skipped. A planner given a `stage_pg`-sized `Topology` emits **group-local** placements — `rank:0/cuda:0`, `rank:1/cuda:1` for a 2-rank stage. Shard placements are interpreted against the **global** rank space, so for a stage on global ranks `{2, 3}` that plan is wrong twice over: rank 0 is not in the group at all, and the device is `cuda:0` rather than `cuda:2`.

```python
remap_plan_to_process_group(plan, stage.stage_pg, device)
```

rewrites group-local rank `r` to `get_global_rank(pg, r)` on `cuda:{g % device_count}`, in place, deterministically — every rank in the group derives the same result. Nothing about it is Maglev-specific; it applies to any DMP scoped below the world, and it lives in `stage.py` only until the planner emits global placements itself.

Two companions to it, both in the benchmark's `_shard_embeddings_in_hsd`: `planner.collective_plan()` **cannot** be used here — it broadcasts from group-local rank 0 but passes that as a *global* src, deadlocking every stage whose group excludes global rank 0 — so plan on the group's leader and broadcast with the correct global src yourself.

The ordering works because the activation specs are captured in the constructor, before any wrapping — a wrapped module may no longer re-expose the `MaglevLayer` API. And `device` is deliberately not a constructor argument: the stage has none until `to()`, so a schedule that runs first raises a clear error instead of allocating hand-off buffers on the wrong device.

## 6. Connecting stages: the wire API

The hand-off is **by position**: rank `p` in HSD `i` exchanges with rank `p` in HSD `i ± 1`. Forward activations flow `i -> i+1`, backward gradients `i+1 -> i`. The two ranks of an HSD are data-parallel lanes; their gradients are averaged once per pass by whatever DP wrapper the caller applied (see §8.6).

The stage owns the wire. It knows its neighbours, its two communicators, and the specs that fix the layout — so a schedule never has to know how a boundary is wired:

```python
start_recv_act()   wait_for_act()    start_send_act()   finish_send_act()
start_recv_grad()  wait_for_grad()   start_send_grad()  finish_send_grad()
```

The asymmetry between the two halves is deliberate:

- **Receives queue.** Each `start` posts another and the matching `wait` dequeues in issue order, so a schedule can run several boundaries ahead of the compute.
- **Sends do not.** One per direction is in flight; the schedule finishes it before starting the next, which bounds the buffers held open to a single transfer.

**No `start` ever blocks.** That is the point of splitting each transfer in two: where the wait falls becomes the schedule's choice, rather than a side effect buried inside a send. Boundary stages make the calls no-ops — `start_recv_act` returns immediately on the first stage, `start_recv_grad` on the last — so a schedule needs no special-casing at the ends of the pipeline.

This mirrors `torch.distributed.pipelining`, where `PipelineStage` owns the send/recv ops and the schedule only orders them.

## 7. Feeding stages: the cascade

Every rank generates a full batch, but needs only its own stage's slice of it. `StageWrapper.take_inputs` closes that gap:

```
dataloader → model_input → preproc → layer_inputs → group_by_stage → cascade all-to-all → this stage's microbatches
```

`send_set(model_input)` runs the model's own `preproc` under `no_grad`, then regroups the per-layer inputs by destination stage. The all-to-all over the cascade turns "the whole batch, held by every rank" into "this stage's inputs, delivered here" — and because it returns one carrier from every cascade rank, **one round yields `num_stages` microbatches**. `InputDistDriver` buffers whole rounds in a FIFO and hands out `n` at a time, decoupling the microbatch count a schedule wants from the stage count a round produces.

The lock-step invariant: the refill count is a pure function of `(queue length, n)`, and the queue starts empty everywhere. Never make a refill depend on rank-local data — a stage that fetches one extra round hangs the whole cascade.

A non-uniform cut makes the exchange **ragged**: with 4 tensors per `ModelInput`, a 2-layer stage receives 8 slots and a 3-layer stage 12. The send side carries `input_split_sizes`; the receive side stays rectangular, because everything a rank receives was built for that rank.

## 8. Driving the stages: the pipeline schedules

```
MaglevPipelineBase                    # one microbatch: forward, backward, step
Maglev1F1B(MaglevPipelineBase)        # each receive posted immediately before its wait
Maglev1F1BRecvAhead(Maglev1F1B)       # each receive posted a microbatch ahead
```

### 8.1 The contract

```python
def progress(self, dataloader_iter: Iterator[Any]) -> Optional[torch.Tensor]
```

One call is **one full pass and exactly one optimizer step**. The signature matches `TrainPipeline.progress(dataloader_iter)` so the caller loop is the familiar one, and the iterator yields raw batches — not layer inputs, not stage inputs, not microbatches. A caller never has to know which layers its rank owns in order to feed it.

The return is the loss on the last stage where a schedule can report one without stalling, `None` elsewhere. `MaglevPipelineBase` returns it; the 1F1B schedules always return `None`, because reading a per-microbatch loss means `.item()`, a device-to-host sync in the middle of the very schedule being measured.

### 8.2 What the base owns, what a subclass supplies

Modelled on `TrainPipelineBase` → `TrainPipelinePT2`: a **concrete base, not a pure ABC**. The base is itself a working schedule (the single-microbatch one the correctness test uses), so there is no abstract type that exists only to be inherited from.

The base owns everything invariant across schedules:

- the stage and the optimizer,
- the **boundary-contract check**, run once at construction: stage 0 must declare no incoming activation, and every later stage must declare one. A model that cannot be pipelined as laid out fails when the pipeline is built, not mid-collective.
- `_forward_context`, which places the pass's single gradient sync (§8.6),
- `microbatches_per_pass`, so a caller measuring throughput knows what to divide by (1 on the base, `num_microbatches` on 1F1B).

A subclass supplies **only `progress`**. `Maglev1F1BRecvAhead` doesn't even supply a constructor — it inherits `Maglev1F1B`'s, since the microbatch validation and warmup/steady derivation are identical.

### 8.3 Anatomy of a pass

Every schedule has the same skeleton:

```python
microbatch_inputs = stage.take_inputs(dataloader_iter, n)   # 1. acquire
self.optimizer.zero_grad()                                  # 2. reset grads
...                                                         # 3. the schedule's ordering
stage.drain_sends()                                         # 4. close the wire
self.optimizer.step()                                       # 5. apply
```

`drain_sends` matters because `forward_micro` / `backward_micro` each finish the *previous* send before starting the next, so exactly one send per direction is still outstanding when a pass ends. Across passes that self-corrects, but on the final pass the work handle would leak with its buffer still pinned.

Two properties fall out of this shape:

**Each pass is self-contained.** Every microbatch that enters also leaves. Unlike `TrainPipelineSparseDist`, nothing straddles `progress` calls except the input driver's queued remainder — so there is no `fill_pipeline`, no drain protocol, and no delay between the iterator running dry and `StopIteration`.

**All input acquisition happens before any P2P.** `take_inputs` is step 1, so if the dataloader runs dry it does so with nothing on the wire. That matters because NCCL has no cancel: a schedule that aborted with `irecv`s posted could not retire them without tearing down the communicator.

### 8.4 A schedule only chooses where the receives go

This is the part that makes the schedules small. `forward_micro` and `backward_micro` each own their whole half of a microbatch:

| | `forward_micro` | `backward_micro` |
|---|---|---|
| wait | `wait_for_act` | `wait_for_grad` |
| compute | forward, park in FIFO | pop FIFO, `backward` |
| send | `finish_send_act`, `start_send_act` | `finish_send_grad`, `start_send_grad` |

So the waits, the sends, and the in-flight FIFO are all out of the schedule's hands. Beyond marking the pass's last microbatch for the gradient sync (§8.6), **the only degree of freedom a schedule has is where `start_recv_act` and `start_recv_grad` are called** — which is exactly the difference between the two 1F1B variants:

```python
# Maglev1F1B — fold the post into the op it feeds
def _forward():   stage.start_recv_act();  stage.forward_micro(...)
def _backward():  stage.start_recv_grad(); stage.backward_micro()

for _ in range(num_warmup): _forward()
for _ in range(num_steady): _forward(); _backward()
for _ in range(num_warmup): _backward()
```

```python
# Maglev1F1BRecvAhead — keep each direction one microbatch ahead
stage.start_recv_act()                                    # seed
for _ in range(num_warmup):
    stage.start_recv_act(); _forward()
for i in range(num_steady):
    stage.start_recv_grad()
    _forward()
    stage.start_recv_act() if i < num_steady - 1 else stage.start_recv_grad()
    stage.backward_micro()
for i in range(num_warmup):
    if i < num_warmup - 1: stage.start_recv_grad()
    stage.backward_micro()
```

Both post exactly `num_microbatches` receives per direction and move identical data; only placement differs. That is what makes them a clean A/B for what overlapping the hand-off is worth — and it is only possible because no `start` blocks, so moving one is purely a scheduling decision.

### 8.5 What is constructor state, and why

`Maglev1F1B` takes `num_microbatches` at construction rather than per call, which lets the schedule's shape be derived once:

```python
self.num_warmup = min(stage.num_stages - stage.stage_index - 1, num_microbatches)
self.num_steady = num_microbatches - self.num_warmup
```

`num_warmup` decreasing with depth is what lines the send/recv pairs up across ranks. The constructor also rejects `num_microbatches < num_stages`: that leaves early stages with no steady phase at all, and since the steady phase is what seeds the gradient receives, those ranks would fail in cooldown while later ones ran on — an asymmetric hang. It is also a pointless schedule, since the pipeline never fills.

`MaglevPipelineBase` deliberately does *not* take a microbatch count. It is not "1F1B with `num_microbatches=1`" — that configuration is precisely the one 1F1B rejects.

### 8.6 One invariant a schedule depends on

Gradients accumulate across all microbatches and are reduced **once** per pass. The schedule arranges that the standard TorchRec way, rather than reducing anything itself: every microbatch but the last runs inside a `no_sync` context, so the DP wrapper's own reducer fires exactly once, on full-shape `.grad`.

```python
with self._forward_context(fwd_idx, self.num_microbatches):
    stage.forward_micro(microbatch_inputs[fwd_idx], fwd_idx)
```

**The context wraps the forward, not the backward** — this is the part that is easy to get wrong, and it fails silently. `DistributedDataParallel` reads `require_backward_grad_sync` in `_pre_forward` / `_post_forward`, and it is `_post_forward` that calls `prepare_for_backward` to arm the reducer. By the time `backward()` runs the decision is already made, so a `no_sync` placed around the backward alone does nothing and every microbatch all-reduces. PyTorch documents the same requirement: *"The forward pass should be included inside the context manager, or else gradients will still be synchronized."*

The last microbatch therefore forwards *outside* the context, and its backward — the final one of the pass — carries the single reduction over everything the earlier microbatches accumulated locally.

This is the same pattern as `GradientAccumulationWrapper` in the train pipeline, one level down — there it spans `progress` calls, here it spans microbatches within one. DDP costs no extra memory for it, since `.grad` is full-shape either way.

The context is derived from `stage.module`, not configured: `_no_sync_modules` collects the root if it merely *has* `no_sync` (covering DDP, FSDP and custom wrappers) plus any descendant `DistributedDataParallel`, since a sharded submodule can hold its own inner DDP that would otherwise reduce on every backward. An unwrapped stage yields an empty context and nothing reduces.

One consequence: **`static_graph` has to be off.** It requires the reducer to be armed on the first backward, which cannot hold here — the first microbatch's forward is deliberately inside `no_sync`. The benchmark passes `DefaultDataParallelWrapper(static_graph=False)`. Little is given up: `static_graph` assumes one forward/backward per iteration, which a pipeline running the module N times per step already violates, and its main saving needs `find_unused_parameters`, which is off.

### 8.7 Adding a schedule

Subclass, override `progress`, and drive the stage's wire API:

```python
class MyMaglevSchedule(Maglev1F1B):
    def progress(self, dataloader_iter):
        stage = self.stage
        microbatch_inputs = stage.take_inputs(dataloader_iter, self.num_microbatches)
        self.optimizer.zero_grad()
        ...                       # place start_recv_* around forward_micro/backward_micro
                                  # and wrap each forward in self._forward_context(...)
        stage.drain_sends()
        self.optimizer.step()
        self._pass_index += 1
        return None
```

The zero-bubble Maglev Rail schedule is intended to slot in here.

## 9. The whole API, in order

```python
# 1. author — parallelism-free, on meta
model = MyMaglevModel([layer0, ..., layer11])        # a MaglevModuleList

# 2. create this rank's stage — every rank runs this identically
stage = StageWrapper(model, layers_per_stage=[2, 3, 4, 3], stage_size=2)

# 3. apply whatever parallelism you want, then materialize
stage.module = DistributedModelParallel(
    stage.module, env=ShardingEnv.from_process_group(stage.stage_pg), ...
)
stage.to(device)
optimizer = torch.optim.SGD(dense_params_of(stage.module), lr=lr, foreach=True)

# 4. drive
pipeline = Maglev1F1BRecvAhead(stage, optimizer, num_microbatches=8)
while True:
    pipeline.progress(dataloader_iter)
```

The same authored `model` also runs standalone in one process by calling it. Both paths must produce identical numerics; that equivalence is what the correctness test asserts.

Which of these you write and which you merely call is worth being explicit about:

- **Implement**: a `MaglevLayer` per block, and `MaglevModuleList.postproc` (plus `preproc` once feature partitioning is real rather than a passthrough). This is the whole modeling surface.
- **Construct**: `StageWrapper` and a schedule. Neither is subclassed in normal use.
- **Extend only to add a capability**: `MaglevPipelineBase`, for a new schedule. Parallelism needs no extension point — you wrap `stage.module` with an existing wrapper.

## 10. Known constraints

**`Maglev1F1BRecvAhead` requires `CUDA_MODULE_LOADING=EAGER`.** CUDA 12 loads kernel modules lazily; the first backward launch triggers a load, and that load allocates device memory — a synchronous operation. Only this schedule keeps a receive outstanding across a backward, and that posted `irecv` is a NCCL kernel spinning until its peer sends: the device never quiesces, the load never completes, and the pipeline deadlocks on the first microbatch with the autograd worker parked in `libcuda` (`cuLibraryGetModule`). The other two schedules wait out each receive before the compute that follows it, so nothing blocks the load.

**Gradient receives cannot run as far ahead as activation receives.** The first gradient receive creates the pair's NCCL communicator and blocks until the peer's matching send, and a peer only touches the gradient direction in its own backward. Posted during the forward phase, the rank parks mid-wave and deadlocks. `Maglev1F1BRecvAhead` therefore holds the first gradient receive until warmup is over.

**Communicators are created lazily**, on first collective rather than at `new_group`. The cascade group's first collective is the input-dist all-to-all, so a cold run charges the entire communicator rendezvous to input distribution. Passing `device_id` to `dist.new_group` initializes the backend eagerly and would move that cost out of the schedule; genuine 2-rank hand-off groups (rather than the current full-membership `act_pg` / `grad_pg`) would shrink it further, since setup cost is largely per-peer. Both are open follow-ups.

**Dataloader exhaustion is not yet collective.** `input_dist` is a collective over the cascade; if one rank's iterator runs dry first, it raises while its peers block. Safe only while every rank's shard has the same length. Open.

**Batch size is assumed constant, so `drop_last=True` is required** — receive buffers are pre-allocated from the declared specs, and any batch of a different size mismatches on the wire. A simplifying assumption for now; the planned fix is to make batch size a model parameter and derive the specs from it. See [§4.1](#41-batch-size-lives-in-the-spec).

**An unwrapped stage does no data parallelism.** The stage reduces nothing itself and the sync comes from the caller's wrapper, so a multi-rank stage left unwrapped never averages gradients across its HSD. That is the intended consequence of the caller owning parallelism, and it is invisible in the correctness test, where both lanes see identical data and the all-reduce would be an identity anyway.

## 11. References

- [#4605](https://github.com/meta-pytorch/torchrec/pull/4605) — the PR implementing this design
- Maglev MVP — the design this supersedes: [#4465](https://github.com/meta-pytorch/torchrec/pull/4465) (skeleton), [#4466](https://github.com/meta-pytorch/torchrec/pull/4466) (`input_dist`), [#4473](https://github.com/meta-pytorch/torchrec/pull/4473) (benchmark wiring)
- [NCCL P2P execution order and buffer size](https://github.com/meta-pytorch/torchrec/pull/4472) — why the hand-off is direction-split
- [#3751](https://github.com/meta-pytorch/torchrec/issues/3751) / [#3750](https://github.com/meta-pytorch/torchrec/pull/3750) — pipeline iterator mismatch: how `TrainPipelineSparseDist` handles iterator exhaustion
- `torch.distributed.pipelining` — `PipelineStage` owning the send/recv ops, schedules only ordering them

### 11.1 Reproducing

Three schedules over the same model — 12 layers cut `[2, 3, 4, 3]`, 4 stages x 2 ranks, embeddings sharded within each HSD. Run sequentially; concurrent 8-rank GPU jobs contend and corrupt the timings. `--name` keeps each run's traces distinct, so one upload at the end collects all three.

```bash
# un-pipelined reference
python -m torchrec.distributed.benchmark.benchmark_maglev \
  --pipeline=base --name=maglev_base

# receive posted immediately before its wait
python -m torchrec.distributed.benchmark.benchmark_maglev \
  --pipeline=1f1b --name=maglev_1f1b

# receive posted a microbatch ahead (default)
CUDA_MODULE_LOADING=EAGER python -m torchrec.distributed.benchmark.benchmark_maglev \
  --pipeline=1f1b-recv-ahead --name=maglev_1f1b_recv_ahead
```

`CUDA_MODULE_LOADING=EAGER` is needed only for `1f1b-recv-ahead` (see [§10](#10-known-constraints)). `num_benchmarks` defaults to 0, so these runs profile only and emit traces without timings; pass `--num_benchmarks=12` to collect a throughput table as well.

The traces below came from running the same flags through the internal build, then uploading with `trace_to_manifold.sh`.

### 11.2 Traces

Stage / layer attribution follows the `[2, 3, 4, 3]` cut with `ranks_per_stage=2`. [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D116674014).
[1F1B.zip](https://github.com/user-attachments/files/31322284/1F1B.zip)
[1F1BRA.zip](https://github.com/user-attachments/files/31322285/1F1BRA.zip)
[Base.zip](https://github.com/user-attachments/files/31322291/Base.zip)

| rank | stage | layers | base | 1f1b | 1f1b-recv-ahead |
|---|---|---|---|---|---|
| 0 | 0 | 0-1 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank0.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank0.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| 1 | 0 | 0-1 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank1.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank1.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank1.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank1.json.gz&bucket=torchrec_benchmark_traces) |
| 2 | 1 | 2-4 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank2.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank2.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank2.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank2.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank2.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank2.json.gz&bucket=torchrec_benchmark_traces) |
| 3 | 1 | 2-4 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank3.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank3.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank3.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank3.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank3.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank3.json.gz&bucket=torchrec_benchmark_traces) |
| 4 | 2 | 5-8 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank4.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank4.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank4.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank4.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank4.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank4.json.gz&bucket=torchrec_benchmark_traces) |
| 5 | 2 | 5-8 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank5.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank5.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank5.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank5.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank5.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank5.json.gz&bucket=torchrec_benchmark_traces) |
| 6 | 3 | 9-11 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank6.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank6.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank6.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank6.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank6.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank6.json.gz&bucket=torchrec_benchmark_traces) |
| 7 | 3 | 9-11 | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank7.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_base-rank7.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank7.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b-rank7.json.gz&bucket=torchrec_benchmark_traces) | [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank7.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D116674014/trace-maglev_1f1b_recv_ahead-rank7.json.gz&bucket=torchrec_benchmark_traces) |


Differential Revision: D116674014
