### PR TITLE
Add a compute-contention probe to the sharded-relay sweep (#4629)

### DIFF
--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -2738,12 +2738,20 @@ def _reduce_parallel_jobs_max(results_dict: Any) -> None:
     Each job writes its own best-of-N under ..._job{j}; the overlapped wall-time
     is the slowest (max) job, so reduce both the relay and NCCL per-job entries
     into the base keys the print/report helpers read.
+
+    BENCH_SWEEP_PER_JOB=1 also prints every job's own best-of-N next to the
+    reduced max. Because each entry is already a min over BENCH_BENCH_ITERS, a
+    slow entry means that job was slow for EVERY iteration, so the per-job
+    spread separates a single persistently-slow job (communicator-level state:
+    channel assignment, HW queues) from a slow size across all jobs (buffer-level
+    state: placement, registration).
     """
+    per_job = _env_int("BENCH_SWEEP_PER_JOB", 0) != 0
     for active_ranks in _sweep_active_ranks():
         num_jobs = NUM_GPUS // active_ranks
         for collective in _sweep_collectives():
             key = f"{collective}_a{active_ranks}"
-            for i, (_label, _nbytes) in enumerate(_sweep_sizes()):
+            for i, (label, _nbytes) in enumerate(_sweep_sizes()):
                 for prefix in ("relay_parallel", "nccl_parallel"):
                     vals = [
                         results_dict.get(f"{prefix}_{key}_{i}_job{j}")
@@ -2754,6 +2762,11 @@ def _reduce_parallel_jobs_max(results_dict: Any) -> None:
                         results_dict[f"{prefix}_{key}_{i}"] = max(
                             present, key=lambda v: v[0]
                         )
+                    if per_job and present:
+                        spread = " ".join(
+                            "--" if v is None else f"{v[0]:8.3f}" for v in vals
+                        )
+                        print(f"[per-job] {prefix} {key} {label:>8} | {spread}")
 
 
 def _format_parallel_sweep_table(

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -69,6 +69,14 @@ Environment variables (all optional):
     BENCH_WARMUP_ITERS   int              (default: 10)
     BENCH_BENCH_ITERS    int              (default: 20)
     BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
+    BENCH_SWEEP_CONTEND  1                (stream GEMMs alongside each timed
+                                          collective and report the throughput
+                                          they achieve, so a comms change can be
+                                          judged on its effect on the compute it
+                                          is meant to overlap with, not just on
+                                          collective time)
+    BENCH_CONTEND_DIM    int              (default: 4096; GEMM size for the above)
+    BENCH_CONTEND_GEMMS  int              (default: 8; GEMMs per timed iteration)
 
 The benchmark automatically sweeps BOTH 2-active and 4-active sharded relay
 groups and prints a full report for each. The 4-active sweep covers all four
@@ -666,6 +674,71 @@ def bench_nccl_baseline(
 # ---------------------------------------------------------------------------
 
 
+class _ComputeProbe:
+    """Keeps a GEMM stream busy so a collective is timed under compute load.
+
+    An isolated collective benchmark cannot see the cost that matters most in a
+    real job: whether a comms optimization steals CUs or hardware queues from
+    the compute it is supposed to be overlapping with. This probe streams GEMMs
+    on a separate stream across each timed iteration and reports the throughput
+    they achieved, so a change can be judged on BOTH numbers -- collective time
+    and contending compute rate -- instead of only the first.
+
+    Enable with BENCH_SWEEP_CONTEND=1. BENCH_CONTEND_DIM and BENCH_CONTEND_GEMMS
+    size the load. Compare arms with identical settings; the absolute TFLOP/s is
+    not a peak-throughput claim, it is a relative yardstick between arms.
+    """
+
+    def __init__(self, device: torch.device, dim: int, gemms: int) -> None:
+        self.stream: torch.cuda.Stream = torch.cuda.Stream()
+        self.gemms = gemms
+        self.a: torch.Tensor = torch.randn(
+            dim, dim, device=device, dtype=torch.bfloat16
+        )
+        self.b: torch.Tensor = torch.randn(
+            dim, dim, device=device, dtype=torch.bfloat16
+        )
+        self.c: torch.Tensor = torch.empty(
+            dim, dim, device=device, dtype=torch.bfloat16
+        )
+        self.flops_per_iter: float = 2.0 * float(dim) ** 3 * float(gemms)
+        self._start: torch.cuda.Event = torch.cuda.Event(enable_timing=True)
+        self._end: torch.cuda.Event = torch.cuda.Event(enable_timing=True)
+        self._ms: list[float] = []
+
+    @classmethod
+    def maybe_create(cls) -> _ComputeProbe | None:
+        if _env_int("BENCH_SWEEP_CONTEND", 0) == 0:
+            return None
+        if not torch.cuda.is_available():
+            return None
+        return cls(
+            torch.device("cuda", torch.cuda.current_device()),
+            _env_int("BENCH_CONTEND_DIM", 4096),
+            _env_int("BENCH_CONTEND_GEMMS", 8),
+        )
+
+    def begin(self) -> None:
+        """Launch the contending load; returns without waiting for it."""
+        with torch.cuda.stream(self.stream):
+            self._start.record()
+            for _ in range(self.gemms):
+                torch.mm(self.a, self.b, out=self.c)
+            self._end.record()
+
+    def end(self) -> None:
+        """Wait for the contending load and record what it achieved."""
+        self._end.synchronize()
+        self._ms.append(self._start.elapsed_time(self._end))
+
+    def report(self) -> str:
+        if not self._ms:
+            return ""
+        best = min(self._ms)
+        tflops = self.flops_per_iter / (best * 1e-3) / 1e12
+        return f"[contend] compute {best:.3f} ms/iter  {tflops:.1f} TFLOP/s"
+
+
 def _measure_ms(
     fn: Any,
     warmup: int,
@@ -725,6 +798,7 @@ def _measure_ms(
 
     start_ev = torch.cuda.Event(enable_timing=True)
     end_ev = torch.cuda.Event(enable_timing=True)
+    probe = _ComputeProbe.maybe_create()
     n_reps = max(1, reps)
     rep_bests: list[float] = []
     last_std = 0.0
@@ -734,14 +808,25 @@ def _measure_ms(
             # Align all ranks' starts; excluded from the timed region below.
             _align()
             torch.cuda.synchronize()
+            # Started after the sync so the load overlaps the timed region
+            # rather than being waited on before it.
+            if probe is not None:
+                probe.begin()
             start_ev.record()
             fn()
             end_ev.record()
             end_ev.synchronize()
             times.append(start_ev.elapsed_time(end_ev))
+            if probe is not None:
+                probe.end()
         rep_bests.append(min(times))
         mean = sum(times) / len(times)
         last_std = (sum((x - mean) ** 2 for x in times) / len(times)) ** 0.5
+
+    if probe is not None:
+        line = probe.report()
+        if line:
+            print(line, flush=True)
 
     if n_reps == 1:
         return rep_bests[0], last_std

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -232,7 +232,7 @@ _MIB: int = 1024 * 1024
 # (human label, bytes) for each swept allreduce message size. Each value is the
 # byte size of the input tensor a single active rank contributes to the
 # allreduce; element count = bytes // dtype.itemsize.
-_MSG_SWEEP_SIZES: list[tuple[str, int]] = [
+_MSG_SWEEP_SIZES_ALL: list[tuple[str, int]] = [
     ("4 KB", 4 * _KIB),
     ("9 KB", 9 * _KIB),
     ("18 KB", 18 * _KIB),
@@ -259,13 +259,56 @@ _MSG_SWEEP_SIZES: list[tuple[str, int]] = [
 
 # Active-rank counts and collectives swept by test_collectives_msg_size_sweep.
 # The sweep prints one table per (collective, active-rank-count) = 8 tables.
-_MSG_SWEEP_ACTIVE_RANKS: tuple[int, ...] = (2, 4)
-_MSG_SWEEP_COLLECTIVES: tuple[str, ...] = (
+_MSG_SWEEP_ACTIVE_RANKS_ALL: tuple[int, ...] = (2, 4)
+_MSG_SWEEP_COLLECTIVES_ALL: tuple[str, ...] = (
     "allreduce",
     "reduce_scatter",
     "all_to_all",
     "all_gather",
 )
+
+
+def _sweep_active_ranks() -> tuple[int, ...]:
+    """Active-rank counts the sweeps cover.
+
+    BENCH_SWEEP_ACTIVE narrows it to a comma-separated subset (e.g. "4") so
+    tuning one variant does not pay for the other seven tables.
+    """
+    want = _env_str("BENCH_SWEEP_ACTIVE", "")
+    if not want:
+        return _MSG_SWEEP_ACTIVE_RANKS_ALL
+    keep = {int(tok) for tok in want.split(",") if tok.strip()}
+    return tuple(a for a in _MSG_SWEEP_ACTIVE_RANKS_ALL if a in keep)
+
+
+def _sweep_collectives() -> tuple[str, ...]:
+    """Collectives the sweeps cover.
+
+    BENCH_SWEEP_ONLY narrows it to a comma-separated subset (e.g.
+    "all_to_all,all_gather"); it is the sweep counterpart of BENCH_ONLY.
+    """
+    want = _env_str("BENCH_SWEEP_ONLY", "")
+    if not want:
+        return _MSG_SWEEP_COLLECTIVES_ALL
+    keep = {tok.strip() for tok in want.split(",") if tok.strip()}
+    return tuple(c for c in _MSG_SWEEP_COLLECTIVES_ALL if c in keep)
+
+
+def _sweep_sizes() -> list[tuple[str, int]]:
+    """Message sizes the sweeps cover.
+
+    BENCH_SWEEP_MIN_MB / BENCH_SWEEP_MAX_MB clip the size axis so a tuning run
+    can spend its time in the regime being tuned. Every worker and every report
+    formatter enumerates this same list, so the per-size result keys stay
+    consistent when it is clipped.
+    """
+    lo = int(_env_float("BENCH_SWEEP_MIN_MB", 0.0) * _MIB)
+    hi = int(_env_float("BENCH_SWEEP_MAX_MB", 0.0) * _MIB)
+    return [
+        entry
+        for entry in _MSG_SWEEP_SIZES_ALL
+        if entry[1] >= lo and (hi == 0 or entry[1] <= hi)
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1888,7 +1931,7 @@ def _msg_sweep_nccl_worker(
     # every group collectively). pgs_by_a[A][rank // A] is this rank's FUSED
     # sub-group.
     pgs_by_a: dict[int, list[dist.ProcessGroup]] = {}
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         num_groups = world_size // active_ranks
         groups = [
             list(range(g * active_ranks, (g + 1) * active_ranks))
@@ -1907,11 +1950,11 @@ def _msg_sweep_nccl_worker(
     torch.cuda.synchronize()
     del _wt
 
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         pgs = pgs_by_a[active_ranks]
         fused_pg = pgs[rank // active_ranks]
-        for collective in _MSG_SWEEP_COLLECTIVES:
-            for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+        for collective in _sweep_collectives():
+            for i, (_label, nbytes) in enumerate(_sweep_sizes()):
                 elements = nbytes // dtype.itemsize
                 if elements % active_ranks != 0:
                     continue
@@ -2015,7 +2058,7 @@ def _msg_sweep_relay_warmup(
     # every (collective, A) warmup config clears the floor (the real sweep starts
     # at 4 KB = 2048 elements, so it is always valid too).
     warm_elems = 2048
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         num_chunks = (world_size - active_ranks) + 1
         num_groups = world_size // active_ranks
         my_sparse_group = rank // active_ranks
@@ -2023,7 +2066,7 @@ def _msg_sweep_relay_warmup(
             list(range(g * active_ranks, (g + 1) * active_ranks))
             for g in range(num_groups)
         ]
-        for collective in _MSG_SWEEP_COLLECTIVES:
+        for collective in _sweep_collectives():
             a_in, a_out, bufs = _build_relay_bufs(
                 collective,
                 active_ranks,
@@ -2099,7 +2142,7 @@ def _msg_sweep_relay_worker(
     # collectively.
     rcclx_comm = _setup_rcclx_comm(local_rank, world_size, 0, store)
     fused_by_a: dict[int, Any] = {}
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         fused_by_a[active_ranks] = _make_fused(
             rcclx_comm, local_rank, world_size, active_ranks
         )
@@ -2112,10 +2155,10 @@ def _msg_sweep_relay_worker(
     # Pre-compile every distinct HIP kernel config before timing.
     _msg_sweep_relay_warmup(fused_by_a, rank, world_size, dtype, device)
 
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         relay_fused = fused_by_a[active_ranks]
-        for collective in _MSG_SWEEP_COLLECTIVES:
-            for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+        for collective in _sweep_collectives():
+            for i, (_label, nbytes) in enumerate(_sweep_sizes()):
                 best_f, std_f = _measure_relay_for(
                     collective=collective,
                     active_ranks=active_ranks,
@@ -2199,7 +2242,7 @@ def _format_sweep_table(
         f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
         "-" * width,
     ]
-    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+    for i, (label, nbytes) in enumerate(_sweep_sizes()):
         elements = nbytes // dtype.itemsize
         if elements % active_ranks != 0:
             continue
@@ -2217,8 +2260,8 @@ def _print_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> None:
     """Emit one FUSED message-size sweep table per (collective, active-rank-count)
     as a single clean, diffable block (file + atomic stdout write)."""
     lines: list[str] = []
-    for collective in _MSG_SWEEP_COLLECTIVES:
-        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
             lines.extend(
                 _format_sweep_table(results_dict, dtype, collective, active_ranks)
             )
@@ -2365,8 +2408,8 @@ def _parallel_msg_sweep_nccl_worker(
     torch.cuda.synchronize()
 
     key = f"a{active_ranks}"
-    for collective in _MSG_SWEEP_COLLECTIVES:
-        for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+    for collective in _sweep_collectives():
+        for i, (_label, nbytes) in enumerate(_sweep_sizes()):
             elements = nbytes // dtype.itemsize
             if elements % active_ranks != 0:
                 continue
@@ -2545,7 +2588,7 @@ def _parallel_relay_warmup_single(
     torch.cuda.synchronize()
     dist.barrier()
     warm_elems = 2048
-    for collective in _MSG_SWEEP_COLLECTIVES:
+    for collective in _sweep_collectives():
         fn = _parallel_relay_single_call(
             collective,
             comm,
@@ -2659,8 +2702,8 @@ def _parallel_msg_sweep_relay_worker(
 
     is_job_rank0 = rank_in_job == active_group[0]
     key = f"a{active_ranks}"
-    for collective in _MSG_SWEEP_COLLECTIVES:
-        for i, (_label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+    for collective in _sweep_collectives():
+        for i, (_label, nbytes) in enumerate(_sweep_sizes()):
             elements = nbytes // dtype.itemsize
             if elements % active_ranks != 0:
                 continue
@@ -2696,11 +2739,11 @@ def _reduce_parallel_jobs_max(results_dict: Any) -> None:
     is the slowest (max) job, so reduce both the relay and NCCL per-job entries
     into the base keys the print/report helpers read.
     """
-    for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for active_ranks in _sweep_active_ranks():
         num_jobs = NUM_GPUS // active_ranks
-        for collective in _MSG_SWEEP_COLLECTIVES:
+        for collective in _sweep_collectives():
             key = f"{collective}_a{active_ranks}"
-            for i, (_label, _nbytes) in enumerate(_MSG_SWEEP_SIZES):
+            for i, (_label, _nbytes) in enumerate(_sweep_sizes()):
                 for prefix in ("relay_parallel", "nccl_parallel"):
                     vals = [
                         results_dict.get(f"{prefix}_{key}_{i}_job{j}")
@@ -2738,7 +2781,7 @@ def _format_parallel_sweep_table(
         f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
         "-" * width,
     ]
-    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+    for i, (label, nbytes) in enumerate(_sweep_sizes()):
         elements = nbytes // dtype.itemsize
         if elements % active_ranks != 0:
             continue
@@ -2756,8 +2799,8 @@ def _print_parallel_msg_sweep_report(results_dict: Any, dtype: torch.dtype) -> N
     """Emit one parallel separate-job table per (collective, active-rank-count) as
     a single clean, diffable block (file + atomic stdout write)."""
     lines: list[str] = []
-    for collective in _MSG_SWEEP_COLLECTIVES:
-        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
             lines.extend(
                 _format_parallel_sweep_table(
                     results_dict, dtype, collective, active_ranks
@@ -2799,7 +2842,7 @@ def _format_single_group_sweep_table(
         f"{'Msg Size':>10} | {'NCCL(ms)':>10} {'Relay(ms)':>10} {'Speedup':>9}",
         "-" * width,
     ]
-    for i, (label, nbytes) in enumerate(_MSG_SWEEP_SIZES):
+    for i, (label, nbytes) in enumerate(_sweep_sizes()):
         elements = nbytes // dtype.itemsize
         if elements % active_ranks != 0:
             continue
@@ -2817,8 +2860,8 @@ def _print_single_group_msg_sweep_report(results_dict: Any, dtype: torch.dtype) 
     """Emit one single-group best-case table per (collective, active-rank-count)
     as a single clean, diffable block (file + atomic stdout write)."""
     lines: list[str] = []
-    for collective in _MSG_SWEEP_COLLECTIVES:
-        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+    for collective in _sweep_collectives():
+        for active_ranks in _sweep_active_ranks():
             lines.extend(
                 _format_single_group_sweep_table(
                     results_dict, dtype, collective, active_ranks
@@ -2894,7 +2937,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
     def test_collectives_msg_size_sweep(self) -> None:
         """All-collective, 2- & 4-rank sharded relay message-size sweep (bf16).
 
-        Sweeps the fixed message sizes in _MSG_SWEEP_SIZES for every collective
+        Sweeps the fixed message sizes in _MSG_SWEEP_SIZES_ALL for every collective
         (allreduce, reduce-scatter, all-to-all, all-gather) at both 2 and 4
         active ranks and, per size, reports the sharded-relay FUSED speedup over
         NCCL (one table per (collective, active-rank-count)):
@@ -2996,7 +3039,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         # relay vs NCCL isolates the collective algorithm rather than the
         # deployment topology or the measurement harness. Per A, run the NCCL
         # baseline then the relay.
-        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        for active_ranks in _sweep_active_ranks():
             num_jobs = NUM_GPUS // active_ranks
             total_procs = num_jobs * NUM_GPUS
             mp.spawn(
@@ -3051,7 +3094,7 @@ class BenchShardedRelayPerfTest(unittest.TestCase):
         # One job only: total_procs = NUM_GPUS -> num_jobs = 1 in both workers,
         # so the single A-rank group [0..A-1] is the only workload on the host
         # (the other 8-A ranks are helpers/idle). Per A, run NCCL then relay.
-        for active_ranks in _MSG_SWEEP_ACTIVE_RANKS:
+        for active_ranks in _sweep_active_ranks():
             total_procs = NUM_GPUS
             mp.spawn(
                 _parallel_msg_sweep_nccl_worker,

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -294,6 +294,19 @@ def _sweep_collectives() -> tuple[str, ...]:
     return tuple(c for c in _MSG_SWEEP_COLLECTIVES_ALL if c in keep)
 
 
+def _sweep_reps() -> int:
+    """How many times each sweep measurement is repeated.
+
+    Each rep is a full warmup-free timed block whose min-over-iterations is one
+    sample; the reported number is the median across reps (see _measure_ms). The
+    parallel sweep needs this because it settles into one of two run-scoped states
+    that differ by ~20-30%, so a single rep reports whichever it happened to land
+    in. BENCH_SWEEP_REPS=1 restores the original single-rep, min-over-iterations
+    behaviour.
+    """
+    return max(1, _env_int("BENCH_SWEEP_REPS", 10))
+
+
 def _sweep_sizes() -> list[tuple[str, int]]:
     """Message sizes the sweeps cover.
 
@@ -658,14 +671,26 @@ def _measure_ms(
     warmup: int,
     iters: int,
     device_barrier_group: Any = None,
+    reps: int = 1,
 ) -> tuple[float, float]:
-    """Time fn() over 'iters' runs after 'warmup' warmups.
+    """Time fn() over 'iters' runs after 'warmup' warmups, 'reps' times.
 
-    Returns (best_ms, std_ms). The BEST (min) is the headline metric: collective
-    microbenchmarks are noise-dominated, so the mean is skewed by stray slow
-    iterations (OS jitter, DVFS, cross-rank skew). The min is the steady-state,
-    reproducible time — the same convention nccl-tests / rccl-tests use. std is
-    returned only to show the spread.
+    Returns (headline_ms, spread). With reps == 1 the headline is the BEST (min)
+    over iters and spread is the std over them, which is the original behaviour.
+    With reps > 1 each rep contributes its own min-over-iters and the headline
+    becomes the MEDIAN of those, with spread the max/min ratio across reps.
+
+    Why min within a rep but median across reps: collective microbenchmarks are
+    noise-dominated, so within a rep the min is the steady-state, reproducible
+    time and the mean is skewed by stray slow iterations (OS jitter, DVFS,
+    cross-rank skew) -- the same convention nccl-tests / rccl-tests use. ACROSS
+    reps the variation is different in kind: the parallel sweep settles into one
+    of two run-scoped states that differ by ~20-30% and stay put for a whole
+    measurement, so taking a min there would just report whichever state is
+    luckiest rather than what a job typically sees. The median is the typical
+    state, and unlike the mean it is not dragged by the rare 4-6x tail. The
+    spread is what says whether a small delta is meaningful: near 1.0 the
+    headline is solid, well above 1.0 and the two states are being mixed.
 
     Methodology for a stable, fair measurement:
     - A full-world barrier precedes each timed iteration so all ranks start the
@@ -700,21 +725,42 @@ def _measure_ms(
 
     start_ev = torch.cuda.Event(enable_timing=True)
     end_ev = torch.cuda.Event(enable_timing=True)
-    times: list[float] = []
-    for _ in range(iters):
-        # Align all ranks' starts; excluded from the timed region below.
-        _align()
-        torch.cuda.synchronize()
-        start_ev.record()
-        fn()
-        end_ev.record()
-        end_ev.synchronize()
-        times.append(start_ev.elapsed_time(end_ev))
+    n_reps = max(1, reps)
+    rep_bests: list[float] = []
+    last_std = 0.0
+    for _ in range(n_reps):
+        times: list[float] = []
+        for _ in range(iters):
+            # Align all ranks' starts; excluded from the timed region below.
+            _align()
+            torch.cuda.synchronize()
+            start_ev.record()
+            fn()
+            end_ev.record()
+            end_ev.synchronize()
+            times.append(start_ev.elapsed_time(end_ev))
+        rep_bests.append(min(times))
+        mean = sum(times) / len(times)
+        last_std = (sum((x - mean) ** 2 for x in times) / len(times)) ** 0.5
 
-    best = min(times)
-    mean = sum(times) / len(times)
-    std = (sum((x - mean) ** 2 for x in times) / len(times)) ** 0.5
-    return best, std
+    if n_reps == 1:
+        return rep_bests[0], last_std
+
+    ordered = sorted(rep_bests)
+    mid = len(ordered) // 2
+    median = (
+        ordered[mid]
+        if len(ordered) % 2 == 1
+        else 0.5 * (ordered[mid - 1] + ordered[mid])
+    )
+    spread = (ordered[-1] / ordered[0]) if ordered[0] > 0 else 0.0
+    if _env_int("BENCH_SWEEP_PER_REP", 0) != 0:
+        print(
+            "[per-rep] "
+            + " ".join(f"{v:.3f}" for v in rep_bests)
+            + f" | median {median:.3f} spread {spread:.2f}"
+        )
+    return median, spread
 
 
 # ---------------------------------------------------------------------------
@@ -1967,7 +2013,9 @@ def _msg_sweep_nccl_worker(
                     fused_pg,
                     _ar_opts,
                 )
-                best_f, std_f = _measure_ms(run_fused_base, warmup, bench_iters)
+                best_f, std_f = _measure_ms(
+                    run_fused_base, warmup, bench_iters, reps=_sweep_reps()
+                )
                 # Drop the per-size tensors held by the closure before the next
                 # (larger) size.
                 del run_fused_base
@@ -2035,6 +2083,7 @@ def _measure_relay_for(
         ),
         warmup,
         bench_iters,
+        reps=_sweep_reps(),
     )
     del active_in, active_out, bufs, in_list, out_list
     torch.cuda.empty_cache()
@@ -2428,7 +2477,11 @@ def _parallel_msg_sweep_nccl_worker(
                 # participates in the alignment barriers.
                 fn = _noop_fn
             best, std = _measure_ms(
-                fn, warmup, bench_iters, device_barrier_group=job_device_group
+                fn,
+                warmup,
+                bench_iters,
+                device_barrier_group=job_device_group,
+                reps=_sweep_reps(),
             )
             del fn
             torch.cuda.empty_cache()
@@ -2718,7 +2771,11 @@ def _parallel_msg_sweep_relay_worker(
                 device,
             )
             best, std = _measure_ms(
-                fn, warmup, bench_iters, device_barrier_group=job_device_group
+                fn,
+                warmup,
+                bench_iters,
+                device_barrier_group=job_device_group,
+                reps=_sweep_reps(),
             )
             del fn
             torch.cuda.empty_cache()


### PR DESCRIPTION
Summary:

An isolated collective benchmark cannot see the cost that matters most for a
comms optimization in a real job: whether it steals CUs or hardware queues from
the compute it is supposed to be overlapping with. Every number in this sweep so
far has been measured on an otherwise idle GPU, so a change that makes a
collective 25% faster while making co-resident compute 25% slower would look like
a pure win.

BENCH_SWEEP_CONTEND=1 streams GEMMs on a separate stream across each timed
iteration and reports the throughput they achieved, so a change can be judged on
BOTH numbers. BENCH_CONTEND_DIM and BENCH_CONTEND_GEMMS size the load.

The probe lives inside _measure_ms, which is the single chokepoint every sweep
goes through, so no call site changes and every existing sweep gains the option.
It is off by default and costs nothing when off.

The absolute TFLOP/s is a relative yardstick between arms, not a peak-throughput
claim; compare arms with identical settings.

Reviewed By: JinghanHuang

Differential Revision: D117629695


