### PR TITLE
Emit KJT_TENSORS_DIST so the tensors AlltoAll has an owning module in traces

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -920,10 +920,19 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         self._contexts = contexts
         self._awaitables: List[
             Union[KJTSplitsAllToAllMeta, Awaitable[Awaitable[KeyedJaggedTensor]]]
-        ] = [awaitable for request in requests for awaitable in request.awaitables]
-        self._output_lengths: List[int] = [
-            len(request.awaitables) for request in requests
-        ]
+        ] = []
+        self._output_lengths: List[int] = []
+        self._annotation_labels: List[Tuple[Optional[str], Optional[str]]] = []
+        for request in requests:
+            self._output_lengths.append(len(request.awaitables))
+            for i, awaitable in enumerate(request.awaitables):
+                self._awaitables.append(awaitable)
+                self._annotation_labels.append(
+                    (
+                        request._module_fqn,
+                        request._sharding_types[i] if request._sharding_types else None,
+                    )
+                )
         self._lengths: List[int] = [
             (
                 len(awaitable.splits_tensors)
@@ -1018,7 +1027,9 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         else:
             splits_per_awaitable = [[] for _ in range(len(self._lengths))]
         tensors_awaitables = []
-        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+        for idx, (splits, awaitable) in enumerate(
+            zip(splits_per_awaitable, self._awaitables)
+        ):
             if not splits:  # NoWait
                 assert isinstance(awaitable, Awaitable)
                 tensors_awaitables.append(awaitable.wait())
@@ -1042,21 +1053,27 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                     keys=awaitable.keys,
                 )
 
-            tensors_awaitables.append(
-                KJTAllToAllTensorsAwaitable(
-                    pg=awaitable.pg,
-                    input=awaitable._input,
-                    splits=awaitable.splits,
-                    input_splits=awaitable.input_splits,
-                    output_splits=output_splits,
-                    input_tensors=awaitable.input_tensors,
-                    labels=awaitable.labels,
-                    keys=awaitable.keys,
-                    device=awaitable.device,
-                    stagger=awaitable.stagger,
-                    stride_per_rank=stride_per_rank,
+            # The constructor issues the AlltoAll, so the annotation wraps it rather
+            # than a later `.wait()`.
+            module_fqn, sharding_type = self._annotation_labels[idx]
+            with maybe_annotate_embedding_event(
+                EmbeddingEvent.KJT_TENSORS_DIST, module_fqn, sharding_type
+            ):
+                tensors_awaitables.append(
+                    KJTAllToAllTensorsAwaitable(
+                        pg=awaitable.pg,
+                        input=awaitable._input,
+                        splits=awaitable.splits,
+                        input_splits=awaitable.input_splits,
+                        output_splits=output_splits,
+                        input_tensors=awaitable.input_tensors,
+                        labels=awaitable.labels,
+                        keys=awaitable.keys,
+                        device=awaitable.device,
+                        stagger=awaitable.stagger,
+                        stride_per_rank=stride_per_rank,
+                    )
                 )
-            )
         output = []
         awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
         for awaitables, ctx in zip(awaitables_per_output, self._contexts):

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import contextlib
 import itertools
 import random
 import unittest
@@ -22,12 +23,13 @@ from typing import (
     TypeVar,
     Union,
 )
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import hypothesis.strategies as st
 import torch
 import torch.distributed as dist
 import torchrec.distributed.collective_utils as cu
+import torchrec.distributed.embedding_sharding as embedding_sharding
 from hypothesis import given, settings
 from pyre_extensions import none_throws
 from torchrec.distributed._collective_tag import _collective_tag_from
@@ -58,7 +60,12 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
-from torchrec.distributed.types import Awaitable, NullShardingContext
+from torchrec.distributed.types import (
+    Awaitable,
+    EmbeddingEvent,
+    NoWait,
+    NullShardingContext,
+)
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
@@ -2440,3 +2447,127 @@ class CheckPgForNcclErrorTest(unittest.TestCase):
 
         self.assertIsNone(_check_pg_for_nccl_error(pg))
         pg._get_backend.assert_called_once()
+
+
+class FusedKJTListSplitsAwaitableAnnotationTest(unittest.TestCase):
+    def _meta(self, label: str) -> KJTSplitsAllToAllMeta:
+        kjt = KeyedJaggedTensor(
+            keys=["f0"],
+            values=torch.tensor([1, 2], dtype=torch.int64),
+            lengths=torch.tensor([1, 1], dtype=torch.int64),
+        )
+        return KJTSplitsAllToAllMeta(
+            pg=None,  # pyre-ignore[6] - not dispatched in this test
+            _input=kjt,
+            splits=[1],
+            splits_tensors=[torch.tensor([1], dtype=torch.int64)],
+            input_splits=[[1]],
+            input_tensors=[kjt.lengths()],
+            labels=[label],
+            keys=["f0"],
+            device=torch.device("cpu"),
+            stagger=1,
+        )
+
+    def _request(
+        self,
+        fqn: Optional[str],
+        sharding_types: Optional[List[str]],
+        nowait_first: bool = False,
+    ) -> KJTListSplitsAwaitable[NullShardingContext]:
+        count = len(sharding_types) if sharding_types else 1
+        entries: List[object] = [self._meta(f"t{i}") for i in range(count)]
+        if nowait_first:
+            entries[0] = NoWait("nowait")
+        return KJTListSplitsAwaitable(
+            awaitables=cast(
+                List[Awaitable[Awaitable[KeyedJaggedTensor]]],
+                entries,
+            ),
+            ctx=NullShardingContext(),
+            module_fqn=fqn,
+            sharding_types=sharding_types,
+        )
+
+    def _fuse(
+        self, *requests: KJTListSplitsAwaitable[NullShardingContext]
+    ) -> FusedKJTListSplitsAwaitable:
+        return FusedKJTListSplitsAwaitable(
+            requests=list(requests), contexts=[r.ctx for r in requests], pg=None
+        )
+
+    def test_labels_align_with_flattened_awaitables(self) -> None:
+        fused = self._fuse(
+            self._request("mod_a", ["row_wise", "table_row_wise"]),
+            self._request("mod_b", ["data_parallel"]),
+        )
+        self.assertEqual(len(fused._annotation_labels), len(fused._awaitables))
+        self.assertEqual(
+            fused._annotation_labels,
+            [
+                ("mod_a", "row_wise"),
+                ("mod_a", "table_row_wise"),
+                ("mod_b", "data_parallel"),
+            ],
+        )
+
+    def test_unlabelled_request_yields_none_so_annotation_is_skipped(self) -> None:
+        fused = self._fuse(self._request(None, None))
+        self.assertEqual(fused._annotation_labels, [(None, None)])
+
+    def test_module_fqn_without_sharding_types_still_skips_annotation(self) -> None:
+        self.assertEqual(
+            self._fuse(self._request("mod_a", None))._annotation_labels,
+            [("mod_a", None)],
+        )
+        self.assertEqual(
+            self._fuse(self._request(None, ["row_wise"]))._annotation_labels,
+            [(None, "row_wise")],
+        )
+
+    def test_no_requests(self) -> None:
+        self.assertEqual(self._fuse()._annotation_labels, [])
+
+    def test_wait_impl_annotates_each_awaitable_with_its_own_label(self) -> None:
+        fused = self._fuse(
+            self._request("mod_a", ["row_wise", "table_row_wise"], nowait_first=True),
+            self._request("mod_b", ["data_parallel"]),
+        )
+        # `pg=None` leaves this unset, so `_wait_impl` would take the no-splits path.
+        splits_awaitable = MagicMock()
+        splits_awaitable.wait.return_value = [[4], [4]]
+        fused._splits_awaitable = splits_awaitable
+
+        # Recording enter/construct/exit rather than just call args is what pins the
+        # AlltoAll as being *inside* the annotation; asserting on arguments alone still
+        # passes if the `with` is dropped.
+        events: List[Tuple[object, ...]] = []
+
+        @contextlib.contextmanager
+        def fake_annotate(
+            event: EmbeddingEvent, fqn: Optional[str], sharding_type: Optional[str]
+        ) -> Generator[None, None, None]:
+            events.append(("enter", event, fqn, sharding_type))
+            yield
+            events.append(("exit",))
+
+        with patch.object(
+            embedding_sharding,
+            "KJTAllToAllTensorsAwaitable",
+            side_effect=lambda **kwargs: events.append(("construct",)),
+        ), patch.object(
+            embedding_sharding, "maybe_annotate_embedding_event", fake_annotate
+        ):
+            fused._wait_impl()
+
+        self.assertEqual(
+            events,
+            [
+                ("enter", EmbeddingEvent.KJT_TENSORS_DIST, "mod_a", "table_row_wise"),
+                ("construct",),
+                ("exit",),
+                ("enter", EmbeddingEvent.KJT_TENSORS_DIST, "mod_b", "data_parallel"),
+                ("construct",),
+                ("exit",),
+            ],
+        )


### PR DESCRIPTION
Summary:
`EmbeddingEvent.KJT_TENSORS_DIST` has been declared in `distributed/types.py` since the
enum was introduced but has **zero call sites** anywhere in torchrec. Every other member
is emitted:

| EmbeddingEvent | emitted? |
|---|---|
| `KJT_SPLITS_DIST` | yes |
| `LOOKUP` | yes |
| `OUTPUT_DIST` | yes |
| `OUTPUT_DIST_WAIT` | yes |
| **`KJT_TENSORS_DIST`** | **no** |

As a result the tensors AlltoAll — the payload transfer of input dist — has no owning
module in a profile **on the fused path**. In a trace it shows up as a bare
`## all2all_data:kjt values ##` / `## all2all_data:kjt lengths ##` scope, so its cost
cannot be attributed to the module whose features it is redistributing.

Scope, precisely: on the *non-fused* path this a2a is already attributed, because
`KJTListSplitsAwaitable._wait_impl` wraps `w.wait()` in `OUTPUT_DIST_WAIT` with the
module, and that `.wait()` is where `KJTAllToAllTensorsAwaitable` is constructed. The gap
this diff closes is the fused path — the one training pipelines use.

## Why the label is missing

`KJTListSplitsAwaitable` is given `module_fqn` and `sharding_types` and already uses them
to annotate `KJT_SPLITS_DIST` and `OUTPUT_DIST_WAIT`. Fusing is what loses them:
`FusedKJTListSplitsAwaitable.__init__` flattens every request's awaitables into a single
list so one fused splits AlltoAll can be issued —

```python
self._awaitables = [awaitable for request in requests for awaitable in request.awaitables]
```

— and by the time `_wait_impl` constructs each `KJTAllToAllTensorsAwaitable`, the mapping
back to a module is gone.

## The change

Append to `_awaitables` and to a new `_annotation_labels` in the same loop, so each
`(module_fqn, sharding_type)` is produced next to the awaitable it describes, and wrap
the `KJTAllToAllTensorsAwaitable` construction in
`maybe_annotate_embedding_event(EmbeddingEvent.KJT_TENSORS_DIST, ...)`.

The two lists are still parallel — building them in lockstep makes that visible at the
point of construction rather than guaranteeing it, so the correspondence is also asserted
by test.

The annotation wraps the **constructor**, not a later `.wait()`, because
`KJTAllToAllTensorsAwaitable.__init__` is what issues the AlltoAll (inside
`record_function(f"## all2all_data:kjt {label} ##")`).

## Cost

`maybe_annotate_embedding_event` returns a `nullcontext()` unless both `module_fqn` and
`sharding_type` are set, so the OSS path and any caller that does not pass them is
behaviourally unchanged. Where they are set this adds one `record_function` per
(module, sharding type) per input dist — the same per-iteration cost as the
`KJT_SPLITS_DIST` annotation immediately upstream.

## Notes for follow-ups (not changed here)

`[tensors_dist]_*` is not in `TORCHREC_ANNOTATIONS` in
`torchrec/fb/analysis/component_gpu_usage_analysis.py` (notebook N8888986), so that
analyzer ignores the new label; its numbers are unchanged by this diff. Whoever adds it
should note these spans nest strictly inside `## wait_sparse_data_dist ##`, which is
already mapped to `INPUT_DIST`, so adding `[tensors_dist]_*` to the same component
double-counts those kernels unless the aggregation accounts for nesting.


`KJTListSplitsAwaitable._wait_impl`, the non-fused path for this same step, annotates
with `EmbeddingEvent.OUTPUT_DIST_WAIT` even though it is the *input* dist path. This is
a mislabel with a live consequence: the analyzer above puts `OUTPUT_DIST_WAIT` in its
`OUTPUT_DIST` component, so input-dist cost from that path is currently reported as
output dist.

It is out of scope here because it cannot be a rename. Consumers match on the
`[output_dist_wait]_*` string, so the annotation and the analyzer have to change
together, and that analyzer change meets the same nesting caveat as above.

Reviewed By: kausv

Differential Revision: D116816588


