### PR TITLE
Record plan-persistence failures on the session (#4623)

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2923,6 +2923,41 @@ class PlannerSessionContext:
     # Empty when persistence is disabled or upload failed; observability only, so
     # the caller/CLI can surface where the run's artifacts live.
     content_urls: Dict[str, str] = field(default_factory=dict)
+    # Plan-persistence failures recorded this session, keyed by operation (e.g.
+    # "plan_upload:<sku>", "planner_debug:<key>") -> "<ExcType>: <message>".
+    # Typed counterpart to the free-text `warnings` entries the same failures also
+    # produce: a detector can key off the presence of an entry here instead of
+    # substring-matching a warning string. Observability only.
+    plan_persist_failures: Dict[str, str] = field(default_factory=dict)
+
+    def record_plan_persist_failure(self, operation: str, exc: BaseException) -> None:
+        """Note that persisting the sharding plan (or its debug bundle) failed.
+
+        These uploads are best-effort, so their call sites swallow the exception
+        and the run continues without the artifact. That makes an outage look
+        exactly like "there was nothing to upload". This records the failure both
+        as a session warning (via ``record_external_failure``, so anything already
+        reading ``warnings`` keeps working) and as typed state, which is what the
+        planner_runs row turns into a clean ``plan_persist_failed`` boolean.
+
+        Observability only, and itself best-effort: never raises, so a failure to
+        record a failure cannot escalate into a planning failure.
+        """
+        # Two independent guards, typed entry first. Independent so neither signal can
+        # suppress the other; typed first because the alertable ``plan_persist_failed``
+        # column is derived from ``plan_persist_failures``, so it must survive even if
+        # ``record_external_failure`` raises (otherwise the flag would stay 0 despite a
+        # real failure). Each uses ``except BaseException`` because ``exc`` is a
+        # ``BaseException`` (e.g. a ``__str__`` that raises a non-``Exception``) and
+        # recording a failure must never escalate into a planning failure.
+        try:
+            self.plan_persist_failures[operation] = f"{type(exc).__name__}: {exc}"
+        except BaseException:  # noqa: B036 -- best-effort: must never propagate
+            pass
+        try:
+            self.record_external_failure("manifold", operation, exc)
+        except BaseException:  # noqa: B036 -- best-effort: must never propagate
+            pass
 
     def record_external_failure(
         self, system: str, operation: str, exc: BaseException


### PR DESCRIPTION
Summary:

The two Manifold writes that persist a sharding plan are best-effort: they
swallow the exception and the run continues without the artifact. That makes an
outage look exactly like "there was nothing to upload" -- which is how a ~45h
`sharding_analysis` write-ACL outage silently dropped plans for 144+ jobs with
nothing queryable to alert on.

D116050403 already built the mechanism for this (`record_external_failure` ->
`session_warnings` -> `torchrec_planner_runs`) and wired it into the reproduction
blobs, the plan-cache read, XDB and the runtime-env lookups. It did not cover the
two paths that actually failed. This diff closes that gap and makes the signal
alertable.

- `PlannerSessionContext.record_plan_persist_failure` (`types.py`): records a
  plan-persistence failure. It wraps `record_external_failure`, so the failure
  still lands in `session_warnings` exactly as before -- nothing already reading
  that channel regresses -- and additionally keeps it as typed state in the new
  `plan_persist_failures` dict. Never raises.
- `stats.py`: `manifold_upload_sharding_plan` takes an optional `session_ctx` and
  `sku` and records in its `except BaseException` before returning the `""`
  sentinel. `ManifoldStats` already held `self._session_ctx` and `self._sku`, so
  the call site just passes them through.
- `utils.py`: `log_planner_data_to_manifold` takes an optional `session_ctx` and
  records per key. Threaded from
  `LinearProgrammingPlanner._log_planner_data_to_manifold`.
- `planner_runs_logger.py`: emits `plan_persist_failed` (int 0/1) on EVERY row,
  plus `plan_persist_error` when non-zero. Emitting 0 rather than omitting the
  column matters: an absent column is ambiguous (it also means "this build
  predates the field"), so a static-threshold detector would have nothing to
  compare against. The companion string is truncated because a Manifold auth
  denial embeds the full identity set.

Best-effort semantics are unchanged throughout -- every new call site is guarded,
the recorder cannot raise, and no new exception can escape to fail a planning run.
All new parameters are optional and keyword-only at the call sites, so existing
callers are unaffected.

This is the durable, TorchRec-owned half of the alerting work: it puts the
failure in an unsampled dataset we own so a OneDetection static detector on
`torchrec_planner_runs` can page the torchrec oncall.

Reviewed By: hammad45

Differential Revision: D117548958


