### PR TITLE
Plumb the HBM lane knobs through torchrec (#4621)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -145,6 +145,9 @@ RES_NUM_CONSUMERS_STR = "res_num_consumers"
 RES_NUM_UVM_HIT_COPY_THREADS_STR = "res_num_uvm_hit_copy_threads"
 RES_NUM_HBM_COPY_THREADS_STR = "res_num_hbm_copy_threads"
 ENABLE_RAW_EMBEDDING_STREAMING_STR = "enable_raw_embedding_streaming"
+ENABLE_HBM_STREAMING_STR = "enable_hbm_streaming"
+RES_HBM_DRAIN_INTERVAL_STR = "res_hbm_drain_interval"
+RES_USE_COPY_DONE_TOKEN_STR = "res_use_copy_done_token"
 
 
 class ReduceScatterResizeAwaitable(LazyAwaitable[torch.Tensor]):
@@ -244,6 +247,15 @@ def _populate_res_params(config: GroupedEmbeddingConfig) -> Tuple[bool, RESParam
             ENABLE_RAW_EMBEDDING_STREAMING_STR
         )
 
+    enable_hbm_streaming = fused_params.pop(ENABLE_HBM_STREAMING_STR, None)
+    if enable_hbm_streaming is not None:
+        res_params.enable_hbm_streaming = enable_hbm_streaming
+    res_hbm_drain_interval = fused_params.pop(RES_HBM_DRAIN_INTERVAL_STR, None)
+    if res_hbm_drain_interval is not None:
+        res_params.res_hbm_drain_interval = res_hbm_drain_interval
+    res_use_copy_done_token = fused_params.pop(RES_USE_COPY_DONE_TOKEN_STR, None)
+    if res_use_copy_done_token is not None:
+        res_params.res_use_copy_done_token = res_use_copy_done_token
     if (
         enable_raw_embedding_streaming is None
         or enable_raw_embedding_streaming is False

--- a/torchrec/distributed/tests/test_populate_res_params.py
+++ b/torchrec/distributed/tests/test_populate_res_params.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, Dict, List, Optional
+
+from torchrec.distributed.batched_embedding_kernel import _populate_res_params
+from torchrec.distributed.embedding_types import (
+    EmbeddingComputeKernel,
+    GroupedEmbeddingConfig,
+    ShardedEmbeddingTable,
+)
+from torchrec.modules.embedding_configs import DataType, PoolingType
+
+
+class PopulateResParamsTest(unittest.TestCase):
+    """`_populate_res_params` reads RES knobs out of `fused_params`.
+
+    Whatever it leaves behind is splatted into
+    `SplitTableBatchedEmbeddingBagsCodegen.__init__`, which takes no
+    `**kwargs`, so a key that is read but not removed is a TypeError on every
+    rank at construction -- not a bad value, a crash.
+    """
+
+    def _config(
+        self,
+        table_names: List[str],
+        fused_params: Optional[Dict[str, Any]] = None,
+    ) -> GroupedEmbeddingConfig:
+        return GroupedEmbeddingConfig(
+            data_type=DataType.FP32,
+            pooling=PoolingType.NONE,
+            is_weighted=False,
+            has_feature_processor=False,
+            compute_kernel=EmbeddingComputeKernel.FUSED,
+            embedding_tables=[
+                ShardedEmbeddingTable(
+                    name=name,
+                    data_type=DataType.FP32,
+                    pooling=PoolingType.NONE,
+                    has_feature_processor=False,
+                    feature_names=[f"feature_{i}"],
+                    compute_kernel=EmbeddingComputeKernel.FUSED,
+                    embedding_dim=16,
+                    num_embeddings=64,
+                )
+                for i, name in enumerate(table_names)
+            ],
+            fused_params=fused_params,
+        )
+
+    _HBM_KNOBS: Dict[str, Any] = {
+        "enable_hbm_streaming": True,
+        "res_hbm_drain_interval": 200,
+        "res_use_copy_done_token": True,
+    }
+
+    def test_hbm_knobs_reach_res_params(self) -> None:
+        fused_params: Dict[str, Any] = {
+            "enable_raw_embedding_streaming": True,
+            "res_enabled_tables": "t0",
+            **self._HBM_KNOBS,
+        }
+        enable_res, res_params = _populate_res_params(
+            self._config(["t0"], fused_params)
+        )
+        self.assertTrue(enable_res)
+        self.assertTrue(res_params.enable_hbm_streaming)
+        self.assertEqual(res_params.res_hbm_drain_interval, 200)
+        self.assertTrue(res_params.res_use_copy_done_token)
+
+    def test_knobs_are_removed_even_when_res_is_disabled(self) -> None:
+        # The crash case, and the reason this test exists. Both early returns
+        # in `_populate_res_params` are reachable on a live model: streaming
+        # off entirely, and streaming on for a TBE group holding none of the
+        # allowlisted tables. Tables are NOT grouped by RES enablement, so on a
+        # model allowlisting one table every other group takes the second
+        # return. A knob read after those returns stays in the dict and
+        # reaches the TBE constructor.
+        for name, fused_params in (
+            (
+                "streaming off",
+                {"enable_raw_embedding_streaming": False, **self._HBM_KNOBS},
+            ),
+            (
+                "no allowlisted table in this group",
+                {
+                    "enable_raw_embedding_streaming": True,
+                    "res_enabled_tables": "elsewhere",
+                    **self._HBM_KNOBS,
+                },
+            ),
+        ):
+            with self.subTest(name):
+                enable_res, _ = _populate_res_params(self._config(["t0"], fused_params))
+                self.assertFalse(enable_res)
+                for key in self._HBM_KNOBS:
+                    self.assertNotIn(key, fused_params)
+
+    def test_absent_knobs_leave_the_defaults(self) -> None:
+        # Absent and present-but-None are the same case: keep whatever fbgemm
+        # defaults to. Asserted against the dataclass rather than literals so
+        # this does not pin fbgemm's chosen defaults.
+        from fbgemm_gpu.split_table_batched_embeddings_ops_training import RESParams
+
+        defaults = RESParams()
+        for name, extra in (
+            ("absent", {}),
+            (
+                "present but None",
+                dict.fromkeys(self._HBM_KNOBS),
+            ),
+        ):
+            with self.subTest(name):
+                _, res_params = _populate_res_params(
+                    self._config(
+                        ["t0"],
+                        {
+                            "enable_raw_embedding_streaming": True,
+                            "res_enabled_tables": "t0",
+                            **extra,
+                        },
+                    )
+                )
+                self.assertEqual(
+                    res_params.enable_hbm_streaming, defaults.enable_hbm_streaming
+                )
+                self.assertEqual(
+                    res_params.res_hbm_drain_interval,
+                    defaults.res_hbm_drain_interval,
+                )
+                self.assertEqual(
+                    res_params.res_use_copy_done_token,
+                    defaults.res_use_copy_done_token,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

torchrec half of the HBM lane knobs:  `_populate_res_params` reads `enable_hbm_streaming`, `res_hbm_drain_interval`  and `res_use_copy_done_token` off `fused_params` onto `RESParams`, and pops them. MVAI half is the diff above.

Reviewed By: chouxi

Differential Revision: D117243554
