### PR TITLE
Fix backward occupancy cliff and bucket short runs by dimension (#4612)

### DIFF
--- a/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
+++ b/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
@@ -814,11 +814,13 @@ def triton_tbe_backward_short_run_unweighted(
     STOCHASTIC_ROUNDING: tl.constexpr,
     stochastic_rounding_seed,
     vbe: tl.constexpr = False,
-    BUFFER_SIZE: tl.constexpr = 8,
+    BUFFER_SIZE: tl.constexpr = 2,
 ) -> None:
     """Backward kernel for short runs only. Each program handles one short run."""
     col_offsets = tl.arange(0, BLOCK_SIZE)
-    # Gather width, tuned per target in TbeBackwardConfig.
+    # Gather width, tuned per target in TbeBackwardConfig. Each buffered row
+    # keeps BLOCK_SIZE 64-bit addresses live, so it trades memory-level
+    # parallelism against register footprint and hence occupancy.
     buffer_size: tl.constexpr = BUFFER_SIZE
     buffer_offsets = tl.arange(0, buffer_size)
 
@@ -1006,7 +1008,7 @@ def triton_tbe_backward_short_run_weighted(
     STOCHASTIC_ROUNDING: tl.constexpr,
     stochastic_rounding_seed,
     vbe: tl.constexpr = False,
-    BUFFER_SIZE: tl.constexpr = 16,
+    BUFFER_SIZE: tl.constexpr = 4,
 ) -> None:
     """Backward kernel for short runs only (weighted). Each program handles one short run."""
     col_offsets = tl.arange(0, BLOCK_SIZE)
@@ -1547,6 +1549,9 @@ class TritonTBE(torch.autograd.Function):
         saved_histogram_plans: Tuple[_SavedHistogramPlan, ...] = (),
         bounds_check_warning: Optional[torch.Tensor] = None,
         fused_bounds_check: bool = False,
+        bwd_bucket_block_sizes: Tuple[int, ...] = (),
+        bwd_feature_bucket_id: Optional[torch.Tensor] = None,
+        bwd_bucket_rows: Tuple[int, ...] = (),
     ) -> torch.Tensor:
         # VBE support: use pre-computed metadata if available, otherwise compute
         vbe = batch_size_per_feature_per_rank is not None
@@ -1725,6 +1730,9 @@ class TritonTBE(torch.autograd.Function):
         ctx.info_B_mask = info_B_mask
         ctx.hoist_transpose_to_forward = hoist_transpose_to_forward
         ctx.saved_histogram_plans = active_saved_histogram_plans
+        ctx.bwd_bucket_block_sizes = bwd_bucket_block_sizes
+        ctx.bwd_feature_bucket_id = bwd_feature_bucket_id
+        ctx.bwd_bucket_rows = bwd_bucket_rows
 
         if hoist_transpose_to_forward:
             # Hoist the backward index transpose (linearize + sort + run-length
@@ -2176,6 +2184,40 @@ class TritonTBE(torch.autograd.Function):
         )
         long_apply_grid_size = max_long_runs
 
+        # Per-dimension bucketing: only worth splitting when the tables actually
+        # span more than one BLOCK_SIZE, and only on the portable CUDA path
+        # (the AMD tier has its own expansion helper).
+        bucket_block_sizes: Tuple[int, ...] = getattr(ctx, "bwd_bucket_block_sizes", ())
+        feature_bucket_id = getattr(ctx, "bwd_feature_bucket_id", None)
+        bucket_rows: Tuple[int, ...] = getattr(ctx, "bwd_bucket_rows", ())
+        use_dim_buckets = (
+            cfg.enable_dim_bucketing
+            and not is_amd()
+            and len(bucket_block_sizes) > 1
+            and feature_bucket_id is not None
+            # The histogram tier strips leading features and rebases
+            # feature_table_map, which would misalign the per-feature bucket ids.
+            and num_valid_histograms == 0
+        )
+        if use_dim_buckets:
+            bucket_caps = [min(r, max_num_runs) for r in bucket_rows]
+            bucket_bases = [0] * len(bucket_caps)
+            running = 0
+            for b, cap in enumerate(bucket_caps):
+                bucket_bases[b] = running
+                running += cap
+            short_run_capacity = running
+            bucket_base_t = torch.tensor(
+                bucket_bases, dtype=torch.int64, device=weight.device
+            )
+            num_buckets = len(bucket_caps)
+        else:
+            bucket_caps = [max_num_runs]
+            bucket_bases = [0]
+            short_run_capacity = max_num_runs
+            bucket_base_t = None
+            num_buckets = 1
+
         if is_amd():
             (
                 short_run_ids,
@@ -2209,6 +2251,12 @@ class TritonTBE(torch.autograd.Function):
                 sorted_linear_indices_num_runs,
                 max_num_runs,
                 max_sl_per_program=cfg.long_run_threshold,
+                infos_sorted=infos_sorted,
+                feature_bucket_id=feature_bucket_id,
+                bucket_base=bucket_base_t,
+                short_run_capacity=short_run_capacity,
+                num_buckets=num_buckets,
+                info_B_num_bits=info_B_num_bits,
             )
 
         temp_grad_buffer = torch.zeros(
@@ -2228,39 +2276,53 @@ class TritonTBE(torch.autograd.Function):
                 if _use_amd
                 else triton_tbe_backward_short_run_weighted
             )
-            bwd_short_w[(short_run_grid_size,)](
-                dout,
-                weight,
-                infos_sorted,
-                sorted_linear_indices_run,
-                sorted_linear_indices_cumulative_run_lengths,
-                short_run_ids,
-                table_offsets,
-                embedding_dims,
-                embedding_offsets,
-                feature_table_map,
-                hash_size_cumsum,
-                momentum,
-                rows_cumsum,
-                sorted_per_sample_weights,
-                num_short_runs_t,
-                vbe_row_output_offsets,
-                vbe_B_offsets,
-                total_embedding_dim,
-                B,
-                learning_rate,
-                eps,
-                OPTIM_TYPE_TO_INT[optimizer],
-                BLOCK_SIZE=block_size,
-                info_B_num_bits=info_B_num_bits,
-                info_B_mask=info_B_mask,
-                num_warps=num_warps,
-                USE_CLC=use_clc,
-                STOCHASTIC_ROUNDING=stochastic_rounding,
-                stochastic_rounding_seed=stochastic_rounding_seed,
-                vbe=vbe,
-                BUFFER_SIZE=cfg.short_run_buffer_size_weighted,
-            )
+            for _b, _bucket_bs in enumerate(
+                bucket_block_sizes if use_dim_buckets else (block_size,)
+            ):
+                _bucket_run_ids = (
+                    short_run_ids[bucket_bases[_b] :]
+                    if use_dim_buckets
+                    else short_run_ids
+                )
+                _bucket_num_short = (
+                    num_short_runs_t[_b : _b + 1]
+                    if use_dim_buckets
+                    else num_short_runs_t
+                )
+                _bucket_grid = min(short_run_grid_size, max(bucket_caps[_b], 1))
+                bwd_short_w[(_bucket_grid,)](
+                    dout,
+                    weight,
+                    infos_sorted,
+                    sorted_linear_indices_run,
+                    sorted_linear_indices_cumulative_run_lengths,
+                    _bucket_run_ids,
+                    table_offsets,
+                    embedding_dims,
+                    embedding_offsets,
+                    feature_table_map,
+                    hash_size_cumsum,
+                    momentum,
+                    rows_cumsum,
+                    sorted_per_sample_weights,
+                    _bucket_num_short,
+                    vbe_row_output_offsets,
+                    vbe_B_offsets,
+                    total_embedding_dim,
+                    B,
+                    learning_rate,
+                    eps,
+                    OPTIM_TYPE_TO_INT[optimizer],
+                    BLOCK_SIZE=_bucket_bs,
+                    info_B_num_bits=info_B_num_bits,
+                    info_B_mask=info_B_mask,
+                    num_warps=num_warps,
+                    USE_CLC=use_clc,
+                    STOCHASTIC_ROUNDING=stochastic_rounding,
+                    stochastic_rounding_seed=stochastic_rounding_seed,
+                    vbe=vbe,
+                    BUFFER_SIZE=cfg.short_run_buffer_size_weighted,
+                )
             use_fused_clc_long_run = (
                 use_clc
                 and max_num_runs > cfg.long_run_fused_programs * cfg.long_run_threshold
@@ -2375,38 +2437,52 @@ class TritonTBE(torch.autograd.Function):
                 if _use_amd
                 else triton_tbe_backward_short_run_unweighted
             )
-            bwd_short_uw[(short_run_grid_size,)](
-                dout,
-                weight,
-                infos_sorted,
-                sorted_linear_indices_run,
-                sorted_linear_indices_cumulative_run_lengths,
-                short_run_ids,
-                table_offsets,
-                embedding_dims,
-                embedding_offsets,
-                feature_table_map,
-                hash_size_cumsum,
-                momentum,
-                rows_cumsum,
-                num_short_runs_t,
-                vbe_row_output_offsets,
-                vbe_B_offsets,
-                total_embedding_dim,
-                B,
-                learning_rate,
-                eps,
-                OPTIM_TYPE_TO_INT[optimizer],
-                BLOCK_SIZE=block_size,
-                info_B_num_bits=info_B_num_bits,
-                info_B_mask=info_B_mask,
-                num_warps=num_warps,
-                USE_CLC=use_clc,
-                STOCHASTIC_ROUNDING=stochastic_rounding,
-                stochastic_rounding_seed=stochastic_rounding_seed,
-                vbe=vbe,
-                BUFFER_SIZE=cfg.short_run_buffer_size_unweighted,
-            )
+            for _b, _bucket_bs in enumerate(
+                bucket_block_sizes if use_dim_buckets else (block_size,)
+            ):
+                _bucket_run_ids = (
+                    short_run_ids[bucket_bases[_b] :]
+                    if use_dim_buckets
+                    else short_run_ids
+                )
+                _bucket_num_short = (
+                    num_short_runs_t[_b : _b + 1]
+                    if use_dim_buckets
+                    else num_short_runs_t
+                )
+                _bucket_grid = min(short_run_grid_size, max(bucket_caps[_b], 1))
+                bwd_short_uw[(_bucket_grid,)](
+                    dout,
+                    weight,
+                    infos_sorted,
+                    sorted_linear_indices_run,
+                    sorted_linear_indices_cumulative_run_lengths,
+                    _bucket_run_ids,
+                    table_offsets,
+                    embedding_dims,
+                    embedding_offsets,
+                    feature_table_map,
+                    hash_size_cumsum,
+                    momentum,
+                    rows_cumsum,
+                    _bucket_num_short,
+                    vbe_row_output_offsets,
+                    vbe_B_offsets,
+                    total_embedding_dim,
+                    B,
+                    learning_rate,
+                    eps,
+                    OPTIM_TYPE_TO_INT[optimizer],
+                    BLOCK_SIZE=_bucket_bs,
+                    info_B_num_bits=info_B_num_bits,
+                    info_B_mask=info_B_mask,
+                    num_warps=num_warps,
+                    USE_CLC=use_clc,
+                    STOCHASTIC_ROUNDING=stochastic_rounding,
+                    stochastic_rounding_seed=stochastic_rounding_seed,
+                    vbe=vbe,
+                    BUFFER_SIZE=cfg.short_run_buffer_size_unweighted,
+                )
             use_fused_clc_long_run = (
                 use_clc
                 and max_num_runs > cfg.long_run_fused_programs * cfg.long_run_threshold
@@ -2611,6 +2687,30 @@ class TritonTableBatchedEmbeddingBags(torch.nn.Module):
         self._max_D = self.max_embedding_dim
 
         self.block_size = triton.next_power_of_2(self.max_embedding_dim)
+
+        # Per-dimension launch buckets for the short-run backward tier.
+        # BLOCK_SIZE is a constexpr, so a single launch has to pad every row to
+        # next_pow2(max_D over all tables). When dims are mixed that wastes
+        # lanes and registers on the narrow tables, which are often the ones
+        # carrying most of the lookups. Routing runs to a bucket per
+        # next_pow2(D) lets each launch size BLOCK_SIZE to its own rows.
+        # Floored at one warp: a BLOCK_SIZE below 32 would idle lanes instead of
+        # saving anything.
+        feature_block_sizes = [max(32, triton.next_power_of_2(d)) for d in feature_dims]
+        bucket_sizes: List[int] = sorted(set(feature_block_sizes))
+        bucket_index: Dict[int, int] = {bs: i for i, bs in enumerate(bucket_sizes)}
+        self._bwd_bucket_block_sizes: Tuple[int, ...] = tuple(bucket_sizes)
+        self._bwd_feature_bucket_id: torch.Tensor = torch.tensor(
+            [bucket_index[bs] for bs in feature_block_sizes],
+            dtype=torch.int32,
+            device=device,
+        )
+        # A run is one distinct row, so a table contributes at most its row
+        # count to its bucket. Used to size each bucket's slice of short_run_ids.
+        bucket_rows: List[int] = [0] * len(bucket_sizes)
+        for rows, dim in embedding_specs:
+            bucket_rows[bucket_index[max(32, triton.next_power_of_2(dim))]] += rows
+        self._bwd_bucket_rows: Tuple[int, ...] = tuple(bucket_rows)
         total_weight_size = sum(table_sizes)
         self.weight = torch.empty(
             [total_weight_size],
@@ -2939,6 +3039,9 @@ class TritonTableBatchedEmbeddingBags(torch.nn.Module):
             self._saved_histogram_plans,
             self.bounds_check_warning,
             use_fused_bounds_check,
+            self._bwd_bucket_block_sizes,
+            self._bwd_feature_bucket_id,
+            self._bwd_bucket_rows,
         )
 
     def split_embedding_weights(self) -> List[torch.Tensor]:

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
@@ -54,34 +54,49 @@ class TbeBackwardConfig:
 
     num_warps: int
 
+    # Split the short-run tier into one launch per next_pow2(D) bucket so each
+    # launch sizes BLOCK_SIZE to its own rows instead of the global max.
+    # Portable: plain Triton, no hardware feature needed.
+    enable_dim_bucketing: bool
+
     # Cluster Launch Control: Blackwell-only work stealing. Purely additive on
     # top of the portable path; also requires TLX to be importable.
     allow_clc: bool
 
 
-# Blackwell (B200 / GB200). Grid matches the value the CLC path already used.
+# Blackwell (B200 / GB200). Measured on GB200 (triton-beta) against the
+# heavy-table-sharing GEM-v6 shape. The short-run grid saturates at 32x the base
+# grid -- 0.97x CUDA TBE on the portable path, 1.01x with CLC layered on -- and
+# the buffer sizes sit at a true interior optimum: narrower starves memory-level
+# parallelism, wider spills occupancy (width 8 costs 184 registers/thread and
+# 12.5% occupancy, versus 64 and 49.9% at width 2).
 _BLACKWELL = TbeBackwardConfig(
     name="blackwell",
     short_run_programs=32 * _CUDA_BASE_GRID,
     long_run_fused_programs=32 * _CUDA_BASE_GRID,
     long_run_accum_programs=_CUDA_BASE_GRID,
     long_run_threshold=256,
-    short_run_buffer_size_unweighted=8,
-    short_run_buffer_size_weighted=16,
+    short_run_buffer_size_unweighted=2,
+    short_run_buffer_size_weighted=4,
     num_warps=1,
+    enable_dim_bucketing=True,
     allow_clc=True,
 )
 
-# Hopper (H100). UNTUNED: retains the historical grid.
+# Hopper (H100). UNTUNED: retains the historical grid. The Blackwell sweep found
+# the base grid badly undersized for large run counts (1.66x slower than 32x on
+# the portable path), so `short_run_programs` is the most likely win from a
+# tuning pass here.
 _HOPPER = TbeBackwardConfig(
     name="hopper",
     short_run_programs=_CUDA_BASE_GRID,
     long_run_fused_programs=_CUDA_BASE_GRID,
     long_run_accum_programs=_CUDA_BASE_GRID,
     long_run_threshold=256,
-    short_run_buffer_size_unweighted=8,
-    short_run_buffer_size_weighted=16,
+    short_run_buffer_size_unweighted=2,
+    short_run_buffer_size_weighted=4,
     num_warps=1,
+    enable_dim_bucketing=True,
     allow_clc=False,
 )
 
@@ -92,9 +107,10 @@ _MI300X = TbeBackwardConfig(
     long_run_fused_programs=_AMD_BASE_GRID,
     long_run_accum_programs=_AMD_BASE_GRID,
     long_run_threshold=256,
-    short_run_buffer_size_unweighted=8,
-    short_run_buffer_size_weighted=16,
+    short_run_buffer_size_unweighted=2,
+    short_run_buffer_size_weighted=4,
     num_warps=1,
+    enable_dim_bucketing=True,
     allow_clc=False,
 )
 
@@ -105,9 +121,10 @@ _MI350X = TbeBackwardConfig(
     long_run_fused_programs=_AMD_BASE_GRID,
     long_run_accum_programs=_AMD_BASE_GRID,
     long_run_threshold=256,
-    short_run_buffer_size_unweighted=8,
-    short_run_buffer_size_weighted=16,
+    short_run_buffer_size_unweighted=2,
+    short_run_buffer_size_weighted=4,
     num_warps=1,
+    enable_dim_bucketing=True,
     allow_clc=False,
 )
 
@@ -118,9 +135,10 @@ _PORTABLE_DEFAULT = TbeBackwardConfig(
     long_run_fused_programs=_CUDA_BASE_GRID,
     long_run_accum_programs=_CUDA_BASE_GRID,
     long_run_threshold=256,
-    short_run_buffer_size_unweighted=8,
-    short_run_buffer_size_weighted=16,
+    short_run_buffer_size_unweighted=2,
+    short_run_buffer_size_weighted=4,
     num_warps=1,
+    enable_dim_bucketing=True,
     allow_clc=False,
 )
 

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_utils.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 import triton  # @manual
@@ -75,12 +75,22 @@ def _classify_runs_kernel(
     num_short_ptr,
     long_run_ids_ptr,
     num_long_ptr,
+    infos_sorted_ptr,
+    feature_bucket_id_ptr,
+    bucket_base_ptr,
+    info_B_num_bits,
     threshold: tl.constexpr,
     CLASSIFY_BLOCK: tl.constexpr,
+    NUM_BUCKETS: tl.constexpr = 1,
 ) -> None:
     """
     Classify runs as short or long and compact into output arrays.
     Uses atomic counters for sync-free stream compaction.
+
+    With NUM_BUCKETS > 1 the short runs are additionally split by the embedding
+    dimension bucket of their feature, so each bucket can be launched with a
+    BLOCK_SIZE that matches its rows instead of the global max. Bucket b's ids
+    live at short_run_ids[bucket_base[b] : bucket_base[b] + num_short[b]].
     """
     pid = tl.program_id(0)
     num_runs = tl.load(num_runs_ptr)
@@ -95,20 +105,31 @@ def _classify_runs_kernel(
     is_long = (run_len >= threshold) & mask
     is_short = (~is_long) & mask
 
-    num_short_block = tl.sum(is_short.to(tl.int32))
     num_long_block = tl.sum(is_long.to(tl.int32))
-
-    short_base = tl.atomic_add(num_short_ptr, num_short_block)
     long_base = tl.atomic_add(num_long_ptr, num_long_block)
-
-    short_local = tl.cumsum(is_short.to(tl.int32), axis=0) - 1
     long_local = tl.cumsum(is_long.to(tl.int32), axis=0) - 1
-
-    short_pos = (short_base + short_local).to(tl.int64)
-    tl.store(short_run_ids_ptr + short_pos, offsets.to(tl.int32), mask=is_short)
-
     long_pos = (long_base + long_local).to(tl.int64)
     tl.store(long_run_ids_ptr + long_pos, offsets.to(tl.int32), mask=is_long)
+
+    if NUM_BUCKETS == 1:
+        num_short_block = tl.sum(is_short.to(tl.int32))
+        short_base = tl.atomic_add(num_short_ptr, num_short_block)
+        short_local = tl.cumsum(is_short.to(tl.int32), axis=0) - 1
+        short_pos = (short_base + short_local).to(tl.int64)
+        tl.store(short_run_ids_ptr + short_pos, offsets.to(tl.int32), mask=is_short)
+    else:
+        # A run maps to exactly one feature, so one info load per run resolves
+        # its dimension bucket.
+        info = tl.load(infos_sorted_ptr + cum_start, mask=mask, other=0).to(tl.uint32)
+        t = (info >> info_B_num_bits).to(tl.int32)
+        bucket_id = tl.load(feature_bucket_id_ptr + t, mask=mask, other=0)
+        for b in tl.static_range(NUM_BUCKETS):
+            sel = is_short & (bucket_id == b)
+            cnt = tl.sum(sel.to(tl.int32))
+            base = tl.atomic_add(num_short_ptr + b, cnt)
+            local = tl.cumsum(sel.to(tl.int32), axis=0) - 1
+            pos = (tl.load(bucket_base_ptr + b) + base + local).to(tl.int64)
+            tl.store(short_run_ids_ptr + pos, offsets.to(tl.int32), mask=sel)
 
 
 @triton.jit
@@ -158,9 +179,15 @@ def _expand_long_runs(
     sorted_linear_indices_num_runs: torch.Tensor,
     max_num_runs: int,
     max_sl_per_program: int = _LONG_RUN_THRESHOLD,
+    infos_sorted: Optional[torch.Tensor] = None,
+    feature_bucket_id: Optional[torch.Tensor] = None,
+    bucket_base: Optional[torch.Tensor] = None,
+    short_run_capacity: Optional[int] = None,
+    num_buckets: int = 1,
+    info_B_num_bits: int = 0,
 ) -> Tuple[
     torch.Tensor,  # short_run_ids
-    torch.Tensor,  # num_short_runs (1-element GPU int32 tensor)
+    torch.Tensor,  # num_short_runs (num_buckets-element GPU int64 tensor)
     torch.Tensor,  # (unused)
     torch.Tensor,  # long_run_program_seg_starts
     torch.Tensor,  # long_run_program_seg_ends
@@ -181,8 +208,12 @@ def _expand_long_runs(
     max_long_run_programs = 2 * max_num_runs // max_sl_per_program + 1
 
     # Allocate output tensors
-    short_run_ids = torch.empty(max_num_runs, dtype=torch.int32, device=device)
-    num_short_runs_t = torch.zeros(1, dtype=torch.int64, device=device)
+    short_run_ids = torch.empty(
+        short_run_capacity if short_run_capacity is not None else max_num_runs,
+        dtype=torch.int32,
+        device=device,
+    )
+    num_short_runs_t = torch.zeros(num_buckets, dtype=torch.int64, device=device)
 
     long_run_original_ids = torch.empty(max_long_runs, dtype=torch.int32, device=device)
     num_long_runs_t = torch.zeros(1, dtype=torch.int64, device=device)
@@ -197,8 +228,13 @@ def _expand_long_runs(
         num_short_runs_t,
         long_run_original_ids,
         num_long_runs_t,
+        infos_sorted,
+        feature_bucket_id,
+        bucket_base,
+        info_B_num_bits,
         threshold=max_sl_per_program,
         CLASSIFY_BLOCK=CLASSIFY_BLOCK,
+        NUM_BUCKETS=num_buckets,
     )
 
     # Allocate expansion output tensors


### PR DESCRIPTION
Summary:

Two kernel changes to the Triton TBE short-run backward tier that together take it from 0.40x to 1.05x CUDA TBE on the heavy-table-sharing shape. Sits on top of the per-hardware config diff, which is pure plumbing.

- **Occupancy cliff**: each buffered gather row keeps `BLOCK_SIZE` 64-bit addresses live, so at `BLOCK_SIZE=256` the unweighted kernel needed 184 registers/thread and the weighted one 204. That pins residency at 8 warps/SM (12.5% occupancy) on kernels that are entirely gather-latency-bound. Narrowing the gather width to 2 (unweighted) and 4 (weighted) gives 64 registers/thread and 49.9% occupancy.
- **No reuse is lost**: short runs are short by construction (`SL < long_run_threshold`), and heavy table-sharing shapes sit near `SL~7`, so the wide gather loop never executed there anyway. The width is a true interior optimum -- 1 starves memory-level parallelism (38.75ms), 2 is best (35.51ms), 4 and 8 pay it back in occupancy (38.03ms, 89.58ms).
- **Per-dimension bucketing**: `BLOCK_SIZE` is a constexpr, so one launch had to pad every row to `next_pow2(max_D)` across all tables -- 256 here, while the table carrying 80% of lookups has D=64. Short runs are now routed during classification into one bucket per `next_pow2(D)` (floored at one warp) and each bucket launches with its own `BLOCK_SIZE`.
- **Bucketing mechanism, measured**: ncu shows registers and occupancy *unchanged* across buckets (62-64 regs, ~49.8%), so the gain is reduced lane waste, not occupancy. Register pressure is dominated by int64 pointer arithmetic and scalar metadata rather than the accumulator.
- **Bucketing is auto-disabled** when the histogram tier is active (it strips leading features and rebases `feature_table_map`, which would misalign per-feature bucket ids), on AMD, and when all tables share one bucket.

Authored with Claude.

Reviewed By: axeisghost

Differential Revision: D117217526


