### PR TITLE
[detailed][ops] Improve 16-bit Triton regroup bandwidth by roofline analysis

### DIFF
--- a/torchrec/sparse/triton_permute_multi_embedding.py
+++ b/torchrec/sparse/triton_permute_multi_embedding.py
@@ -19,12 +19,15 @@ import triton.language as tl
 _PERMUTE_PARAM_SIZE = 6
 
 
-# Triton TR001: tune batch and copy tiles across workloads and GPU generations.
+# Triton TR001: decouple batch tiling from warp count so 16-bit types keep
+# enough copy work per thread to amortize indexing and memory instructions.
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_BATCH": 1, "BLOCK_SIZE": 128}, num_warps=1),
         triton.Config({"BLOCK_BATCH": 2, "BLOCK_SIZE": 128}, num_warps=2),
+        triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
     ],
     key=["batch_size", "num_permutes"],
@@ -87,12 +90,15 @@ def _permute_multi_embedding_kernel(
         )
 
 
-# Triton TR001: tune batch and copy tiles across workloads and GPU generations.
+# Triton TR001: decouple batch tiling from warp count so 16-bit types keep
+# enough copy work per thread to amortize indexing and memory instructions.
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_BATCH": 1, "BLOCK_SIZE": 128}, num_warps=1),
         triton.Config({"BLOCK_BATCH": 2, "BLOCK_SIZE": 128}, num_warps=2),
+        triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
+        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
     ],
     key=["batch_size", "num_permutes"],


### PR DESCRIPTION
Summary:
## Context

D117639963 introduced an experimental Triton pooled-embedding regroup operator and established the initial H100 benchmark. Its FP32 kernel reaches 2.179 TB/s, or 90.8% of the H100 PCIe 96 GB theoretical HBM bandwidth, showing that this launch decomposition can approach the hardware bandwidth limit.

The same kernel originally reached only 1.889 TB/s for FP16 and 1.881 TB/s for BF16, about 79% of peak. Because the element count and CTA bookkeeping are unchanged while the payload bytes are halved, this gap points to insufficient useful memory work per thread: indexing, masking, scheduling, and memory-instruction costs consume a larger fraction of each 16-bit CTA.

## Approach

The original autotune space coupled `BLOCK_BATCH` and `num_warps`, keeping approximately four elements per thread. This change adds two configurations that vary those controls independently:

- `BLOCK_BATCH=4, num_warps=2`
- `BLOCK_BATCH=8, num_warps=2`

For 16-bit inputs, these configurations increase useful bytes handled per thread and amortize per-CTA work. Autotuning selects B8/W2 for forward and B4/W2 for backward. FP32 continues to select the existing B2/W2 configuration, so its performance is unchanged.

Tensor dtypes already participate in Triton's autotune cache signature in addition to the explicit `(batch_size, num_permutes)` key. No additional dtype key or manual dtype dispatch is required.

## Reproduction commands

The benchmark defaults provide 100 timed iterations and 10 profiled iterations. The checkout, rather than the benchmark arguments, selects the before or after kernel.

```
# Before
sl goto D117639963
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_fp16_fwd_before --dtype=float16
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_fp16_fwd_bwd_before \
  --dtype=float16 --run_backward=True
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_bf16_fwd_before --dtype=bfloat16
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_bf16_fwd_bwd_before \
  --dtype=bfloat16 --run_backward=True

# After
sl goto D118082161
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_fp16_fwd_after --dtype=float16
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_fp16_fwd_bwd_after \
  --dtype=float16 --run_backward=True
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_bf16_fwd_after --dtype=bfloat16
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_bf16_fwd_bwd_after \
  --dtype=bfloat16 --run_backward=True

# FBGEMM references and FP32 regression check
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_fbgemm --name=h100_fp16_fwd --dtype=float16
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_fbgemm --name=h100_fp16_fwd_bwd \
  --dtype=float16 --run_backward=True
python -m torchrec.distributed.benchmark.benchmark_triton_ops \
  regroup_triton --name=h100_fp32_fwd
```

## Hardware-guided results

| Property | Value |
| --- | ---: |
| GPU | NVIDIA H100 PCIe |
| HBM | 96 GB HBM2e |
| Streaming multiprocessors | 132 |
| Theoretical aggregate HBM bandwidth | 2.40 TB/s |
| Theoretical average bandwidth per SM | 18.18 GB/s/SM |

The hardware lower bound for the default 16-bit forward's 529,530,880 useful bytes is 220.6 us at 2.40 TB/s. The change reduces FP16 from 280.3 to 251.5 us and BF16 from 281.5 to 251.1 us, recovering roughly half of the gap to that theoretical limit.

| Dtype | Path | Triton before | Triton after | FBGEMM | Triton latency improvement | Triton bandwidth before -> after | Per-SM bandwidth before -> after | H100 peak before -> after | Traces |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| FP32 | forward | 486.0 us (B2/W2) | 486.0 us (B2/W2) | 495.6 us | unchanged | 2.179 -> 2.179 TB/s | 16.51 -> 16.51 GB/s/SM | 90.8% -> 90.8% | Triton: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| FP32 | forward + backward | 973.8 us (B2/W2) | 973.8 us (B2/W2) | 986.9 us | unchanged | 2.175 -> 2.175 TB/s | 16.48 -> 16.48 GB/s/SM | 90.6% -> 90.6% | Triton: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_fp32_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| FP16 | forward | 280.3 us (B4/W4) | 251.5 us (B8/W2) | 275.3 us | 10.3% | 1.889 -> 2.106 TB/s | 14.31 -> 15.95 GB/s/SM | 78.7% -> 87.7% | Before: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_before-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_before-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>After: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_fbgemm_h100_fp16_fwd_baseline-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_fbgemm_h100_fp16_fwd_baseline-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| FP16 | forward + backward | 550.0 us (B4/W4 + B4/W4) | 503.0 us (B8/W2 + B4/W2) | 551.2 us | 8.5% | 1.926 -> 2.105 TB/s | 14.59 -> 15.95 GB/s/SM | 80.2% -> 87.7% | Before: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_bwd_before-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_bwd_before-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>After: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_bwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_fp16_fwd_bwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_fbgemm_h100_fp16_fwd_bwd_baseline-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_fbgemm_h100_fp16_fwd_bwd_baseline-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| BF16 | forward | 281.5 us (B4/W4) | 251.1 us (B8/W2) | 311.9 us | 10.8% | 1.881 -> 2.109 TB/s | 14.25 -> 15.98 GB/s/SM | 78.4% -> 87.9% | Before: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>After: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_bf16_fwd_final-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_bf16_fwd_final-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| BF16 | forward + backward | 558.7 us (B4/W4 + B4/W4) | 490.8 us (B8/W2 + B4/W2) | 628.8 us | 12.2% | 1.896 -> 2.158 TB/s | 14.36 -> 16.35 GB/s/SM | 79.0% -> 89.9% | Before: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_triton_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>After: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_bf16_fwd_bwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118082161/trace-regroup_triton_h100_bf16_fwd_bwd_b8w2-rank0.json.gz&bucket=torchrec_benchmark_traces)<br>FBGEMM: [PD](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D117639963/trace-regroup_fbgemm_h100_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |

The trace-derived before/after results show:

- FP16 forward improves by 10.3%; bandwidth rises from 1.889 to 2.106 TB/s, an 11.5% increase.
- FP16 forward + backward improves by 8.5%; bandwidth rises from 1.926 to 2.105 TB/s, a 9.3% increase.
- BF16 forward improves by 10.8%; bandwidth rises from 1.881 to 2.109 TB/s, a 12.1% increase.
- BF16 forward + backward improves by 12.2%; bandwidth rises from 1.896 to 2.158 TB/s, a 13.8% increase.
- FP32 retains the existing B2/W2 selection and remains at 90.8% of peak.

Effective bandwidth counts useful input reads and output writes rather than measured DRAM transactions. The hardware comparison is therefore a roofline indicator, not an NCU hardware-counter measurement. It exposed the 16-bit utilization gap and verifies that increasing per-thread copy work substantially closes it.

New traces: [Manifold folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D118082161). Unchanged FP32 and BF16 reference traces come from D117639963.

## Scope

This diff only expands the forward and backward autotune candidate sets. It does not change operator semantics or production routing. B200, GB200, and GB300 validation remains follow-up work.

Differential Revision: D118082161


