### PR TITLE
Fix empty-KJT to_dict crashes (list-index + TBE bounds-check segfault) (#4638)

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -1630,10 +1630,16 @@ def _maybe_compute_kjt_to_jt_dict(
                 _batched_lengths_to_offsets(strided_lengths), dim=0
             )
     else:
-        split_lengths = torch.unbind(lengths, dim=0)
+        # empty lengths: emit empty lengths and [0] offsets per key.
+        split_lengths = [
+            torch.zeros(0, dtype=lengths.dtype, device=lengths.device)
+            for _ in range(len(keys))
+        ]
         if compute_offsets:
-            # pyrefly: ignore[bad-assignment]
-            split_offsets = split_lengths
+            split_offsets = [
+                torch.zeros(1, dtype=lengths.dtype, device=lengths.device)
+                for _ in range(len(keys))
+            ]
 
     if weights is not None:
         weights_list = torch.split(weights, length_per_key)

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -315,8 +315,10 @@ class TestKeyedJaggedTensor(unittest.TestCase):
     def test_empty_to_dict(self) -> None:
         keys = ["index_0", "index_1"]
         values = torch.tensor([])
-        lengths = torch.tensor([[], []])
+        lengths = torch.zeros((2, 0), dtype=torch.int32)
         length_per_key = [0, 0]
+        empty_lengths = torch.tensor([], dtype=torch.int32)
+        expected_offsets = torch.tensor([0], dtype=torch.int32)
 
         jag_tensor = KeyedJaggedTensor(
             keys=keys, values=values, lengths=lengths, length_per_key=length_per_key
@@ -326,12 +328,12 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         j1 = jag_tensor_dict["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
-        torch.testing.assert_close(j0.lengths(), torch.Tensor([]), rtol=0, atol=0)
-        torch.testing.assert_close(j0.offsets(), torch.Tensor([]), rtol=0, atol=0)
+        torch.testing.assert_close(j0.lengths(), empty_lengths, rtol=0, atol=0)
+        torch.testing.assert_close(j0.offsets(), expected_offsets, rtol=0, atol=0)
         torch.testing.assert_close(j0.values(), torch.Tensor([]), rtol=0, atol=0)
         self.assertTrue(isinstance(j1, JaggedTensor))
-        torch.testing.assert_close(j1.lengths(), torch.Tensor([]), rtol=0, atol=0)
-        torch.testing.assert_close(j1.offsets(), torch.Tensor([]), rtol=0, atol=0)
+        torch.testing.assert_close(j1.lengths(), empty_lengths, rtol=0, atol=0)
+        torch.testing.assert_close(j1.offsets(), expected_offsets, rtol=0, atol=0)
         torch.testing.assert_close(j1.values(), torch.Tensor([]), rtol=0, atol=0)
 
         jag_tensor = KeyedJaggedTensor.from_lengths_sync(
@@ -342,13 +344,40 @@ class TestKeyedJaggedTensor(unittest.TestCase):
         j1 = jag_tensor_dict["index_1"]
 
         self.assertTrue(isinstance(j0, JaggedTensor))
-        torch.testing.assert_close(j0.lengths(), torch.Tensor([]), rtol=0, atol=0)
-        torch.testing.assert_close(j0.offsets(), torch.Tensor([]), rtol=0, atol=0)
+        torch.testing.assert_close(j0.lengths(), empty_lengths, rtol=0, atol=0)
+        torch.testing.assert_close(j0.offsets(), expected_offsets, rtol=0, atol=0)
         torch.testing.assert_close(j0.values(), torch.Tensor([]), rtol=0, atol=0)
         self.assertTrue(isinstance(j1, JaggedTensor))
-        torch.testing.assert_close(j1.lengths(), torch.Tensor([]), rtol=0, atol=0)
-        torch.testing.assert_close(j1.offsets(), torch.Tensor([]), rtol=0, atol=0)
+        torch.testing.assert_close(j1.lengths(), empty_lengths, rtol=0, atol=0)
+        torch.testing.assert_close(j1.offsets(), expected_offsets, rtol=0, atol=0)
         torch.testing.assert_close(j1.values(), torch.Tensor([]), rtol=0, atol=0)
+
+    def test_empty_to_dict_1d_lengths(self) -> None:
+        # Regression: a 1D empty lengths must yield one empty JaggedTensor per key.
+        keys = ["index_0", "index_1"]
+        jag_tensor = KeyedJaggedTensor(
+            keys=keys,
+            values=torch.tensor([]),
+            lengths=torch.zeros(0, dtype=torch.int32),
+            length_per_key=[0, 0],
+        )
+        self.assertFalse(jag_tensor.variable_stride_per_key())
+        self.assertEqual(jag_tensor.lengths().dim(), 1)
+
+        jag_tensor_dict = jag_tensor.to_dict()
+        self.assertEqual(set(jag_tensor_dict.keys()), set(keys))
+        for key in keys:
+            jt = jag_tensor_dict[key]
+            self.assertTrue(isinstance(jt, JaggedTensor))
+            torch.testing.assert_close(
+                jt.lengths(), torch.tensor([], dtype=torch.int32), rtol=0, atol=0
+            )
+            torch.testing.assert_close(jt.values(), torch.Tensor([]), rtol=0, atol=0)
+            # offsets must be [0], never empty: the TBE bounds check reads
+            # offsets.size(0) - 1.
+            torch.testing.assert_close(
+                jt.offsets(), torch.tensor([0], dtype=torch.int32), rtol=0, atol=0
+            )
 
     def test_split(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])


### PR DESCRIPTION
Summary:

_maybe_compute_kjt_to_jt_dict crashed on a scalar-stride KeyedJaggedTensor that
has keys but a zero-length batch (empty EBF sequence features in disaggregated
serving), in two ways: torch.unbind on a 1D empty lengths returns an empty list,
so the per-key indexing raised "list index out of range"; and the per-key offsets
were set to the empty lengths, so offsets.size(0) - 1 == -1 caused an
out-of-bounds read in fbgemm bounds_check_indices.

Fix: in that branch (reached only when lengths.numel() == 0), emit one empty
lengths and a [0] offsets per key, matching what the non-empty and
variable-stride branches already produce for a zero-length batch. The
numel() != 0 fallback keeps the original unbind, so only the empty path changes.

Differential Revision: D114773154


