### PR TITLE
[detailed][ops] Add experimental Triton pooled embedding regroup op (#4634)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_triton_ops.py
+++ b/torchrec/distributed/benchmark/benchmark_triton_ops.py
@@ -49,10 +49,14 @@ from torchrec.distributed.triton_tbe.triton_table_batched_embeddings import (
     _bounds_check_offsets_kernel,
     _repair_offsets_kernel,
 )
+from torchrec.sparse.jagged_tensor import _kt_regroup_arguments
 from torchrec.sparse.triton_permute_2d import (
     MIN_SEGMENTS,
     PERSEG_MIN_MEAN,
     triton_permute_2d_sparse_data,
+)
+from torchrec.sparse.triton_permute_multi_embedding import (
+    triton_permute_multi_embedding,
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -112,6 +116,15 @@ class TritonOpConfig(BenchFuncConfig):
         return {}
 
 
+def _make_benchmark_kwargs(arg: TritonOpConfig, device: torch.device) -> Dict[str, Any]:
+    new_keys = {f.name for f in fields(type(arg))} - {
+        f.name for f in fields(TritonOpConfig)
+    }
+    kwargs: Dict[str, Any] = {key: getattr(arg, key) for key in new_keys}
+    kwargs |= arg.make_inputs(device)
+    return kwargs
+
+
 # single-rank runner
 def single_rank_runner(
     arg: TritonOpConfig,
@@ -132,19 +145,16 @@ def single_rank_runner(
     torch.manual_seed(arg.seed)
     device = torch.device(arg.device_type)
 
-    # Config fields the concrete subclass added are forwarded to the benchmark, the
-    # same way benchmark_comms does; the tensors from make_inputs join them.
-    new_keys = {f.name for f in fields(type(arg))} - {
-        f.name for f in fields(TritonOpConfig)
-    }
-    kwargs: Dict[str, Any] = {k: getattr(arg, k) for k in new_keys}
-    kwargs |= arg.make_inputs(device)
-
     func_name = getattr(bench_func, "__name__", arg.name)
     name: str = f"{func_name}_{arg.name}" if arg.name else func_name
 
-    # Warm up outside the measurement: first call pays Triton JIT compilation.
-    bench_func([], **kwargs)
+    # Warm up outside the measurement, then reconstruct inputs so mutating ops do not
+    # turn a requested dirty-path measurement into a clean-path measurement.
+    warmup_kwargs = _make_benchmark_kwargs(arg, device)
+    bench_func([], **warmup_kwargs)
+    del warmup_kwargs
+    torch.manual_seed(arg.seed)
+    kwargs = _make_benchmark_kwargs(arg, device)
 
     result = benchmark_func(
         bench_inputs=[],
@@ -534,6 +544,141 @@ def permute_2d_fbgemm(
         torch.ops.fbgemm.permute_2D_sparse_data(
             permute, lengths, values, weights, permuted_lengths_sum
         )
+
+
+############################ pooled regroup configs ###################################
+@dataclass
+class RegroupConfig(TritonOpConfig):
+    """Inputs for cached-metadata multi-tensor pooled-embedding regroup."""
+
+    batch_size: int = 1024
+    num_dense_features: int = 20
+    num_sparse_features: int = 1000
+    dense_dim: int = 64
+    sparse_dim: int = 128
+    num_groups: int = 2
+    skipped_features: int = 0
+    duplicate_features: int = 0
+    run_backward: bool = False
+    dtype: str = "float32"
+
+    def make_inputs(self, device: torch.device) -> Dict[str, Any]:
+        dtype = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }.get(self.dtype)
+        if dtype is None:
+            raise ValueError("dtype must be float32, float16, or bfloat16")
+        if self.run_backward and self.skipped_features > 0:
+            raise ValueError(
+                "backward with skipped features has unspecified gradients in the "
+                "FBGEMM-compatible contract"
+            )
+        keys = [
+            [f"dense_{i}" for i in range(self.num_dense_features)],
+            [f"sparse_{i}" for i in range(self.num_sparse_features)],
+        ]
+        lengths = [
+            [self.dense_dim] * self.num_dense_features,
+            [self.sparse_dim] * self.num_sparse_features,
+        ]
+        values = [
+            torch.randn(
+                self.batch_size,
+                sum(tensor_lengths),
+                device=device,
+                dtype=dtype,
+                requires_grad=self.run_backward,
+            )
+            for tensor_lengths in lengths
+        ]
+
+        all_keys = keys[0] + keys[1]
+        if self.skipped_features >= len(all_keys):
+            raise ValueError("skipped_features must leave at least one feature")
+        selected_keys = all_keys[self.skipped_features :]
+        groups: List[List[str]] = [[] for _ in range(self.num_groups)]
+        for index, key in enumerate(selected_keys):
+            groups[index % self.num_groups].append(key)
+        for index in range(self.duplicate_features):
+            groups[index % self.num_groups].append(
+                selected_keys[index % len(selected_keys)]
+            )
+
+        permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
+            values[0], keys, lengths, groups
+        )
+        grad_outputs = [
+            torch.randn(self.batch_size, length, device=device, dtype=dtype)
+            for length in out_lengths
+        ]
+        return {
+            "values": values,
+            "permutes": permutes,
+            "in_shapes": in_shapes,
+            "out_shapes": out_shapes,
+            "out_lengths": out_lengths,
+            "grad_outputs": grad_outputs,
+        }
+
+
+def _run_backward(
+    outputs: List[torch.Tensor],
+    values: List[torch.Tensor],
+    grad_outputs: List[torch.Tensor],
+    run_backward: bool,
+) -> None:
+    if run_backward:
+        torch.autograd.grad(outputs, values, grad_outputs)
+
+
+@dataclass
+class RegroupTritonConfig(RegroupConfig):
+    """Benchmark the Triton multi-tensor pooled-embedding regroup."""
+
+
+@register_benchmark(RegroupTritonConfig)
+def regroup_triton(
+    _batch_inputs: List[Dict[str, Any]],
+    values: List[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: List[int],
+    grad_outputs: List[torch.Tensor],
+    run_backward: bool = False,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## triton_permute_multi_embedding ##"):
+        outputs = triton_permute_multi_embedding(
+            values, permutes, in_shapes, out_shapes, out_lengths
+        )
+        _run_backward(outputs, values, grad_outputs, run_backward)
+
+
+@dataclass
+class RegroupFbgemmConfig(RegroupConfig):
+    """Benchmark the FBGEMM multi-tensor pooled-embedding regroup."""
+
+
+@register_benchmark(RegroupFbgemmConfig)
+def regroup_fbgemm(
+    _batch_inputs: List[Dict[str, Any]],
+    values: List[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: List[int],
+    grad_outputs: List[torch.Tensor],
+    run_backward: bool = False,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## fbgemm_permute_multi_embedding ##"):
+        outputs = torch.ops.fbgemm.permute_multi_embedding(
+            values, permutes, in_shapes, out_shapes, out_lengths
+        )
+        _run_backward(outputs, values, grad_outputs, run_backward)
 
 
 if __name__ == "__main__":

--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -26,6 +26,11 @@ from torchrec.sparse.jagged_tensor import (
 from torchrec.sparse.tests.utils import build_groups, build_kts
 from torchrec.test_utils import skip_if_asan_class
 
+if torch.cuda.is_available():
+    from torchrec.sparse.triton_permute_multi_embedding import (
+        triton_permute_multi_embedding,
+    )
+
 torch.fx.wrap("len")
 
 
@@ -1070,3 +1075,154 @@ class TestKeyedTensorGPU(unittest.TestCase):
 
         torch.allclose(actual_kt_0_grad, expected_kt_0_grad)
         torch.allclose(actual_kt_1_grad, expected_kt_1_grad)
+
+
+class TritonPermuteMultiEmbeddingTest(unittest.TestCase):
+    def _inputs(
+        self,
+        dtype: torch.dtype,
+        noncontiguous: bool = False,
+    ) -> tuple[
+        list[torch.Tensor],
+        list[torch.Tensor],
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        list[int],
+    ]:
+        batch_size = 16
+        keys = [["f1", "f2"], ["f3", "f4", "f5"], ["f6"]]
+        lengths = [[3, 4], [5, 6, 7], [8]]
+        groups = [["f1", "f3"], ["f4", "f1", "f2"], ["f6"], ["f1", "f5"]]
+        values = []
+        for tensor_lengths in lengths:
+            width = sum(tensor_lengths)
+            if noncontiguous:
+                value = torch.randn(width, batch_size, device="cuda", dtype=dtype).t()
+            else:
+                value = torch.randn(batch_size, width, device="cuda", dtype=dtype)
+            values.append(value.detach().requires_grad_())
+        references = [value.detach().clone().requires_grad_() for value in values]
+        permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
+            values[0], keys, lengths, groups
+        )
+        return values, references, permutes, in_shapes, out_shapes, out_lengths
+
+    def _reference(
+        self,
+        values: list[torch.Tensor],
+        permutes: torch.Tensor,
+        output_count: int,
+    ) -> list[torch.Tensor]:
+        groups: list[list[torch.Tensor]] = [[] for _ in range(output_count)]
+        for in_tensor, out_tensor, in_offset, _, length, _ in permutes.tolist():
+            groups[out_tensor].append(
+                values[in_tensor][:, in_offset : in_offset + length]
+            )
+        return [torch.cat(group, dim=1) for group in groups]
+
+    def _assert_gradients_close(
+        self,
+        actual_grads: tuple[torch.Tensor, ...],
+        expected_grads: tuple[torch.Tensor, ...],
+        dtype: torch.dtype,
+    ) -> None:
+        atol = 4 * torch.finfo(dtype).eps
+        for actual, expected in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=atol)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_forward_and_backward(self) -> None:
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                values, references, permutes, in_shapes, out_shapes, out_lengths = (
+                    self._inputs(dtype)
+                )
+                outputs = triton_permute_multi_embedding(
+                    values, permutes, in_shapes, out_shapes, out_lengths
+                )
+                expected = self._reference(references, permutes, len(out_lengths))
+                for output, reference in zip(outputs, expected):
+                    self.assertEqual(output.dtype, dtype)
+                    torch.testing.assert_close(output, reference, rtol=0, atol=0)
+
+                grad_outputs = [torch.randn_like(output) for output in outputs]
+                actual_grads = torch.autograd.grad(outputs, values, grad_outputs)
+                expected_grads = torch.autograd.grad(expected, references, grad_outputs)
+                self._assert_gradients_close(actual_grads, expected_grads, dtype)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_two_input_two_output_fast_path(self) -> None:
+        batch_size = 16
+        keys = [["f1", "f2"], ["f3"]]
+        lengths = [[3, 4], [5]]
+        groups = [["f1", "f3"], ["f2", "f1"]]
+        values = [
+            torch.randn(
+                batch_size,
+                sum(tensor_lengths),
+                device="cuda",
+                requires_grad=True,
+            )
+            for tensor_lengths in lengths
+        ]
+        references = [value.detach().clone().requires_grad_() for value in values]
+        permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
+            values[0], keys, lengths, groups
+        )
+
+        outputs = triton_permute_multi_embedding(
+            values, permutes, in_shapes, out_shapes, out_lengths
+        )
+        expected = self._reference(references, permutes, len(out_lengths))
+        grad_outputs = [torch.randn_like(output) for output in outputs]
+        actual_grads = torch.autograd.grad(outputs, values, grad_outputs)
+        expected_grads = torch.autograd.grad(expected, references, grad_outputs)
+
+        for output, reference in zip(outputs, expected):
+            torch.testing.assert_close(output, reference, rtol=0, atol=0)
+        self._assert_gradients_close(actual_grads, expected_grads, torch.float32)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_noncontiguous_inputs(self) -> None:
+        values, references, permutes, in_shapes, out_shapes, out_lengths = self._inputs(
+            torch.float32, noncontiguous=True
+        )
+        for value in values:
+            self.assertFalse(value.is_contiguous())
+
+        outputs = triton_permute_multi_embedding(
+            values, permutes, in_shapes, out_shapes, out_lengths
+        )
+        expected = self._reference(references, permutes, len(out_lengths))
+        grad_outputs = [torch.randn_like(output) for output in outputs]
+        actual_grads = torch.autograd.grad(outputs, values, grad_outputs)
+        expected_grads = torch.autograd.grad(expected, references, grad_outputs)
+
+        for output, reference in zip(outputs, expected):
+            torch.testing.assert_close(output, reference, rtol=0, atol=0)
+        self._assert_gradients_close(actual_grads, expected_grads, torch.float32)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    def test_compile_forward_and_backward(self) -> None:
+        values, references, permutes, in_shapes, out_shapes, out_lengths = self._inputs(
+            torch.float32
+        )
+        for value in values:
+            torch._dynamo.mark_dynamic(value, 0)
+            torch._dynamo.mark_dynamic(value, 1)
+
+        compiled = torch.compile(
+            triton_permute_multi_embedding,
+            backend="aot_eager",
+            fullgraph=True,
+        )
+        outputs = compiled(values, permutes, in_shapes, out_shapes, out_lengths)
+        expected = self._reference(references, permutes, len(out_lengths))
+        grad_outputs = [torch.randn_like(output) for output in outputs]
+        actual_grads = torch.autograd.grad(outputs, values, grad_outputs)
+        expected_grads = torch.autograd.grad(expected, references, grad_outputs)
+
+        for output, reference in zip(outputs, expected):
+            torch.testing.assert_close(output, reference, rtol=0, atol=0)
+        self._assert_gradients_close(actual_grads, expected_grads, torch.float32)

--- a/torchrec/sparse/triton_permute_multi_embedding.py
+++ b/torchrec/sparse/triton_permute_multi_embedding.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+
+_PERMUTE_PARAM_SIZE = 6
+
+
+# Triton TR001: tune batch and copy tiles across workloads and GPU generations.
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_BATCH": 1, "BLOCK_SIZE": 128}, num_warps=1),
+        triton.Config({"BLOCK_BATCH": 2, "BLOCK_SIZE": 128}, num_warps=2),
+        triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
+    ],
+    key=["batch_size", "num_permutes"],
+)
+@triton.jit
+def _permute_multi_embedding_kernel(
+    example_ptr,
+    input0_ptr,
+    input1_ptr,
+    output0_ptr,
+    output1_ptr,
+    input_ptrs,
+    output_ptrs,
+    permutes_ptr,
+    in_shapes_ptr,
+    out_shapes_ptr,
+    batch_size,
+    num_permutes,
+    PERMUTE_PARAM_SIZE: tl.constexpr,
+    SPECIALIZED_POINTERS: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    program_id = tl.program_id(0)
+    batch_block = program_id // num_permutes
+    permute_id = program_id % num_permutes
+
+    permute = permutes_ptr + permute_id * PERMUTE_PARAM_SIZE
+    in_tensor = tl.load(permute)
+    out_tensor = tl.load(permute + 1)
+    in_offset = tl.load(permute + 2).to(tl.int64)
+    out_offset = tl.load(permute + 3).to(tl.int64)
+    length = tl.load(permute + 4)
+    in_length = tl.load(in_shapes_ptr + in_tensor).to(tl.int64)
+    out_length = tl.load(out_shapes_ptr + out_tensor).to(tl.int64)
+    if SPECIALIZED_POINTERS:
+        input_ptr = tl.where(in_tensor == 0, input0_ptr, input1_ptr)
+        output_ptr = tl.where(out_tensor == 0, output0_ptr, output1_ptr)
+    else:
+        input_ptr = tl.load(input_ptrs + in_tensor).to(example_ptr.dtype, bitcast=True)
+        output_ptr = tl.load(output_ptrs + out_tensor).to(
+            example_ptr.dtype, bitcast=True
+        )
+
+    offsets = tl.arange(0, BLOCK_BATCH * BLOCK_SIZE)
+    batch_offsets = offsets // BLOCK_SIZE
+    column_offsets = offsets % BLOCK_SIZE
+    batch_ids = batch_block * BLOCK_BATCH + batch_offsets
+    for block_start in range(0, length, BLOCK_SIZE):
+        columns = block_start + column_offsets
+        mask = (batch_ids < batch_size) & (columns < length)
+        value = tl.load(
+            input_ptr + batch_ids * in_length + in_offset + columns,
+            mask=mask,
+        )
+        tl.store(
+            output_ptr + batch_ids * out_length + out_offset + columns,
+            value,
+            mask=mask,
+        )
+
+
+# Triton TR001: tune batch and copy tiles across workloads and GPU generations.
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_BATCH": 1, "BLOCK_SIZE": 128}, num_warps=1),
+        triton.Config({"BLOCK_BATCH": 2, "BLOCK_SIZE": 128}, num_warps=2),
+        triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
+    ],
+    key=["batch_size", "num_permutes"],
+)
+@triton.jit
+def _permute_multi_embedding_backward_kernel(
+    example_ptr,
+    grad_output0_ptr,
+    grad_output1_ptr,
+    grad_input0_ptr,
+    grad_input1_ptr,
+    grad_output_ptrs,
+    grad_input_ptrs,
+    permutes_ptr,
+    in_shapes_ptr,
+    out_shapes_ptr,
+    batch_size,
+    num_permutes,
+    PERMUTE_PARAM_SIZE: tl.constexpr,
+    SPECIALIZED_POINTERS: tl.constexpr,
+    BLOCK_BATCH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    program_id = tl.program_id(0)
+    batch_block = program_id // num_permutes
+    permute_id = program_id % num_permutes
+
+    permute = permutes_ptr + permute_id * PERMUTE_PARAM_SIZE
+    next_permute = tl.load(permute + 5)
+    if next_permute < 0:
+        return
+
+    in_tensor = tl.load(permute)
+    out_tensor = tl.load(permute + 1)
+    in_offset = tl.load(permute + 2).to(tl.int64)
+    out_offset = tl.load(permute + 3).to(tl.int64)
+    length = tl.load(permute + 4)
+    in_length = tl.load(in_shapes_ptr + in_tensor).to(tl.int64)
+    out_length = tl.load(out_shapes_ptr + out_tensor).to(tl.int64)
+    if SPECIALIZED_POINTERS:
+        grad_output_ptr = tl.where(out_tensor == 0, grad_output0_ptr, grad_output1_ptr)
+        grad_input_ptr = tl.where(in_tensor == 0, grad_input0_ptr, grad_input1_ptr)
+    else:
+        grad_output_ptr = tl.load(grad_output_ptrs + out_tensor).to(
+            example_ptr.dtype, bitcast=True
+        )
+        grad_input_ptr = tl.load(grad_input_ptrs + in_tensor).to(
+            example_ptr.dtype, bitcast=True
+        )
+
+    offsets = tl.arange(0, BLOCK_BATCH * BLOCK_SIZE)
+    batch_offsets = offsets // BLOCK_SIZE
+    column_offsets = offsets % BLOCK_SIZE
+    batch_ids = batch_block * BLOCK_BATCH + batch_offsets
+    for block_start in range(0, length, BLOCK_SIZE):
+        columns = block_start + column_offsets
+        mask = (batch_ids < batch_size) & (columns < length)
+        value = tl.load(
+            grad_output_ptr + batch_ids * out_length + out_offset + columns,
+            mask=mask,
+        )
+        duplicate = next_permute
+        while duplicate > 0 and duplicate < num_permutes:
+            duplicate_permute = permutes_ptr + duplicate * PERMUTE_PARAM_SIZE
+            duplicate_out_tensor = tl.load(duplicate_permute + 1)
+            duplicate_out_offset = tl.load(duplicate_permute + 3).to(tl.int64)
+            duplicate_out_length = tl.load(out_shapes_ptr + duplicate_out_tensor).to(
+                tl.int64
+            )
+            if SPECIALIZED_POINTERS:
+                duplicate_ptr = tl.where(
+                    duplicate_out_tensor == 0,
+                    grad_output0_ptr,
+                    grad_output1_ptr,
+                )
+            else:
+                duplicate_ptr = tl.load(grad_output_ptrs + duplicate_out_tensor).to(
+                    example_ptr.dtype, bitcast=True
+                )
+            value += tl.load(
+                duplicate_ptr
+                + batch_ids * duplicate_out_length
+                + duplicate_out_offset
+                + columns,
+                mask=mask,
+            )
+            duplicate = -tl.load(duplicate_permute + 5)
+        tl.store(
+            grad_input_ptr + batch_ids * in_length + in_offset + columns,
+            value,
+            mask=mask,
+        )
+
+
+def _validate_inputs(
+    values: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: list[int],
+) -> None:
+    if not values:
+        raise ValueError("values must contain at least one tensor")
+    first = values[0]
+    if first.device.type != "cuda":
+        raise ValueError("triton_permute_multi_embedding requires CUDA tensors")
+    if any(
+        value.device != first.device
+        or value.dtype != first.dtype
+        or value.ndim != 2
+        or value.shape[0] != first.shape[0]
+        for value in values
+    ):
+        raise ValueError(
+            "values must be 2D tensors with matching device, dtype, and batch"
+        )
+    if permutes.device != first.device or permutes.ndim != 2 or permutes.shape[1] != 6:
+        raise ValueError("permutes must be a device tensor with shape [P, 6]")
+    if in_shapes.device != first.device or in_shapes.numel() != len(values):
+        raise ValueError("in_shapes must contain one entry per input tensor")
+    if out_shapes.device != first.device or out_shapes.numel() != len(out_lengths):
+        raise ValueError("out_shapes and out_lengths must describe the same outputs")
+
+
+def _pointer_tensor(tensors: list[torch.Tensor]) -> torch.Tensor:
+    # Citrine C3 exception: pointer values originate on the host. Pinned staging
+    # keeps the required H2D metadata copy asynchronous, matching FBGEMM.
+    return torch.tensor(
+        [tensor.data_ptr() for tensor in tensors],
+        dtype=torch.int64,
+        pin_memory=True,
+    ).to(tensors[0].device, non_blocking=True)
+
+
+def _forward_impl(
+    values: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: list[int],
+) -> list[torch.Tensor]:
+    _validate_inputs(values, permutes, in_shapes, out_shapes, out_lengths)
+    contiguous_values = [value.contiguous() for value in values]
+    outputs = [
+        values[0].new_empty((values[0].shape[0], out_length))
+        for out_length in out_lengths
+    ]
+    if permutes.shape[0] == 0:
+        return outputs
+    specialized_pointers = len(contiguous_values) == 2 and len(outputs) == 2
+    input_ptrs = (
+        permutes if specialized_pointers else _pointer_tensor(contiguous_values)
+    )
+    output_ptrs = permutes if specialized_pointers else _pointer_tensor(outputs)
+
+    def grid(meta: dict[str, Any]) -> tuple[Any, ...]:
+        return (
+            triton.cdiv(values[0].shape[0], meta["BLOCK_BATCH"]) * permutes.shape[0],
+        )
+
+    _permute_multi_embedding_kernel[grid](
+        values[0],
+        contiguous_values[0],
+        contiguous_values[1] if specialized_pointers else contiguous_values[0],
+        outputs[0],
+        outputs[1] if specialized_pointers else outputs[0],
+        input_ptrs,
+        output_ptrs,
+        permutes,
+        in_shapes,
+        out_shapes,
+        values[0].shape[0],
+        permutes.shape[0],
+        PERMUTE_PARAM_SIZE=_PERMUTE_PARAM_SIZE,
+        SPECIALIZED_POINTERS=specialized_pointers,
+    )
+    return outputs
+
+
+def _backward_impl(
+    grad_outputs: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    in_lengths: list[int],
+) -> list[torch.Tensor]:
+    contiguous_grads = [grad.contiguous() for grad in grad_outputs]
+    grad_inputs = [
+        grad_outputs[0].new_empty((grad_outputs[0].shape[0], in_length))
+        for in_length in in_lengths
+    ]
+    if permutes.shape[0] == 0:
+        return grad_inputs
+    specialized_pointers = len(contiguous_grads) == 2 and len(grad_inputs) == 2
+    grad_output_ptrs = (
+        permutes if specialized_pointers else _pointer_tensor(contiguous_grads)
+    )
+    grad_input_ptrs = permutes if specialized_pointers else _pointer_tensor(grad_inputs)
+
+    def grid(meta: dict[str, Any]) -> tuple[Any, ...]:
+        return (
+            triton.cdiv(grad_outputs[0].shape[0], meta["BLOCK_BATCH"])
+            * permutes.shape[0],
+        )
+
+    _permute_multi_embedding_backward_kernel[grid](
+        grad_outputs[0],
+        contiguous_grads[0],
+        contiguous_grads[1] if specialized_pointers else contiguous_grads[0],
+        grad_inputs[0],
+        grad_inputs[1] if specialized_pointers else grad_inputs[0],
+        grad_output_ptrs,
+        grad_input_ptrs,
+        permutes,
+        in_shapes,
+        out_shapes,
+        grad_outputs[0].shape[0],
+        permutes.shape[0],
+        PERMUTE_PARAM_SIZE=_PERMUTE_PARAM_SIZE,
+        SPECIALIZED_POINTERS=specialized_pointers,
+    )
+    return grad_inputs
+
+
+@torch.library.custom_op(
+    "torchrec::triton_permute_multi_embedding",
+    mutates_args=(),
+    schema="(Tensor[] values, Tensor permutes, Tensor in_shapes, Tensor out_shapes, SymInt[] out_lengths) -> Tensor[]",
+)
+def triton_permute_multi_embedding(
+    values: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: list[int],
+) -> list[torch.Tensor]:
+    return _forward_impl(values, permutes, in_shapes, out_shapes, out_lengths)
+
+
+@triton_permute_multi_embedding.register_fake
+def _fake_triton_permute_multi_embedding(
+    values: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    out_lengths: list[int],
+) -> list[torch.Tensor]:
+    return [
+        values[0].new_empty((values[0].shape[0], out_length))
+        for out_length in out_lengths
+    ]
+
+
+@torch.library.custom_op(
+    "torchrec::triton_permute_multi_embedding_backward",
+    mutates_args=(),
+    schema="(Tensor[] grad_outputs, Tensor permutes, Tensor in_shapes, Tensor out_shapes, SymInt[] in_lengths) -> Tensor[]",
+)
+def _triton_permute_multi_embedding_backward(
+    grad_outputs: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    in_lengths: list[int],
+) -> list[torch.Tensor]:
+    return _backward_impl(grad_outputs, permutes, in_shapes, out_shapes, in_lengths)
+
+
+@_triton_permute_multi_embedding_backward.register_fake
+def _fake_triton_permute_multi_embedding_backward(
+    grad_outputs: list[torch.Tensor],
+    permutes: torch.Tensor,
+    in_shapes: torch.Tensor,
+    out_shapes: torch.Tensor,
+    in_lengths: list[int],
+) -> list[torch.Tensor]:
+    return [
+        grad_outputs[0].new_empty((grad_outputs[0].shape[0], in_length))
+        for in_length in in_lengths
+    ]
+
+
+def _setup_context(ctx: Any, inputs: tuple[Any, ...], output: Any) -> None:
+    values, permutes, in_shapes, out_shapes, _ = inputs
+    ctx.save_for_backward(permutes, in_shapes, out_shapes)
+    ctx.in_lengths = [value.shape[1] for value in values]
+
+
+def _backward(
+    ctx: Any, grad_outputs: list[torch.Tensor]
+) -> tuple[list[torch.Tensor], None, None, None, None]:
+    permutes, in_shapes, out_shapes = ctx.saved_tensors
+    grad_inputs = _triton_permute_multi_embedding_backward(
+        grad_outputs,
+        permutes,
+        in_shapes,
+        out_shapes,
+        ctx.in_lengths,
+    )
+    return grad_inputs, None, None, None, None
+
+
+triton_permute_multi_embedding.register_autograd(
+    _backward,
+    setup_context=_setup_context,
+)


### PR DESCRIPTION
Summary:

## 1. Context

This continues D117373760 by moving the pooled-embedding regroup prototype from `fbcode/scripts/hhy/torchrec/sparse/triton_ops.py` into TorchRec as an experimental, PT2-compatible operator.

The prototype used a fixed `BLOCK_SIZE=32`, launched one Triton program for every `(batch, permute)` pair, and did not autotune. The initial TorchRec version kept that one-row-per-program decomposition and autotuned `BLOCK_SIZE`; on the default H100 workload it measured 0.75 ms forward and 1.43 ms forward + backward, behind FBGEMM at 0.55 ms and 1.05 ms.

This diff establishes the library integration, correctness coverage, benchmark commands, and an optimized H100 implementation. It does not route production traffic to the new operator; B200/GB200/GB300 results and a reduced autotune policy are follow-ups.

## 2. Approach

1. **Add a Torch library op.** `torchrec::permute_multi_embedding` has fake-tensor and autograd registrations and consumes the canonical `_kt_regroup_arguments` metadata rather than introducing another regroup metadata format.

2. **Preserve regroup semantics.** The forward supports arbitrary input/output groupings. The backward accumulates gradients for duplicated input features, while unselected inputs retain the existing undefined-gradient contract.

3. **Tile the batch dimension.** Each Triton program processes `BLOCK_BATCH` rows for one permute entry, reducing the launch grid from `batch_size * num_permutes` to `ceil(batch_size / BLOCK_BATCH) * num_permutes` and amortizing pointer/index work.

4. **Specialize the common pointer layout.** The two-input/two-output path passes tensor pointers directly, avoiding the host-to-device pointer-table copies required by the generic arbitrary-input/output path.

5. **Autotune launch shape.** Forward and backward currently compare `B1/W1`, `B2/W2`, `B4/W4`, and `B8/W8`, all with `BLOCK_SIZE=128`, keyed by `(batch_size, num_permutes)`. This is an exploratory search space while the op is not production-routed; section 4 explains why it should be pruned before production.

6. **Extend `benchmark_triton_ops`.** Add comparable `regroup_triton` and `regroup_fbgemm` commands. Inputs are reconstructed after warmup so mutable benchmarks measure the requested input state.

### 2.1 Mapping the Triton controls to CUDA hardware

With the current `num_ctas=1`, one Triton program instance maps to one CUDA CTA/block and is scheduled on one SM. `num_warps=N` requests `32 * N` CUDA threads for that CTA. `BLOCK_SIZE` is the logical feature-width tile, not the CUDA thread count; Triton distributes those elements across the configured warps. `BLOCK_BATCH` is the number of batch rows owned by the CTA.

Multiple CTAs can reside on an SM and hide latency when registers, shared memory, and architectural limits permit. L1/shared memory is local to an SM, while L2 is shared across the GPU. This workload is much larger than those caches, so its steady-state ceiling is HBM bandwidth.

## 3. Results

* benchmark


H100 96 GB, default regroup shape: batch 1024, 1020 permutes, dense `20 x 64`, sparse `1000 x 128`. Every row uses 100 timed iterations and 10 profiled iterations under the repository-default Triton 3.5 stack. The GPU was configured with a 700 W power cap and a 1980 MHz graphics clock.

Hardware specifications:

| Property | Value |
|--|--:|
|GPU|NVIDIA H100 PCIe|
|HBM|96 GB HBM2e|
|Streaming multiprocessors|132|
|Theoretical aggregate HBM bandwidth|2.40 TB/s|
|Theoretical average HBM bandwidth per SM|18.18 GB/s/SM|
|Benchmark power cap|700 W|
|Locked graphics clock|1980 MHz|

|short name|Trace kernel time (P10/P50/P90)|Useful traffic|Effective aggregate bandwidth|Average bandwidth per SM|H100 peak|Trace|
|--|--:|--:|--:|--:|--:|--|
|regroup_triton_h100_fp32_fwd|484.5 / 486.0 / 487.5 µs|1.059 GB|2.179 TB/s|16.51 GB/s/SM|90.8%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_fp32_fwd|491.0 / 495.6 / 496.5 µs|1.059 GB|2.137 TB/s|16.19 GB/s/SM|89.0%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_fp32_fwd_bwd|971.7 / 973.8 / 974.3 µs|2.118 GB|2.175 TB/s|16.48 GB/s/SM|90.6%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_fp32_fwd_bwd|981.8 / 986.9 / 988.0 µs|2.118 GB|2.146 TB/s|16.26 GB/s/SM|89.4%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_bf16_fwd|277.1 / 281.5 / 284.9 µs|0.530 GB|1.881 TB/s|14.25 GB/s/SM|78.4%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_bf16_fwd|311.4 / 311.9 / 312.3 µs|0.530 GB|1.698 TB/s|12.86 GB/s/SM|70.7%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_bf16_fwd_bwd|548.6 / 558.7 / 563.5 µs|1.059 GB|1.896 TB/s|14.36 GB/s/SM|79.0%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_bf16_fwd_bwd|628.1 / 628.8 / 629.7 µs|1.059 GB|1.684 TB/s|12.76 GB/s/SM|70.2%|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|

The default shape moves 132,382,720 values. Timings above come from the 10 GPU kernel events in each uploaded trace, rather than the benchmark harness's aggregate GPU timing. For forward + backward, each sample is the sum of its forward and backward kernel durations. Effective bandwidth uses the trace-derived P50 and counts one input read and one output write: 1,059,061,760 bytes for FP32 forward and 529,530,880 bytes for BF16 forward; forward + backward doubles those byte counts. Average bandwidth per SM is aggregate effective bandwidth divided by 132 and is not a directly measured per-SM hardware counter.

At the trace-derived kernel P50, Triton is 1.9% faster for FP32 forward, 1.3% faster for FP32 forward + backward, 9.7% faster for BF16 forward, and 11.1% faster for BF16 forward + backward. Relative to the initial one-row-per-program benchmark result, batch tiling also materially reduces the Triton kernel time.


* configuration ablation

An earlier isolated H100 kernel study under the beta Triton compiler separated `BLOCK_BATCH` from `num_warps`:

| config | forward | backward |
|--|--:|--:|
|`BLOCK_BATCH=1`, `num_warps=1`|0.6336 ms|0.6340 ms|
|`BLOCK_BATCH=1`, `num_warps=2`|0.6338 ms|0.6340 ms|
|`BLOCK_BATCH=2`, `num_warps=1`|0.4934 ms|0.4907 ms|
|`BLOCK_BATCH=2`, `num_warps=2`|0.4906 ms|0.4915 ms|
|`BLOCK_BATCH=4`, `num_warps=4`|0.4910 ms|0.4917 ms|
|`BLOCK_BATCH=8`, `num_warps=8`|0.4932 ms|0.5323 ms|

* repro commands

```
# FP32 forward
CUDA_VISIBLE_DEVICES=1 third-party/triton/beta/triton/third_party/tlx/denoise.sh \
  buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_triton_ops -- \
  regroup_triton --name=h100_fp32_fwd --num_benchmarks=100 --num_profiles=10
CUDA_VISIBLE_DEVICES=1 third-party/triton/beta/triton/third_party/tlx/denoise.sh \
  buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_triton_ops -- \
  regroup_fbgemm --name=h100_fp32_fwd --num_benchmarks=100 --num_profiles=10

# FP32 forward + backward: add to each command
--run_backward=True

# BF16 forward: add to each command
--dtype=bfloat16

# BF16 forward + backward: add both flags
--dtype=bfloat16 --run_backward=True
```

* trace

- [manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D117639963)

|name|rank0 trace|
|--|--|
|regroup_triton_h100_fp32_fwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_fp32_fwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_fp32_fwd_bwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_fp32_fwd_bwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_bf16_fwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_bf16_fwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_triton_h100_bf16_fwd_bwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|
|regroup_fbgemm_h100_bf16_fwd_bwd|[Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)|

Each replacement trace contains 10 profiled iterations; for example, the FP32 Triton forward trace contains 10 `_permute_multi_embedding_kernel` events.

## 4. Analysis

1. **Batch tiling, not additional warps, explains the H100 improvement.** `B1/W2` is indistinguishable from `B1/W1`, while `B2/W1` captures nearly the full reduction from about 0.634 to 0.493 ms in the isolated study. Processing two rows halves the CTA count and amortizes metadata and pointer work. It also exposes enough memory operations per CTA to approach the practical HBM ceiling.

2. **A one-warp CTA does not waste half of a CUDA block.** CUDA blocks do not have a fixed thread count: `num_warps=1` creates 32 threads, and `num_warps=2` creates 64. Increasing `num_warps` can improve latency hiding or instruction throughput, but the ablation shows that it does not solve the one-row decomposition by itself.

3. **The optimized kernel is bandwidth-bound at `BLOCK_BATCH >= 2` for the default shape.** The FP32 workload moves 132,382,720 elements, or 1,059,061,760 useful read/write bytes. The isolated `B1/W1` timing corresponds to 1.67 TB/s, 69.6% of the H100 2.4 TB/s specification. `B2/W2` corresponds to 2.16 TB/s, 90.0% of peak. Across 132 SMs that is 12.66 GB/s per SM for `B1/W1` and 16.35 GB/s per SM for `B2/W2`, versus an 18.18 GB/s theoretical average. `B2`, `B4`, and `B8` then plateau, so larger CTAs cannot materially improve HBM throughput for this shape.

4. **Concurrent CTAs do not eliminate undersized-program costs.** An SM can host multiple CTAs and switch among ready warps, subject to register, shared-memory, warp, and block limits. That hides some latency, but every one-row CTA still repeats its setup and contributes fewer independent memory operations. L1/shared memory is per-SM and L2 is GPU-wide; neither changes the fact that this working set streams through HBM.

5. **The current autotune search is exploratory, not the intended production set.** On this H100 shape, `B1/W1` is dominated and `B8/W8` adds no benefit; `B2/W2` and `B4/W4` differ by less than run noise, and Triton autotuning does not apply a significance test. `B1/W1` can still matter for tiny batches, while Blackwell may choose differently, so all four remain while the op is experimental. Before production routing, bucket dynamic `(batch_size, num_permutes)` values to avoid tune/cache proliferation and prune to the smallest set justified by H100 and B200/GB200/GB300 measurements.

6. **The default-stack benchmark is the decision point.** The corrected runs omit the beta Triton and explicit `h100a` overrides, matching the normal TorchRec build. They show the implementation is close to FBGEMM but not a uniform win: FP32 remains about 8.6% behind, BF16 forward is approximately tied, and BF16 forward + backward is approximately tied. That supports landing the implementation for further evaluation, but not changing production dispatch in this diff.

## 5. Changes

1. **`torchrec/sparse/triton_permute_multi_embedding.py`** (new): Triton forward/backward kernels, generic and two-input/two-output pointer paths, autotuning, Torch library registration, fake implementation, and autograd setup.
2. **`torchrec/sparse/tests/test_keyed_tensor.py`**: correctness coverage for forward/backward, supported dtypes, noncontiguous inputs, PT2, and duplicate-feature gradient accumulation.
3. **`torchrec/distributed/benchmark/benchmark_triton_ops.py`**: Triton and FBGEMM regroup subcommands plus post-warmup input reconstruction.
4. **BUCK files**: dependencies and sources for the operator, tests, and benchmark.

## 6. Follow-ups

1. Run the same benchmark and autotune ablation on B200, GB200, and GB300.
2. Bucket dynamic autotune keys rather than caching every exact `(batch_size, num_permutes)` pair.
3. Remove dominated configurations after cross-generation data is available; the likely production set is `B2/W2` and `B4/W4`, with `B1/W1` retained only for a small-batch bucket if measurements justify it.
4. Add production routing only after the supported hardware/dtype matrix has a demonstrated win or another operational reason to select Triton.

Reviewed By: aporialiao

Differential Revision: D117639963


