### PR TITLE
Skip no-op batch record_stream in SDD _wait_for_batch under in-place copy

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -1236,6 +1236,53 @@ class TrainPipelineSparseDist2DShardingTest(unittest.TestCase):
         dmp.assert_called_once()
 
 
+class TrainPipelineRecordStreamGateTest(unittest.TestCase):
+    """`_wait_for_batch` gates its per-leaf `record_stream` on
+    `enable_inplace_copy_batch`.
+
+    The gate is load-bearing in BOTH directions, which is why this pins both:
+      - flag on: the batch is allocated on the caller's current stream, which is
+        also the stream consuming it here, so the allocator ignores the
+        registration. Skipping it is safe and drops one call per leaf tensor.
+      - flag off: the destination is allocated on the memcpy stream instead, so
+        the batch really is consumed cross-stream and the registration is
+        REQUIRED. Turning this into an unconditional skip would be a silent
+        use-after-free, not a test failure -- hence the guard.
+    """
+
+    def _pipeline(self, enable_inplace_copy_batch: bool) -> TrainPipelineSparseDist:
+        dmp = MagicMock(spec=DMPCollection)
+        dmp.training = True
+        pipeline = TrainPipelineSparseDist(
+            dmp,
+            MagicMock(spec=torch.optim.Optimizer),
+            device=torch.device("cpu"),
+            enable_inplace_copy_batch=enable_inplace_copy_batch,
+        )
+        context = TrainPipelineContext()
+        context.index = 0
+        pipeline.batches.append(MagicMock(spec=Pipelineable))
+        pipeline.contexts.append(context)
+        return pipeline
+
+    def test_record_stream_gated_on_inplace_copy(self) -> None:
+        for enable_inplace_copy_batch, expected_record_stream in (
+            (True, False),
+            (False, True),
+        ):
+            with self.subTest(enable_inplace_copy_batch=enable_inplace_copy_batch):
+                pipeline = self._pipeline(enable_inplace_copy_batch)
+                with patch(
+                    "torchrec.distributed.train_pipeline.train_pipelines._wait_for_batch"
+                ) as mock_wait_for_batch:
+                    pipeline._wait_for_batch()
+                mock_wait_for_batch.assert_called_once()
+                self.assertEqual(
+                    mock_wait_for_batch.call_args.kwargs["record_stream"],
+                    expected_record_stream,
+                )
+
+
 class TrainPipelineAttachDetachTest(TrainPipelineSparseDistTestBase):
     @unittest.skipIf(
         not torch.cuda.is_available(),

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -836,7 +836,18 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out], AsyncInplaceCopyMixin[In])
     def _wait_for_batch(self) -> None:
         batch_id = self.contexts[0].index if len(self.contexts) > 0 else "?"
         with record_function(f"## wait_for_batch {batch_id} ##"):
-            _wait_for_batch(cast(In, self.batches[0]), self._data_dist_stream)
+            _wait_for_batch(
+                cast(In, self.batches[0]),
+                self._data_dist_stream,
+                # Under in-place copy the batch is allocated on the caller's current
+                # stream, which is the same stream consuming it here -- so the
+                # allocator ignores this record_stream anyway (it early-returns for
+                # uses on a block's own allocation stream). Skipping it drops ~780
+                # no-op calls per leaf tensor per step. Mirrors TrainPipelineBase.
+                # The gate is load-bearing: without in-place copy the destination is
+                # allocated on the memcpy stream and the registration IS required.
+                record_stream=not self._enable_inplace_copy_batch,
+            )
 
     def _backward(self, losses: torch.Tensor) -> None:
         batch_id = self.contexts[0].index if len(self.contexts) > 0 else "?"


### PR DESCRIPTION
Summary:
`TrainPipelineSparseDist._wait_for_batch` calls `batch.record_stream(curr_stream)` unconditionally, which fans out over every leaf tensor in the batch. On a 64-trainer MTML CTR IG job that is ~780 calls per step from this site alone.

Under `enable_inplace_copy_batch` those calls do nothing. In-place copy allocates the destination with `empty_like` on the **caller's current stream**, and the consumer here runs on that same stream, so the CUDA caching allocator early-returns (`CUDACachingAllocator.cpp`: "ignore uses on the allocation stream, since those don't require any special synchronization"). They are pure Python fan-out over a no-op.

`TrainPipelineBase` already gates this on the flag (`record_stream=not self._enable_inplace_copy_batch`); `TrainPipelineSparseDist` never got the same treatment. This applies the same gate to the one site where it is safe.

**This is a cleanup, not a perf change.** Measured worth is ~1.1 ms of a 1333 ms step — about **0.08%**. The reasons to do it are:
- trace hygiene: this site is a large share of the `record_stream` noise in every trace taken of this pipeline, which is what prompted the question on D112193190 in the first place;
- consistency with `TrainPipelineBase`, whose divergence is a latent trap.

**Deliberately NOT changed: the `start_sparse_data_dist` site.** An earlier revision of this diff gated that one too. It runs inside the `data_dist` stream context, so the batch (allocated on the compute stream) is genuinely consumed cross-stream and the registration is required. Skipping it risks silent memory reuse for the same ~1.1 ms. That is a bad trade and has been dropped.

The gate is load-bearing in the other direction too: with in-place copy off, the destination is allocated on the memcpy stream and the `record_stream` IS needed, which is why this is conditional rather than removed.

Adds `TrainPipelineRecordStreamGateTest` covering both directions of the gate. There was no prior coverage: the identical gate in `TrainPipelineBase` (`train_pipelines.py:339`) is untested and nothing in the suite referenced the `record_stream=` kwarg. Both directions matter, because turning this into an unconditional skip would surface as silent memory reuse rather than a test failure.

Reviewed By: TroyGarden

Differential Revision: D112635018


