### PR TITLE
Fix Gloo rendezvous cleanup in metric test

### DIFF
--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -240,10 +240,11 @@ class MetricModuleTest(unittest.TestCase):
             throughput_metric=ThroughputDef(warmup_steps=1),
             state_metrics=[StateMetricEnum.OPTIMIZERS],
         )
-        with tempfile.NamedTemporaryFile(delete=True) as backend:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            backend_path = os.path.join(temp_dir, "store")
             dist.init_process_group(
                 backend="gloo",
-                init_method=f"file://{backend.name}",
+                init_method=f"file://{backend_path}",
                 world_size=1,
                 rank=0,
             )


### PR DESCRIPTION
Summary: The test previously used a pre-created `NamedTemporaryFile` as the Gloo rendezvous target. Gloo removes its file-store path during process-group teardown, so the temporary-file context could attempt to delete the same path and raise `FileNotFoundError`. Use a temporary directory with a child store path so ownership and cleanup are unambiguous.

Differential Revision: D117209080


