### PR TITLE
[detailed][maglev] Add async in-place copy to input distribution

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_maglev.py
+++ b/torchrec/distributed/benchmark/benchmark_maglev.py
@@ -323,6 +323,8 @@ def _make_input(
         weighted_tables=[],
         num_float_features=num_float_features,
         device=device,
+        # Citrine C0: pin host input memory for efficient CPU-to-GPU transfer.
+        pin_memory=True,
     )
 
 
@@ -428,17 +430,18 @@ def runner(
         )
         pipeline = run_option.generate_pipeline(stage=stage, optimizer=optimizer)
 
-        # One batch, replayed forever: data loading is not what we benchmark, so
-        # the dataloader hands back the same pre-built batch every round and only
-        # the input-dist all-to-all inside progress() is measured. A batch here is
-        # one ModelInput per layer of the whole model, which is what the model's
-        # (passthrough) preproc consumes.
+        # One CPU batch, replayed forever: data loading is not what we benchmark,
+        # so the dataloader hands back the same pre-built batch every round. A
+        # batch here is one ModelInput per layer of the whole model, which is what
+        # the model's (passthrough) preproc consumes. Input distribution owns the
+        # H2D copy, as it does for a real dataloader.
+        cpu_device = torch.device("cpu")
         model_input = [
             _make_input(
                 all_tables[l],
                 run_option.batch_size,
                 run_option.num_float_features,
-                device,
+                cpu_device,
             )
             for l in range(num_layers)
         ]

--- a/torchrec/distributed/maglev/input_dist.py
+++ b/torchrec/distributed/maglev/input_dist.py
@@ -20,7 +20,18 @@ over CPU/gloo, then bulk tensors over nccl -- both async, returning a
 import math
 from collections import deque
 from dataclasses import fields, is_dataclass
-from typing import Any, Callable, Deque, Dict, Generic, Iterator, List, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 import torch
 import torch.distributed as dist
@@ -167,56 +178,87 @@ def _next(it: Iterator[torch.Tensor]) -> torch.Tensor:
         ) from None
 
 
-class _InputSizeAwaitable(
-    LazyAwaitable[Tuple[List[List[torch.Tensor]], List[List[int]]]]
-):
+def inplace_copy_to_gpu(
+    source_tensors: List[torch.Tensor],
+    destination_tensors: List[torch.Tensor],
+    memcpy_stream: torch.Stream,
+) -> None:
+    """Copy flattened CPU tensors into preallocated GPU tensors.
+
+    The dedicated memcpy stream waits for the current stream, which allocated the
+    destination storage, before issuing the nonblocking ``copy_`` operations.
+
+    The caller is responsible for making the consuming stream wait for
+    ``memcpy_stream`` before reading the destination tensors.
+    """
+    device = destination_tensors[0].device
+    device_module = torch.get_device_module(device)
+    current_stream = device_module.current_stream(device)
+    with record_function("## inplace_copy_to_gpu ##"):
+        with device_module.stream(memcpy_stream):
+            memcpy_stream.wait_stream(current_stream)
+            for destination, source in zip(destination_tensors, source_tensors):
+                destination.copy_(source, non_blocking=True)
+
+
+class _InputSizeAwaitable(LazyAwaitable[List[List[int]]]):
     """Awaitable for the size-metadata all-to-all (:func:`input_size_dist`).
 
-    ``wait()`` completes the async exchange and returns ``(flat_send, recv_sizes)``:
-    the flattened send tensors (available immediately, threaded through so phase two
-    need not re-flatten) and ``recv_sizes[i][k]`` -- the dim-0 size of slot ``k`` of
-    the carrier rank ``i`` is sending to this rank. The sizes arrive flat and are
-    reshaped to ``[world_size, recv_slots]`` here.
+    ``wait()`` completes the async size exchange and returns ``recv_sizes``, where
+    ``recv_sizes[i][k]`` is the dim-0 size of slot ``k`` of the carrier rank ``i``
+    is sending to this rank.
     """
 
     def __init__(
         self,
-        # pyre-ignore[2]: dist work handle has no public type
-        work: Any,
         flat_send: List[List[torch.Tensor]],
-        recv_sizes: torch.Tensor,
         recv_slots: int,
+        world_size: int,
+        pg_gloo: dist.ProcessGroup,
         batch_id: int,
     ) -> None:
         super().__init__()
-        self._work = work
-        self._flat_send = flat_send
-        self._recv_sizes = recv_sizes
         self._recv_slots = recv_slots
         self._batch_id = batch_id
+        send_sizes = torch.tensor(
+            [tensor.shape[0] for tensors in flat_send for tensor in tensors],
+            dtype=torch.int64,
+        )
+        in_splits = [len(tensors) for tensors in flat_send]
+        out_splits = [recv_slots] * world_size
+        self._recv_sizes = torch.empty(recv_slots * world_size, dtype=torch.int64)
+        with record_function(f"## input_size_dist batch{batch_id} ##"):
+            self._work = dist.all_to_all_single(
+                self._recv_sizes,
+                send_sizes,
+                out_splits,
+                in_splits,
+                group=pg_gloo,
+                async_op=True,
+            )
 
-    def _wait_impl(self) -> Tuple[List[List[torch.Tensor]], List[List[int]]]:
+    def _wait_impl(self) -> List[List[int]]:
         with record_function(f"## input_size_dist wait batch{self._batch_id} ##"):
             if self._work is not None:
                 self._work.wait()
             # Flat on the wire, [source rank][slot] to the caller.
-            return self._flat_send, self._recv_sizes.view(-1, self._recv_slots).tolist()
+            return self._recv_sizes.view(-1, self._recv_slots).tolist()
 
 
 class _InputDataAwaitable(LazyAwaitable[List[T]]):
     """Awaitable for the bulk tensor all-to-all (:func:`input_data_dist`).
 
-    ``wait()`` completes the per-dtype async exchanges, slices each fused receive
-    buffer back into its tensor slots, then regroups them per source rank and
-    reconstructs each carrier from ``example``.
+    ``wait()`` orders the caller's current stream after ``pp_data_dist_stream``,
+    slices each fused receive buffer back into its tensor slots, then regroups
+    them per source rank and reconstructs each carrier from ``example``.
     """
 
     def __init__(
         self,
-        # pyre-ignore[2]: dist work handles have no public type
-        works: List[Any],
         out_bufs: List[torch.Tensor],
         in_bufs: List[torch.Tensor],
+        out_splits_by_bucket: List[List[int]],
+        in_splits_by_bucket: List[List[int]],
         bucket_slots: List[List[int]],
         recv_sizes: List[List[int]],
         row_elems: List[int],
@@ -224,10 +266,34 @@ class _InputDataAwaitable(LazyAwaitable[List[T]]):
         example: T,
         world_size: int,
         num_tensors: int,
+        device: torch.device,
+        pg_nccl: dist.ProcessGroup,
+        pp_data_dist_stream: torch.Stream,
         batch_id: int,
     ) -> None:
         super().__init__()
-        self._works = works
+        device_module = torch.get_device_module(device)
+        data_done_event = device_module.Event()
+        with device_module.stream(pp_data_dist_stream):
+            for out_buf, in_buf, out_splits, in_splits in zip(
+                out_bufs,
+                in_bufs,
+                out_splits_by_bucket,
+                in_splits_by_bucket,
+            ):
+                with record_function(
+                    f"## input_data_dist batch{batch_id} {out_buf.dtype} ##"
+                ):
+                    dist.all_to_all_single(
+                        out_buf,
+                        in_buf,
+                        out_splits,
+                        in_splits,
+                        group=pg_nccl,
+                        async_op=False,
+                    )
+            data_done_event.record(pp_data_dist_stream)
+
         self._out_bufs = out_bufs
         # Held only to keep the send buffers alive until the collectives complete.
         self._in_bufs = in_bufs
@@ -239,12 +305,15 @@ class _InputDataAwaitable(LazyAwaitable[List[T]]):
         self._world_size = world_size
         self._num_tensors = num_tensors
         self._batch_id = batch_id
+        self._device = device
+        self._data_done_event = data_done_event
 
     def _wait_impl(self) -> List[T]:
         with record_function(f"## input_data_dist wait batch{self._batch_id} ##"):
-            for work in self._works:
-                if work is not None:
-                    work.wait()
+            current_stream = torch.get_device_module(self._device).current_stream(
+                self._device
+            )
+            current_stream.wait_event(self._data_done_event)
             # recv_slot[(k, i)] = slot k of the carrier received from rank i. Each
             # fused buffer is laid out source-major then slot-major, matching the
             # destination-major / slot-major send layout in input_data_dist.
@@ -270,182 +339,220 @@ def input_size_dist(
     send: List[T],
     example: T,
     pg_gloo: dist.ProcessGroup,
+    device: torch.device,
+    memcpy_stream: torch.Stream,
     batch_id: int = 0,
-) -> LazyAwaitable[Tuple[List[List[torch.Tensor]], List[List[int]]]]:
-    """Phase one: flatten each carrier and async all-to-all the tensor-size metadata.
+) -> Tuple[
+    List[torch.Tensor],
+    List[List[int]],
+    _InputSizeAwaitable,
+    List[torch.Tensor],
+    Any,
+]:
+    """Flatten and copy the input, then exchange tensor-size metadata.
 
-    ``send`` must have one carrier per rank in ``pg_gloo`` (``send[j]`` is destined
-    for rank ``j``), and each must have the structure *that destination* expects --
-    which is what ``example`` describes locally. Carriers may therefore differ in
-    tensor count between destinations: a rank sending a 2-slot carrier to one peer
-    and a 3-slot carrier to another is fine, as long as each peer's own example
-    agrees. What is *received* is always homogeneous, since every incoming carrier
-    is built for this rank.
+    ``send`` must have one carrier per rank in ``pg_gloo``. Each carrier is
+    flattened and grouped by dtype. One fused GPU input buffer is allocated per
+    dtype, and the CPU tensors are copied directly into views of those buffers on
+    ``memcpy_stream``. The CPU dim-0 sizes are exchanged asynchronously over gloo
+    while that copy is in flight.
 
     Only each tensor's dim-0 size varies; trailing dims and dtype are fixed per
-    slot and recovered from the example in phase two. This issues an async
-    all-to-all of the dim-0 sizes over the (cheap, CPU) gloo group -- ragged on the
-    way out (``input_split_sizes`` is each carrier's tensor count) and rectangular
-    on the way back (every peer sends this rank ``K`` sizes, ``K`` taken from
-    ``example``) -- so every rank learns the sizes of the tensors it is about to
-    receive.
+    slot and recovered from ``example`` in :func:`input_data_dist`.
 
     Args:
         send: one carrier per destination rank; ``send[j]`` goes to rank ``j``.
-        example: template carrier for what this rank *receives*; its tensor count
-            fixes how many sizes to expect from each peer.
+        example: template carrier defining the received structure and tensor slots.
         pg_gloo: a gloo process group used only for the tiny size exchange.
+        device: CUDA device for the copied input tensors.
+        memcpy_stream: dedicated stream for the CPU-to-GPU copy.
         batch_id: identifier for this input batch, used only to tag the profiler
             ranges (``## input_size_dist batch{batch_id} ##``).
 
     Returns:
-        A :class:`LazyAwaitable` whose ``wait()`` yields ``(flat_send, recv_sizes)``:
-        ``flat_send[j]`` is the flattened tensors of ``send[j]`` (threaded through so
-        phase two need not re-flatten), and ``recv_sizes[i][k]`` is the dim-0 size of
-        slot ``k`` of the carrier rank ``i`` is sending to this rank.
+        The fused GPU input buffers, their per-destination split sizes, the size-
+        exchange awaitable, flattened example tensors, and copy-completion event
+        consumed by :func:`input_data_dist`.
 
     Raises:
-        ValueError: if ``len(send)`` does not match the group size.
+        ValueError: if ``device`` is not CUDA or ``len(send)`` does not match the
+            group size.
     """
+    if device.type != "cuda":
+        raise ValueError(f"input_size_dist requires a CUDA device, got {device}")
+
     world_size = dist.get_world_size(pg_gloo)
     if len(send) != world_size:
         raise ValueError(
             f"expected one carrier per rank: got {len(send)} for world size "
             f"{world_size}"
         )
-    flat_send: List[List[torch.Tensor]] = [flatten_to_tensors(item) for item in send]
-    # Every carrier this rank receives is built for this rank, so they all have the
-    # example's slot count -- the receive side stays rectangular even when the send
-    # side is ragged.
-    recv_slots = len(flatten_to_tensors(example))
 
-    with record_function(f"## input_size_dist batch{batch_id} ##"):
-        send_sizes = torch.tensor(
-            [t.shape[0] for tensors in flat_send for t in tensors],
-            dtype=torch.int64,
-        )
-        in_splits = [len(tensors) for tensors in flat_send]
-        out_splits = [recv_slots] * world_size
-        recv_sizes = torch.empty(recv_slots * world_size, dtype=torch.int64)
-        work = dist.all_to_all_single(
-            recv_sizes,
-            send_sizes,
-            out_splits,
-            in_splits,
-            group=pg_gloo,
-            async_op=True,
-        )
-    return _InputSizeAwaitable(work, flat_send, recv_sizes, recv_slots, batch_id)
-
-
-def input_data_dist(
-    flat_send: List[List[torch.Tensor]],
-    recv_sizes: List[List[int]],
-    example: T,
-    pg_nccl: dist.ProcessGroup,
-    batch_id: int = 0,
-) -> LazyAwaitable[List[T]]:
-    """Phase two: async all-to-all the bulk tensors and rebuild the carriers.
-
-    Issues one async :func:`torch.distributed.all_to_all_single` per *dtype*: the
-    tensor slots are bucketed by dtype (read from ``example``), and within a bucket
-    every slot is flattened to 1-D and concatenated into one fused buffer, so a
-    single collective moves all same-dtype slots at once. This mirrors TorchRec's
-    ``KJTAllToAll``, which keeps native dtypes (never byte-packs) but fuses what it
-    can -- here a mixed-dtype carrier collapses to one collective per distinct dtype
-    rather than one per slot. The returned awaitable's ``wait()`` completes the
-    collectives, slices each fused buffer back into its slots, regroups per source
-    rank, and reconstructs each carrier with :func:`unflatten_from_tensors`.
-
-    Args:
-        flat_send: per-destination flattened tensors, from :func:`input_size_dist`.
-        recv_sizes: per-source dim-0 sizes, from :func:`input_size_dist`.
-        example: template carrier defining structure, dtypes, and non-tensor parts.
-        pg_nccl: an nccl process group carrying the (CUDA) tensor data.
-        batch_id: identifier for this input batch, used only to tag the profiler
-            ranges (``## input_data_dist batch{batch_id} ##``).
-
-    Returns:
-        A :class:`LazyAwaitable` whose ``wait()`` yields ``recv`` with ``recv[i]``
-        the carrier received from rank ``i``.
-    """
-    world_size = len(flat_send)
+    source_flat_send = [flatten_to_tensors(item) for item in send]
     example_flat = flatten_to_tensors(example)
-    num_tensors = len(example_flat)
-    # Per-slot layout from the example: elements per dim-0 row and the trailing shape
-    # (only dim-0 varies between carriers, so these are fixed per slot). This is the
-    # *receive* side, which is homogeneous -- every incoming carrier is built for
-    # this rank.
-    row_elems = [math.prod(t.shape[1:]) for t in example_flat]
-    trailing = [tuple(t.shape[1:]) for t in example_flat]
-    # Bucket slots by dtype in first-seen order. The example is a shared template, so
-    # every rank derives the same buckets and the per-dtype collectives line up.
-    buckets: Dict[torch.dtype, List[int]] = {}
-    for k in range(num_tensors):
-        buckets.setdefault(example_flat[k].dtype, []).append(k)
+    (
+        in_bufs,
+        in_splits_by_bucket,
+        source_tensors,
+        destination_tensors,
+    ) = prepare_input_buffers(source_flat_send, example_flat, device)
+    inplace_copy_to_gpu(
+        source_tensors,
+        destination_tensors,
+        memcpy_stream,
+    )
+    device_module = torch.get_device_module(device)
+    copy_done_event = device_module.Event()
+    copy_done_event.record(memcpy_stream)
 
-    # The *send* side may be ragged: a carrier built for a destination with more
-    # layers has more slots than this rank's own example. So bucket each
-    # destination's slots by its own dtypes rather than reusing the example's slot
-    # indices, which describe a different carrier.
+    return (
+        in_bufs,
+        in_splits_by_bucket,
+        _InputSizeAwaitable(
+            source_flat_send,
+            len(example_flat),
+            world_size,
+            pg_gloo,
+            batch_id,
+        ),
+        example_flat,
+        copy_done_event,
+    )
+
+
+def prepare_input_buffers(
+    source_flat_send: List[List[torch.Tensor]],
+    example_flat: List[torch.Tensor],
+    device: torch.device,
+) -> Tuple[
+    List[torch.Tensor],
+    List[List[int]],
+    List[torch.Tensor],
+    List[torch.Tensor],
+]:
+    """Allocate fused GPU input buffers and views for direct CPU-to-GPU copy.
+
+    Returns the fused buffers, their per-destination split sizes, CPU source
+    tensors, and matching GPU destination views.
+    """
+    slots_by_dtype: Dict[torch.dtype, List[int]] = {}
+    for k, tensor in enumerate(example_flat):
+        slots_by_dtype.setdefault(tensor.dtype, []).append(k)
+
     send_slots: List[Dict[torch.dtype, List[int]]] = []
-    for j in range(world_size):
+    for j, tensors in enumerate(source_flat_send):
         by_dtype: Dict[torch.dtype, List[int]] = {}
-        for k, tensor in enumerate(flat_send[j]):
-            if tensor.dtype not in buckets:
+        for k, tensor in enumerate(tensors):
+            if tensor.dtype not in slots_by_dtype:
                 raise ValueError(
-                    f"send[{j}] slot {k} has dtype {tensor.dtype}, which the example "
-                    "does not have; a carrier may differ from the example in slot "
-                    "count, not in the dtypes it carries"
+                    f"send[{j}] slot {k} has dtype {tensor.dtype}, which the "
+                    "example does not have; a carrier may differ from the "
+                    "example in slot count, not in the dtypes it carries"
                 )
             by_dtype.setdefault(tensor.dtype, []).append(k)
         send_slots.append(by_dtype)
 
-    device = flat_send[0][0].device
-    # pyre-ignore[33]: dist work handles have no public type
-    works: List[Any] = []
-    out_bufs: List[torch.Tensor] = []
     in_bufs: List[torch.Tensor] = []
-    bucket_slots: List[List[int]] = []
+    in_splits_by_bucket: List[List[int]] = []
+    source_tensors: List[torch.Tensor] = []
+    destination_tensors: List[torch.Tensor] = []
+    for dtype in slots_by_dtype:
+        in_splits = [
+            sum(source_flat_send[j][k].numel() for k in send_slots[j].get(dtype, []))
+            for j in range(len(source_flat_send))
+        ]
+        in_buf = torch.empty(sum(in_splits), dtype=dtype, device=device)
+        pos = 0
+        for j, tensors in enumerate(source_flat_send):
+            for k in send_slots[j].get(dtype, []):
+                source = tensors[k]
+                next_pos = pos + source.numel()
+                source_tensors.append(source)
+                destination_tensors.append(in_buf[pos:next_pos].view(source.shape))
+                pos = next_pos
+        in_bufs.append(in_buf)
+        in_splits_by_bucket.append(in_splits)
+
+    return in_bufs, in_splits_by_bucket, source_tensors, destination_tensors
+
+
+def prepare_output_buffers(
+    recv_sizes: List[List[int]],
+    example_flat: List[torch.Tensor],
+    device: torch.device,
+) -> Tuple[
+    Dict[torch.dtype, List[int]],
+    List[torch.Tensor],
+    List[List[int]],
+    List[int],
+]:
+    """Allocate fused receive buffers and their per-source split sizes."""
+    world_size = len(recv_sizes)
+    row_elems = [math.prod(tensor.shape[1:]) for tensor in example_flat]
+    slots_by_dtype: Dict[torch.dtype, List[int]] = {}
+    for k, tensor in enumerate(example_flat):
+        slots_by_dtype.setdefault(tensor.dtype, []).append(k)
+
+    out_bufs: List[torch.Tensor] = []
+    out_splits_by_bucket: List[List[int]] = []
+    for dtype, slots in slots_by_dtype.items():
+        out_splits = [
+            sum(recv_sizes[i][k] * row_elems[k] for k in slots)
+            for i in range(world_size)
+        ]
+        out_bufs.append(torch.empty(sum(out_splits), dtype=dtype, device=device))
+        out_splits_by_bucket.append(out_splits)
+
+    return (
+        slots_by_dtype,
+        out_bufs,
+        out_splits_by_bucket,
+        row_elems,
+    )
+
+
+def input_data_dist(
+    in_bufs: List[torch.Tensor],
+    in_splits_by_bucket: List[List[int]],
+    recv_sizes: List[List[int]],
+    example: T,
+    example_flat: List[torch.Tensor],
+    pg_nccl: dist.ProcessGroup,
+    pp_data_dist_stream: torch.Stream,
+    copy_done_event: Any,
+    batch_id: int = 0,
+) -> LazyAwaitable[List[T]]:
+    """Launch CUDA input-data distribution and return its awaitable.
+
+    Receive buffers are allocated from the exchanged sizes. The collectives use
+    the fused input buffers prepared by :func:`input_size_dist` and are enqueued on
+    ``pp_data_dist_stream`` after the CPU-to-GPU copy.
+    """
+    device = in_bufs[0].device
+    device_module = torch.get_device_module(device)
+    current_stream = device_module.current_stream(device)
+    world_size = len(recv_sizes)
+    num_tensors = len(example_flat)
+    trailing = [tuple(tensor.shape[1:]) for tensor in example_flat]
+
     with record_function(f"## input_data_dist batch{batch_id} ##"):
-        for dtype, slots in buckets.items():
-            # Destination-major, then slot-major: chunk j (-> rank j) is this rank's
-            # slots for j laid end to end; input_split_sizes marks the j boundaries.
-            # Each destination contributes its *own* slots of this dtype, in slot
-            # order -- which lines up with how that peer's example slices them out,
-            # since the carrier was built to its structure.
-            in_splits = [
-                sum(flat_send[j][k].numel() for k in send_slots[j].get(dtype, []))
-                for j in range(world_size)
-            ]
-            parts = [
-                flat_send[j][k].reshape(-1)
-                for j in range(world_size)
-                for k in send_slots[j].get(dtype, [])
-            ]
-            in_buf = (
-                torch.cat(parts)
-                if parts
-                else torch.empty(0, dtype=dtype, device=device)
-            )
-            out_splits = [
-                sum(recv_sizes[i][k] * row_elems[k] for k in slots)
-                for i in range(world_size)
-            ]
-            out_buf = torch.empty(sum(out_splits), dtype=dtype, device=device)
-            with record_function(f"## input_data_dist batch{batch_id} {dtype} ##"):
-                work = dist.all_to_all_single(
-                    out_buf, in_buf, out_splits, in_splits, group=pg_nccl, async_op=True
-                )
-            works.append(work)
-            out_bufs.append(out_buf)
-            in_bufs.append(in_buf)
-            bucket_slots.append(slots)
+        (
+            buckets,
+            out_bufs,
+            out_splits_by_bucket,
+            row_elems,
+        ) = prepare_output_buffers(recv_sizes, example_flat, device)
+
+    bucket_slots = list(buckets.values())
+
+    pp_data_dist_stream.wait_event(copy_done_event)
+    pp_data_dist_stream.wait_stream(current_stream)
 
     return _InputDataAwaitable(
-        works,
         out_bufs,
         in_bufs,
+        out_splits_by_bucket,
+        in_splits_by_bucket,
         bucket_slots,
         recv_sizes,
         row_elems,
@@ -453,6 +560,9 @@ def input_data_dist(
         example,
         world_size,
         num_tensors,
+        device,
+        pg_nccl,
+        pp_data_dist_stream,
         batch_id,
     )
 
@@ -462,6 +572,9 @@ def input_dist(
     example: T,
     pg_gloo: dist.ProcessGroup,
     pg_nccl: dist.ProcessGroup,
+    device: torch.device,
+    memcpy_stream: torch.Stream,
+    pp_data_dist_stream: torch.Stream,
     batch_id: int = 0,
 ) -> LazyAwaitable[List[T]]:
     """All-to-all a list of structured carriers: one per rank in, one per rank out.
@@ -471,9 +584,10 @@ def input_dist(
     to rank ``j``; the returned awaitable's ``wait()`` yields ``recv[i]`` -- the
     carrier from rank ``i``.
 
-    The size exchange is awaited here (its result is needed to lay out the data
-    collectives), then the data all-to-alls are launched async and returned as a
-    :class:`LazyAwaitable` so the caller can overlap work before ``wait()``.
+    The size exchange is awaited here because its result lays out the data
+    collectives. The data all-to-alls are then enqueued on ``pp_data_dist_stream``
+    and returned as a :class:`LazyAwaitable` so the caller can overlap work before
+    ``wait()`` establishes the stream dependency.
 
     Args:
         send: one carrier per destination rank; ``send[j]`` goes to rank ``j``.
@@ -482,13 +596,32 @@ def input_dist(
         pg_nccl: nccl group for the tensor-data exchange.
         batch_id: identifier for this input batch, threaded to both phases to tag
             the profiler ranges.
+        device: CUDA device for the input and data collectives.
+        memcpy_stream: dedicated stream for the CPU-to-GPU copy.
+        pp_data_dist_stream: dedicated stream for the tensor-data all-to-alls.
 
     Returns:
         A :class:`LazyAwaitable` whose ``wait()`` yields ``recv`` with ``recv[i]``
         the carrier received from rank ``i``.
     """
-    flat_send, recv_sizes = input_size_dist(send, example, pg_gloo, batch_id).wait()
-    return input_data_dist(flat_send, recv_sizes, example, pg_nccl, batch_id)
+    (
+        in_bufs,
+        in_splits_by_bucket,
+        size_awaitable,
+        example_flat,
+        copy_done_event,
+    ) = input_size_dist(send, example, pg_gloo, device, memcpy_stream, batch_id)
+    return input_data_dist(
+        in_bufs,
+        in_splits_by_bucket,
+        size_awaitable.wait(),
+        example,
+        example_flat,
+        pg_nccl,
+        pp_data_dist_stream,
+        copy_done_event,
+        batch_id,
+    )
 
 
 class InputDistDriver(Generic[T]):
@@ -537,8 +670,19 @@ class InputDistDriver(Generic[T]):
         self._pg_nccl = pg_nccl
         self._self_index = self_index
         self._queue: Deque[T] = deque()
+        self._device: Optional[torch.device] = None
+        self._memcpy_stream: Optional[torch.Stream] = None
+        self._pp_data_dist_stream: Optional[torch.Stream] = None
         # Monotonic round counter, tagging the profiler ranges.
         self._batch_id = 0
+
+    def set_device(self, device: torch.device) -> None:
+        """Create the copy and data-distribution streams for future exchanges."""
+        if device.type != "cuda":
+            raise ValueError(f"InputDistDriver requires a CUDA device, got {device}")
+        self._device = device
+        self._memcpy_stream = torch.get_device_module(device).Stream()
+        self._pp_data_dist_stream = torch.get_device_module(device).Stream()
 
     @property
     def pending(self) -> int:
@@ -558,12 +702,22 @@ class InputDistDriver(Generic[T]):
         """
         batch_id = self._batch_id
         self._batch_id += 1
+        device = self._device
+        if device is None:
+            raise ValueError("call set_device() before input distribution")
+        memcpy_stream = self._memcpy_stream
+        pp_data_dist_stream = self._pp_data_dist_stream
+        if memcpy_stream is None or pp_data_dist_stream is None:
+            raise ValueError("CUDA input distribution streams are not initialized")
         return input_dist(
             send,
             send[self._self_index],
             pg_gloo=self._pg_gloo,
             pg_nccl=self._pg_nccl,
             batch_id=batch_id,
+            device=device,
+            memcpy_stream=memcpy_stream,
+            pp_data_dist_stream=pp_data_dist_stream,
         )
 
     def take(self, next_send: Callable[[], List[T]], n: int) -> List[T]:

--- a/torchrec/distributed/maglev/stage.py
+++ b/torchrec/distributed/maglev/stage.py
@@ -16,7 +16,6 @@ wire between stages. The authoring side is in
 :mod:`torchrec.distributed.maglev.module`.
 """
 
-import abc
 from collections import deque
 from typing import Any, Callable, cast, Deque, Iterator, List, Optional, Sequence, Tuple
 
@@ -589,6 +588,7 @@ class StageWrapper(nn.Module):
         """
         init_parameters(self.module, device)
         self.device = device
+        self._input_driver.set_device(device)
         return self
 
     @property

--- a/torchrec/distributed/maglev/tests/test_input_dist.py
+++ b/torchrec/distributed/maglev/tests/test_input_dist.py
@@ -9,20 +9,16 @@
 
 import unittest
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
 from torchrec.distributed.maglev.input_dist import (
     flatten_to_tensors,
     input_data_dist,
-    input_dist,
     input_size_dist,
     unflatten_from_tensors,
-)
-from torchrec.distributed.test_utils.multi_process import (
-    MultiProcessContext,
-    MultiProcessTestBase,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
@@ -190,61 +186,8 @@ def _make_carrier(src: int, dst: int) -> _Batch:
     )
 
 
-def _run_all_to_all(rank: int, world_size: int) -> None:
-    with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo") as ctx:
-        pg = ctx.pg
-        assert pg is not None
-
-        send = [_make_carrier(src=rank, dst=dst) for dst in range(world_size)]
-        # Structure/dtype template; its sizes and content are irrelevant.
-        example = _make_carrier(src=0, dst=0)
-        example.tag = "from_example"
-
-        # gloo stands in for nccl here: all_to_all_single is backend-agnostic, so
-        # the same group drives both the size and the data phase in the test.
-        recv = input_dist(send, example, pg_gloo=pg, pg_nccl=pg).wait()
-
-        assert (
-            len(recv) == world_size
-        ), f"expected {world_size} carriers, got {len(recv)}"
-        for src in range(world_size):
-            expected = _make_carrier(src=src, dst=rank)
-            got = recv[src]
-            torch.testing.assert_close(got.dense, expected.dense)
-            torch.testing.assert_close(got.label, expected.label)
-            torch.testing.assert_close(got.ids, expected.ids)
-            assert got.ids.dtype == torch.int32
-            assert len(got.extras) == 2
-            for g_t, e_t in zip(got.extras, expected.extras):
-                torch.testing.assert_close(g_t, e_t)
-            torch.testing.assert_close(got.meta["m"], expected.meta["m"])
-            assert got.features.keys() == ["f1", "f2"]
-            torch.testing.assert_close(
-                got.features.values(), expected.features.values()
-            )
-            torch.testing.assert_close(
-                got.features.lengths(), expected.features.lengths()
-            )
-            # non-tensor leaf comes from the example, not the sender.
-            assert got.tag == "from_example", got.tag
-
-
-class InputAllToAllTest(MultiProcessTestBase):
-    def test_all_to_all_roundtrip(self) -> None:
-        self._run_multi_process_test(
-            callable=_run_all_to_all,
-            world_size=4,
-        )
-
-
 class InputDistInProcessTest(unittest.TestCase):
-    """In-process (single-rank, gloo) coverage of the dist entry points.
-
-    A ``world_size == 1`` all-to-all is the identity (``send[0]`` -> self), so this
-    exercises ``input_size_dist`` / ``input_data_dist`` / ``input_dist`` and their
-    awaitables in the test process (unlike the multi-process test, whose spawned
-    workers run outside coverage) without needing more than one rank.
-    """
+    """Single-rank coverage for size exchange and CUDA data distribution."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -256,80 +199,85 @@ class InputDistInProcessTest(unittest.TestCase):
         dist.destroy_process_group()
         super().tearDown()
 
-    def test_input_dist_single_rank(self) -> None:
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_input_size_dist_copies_into_fused_gpu_buffers(self) -> None:
         pg = dist.group.WORLD
         assert pg is not None
+        device = torch.device("cuda")
+        memcpy_stream = torch.cuda.Stream(device=device)
         send = [_make_carrier(src=0, dst=0)]
         example = _make_carrier(src=0, dst=0)
-        example.tag = "from_example"
+        source_tensors = flatten_to_tensors(send[0])
 
-        recv = input_dist(send, example, pg_gloo=pg, pg_nccl=pg).wait()
+        (
+            in_bufs,
+            in_splits_by_bucket,
+            size_awaitable,
+            example_flat,
+            copy_done_event,
+        ) = input_size_dist(send, example, pg, device, memcpy_stream)
+        recv_sizes = size_awaitable.wait()
+        copy_done_event.synchronize()
 
-        self.assertEqual(len(recv), 1)
-        got = recv[0]
-        torch.testing.assert_close(got.dense, send[0].dense)
-        torch.testing.assert_close(got.label, send[0].label)
-        torch.testing.assert_close(got.ids, send[0].ids)
-        self.assertEqual(got.ids.dtype, torch.int32)
-        torch.testing.assert_close(got.features.values(), send[0].features.values())
-        torch.testing.assert_close(got.features.lengths(), send[0].features.lengths())
-        self.assertEqual(got.tag, "from_example")
+        self.assertEqual(recv_sizes[0], [tensor.shape[0] for tensor in source_tensors])
+        self.assertEqual(len(example_flat), len(source_tensors))
+        expected_by_dtype: Dict[torch.dtype, List[torch.Tensor]] = {}
+        for tensor in source_tensors:
+            expected_by_dtype.setdefault(tensor.dtype, []).append(tensor.reshape(-1))
+        self.assertEqual(len(in_bufs), len(expected_by_dtype))
+        for in_buf, in_splits, parts in zip(
+            in_bufs,
+            in_splits_by_bucket,
+            expected_by_dtype.values(),
+        ):
+            self.assertEqual(in_buf.device.type, "cuda")
+            self.assertEqual(in_splits, [sum(part.numel() for part in parts)])
+            torch.testing.assert_close(in_buf.cpu(), torch.cat(parts))
 
-    def test_ragged_carriers(self) -> None:
-        """A carrier may have more slots than the example, if its peer expects them.
-
-        The maglev case: with a non-uniform cut like ``[2, 3]``, the carrier a rank
-        sends to a 3-layer stage flattens to more tensors than the one it sends to a
-        2-layer stage. Only what this rank *receives* has to match its example.
-        """
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    @patch("torchrec.distributed.maglev.input_dist.dist.all_to_all_single")
+    def test_input_data_dist_uses_pp_stream(self, all_to_all_single: Any) -> None:
         pg = dist.group.WORLD
         assert pg is not None
-        # world_size == 1, so this rank sends to itself: the carrier it sends must
-        # match its own example. Make both two carriers deep to prove the flat
-        # (rather than rectangular) size exchange round-trips a multi-slot carrier.
-        send = [[_make_carrier(src=0, dst=0), _make_carrier(src=0, dst=1)]]
-        example = [_make_carrier(src=0, dst=0), _make_carrier(src=0, dst=1)]
+        device = torch.device("cuda")
+        pp_data_dist_stream = torch.cuda.Stream(device=device)
+        source = _make_carrier(src=0, dst=0)
+        source_tensors = flatten_to_tensors(source)
+        tensors_by_dtype: Dict[torch.dtype, List[torch.Tensor]] = {}
+        for tensor in source_tensors:
+            tensors_by_dtype.setdefault(tensor.dtype, []).append(tensor.reshape(-1))
+        in_bufs = [torch.cat(parts).to(device) for parts in tensors_by_dtype.values()]
+        in_splits_by_bucket = [[in_buf.numel()] for in_buf in in_bufs]
+        recv_sizes = [[tensor.shape[0] for tensor in source_tensors]]
 
-        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
-        # Sizes come back reshaped to [source rank][slot], covering both carriers.
-        self.assertEqual(len(recv_sizes), 1)
-        self.assertEqual(len(recv_sizes[0]), len(flat_send[0]))
-        self.assertEqual(recv_sizes[0], [t.shape[0] for t in flat_send[0]])
+        copy_done_event = torch.cuda.Event()
+        copy_done_event.record(torch.cuda.current_stream(device))
 
-        recv = input_data_dist(flat_send, recv_sizes, example, pg).wait()
-        self.assertEqual(len(recv), 1)
-        self.assertEqual(len(recv[0]), 2)
-        for got, expected in zip(recv[0], send[0]):
-            torch.testing.assert_close(got.dense, expected.dense)
-            torch.testing.assert_close(got.ids, expected.ids)
-            torch.testing.assert_close(
-                got.features.values(), expected.features.values()
-            )
+        def _all_to_all(
+            out_buf: torch.Tensor,
+            in_buf: torch.Tensor,
+            out_splits: List[int],
+            in_splits: List[int],
+            group: dist.ProcessGroup,
+            async_op: bool,
+        ) -> None:
+            self.assertFalse(async_op)
+            self.assertEqual(torch.cuda.current_stream(device), pp_data_dist_stream)
+            self.assertEqual(out_splits, in_splits)
+            out_buf.copy_(in_buf)
 
-    def test_send_dtype_absent_from_example_is_rejected(self) -> None:
-        """A carrier may differ from the example in slot count, not in dtypes."""
-        pg = dist.group.WORLD
-        assert pg is not None
-        send = [_make_carrier(src=0, dst=0)]
-        example = _make_carrier(src=0, dst=0)
-        # float64 appears in no bucket the example defines.
-        send[0].extras = [t.to(torch.float64) for t in send[0].extras]
+        all_to_all_single.side_effect = _all_to_all
 
-        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
-        with self.assertRaisesRegex(ValueError, "which the example does not have"):
-            input_data_dist(flat_send, recv_sizes, example, pg)
+        (received,) = input_data_dist(
+            in_bufs,
+            in_splits_by_bucket,
+            recv_sizes,
+            source,
+            source_tensors,
+            pg,
+            pp_data_dist_stream=pp_data_dist_stream,
+            copy_done_event=copy_done_event,
+        ).wait()
 
-    def test_size_then_data_phase(self) -> None:
-        pg = dist.group.WORLD
-        assert pg is not None
-        send = [_make_carrier(src=0, dst=0)]
-        example = _make_carrier(src=0, dst=0)
-
-        flat_send, recv_sizes = input_size_dist(send, example, pg).wait()
-        # One carrier -> one row; sizes match the flattened tensors' dim-0.
-        self.assertEqual(len(recv_sizes), 1)
-        self.assertEqual(recv_sizes[0], [t.shape[0] for t in flat_send[0]])
-
-        recv = input_data_dist(flat_send, recv_sizes, example, pg).wait()
-        self.assertEqual(len(recv), 1)
-        torch.testing.assert_close(recv[0].dense, send[0].dense)
+        for expected, actual in zip(source_tensors, flatten_to_tensors(received)):
+            torch.testing.assert_close(actual.cpu(), expected)

--- a/torchrec/distributed/maglev/tests/test_module.py
+++ b/torchrec/distributed/maglev/tests/test_module.py
@@ -13,13 +13,8 @@ from typing import Any, List, Tuple
 
 import torch
 from torchrec.distributed.maglev.module import MaglevModuleList
-from torchrec.distributed.maglev.pipeline import MaglevPipelineBase
 from torchrec.distributed.maglev.stage import StageWrapper
 from torchrec.distributed.test_utils.model_input import ModelInput
-from torchrec.distributed.test_utils.multi_process import (
-    MultiProcessContext,
-    MultiProcessTestBase,
-)
 from torchrec.distributed.test_utils.table_config import EmbeddingTablesConfig
 from torchrec.distributed.test_utils.test_model import MaglevTestLayer, MaglevTestModel
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
@@ -93,129 +88,6 @@ def _build_model(
             )
         )
     return MaglevTestModel(layers)
-
-
-def _run_correctness(
-    rank: int,
-    world_size: int,
-    num_stages: int,
-    layers_per_stage: int,
-    ranks_per_stage: int,
-    batch_size: int,
-    num_tables: int,
-    num_embeddings: int,
-    emb_dim: int,
-    num_float_features: int,
-    layer_dim: int,
-) -> None:
-    # CPU + gloo keeps the 8-rank repro portable (no 8-GPU requirement).
-    with MultiProcessContext(rank=rank, world_size=world_size, backend="gloo"):
-        device = torch.device("cpu")
-        num_layers = num_stages * layers_per_stage
-        partition = [layers_per_stage] * num_stages
-
-        my_stage_index, _position = StageWrapper.locate_rank(ranks_per_stage, rank)
-
-        # Deterministic per-layer inputs / label, identical on every rank (so the
-        # two DP lanes of an HSD see the same data and the DP all-reduce is an
-        # identity -- keeping the distributed grads exactly comparable to the
-        # single-process reference).
-        all_tables = [
-            _make_tables(l, num_tables, num_embeddings, emb_dim)
-            for l in range(num_layers)
-        ]
-        layer_inputs: List[Any] = [
-            _make_input(
-                all_tables[l], batch_size, num_float_features, _INPUT_SEED + l, device
-            )
-            for l in range(num_layers)
-        ]
-        # ---- distributed pipeline: forward + backward for this rank's stage ----
-        # Every rank authors the same full model and hands it to StageWrapper,
-        # which keeps only this rank's stage; the kept layers are the model's own
-        # modules.
-        dist_model = _build_model(
-            num_layers,
-            batch_size,
-            num_tables,
-            num_embeddings,
-            emb_dim,
-            num_float_features,
-            layer_dim,
-            device,
-        )
-        # The wrapper derives this rank's stage from stage_size and builds
-        # every process group it and the pipeline need.
-        stage = StageWrapper(
-            model=dist_model,
-            layers_per_stage=partition,
-            stage_size=ranks_per_stage,
-        )
-        # Unwrapped: the numerics-transparent path this test compares against a
-        # single-process reference. to() materializes the meta-authored layers.
-        stage.to(device)
-        # lr=0: weights are unchanged, grads remain populated for comparison.
-        optimizer = torch.optim.SGD(stage.parameters(), lr=0.0, foreach=True)
-        pipeline = MaglevPipelineBase(stage=stage, optimizer=optimizer)
-        # One batch, the whole model's per-layer inputs; the stage pulls it,
-        # partitions it and all-to-alls it to get its own. No label or criterion:
-        # the model scores itself in postproc, against the target carried by the
-        # last layer's own ModelInput.
-        dist_loss = pipeline.progress(iter([layer_inputs]))
-
-        # ---- single-process reference: the whole MaglevModuleList in-process ----
-        ref_model = _build_model(
-            num_layers,
-            batch_size,
-            num_tables,
-            num_embeddings,
-            emb_dim,
-            num_float_features,
-            layer_dim,
-            device,
-        )
-        ref_loss, _ref_output = ref_model(layer_inputs)
-        ref_loss.backward()
-
-        # 1. Last-stage loss matches the reference.
-        if pipeline.is_last:
-            assert dist_loss is not None
-            torch.testing.assert_close(dist_loss, ref_loss)
-
-        # 2. This stage's gradients (after DP all-reduce) match the reference
-        #    model's gradients for the same layers => forward + backward numerics
-        #    of the pipelined execution match the standalone model.
-        checked = 0
-        for offset in range(layers_per_stage):
-            layer_index = my_stage_index * layers_per_stage + offset
-            ref_params = dict(ref_model[layer_index].named_parameters())
-            for name, param in dist_model[layer_index].named_parameters():
-                assert param.grad is not None, f"no grad for layer{layer_index}.{name}"
-                ref_grad = ref_params[name].grad
-                assert (
-                    ref_grad is not None
-                ), f"no reference grad for layer{layer_index}.{name}"
-                torch.testing.assert_close(param.grad, ref_grad)
-                checked += 1
-        assert checked > 0, "no parameters were checked"
-
-
-class MaglevPipelineTest(MultiProcessTestBase):
-    def test_pipeline_matches_single_process(self) -> None:
-        """Multi-layer stages: 8 layers partitioned into 4 stages of 2 layers each."""
-        self._run_multi_process_test(
-            callable=_run_correctness,
-            world_size=8,
-            num_stages=4,
-            layers_per_stage=2,
-            ranks_per_stage=2,
-            batch_size=16,
-            num_tables=6,
-            num_embeddings=64,
-            emb_dim=8,
-            num_float_features=8,
-            layer_dim=12,
-        )
 
 
 class MaglevModuleListTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
## 1. Context
Maglev input distribution previously assumed that structured inputs were already resident on the collective device before the size and data exchanges began. Real dataloaders produce CPU tensors, so moving a batch to GPU outside input distribution serializes host-to-device transfer with the Gloo size exchange and leaves less work available to overlap with pipeline communication.

This change makes CPU-to-GPU transfer part of Maglev input distribution. It also avoids introducing a second device-side packing copy: tensors are grouped by dtype before transfer, fused GPU buffers are allocated up front, and each CPU tensor is copied directly into its final slice of the fused buffer used by NCCL.

## 2. Approach
1. **Separate size and data phases**: input_size_dist flattens the structured carriers, starts the Gloo dim-0 size exchange, prepares dtype-grouped input layouts, and launches nonblocking CPU-to-GPU copies. It returns the fused input buffers, input split sizes, the size awaitable, the flattened reconstruction example, and a copy-completion event for input_data_dist.
2. **Copy directly into collective buffers**: prepare_input_buffers allocates one contiguous GPU input buffer per dtype and exposes shaped views for each source tensor in destination-major and slot-major order. inplace_copy_to_gpu copies CPU tensors directly into those views on a dedicated memcpy stream, removing the intermediate per-tensor GPU allocations and subsequent torch.cat from the critical path.
3. **Prepare receives after sizes arrive**: prepare_output_buffers uses the received dim-0 sizes and the example tensor layout to allocate one receive buffer per dtype and calculate the corresponding output splits.
4. **Keep collective execution in the awaitable**: _InputDataAwaitable receives prepared input/output buffers and split sizes, enqueues the per-dtype all_to_all_single operations on the dedicated pipeline-parallel data-distribution stream, records completion, and reconstructs carriers when waited.
5. **Use explicit CUDA stream ordering**: the memcpy stream waits for allocation on the caller stream, the data-distribution stream waits for both H2D completion and receive-buffer allocation, and the caller stream waits for data-distribution completion only when the lazy result is consumed.
6. **Integrate with Maglev stages and benchmarks**: InputDistDriver.set_device creates the dedicated CUDA streams when a stage is materialized. The Maglev benchmark now creates pinned CPU inputs so the benchmark exercises the same H2D path as a real dataloader.

## 3. Results
1. The Gloo size exchange and H2D transfer can execute concurrently.
2. The NCCL input is already fused by dtype when the copy finishes, eliminating the previous device-side torch.cat and its additional full-buffer copy.
3. The maglev_1f1b benchmark reports 8,090 QPS with 8.10 s median GPU runtime and 18.00 GB median peak allocated GPU memory. This is a single-configuration result rather than a baseline/experiment comparison.

|short name|GPU Runtime (P10/P50/P90)|CPU Runtime (P10/P50/P90)|CPU Utilization (P10/P50/P90)|GPU Peak Mem allocated (P10/P50/P90)|GPU Peak Mem reserved (P10/P50/P90)|GPU Mem used (P10/P50/P90)|CPU Peak RSS (P10/P50/P90)|QPS (P10/P50/P90)|
|--|--|--|--|--|--|--|--|--|
|maglev_1f1b|8101.33 / 8101.33 / 8101.33 ms|7505.94 / 7505.94 / 7505.94 ms|92.66% / 92.66% / 92.66%|12.27 / 18.00 / 21.68 GB|12.38 / 18.10 / 21.89 GB|16.69 / 23.07 / 26.85 GB|3.14 / 3.16 / 3.18 GB|8090 / 8090 / 8090|

## 4. Analysis
1. **Collective layout**: the number and ordering of data collectives remain one all_to_all_single per dtype. Input and output splits preserve destination/source-major ordering, while received buffers are sliced back into the original tensor-slot order before carrier reconstruction.
2. **Stream safety**: allocation, H2D copy, NCCL launch, and result consumption are connected with explicit stream waits and CUDA events. The input and output buffers remain owned by _InputDataAwaitable until communication completes.
3. **API compatibility**: the public Maglev input_size_dist, input_data_dist, and input_dist signatures and intermediate return values change. InputDistDriver now requires set_device before exchange. Direct downstream callers will require a follow-up migration; the Ads call site is intentionally excluded from this TorchRec-only diff.
4. **CPU compatibility**: the new distribution path is CUDA-only; CPU execution is outside the scope of this change.
5. **Coverage**: focused tests cover structured flatten/unflatten behavior, dtype-fused H2D buffer construction, size exchange, PP-stream collective launch, and reconstruction. There is not yet a multi-rank NCCL test for the new stream choreography.

## 5. Changes
1. **torchrec/distributed/maglev/input_dist.py**: adds direct-to-fused-buffer H2D copying, splits size and data distribution responsibilities, introduces explicit CUDA stream/event ordering, and initializes driver streams per device.
2. **torchrec/distributed/maglev/stage.py**: initializes the input-distribution driver when the stage is moved to its execution device and removes an unused import.
3. **torchrec/distributed/benchmark/benchmark_maglev.py**: generates pinned CPU model inputs so input distribution owns and measures the H2D transfer.
4. **torchrec/distributed/maglev/tests/test_input_dist.py**: replaces CPU/Gloo data-path coverage with CUDA-focused tests for fused H2D buffers and PP-stream execution while retaining carrier flatten/unflatten coverage.
5. **torchrec/distributed/maglev/tests/test_module.py**: removes the obsolete CPU/Gloo distributed pipeline test now that Maglev input distribution is CUDA-only.
6. **torchrec/distributed/maglev/tests/BUCK**: removes the unused multi-process dependency and documents why coverage enforcement is disabled for CUDA-gated input-distribution tests on CPU CI.

Differential Revision: D118023636


