### PR TITLE
Add non-VBE batched pooled embedding lookup pallas kernel on TPU

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
         TritonTableBatchedEmbeddingBags,
     )
     from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+        PallasTableBatchedEmbeddingBags,
         PooledLookupKernel,
         TPUEmbeddingBagUnfused,
         TPUEmbeddingUnfused,
@@ -4847,10 +4848,13 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     """Pooled TPU compute kernel (`UNFUSED_TPU`).
 
     TPU specific `BatchedDenseEmbeddingBag` in the pooled dispatch
-    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`). Uses one
+    (`GroupedPooledEmbeddingsLookup._create_embedding_kernel`).
+
+
+    If pooled_lookup_kernel is "offset" or "padded" then uses one
     `TPUEmbeddingUnfused` table per table in the group; `forward` routes
     each feature to its table, gathers its ids, and pools per sample (SUM or MEAN
-    per `config.pooling`).
+    per `config.pooling`). Otherwise it is batched lookup across all tables/features.
 
     Args:
         config (GroupedEmbeddingConfig): grouped table config (one or more tables).
@@ -4875,37 +4879,60 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     ) -> None:
         # Lazy import to avoid pulling in experimental TPU code at module load time.
         from torchrec.experimental.torch_tpu.modules.embedding_modules import (
+            PallasTableBatchedEmbeddingBags,
             PooledLookupKernel,
             TPUEmbeddingBagUnfused,
         )
 
         if pooled_lookup_kernel is None:
             pooled_lookup_kernel = PooledLookupKernel.OFFSET
+        self.pooled_lookup_kernel = pooled_lookup_kernel
+        self._use_batched_lookup = (
+            pooled_lookup_kernel == PooledLookupKernel.BATCHED_OFFSET
+        )
 
         super().__init__(config, pg, device, sharding_type)
         dtype = data_type_to_sparse_type(config.data_type).as_dtype()
 
         self._emb_modules: nn.ModuleList = nn.ModuleList()
-        for local_rows, local_cols in zip(self._local_rows, self._local_cols):
-            self._emb_modules.append(
-                TPUEmbeddingBagUnfused(
-                    num_embeddings=local_rows,
-                    embedding_dim=local_cols,
-                    device=device,
-                    dtype=dtype,
-                    mode="mean" if self._pooling == PoolingMode.MEAN else "sum",
-                    kernel=pooled_lookup_kernel,
-                )
+        if self._use_batched_lookup:
+            self._emb_module = PallasTableBatchedEmbeddingBags(
+                embedding_specs=list(zip(self._local_rows, self._local_cols)),
+                feature_table_map=self._feature_table_map,
+                weights_precision=dtype,
+                mode="mean" if self._pooling == PoolingMode.MEAN else "sum",
+                device=device,
             )
+        else:
+            for local_rows, local_cols in zip(self._local_rows, self._local_cols):
+                self._emb_modules.append(
+                    TPUEmbeddingBagUnfused(
+                        num_embeddings=local_rows,
+                        embedding_dim=local_cols,
+                        device=device,
+                        dtype=dtype,
+                        mode="mean" if self._pooling == PoolingMode.MEAN else "sum",
+                        kernel=pooled_lookup_kernel,
+                    )
+                )
         self.init_parameters()
 
     @property
     # pyrefly: ignore [bad-override]
-    def emb_module(self) -> "TPUEmbeddingBagUnfused":
+    def emb_module(
+        self,
+    ) -> Union["TPUEmbeddingBagUnfused", "PallasTableBatchedEmbeddingBags"]:
+        if self._use_batched_lookup:
+            return self._emb_module
         # pyre-ignore[16]: ModuleList returns Module, pyre thinks Union
         return self._emb_modules[0]
 
     def split_embedding_weights(self) -> List[torch.Tensor]:
+        if self._use_batched_lookup:
+            split_weights = self._emb_module.split_embedding_weights()
+            for weight in split_weights:
+                weight.requires_grad_(self._emb_module.weights.requires_grad)
+            return split_weights
         # pyre-ignore[16]
         return [emb_module.weight for emb_module in self._emb_modules]
 
@@ -4915,6 +4942,13 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
         assert (
             remove_duplicate
         ), "remove_duplicate=False not supported in named_split_embedding_weights"
+        if self._use_batched_lookup:
+            for table, weight in zip(
+                self._config.embedding_tables,
+                self._emb_module.split_embedding_weights(),
+            ):
+                yield append_prefix(prefix, f"{table.name}.weight"), weight
+            return
         for table, emb_module in zip(self._config.embedding_tables, self._emb_modules):
             # pyre-ignore[16]
             yield append_prefix(prefix, f"{table.name}.weight"), emb_module.weight
@@ -4922,6 +4956,14 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
     def named_parameters(
         self, prefix: str = "", recurse: bool = True, remove_duplicate: bool = True
     ) -> Iterator[Tuple[str, nn.Parameter]]:
+        if self._use_batched_lookup:
+            combined_key = "/".join(
+                table.name for table in self._config.embedding_tables
+            )
+            yield append_prefix(
+                prefix, f"{combined_key}.weight"
+            ), self._emb_module.weights
+            return
         for name, tensor in self.named_split_embedding_weights(
             prefix, recurse, remove_duplicate
         ):
@@ -4933,6 +4975,34 @@ class BatchedTPUEmbeddingBag(BaseBatchedEmbeddingBag[torch.Tensor]):
         vbe_output: Optional[torch.Tensor] = None,
         vbe_output_offsets: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if self._use_batched_lookup:
+            if features.variable_stride_per_key():
+                raise NotImplementedError("VBE on Pallas Batched EBC is not supported.")
+
+            offsets = features.offsets_or_none()
+            if offsets is None:
+                lengths = features.lengths()
+                # KJT's fallback uses an FBGEMM op without a TPU implementation.
+                # Scan batches independently, then add the much shorter feature-prefix
+                # scan to produce the same global offsets as a flat cumulative sum.
+                num_features = len(features.keys())
+                lengths_2d = lengths.view(num_features, -1)
+                local_ends = torch.cumsum(lengths_2d, dim=1).to(lengths.dtype)
+                zero = lengths.new_zeros(1)
+                feature_bases = torch.cat(
+                    [
+                        zero,
+                        torch.cumsum(local_ends[:, -1], dim=0).to(lengths.dtype)[:-1],
+                    ]
+                )
+                global_ends = local_ends + feature_bases.unsqueeze(1)
+                offsets = torch.cat([zero, global_ends.reshape(-1)])
+
+            return self.emb_module(
+                indices=features.values(),
+                offsets=offsets,
+            )
+
         jt_dict = features.to_dict()
         outputs = []
         for feature_idx, key in enumerate(features.keys()):

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -738,6 +738,11 @@ class GroupedPooledEmbeddingsLookup(
                 pg=pg,
                 device=device,
                 sharding_type=sharding_type,
+                pooled_lookup_kernel=(
+                    config.fused_params.get("pooled_lookup_kernel")
+                    if config.fused_params is not None
+                    else None
+                ),
             )
         elif config.compute_kernel in {
             EmbeddingComputeKernel.KEY_VALUE,

--- a/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
+++ b/torchrec/experimental/torch_tpu/benchmarks/train_dlrm_mlperf_tpu.py
@@ -66,6 +66,9 @@ from torchrec.distributed.types import ShardingEnv, ShardingPlan
 
 # Registers the TPU (SparseCore) impls of torchrec::embedding_lookup{,_backward};
 # pallas/ops.py only registers the CPU ones, so the UNFUSED_TPU lookup needs this.
+from torchrec.experimental.torch_tpu.modules.embedding_modules import (  # noqa: F401
+    PooledLookupKernel,
+)
 from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
 from torchrec.models.dlrm import DLRM_DCN
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -230,6 +233,9 @@ def _build_sharded(
     dcn_low_rank_dim: int,
 ) -> nn.Module:
     """Faithful MLPerf DLRM_DCN with a CW / UNFUSED_TPU EmbeddingBagCollection under DMP."""
+    sharder = EmbeddingBagCollectionSharder(
+        fused_params={"pooled_lookup_kernel": PooledLookupKernel.BATCHED_OFFSET}
+    )
     ebc = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
     model = DLRM_DCN(
         embedding_bag_collection=ebc,
@@ -257,20 +263,22 @@ def _build_sharded(
                 },
                 # pyre-ignore[6]: ModuleSharder is invariant; the EBC sharder is
                 # the correct sharder for this module type.
-                sharder=EmbeddingBagCollectionSharder(),
+                sharder=sharder,
                 local_size=1,
                 world_size=world_size,
                 device_type="tpu",
             )
         }
     )
+    if dist.get_rank(pg) == 0:
+        print(f"Sharding plan:\n{plan}", flush=True)
     return DistributedModelParallel(
         module=model,
         env=ShardingEnv.from_process_group(pg),
         device=device,
         plan=plan,
         # pyre-ignore[6]: see note above on ModuleSharder invariance.
-        sharders=[EmbeddingBagCollectionSharder()],
+        sharders=[sharder],
     )
 
 
@@ -316,6 +324,11 @@ def _median(xs: list[float]) -> float:
     s = sorted(xs)
     n = len(s)
     return s[n // 2] if n % 2 else 0.5 * (s[n // 2 - 1] + s[n // 2])
+
+
+def _cache_misses() -> int:
+    # pyre-ignore[16]: registered at runtime by torch_tpu.
+    return int(torch.tpu._get_cache_misses())
 
 
 def parse_args() -> argparse.Namespace:
@@ -397,6 +410,7 @@ def main() -> None:
     assert args.warmup >= 0, "--warmup cannot be negative"
 
     nepf = NEPF_CANONICAL if args.cardinality == "canonical" else NEPF_SHRUNK
+
     tables = _build_tables(nepf)
     table_rows = [t.num_embeddings for t in tables]
     features = [t.feature_names[0] for t in tables]
@@ -423,7 +437,7 @@ def main() -> None:
 
     kjt_gen = torch.Generator()
 
-    def run_step(step: int, timed: bool) -> float:
+    def run_step(step: int) -> float:
         # KJT is built on host then moved to device; the sharded EBC input_dist
         # all2alls it feature-wise (CW: even). It must already be on device -- the
         # splits all2all inside KJTAllToAll runs on the KJT's device.
@@ -432,16 +446,29 @@ def main() -> None:
         opt.zero_grad()
         t0 = time.perf_counter()
         logits = sharded_model(dense_x, kjt)
+
         loss = F.binary_cross_entropy_with_logits(logits, labels)
         loss.backward()
         opt.step()
-        if timed:
-            _materialize()  # flush fwd+bwd+opt for this step
+        _materialize()
         return time.perf_counter() - t0
 
+    cache_misses_before_warmup = _cache_misses()
     for w in range(args.warmup):
-        run_step(w, timed=False)
+        step_cache_misses_before = _cache_misses()
+        duration = run_step(w)
+        step_cache_misses_after = _cache_misses()
+        if rank == 0:
+            print(
+                f"Warmup step {w}: {duration:.3f}s, "
+                f"cache misses +{step_cache_misses_after - step_cache_misses_before} "
+                f"(total={step_cache_misses_after})",
+                flush=True,
+            )
     _materialize()
+
+    cache_misses_after_warmup = _cache_misses()
+    warmup_compiles = cache_misses_after_warmup - cache_misses_before_warmup
 
     # Optional xprof capture of the timed steps. jax.profiler records the TPU device
     # timeline (SC/TC ops) via libtpu regardless of framework; rank 0 captures.
@@ -452,9 +479,22 @@ def main() -> None:
         os.makedirs(args.profile_dir, exist_ok=True)
         jax.profiler.start_trace(args.profile_dir)
 
+    cache_misses_before_timed = _cache_misses()
     step_ms: list[float] = []
     for s in range(args.steps):
-        step_ms.append(run_step(args.warmup + s, timed=True) * 1e3)
+        step_cache_misses_before = _cache_misses()
+        step_ms.append(run_step(args.warmup + s) * 1e3)
+        step_cache_misses_after = _cache_misses()
+        if rank == 0:
+            print(
+                f"Timed iter {s}: {step_ms[-1]:.3f}ms, "
+                f"cache misses +{step_cache_misses_after - step_cache_misses_before} "
+                f"(total={step_cache_misses_after})",
+                flush=True,
+            )
+
+    cache_misses_after_timed = _cache_misses()
+    timed_compiles = cache_misses_after_timed - cache_misses_before_timed
 
     if profiling:
         _materialize()  # flush pending TPU work into the trace window
@@ -470,6 +510,20 @@ def main() -> None:
     dist.all_reduce(xsum, op=dist.ReduceOp.SUM)
     xrank_max = xmax.cpu().item()
     xrank_mean = (xsum / world_size).cpu().item()
+
+    local_compile_counts = torch.tensor(
+        [warmup_compiles, timed_compiles], dtype=torch.float32, device=device
+    )
+    compile_sum = local_compile_counts.clone()
+    dist.all_reduce(compile_sum, op=dist.ReduceOp.SUM)
+    compile_max = local_compile_counts.clone()
+    dist.all_reduce(compile_max, op=dist.ReduceOp.MAX)
+    warmup_compile_sum, timed_compile_sum = [
+        int(value) for value in compile_sum.cpu().tolist()
+    ]
+    warmup_compile_max, timed_compile_max = [
+        int(value) for value in compile_max.cpu().tolist()
+    ]
 
     if rank == 0:
         # K samples/s/chip = per_chip_batch / step_time_s / 1000 (straggler-bound).
@@ -493,6 +547,18 @@ def main() -> None:
             flush=True,
         )
         print(f"  K samples/s/chip (straggler-bound) = {kspc:.1f}", flush=True)
+        print(
+            "  compilation cache misses: "
+            f"warmup total={warmup_compile_sum} max/rank={warmup_compile_max}; "
+            f"timed total={timed_compile_sum} max/rank={timed_compile_max}",
+            flush=True,
+        )
+        if timed_compile_sum != 0:
+            print(
+                "  WARNING: timed compilation cache misses make this throughput "
+                "result invalid for steady-state comparison.",
+                flush=True,
+            )
 
     dist.barrier()
     dist.destroy_process_group()

--- a/torchrec/experimental/torch_tpu/modules/embedding_modules.py
+++ b/torchrec/experimental/torch_tpu/modules/embedding_modules.py
@@ -8,9 +8,11 @@
 # pyre-strict
 
 from enum import Enum
-from typing import List, Optional
+from itertools import accumulate
+from typing import cast, List, Optional, Tuple
 
 import torch
+from torch import nn
 
 # Imported is needed: defines torchrec::embedding_lookup
 from torchrec.experimental.torch_tpu.pallas import ops  # noqa: F401
@@ -19,6 +21,7 @@ from torchrec.experimental.torch_tpu.pallas import ops  # noqa: F401
 class PooledLookupKernel(Enum):
     PADDED = "padded"
     OFFSET = "offset"
+    BATCHED_OFFSET = "batched_offset"
 
 
 class TPUEmbeddingUnfused(torch.nn.Module):
@@ -288,3 +291,217 @@ class TPUEmbeddingBagUnfused(torch.nn.Module):
         if self._kernel is PooledLookupKernel.OFFSET:
             return self._offset_lookup(input, offsets)
         return self._padded_lookup(input, offsets)
+
+
+def _construct_weight_offsets(
+    embedding_specs: List[Tuple[int, int]],
+) -> Tuple[int, List[int]]:
+    """Converts global information about embedding table to local information
+
+    Equivalent to "construct_split_state"
+
+    Returns
+    - tpu_size: total size
+    - offsets: global offsets of flattened table
+
+    """
+    tpu_size = 0
+    offsets = []
+    for row, dim in embedding_specs:
+        offsets.append(tpu_size)
+        tpu_size += row * dim
+    return (tpu_size, offsets)
+
+
+def _bucket_index_count(num_indices: int) -> int:
+    """Round an id count up to a power-of-two bucket."""
+    # Smallest id bucket; below this the padding is free and the extra distinct programs
+    # are not worth compiling.
+    MIN_INDEX_BUCKET = 1024
+
+    if num_indices <= MIN_INDEX_BUCKET:
+        return MIN_INDEX_BUCKET
+    return 1 << (num_indices - 1).bit_length()
+
+
+class PallasTableBatchedEmbeddingBags(nn.Module):
+    """Batched pooled lookup over a row-stacked collection of embedding tables.
+
+    Args:
+        embedding_specs: Local row count and dimension for each table.
+        feature_table_map: Table index used by each feature.
+        weights_precision: Weight dtype; currently only torch.float32.
+        mode: Pooling mode, either sum or mean.
+        device: Device on which weights and lookup buffers are allocated.
+
+    Example::
+
+        module = PallasTableBatchedEmbeddingBags(
+            embedding_specs=[(8, 16), (4, 16)],
+            device=torch.device("cpu"),
+        )
+    """
+
+    def __init__(
+        self,
+        embedding_specs: List[Tuple[int, int]],
+        feature_table_map: Optional[List[int]] = None,
+        weights_precision: torch.dtype = torch.float32,
+        mode: str = "sum",
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self.device = device if device is not None else torch.device("tpu")
+        if mode not in {"sum", "mean"}:
+            raise ValueError(f"mode must be 'sum' or 'mean', got {mode}")
+        self.mode = mode
+        self.weights_precision = weights_precision
+        assert (
+            self.weights_precision == torch.float32
+        ), "TPU lookup only supports float32 for now."
+
+        self.embedding_specs = embedding_specs
+        rows, dims = zip(*embedding_specs)
+        if len(set(dims)) != 1:
+            raise ValueError(
+                "All TPU-batched tables must have the same local dimension."
+            )
+
+        T_ = len(self.embedding_specs)
+        assert T_ > 0
+
+        self.size, self.offsets = _construct_weight_offsets(embedding_specs)
+        self.feature_table_map: list[int] = (
+            feature_table_map if feature_table_map is not None else list(range(T_))
+        )
+        table_row_offsets = [0] + list(accumulate(rows))
+        feature_row_offsets = [
+            table_row_offsets[table] for table in self.feature_table_map
+        ]
+        self.register_buffer(
+            "weights_offsets",
+            torch.tensor(
+                feature_row_offsets,
+                dtype=torch.int32,
+                device=self.device,
+            ),
+        )
+        self._cached_row_offsets: Optional[torch.Tensor]
+        self.register_buffer("_cached_row_offsets", None, persistent=False)
+        self._cached_row_offsets_batch_size: int = -1
+        feature_weight_offsets = [
+            self.offsets[table_idx] for table_idx in self.feature_table_map
+        ]
+
+        feature_dims = [dims[t] for t in self.feature_table_map]  # Needed for VBE
+        D_offsets = [0] + list(accumulate(feature_dims))
+        self.total_D: int = D_offsets[-1]
+        self.max_D: int = max(dims)
+        # TODO ADD ASSERT TO MAKE SURE ALL DIMENSIONS SAME
+        hash_size_cumsum = [0] + list(accumulate(rows))
+        self.total_hash_size: int = int(hash_size_cumsum[-1])
+
+        # Construct the weights
+        self.weights = self.construct_weights()
+
+        # Register the buffers needed
+        self.register_buffer(
+            "D_offsets",
+            torch.tensor(D_offsets, dtype=torch.int32, device=self.device),
+        )
+        # Note feature_weight_offsets need ot be int64, but isn't used within the TPU lookup kernel.
+        self.register_buffer(
+            "feature_weight_offsets",
+            torch.tensor(feature_weight_offsets, dtype=torch.int64, device=self.device),
+        )
+
+    def construct_weights(self) -> nn.Parameter:
+        rows, dims = zip(*self.embedding_specs)
+
+        # TODO: make this similar to how BatchedFused is doing with normal
+        return nn.Parameter(
+            torch.zeros(
+                size=(sum(rows), max(dims)),
+                dtype=self.weights_precision,
+                device=self.device,
+            )
+        )
+
+    def split_embedding_weights(self) -> list[torch.Tensor]:
+        splits = []
+        for t, (rows, dim) in enumerate(self.embedding_specs):
+            offset = self.offsets[t]
+
+            weights = self.weights
+            if weights.dim() == 2:
+                weights = weights.flatten()
+            split_weight = weights.detach()[offset : offset + rows * dim].view(
+                rows, dim
+            )
+            if self.weights.grad is not None:
+                split_weight.grad = (
+                    self.weights.grad.detach()
+                    .flatten()[offset : offset + rows * dim]
+                    .view(rows, dim)
+                )
+            splits.append(split_weight)
+        return splits
+
+    def forward(
+        self,
+        indices: torch.Tensor,
+        offsets: torch.Tensor,
+        # per_sample_weights: Tensor | None = None,
+        # feature_requires_grad: Tensor | None = None,
+        # batch_size_per_feature_per_rank: list[list[int]] | None = None,
+        # total_unique_indices: int | None = None,
+        # hash_zch_identities: Tensor | None = None,
+        # hash_zch_runtime_meta: Tensor | None = None,
+        # vbe_output: Tensor | None = None,
+        # vbe_output_offsets: Tensor | None = None,
+    ) -> torch.Tensor:
+        """Pool feature-major jagged IDs and return batch-major embeddings.
+
+        Args:
+            indices: Flattened local row IDs for all feature bags.
+            offsets: Boundaries for feature-major bags.
+
+        Returns:
+            Tensor shaped as batch size by features times embedding dimension.
+        """
+        num_features = len(self.feature_table_map)
+        batch_size = (offsets.numel() - 1) // num_features  # ASSUMES NON-VBE
+
+        # Instead of having an offset per feature, repeat it to have one per bag.
+        # Cache the result because fixed-batch workloads otherwise rebuild the same
+        # device tensor on every forward.
+        row_offsets = self._cached_row_offsets
+        if row_offsets is None or self._cached_row_offsets_batch_size != batch_size:
+            row_offsets = torch.repeat_interleave(
+                cast(torch.Tensor, self.weights_offsets), batch_size
+            )
+            self._cached_row_offsets = row_offsets
+            self._cached_row_offsets_batch_size = batch_size
+
+        # `offsets` and `row_offsets` are a fixed [F * B (+1)] for non-VBE, but the id
+        # count moves with every batch, so an unbucketed call retraces and recompiles
+        # the kernel on every step.
+        # TODO: We need to optimize this the right number of bucket
+        bucket = _bucket_index_count(indices.numel())
+        if bucket != indices.numel():
+            indices = nn.functional.pad(indices, (0, bucket - indices.numel()))
+
+        pooled_embs = torch.ops.torchrec.embedding_pooled_batched_lookup_offset(
+            indices, offsets, self.weights, row_offsets, self.max_D
+        )
+        if self.mode == "mean":
+            lengths = offsets[1:] - offsets[:-1]
+            pooled_embs = pooled_embs / lengths.clamp(min=1).unsqueeze(1).to(
+                pooled_embs.dtype
+            )
+
+        return (
+            pooled_embs.view(num_features, batch_size, self.max_D)
+            .permute(1, 0, 2)
+            .reshape(batch_size, num_features * self.max_D)
+        )

--- a/torchrec/experimental/torch_tpu/pallas/impl.py
+++ b/torchrec/experimental/torch_tpu/pallas/impl.py
@@ -34,6 +34,14 @@ _pooled_offset_bwd = pallas.jax_op(
     "torchrec_pallas::embedding_pooled_lookup_offset_bwd",
     pooled_lookup_offset.embedding_pooled_lookup_bwd_jax,
 )
+_pooled_batched_offset_fwd = pallas.jax_op(
+    "torchrec_pallas::embedding_pooled_batched_lookup_offset",
+    pooled_lookup_offset.embedding_pooled_batched_lookup_jax,
+)
+_pooled_batched_offset_bwd = pallas.jax_op(
+    "torchrec_pallas::embedding_pooled_batched_lookup_offset_bwd",
+    pooled_lookup_offset.embedding_pooled_batched_lookup_bwd_jax,
+)
 
 
 def embedding_lookup_tpu(indices, weights, emb_dim):
@@ -81,6 +89,31 @@ def embedding_pooled_lookup_offset_backward_tpu(
     )
 
 
+def embedding_pooled_batched_lookup_offset_tpu(
+    indices, offsets, weights, row_offsets, emb_dim
+):
+    return _pooled_batched_offset_fwd(
+        indices=indices,
+        offsets=offsets,
+        dev_weights=weights,
+        row_offsets=row_offsets,
+        emb_dim=emb_dim,
+    )
+
+
+def embedding_pooled_batched_lookup_offset_backward_tpu(
+    grad_out, indices, offsets, row_offsets, num_rows, emb_dim
+):
+    return _pooled_batched_offset_bwd(
+        grad_out=grad_out,
+        indices=indices,
+        offsets=offsets,
+        row_offsets=row_offsets,
+        num_rows=num_rows,
+        emb_dim=emb_dim,
+    )
+
+
 lib: torch.library.Library = torch.library.Library("torchrec", "IMPL")
 lib.impl("embedding_lookup", embedding_lookup_tpu, "TPU")
 lib.impl("embedding_lookup_backward", embedding_lookup_backward_tpu, "TPU")
@@ -94,5 +127,16 @@ lib.impl(
     embedding_pooled_lookup_offset_backward_tpu,
     "TPU",
 )
+lib.impl(
+    "embedding_pooled_batched_lookup_offset",
+    embedding_pooled_batched_lookup_offset_tpu,
+    "TPU",
+)
+lib.impl(
+    "embedding_pooled_batched_lookup_offset_backward",
+    embedding_pooled_batched_lookup_offset_backward_tpu,
+    "TPU",
+)
+
 
 _ = ops

--- a/torchrec/experimental/torch_tpu/pallas/ops.py
+++ b/torchrec/experimental/torch_tpu/pallas/ops.py
@@ -30,6 +30,16 @@ lib.define(
     "Tensor grad_out, Tensor indices, Tensor offsets, "
     "int num_rows, int emb_dim) -> Tensor"
 )
+lib.define(
+    "embedding_pooled_batched_lookup_offset("
+    "Tensor indices, Tensor offsets, Tensor weights, Tensor row_offsets, "
+    "int emb_dim) -> Tensor"
+)
+lib.define(
+    "embedding_pooled_batched_lookup_offset_backward("
+    "Tensor grad_out, Tensor indices, Tensor offsets, Tensor row_offsets, "
+    "int num_rows, int emb_dim) -> Tensor"
+)
 
 
 def embedding_lookup_cpu(
@@ -106,6 +116,41 @@ def embedding_pooled_lookup_offset_backward_cpu(
     )
 
 
+def embedding_pooled_batched_lookup_offset_cpu(
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    weights: torch.Tensor,
+    row_offsets: torch.Tensor,
+    emb_dim: int,
+) -> torch.Tensor:
+    bag_indices = _bag_indices(offsets)
+    active_indices = indices[: bag_indices.numel()]
+    weight_indices = active_indices.long() + row_offsets[bag_indices].long()
+    return weights.new_zeros((offsets.numel() - 1, emb_dim)).index_add_(
+        0,
+        bag_indices,
+        weights[weight_indices],
+    )
+
+
+def embedding_pooled_batched_lookup_offset_backward_cpu(
+    grad_out: torch.Tensor,
+    indices: torch.Tensor,
+    offsets: torch.Tensor,
+    row_offsets: torch.Tensor,
+    num_rows: int,
+    emb_dim: int,
+) -> torch.Tensor:
+    bag_indices = _bag_indices(offsets)
+    active_indices = indices[: bag_indices.numel()]
+    weight_indices = active_indices.long() + row_offsets[bag_indices].long()
+    return grad_out.new_zeros((num_rows, emb_dim)).index_add_(
+        0,
+        weight_indices,
+        grad_out[bag_indices],
+    )
+
+
 lib.impl("embedding_pooled_lookup", embedding_pooled_lookup_cpu, "CPU")
 lib.impl(
     "embedding_pooled_lookup_backward", embedding_pooled_lookup_backward_cpu, "CPU"
@@ -114,6 +159,16 @@ lib.impl("embedding_pooled_lookup_offset", embedding_pooled_lookup_offset_cpu, "
 lib.impl(
     "embedding_pooled_lookup_offset_backward",
     embedding_pooled_lookup_offset_backward_cpu,
+    "CPU",
+)
+lib.impl(
+    "embedding_pooled_batched_lookup_offset",
+    embedding_pooled_batched_lookup_offset_cpu,
+    "CPU",
+)
+lib.impl(
+    "embedding_pooled_batched_lookup_offset_backward",
+    embedding_pooled_batched_lookup_offset_backward_cpu,
     "CPU",
 )
 
@@ -169,6 +224,26 @@ def _pooled_offset_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
     return None, None, grad_weights, None
 
 
+def _setup_pooled_batched_offset_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    indices, offsets, weights, row_offsets, emb_dim = inputs
+    ctx.save_for_backward(indices, offsets, row_offsets)
+    ctx.num_rows = weights.shape[0]
+    ctx.emb_dim = emb_dim
+
+
+def _pooled_batched_offset_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
+    indices, offsets, row_offsets = ctx.saved_tensors
+    grad_weights = torch.ops.torchrec.embedding_pooled_batched_lookup_offset_backward(
+        grad_out.contiguous(),
+        indices,
+        offsets,
+        row_offsets,
+        ctx.num_rows,
+        ctx.emb_dim,
+    )
+    return None, None, grad_weights, None, None
+
+
 torch.library.register_autograd(
     "torchrec::embedding_pooled_lookup",
     _pooled_backward,
@@ -178,4 +253,9 @@ torch.library.register_autograd(
     "torchrec::embedding_pooled_lookup_offset",
     _pooled_offset_backward,
     setup_context=_setup_pooled_offset_context,
+)
+torch.library.register_autograd(
+    "torchrec::embedding_pooled_batched_lookup_offset",
+    _pooled_batched_offset_backward,
+    setup_context=_setup_pooled_batched_offset_context,
 )

--- a/torchrec/experimental/torch_tpu/pallas/pooled_lookup_offset.py
+++ b/torchrec/experimental/torch_tpu/pallas/pooled_lookup_offset.py
@@ -6,14 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-"""Fused jagged pooled (gather + sum) TPU embedding lookup on the SparseCore (v2).
+"""Fused jagged pooled (gather + sum) TPU embedding lookup on the SparseCore.
 
 This version is fully offset-driven.
-
-The only host-side work is a `concat` padding `offsets` up to the grid size (+ window slack) and
-a small tail pad on `indices` so the last aligned chunk read stays in bounds -- the out-of-bag
-ids such reads gather are masked out in the reduction.
-
 """
 
 import functools
@@ -41,7 +36,7 @@ def run_sc_pooled_lookup(  # noqa: C901
     emb_dim: int,
 ) -> jax.Array:
     assert emb_dim % NL == 0, f"emb_dim={emb_dim} must be a multiple of {NL}"
-    assert (sc := pltpu.get_tpu_info().sparse_core)  # pyre-ignore[16]
+    sc = pltpu.get_tpu_info().sparse_core  # pyre-ignore
     num_sub = sc.num_cores * sc.num_subcores
     num_bags = offsets.shape[0] - 1
     n_slices = emb_dim // NL
@@ -205,3 +200,410 @@ def embedding_pooled_lookup_bwd_jax(
     )
     grad_per_id = grad_out[seg]  # [total_ids, emb_dim]
     return jnp.zeros((num_rows, emb_dim), grad_out.dtype).at[indices].add(grad_per_id)
+
+
+@jax.jit(static_argnames=["emb_dim"])  # pyre-ignore[20]
+def run_sc_pooled_lookup_batch_parallel(  # noqa: C901
+    indices: jax.Array,
+    offsets: jax.Array,
+    dev_weights: jax.Array,
+    row_offsets: jax.Array,
+    emb_dim: int,
+) -> jax.Array:
+    """
+    Batched pooled embedding lookup on sparse-core parallelizes over batches.
+
+    This algorithm performs pooled embedding lookup using indices and offsets. Effectively
+    each subcore is assigned to a group of batches defined by `NUMB_BATCHES_PER_ITERATION`.
+    A subcore would grab the offsets and create a temporary zeroed out buffer for the pooled
+    embeddings. Afterwards a ping-pong style algorithm is performed to overlap the HBM->VMEM
+    transfers of ids within `i`th batch, with pooling of the previous embeddings on previous ids
+    within the `i`th batch.
+
+    The way pooling is performed is that each subcore would process `NUMB_IDS_PROCESSED_PER_STEP`
+    indices at a time within a batch. Now the first row of the temprory buffer is used and
+    each embedding is added to it. The embedding dimensions are split to lane size, and so
+    only `LANE_SIZE` columns are processed in each step.
+
+
+    Notes:
+    - Embedding dimensions are padded only for VMEM but not HBM saving memory. However non-16
+        multiple embedding dimension is not yet supported.
+    - Indices, and offsets are padded to length of a lane.
+    - Grabbing the offsets is async while it creates a zeroed out temporary buffer.
+    - Each subcore gets a chunk of certain number of batch.
+    - Subcore processes one batch, but it iterates through groups of batches
+    - Each SIMD lane/threads within the subcore processes embedding columns together
+    - One could do grid=(number_of_blocks,) with PARALLEL, so each block gets assigned to a subcore
+        - but for pingpong buffers, it is much easier to do with 2D-style
+    - Bulk transfer of offsets are done for each batch, once could do sequential batch processing per subcore
+    - Removes the assumption that embedding dimension should be a multiple of tiles,
+        - Decided to do masking, but maybe we cna pad within VMEM but HBM tranffer needs to be properly handled
+    - Assumption is that maximum number of batch size >= 16
+
+
+    TODO: Profile against doing a post-kernel permute/reshape of the embedding table against
+          doing one where the output layout is done wihtin the kernel. Right now, the kernel return [F * B, D] whereas
+          it is expected to be in feature-major order. [B, F * D]. Another option is to re-order the KJT, so three approaches
+          can be tested out here.
+    TODO: Benchmark against pre-shifting every index before calling this pallas kernel (for table batched), or do it within
+          the kernel. FBGEMM does it within the kernel. Note that pre-shifting would cause this to be in the
+    TODO: Benchmark against analytic calculation of  VMEM size.
+    TODO: Implement to work over any embedding-dimension
+    TODO: Prefetch batch i + 1 while doing hte pooling of the last chunk of bag i.
+    TODO: Implement for embedding-dimension 8.
+    TODO: Test against BF16, and implement it
+    TODO: check if using repeat_interleave for the row_offset can cause performance regressions in e2e model.
+    TODO: xla compiler for sparseCore can only supports 16 GiB of HBM per tensor, so if we have large stacked embeddings
+          then we would need to either split them up, or re-think how we want to shard.
+    TODO: Remove the output from [F, B, D] = [F* B, D] shape to [B, F * D] so that we can remove operations inside PallasTBE class.
+    """
+    # Only do eight batch at a time since it can fit inside a 16-lane offset load
+    NUMB_BATCHES_PER_ITERATION = 8  # TODO: Tune this parameter
+    LANE_SIZE = 16
+    NUMB_IDS_PROCESSED_PER_STEP = 16  # TODO: Explicitly figure out this formula # IDS gathered per chunk wihtin one batch
+    TILE = 8
+    assert NUMB_BATCHES_PER_ITERATION % TILE == 0
+    assert NUMB_IDS_PROCESSED_PER_STEP % TILE == 0
+    assert NUMB_BATCHES_PER_ITERATION + 1 <= LANE_SIZE
+    assert emb_dim == 8 or emb_dim % LANE_SIZE == 0
+    num_batches = offsets.shape[0] - 1
+
+    # Get Sparse-core information
+    sc = pltpu.get_tpu_info().sparse_core  # pyre-ignore
+    total_num_subcores = sc.num_cores * sc.num_subcores
+
+    # Pad the embedding dimensions to be alinged to a LANE size
+    # note we want to avoid doing it to full HBM, so we do it on VMEM/output instead
+    aligned_emb_dim = ((emb_dim + LANE_SIZE - 1) // LANE_SIZE) * LANE_SIZE
+
+    # Embedding dimension processes per SIMD lanes
+    numb_cols_chunks = aligned_emb_dim // LANE_SIZE
+
+    # Number of chunks (grouping of batch) to compute
+    numb_chunks = (
+        num_batches + NUMB_BATCHES_PER_ITERATION - 1
+    ) // NUMB_BATCHES_PER_ITERATION
+
+    # Distribute chunks to number of available subcores
+    number_of_blocks = (numb_chunks + total_num_subcores - 1) // total_num_subcores
+    grid_blocks = number_of_blocks * total_num_subcores
+    grid_rows = grid_blocks * NUMB_BATCHES_PER_ITERATION
+
+    # Pad offsets to be multiple of lane size 16
+    pad_size = grid_rows + LANE_SIZE - offsets.shape[0]
+    offsets = jnp.concatenate(
+        [
+            offsets,
+            jnp.full(
+                (pad_size,),
+                offsets[-1],
+                dtype=offsets.dtype,
+            ),
+        ]
+    )
+
+    # Tail-pad the ids so a batch's last tile-aligned chunk cannot read past the end
+    # of the array (bounds checks are disabled); the extra rows are masked out.
+    indices = jnp.pad(indices, (0, NUMB_IDS_PROCESSED_PER_STEP), constant_values=0)
+
+    # Pad the feature/row offsets
+    row_offsets = jnp.pad(
+        row_offsets,
+        (0, grid_rows + LANE_SIZE - row_offsets.shape[0]),
+        constant_values=0,
+    )
+
+    mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="c",
+        subcore_axis_name="s",
+        num_cores=sc.num_cores,
+        num_subcores=sc.num_subcores,  # pyre-ignore[16]
+    )
+
+    # pyre-ignore[16]
+    @pl.kernel(
+        out_type=jax.ShapeDtypeStruct((grid_rows, aligned_emb_dim), dev_weights.dtype),
+        mesh=mesh,  # pyre-ignore[16]
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=False,
+            use_tc_tiling_on_sc=False,  # pyre-ignore[16]
+            needs_layout_passes=False,  # pyre-ignore[16]
+        ),
+        scratch_types=[
+            pltpu.VMEM((LANE_SIZE,), offsets.dtype),  # offsets
+            pltpu.VMEM((2, NUMB_IDS_PROCESSED_PER_STEP), indices.dtype),  # indices
+            pltpu.VMEM((LANE_SIZE,), offsets.dtype),  # per-batch row offsets
+            pltpu.VMEM(
+                (2, NUMB_IDS_PROCESSED_PER_STEP, aligned_emb_dim),
+                dev_weights.dtype,  # embedding in vmem
+            ),
+            pltpu.VMEM(
+                (NUMB_BATCHES_PER_ITERATION, aligned_emb_dim),
+                dev_weights.dtype,  # post pooled emb in vmem
+            ),
+            pltpu.SemaphoreType.DMA((2,)),
+            pltpu.SemaphoreType.DMA(()),
+            pltpu.SemaphoreType.DMA(()),
+        ],
+    )
+    def lookup_kernel(
+        weights_hbm,
+        indices_hbm,
+        offsets_hbm,
+        row_offsets_hbm,
+        out_hbm,
+        offsets_vmem,
+        indices_vmem,
+        row_offsets_vmem,
+        buf_vmem,
+        post_pooled_emb_vmem,
+        sem,
+        offset_sem,
+        row_offset_sem,
+    ):
+        @functools.partial(
+            pltpu.emit_pipeline,
+            grid=(number_of_blocks, total_num_subcores),
+            core_axis_name=("c", "s"),
+            dimension_semantics=(pltpu.ARBITRARY, pltpu.PARALLEL),
+        )
+        def _inner():
+            # Calculate which batch corresponds to this subcore
+            # TODO: Could assign contigious batches to each subcore instead versus doing strided here
+            chunk_id = pl.program_id(0)
+            core_id = pl.program_id(1)
+            chunk_id = chunk_id * total_num_subcores + core_id
+
+            # Fetch all the offsets in bulk at once that requires to be processed by subcore
+            base = pl.multiple_of(
+                chunk_id * NUMB_BATCHES_PER_ITERATION,
+                TILE,
+            )
+            offset_start = pltpu.make_async_copy(
+                offsets_hbm.at[
+                    pl.ds(
+                        base,
+                        LANE_SIZE,
+                    )
+                ],
+                offsets_vmem,
+                offset_sem,
+            )
+
+            row_offset_start = pltpu.make_async_copy(
+                row_offsets_hbm.at[
+                    pl.ds(
+                        base,
+                        LANE_SIZE,
+                    )
+                ],
+                row_offsets_vmem,
+                row_offset_sem,
+            )
+            offset_start.start()
+            row_offset_start.start()
+
+            # Zero out the temporary embedding rows in VMEM
+            for i in range(NUMB_BATCHES_PER_ITERATION):
+                for j in range(numb_cols_chunks):
+                    post_pooled_emb_vmem[i, pl.ds(j * LANE_SIZE, LANE_SIZE)] = (
+                        jnp.zeros((LANE_SIZE,), dtype=post_pooled_emb_vmem.dtype)
+                    )
+
+            # Bring from VMEM to registers
+            offset_start.wait()
+            row_offset_start.wait()
+            offsets_reg = offsets_vmem[...]
+            row_offsets_reg = row_offsets_vmem[...]
+
+            def _gather(base, slot, off_start, off_end, row_offset):
+                # Copy the sync indices on chunks based due to VMEM shortage
+                base = pl.multiple_of(base, TILE)
+                pltpu.sync_copy(
+                    indices_hbm.at[pl.ds(base, NUMB_IDS_PROCESSED_PER_STEP)],
+                    indices_vmem.at[slot],
+                )
+
+                positions = base + jnp.arange(NUMB_IDS_PROCESSED_PER_STEP)
+                valid = (positions >= off_start) & (positions < off_end)
+
+                indices_vmem[slot, ...] = (
+                    jnp.where(valid, indices_vmem[slot, ...], 0) + row_offset
+                )
+
+                # Start copying the weights
+                pltpu.make_async_copy(
+                    weights_hbm.at[plsc.Indices(indices_vmem.at[slot])],
+                    buf_vmem.at[slot],
+                    sem.at[slot],
+                ).start()
+
+            def _wait(slot):
+                pltpu.make_async_copy(
+                    weights_hbm.at[plsc.Indices(indices_vmem.at[slot])],
+                    buf_vmem.at[slot],
+                    sem.at[slot],
+                ).wait()
+
+            output_start = pl.multiple_of(
+                chunk_id * NUMB_BATCHES_PER_ITERATION,
+                TILE,
+            )
+
+            # Go through each batch per iteration
+            for i_batch in range(NUMB_BATCHES_PER_ITERATION):
+                # Grab the offset start and end
+                off_start, off_end = offsets_reg[i_batch], offsets_reg[i_batch + 1]
+
+                # Row offset of the table this batch's feature maps into.
+                feat_offset = row_offsets_reg[i_batch]
+
+                # An HBM slice has to start on a tile boundary, and so masking is required
+                aligned_start = (off_start // TILE) * TILE
+
+                # Mask the number of batches needed to be processed per step
+                numb_id_chunks = jnp.where(
+                    off_end == off_start,
+                    0,
+                    (off_end - aligned_start + NUMB_IDS_PROCESSED_PER_STEP - 1)
+                    // NUMB_IDS_PROCESSED_PER_STEP,
+                )
+
+                # Grab the initial chunk of ids and rows
+                @pl.when(numb_id_chunks > 0)
+                def _(
+                    aligned_start=aligned_start,
+                    off_start=off_start,
+                    off_end=off_end,
+                    feat_offset=feat_offset,
+                ):
+                    pingpong_id = 0
+                    _gather(aligned_start, pingpong_id, off_start, off_end, feat_offset)
+
+                @pl.loop(0, numb_id_chunks)
+                def _process_cols(
+                    i_id_chunk,
+                    i=i_batch,
+                    numb_id_chunks=numb_id_chunks,
+                    off_end=off_end,
+                    off_start=off_start,
+                    aligned_start=aligned_start,
+                    feat_offset=feat_offset,
+                ):
+                    # Current pingpong id/batch
+                    pingpong_id = i_id_chunk % 2
+
+                    @pl.when(i_id_chunk + 1 < numb_id_chunks)
+                    def _(
+                        i_id_chunk=i_id_chunk,
+                        aligned_start=aligned_start,
+                        off_start=off_start,
+                        off_end=off_end,
+                        feat_offset=feat_offset,
+                    ):
+                        # Alternate to do the next set of ids
+                        next_pingpong_id = (i_id_chunk + 1) % 2
+
+                        # Grab the next chunk of ids and their embedding.
+                        _gather(
+                            aligned_start
+                            + (i_id_chunk + 1) * NUMB_IDS_PROCESSED_PER_STEP,
+                            next_pingpong_id,
+                            off_start,
+                            off_end,
+                            feat_offset,
+                        )
+
+                    # Wait for the ids/embedding rows to arrive
+                    _wait(pingpong_id)
+
+                    # Do masking over ids within a batch. The chunk is tile-aligned
+                    # so it can start before the batch does: mask both ends.
+                    chunk_base = (
+                        aligned_start + i_id_chunk * NUMB_IDS_PROCESSED_PER_STEP
+                    )
+                    one = jnp.ones((LANE_SIZE,), dtype=post_pooled_emb_vmem.dtype)
+                    zero = jnp.zeros((LANE_SIZE,), dtype=post_pooled_emb_vmem.dtype)
+                    masks = [
+                        jnp.where(
+                            (chunk_base + row >= off_start)
+                            & (chunk_base + row < off_end),
+                            one,
+                            zero,
+                        )
+                        for row in range(NUMB_IDS_PROCESSED_PER_STEP)
+                    ]
+
+                    # Do pooling of the embedding table by going through column dimension
+                    # TODO: Benchmark with different temp arrays for the summation.
+                    @plsc.parallel_loop(0, aligned_emb_dim, step=LANE_SIZE)
+                    def _cols(i_col, i=i, masks=masks, pingpong_id=pingpong_id):
+                        col_ids = pl.ds(i_col, LANE_SIZE)
+
+                        # Mask due to the embedding dimension not being alined to the lane-size
+                        lane_ids = i_col + jnp.arange(LANE_SIZE)
+                        valid_lanes = lane_ids < emb_dim
+
+                        # Accumulate it in the first row of temp buffer
+                        total = post_pooled_emb_vmem[i, col_ids]
+
+                        # Each subcore goes through certain number of IDS within its batch
+                        for row in range(NUMB_IDS_PROCESSED_PER_STEP):
+                            embs_out = buf_vmem[pingpong_id, row, col_ids]
+                            masked_emb = jnp.where(valid_lanes, embs_out, 0)
+                            total = total + masked_emb * masks[row]
+                        post_pooled_emb_vmem[i, col_ids] = total
+
+            pltpu.sync_copy(
+                post_pooled_emb_vmem,
+                out_hbm.at[pl.ds(output_start, NUMB_BATCHES_PER_ITERATION)],
+            )
+
+        _inner()
+
+    return lookup_kernel(dev_weights, indices, offsets, row_offsets)[
+        :num_batches, :emb_dim
+    ]
+
+
+def embedding_pooled_batched_lookup_jax(
+    indices: jax.Array,
+    offsets: jax.Array,
+    dev_weights: jax.Array,
+    row_offsets: jax.Array,
+    emb_dim: int,
+) -> jax.Array:
+    return run_sc_pooled_lookup_batch_parallel(
+        indices, offsets, dev_weights, row_offsets, emb_dim
+    )
+
+
+def embedding_pooled_batched_lookup_bwd_jax(
+    grad_out: jax.Array,
+    indices: jax.Array,
+    offsets: jax.Array,
+    row_offsets: jax.Array,
+    num_rows: int,
+    emb_dim: int,
+) -> jax.Array:
+    """Dense gradient for a stacked table-batched sum-pooled lookup."""
+    num_bags = grad_out.shape[0]
+    assert num_bags > 0
+
+    positions = jnp.arange(indices.shape[0], dtype=offsets.dtype)
+    bag_indices = jnp.searchsorted(offsets[1:], positions, side="right")
+    valid = positions < offsets[-1]
+    safe_bag_indices = jnp.minimum(bag_indices, num_bags - 1)
+    weight_indices = indices + row_offsets[safe_bag_indices]
+    safe_weight_indices = jnp.where(valid, weight_indices, 0)
+    grad_per_id = jnp.where(
+        valid[:, None],
+        grad_out[safe_bag_indices],
+        jnp.zeros((), dtype=grad_out.dtype),
+    )
+    return (
+        jnp.zeros((num_rows, emb_dim), grad_out.dtype)
+        .at[safe_weight_indices]
+        .add(grad_per_id)
+    )

--- a/torchrec/experimental/torch_tpu/pallas/tests/test_ebc_lookup.py
+++ b/torchrec/experimental/torch_tpu/pallas/tests/test_ebc_lookup.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import List
+from typing import Any, Dict, List, Optional
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -103,6 +103,7 @@ def _grouped_config(
     compute_kernel: EmbeddingComputeKernel,
     tables: List[EmbeddingBagConfig],
     pooling: PoolingType,
+    fused_params: Optional[Dict[str, Any]] = None,
 ) -> GroupedEmbeddingConfig:
     sharded = [
         ShardedEmbeddingTable(
@@ -127,6 +128,7 @@ def _grouped_config(
         has_feature_processor=False,
         compute_kernel=compute_kernel,
         embedding_tables=sharded,
+        fused_params=fused_params,
     )
 
 
@@ -176,11 +178,19 @@ class EBCLookupTest(TestCase):
                         EmbeddingComputeKernel.UNFUSED_TPU,
                         TABLES,
                         PoolingType.SUM,
+                        fused_params={
+                            "pooled_lookup_kernel": PooledLookupKernel.BATCHED_OFFSET
+                        },
                     )
                 ],
                 device=torch.device(device),
             )
-        self.assertIsInstance(lookup._emb_modules[0], BatchedTPUEmbeddingBag)
+        kernel = lookup._emb_modules[0]
+        self.assertIsInstance(kernel, BatchedTPUEmbeddingBag)
+        self.assertEqual(kernel.pooled_lookup_kernel, PooledLookupKernel.BATCHED_OFFSET)
+        self.assertTrue(
+            all(weight.requires_grad for weight in kernel.split_embedding_weights())
+        )
 
     @parameterized.expand(DEVICE_KERNEL_CASES)
     def test_forward_matches_embedding_bag_collection(


### PR DESCRIPTION
Summary:
Context
---------

There are two current implementations of non-VBE pooled embedding lookups within TREC. However, they did not have table-stacking implemented. The goal of this diff to implement the offset kernel (within single_pooled_lookup_v2.py) with table-stacking. The latency is reported to be < 0.5 ms for a 1M table:

```
dim  tables feat/table   pool   latency_ms   effective_GB/s
  256       8          4      1        0.219           616.37
  256       8          4      8        0.210          2724.27
  256       8          4     32        0.208         10534.21
  256      12          4      1        0.179          1128.46
  256      12          4      8        0.148          5823.94
```

These are the current list of assumptions that were made in written these class:

1) Same embedding dimensions across all tables (Fine cause of TorchRec)
2) Unfused optimizer
3) Many features to a single table
4) Pooled
5) non-VBE
6) FP32 weights
7) (No multi-compute kernel tables) i.e. all tables are on TPU (Fine cause of TorchRec groups compute kernels)
8) Tables are stored row-wise order (FBGEMM default too)
9) Does early-style pooling before output_dist (FBGEMM default too)
10) Sparse compiler can only support 16 GiB of HBM per tensor, and so we will need to split the tables within a tbe into chunks that fit this criteria.


Implementation
------------------

Constructed two classes (`PallasTableBatchedEmbeddingBags` analogous to SplitTableTBE within FBGEMM, and `BatchedUnFusedTPUEmbeddingBag` analogous to BatchedEmbeddingKernel within TREC.

The parallelization strategy of this pallas kernel is assigning groups of batches to subcores, where each subcore is processing one batch at a time from its group. The pallas kernel still overlaps the DMA transfer of `i`th chunk of IDS within the same batch i, with pooling of previous `i-1`th chunk IDS within the same batch i, each lane goes through each emb-dimension and does pooling column wise.  This parallelization strategy is most effective when the pooling factor is consistent across subcores.

However, there are couple changes to the previous kernel:
* Output embedding dimension is now padded within VMEM. Padding of the input embedding is avoided. Currently embedding dimension still needs to be a multiple of 16.
* Some of the DMA transfers are now async to overlap with compute.
* Pooling adds one column vector at a time into a dedicated VMEM output buffer, this is to reduce amount of registers required.
* Per-feature row offset convert the indices into rows of the stacked table and now supports multiple features mapping to the same table.

NOTE: we expand each feature’s table row offset into one offset per batch using repeat_interleave, since we like to pad to 16-element windows for DMA, to avoid dynamic feature-offset lookup. This may cause a CPU sync, so we might need to remove.

NOTE:  Based on error `E0000 00:00:1787330558.676673 1009652 materialize.cc:366] [MaterializationWorker] ExecutionTask failed: INVALID_ARGUMENT: failed to compile MLIR module -- the XLA compiler failed with: sparseCore only supports 16 GiB of HBM per tensor, got 24576000000 in %param_0.4 = f32[12000000,512]{1,0:T(8)L(1024)} parameter(0)` for large embeddings we will need ot make sure not many tables are within a TBE.

NOTE: we highlighted many potential improvements to the kernel that could be made, e.g making it work with embedding-dimensions 8 (for CW sharding with planner default algorithms), utilization of different parallelization strategies over sub-cores, work over any embedding dimension, etc.

NOTE: In the process of comparing DLRM performance, it was found that offset computation was significantly slower in batch vs unbatched, that was due to cumsum evaluation of a large 1D tensor for batch across all features and batches vs 2D seperate calculation per feature in unbatched. So the batched path was changed to do a parallel 2D per-feature calculation followed by a short calculation over the total. This reduced the forward latency from approximately 871 ms to 86 ms.

Differential Revision: D116941462


