### PR TITLE
Isolate throughput state in ZORM comms

### DIFF
--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -7,11 +7,13 @@
 
 # pyre-strict
 import logging
-from typing import Any, cast, Dict
+from typing import Any, cast, Dict, Optional, Union
 
+import torch.distributed as dist
 from torch import nn
+from torch.distributed.tensor import DeviceMesh
 from torch.profiler import record_function
-from torchrec.metrics.metric_module import RecMetricModule
+from torchrec.metrics.metric_module import PreComputeStates, RecMetricModule
 from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
 from torchrec.metrics.rec_metric import (
     RecComputeMode,
@@ -59,6 +61,15 @@ class CPUCommsRecMetricModule(RecMetricModule):
             for computation in metric._metrics_computations:
                 computation = cast(RecMetricComputation, computation)
                 computation._to_sync = False
+
+    # Throughput is already isolated in MetricStateSnapshot.
+    def get_pre_compute_states(
+        self, pg: Optional[Union[dist.ProcessGroup, DeviceMesh]] = None
+    ) -> PreComputeStates:
+        return self._get_rec_metric_states(pg)
+
+    def load_pre_compute_states(self, source: PreComputeStates) -> None:
+        self._load_rec_metric_states(source)
 
     def load_local_metric_state_snapshot(
         self, state_snapshot: MetricStateSnapshot

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -170,6 +170,8 @@ MODEL_METRIC_LABEL: str = "model"
 
 
 MetricValue = Union[torch.Tensor, float]
+MetricState = Union[torch.Tensor, List[torch.Tensor]]
+PreComputeStates = Dict[str, Dict[str, Dict[str, MetricState]]]
 MetricsResult = Dict[str, MetricValue]
 # pyrefly: ignore[implicit-import]
 MetricsFuture = concurrent.futures.Future[MetricsResult]
@@ -546,9 +548,37 @@ class RecMetricModule(nn.Module):
 
         return result
 
+    def _get_rec_metric_states(
+        self, pg: Optional[Union[dist.ProcessGroup, DeviceMesh]] = None
+    ) -> PreComputeStates:
+        pg = pg if pg is not None else dist.group.WORLD
+        process_group: dist.ProcessGroup = (
+            # pyrefly: ignore[bad-assignment]
+            pg.get_group(mesh_dim="shard")
+            if isinstance(pg, DeviceMesh)
+            else pg
+        )
+
+        aggregated_states: PreComputeStates = {}
+        world_size = dist.get_world_size(
+            process_group
+        )  # Under 2D parallel context, this should be sharding world size
+
+        for metric in self.rec_metrics.rec_metrics:
+            #  `value`.
+            # pyrefly: ignore[missing-attribute]
+            aggregated_states[metric._namespace.value] = self._get_metric_states(
+                # pyrefly: ignore[bad-argument-type]
+                metric,
+                world_size,
+                process_group,
+            )
+
+        return aggregated_states
+
     def get_pre_compute_states(
         self, pg: Optional[Union[dist.ProcessGroup, DeviceMesh]] = None
-    ) -> Dict[str, Dict[str, Dict[str, Union[torch.Tensor, List[torch.Tensor]]]]]:
+    ) -> PreComputeStates:
         """
         This function returns the states per rank for each metric to be saved. The states are are aggregated by the state defined reduction_function.
         This can be optionall disabled by setting ``reduce_metrics`` to False. The output on each rank is identical.
@@ -568,28 +598,7 @@ class RecMetricModule(nn.Module):
         Returns:
             Dict[str, Dict[str, Dict[str, torch.Tensor]]]: the states for each metric to be saved
         """
-        pg = pg if pg is not None else dist.group.WORLD
-        process_group: dist.ProcessGroup = (
-            # pyrefly: ignore[bad-assignment]
-            pg.get_group(mesh_dim="shard")
-            if isinstance(pg, DeviceMesh)
-            else pg
-        )
-
-        aggregated_states = {}
-        world_size = dist.get_world_size(
-            process_group
-        )  # Under 2D parallel context, this should be sharding world size
-
-        for metric in self.rec_metrics.rec_metrics:
-            #  `value`.
-            # pyrefly: ignore[missing-attribute]
-            aggregated_states[metric._namespace.value] = self._get_metric_states(
-                # pyrefly: ignore[bad-argument-type]
-                metric,
-                world_size,
-                process_group,
-            )
+        aggregated_states = self._get_rec_metric_states(pg)
 
         # throughput metric requires special handling, since it's not a RecMetric
         throughput_metric = self.throughput_metric
@@ -602,22 +611,7 @@ class RecMetricModule(nn.Module):
 
         return aggregated_states
 
-    def load_pre_compute_states(
-        self,
-        source: Dict[
-            str, Dict[str, Dict[str, Union[torch.Tensor, List[torch.Tensor]]]]
-        ],
-    ) -> None:
-        """
-        Load states from ``get_pre_compute_states``. This is called on every rank, no collectives are called in this function.
-
-        Args:
-            source (Dict[str, Dict[str, Union[torch.Tensor, List[torch.Tensor]]]]): the source states to load from. This
-                is the output of ``get_pre_compute_states``.
-
-        Returns:
-            None
-        """
+    def _load_rec_metric_states(self, source: PreComputeStates) -> None:
         for metric in self.rec_metrics.rec_metrics:
             #  `value`.
             # pyrefly: ignore[missing-attribute]
@@ -635,6 +629,18 @@ class RecMetricModule(nn.Module):
                 state = states[task.name]
                 for attr, tensor in state.items():
                     setattr(metric_computation, attr, tensor)
+
+    def load_pre_compute_states(self, source: PreComputeStates) -> None:
+        """
+        Load states from ``get_pre_compute_states``. This is called on every rank, no collectives are called in this function.
+
+        Args:
+            source (PreComputeStates): the source states to load from. This is the output of ``get_pre_compute_states``.
+
+        Returns:
+            None
+        """
+        self._load_rec_metric_states(source)
 
         if self.throughput_metric is not None:
             # pyrefly: ignore[bad-index]

--- a/torchrec/metrics/tests/test_cpu_comms_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_comms_metric_module.py
@@ -9,13 +9,15 @@
 
 import unittest
 from collections import defaultdict
-from typing import cast, DefaultDict, List
+from typing import Any, cast, DefaultDict, List
+from unittest.mock import MagicMock, patch
 
 import torch
 from torchrec.metrics.auc import _state_reduction
 from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
 from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
 from torchrec.metrics.metrics_config import BatchSizeStage
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace
 from torchrec.metrics.ne import NEMetric, NEMetricComputation
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
 from torchrec.metrics.test_utils import gen_test_tasks
@@ -25,7 +27,13 @@ from torchrec.metrics.test_utils.mock_metrics import (
     create_tensor_states,
     MockRecMetric,
 )
+from torchrec.metrics.throughput import ThroughputMetric
 from torchrec.metrics.tower_qps import TowerQPSMetric
+
+
+class _QPSThroughputMetric(ThroughputMetric):
+    _namespace = MetricNamespace.TOWER_QPS
+    _metric_name = MetricName.TOWER_QPS
 
 
 class CPUCommsRecMetricModuleTest(unittest.TestCase):
@@ -466,6 +474,62 @@ class CPUCommsRecMetricModuleTest(unittest.TestCase):
         assert_tensor_dict_equals(
             metric.get_computation_states(),
             ne_states,
+        )
+
+    def test_qps_namespace_and_name_collision_preserves_states(self) -> None:
+        tasks = gen_test_tasks(["qps", "task2", "task3", "task4"])
+        tower_qps = TowerQPSMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=self.batch_size,
+            tasks=tasks,
+            compute_mode=RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION,
+        )
+        expected_warmup_examples = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+        source_computation = cast(Any, tower_qps._metrics_computations[0])
+        source_computation.warmup_examples = expected_warmup_examples
+        throughput_metric = _QPSThroughputMetric(
+            batch_size=self.batch_size,
+            world_size=1,
+            window_seconds=100,
+        )
+        throughput_metric.get_buffer("warmup_examples").fill_(100)
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=1,
+            rec_tasks=tasks,
+            rec_metrics=RecMetricList([tower_qps]),
+            throughput_metric=throughput_metric,
+        )
+        cpu_comms_module.load_local_metric_state_snapshot(
+            MetricStateSnapshot.from_metrics(
+                RecMetricList([tower_qps]), throughput_metric
+            )
+        )
+
+        with patch(
+            "torchrec.metrics.metric_module.dist.get_world_size", return_value=1
+        ), patch(
+            "torchrec.metrics.metric_module._all_gather_tensor",
+            side_effect=lambda tensor, *_: [tensor],
+        ):
+            states = cpu_comms_module.get_pre_compute_states(MagicMock())
+        cpu_comms_module.load_pre_compute_states(states)
+
+        restored_tower_qps = cast(
+            TowerQPSMetric, cpu_comms_module.rec_metrics.rec_metrics[0]
+        )
+        computation = cast(Any, restored_tower_qps._metrics_computations[0])
+        torch.testing.assert_close(
+            computation.warmup_examples,
+            expected_warmup_examples,
+        )
+        restored_throughput_metric = cpu_comms_module.throughput_metric
+        self.assertIsNotNone(restored_throughput_metric)
+        assert restored_throughput_metric is not None
+        torch.testing.assert_close(
+            restored_throughput_metric.get_buffer("warmup_examples"),
+            torch.tensor(100, dtype=torch.long),
         )
 
 


### PR DESCRIPTION
Summary: Keep throughput state separate from RecMetric aggregation in the CPU-offloaded compute path. This prevents overlapping metric keys from replacing RecMetric state while preserving the existing RecMetricModule API.

Differential Revision: D117398915


