### PR TITLE
Make CPU KJT FX wrapping opt-in (#4611)

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -27,6 +27,7 @@ FUSED_PARAM_BOUNDS_CHECK_MODE: str = "__register_tbe_bounds_check_mode"
 # with certain ways to split models.
 FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP: str = "__register_lengths_to_offsets_lookup"
 FUSED_PARAM_IS_DEVICE_RO: str = "__register_is_device_ro"
+FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING: str = "__use_cpu_kjt_for_fx_tracing"
 
 # Fused param storing list of cpu embedding tables offloaded to ssd to scale
 # the embedding table size
@@ -106,6 +107,14 @@ def is_fused_param_device_ro(fused_params: Optional[Dict[str, Any]]) -> bool:
     )
 
 
+def is_fused_param_use_cpu_kjt_for_fx_tracing(
+    fused_params: Optional[Dict[str, Any]],
+) -> bool:
+    return bool(
+        fused_params and fused_params.get(FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING, False)
+    )
+
+
 def is_fused_param_quant_state_dict_split_scale_bias(
     fused_params: Optional[Dict[str, Any]],
 ) -> bool:
@@ -136,6 +145,8 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP)
     if FUSED_PARAM_IS_DEVICE_RO in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_IS_DEVICE_RO)
+    if FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING)
     if FUSED_PARAM_SSD_TABLE_LIST in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_SSD_TABLE_LIST)
 

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -38,6 +38,7 @@ from torchrec.distributed.fused_params import (
     is_fused_param_device_ro,
     is_fused_param_quant_state_dict_split_scale_bias,
     is_fused_param_register_tbe,
+    is_fused_param_use_cpu_kjt_for_fx_tracing,
     tbe_fused_params,
     TBEToRegisterMixIn,
 )
@@ -213,6 +214,13 @@ def _unwrap_kjt_for_cpu(
 
 
 @torch.fx.wrap
+def _unwrap_kjt_for_cpu_fx(
+    features: KeyedJaggedTensor, weighted: bool
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    return _unwrap_kjt_for_cpu(features, weighted)
+
+
+@torch.fx.wrap
 def _unwrap_kjt_lengths(
     features: KeyedJaggedTensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -288,6 +296,9 @@ class QuantBatchedEmbeddingBag(
             is_fused_param_quant_state_dict_split_scale_bias(fused_params)
         )
         self._is_device_ro: bool = is_fused_param_device_ro(fused_params)
+        self._use_cpu_kjt_for_fx_tracing: bool = (
+            is_fused_param_use_cpu_kjt_for_fx_tracing(fused_params)
+        )
         bounds_check_mode: Optional[BoundsCheckMode] = fused_param_bounds_check_mode(
             fused_params
         )
@@ -439,7 +450,12 @@ class QuantBatchedEmbeddingBag(
             if self.lengths_to_tbe:
                 indices, lengths, per_sample_weights = _unwrap_kjt_lengths(features)
             else:
-                indices, offsets, per_sample_weights = _unwrap_kjt_for_cpu(
+                cpu_unwrap = (
+                    _unwrap_kjt_for_cpu_fx
+                    if getattr(self, "_use_cpu_kjt_for_fx_tracing", False)
+                    else _unwrap_kjt_for_cpu
+                )
+                indices, offsets, per_sample_weights = cpu_unwrap(
                     features, self._config.is_weighted
                 )
         else:
@@ -561,6 +577,9 @@ class QuantBatchedEmbedding(
         self._runtime_device: torch.device = _get_runtime_device(
             device, config, shard_index
         )
+        self._use_cpu_kjt_for_fx_tracing: bool = (
+            is_fused_param_use_cpu_kjt_for_fx_tracing(fused_params)
+        )
         # 16 for CUDA, 1 for others like CPU and MTIA.
         self._tbe_row_alignment: int = 16 if self._runtime_device.type == "cuda" else 1
         embedding_clazz = (
@@ -654,9 +673,12 @@ class QuantBatchedEmbedding(
     def forward(self, features: KeyedJaggedTensor) -> torch.Tensor:
         if self._runtime_device.type == "cpu":
             # To distinguish fx tracing on CPU embedding.
-            values, offsets, _ = _unwrap_kjt_for_cpu(
-                features, weighted=self._config.is_weighted
+            cpu_unwrap = (
+                _unwrap_kjt_for_cpu_fx
+                if getattr(self, "_use_cpu_kjt_for_fx_tracing", False)
+                else _unwrap_kjt_for_cpu
             )
+            values, offsets, _ = cpu_unwrap(features, weighted=self._config.is_weighted)
         else:
             values, offsets, _ = _unwrap_kjt(features)
 

--- a/torchrec/distributed/tests/test_quant_embedding_kernel.py
+++ b/torchrec/distributed/tests/test_quant_embedding_kernel.py
@@ -15,10 +15,78 @@ import torch
 import torchrec.distributed.quant_embedding_kernel as qek
 from torchrec.distributed.fused_params import (
     FUSED_PARAM_IS_DEVICE_RO,
+    FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING,
     is_fused_param_device_ro,
+    is_fused_param_use_cpu_kjt_for_fx_tracing,
     tbe_fused_params,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class _CpuKJTUnwrapModule(torch.nn.Module):
+    def __init__(self, *, use_fx_helper: bool) -> None:
+        super().__init__()
+        self._use_fx_helper = use_fx_helper
+
+    def forward(
+        self, features: KeyedJaggedTensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if self._use_fx_helper:
+            return qek._unwrap_kjt_for_cpu_fx(features, weighted=False)
+        return qek._unwrap_kjt_for_cpu(features, weighted=False)
+
+
+class QuantEmbeddingKernelFxTest(unittest.TestCase):
+    def test_cpu_kjt_fx_helper_is_opt_in(self) -> None:
+        default_graph = torch.fx.symbolic_trace(
+            _CpuKJTUnwrapModule(use_fx_helper=False)
+        )
+        default_call_targets = [
+            node.target
+            for node in default_graph.graph.nodes
+            if node.op == "call_function"
+        ]
+        self.assertNotIn(qek._unwrap_kjt_for_cpu, default_call_targets)
+        self.assertNotIn(qek._unwrap_kjt_for_cpu_fx, default_call_targets)
+
+        graph_module = torch.fx.symbolic_trace(_CpuKJTUnwrapModule(use_fx_helper=True))
+
+        cpu_unwrap_nodes = [
+            node
+            for node in graph_module.graph.nodes
+            if node.op == "call_function" and node.target is qek._unwrap_kjt_for_cpu_fx
+        ]
+        self.assertEqual(len(cpu_unwrap_nodes), 1)
+
+        fake_mode = torch._subclasses.FakeTensorMode(allow_non_fake_inputs=True)
+        fake_values = fake_mode.from_tensor(torch.tensor([1, 2], dtype=torch.int64))
+        fake_offsets = fake_mode.from_tensor(torch.tensor([0, 2], dtype=torch.int32))
+        features = KeyedJaggedTensor(
+            keys=["feature"],
+            values=fake_values,
+            offsets=fake_offsets,
+        )
+
+        values, offsets, weights = graph_module(features)
+
+        self.assertIsInstance(values, torch._subclasses.FakeTensor)
+        self.assertIsInstance(offsets, torch._subclasses.FakeTensor)
+        self.assertEqual(values.dtype, torch.int64)
+        self.assertEqual(offsets.dtype, torch.int64)
+        self.assertIsNone(weights)
+
+    def test_cpu_kjt_fx_fused_param_is_internal_to_torchrec(self) -> None:
+        fused_params: Dict[str, Any] = {
+            FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING: True,
+            "output_dtype": object(),
+        }
+
+        self.assertTrue(is_fused_param_use_cpu_kjt_for_fx_tracing(fused_params))
+        self.assertFalse(is_fused_param_use_cpu_kjt_for_fx_tracing({}))
+        filtered_params = tbe_fused_params(fused_params)
+        self.assertIsNotNone(filtered_params)
+        self.assertNotIn(FUSED_PARAM_USE_CPU_KJT_FOR_FX_TRACING, filtered_params)
+        self.assertIn("output_dtype", filtered_params)
 
 
 class QuantBatchedEmbeddingBagDeviceRoTest(unittest.TestCase):
@@ -27,12 +95,58 @@ class QuantBatchedEmbeddingBagDeviceRoTest(unittest.TestCase):
         *,
         is_device_ro: bool,
         lengths_to_tbe: bool = False,
+        runtime_device: str = "cuda",
+        use_cpu_kjt_for_fx_tracing: bool = False,
     ) -> qek.QuantBatchedEmbeddingBag:
         bag = qek.QuantBatchedEmbeddingBag.__new__(qek.QuantBatchedEmbeddingBag)
-        bag._runtime_device = torch.device("cuda")
+        bag._runtime_device = torch.device(runtime_device)
         bag.lengths_to_tbe = lengths_to_tbe
         bag._is_device_ro = is_device_ro
+        bag._use_cpu_kjt_for_fx_tracing = use_cpu_kjt_for_fx_tracing
+        bag._config = MagicMock(is_weighted=False)
         return bag
+
+    def test_cpu_forward_uses_unwrapped_helper_by_default(self) -> None:
+        bag = self._make_bag(is_device_ro=False, runtime_device="cpu")
+        output = torch.tensor([1.0])
+        indices = torch.tensor([1])
+        offsets = torch.tensor([0, 1])
+        bag._emb_module_forward = MagicMock(return_value=output)
+        features = cast(KeyedJaggedTensor, object())
+
+        with patch.object(
+            qek, "_unwrap_kjt_for_cpu", return_value=(indices, offsets, None)
+        ) as mock_unwrapped, patch.object(
+            qek, "_unwrap_kjt_for_cpu_fx", return_value=(indices, offsets, None)
+        ) as mock_fx_wrapped:
+            result = bag.forward(features)
+
+        self.assertIs(result, output)
+        mock_unwrapped.assert_called_once_with(features, False)
+        mock_fx_wrapped.assert_not_called()
+
+    def test_cpu_forward_uses_fx_helper_when_enabled(self) -> None:
+        bag = self._make_bag(
+            is_device_ro=False,
+            runtime_device="cpu",
+            use_cpu_kjt_for_fx_tracing=True,
+        )
+        output = torch.tensor([1.0])
+        indices = torch.tensor([1])
+        offsets = torch.tensor([0, 1])
+        bag._emb_module_forward = MagicMock(return_value=output)
+        features = cast(KeyedJaggedTensor, object())
+
+        with patch.object(
+            qek, "_unwrap_kjt_for_cpu", return_value=(indices, offsets, None)
+        ) as mock_unwrapped, patch.object(
+            qek, "_unwrap_kjt_for_cpu_fx", return_value=(indices, offsets, None)
+        ) as mock_fx_wrapped:
+            result = bag.forward(features)
+
+        self.assertIs(result, output)
+        mock_fx_wrapped.assert_called_once_with(features, False)
+        mock_unwrapped.assert_not_called()
 
     def test_forward_uses_ro_unwrap_for_cuda_devicero(self) -> None:
         bag = self._make_bag(is_device_ro=True)


### PR DESCRIPTION
Summary:

TorchRec CPU quantized embedding modules normally trace through `_unwrap_kjt_for_cpu`, producing tensor-level FX operations. TGIF CPU-only sharding needs an opaque function node so its split rules can identify the embedding boundary, but applying `torch.fx.wrap` to the existing helper would change FX graphs for every CPU consumer.

Add a separate `_unwrap_kjt_for_cpu_fx` leaf helper and an internal fused parameter that selects it when constructing quantized embedding kernels. The parameter defaults to disabled and is stripped before fused parameters reach FBGEMM. Existing TorchRec CPU tracing therefore continues to use `_unwrap_kjt_for_cpu`; GPU tracing and eager execution are unchanged.

TGIF creates opt-in sharder variants only when `patch_runtime_device_for_tracing=True`, contributes the new helper as the `remote` boundary, and keeps the existing default sharder objects and serialized configuration behavior. The invalid runtime `torch.fx.wrap()` call and duplicate warmup remain removed.

Differential Revision: D117255372


