### PR TITLE
Add pooled embedding bag lookup with padding via pallas TPU kernel (#4609)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
         TritonTableBatchedEmbeddingBags,
     )
     from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+        TPUEmbeddingBagUnfused,
         TPUEmbeddingUnfused,
     )
 
@@ -4806,15 +4807,11 @@ class BatchedTPUEmbedding(BaseBatchedEmbedding[torch.Tensor]):
 class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     """Pooled TPU compute kernel (`UNFUSED_TPU`).
 
-    Pooled sibling of `BatchedTPUEmbedding`, and a drop-in alongside
-    `BatchedDenseEmbeddingBag` in the pooled dispatch
-    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`). Backs the lookup with one
-    `TPUEmbeddingUnfused` table per table in the group; `forward` routes each feature to
-    its table, gathers its ids, and pools per sample (SUM or MEAN per `config.pooling`).
-
-    Pooling is done in torch (scatter-add over per-id sample indices) on top of the
-    unfused gather, so no dedicated pooled kernel is required and the backward flows
-    through the gather op's autograd.
+    TPU specific `BatchedDenseEmbeddingBag` in the pooled dispatch
+    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`). Uses one
+    `TPUEmbeddingUnfused` table per table in the group; `forward` routes
+    each feature to its table, gathers its ids, and pools per sample (SUM or MEAN
+    per `config.pooling`).
 
     Args:
         config (GroupedEmbeddingConfig): grouped table config (one or more tables).
@@ -4835,31 +4832,30 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
         device: Optional[torch.device] = None,
         sharding_type: Optional[ShardingType] = None,
     ) -> None:
-        super().__init__(config, pg, device, sharding_type)
         # Lazy import to avoid pulling in experimental TPU code at module load time.
         from torchrec.experimental.torch_tpu.modules.embedding_modules import (
-            TPUEmbeddingUnfused,
+            TPUEmbeddingBagUnfused,
         )
 
+        super().__init__(config, pg, device, sharding_type)
         dtype = data_type_to_sparse_type(config.data_type).as_dtype()
-        # One TPUEmbeddingUnfused per table in the group (mirrors BatchedTPUEmbedding);
-        # the base class fills _local_rows / _local_cols / _feature_table_map.
+
         self._emb_modules: nn.ModuleList = nn.ModuleList()
         for local_rows, local_cols in zip(self._local_rows, self._local_cols):
             self._emb_modules.append(
-                TPUEmbeddingUnfused(
+                TPUEmbeddingBagUnfused(
                     num_embeddings=local_rows,
                     embedding_dim=local_cols,
                     device=device,
                     dtype=dtype,
+                    mode="mean" if self._pooling == PoolingMode.MEAN else "sum",
                 )
             )
         self.init_parameters()
 
     @property
-    # pyrefly: ignore [bad-override]  # TPUEmbeddingUnfused is not one of the
-    # fbgemm codegen types the base class enumerates (same as the Triton kernel).
-    def emb_module(self) -> "TPUEmbeddingUnfused":  # noqa: F821
+    # pyrefly: ignore [bad-override]
+    def emb_module(self) -> "TPUEmbeddingBagUnfused":
         # pyre-ignore[16]: ModuleList returns Module, pyre thinks Union
         return self._emb_modules[0]
 
@@ -4880,57 +4876,27 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     def named_parameters(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, nn.Parameter]]:
-        for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
-            # pyre-ignore[7]
-            yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
+        for name, tensor in self.named_split_embedding_weights(
+            prefix, recurse, remove_duplicate
+        ):
+            yield name, cast(nn.Parameter, tensor)
 
-    def _pool(
-        self, gathered: torch.Tensor, lengths: torch.Tensor, batch_size: int
+    def forward(
+        self,
+        features: KeyedJaggedTensor,
+        vbe_output: Optional[torch.Tensor] = None,
+        vbe_output_offsets: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Pool a feature's per-id embeddings [L, dim] into [batch, dim].
-
-        Sum-pool by scatter-adding each id's row into its sample slot; MEAN divides by
-        the bag length. `lengths` are this feature's per-sample bag sizes (may be jagged
-        after the row-wise all2all), summing to L. Uses only arange / repeat_interleave /
-        index_add_ / div, so it lowers on TPU without a bespoke pooled kernel.
-        """
-        dim = gathered.shape[1]
-        device = gathered.device
-        pooled = torch.zeros(batch_size, dim, dtype=gathered.dtype, device=device)
-        # sample index for each gathered row: sample b repeated lengths[b] times.
-        sample_idx = torch.repeat_interleave(
-            torch.arange(batch_size, device=device), lengths
-        )
-        pooled.index_add_(0, sample_idx, gathered)
-        if self._pooling == PoolingMode.MEAN:
-            denom = lengths.clamp(min=1).unsqueeze(1).to(pooled.dtype)
-            pooled = pooled / denom
-        return pooled
-
-    # pyrefly: ignore [bad-override]  # same signature shape as the sequence kernel
-    def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
-        batch_size = features.stride()
-        length_per_key = features.length_per_key()
-        # KJT lengths are feature-major: feature i's per-sample bag sizes are the
-        # i-th block of batch_size entries.
-        all_lengths = features.lengths()
-        per_feature_values = (
-            torch.split(features.values(), length_per_key)
-            if len(length_per_key) > 1
-            else [features.values()]
-        )
-        outputs: List[torch.Tensor] = []
-        for feature_idx, feature_values in enumerate(per_feature_values):
+        jt_dict = features.to_dict()
+        outputs = []
+        for feature_idx, key in enumerate(features.keys()):
+            jt = jt_dict[key]
             emb_module = self._emb_modules[self._feature_table_map[feature_idx]]
-            # pyre-ignore[9, 16]: ModuleList returns Module, pyre thinks Union;
-            # the table's `weight` is a Tensor so `.device` is a torch.device.
-            device: torch.device = emb_module.weight.device
-            gathered = emb_module(
-                feature_values.to(device=device, dtype=torch.int32)
-            )  # [L_i, dim]
-            lengths_i = all_lengths[
-                feature_idx * batch_size : (feature_idx + 1) * batch_size
-            ].to(device)
-            outputs.append(self._pool(gathered, lengths_i, batch_size))
+            outputs.append(
+                emb_module(
+                    input=jt.values(),
+                    offsets=jt.offsets(),
+                )
+            )
         # Pooled features concatenate along the embedding dim -> [batch, sum(dim)].
         return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=1)

--- a/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/benchmark_single_lookup.py
@@ -7,73 +7,86 @@
 
 # pyre-strict
 
-"""
-Accuracy + latency benchmark for the single-lookup TPU Pallas embedding kernel.
-"""
+"""Accuracy and latency benchmark for TPU Pallas embedding lookups."""
 
 import argparse
 import os
 import time
-from typing import List
+from typing import Any, cast, List, Optional, Tuple
 
 import torch
 
 # pyre-ignore[21]: torch_tpu ships in the TPU pod venv, not as a buck dep.
 from torch_tpu._internal import profiler, sync
-from torchrec.distributed.batched_embedding_kernel import BatchedTPUEmbedding
+from torchrec.distributed.batched_embedding_kernel import (
+    BatchedTPUEmbedding,
+    BatchedTPUEmbeddingBag,
+)
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.test_utils.test_model import ModelInput
-from torchrec.modules.embedding_configs import DataType, EmbeddingConfig, PoolingType
-from torchrec.modules.embedding_modules import EmbeddingCollection
+from torchrec.modules.embedding_configs import (
+    DataType,
+    EmbeddingBagConfig,
+    EmbeddingConfig,
+    PoolingType,
+)
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+)
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 WORLD_SIZE = 8
 PROFILE_NUMBER_TIMES = 10
 BENCHMARK_TIMES = 100
-
-embedding_configs: List[EmbeddingConfig] = [
-    EmbeddingConfig(
-        name="user_table",
-        embedding_dim=32,
-        num_embeddings=100000,
-        feature_names=["user"],
-    ),
-    EmbeddingConfig(
-        name="product_table",
-        embedding_dim=32,
-        num_embeddings=1000000,
-        feature_names=["product"],
-    ),
-]
+BATCH_SIZES = [10, 40, 160, 640, 1024, 2048, 1024 * 32]
+EMBEDDING_DIMS = [32, 64, 128, 256, 512]
+BENCH_BATCH_SIZE = 2048
 
 
-def make_configs(dim: int) -> List[EmbeddingConfig]:
-    # Mirrors the module-level `embedding_configs`, varying only embedding_dim.
+def make_configs(collection: str, dim: int) -> List[Any]:
+    if collection == "ec":
+        return [
+            EmbeddingConfig(
+                name="user_table",
+                embedding_dim=dim,
+                num_embeddings=100000,
+                feature_names=["user"],
+            ),
+            EmbeddingConfig(
+                name="product_table",
+                embedding_dim=dim,
+                num_embeddings=1000000,
+                feature_names=["product"],
+            ),
+        ]
     return [
-        EmbeddingConfig(
+        EmbeddingBagConfig(
             name="user_table",
             embedding_dim=dim,
             num_embeddings=100000,
             feature_names=["user"],
+            pooling=PoolingType.SUM,
         ),
-        EmbeddingConfig(
+        EmbeddingBagConfig(
             name="product_table",
             embedding_dim=dim,
             num_embeddings=1000000,
             feature_names=["product"],
+            pooling=PoolingType.SUM,
         ),
     ]
 
 
-def grouped_config(configs: List[EmbeddingConfig]) -> GroupedEmbeddingConfig:
-    """One `UNFUSED_TPU` group holding every table, as the sharded path builds it."""
+def grouped_config(collection: str, configs: List[Any]) -> GroupedEmbeddingConfig:
+    pooling = PoolingType.NONE if collection == "ec" else PoolingType.SUM
     return GroupedEmbeddingConfig(
         data_type=DataType.FP32,
-        pooling=PoolingType.NONE,
+        pooling=pooling,
         is_weighted=False,
         has_feature_processor=False,
         compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU,
@@ -84,7 +97,7 @@ def grouped_config(configs: List[EmbeddingConfig]) -> GroupedEmbeddingConfig:
                 embedding_dim=config.embedding_dim,
                 data_type=DataType.FP32,
                 feature_names=config.feature_names,
-                pooling=PoolingType.NONE,
+                pooling=pooling,
                 is_weighted=False,
                 has_feature_processor=False,
                 compute_kernel=EmbeddingComputeKernel.UNFUSED_TPU,
@@ -96,206 +109,152 @@ def grouped_config(configs: List[EmbeddingConfig]) -> GroupedEmbeddingConfig:
     )
 
 
+def make_modules(
+    collection: str, configs: List[Any]
+) -> Tuple[torch.nn.Module, torch.nn.Module]:
+    config = grouped_config(collection, configs)
+    if collection == "ec":
+        return (
+            EmbeddingCollection(tables=configs, device=torch.device("cpu")),
+            BatchedTPUEmbedding(config=config, device=torch.device("tpu")),
+        )
+    return (
+        EmbeddingBagCollection(tables=configs, device=torch.device("cpu")),
+        BatchedTPUEmbeddingBag(config=config, device=torch.device("tpu")),
+    )
+
+
+def copy_weights(
+    collection: str,
+    cpu_collection: torch.nn.Module,
+    tpu_kernel: torch.nn.Module,
+    configs: List[Any],
+) -> None:
+    assert isinstance(tpu_kernel, (BatchedTPUEmbedding, BatchedTPUEmbeddingBag))
+    for weight, config in zip(tpu_kernel.split_embedding_weights(), configs):
+        if collection == "ec":
+            assert isinstance(cpu_collection, EmbeddingCollection)
+            source = cpu_collection.embeddings[config.name].weight
+        else:
+            assert isinstance(cpu_collection, EmbeddingBagCollection)
+            source = cpu_collection.embedding_bags[config.name].weight
+        weight.copy_(cast(torch.Tensor, source))
+
+
 def reference_output(
-    ref_ec: EmbeddingCollection, kjt: KeyedJaggedTensor
+    collection: str, module: torch.nn.Module, kjt: KeyedJaggedTensor
 ) -> torch.Tensor:
-    """`EmbeddingCollection` output flattened to match `BatchedTPUEmbedding`."""
-    ref_jt = ref_ec(kjt)
-    return torch.cat([ref_jt[key].values() for key in kjt.keys()], dim=0)
+    if collection == "ec":
+        assert isinstance(module, EmbeddingCollection)
+        jt_dict = module(kjt)
+        return torch.cat([jt_dict[key].values() for key in kjt.keys()], dim=0)
+    assert isinstance(module, EmbeddingBagCollection)
+    keyed_tensor = module(kjt)
+    return torch.cat([keyed_tensor[key] for key in kjt.keys()], dim=1)
 
 
-def main() -> None:
-    # CLI flag overrides the env var, which overrides the v1_sc default.
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--lookup-mode",
-        default=os.environ.get("LOOKUP_MODE", "v1_sc"),
-        choices=["v1_tpu", "v1_sc"],
-        help="Embedding lookup kernel to use (default from $LOOKUP_MODE or v1_sc).",
-    )
-    args = parser.parse_args()
-    lookup_mode = args.lookup_mode
+def tpu_output(module: torch.nn.Module, kjt: KeyedJaggedTensor) -> torch.Tensor:
+    assert isinstance(module, (BatchedTPUEmbedding, BatchedTPUEmbeddingBag))
+    return module(kjt)
 
-    # The flag must be in the env before either module is imported.
-    os.environ["LOOKUP_MODE"] = lookup_mode
-    from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
 
-    print(f"LOOKUP_MODE = {lookup_mode}")
-
-    traces_dir = os.environ.get("TRACE_DIR")
-
-    # --- Reference: TorchRec EmbeddingCollection (uses nn.Embedding on CPU) ---
-    ref_module = EmbeddingCollection(
-        tables=embedding_configs, device=torch.device("cpu")
+def to_tpu(kjt: KeyedJaggedTensor) -> KeyedJaggedTensor:
+    return KeyedJaggedTensor(
+        keys=kjt.keys(),
+        values=kjt.values().to(device="tpu", dtype=torch.int32),
+        lengths=kjt.lengths().to(device="tpu"),
     )
 
-    # --- TPU: the UNFUSED_TPU compute kernel, i.e. what the sharded path runs ---
-    tpu_kernel = BatchedTPUEmbedding(
-        config=grouped_config(embedding_configs), device=torch.device("tpu")
+
+def generate_input(configs: List[Any], batch_size: int) -> KeyedJaggedTensor:
+    model_input, _ = ModelInput.generate(
+        batch_size=batch_size,
+        world_size=WORLD_SIZE,
+        num_float_features=0,
+        tables=configs,
+        weighted_tables=[],
+        pooling_avg=5,
+        random_seed=100,
     )
+    kjt = model_input.idlist_features
+    assert isinstance(kjt, KeyedJaggedTensor)
+    return kjt
 
-    # Copy weights from reference into the TPU tables so outputs are comparable.
-    # split_embedding_weights() returns one weight per table, in table order.
-    for weight, config in zip(tpu_kernel.split_embedding_weights(), embedding_configs):
-        # pyre-ignore[6]: EmbeddingCollection.embeddings is a ModuleDict, so indexing it types as Module.
-        weight.data.copy_(ref_module.embeddings[config.name].weight.data)
 
-    # --- Accuracy test: compare outputs across different batch sizes ---
-    BATCH_SIZES = [10, 40, 160, 640, 1024, 2048, 1024 * 32]
+def run_accuracy(collection: str) -> None:
+    configs = make_configs(collection, 32)
+    cpu_collection, tpu_kernel = make_modules(collection, configs)
+    with torch.no_grad():
+        copy_weights(collection, cpu_collection, tpu_kernel, configs)
+        for batch_size in BATCH_SIZES:
+            kjt = generate_input(configs, batch_size)
+            expected = reference_output(collection, cpu_collection, kjt)
+            tpu_result = tpu_output(tpu_kernel, to_tpu(kjt))
+            sync.synchronize(tpu_result, wait=True)
+            actual = tpu_result.to("cpu")
+            assert expected.shape == actual.shape, f"{expected.shape} != {actual.shape}"
+            error = (expected - actual).abs()
+            assert torch.allclose(expected, actual, atol=1e-5)
+            print(
+                f"accuracy collection={collection} batch_size={batch_size}: "
+                f"shape={tuple(actual.shape)}, max_abs_diff={error.max().item():.3e}"
+            )
 
-    for batch_size in BATCH_SIZES:
-        print("Create Model Input")
-        model_input, _ = ModelInput.generate(
-            batch_size=batch_size,
-            world_size=WORLD_SIZE,
-            num_float_features=0,
-            tables=embedding_configs,
-            weighted_tables=[],
-            pooling_avg=5,
-            random_seed=100,
-        )
-        # CPU embedding needs int64 on torch 2.13
-        kjt = model_input.idlist_features
-        assert isinstance(kjt, KeyedJaggedTensor)
-        # Convert to int32/TPU outside the forward, before ref_module caches a CPU _jt_dict on kjt.
-        kjt_tpu = KeyedJaggedTensor(
-            keys=kjt.keys(),
-            values=kjt.values().to(device="tpu", dtype=torch.int32),
-            lengths=kjt.lengths(),
-        )
-        print("Lookup on CPU")
-        ref_vals = reference_output(ref_module, kjt)
-        print("Lookup on TPU")
-        tpu_vals = tpu_kernel(kjt_tpu).to("cpu")
 
-        print(f"\n=== batch_size={batch_size} ===")
-        print(f"  ref shape={ref_vals.shape}, tpu shape={tpu_vals.shape}")
-        assert ref_vals.shape == tpu_vals.shape, f"{ref_vals.shape} != {tpu_vals.shape}"
-        err = (ref_vals - tpu_vals).abs()
-        if err.max() > 1e-5:
-            print("CPU", ref_vals)
-            print("TPU", tpu_vals)
-        assert torch.allclose(ref_vals, tpu_vals, atol=1e-5)
-        print(f"    match=True, max abs diff={err.max().item():.3e}")
-        sync.synchronize()
-
-    # --- Profiler: single step with torch_tpu xprof trace ---
+def run_profile(collection: str, traces_dir: Optional[str]) -> None:
     if traces_dir is None:
         print("\nTRACE_DIR unset, skipping the profiled step")
-    else:
-        print(f"Profiler Start, traces printed to {traces_dir}")
-        tpu_output: torch.Tensor | None = None
-        with profiler.profile(
-            activities=[
-                profiler.ProfilerActivity.CPU,
-                profiler.ProfilerActivity.TPU,
-            ],
-            on_trace_ready=profiler.xprof_trace_handler(dir_name=traces_dir),
-        ):
-            for _ in range(PROFILE_NUMBER_TIMES):
-                model_input, _ = ModelInput.generate(
-                    batch_size=2048,
-                    world_size=WORLD_SIZE,
-                    num_float_features=0,
-                    tables=embedding_configs,
-                    weighted_tables=[],
-                    pooling_avg=5,
-                    random_seed=100,
-                )
-                # CPU embedding needs int64
-                kjt = model_input.idlist_features
-                assert isinstance(kjt, KeyedJaggedTensor)
+        return
 
-                # Convert to int32/TPU outside the forward.
-                kjt_tpu = KeyedJaggedTensor(
-                    keys=kjt.keys(),
-                    values=kjt.values().to(device="tpu", dtype=torch.int32),
-                    lengths=kjt.lengths(),  # stays on CPU so to_dict() splits on CPU
-                )
-                tpu_output = tpu_kernel(kjt_tpu)
+    configs = make_configs(collection, 32)
+    _, tpu_kernel = make_modules(collection, configs)
+    print(f"Profiler start, traces written to {traces_dir}")
+    tpu_result: torch.Tensor | None = None
+    with torch.no_grad(), profiler.profile(
+        activities=[
+            profiler.ProfilerActivity.CPU,
+            profiler.ProfilerActivity.TPU,
+        ],
+        on_trace_ready=profiler.xprof_trace_handler(dir_name=traces_dir),
+    ):
+        for _ in range(PROFILE_NUMBER_TIMES):
+            kjt = generate_input(configs, 2048)
+            tpu_result = tpu_output(tpu_kernel, to_tpu(kjt))
+            sync.synchronize(tpu_result, wait=True)
 
-        assert (
-            tpu_output is not None
-        ), "profiled step never ran; PROFILE_NUMBER_TIMES must be > 0"
-        print("Profiled TPU output shape:", tuple(tpu_output.shape))
+    assert tpu_result is not None
+    print("Profiled TPU output shape:", tuple(tpu_result.shape))
 
-    # --- Benchmark here -------
-    EMBEDDING_DIMS = [32, 64, 128, 256, 512]
-    BENCH_BATCH_SIZE = 2048
 
+def run_benchmark(collection: str, lookup_mode: str, embedding_dims: List[int]) -> None:
     print(
-        f"\n========== Benchmark sweep: kernel={lookup_mode}, iters={BENCHMARK_TIMES} =========="
+        f"\n========== Benchmark: collection={collection}, kernel={lookup_mode}, "
+        f"iters={BENCHMARK_TIMES} =========="
     )
     results = []
-    for dim in EMBEDDING_DIMS:
-        configs = make_configs(dim)
-        # Both sides are the same compute kernel, so the only variable is the
-        # backend the lookup op dispatches to -- Pallas on TPU, the reference
-        # gather on CPU. Timing EmbeddingCollection on CPU instead would charge
-        # the CPU column for to_dict()/JaggedTensor work the TPU column skips.
-        tpu_kernel = BatchedTPUEmbedding(
-            config=grouped_config(configs), device=torch.device("tpu")
-        )
-        cpu_kernel = BatchedTPUEmbedding(
-            config=grouped_config(configs), device=torch.device("cpu")
-        )
+    for dim in embedding_dims:
+        configs = make_configs(collection, dim)
+        cpu_collection, tpu_kernel = make_modules(collection, configs)
+        kjt = generate_input(configs, BENCH_BATCH_SIZE)
+        kjt_tpu = to_tpu(kjt)
 
-        # warm-up both backends
-        model_input, _ = ModelInput.generate(
-            batch_size=BENCH_BATCH_SIZE,
-            world_size=WORLD_SIZE,
-            num_float_features=0,
-            tables=configs,
-            weighted_tables=[],
-            pooling_avg=5,
-            random_seed=100,
-        )
-        # CPU embedding needs int64
-        kjt = model_input.idlist_features
-        assert isinstance(kjt, KeyedJaggedTensor)
-        # Convert to int32/TPU
-        kjt_tpu = KeyedJaggedTensor(
-            keys=kjt.keys(),
-            values=kjt.values().to(device="tpu", dtype=torch.int32),
-            lengths=kjt.lengths(),
-        )
-        _ = tpu_kernel(kjt_tpu)
-        _ = cpu_kernel(kjt)
-        sync.synchronize()
+        with torch.no_grad():
+            copy_weights(collection, cpu_collection, tpu_kernel, configs)
+            _ = reference_output(collection, cpu_collection, kjt)
+            tpu_result = tpu_output(tpu_kernel, kjt_tpu)
+            sync.synchronize(tpu_result, wait=True)
 
-        tpu_times = []
-        cpu_times = []
-        for _ in range(BENCHMARK_TIMES):
-            model_input, _ = ModelInput.generate(
-                batch_size=BENCH_BATCH_SIZE,
-                world_size=WORLD_SIZE,
-                num_float_features=0,
-                tables=configs,
-                weighted_tables=[],
-                pooling_avg=5,
-                random_seed=100,
-            )
-            # CPU embedding needs int64
-            kjt = model_input.idlist_features
-            assert isinstance(kjt, KeyedJaggedTensor)
-            # Convert to int32/TPU
-            kjt_tpu = KeyedJaggedTensor(
-                keys=kjt.keys(),
-                values=kjt.values().to(device="tpu", dtype=torch.int32),
-                lengths=kjt.lengths(),
-            )
+            tpu_times = []
+            cpu_times = []
+            for _ in range(BENCHMARK_TIMES):
+                start = time.perf_counter()
+                _ = reference_output(collection, cpu_collection, kjt)
+                cpu_times.append(time.perf_counter() - start)
 
-            # CPU reference gather
-            start = time.perf_counter()
-            _ = cpu_kernel(kjt)
-            cpu_times.append(time.perf_counter() - start)
-
-            # TPU Pallas kernel
-            sync.synchronize()
-            start = time.perf_counter()
-            _ = tpu_kernel(kjt_tpu)
-            sync.synchronize()
-            tpu_times.append(time.perf_counter() - start)
+                start = time.perf_counter()
+                tpu_result = tpu_output(tpu_kernel, kjt_tpu)
+                sync.synchronize(tpu_result, wait=True)
+                tpu_times.append(time.perf_counter() - start)
 
         tpu_ms = sum(tpu_times) / len(tpu_times) * 1000
         cpu_ms = sum(cpu_times) / len(cpu_times) * 1000
@@ -305,10 +264,53 @@ def main() -> None:
             f"CPU={cpu_ms:.2f} ms, speedup={cpu_ms / tpu_ms:.2f}x"
         )
 
-    print(f"\n=== Summary: kernel={lookup_mode}, iters={BENCHMARK_TIMES} ===")
+    print(
+        f"\n=== Summary: collection={collection}, kernel={lookup_mode}, "
+        f"iters={BENCHMARK_TIMES} ==="
+    )
     print(f"{'dim':>6} {'TPU (ms)':>12} {'CPU (ms)':>12} {'speedup':>10}")
     for dim, tpu_ms, cpu_ms in results:
         print(f"{dim:>6} {tpu_ms:>12.2f} {cpu_ms:>12.2f} {cpu_ms / tpu_ms:>9.2f}x")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--lookup-mode",
+        default=os.environ.get("LOOKUP_MODE", "v1_sc"),
+        choices=["v1_tpu", "v1_sc"],
+        help="Embedding lookup kernel to use (default from $LOOKUP_MODE or v1_sc).",
+    )
+    parser.add_argument(
+        "--collection",
+        choices=["ec", "ebc"],
+        default="ec",
+        help="Benchmark EmbeddingCollection or EmbeddingBagCollection.",
+    )
+    parser.add_argument(
+        "--embedding-dim",
+        type=int,
+        choices=EMBEDDING_DIMS,
+        help="Run only one embedding dimension from the standard sweep.",
+    )
+    parser.add_argument("--skip-accuracy", action="store_true")
+    parser.add_argument("--skip-profile", action="store_true")
+    args = parser.parse_args()
+    lookup_mode = args.lookup_mode
+    collection = args.collection
+
+    os.environ["LOOKUP_MODE"] = lookup_mode
+    from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
+
+    embedding_dims = (
+        [args.embedding_dim] if args.embedding_dim is not None else EMBEDDING_DIMS
+    )
+    print(f"LOOKUP_MODE={lookup_mode}, collection={collection}")
+    if not args.skip_accuracy:
+        run_accuracy(collection)
+    if not args.skip_profile:
+        run_profile(collection, os.environ.get("TRACE_DIR"))
+    run_benchmark(collection, lookup_mode, embedding_dims)
 
 
 if __name__ == "__main__":

--- a/torchrec/experimental/torch_tpu/modules/embedding_modules.py
+++ b/torchrec/experimental/torch_tpu/modules/embedding_modules.py
@@ -85,3 +85,153 @@ class TPUEmbeddingUnfused(torch.nn.Module):
         return torch.ops.torchrec.embedding_lookup(
             input, self._weight, self._embedding_dim
         )
+
+
+class TPUEmbeddingBagUnfused(torch.nn.Module):
+    """Single-table TPU pooled embedding lookup backed by a Pallas kernel.
+
+    Performs a pooled gather; the backward/optimizer is not fused.
+
+    Args:
+        num_embeddings (int): number of rows in the embedding table.
+        embedding_dim (int): width of each embedding row; must be a multiple of 16.
+        device: device the table lives on (e.g. ``"tpu"``).
+        dtype (torch.dtype): dtype of the embedding table.
+        mode (str): Either `mean` or `sum`. Default is `mean`.
+
+    Example::
+
+        emb_module = TPUEmbeddingBagUnfused(
+            num_embeddings=10,
+            embedding_dim=16,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+
+    """
+
+    _PADDING_SENTINEL: int = 0
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        device: Optional[torch.device],
+        dtype: torch.dtype,
+        mode: str = "mean",
+    ) -> None:
+        super().__init__()
+        if embedding_dim % 16 != 0:
+            raise ValueError(
+                "TPUEmbeddingBagUnfused requires embedding_dim to be a multiple of 16"
+            )
+        self._num_embeddings = num_embeddings
+        self._embedding_dim = embedding_dim
+        self._device = device
+        self._dtype = dtype
+        self._weight = torch.nn.Parameter(
+            torch.zeros((num_embeddings, embedding_dim), dtype=dtype, device=device)
+        )
+        self.output_dtype = dtype
+        self.mode = mode
+
+    @property
+    def weight(self) -> torch.nn.Parameter:
+        return self._weight
+
+    def split_embedding_weights(self) -> List[torch.Tensor]:
+        """Single-table weight list, matching the FBGEMM emb_module interface.
+
+        Lets ``BatchedTPUEmbedding`` (a ``BaseBatchedEmbedding``) use this module as
+        its ``emb_module`` and inherit ``split_embedding_weights``/state handling.
+        """
+        return [self._weight]
+
+    def _build_pooled_idx(
+        self,
+        indices: torch.Tensor,
+        lengths: torch.Tensor,
+        B: int,
+        K: int,
+        sentinel: int,
+    ) -> torch.Tensor:
+        start = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32, device=lengths.device),
+                lengths.cumsum(0)[:-1],
+            ]
+        )
+        col = torch.arange(K, dtype=torch.int32, device=lengths.device)
+        gather = start[:, None] + col[None, :]  # [B,K]
+        valid = col[None, :] < lengths[:, None]
+        gathered = indices[torch.clamp(gather, 0, B * K - 1)]
+        return torch.where(
+            valid,
+            gathered,
+            torch.tensor(sentinel, dtype=torch.int32, device=indices.device),
+        ).reshape(-1)
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Pooled embedding rows for ``input`` indices via the Pallas kernel.
+
+        Args:
+            input (torch.Tensor): 1-D row indices on the embedding table's device.
+            offsets (torch.Tensor): 1-D bag boundaries on the embedding table's device.
+
+        Returns:
+            torch.Tensor: pooled rows, shape ``[offsets.numel() - 1, embedding_dim]``.
+        """
+        B = offsets.numel() - 1
+        if B == 0:
+            return self._weight[:0]
+        # NACC: Number of accumulators to shorten the reduction within the kernel
+        # The pooled embeddings are accumulated round-robin into `NACC`
+        # vectors, then reduced into one pooled embedding.
+        # Keep this value in sync with pallas.pooled_lookup.NACC.
+        NACC = 16
+        device = self._weight.device
+        if input.device != device or offsets.device != device:
+            raise ValueError(
+                "input and offsets must already be on the embedding table's device"
+            )
+
+        # Repack on-device (no host round trip): only the pool size K needs a host value.
+        off = offsets.to(dtype=torch.int64)
+        lengths = off[1:] - off[:-1]
+        max_len = (
+            int(lengths.max().item()) if B > 0 else 0
+        )  # scalar sync (only host value K needs)
+        # K rounded up to the SparseCore id tile (8) so RBLK*K stays tile-aligned
+        K = max(((max_len + 7) // 8) * 8, NACC)
+
+        # Build the [B, K] pad-to-max index matrix
+        # This replaces an eager `repeat_interleave` + advanced-index scatter
+        indices_d = input.to(dtype=torch.int32)
+        pad = B * K - int(indices_d.numel())  # a shape read, no device sync
+        if pad > 0:
+            indices_d = torch.nn.functional.pad(indices_d, (0, pad))
+        elif pad < 0:
+            indices_d = indices_d[: B * K]
+        idx_flat = self._build_pooled_idx(
+            indices=indices_d,
+            lengths=lengths.to(torch.int32),
+            B=B,
+            K=K,
+            sentinel=self._PADDING_SENTINEL,
+        )
+
+        out = torch.ops.torchrec.embedding_pooled_lookup(
+            idx=idx_flat, table=self._weight, pool=K
+        )
+
+        # Remove the embedding contributions from padded IDs.
+        padding_count = (K - lengths).unsqueeze(1).to(out.dtype)
+        out = out - padding_count * self._weight[self._PADDING_SENTINEL].unsqueeze(0)
+        if self.mode == "mean":
+            denom = lengths.clamp(min=1).unsqueeze(1).to(out.dtype)
+            out = out / denom
+        return out

--- a/torchrec/experimental/torch_tpu/pallas/impl.py
+++ b/torchrec/experimental/torch_tpu/pallas/impl.py
@@ -7,11 +7,23 @@
 
 import torch
 from torch_tpu._internal import pallas  # pyre-ignore[21]
-from torchrec.experimental.torch_tpu.pallas import lookup, ops  # noqa: F401
+from torchrec.experimental.torch_tpu.pallas import (  # noqa: F401
+    lookup,
+    ops,
+    pooled_lookup,
+)
 
 _fwd = pallas.jax_op("torchrec_pallas::embedding_lookup", lookup.embedding_lookup_jax)
 _bwd_tc = pallas.jax_op(
     "torchrec_pallas::embedding_lookup_bwd_tc", lookup.embedding_lookup_bwd_jax
+)
+_pooled_fwd = pallas.jax_op(
+    "torchrec_pallas::embedding_pooled_lookup",
+    pooled_lookup.embedding_pooled_lookup_jax,
+)
+_pooled_bwd = pallas.jax_op(
+    "torchrec_pallas::embedding_pooled_lookup_bwd",
+    pooled_lookup.embedding_pooled_gather_bwd_jax,
 )
 
 
@@ -26,6 +38,24 @@ def embedding_lookup_backward_tpu(grad_out, indices, num_rows, emb_dim):
     )
 
 
+def embedding_pooled_lookup_tpu(idx, table, pool):
+    return _pooled_fwd(idx=idx, table=table, pool=pool)
+
+
+def embedding_pooled_lookup_backward_tpu(grad_out, idx, pool, num_rows, emb_dim):
+    return _pooled_bwd(
+        grad_out=grad_out,
+        idx=idx,
+        pool=pool,
+        num_rows=num_rows,
+        emb_dim=emb_dim,
+    )
+
+
 lib: torch.library.Library = torch.library.Library("torchrec", "IMPL")
 lib.impl("embedding_lookup", embedding_lookup_tpu, "TPU")
 lib.impl("embedding_lookup_backward", embedding_lookup_backward_tpu, "TPU")
+lib.impl("embedding_pooled_lookup", embedding_pooled_lookup_tpu, "TPU")
+lib.impl(
+    "embedding_pooled_lookup_backward", embedding_pooled_lookup_backward_tpu, "TPU"
+)

--- a/torchrec/experimental/torch_tpu/pallas/ops.py
+++ b/torchrec/experimental/torch_tpu/pallas/ops.py
@@ -16,6 +16,11 @@ lib.define(
     "embedding_lookup_backward("
     "Tensor grad_out, Tensor indices, int num_rows, int emb_dim) -> Tensor"
 )
+lib.define("embedding_pooled_lookup(Tensor idx, Tensor table, int pool) -> Tensor")
+lib.define(
+    "embedding_pooled_lookup_backward("
+    "Tensor grad_out, Tensor idx, int pool, int num_rows, int emb_dim) -> Tensor"
+)
 
 
 def embedding_lookup_cpu(
@@ -36,6 +41,32 @@ lib.impl("embedding_lookup", embedding_lookup_cpu, "CPU")
 lib.impl("embedding_lookup_backward", embedding_lookup_backward_cpu, "CPU")
 
 
+def embedding_pooled_lookup_cpu(
+    idx: torch.Tensor, table: torch.Tensor, pool: int
+) -> torch.Tensor:
+    return table[idx.long()].reshape(-1, pool, table.shape[1]).sum(dim=1)
+
+
+def embedding_pooled_lookup_backward_cpu(
+    grad_out: torch.Tensor,
+    idx: torch.Tensor,
+    pool: int,
+    num_rows: int,
+    emb_dim: int,
+) -> torch.Tensor:
+    return grad_out.new_zeros((num_rows, emb_dim)).index_add_(
+        0,
+        idx.long(),
+        grad_out.repeat_interleave(pool, dim=0),
+    )
+
+
+lib.impl("embedding_pooled_lookup", embedding_pooled_lookup_cpu, "CPU")
+lib.impl(
+    "embedding_pooled_lookup_backward", embedding_pooled_lookup_backward_cpu, "CPU"
+)
+
+
 def _setup_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
     indices, weights, emb_dim = inputs
     ctx.save_for_backward(indices)
@@ -54,4 +85,27 @@ def _backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
 
 torch.library.register_autograd(
     "torchrec::embedding_lookup", _backward, setup_context=_setup_context
+)
+
+
+def _setup_pooled_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    idx, table, pool = inputs
+    ctx.save_for_backward(idx)
+    ctx.pool = pool
+    ctx.num_rows = table.shape[0]
+    ctx.emb_dim = table.shape[1]
+
+
+def _pooled_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
+    (idx,) = ctx.saved_tensors
+    grad_table = torch.ops.torchrec.embedding_pooled_lookup_backward(
+        grad_out.contiguous(), idx, ctx.pool, ctx.num_rows, ctx.emb_dim
+    )
+    return None, grad_table, None
+
+
+torch.library.register_autograd(
+    "torchrec::embedding_pooled_lookup",
+    _pooled_backward,
+    setup_context=_setup_pooled_context,
 )

--- a/torchrec/experimental/torch_tpu/pallas/pooled_lookup.py
+++ b/torchrec/experimental/torch_tpu/pallas/pooled_lookup.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu, tpu_sc as plsc
+
+
+NL, NACC = 16, 16
+
+
+def _rblk(K, D):
+    """Rows-per-block: largest power-of-two (<=4) bag block whose double-buffered
+    gather buffer stays under the ~500 KiB VMEM budget."""
+    r = 1
+    while 2 * (r * 2) * K * D * 4 <= 500 * 1024 and r * 2 <= 4:
+        r *= 2
+    return r
+
+
+# Fused SparseCore gather-sum kernel (from Google/torus bench_tpu_gather_pool_pallas_sc)
+def _kernel(idx_hbm, table_hbm, out_hbm, idx_v, buf, ov, sem, *, RBLK, K):
+    sc = pltpu.get_tpu_info().sparse_core
+    num_sub = sc.num_cores * sc.num_subcores
+    B, D, TILE = out_hbm.shape[0], buf.shape[-1], RBLK * K
+    nb = pl.cdiv(B, RBLK * num_sub)
+
+    @functools.partial(
+        pltpu.emit_pipeline,
+        grid=(nb + 1, num_sub),
+        core_axis_name=("c", "s"),
+        dimension_semantics=(pltpu.ARBITRARY, pltpu.PARALLEL),
+    )
+    def _inner():
+        blk, core = pl.program_id(0), pl.program_id(1)
+
+        @pl.when(blk < nb)  # gather block blk
+        def _():
+            p = jax.lax.rem(blk, 2)
+            o0 = (blk * num_sub + core) * RBLK
+            pltpu.sync_copy(idx_hbm.at[pl.ds(o0 * K, TILE)], idx_v.at[p])
+            pltpu.make_async_copy(
+                table_hbm.at[plsc.Indices(idx_v.at[p])], buf.at[p], sem.at[p]
+            ).start()
+
+        @pl.when(blk > 0)  # reduce block blk-1 (overlaps gather)
+        def _():
+            q = jax.lax.rem(blk - 1, 2)
+            o0 = ((blk - 1) * num_sub + core) * RBLK
+            pltpu.make_async_copy(
+                table_hbm.at[plsc.Indices(idx_v.at[q])], buf.at[q], sem.at[q]
+            ).wait()
+            for r in range(RBLK):
+                base = r * K
+
+                @plsc.parallel_loop(0, D, step=NL)
+                def _cols(c0, base=base, r=r):  # bind loop vars (flake8 B023)
+                    cs = pl.ds(c0, NL)
+                    accs = [buf[q, base + a, cs] for a in range(NACC)]
+                    for k in range(NACC, K):
+                        accs[k % NACC] = accs[k % NACC] + buf[q, base + k, cs]
+                    acc = accs[0]
+                    for a in range(1, NACC):
+                        acc = acc + accs[a]
+                    ov[r, cs] = acc
+
+            pltpu.sync_copy(ov, out_hbm.at[pl.ds(o0, RBLK)])
+
+    _inner()
+
+
+def build(B, K, D):
+    """f(table[V, D] f32, idx[B*K] i32) -> out[B, D] f32 (fused gather + sum-pool).
+
+    Returns the plain JAX function (not jitted) so ``jax_op`` can trace/export it.
+    """
+    RBLK = _rblk(K, D)
+    sc = pltpu.get_tpu_info().sparse_core
+    num_sub = sc.num_cores * sc.num_subcores
+    Bpad = pl.cdiv(B, RBLK * num_sub) * RBLK * num_sub
+    mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="c",
+        subcore_axis_name="s",
+        num_cores=sc.num_cores,
+        num_subcores=sc.num_subcores,
+    )
+    ker = pl.kernel(
+        functools.partial(_kernel, RBLK=RBLK, K=K),
+        out_type=jax.ShapeDtypeStruct((Bpad, D), jnp.float32),
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            use_tc_tiling_on_sc=False,
+            needs_layout_passes=False,
+        ),
+        scratch_types=[
+            pltpu.VMEM((2, RBLK * K), jnp.int32),
+            pltpu.VMEM((2, RBLK * K, D), jnp.float32),
+            pltpu.VMEM((RBLK, D), jnp.float32),
+            pltpu.SemaphoreType.DMA((2,)),
+        ],
+        mesh=mesh,
+    )
+
+    def run(table, idx):
+        idxp = idx if Bpad == B else jnp.pad(idx, (0, (Bpad - B) * K))
+        return ker(idxp, table)[:B]
+
+    return run
+
+
+def embedding_pooled_lookup_jax(
+    idx: jax.Array, table: jax.Array, pool: int
+) -> jax.Array:
+    """Fused uniform gather + sum-pool: idx[B*pool] i32, table[V, D] f32 -> [B, D]."""
+    B = idx.shape[0] // pool
+    D = table.shape[1]
+    return build(B, pool, D)(table, idx)
+
+
+def embedding_pooled_gather_bwd_jax(
+    grad_out: jax.Array, idx: jax.Array, pool: int, num_rows: int, emb_dim: int
+) -> jax.Array:
+    grad_expanded = jnp.repeat(
+        grad_out, pool, axis=0
+    )  # [B*pool, D]; row j -> grad_out[j//pool]
+    return (
+        jnp.zeros((num_rows, emb_dim), dtype=grad_out.dtype).at[idx].add(grad_expanded)
+    )

--- a/torchrec/experimental/torch_tpu/pallas/tests/test_ebc_lookup.py
+++ b/torchrec/experimental/torch_tpu/pallas/tests/test_ebc_lookup.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+from unittest.mock import patch
+
+import torch
+from parameterized import parameterized
+from torchrec.distributed.batched_embedding_kernel import BatchedTPUEmbeddingBag
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.distributed.test_utils.test_model import ModelInput
+from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+    TPUEmbeddingBagUnfused,
+)
+from torchrec.experimental.torch_tpu.pallas import ops  # noqa: F401
+from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig, PoolingType
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+WORLD_SIZE = 8
+
+TABLES: List[EmbeddingBagConfig] = [
+    EmbeddingBagConfig(
+        name="user_table",
+        embedding_dim=32,
+        num_embeddings=100000,
+        feature_names=["user"],
+        pooling=PoolingType.SUM,
+    ),
+    EmbeddingBagConfig(
+        name="item_table",
+        embedding_dim=32,
+        num_embeddings=50000,
+        feature_names=["item"],
+        pooling=PoolingType.SUM,
+    ),
+]
+
+# Exercised batch / pooling grid — mirrors single_pooled_lookup.py's
+# `if __name__ == "__main__"` sweep (BATCH_SIZES x {"sum","mean"}).
+BATCH_SIZES = [1, 8, 64, 512]
+
+
+def _tables_for_pooling(pooling: PoolingType) -> List[EmbeddingBagConfig]:
+    """Clone TABLES with the requested pooling (EBC reference depends on it)."""
+    return [
+        EmbeddingBagConfig(
+            name=t.name,
+            embedding_dim=t.embedding_dim,
+            num_embeddings=t.num_embeddings,
+            feature_names=t.feature_names,
+            pooling=pooling,
+        )
+        for t in TABLES
+    ]
+
+
+def tpu_is_available() -> bool:
+    """Whether a TPU backend is importable and has a device attached."""
+    try:
+        import torch_tpu  # pyre-ignore[21]  # noqa: F401
+    except ImportError:
+        return False
+    tpu = getattr(torch, "tpu", None)
+    if tpu is None:
+        return False
+    is_available = getattr(tpu, "is_available", None)
+    if callable(is_available):
+        return bool(is_available())
+    return bool(getattr(tpu, "available", False))
+
+
+def _register_tpu_kernels() -> None:
+    """Bind the Pallas kernels to the TPU dispatch key.
+
+    Imported lazily: `impl` pulls in `torch_tpu` and `jax`, which are only
+    present on a TPU host, so importing it at module scope would break the CPU
+    tests.
+    """
+    from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
+
+
+def _grouped_config(
+    compute_kernel: EmbeddingComputeKernel,
+    tables: List[EmbeddingBagConfig],
+    pooling: PoolingType,
+) -> GroupedEmbeddingConfig:
+    sharded = [
+        ShardedEmbeddingTable(
+            name=table.name,
+            num_embeddings=table.num_embeddings,
+            embedding_dim=table.embedding_dim,
+            data_type=DataType.FP32,
+            feature_names=table.feature_names,
+            pooling=pooling,
+            is_weighted=False,
+            has_feature_processor=False,
+            compute_kernel=compute_kernel,
+            local_rows=table.num_embeddings,
+            local_cols=table.embedding_dim,
+        )
+        for table in tables
+    ]
+    return GroupedEmbeddingConfig(
+        data_type=DataType.FP32,
+        pooling=pooling,
+        is_weighted=False,
+        has_feature_processor=False,
+        compute_kernel=compute_kernel,
+        embedding_tables=sharded,
+    )
+
+
+class EBCLookupTest(unittest.TestCase):
+    def _setup_device(self, device: str) -> None:
+        """Skip the TPU cases off-hardware; bind the Pallas kernels on it.
+
+        The check runs here rather than in a `skipIf` decorator so that
+        `torch_tpu` is only imported when a TPU case actually executes.
+        """
+        if device != "tpu":
+            return
+        if not tpu_is_available():
+            self.skipTest("requires an attached TPU")
+        _register_tpu_kernels()
+
+    def test_rejects_unaligned_embedding_dim(self) -> None:
+        with self.assertRaisesRegex(ValueError, "multiple of 16"):
+            TPUEmbeddingBagUnfused(
+                num_embeddings=10,
+                embedding_dim=15,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            )
+
+    def test_parameter_names_match_state_dict(self) -> None:
+        config = _grouped_config(
+            EmbeddingComputeKernel.UNFUSED_TPU, TABLES, PoolingType.SUM
+        )
+        kernel = BatchedTPUEmbeddingBag(config=config, device=torch.device("cpu"))
+        expected_names = [f"{table.name}.weight" for table in TABLES]
+
+        self.assertEqual(expected_names, list(dict(kernel.named_parameters())))
+        self.assertEqual(expected_names, list(kernel.state_dict()))
+
+    @parameterized.expand([("cpu",), ("tpu",)])
+    def test_dispatch(self, device: str) -> None:
+        """`GroupedPooledEmbeddingsLookup` builds a `BatchedTPUEmbeddingBag` for UNFUSED_TPU."""
+        self._setup_device(device)
+        with patch(
+            "torchrec.distributed.embedding_lookup.dist.get_world_size",
+            return_value=1,
+        ):
+            lookup = GroupedPooledEmbeddingsLookup(
+                grouped_configs=[
+                    _grouped_config(
+                        EmbeddingComputeKernel.UNFUSED_TPU,
+                        TABLES,
+                        PoolingType.SUM,
+                    )
+                ],
+                device=torch.device(device),
+            )
+        self.assertIsInstance(lookup._emb_modules[0], BatchedTPUEmbeddingBag)
+
+    @parameterized.expand([("cpu",), ("tpu",)])
+    def test_forward_matches_embedding_bag_collection(self, device: str) -> None:
+        """Pooled forward matches `EmbeddingBagCollection` across both poolings and batch sizes.
+
+        Mirrors `single_pooled_lookup.py`'s main correctness sweep (sum/mean x
+        BATCH_SIZES, fwd `F.embedding_bag` reference, bwd scatter check) but
+        exercised through the TorchRec pooled stack:
+        `GroupedPooledEmbeddingsLookup` / `BatchedTPUEmbeddingBag`. Each case
+        shares identical weights between the CPU `EmbeddingBagCollection`
+        reference (one `EmbeddingBagConfig` per feature, pooled per-batch) and
+        the kernel, then checks the pooled `[B, sum(dim)]` output.
+        """
+        self._setup_device(device)
+        for pooling in (PoolingType.SUM, PoolingType.MEAN):
+            tables_pooled = _tables_for_pooling(pooling)
+            config = _grouped_config(
+                EmbeddingComputeKernel.UNFUSED_TPU, tables_pooled, pooling
+            )
+            # Reference pooled collection — one bag per feature, pooled per sample.
+            ref_ebc = EmbeddingBagCollection(
+                tables=tables_pooled, device=torch.device("cpu")
+            )
+            kernel = BatchedTPUEmbeddingBag(config=config, device=torch.device(device))
+
+            # split_embedding_weights() returns one weight per table, in table order.
+            for weight, table in zip(kernel.split_embedding_weights(), tables_pooled):
+                weight.data.copy_(  # pyre-ignore[16]
+                    ref_ebc.embedding_bags[table.name].weight.data  # pyre-ignore[16]
+                )
+
+            for batch_size in BATCH_SIZES:
+                # Generate KJT with jagged bags (pooling_avg controls avg bag length).
+                # Use a deterministic seed per (pooling, batch) so cpu/tpu cases compare
+                # the same ids/offsets.
+                model_input, _ = ModelInput.generate(
+                    batch_size=batch_size,
+                    world_size=WORLD_SIZE,
+                    num_float_features=0,
+                    tables=tables_pooled,
+                    weighted_tables=[],
+                    pooling_avg=5,
+                    random_seed=100
+                    + batch_size
+                    + (10 if pooling == PoolingType.MEAN else 0),
+                )
+                kjt = (
+                    model_input.idlist_features
+                )  # int64 indices on cpu, keys in table order
+                assert isinstance(kjt, KeyedJaggedTensor)
+                # The caller owns device placement; the module only normalizes dtype.
+                kjt_device = KeyedJaggedTensor(
+                    keys=kjt.keys(),  # pyre-ignore[16]
+                    values=kjt.values().to(
+                        device=device, dtype=torch.int32
+                    ),  # pyre-ignore[16]
+                    lengths=kjt.lengths().to(device=device),  # pyre-ignore[16]
+                )
+
+                ref_kt = ref_ebc(kjt)  # KeyedTensor: ref_kt[key] -> [B, dim]
+                # Pooled features concatenate along the embedding dim -> [B, sum(dim)].
+                expected = torch.cat(
+                    [ref_kt[key] for key in kjt.keys()], dim=1  # pyre-ignore[16]
+                )
+                actual = kernel(kjt_device).to("cpu")
+
+                self.assertEqual(
+                    expected.shape,
+                    actual.shape,
+                    f"pooling={pooling} B={batch_size}: shape {expected.shape} != {actual.shape}",
+                )
+                torch.testing.assert_close(
+                    actual,
+                    expected,
+                    atol=1e-4,
+                    rtol=1e-4,
+                    msg=lambda m, p=pooling, b=batch_size: f"pooling={p} B={b}: {m}",
+                )
+
+    @parameterized.expand([("cpu",), ("tpu",)])
+    def test_backward_populates_grads(self, device: str) -> None:
+        """`loss.backward()` populates every table's gradient for each pooling."""
+        self._setup_device(device)
+        for pooling in (PoolingType.SUM, PoolingType.MEAN):
+            config = _grouped_config(
+                EmbeddingComputeKernel.UNFUSED_TPU, TABLES, pooling
+            )
+            kernel = BatchedTPUEmbeddingBag(config=config, device=torch.device(device))
+
+            model_input, _ = ModelInput.generate(
+                batch_size=128,
+                world_size=WORLD_SIZE,
+                num_float_features=0,
+                tables=TABLES,
+                weighted_tables=[],
+                pooling_avg=5,
+                random_seed=100,
+            )
+            kjt = model_input.idlist_features
+            assert isinstance(kjt, KeyedJaggedTensor)
+            kjt_device = KeyedJaggedTensor(
+                keys=kjt.keys(),  # pyre-ignore[16]
+                values=kjt.values().to(
+                    device=device, dtype=torch.int32
+                ),  # pyre-ignore[16]
+                lengths=kjt.lengths().to(device=device),  # pyre-ignore[16]
+            )
+
+            # Zero grads from previous pooling iteration if reused.
+            for w in kernel.split_embedding_weights():
+                w.grad = None
+            kernel(kjt_device).float().sum().backward()
+
+            for weight, table in zip(kernel.split_embedding_weights(), TABLES):
+                self.assertIsNotNone(
+                    weight.grad,
+                    f"pooling={pooling}: no gradient for table {table.name}",
+                )
+                self.assertGreater(
+                    torch.count_nonzero(weight.grad).item(),
+                    0,
+                    f"pooling={pooling}: all-zero gradient for table {table.name}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Context
---------

This diff adds the pooled embedding bag kernel from Google's/Torus's implementation. Note that the tables are still unbatched and the gradient is the typical tensorcore unfused naive approach. This kernel uses lengths instead of offsets for lookup, and requires that the indices are padded.

NOTE: This kernel assumes that embedding dimension is a multiple of 16.

Implementation
-----------------

Added a `BatchedTPUEmbeddingBag` compute kernel to `batched_embedding_kernel`, which creates a `TPUEmbeddingBagUnfused` embedding lookup module.
Note that the KJT indices are padded within the forward method.

Reviewed By: kausv

Differential Revision: D111099370


