### PR TITLE
[detailed][ops] Add benchmark_triton_ops for TBE bounds check and 2D permute

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_ops.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_ops.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Microbenchmarks for TorchRec's Triton ops, each against its fbgemm CUDA baseline.
+
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_triton_ops -- \
+        bounds_check_triton --name=$(hg whereami | cut -c 1-10)
+
+OSS (external):
+    python -m torchrec.distributed.benchmark.benchmark_triton_ops \
+        permute_2d_triton --name=$(git rev-parse --short HEAD || echo $USER)
+
+Every benchmark is single-rank and single-process: these are kernel microbenchmarks,
+so there is no MultiProcessContext and no collective.
+
+see README.md for more details
+"""
+
+import logging
+from dataclasses import dataclass, fields
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+import triton
+from torch.autograd.profiler import record_function
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import BoundsCheckMode
+except ImportError:
+    # Base layers predating the tbe.config leaf module still re-export it here.
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import BoundsCheckMode
+
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    cmd_conf,
+)
+from torchrec.distributed.triton_tbe.triton_table_batched_embeddings import (
+    _bounds_check_offsets_kernel,
+    _repair_offsets_kernel,
+)
+from torchrec.sparse.triton_permute_2d import (
+    MIN_SEGMENTS,
+    PERSEG_MIN_MEAN,
+    triton_permute_2d_sparse_data,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# permute_2D_sparse_data lives in sparse_ops. Importing triton_permute_2d does not pull
+# in jagged_tensor, which is where torchrec normally registers these, so load them here
+# the same guarded way. bounds_check_indices needs no equivalent: importing the Triton
+# TBE module imports fbgemm_gpu, which registers the TBE ops on package init.
+try:
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
+    torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops_cpu")
+except OSError:
+    pass
+
+# pyrefly: ignore[missing-argument]
+_cc = cmd_conf()
+
+# Mirrors the launch in TritonTableBatchedEmbeddingBags.forward. Both are part of what
+# is being measured, so they are pinned here rather than left to a default.
+_BOUNDS_CHECK_BLOCK_SIZE = 256
+_BOUNDS_CHECK_NUM_WARPS = 8
+
+# The module default is V2_WARNING, which _bounds_check_config() splits into the base
+# mode plus a version: the C++ op only accepts FATAL/WARNING/IGNORE, and V2 is selected
+# by the separate bounds_check_version argument.
+_BOUNDS_CHECK_MODE_WARNING: int = int(BoundsCheckMode.WARNING)
+_BOUNDS_CHECK_VERSION_V2 = 2
+
+
+#################################### util functions ####################################
+def _pick(numel: int, pct: int, device: torch.device) -> Optional[torch.Tensor]:
+    """Indices of ``pct`` percent of ``numel`` entries, or None when pct <= 0."""
+    if pct <= 0 or numel == 0:
+        return None
+    count = max(1, (numel * pct) // 100)
+    return torch.randperm(numel, device=device)[:count]
+
+
+################################# framework components #################################
+@dataclass
+class TritonOpConfig(BenchFuncConfig):
+    name: str = ""
+    world_size: int = 1
+    device_type: str = "cuda"
+    profile_dir: str = "."
+    num_benchmarks: int = 100
+    num_profiles: int = 10
+    seed: int = 42
+    debug_mode: bool = False
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        """Build everything the benchmark consumes.
+
+        Runs once per invocation, outside the timed region, so tensor allocation and
+        data generation never land in the measurement.
+        """
+        return {}
+
+
+# single-rank runner
+def single_rank_runner(
+    arg: TritonOpConfig,
+    bench_func: Callable[..., None],
+) -> None:
+    assert torch.cuda.is_available(), "these kernels require a CUDA device"
+
+    arg.set_log_level()
+
+    # debug mode only works with vscode for now.
+    if arg.debug_mode:
+        # pyrefly: ignore[missing-module-attribute]
+        from fbvscode import attach_debugger
+
+        attach_debugger()
+
+    # Same seed for every subcommand, so a Triton/CUDA pair sees identical input.
+    torch.manual_seed(arg.seed)
+    device = torch.device(arg.device_type)
+
+    # Config fields the concrete subclass added are forwarded to the benchmark, the
+    # same way benchmark_comms does; the tensors from make_inputs join them.
+    new_keys = {f.name for f in fields(type(arg))} - {
+        f.name for f in fields(TritonOpConfig)
+    }
+    kwargs: Dict[str, Any] = {k: getattr(arg, k) for k in new_keys}
+    kwargs |= arg.make_inputs(device)
+
+    func_name = getattr(bench_func, "__name__", arg.name)
+    name: str = f"{func_name}_{arg.name}" if arg.name else func_name
+
+    # Warm up outside the measurement: first call pays Triton JIT compilation.
+    bench_func([], **kwargs)
+
+    result = benchmark_func(
+        bench_inputs=[],
+        prof_inputs=[],
+        benchmark_func_kwargs=kwargs,
+        func_to_benchmark=bench_func,
+        rank=0,
+        # Input is empty, actual traffic is determined by the benchmark function
+        sample_count=0,
+        **arg.benchmark_func_kwargs(name=name),
+    )
+
+    print(result)
+
+
+def register_benchmark(
+    config: type[TritonOpConfig],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    Decorator factory: register a benchmark function with the CLI, bound to the
+    given config class. The decorated function is the per-iteration benchmark and
+    its name is the CLI subcommand. Define the config class first, then:
+
+    @register_benchmark(BoundsCheckTritonConfig)
+    def bounds_check_triton(_batch_inputs, offsets, ..., **_kwargs): ...
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable[..., None]:
+        def dispatch(arg: TritonOpConfig) -> None:
+            single_rank_runner(arg=arg, bench_func=func)
+
+        # CLI subcommand key = benchmark function name; the annotation must be the
+        # concrete config subclass so cmd_conf builds its argparse from its fields
+        dispatch.__name__ = func.__name__
+        dispatch.__annotations__ = {"arg": config, "return": None}
+        # pyrefly: ignore[missing-attribute]
+        _cc.register(dispatch)
+        return func
+
+    return decorator
+
+
+############################### TBE bounds check configs ###############################
+@dataclass
+class BoundsCheckConfig(TritonOpConfig):
+    """Shared input generation for both bounds-check backends.
+
+    Corrupt-input caveat: a bounds check in WARNING mode is a *repair* operation. Both
+    backends rewrite the offending entries on the first iteration, so with a non-zero
+    corruption percentage the remaining iterations measure already-clean data and the
+    reported cost understates the dirty path. Pass --num_benchmarks=1 for a true
+    dirty-path number.
+
+    The two corruption knobs are not interchangeable. bad_offsets_pct breaks the offsets
+    array and is the only one _bounds_check_offsets_kernel can see; oob_pct puts row ids
+    out of range, which only the CUDA op and the in-gather _load_checked_index check.
+    """
+
+    # Defaults follow the shape used by the Triton-vs-FBGEMM TBE benchmark so numbers
+    # are comparable against it.
+    num_tables: int = 32
+    batch_size: int = 131072
+    bag_size: int = 20
+    num_embeddings: int = 10_000_000
+    oob_pct: int = 0
+    bad_offsets_pct: int = 0
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        """Build (indices, offsets, rows_per_table, warning) in the TBE CSR layout.
+
+        ``offsets`` is feature-major with ``num_tables * batch_size + 1`` entries,
+        matching what TritonTableBatchedEmbeddingBags.forward receives from a KJT.
+        """
+        total_bags = self.num_tables * self.batch_size
+        lengths = torch.randint(
+            low=0,
+            high=2 * self.bag_size + 1,
+            size=(total_bags,),
+            dtype=torch.int64,
+            device=device,
+        )
+        offsets = torch.zeros(total_bags + 1, dtype=torch.int64, device=device)
+        torch.cumsum(lengths, 0, out=offsets[1:])
+        # Setup-time sync only; nothing in the timed region reads back to host.
+        num_indices = int(offsets[-1].item())
+
+        indices = torch.randint(
+            low=0,
+            high=self.num_embeddings,
+            size=(num_indices,),
+            dtype=torch.int64,
+            device=device,
+        )
+
+        oob = _pick(num_indices, self.oob_pct, device)
+        if oob is not None:
+            # Past the end of every table, so the row-id range test fires.
+            indices[oob] = self.num_embeddings + 1
+
+        bad = _pick(total_bags, self.bad_offsets_pct, device)
+        if bad is not None:
+            # Negative trips both `starts < 0` on this lane and `starts > ends` on the
+            # previous one, which is what the offsets kernel is looking for.
+            offsets[bad] = -1
+
+        logger.info(
+            "T=%d B=%d L=%d -> %d bags, %d indices",
+            self.num_tables,
+            self.batch_size,
+            self.bag_size,
+            total_bags,
+            num_indices,
+        )
+        return {
+            "indices": indices,
+            "offsets": offsets,
+            "rows_per_table": torch.full(
+                (self.num_tables,),
+                self.num_embeddings,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "warning": torch.zeros(1, dtype=torch.int64, device=device),
+            "num_indices": num_indices,
+            "total_bags": total_bags,
+        }
+
+
+@dataclass
+class BoundsCheckTritonConfig(BoundsCheckConfig):
+    """
+    run commands:
+    1. offsets kernel only (default)
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_triton \
+        --name=clean
+
+    2. include the repair kernel
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_triton \
+        --name=repair \
+        --include_repair=True
+
+    3. dirty offsets, one iteration (see the caveat on BoundsCheckConfig)
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_triton \
+        --name=dirty \
+        --bad_offsets_pct=5 --num_benchmarks=1
+
+    use case:
+        time _bounds_check_offsets_kernel on its own. The kernels are launched directly
+        rather than through TritonTableBatchedEmbeddingBags, for two reasons: the module
+        would wrap them in a full forward, and its fused path silently falls back to the
+        CUDA op unless mode is WARNING and there is no VBE, no per-sample weights, no
+        hoisted transpose, and no AMD -- so a module-level benchmark can quietly measure
+        the wrong backend.
+    """
+
+    include_repair: bool = False
+
+
+@register_benchmark(BoundsCheckTritonConfig)
+def bounds_check_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    offsets: torch.Tensor,
+    warning: torch.Tensor,
+    num_indices: int,
+    total_bags: int,
+    include_repair: bool = False,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## zero warning counter ##"):
+        # The module zeroes the counter on every forward, so it is inside the timed
+        # region for both backends and cancels out of the comparison.
+        warning.zero_()
+
+    with record_function("## bounds check offsets ##"):
+        # constexpr params and the num_warps launch knob are part of Triton's launch
+        # protocol, which the type checker does not model.
+        _bounds_check_offsets_kernel[
+            (triton.cdiv(total_bags, _BOUNDS_CHECK_BLOCK_SIZE),)
+        ](
+            offsets,
+            warning,
+            num_indices,
+            total_bags,
+            # pyrefly: ignore[bad-argument-type]
+            BLOCK_SIZE=_BOUNDS_CHECK_BLOCK_SIZE,
+            # pyrefly: ignore[unexpected-keyword]
+            num_warps=_BOUNDS_CHECK_NUM_WARPS,
+        )
+
+    if include_repair:
+        with record_function("## repair offsets ##"):
+            # Serial O(total_bags) scan on one program, guarded on the warning counter,
+            # so this is a near-free early-exit unless the offsets are actually broken.
+            _repair_offsets_kernel[(1,)](
+                offsets,
+                warning,
+                num_indices,
+                total_bags,
+                # pyrefly: ignore[unexpected-keyword]
+                num_warps=1,
+            )
+
+
+@dataclass
+class BoundsCheckCudaConfig(BoundsCheckConfig):
+    """
+    run commands:
+    1. baseline against bounds_check_triton on identical input
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_cuda \
+        --name=clean
+
+    use case:
+        the fbgemm CUDA op the Triton kernels replace, run on the same seed and shape.
+        Note it does strictly more work than the Triton offsets kernel: it validates row
+        ids as well as the offsets array, which the Triton path folds into the gather
+        loop instead (_load_checked_index). Read the pair as backend A/B on the offsets
+        sweep, not as an equal-work comparison.
+    """
+
+
+@register_benchmark(BoundsCheckCudaConfig)
+def bounds_check_cuda(
+    _batch_inputs: List[Dict[str, Any]],
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    rows_per_table: torch.Tensor,
+    warning: torch.Tensor,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## zero warning counter ##"):
+        warning.zero_()
+
+    with record_function("## bounds_check_indices ##"):
+        torch.ops.fbgemm.bounds_check_indices(
+            rows_per_table,
+            indices,
+            offsets,
+            _BOUNDS_CHECK_MODE_WARNING,
+            warning,
+            None,
+            bounds_check_version=_BOUNDS_CHECK_VERSION_V2,
+        )
+
+
+################################ 2D permute configs ####################################
+@dataclass
+class Permute2dConfig(TritonOpConfig):
+    """Shared input generation for both 2D-permute backends.
+
+    Defaults give 1,048,576 segments, above triton_permute_2d.MIN_SEGMENTS (700k) where
+    should_use_triton() takes over, at a mean length below PERSEG_MIN_MEAN so the
+    load-balanced kernel is the one measured. Raise mean_pooling_factor past
+    PERSEG_MIN_MEAN to measure the per-segment kernel instead.
+    """
+
+    num_features: int = 1024
+    permute_batch_size: int = 1024
+    mean_pooling_factor: int = 1
+    has_weight: bool = False
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        """Build (permute, lengths, values, weights, permuted_lengths_sum).
+
+        ``permute`` is a full permutation, so ``permuted_lengths_sum`` is just the
+        total. Real call sites also pass subsets and repeats, which is why fbgemm
+        carries the sum as a separate argument; this keeps the simple case so the two
+        backends move exactly the same bytes.
+        """
+        lengths = torch.randint(
+            low=0,
+            high=max(2 * self.mean_pooling_factor, 2),
+            size=(self.num_features, self.permute_batch_size),
+            dtype=torch.int32,
+            device=device,
+        )
+        permuted_lengths_sum = int(lengths.sum().item())
+        values = torch.randint(
+            low=0,
+            high=int(1e5),
+            size=(permuted_lengths_sum,),
+            dtype=torch.int32,
+            device=device,
+        )
+        permute = torch.randperm(self.num_features, device=device).to(torch.int32)
+
+        num_segments = self.num_features * self.permute_batch_size
+        logger.info(
+            "%d segments (MIN_SEGMENTS=%d), %d values, mean length %.2f -> %s kernel",
+            num_segments,
+            MIN_SEGMENTS,
+            permuted_lengths_sum,
+            permuted_lengths_sum / max(num_segments, 1),
+            (
+                "per-segment"
+                if permuted_lengths_sum >= num_segments * PERSEG_MIN_MEAN
+                else "blocked"
+            ),
+        )
+        if num_segments < MIN_SEGMENTS:
+            logger.warning(
+                "%d segments is below MIN_SEGMENTS=%d, where should_use_triton() defers "
+                "to fbgemm; this does not reflect a shape the Triton path would serve.",
+                num_segments,
+                MIN_SEGMENTS,
+            )
+        return {
+            "permute": permute,
+            "lengths": lengths,
+            "values": values,
+            "weights": (
+                torch.rand(permuted_lengths_sum, dtype=torch.float32, device=device)
+                if self.has_weight
+                else None
+            ),
+            "permuted_lengths_sum": permuted_lengths_sum,
+        }
+
+
+@dataclass
+class Permute2dTritonConfig(Permute2dConfig):
+    """
+    run commands:
+    1. blocked kernel (default): many short segments
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton \
+        --name=blocked
+
+    2. per-segment kernel: fewer, longer segments
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton \
+        --name=perseg \
+        --mean_pooling_factor=1024
+
+    use case:
+        the Triton replacement for fbgemm.permute_2D_sparse_data, which wins on the two
+        regimes fbgemm's per-segment launch shape handles badly: very many short
+        segments, and length skew across keys. Pair with permute_2d_fbgemm on the same
+        seed and shape.
+    """
+
+
+@register_benchmark(Permute2dTritonConfig)
+def permute_2d_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    permute: torch.Tensor,
+    lengths: torch.Tensor,
+    values: torch.Tensor,
+    weights: Optional[torch.Tensor],
+    permuted_lengths_sum: int,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_permute_2d_sparse_data ##"):
+        triton_permute_2d_sparse_data(
+            permute, lengths, values, weights, permuted_lengths_sum
+        )
+
+
+@dataclass
+class Permute2dFbgemmConfig(Permute2dConfig):
+    """
+    run commands:
+    1. baseline against permute_2d_triton on identical input
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm \
+        --name=blocked
+
+    2. baseline against permute_2d_triton on identical input with pf=1024
+    > python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm \
+        --name=blocked_1024 \
+        --mean_pooling_factor=1024
+
+    use case:
+        the fbgemm CUDA baseline. It hands each block 32 consecutive segments and picks
+        vectorised or scalar loads per segment, which is efficient for few long aligned
+        segments and degrades as segment count and key-level length skew grow.
+    """
+
+
+@register_benchmark(Permute2dFbgemmConfig)
+def permute_2d_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    permute: torch.Tensor,
+    lengths: torch.Tensor,
+    values: torch.Tensor,
+    weights: Optional[torch.Tensor],
+    permuted_lengths_sum: int,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## permute_2D_sparse_data ##"):
+        torch.ops.fbgemm.permute_2D_sparse_data(
+            permute, lengths, values, weights, permuted_lengths_sum
+        )
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[missing-attribute]
+    _cc.main()


### PR DESCRIPTION
Summary:
## 1. Context

TorchRec has two Triton ops with fbgemm CUDA counterparts, and neither can be compared against its baseline in isolation today.

1. **TBE bounds checking.** `torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py` carries three pieces: `_bounds_check_offsets_kernel` (one lane per bag, validating the offsets array), `_repair_offsets_kernel` (a serial prefix-max scan that clamps a broken array back to monotonic), and `_load_checked_index` (the per-index range test folded into the forward gather). The only coverage is a `--fused-bounds-check` on/off flag on the end-to-end Triton-vs-FBGEMM TBE benchmark in fbgemm, which measures a whole forward pass. fbgemm does have an isolated benchmark for the CUDA op it replaces (`bench/tbe:tbe_utils -- bounds-check-indices`), so the baseline is measurable and the Triton side is not.

2. **2D sparse permute.** `torchrec/sparse/triton_permute_2d.py` has no benchmark at all, even though its dispatch thresholds (`MIN_SEGMENTS = 700_000`, `PERSEG_MIN_MEAN = 128`) and its choice between the per-segment and blocked kernels were tuned from measurements that cannot be reproduced from anything in the repo.

3. **Both ops are tuned entirely by hand.** Neither uses `triton.autotune`. Every tile size, coarsening factor, unroll width, and grid dimension is selected analytically on the host from hardcoded constants: `B >= 65536`, `192 SMs x 32 warps x 4 waves`, `MIN_SEGMENTS = 700_000`, `PERSEG_MIN_MEAN = 128`. That is a defensible choice, because autotuning costs first-call latency and introduces nondeterminism. It does mean each heuristic is only as good as the measurements it was derived from, and nothing checked into the repo can re-derive them or notice when they go stale on new hardware.

## 2. Approach

1. **New `benchmark_triton_ops` binary**, structured like `benchmark_comms.py`: a module-level `cmd_conf()` registry, one config dataclass plus one benchmark function per CLI subcommand, wired by a `register_benchmark(Config)` decorator. Four subcommands: `bounds_check_triton`, `bounds_check_cuda`, `permute_2d_triton`, `permute_2d_fbgemm`.

2. **Kernels launched directly rather than through the module.** Going through `TritonTableBatchedEmbeddingBags` would both wrap the kernel in a full forward and risk measuring the wrong backend: the fused path is gated on mode being `WARNING` (the module defaults to `V2_WARNING`) with no VBE, no per-sample weights, no hoisted transpose, and no AMD, and it falls back to the CUDA op silently when any gate fails.

3. **Setup hoisted out of the timed region.** `benchmark_comms` generates data inside the timed function because there the compute *is* the load. Here tensor allocation would swamp the kernel, so `TritonOpConfig` gains a `make_inputs(device)` hook that the runner calls once and merges into `benchmark_func_kwargs`, alongside the subclass-field forwarding that comms does via `fields(type(arg)) - fields(CommsConfig)`.

4. **Shared input generation per op family.** `BoundsCheckConfig` and `Permute2dConfig` own `make_inputs`, and the Triton and CUDA subcommands inherit it, so with a fixed seed each A/B pair sees byte-identical input.

5. **Two independent corruption knobs.** `bad_offsets_pct` writes negative offsets, which is the only thing `_bounds_check_offsets_kernel` can observe; `oob_pct` puts row ids past the end of the table, which only the CUDA op and the in-gather check look at. They are not interchangeable and are documented as such.

6. **`record_function` annotations** on each phase, so a trace separates the `warning.zero_()` launch from the kernel itself.

### 2.1 Single-rank, not multi-process

These are kernel microbenchmarks with no collective, so `single_rank_runner` takes the config directly instead of the `(rank, world_size)` pair that `benchmark_comms` threads through `run_multi_process_func` and `MultiProcessContext`.

## 3. Results

* benchmark

|short name|mean L|GPU Runtime (P10/P50/P90)|CPU Runtime (P10/P50/P90)|Wall Runtime (P10/P50/P90)|CPU Utilization (P10/P50/P90)|GPU Peak Mem alloc|GPU Peak Mem reserved|GPU Mem used|Malloc retries (P50/P90/P100)|CPU Peak RSS|
|--|--|--|--|--|--|--|--|--|--|--|
|bounds_check_triton_clean|n/a|0.07 / 0.08 / 0.11 ms|0.06 / 0.08 / 0.27 ms|0.06 / 0.07 / 0.09 ms|100.69% / 102.33% / 312.25%|0.67 GB|0.71 GB|2.78 GB|0.0 / 0.0 / 0.0|1.50 GB|
|bounds_check_cuda_clean|n/a|1.06 / 1.06 / 1.07 ms|0.06 / 0.06 / 0.33 ms|0.05 / 0.06 / 0.07 ms|103.31% / 105.07% / 552.63%|0.67 GB|0.71 GB|2.78 GB|0.0 / 0.0 / 0.0|1.43 GB|
|permute_2d_fbgemm_blocked|0.5|0.19 / 0.19 / 0.20 ms|0.07 / 0.07 / 0.33 ms|0.06 / 0.07 / 0.08 ms|101.46% / 102.04% / 383.21%|0.02 GB|0.04 GB|2.12 GB|0.0 / 0.0 / 0.0|1.52 GB|
|permute_2d_triton_blocked|0.5|0.31 / 0.43 / 0.48 ms|0.31 / 0.71 / 1.40 ms|0.29 / 0.40 / 0.43 ms|100.54% / 183.64% / 368.25%|0.03 GB|0.04 GB|2.12 GB|0.0 / 0.0 / 0.0|1.53 GB|
|permute_2d_triton_perseq|1024|4.13 / 4.15 / 4.18 ms|0.18 / 0.34 / 1.16 ms|0.17 / 0.18 / 0.22 ms|102.40% / 192.43% / 575.79%|8.22 GB|8.23 GB|8.98 GB|0.0 / 0.0 / 0.0|1.63 GB|
|permute_2d_fbgemm_blocked_1024|1024|5.69 / 5.74 / 5.86 ms|0.15 / 0.30 / 1.09 ms|0.13 / 0.17 / 0.28 ms|105.17% / 171.22% / 497.09%|8.21 GB|8.21 GB|10.29 GB|0.0 / 0.0 / 0.0|1.57 GB|

The `mean L` column is `mean_pooling_factor` as configured; the mean segment length is `n_out / n_seg`, which is what `PERSEG_MIN_MEAN = 128` dispatches on. All permute rows use 1024 features x 1024 batch, so `n_seg = 1,048,576`. The two `mean L = 1024` rows report peak allocations of 8.21 and 8.22 GB, which confirms they ran the same shape and can be compared directly.

* repro commands

```
# TBE bounds check, T=32 B=131072 L=20
python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_triton --name=clean
python -m torchrec.distributed.benchmark.benchmark_triton_ops bounds_check_cuda   --name=clean

# 2D permute, 1024 x 1024 = 1,048,576 segments, mean length 0.5 (blocked kernel)
python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm --name=blocked
python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton --name=blocked

# 2D permute, long segments (per-segment kernel, above PERSEG_MIN_MEAN = 128)
python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_triton --name=perseq --mean_pooling_factor=1024
python -m torchrec.distributed.benchmark.benchmark_triton_ops permute_2d_fbgemm --name=blocked_1024 --mean_pooling_factor=1024
```

* trace

- [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D117373760)

|name|rank0 trace|
|--|--|
|bounds_check_triton_clean|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-bounds_check_triton_clean-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-bounds_check_triton_clean-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|bounds_check_cuda_clean|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-bounds_check_cuda_clean-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-bounds_check_cuda_clean-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|permute_2d_fbgemm_blocked|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_fbgemm_blocked-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_fbgemm_blocked-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|permute_2d_triton_blocked|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_triton_blocked-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_triton_blocked-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|permute_2d_triton_perseq|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_triton_perseq-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_triton_perseq-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|permute_2d_fbgemm_blocked_1024|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_fbgemm_blocked_1024-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117373760/trace-permute_2d_fbgemm_blocked_1024-rank0.json.gz&bucket=torchrec_benchmark_traces)|

## 4. Analysis

1. **Risk is low.** Benchmark-only. No library code is touched, no public API changes, no BC implications. The one non-benchmark edit is a new `python_binary` target in the benchmark BUCK file.

2. **The bounds-check pair is not a like-for-like comparison, and the ratio must not be read as a speedup.** At this shape the Triton kernel reads only `offsets` (33.6 MB) while the CUDA op reads `offsets` plus all 83,886,080 indices (704.6 MB) -- 21x more bytes -- because it also validates row ids, which the Triton path defers to `_load_checked_index` inside the forward gather. Measured time differs by 13.2x against a 21x work difference, so the Triton kernel is in fact achieving *lower* effective bandwidth (0.42 TB/s against 0.66 TB/s). It finishes sooner only because it does less.

3. **The Triton bounds-check measurement is launch-bound, not kernel-bound.** GPU runtime (0.08 ms) is essentially equal to CPU runtime (0.08 ms) and wall time (0.07 ms), whereas the CUDA op shows 1.06 ms GPU against 0.06 ms CPU. Trace inspection puts the offsets kernel itself near 20 us, so most of the 80 us window is the two Python-side Triton launches (`warning.zero_()` and the kernel) and the GPU idling between them. At this shape the Triton path costs more in launch overhead than in compute.

4. **The 2D permute result is a regression at short segments.** At mean length 0.5 Triton is 2.3x slower on GPU (0.43 vs 0.19 ms) and 10x slower on CPU (0.71 vs 0.07 ms). Run-to-run variance on that Triton figure is high: the same config measured 0.32 ms on an earlier run against 0.43 ms here, a 34% swing, so treat the multiple as approximate. Both are far from bandwidth-bound -- only ~4.2 MB moves, at 13 and 22 GB/s -- so this regime is dominated by launch and host overhead, and the Triton path adds six host-side ops before its kernel (`lengths[permute.long()]`, two `cumsum`, two `searchsorted`, an `arange`/`clamp`) which shows up directly in the CPU column. With 1,048,576 segments the shape sits above `MIN_SEGMENTS = 700_000`, so `should_use_triton()` would select this slower kernel in production.

5. **At a high pooling factor the Triton per-segment kernel beats fbgemm by 1.38x, on a confirmed matched pair.** Both rows ran at `--mean_pooling_factor=1024`, and their peak allocations agree to within 0.01 GB (8.21 against 8.22), so they moved the same 8.59 GB. fbgemm takes 5.74 ms (1.50 TB/s) and the Triton per-segment kernel takes 4.15 ms (2.07 TB/s). Neither is at HBM peak, so the op is not purely bandwidth-bound even here, and there is headroom on both sides. This is the first measurement that exercises `_permute_2d_perseg_kernel` at all, and it is the clearest positive result in the diff.

6. **The short-segment regression is most likely a gap in the benchmark's data, not a refutation of the module.** `triton_permute_2d`'s tuning notes attribute its wins to two properties jointly: very many segments *and* key-level length skew (fbgemm degrades 1470 -> 1889 -> 2173 us as lognormal sigma goes 4 -> 6 -> 8, while the Triton kernel stays flat). The generator here produces uniform `randint` lengths with no key-level skew and 1.05M segments against the 5.2M in the tuning notes, so it reproduces only the first property. Adding a skew knob is the obvious follow-up, and until then this number should not be used to question `MIN_SEGMENTS`. Note the shape of the two permute results together: the per-segment kernel wins at long segments (point 5), while the blocked kernel loses at short *uniform* segments. The module's notes claim the blocked kernel's win specifically for many short segments *with* key-level skew, so losing without skew is consistent with those notes rather than contradicting them.

7. **Op registration is explicit.** Importing `triton_permute_2d` does not pull in `jagged_tensor`, which is where TorchRec normally calls `torch.ops.load_library` for `sparse_ops`, so the benchmark loads it directly in the same guarded form. The TBE ops need no equivalent, since importing the Triton TBE module imports `fbgemm_gpu` and registers them on package init.

8. **Three `pyrefly: ignore` suppressions** cover Triton's launch protocol, which the type checker does not model: `constexpr` parameters and the `num_warps` launch knob. This matches how `triton_permute_2d.py` handles the same calls.

### 4.1 The tuning knobs these benchmarks exist to validate

Both ops are configured through `tl.constexpr` parameters, which Triton specializes on, so each combination compiles to a separate binary. The standard names for what they control:

| Knob | Term | Trades away | Buys |
|--|--|--|--|
| `BLOCK_SIZE` | tile size | masked-lane waste when dims vary | fewer instructions per element |
| `BAGS_PER_PROGRAM` | thread coarsening factor | thread-level parallelism | per-item setup amortization, ILP |
| `UNROLL8` | unroll factor | registers | memory-level parallelism |
| grid shape, `num_warps` | launch configuration | grid right-sizing | load balancing under skew |

The tension is always parallelism against per-item efficiency. Too many small programs and launch overhead dominates while per-item setup is repaid every time; too few large ones and the SMs cannot be filled. The TBE forward heuristic encodes that as a decision over data shape:

| Data | Problem | Response in the code |
|--|--|--|
| large B | none, parallelism is abundant | coarsen, via the `B >= 65536` gate |
| small B | too few programs to fill SMs | `BAGS_PER_PROGRAM = 1` |
| long bags | dependent gather latency | widen the unroll to 8 |
| FP32 weights, so an FP64 accumulator | register pressure | the `weight.dtype != float32` gate |
| skewed work per item | load imbalance | fixed grid plus a work-distribution loop (backward) |
| tiny table, huge pooling factor | the gather loop is the wrong shape | a different kernel, histogram plus `tl.dot` |

The last two rows are why benchmark coverage matters more than it might appear. Those cases are not reachable by tuning a constant, and the constants that do exist encode hardware assumptions no test currently checks.

### 4.2 The two permute kernels, and which one this measured

`triton_permute_2d` carries two kernels that differ in decomposition, not in what they compute:

| | a program owns | work per program | cost of the choice |
|--|--|--|--|
| `_permute_2d_perseg_kernel` | one segment | that segment's length, variable | none, the program id *is* the segment |
| `_permute_2d_blocked_kernel` | one BLOCK of output elements | exactly BLOCK, fixed | a binary search to recover which segment each output element came from |

Blocked starts from an output position and has to work backwards to the segment, which is why it carries the search, bounded per block by a host-side `searchsorted` pair. In exchange its work per program is constant however the lengths fall. The crossover is `PERSEG_MIN_MEAN = 128`: per-segment wins at mean length 298 (1172 against 1522 us), and blocked wins below it, reaching 2.9x by mean 0.6. Those figures are Triton against Triton, not against fbgemm.

The motivation for either kernel is narrow. fbgemm hands each block 32 consecutive segments and picks vectorised or scalar loads per segment from an alignment test, which is efficient for few, long, aligned segments. The module's notes name two regimes where that degrades: very many tiny segments (5.2M averaging 0.6 elements, where fbgemm needs 610 us to move 3.1M values), and key-level length skew (fbgemm going 1470 -> 1889 -> 2173 us as lognormal sigma goes 4 -> 6 -> 8, against a flat 1172 -> 1257 -> 1300 for Triton).

This benchmark reproduced the first regime and not the second, which is the most likely explanation for the regression in point 4, and is expanded in point 6. One supporting detail. The module's notes characterise the *losing* regime as fbgemm at 32-103 us against 94-320 us for either Triton kernel. The Triton number measured here is 320 us, exactly the top of that band, while fbgemm's 190 us sits well above its own. This shape therefore does not resemble the traced shapes, despite clearing `MIN_SEGMENTS` by 50%. Segment count alone is evidently not the discriminator, which is worth noting given that `should_use_triton()` keys on exactly that.

The per-segment kernel was exercised for the first time in this run, at `--mean_pooling_factor=1024`, and beat fbgemm 4.15 ms against 5.74 ms on the same shape. Its setup amortizes over ~1024 elements per segment there, against half an element in the blocked regime, which is the whole content of the `PERSEG_MIN_MEAN = 128` crossover.

## 5. Changes

1. **`torchrec/distributed/benchmark/benchmark_triton_ops.py`** (new): four benchmark subcommands with their config dataclasses, a `single_rank_runner`, a `register_benchmark` decorator, and shared input generation for each op family.
2. **`torchrec/distributed/benchmark/BUCK`**: new `benchmark_triton_ops` `python_binary` target.

## 6. Follow-ups

1. Add a key-level length-skew knob to `Permute2dConfig`, so the shape the Triton permute was tuned for can actually be reproduced.
2. Report bytes touched and effective bandwidth per variant in the results table, so work asymmetry is visible in the output rather than only in this summary.
3. Add a variant that measures the two bounds-check *paths* end to end -- a TBE forward with `fused_bounds_check=True` against `bounds_check_indices` plus a forward with `BoundsCheckMode.NONE` -- which is the comparison the fused design actually claims to win.
4. Sweep `--mean_pooling_factor` across `PERSEG_MIN_MEAN = 128` to locate the blocked/per-segment crossover empirically, rather than only sampling the two ends at 0.5 and 1024.

Reviewed By: spmex

Differential Revision: D117373760


