### PR TITLE
Accept a JSON-encoded res_enabled_tables (#4631)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -11,6 +11,7 @@ import abc
 import copy
 import inspect
 import itertools
+import json
 import logging
 import tempfile
 from dataclasses import dataclass
@@ -200,6 +201,39 @@ class ReduceScatterResizeAwaitable(LazyAwaitable[torch.Tensor]):
         return self._shard_buf
 
 
+def _decode_res_enabled_tables(encoded: Optional[str]) -> Optional[List[str]]:
+    """Decode the ``res_enabled_tables`` fused param.
+
+    Two encodings are accepted, because the producer opts in to the second one
+    per model and this has to stay backward compatible with the first:
+
+    - Comma-joined, e.g. ``'a,b'`` -- the original encoding, still the default.
+    - JSON list, e.g. ``'["a", "b"]'`` -- needed because some table names are
+      feature-store derived and contain a comma, which comma-joining splits
+      into two names that match nothing.
+
+    A JSON list always starts with ``[``. Table names are feature-store
+    identifiers and never do, so the prefix discriminates the two without a
+    second fused param -- an unrecognised key would survive into the TBE
+    constructor and raise TypeError there.
+    """
+    if encoded is None:
+        return None
+    if not encoded.startswith("["):
+        return encoded.split(",")
+    decoded = json.loads(encoded)
+    # Fail loudly on a malformed list. Non-string elements would compare unequal
+    # to every table name and disable streaming silently, which is the failure
+    # this decoding exists to remove.
+    if not isinstance(decoded, list) or not all(
+        isinstance(name, str) for name in decoded
+    ):
+        raise ValueError(
+            f"{RES_ENABLED_TABLES_STR} must be a JSON list of strings, got {encoded!r}"
+        )
+    return decoded
+
+
 def _populate_res_params(config: GroupedEmbeddingConfig) -> Tuple[bool, RESParams]:
     # populate res_params, which is used for raw embedding streaming
     # here only populates the params available in fused_params and TBE configs
@@ -235,11 +269,8 @@ def _populate_res_params(config: GroupedEmbeddingConfig) -> Tuple[bool, RESParam
         del fused_params[RES_NUM_HBM_COPY_THREADS_STR]
     res_enabled_tables: Optional[List[str]] = None
     if RES_ENABLED_TABLES_STR in fused_params:
-        res_enabled_tables = (
-            # pyrefly: ignore [missing-attribute]
-            fused_params.get(RES_ENABLED_TABLES_STR).split(",")
-            if fused_params.get(RES_ENABLED_TABLES_STR) is not None
-            else None
+        res_enabled_tables = _decode_res_enabled_tables(
+            fused_params.get(RES_ENABLED_TABLES_STR)
         )
         del fused_params[RES_ENABLED_TABLES_STR]
     enable_raw_embedding_streaming: Optional[bool] = None

--- a/torchrec/distributed/tests/test_populate_res_params.py
+++ b/torchrec/distributed/tests/test_populate_res_params.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import json
 import unittest
 from typing import Any, Dict, List, Optional
 
@@ -102,6 +103,82 @@ class PopulateResParamsTest(unittest.TestCase):
                 self.assertFalse(enable_res)
                 for key in self._HBM_KNOBS:
                     self.assertNotIn(key, fused_params)
+
+    # A real name from the RES table set: feature-store derived, with a comma
+    # inside the brace-delimited event spec.
+    _COMMA_NAME = (
+        "VIEWER_CLIPS_LAST_N_ENGAGED_MEDIA_NOT_INTERESTED VIEWER INF ONLINE "
+        "{ EVENT_TYPE=ig_unified_not_interested, ACTION_SOURCE=three_dot_menu }_fs1003"
+    )
+
+    def _decode_enabled_tables(self, encoded: str) -> List[str]:
+        """Decode via the real entry point, on a group holding every candidate
+        table so the allowlist-intersection early return cannot mask the result.
+        """
+        fused_params: Dict[str, Any] = {
+            "enable_raw_embedding_streaming": True,
+            "res_enabled_tables": encoded,
+        }
+        _, res_params = _populate_res_params(
+            self._config(["a", "b", self._COMMA_NAME], fused_params)
+        )
+        # Same crash condition as the test above: the key must not survive.
+        self.assertNotIn("res_enabled_tables", fused_params)
+        return res_params.res_enabled_tables
+
+    def test_comma_joined_encoding_still_decodes(self) -> None:
+        # The default encoding; must keep working unchanged.
+        self.assertEqual(self._decode_enabled_tables("a,b"), ["a", "b"])
+
+    def test_json_encoding_decodes(self) -> None:
+        self.assertEqual(self._decode_enabled_tables('["a", "b"]'), ["a", "b"])
+
+    def test_comma_bearing_name_survives_json_but_not_comma_joining(self) -> None:
+        # The reason the JSON encoding exists.
+        self.assertEqual(
+            self._decode_enabled_tables(json.dumps([self._COMMA_NAME])),
+            [self._COMMA_NAME],
+        )
+        # Comma-joined, the same name splits into two that match no table.
+        self.assertNotIn(
+            self._COMMA_NAME, self._decode_enabled_tables(self._COMMA_NAME)
+        )
+
+    def test_single_name_unaffected_by_either_encoding(self) -> None:
+        self.assertEqual(self._decode_enabled_tables("a"), ["a"])
+        self.assertEqual(self._decode_enabled_tables('["a"]'), ["a"])
+
+    def test_the_two_empty_encodings_do_not_mean_the_same_thing(self) -> None:
+        # The allowlist is only applied when it is non-empty, so an empty list
+        # means "no filter" and every table in the group streams. Only the JSON
+        # form can express that. The comma-joined form cannot: "".split(",") is
+        # [""], a one-name allowlist that matches nothing and switches
+        # streaming off -- the opposite of what an empty allowlist means.
+        # Pinned rather than fixed, since changing it would silently turn
+        # streaming on for any model that sends an empty list.
+        for encoded, expected_enabled, expected_tables in (
+            ("[]", True, []),
+            ("", False, [""]),
+        ):
+            with self.subTest(encoded):
+                fused_params: Dict[str, Any] = {
+                    "enable_raw_embedding_streaming": True,
+                    "res_enabled_tables": encoded,
+                }
+                enable_res, res_params = _populate_res_params(
+                    self._config(["a", "b"], fused_params)
+                )
+                self.assertEqual(enable_res, expected_enabled)
+                self.assertEqual(res_params.res_enabled_tables, expected_tables)
+                self.assertNotIn("res_enabled_tables", fused_params)
+
+    def test_malformed_json_list_raises(self) -> None:
+        # Non-string elements would compare unequal to every table name and
+        # disable streaming silently, so they have to fail loudly instead.
+        for encoded in ("[123]", '["a", 2]'):
+            with self.subTest(encoded):
+                with self.assertRaisesRegex(ValueError, "JSON list of strings"):
+                    self._decode_enabled_tables(encoded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

`res_enabled_tables` is comma-joined, so a table name containing a comma is split into two names that match nothing and the table silently never streams. Three names in the RES table set are affected -- they are feature-store derived and carry a brace-delimited event spec

Teach the decoder to also accept a JSON list. A JSON list starts with `[`, which a feature-store table name never does, so the prefix discriminates the two encodings.

Inert on its own: nothing emits the JSON encoding yet, and the comma-joined path is unchanged. Landing the decoder first is what lets the producer opt in later.

The json encoding is controlled by a config from upstream to avoid the backward compatibility issue.

Reviewed By: FriedCosey

Differential Revision: D117737016


