### PR TITLE
Place zero-perf shards by free HBM in GreedyPerfPartitioner (#4613)

### DIFF
--- a/torchrec/distributed/planner/partitioners.py
+++ b/torchrec/distributed/planner/partitioners.py
@@ -24,6 +24,7 @@ from torchrec.distributed.planner.types import (
     PerfModel,
     PlannerError,
     PlannerErrorType,
+    Shard,
     ShardingOption,
     Storage,
     Topology,
@@ -32,6 +33,9 @@ from torchrec.distributed.planner.utils import (
     bytes_to_gb,
     mb_to_bytes,
     reset_shard_rank,
+)
+from torchrec.distributed.planner.zero_perf_shard_placement import (
+    should_place_zero_perf_shards_by_storage,
 )
 from torchrec.distributed.types import ShardingType
 
@@ -78,6 +82,12 @@ def _apply_shards_assignment(
     for sharding_option, assignment in zip(sharding_options, assignment_per_option):
         for shard_id, rank in enumerate(assignment):
             sharding_option.shards[shard_id].rank = rank
+
+
+def _place_shard_on_device(shard: Shard, device: DeviceHardware) -> None:
+    shard.rank = device.rank
+    device.storage -= cast(Storage, shard.storage)
+    device.perf += cast(Perf, shard.perf)
 
 
 @dataclass
@@ -173,6 +183,39 @@ class OrderedDeviceHardware:
         )
 
 
+def _place_zero_perf_shard_by_free_hbm(
+    shard: Shard,
+    sharding_option: ShardingOption,
+    minheap_devices: List[OrderedDeviceHardware],
+) -> None:
+    storage = cast(Storage, shard.storage)
+    available_devices = [
+        ordered_device
+        for ordered_device in minheap_devices
+        if storage.fits_in(ordered_device.device.storage)
+    ]
+    if not available_devices:
+        raise PlannerError(
+            error_type=PlannerErrorType.PARTITION,
+            message=(
+                f"Device partition failed. Couldn't find a rank for zero-perf shard {shard} "
+                f"of table {sharding_option.name}, largest device storage: "
+                f"{max(ordered_device.device.storage for ordered_device in minheap_devices)}"
+            ),
+        )
+    _place_shard_on_device(
+        shard,
+        max(
+            available_devices,
+            key=lambda ordered_device: (
+                ordered_device.device.storage.hbm,
+                -(ordered_device.device.rank % ordered_device.local_world_size),
+                -ordered_device.device.rank,
+            ),
+        ).device,
+    )
+
+
 class GreedyPerfPartitioner(Partitioner):
     """Greedy Partitioner.
 
@@ -185,7 +228,9 @@ class GreedyPerfPartitioner(Partitioner):
     """
 
     def __init__(
-        self, sort_by: SortBy = SortBy.STORAGE, balance_modules: bool = False
+        self,
+        sort_by: SortBy = SortBy.STORAGE,
+        balance_modules: bool = False,
     ) -> None:
         self._sort_by = sort_by
         self._balance_modules = balance_modules
@@ -403,9 +448,7 @@ class GreedyPerfPartitioner(Partitioner):
 
                 if storage.fits_in(device.storage):
                     # Successfully place the shard
-                    shard.rank = device.rank
-                    device.storage -= storage
-                    device.perf += cast(Perf, shard.perf)
+                    _place_shard_on_device(shard, device)
                     used_ranks.add(device.rank)
                     found_device = True
                     break
@@ -431,15 +474,22 @@ class GreedyPerfPartitioner(Partitioner):
     ) -> None:
         pushlimit = len(minheap_devices) * bulk_heapify_threshold
         for shard in sharding_option.shards:
+            if (
+                not cast(Perf, shard.perf).total
+                and cast(Storage, shard.storage).hbm
+                and should_place_zero_perf_shards_by_storage()
+            ):
+                _place_zero_perf_shard_by_free_hbm(
+                    shard, sharding_option, minheap_devices
+                )
+                continue
             tmp_heap = []
             while minheap_devices:
                 ordered_device = minheap_devices[0]
                 device = ordered_device.device
                 storage = cast(Storage, shard.storage)
                 if storage.fits_in(device.storage):
-                    shard.rank = device.rank
-                    device.storage -= cast(Storage, shard.storage)
-                    device.perf += cast(Perf, shard.perf)
+                    _place_shard_on_device(shard, device)
                     heapq.heapreplace(minheap_devices, ordered_device)
                     break
                 else:

--- a/torchrec/distributed/planner/tests/test_partitioners.py
+++ b/torchrec/distributed/planner/tests/test_partitioners.py
@@ -9,7 +9,7 @@
 
 import unittest
 from typing import cast, List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pyre_extensions import none_throws
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
@@ -36,6 +36,10 @@ from torchrec.distributed.planner.utils import reset_shard_rank
 from torchrec.distributed.test_utils.test_model import TestSparseNN
 from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+_GATE = (
+    "torchrec.distributed.planner.partitioners.should_place_zero_perf_shards_by_storage"
+)
 
 
 class RWSharder(EmbeddingBagCollectionSharder):
@@ -240,7 +244,9 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
             )
 
             GreedyPerfPartitioner._device_partition(
-                sharding_option, minheap_devices, threshold
+                sharding_option,
+                minheap_devices,
+                threshold,
             )
 
             want_minheap_devices = GreedyPerfPartitioner._establish_minheap(
@@ -250,6 +256,110 @@ class TestGreedyPerfPartitioner(unittest.TestCase):
 
         validate(0)  # force heapify
         validate(1)  # force incremental rebuild
+
+    @staticmethod
+    def _single_shard_option(storage: Storage, perf: Perf) -> ShardingOption:
+        return ShardingOption(
+            name=MagicMock(),
+            tensor=MagicMock(),
+            module=MagicMock(),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=MagicMock(),
+            partition_by=MagicMock(),
+            compute_kernel=MagicMock(),
+            shards=[Shard(storage=storage, perf=perf, size=[], offset=[])],
+        )
+
+    @staticmethod
+    def _partition_zero_perf_shards(
+        starting_storage: List[Storage],
+        shard_storage: Storage,
+        num_shards: int,
+        should_place_by_storage: bool,
+    ) -> List[Storage]:
+        zero_perf = Perf(fwd_compute=0, fwd_comms=0, bwd_compute=0, bwd_comms=0)
+        devices = [
+            DeviceHardware(
+                rank=rank,
+                storage=storage,
+                perf=Perf(fwd_compute=rank, fwd_comms=0, bwd_compute=0, bwd_comms=0),
+            )
+            for rank, storage in enumerate(starting_storage)
+        ]
+        minheap_devices = GreedyPerfPartitioner._establish_minheap(devices, 2)
+        with patch(_GATE, return_value=should_place_by_storage):
+            for _ in range(num_shards):
+                GreedyPerfPartitioner._device_partition(
+                    TestGreedyPerfPartitioner._single_shard_option(
+                        shard_storage, zero_perf
+                    ),
+                    minheap_devices,
+                )
+
+        return [device.storage for device in devices]
+
+    def test_zero_perf_shards_are_spread_across_devices(self) -> None:
+        starting_hbm = [1_000_000, 900_000, 800_000, 700_000]
+        remaining = self._partition_zero_perf_shards(
+            [Storage(hbm=hbm, ddr=0) for hbm in starting_hbm],
+            Storage(hbm=100_000, ddr=0),
+            6,
+            should_place_by_storage=True,
+        )
+        self.assertEqual([storage.hbm for storage in remaining], [700_000] * 4)
+
+    def test_zero_perf_shards_with_no_hbm_are_left_on_the_perf_minimum_device(
+        self,
+    ) -> None:
+        starting_ddr = [1_000_000, 900_000, 800_000, 700_000]
+        remaining = self._partition_zero_perf_shards(
+            [Storage(hbm=0, ddr=ddr) for ddr in starting_ddr],
+            Storage(hbm=0, ddr=100_000),
+            6,
+            should_place_by_storage=True,
+        )
+        self.assertEqual(
+            [storage.ddr for storage in remaining],
+            [400_000, 900_000, 800_000, 700_000],
+        )
+
+    def test_zero_perf_shards_stack_on_one_device_when_gated_off(self) -> None:
+        starting_hbm = [1_000_000, 900_000, 800_000, 700_000]
+        remaining = self._partition_zero_perf_shards(
+            [Storage(hbm=hbm, ddr=0) for hbm in starting_hbm],
+            Storage(hbm=100_000, ddr=0),
+            6,
+            should_place_by_storage=False,
+        )
+        self.assertEqual(
+            [storage.hbm for storage in remaining],
+            [400_000, 900_000, 800_000, 700_000],
+        )
+
+    def test_nonzero_perf_shard_still_goes_to_the_perf_minimum_device(self) -> None:
+        devices = [
+            DeviceHardware(
+                rank=rank,
+                storage=Storage(hbm=(4 - rank) * 1_000_000, ddr=0),
+                perf=Perf(
+                    fwd_compute=4 - rank, fwd_comms=0, bwd_compute=0, bwd_comms=0
+                ),
+            )
+            for rank in range(4)
+        ]
+        sharding_option = self._single_shard_option(
+            Storage(hbm=1000, ddr=0),
+            Perf(fwd_compute=1, fwd_comms=0, bwd_compute=0, bwd_comms=0),
+        )
+
+        with patch(_GATE, return_value=True):
+            GreedyPerfPartitioner._device_partition(
+                sharding_option,
+                GreedyPerfPartitioner._establish_minheap(devices, 2),
+            )
+
+        self.assertEqual(sharding_option.shards[0].rank, 3)
 
     def test_tw_unbalanced_perf_device(self) -> None:
         sharding_options = self.enumerator.enumerate(

--- a/torchrec/distributed/planner/zero_perf_shard_placement.py
+++ b/torchrec/distributed/planner/zero_perf_shard_placement.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+def should_place_zero_perf_shards_by_storage() -> bool:
+    return True


### PR DESCRIPTION
Summary:

Today, the partitioner will dump all 0 `perf` shards onto a single rank, which needlessly increases peak memory and tends to harm `perf` balance by filling up a rank before it can take its share of live shards.

Instead,
* Inside `GreedyPerfPartitioner`, place HBM shards with 0 `perf` onto the rank with the least HBM utilization.
* Put this behind a gate so we can run an experiment (Meta-only. For OSS external users this is enabled by default.)

Differential Revision: D116860939


