### PR TITLE
Propagate opaque per-table planner metadata (#4640)

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -71,7 +71,10 @@ from torchrec.distributed.embedding_types import (
     ListOfKJTList,
     ShardedEmbeddingTable,
 )
-from torchrec.distributed.fused_params import FUSED_PARAM_SSD_TABLE_LIST
+from torchrec.distributed.fused_params import (
+    FUSED_PARAM_SSD_TABLE_LIST,
+    FUSED_PARAM_TORCHREC_ROUTING_KEYS,
+)
 from torchrec.distributed.types import (
     Awaitable,
     EmbeddingEvent,
@@ -496,6 +499,33 @@ def _get_grouping_fused_params(
     return grouping_fused_params
 
 
+def _canonicalize_fused_param_for_grouping(value: Any) -> Any:
+    """Convert nested containers into hashable, order-independent group keys."""
+    value_type = type(value)
+    if value_type is dict:
+        return (
+            value_type,
+            frozenset(
+                (
+                    _canonicalize_fused_param_for_grouping(key),
+                    _canonicalize_fused_param_for_grouping(nested_value),
+                )
+                for key, nested_value in value.items()
+            ),
+        )
+    if value_type in (list, tuple):
+        return (
+            value_type,
+            tuple(_canonicalize_fused_param_for_grouping(item) for item in value),
+        )
+    if value_type in (set, frozenset):
+        return (
+            value_type,
+            frozenset(_canonicalize_fused_param_for_grouping(item) for item in value),
+        )
+    return value
+
+
 def _get_compute_kernel_type(
     compute_kernel: EmbeddingComputeKernel,
 ) -> EmbeddingComputeKernel:
@@ -610,7 +640,7 @@ def group_tables(
                 table.data_type if not is_inference else None,
                 table.pooling,
                 table.has_feature_processor,
-                tuple(sorted(group_fused_params.items())),
+                _canonicalize_fused_param_for_grouping(group_fused_params),
                 _get_compute_kernel_type(table.compute_kernel),
                 # TODO: Unit test to check if table.data_type affects table grouping
                 bucketer.get_bucket(
@@ -632,7 +662,7 @@ def group_tables(
                 data_type,
                 pooling,
                 has_feature_processor,
-                fused_params_tuple,
+                _,
                 compute_kernel_type,
                 _,
                 _,
@@ -641,11 +671,20 @@ def group_tables(
                 _,
             ) = grouping_key
             grouped_tables = groups[grouping_key]
+            representative_table = grouped_tables[0]
+            group_fused_params = (
+                _get_grouping_fused_params(
+                    representative_table.fused_params,
+                    representative_table.name,
+                )
+                or {}
+            )
             # remove non-native fused params
             per_tbe_fused_params = {
-                k: v
-                for k, v in fused_params_tuple
+                k: group_fused_params[k]
+                for k in sorted(group_fused_params)
                 if k not in ["_batch_key", USE_ONE_TBE_PER_TABLE]
+                and k not in FUSED_PARAM_TORCHREC_ROUTING_KEYS
             }
             cache_load_factor = _get_weighted_avg_cache_load_factor(grouped_tables)
             if cache_load_factor is not None:

--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, FrozenSet, Iterable, Optional
 
 import torch
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
@@ -33,6 +33,17 @@ FUSED_PARAM_IS_DEVICE_RO: str = "__register_is_device_ro"
 FUSED_PARAM_SSD_TABLE_LIST: str = "__register_ssd_table_list"
 # Bool fused param per table to check if the table is offloaded to SSD
 FUSED_PARAM_IS_SSD_TABLE: str = "__register_is_ssd_table"
+
+# Per-table planner markers for CPU-backed embedding implementations. These are
+# TorchRec routing metadata and must not be forwarded to FBGEMM constructors.
+FUSED_PARAM_SHARED_MEMORY: str = "__shared_memory"
+FUSED_PARAM_CPU_OFFLOAD: str = "__cpu_offload"
+FUSED_PARAM_TORCHREC_ROUTING_KEYS: FrozenSet[str] = frozenset(
+    {
+        FUSED_PARAM_SHARED_MEMORY,
+        FUSED_PARAM_CPU_OFFLOAD,
+    }
+)
 
 # Embedding table index type for int32 support. Defaults to torch.int64 if not specified.
 FUSED_PARAM_EMBEDDING_TABLE_INDEX_TYPE: str = "embedding_table_index_type"
@@ -138,6 +149,8 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_IS_DEVICE_RO)
     if FUSED_PARAM_SSD_TABLE_LIST in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_SSD_TABLE_LIST)
+    for key in FUSED_PARAM_TORCHREC_ROUTING_KEYS:
+        fused_params_for_tbe.pop(key, None)
 
     return fused_params_for_tbe
 

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -216,6 +216,7 @@ class EmbeddingEnumerator(Enumerator):
                     output_dtype,
                     device_group,
                     key_value_params,
+                    fused_params,
                 ) = _extract_constraints_for_param(self._constraints, name)
 
                 # skip for other device groups
@@ -290,6 +291,7 @@ class EmbeddingEnumerator(Enumerator):
                                 stash_weights=self._get_stash_weights(
                                     name, child_module
                                 ),
+                                fused_params=fused_params,
                             )
                         )
                 if not sharding_options_per_table:
@@ -543,6 +545,7 @@ def _extract_constraints_for_param(
     Optional[DataType],
     Optional[str],
     Optional[KeyValueParams],
+    Optional[Dict[str, Any]],
 ]:
     input_lengths = [POOLING_FACTOR]
     col_wise_shard_dim = None
@@ -554,6 +557,7 @@ def _extract_constraints_for_param(
     output_dtype = None
     device_group = None
     key_value_params = None
+    fused_params = None
 
     if constraints and constraints.get(name):
         # For nested fields return a deep copy instead
@@ -567,6 +571,8 @@ def _extract_constraints_for_param(
         output_dtype = constraints[name].output_dtype
         device_group = constraints[name].device_group
         key_value_params = copy.deepcopy(constraints[name].key_value_params)
+        if constraints[name].fused_params:
+            fused_params = copy.deepcopy(constraints[name].fused_params)
 
     return (
         input_lengths,
@@ -579,6 +585,7 @@ def _extract_constraints_for_param(
         output_dtype,
         device_group,
         key_value_params,
+        fused_params,
     )
 
 

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -45,6 +45,8 @@ from torchrec.distributed.planner.storage_reservations import (
 from torchrec.distributed.planner.types import (
     Enumerator,
     hash_planner_context_inputs,
+    hash_planner_context_inputs_legacy,
+    hash_planner_context_inputs_legacy_str,
     hash_planner_context_inputs_str,
     ParameterConstraints,
     Partitioner,
@@ -204,6 +206,15 @@ def to_sharding_plan(
             bounds_check_mode=sharding_option.bounds_check_mode,
             output_dtype=sharding_option.output_dtype,
             key_value_params=sharding_option.key_value_params,
+            # ``None`` is reserved for plans whose per-table metadata could not
+            # be recovered (for example, an unvalidated structural cache hit).
+            # A freshly selected option always knows that an absent marker is
+            # false, so preserve that knowledge as an empty mapping.
+            fused_params=copy.deepcopy(
+                sharding_option.fused_params
+                if sharding_option.fused_params is not None
+                else {}
+            ),
         )
         plan[sharding_option.path] = module_plan
     # pyrefly: ignore[bad-argument-type]
@@ -481,6 +492,7 @@ def extract_plan(
                     feature_names=so.feature_names,
                     output_dtype=so.output_dtype,
                     key_value_params=so.key_value_params,
+                    fused_params=so.fused_params,
                 )
             )
 
@@ -631,6 +643,26 @@ class EmbeddingPlannerBase(ShardingPlanner):
             Generates a hash capturing topology, batch size, enumerator, storage reservation, stats and constraints.
         """
         return hash_planner_context_inputs_str(
+            self._topology,
+            self._batch_size,
+            self._enumerator,
+            self._storage_reservation,
+            self._constraints,
+        )
+
+    def hash_planner_context_inputs_legacy(self) -> Optional[int]:
+        """Generate the pre-canonicalization hash for stored-plan compatibility."""
+        return hash_planner_context_inputs_legacy(
+            self._topology,
+            self._batch_size,
+            self._enumerator,
+            self._storage_reservation,
+            self._constraints,
+        )
+
+    def hash_planner_context_inputs_legacy_str(self) -> Optional[str]:
+        """Generate the legacy string hash when old inputs can represent context."""
+        return hash_planner_context_inputs_legacy_str(
             self._topology,
             self._batch_size,
             self._enumerator,
@@ -1280,7 +1312,7 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         self, current_planner_hash: str, loaded_plan_hash: Optional[str]
     ) -> None:
         """
-        Validates that the current planner context hash matches the loaded plan context hash.
+        Validate the loaded hash against the canonical or legacy planner context.
 
         Args:
             current_planner_hash (str): Hash from current planner context
@@ -1289,15 +1321,28 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         Raises:
             PlannerError: If hashes don't match
         """
-        if loaded_plan_hash is not None and current_planner_hash != loaded_plan_hash:
+        if loaded_plan_hash is None or current_planner_hash == loaded_plan_hash:
+            return
+
+        legacy_planner_hash = self.hash_planner_context_inputs_legacy_str()
+        if legacy_planner_hash == loaded_plan_hash:
             # pyrefly: ignore[missing-attribute]
             plan_id = self.plan_loader.get_plan_id() if self.plan_loader else None
-            error_msg = (
-                f"Planner input context mismatch detected for {plan_id} and current planner set up:"
-                f"\nCurrent planner hash: {current_planner_hash}, Loaded plan hash: {loaded_plan_hash}"
+            logger.warning(
+                "Plan %s uses the legacy order-sensitive planner context hash; "
+                "regenerate it to store the canonical hash",
+                plan_id,
             )
-            raise PlannerError(
-                error_type=PlannerErrorType.PLANNER_INPUT_CONTEXT_MISMATCH,
-                message="Unable to load, because of planner input mismatch - cannot validate this plan is the best plan for current context.. \n"
-                + error_msg,
-            )
+            return
+
+        # pyrefly: ignore[missing-attribute]
+        plan_id = self.plan_loader.get_plan_id() if self.plan_loader else None
+        error_msg = (
+            f"Planner input context mismatch detected for {plan_id} and current planner set up:"
+            f"\nCurrent planner hash: {current_planner_hash}, Loaded plan hash: {loaded_plan_hash}"
+        )
+        raise PlannerError(
+            error_type=PlannerErrorType.PLANNER_INPUT_CONTEXT_MISMATCH,
+            message="Unable to load, because of planner input mismatch - cannot validate this plan is the best plan for current context.. \n"
+            + error_msg,
+        )

--- a/torchrec/distributed/planner/tests/test_planners.py
+++ b/torchrec/distributed/planner/tests/test_planners.py
@@ -17,6 +17,7 @@ from torchrec import EmbeddingBagCollection, EmbeddingConfig
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.fused_params import FUSED_PARAM_CPU_OFFLOAD
 from torchrec.distributed.planner.constants import BATCH_SIZE
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.perf_models import NoopPerfModel
@@ -290,6 +291,10 @@ class TestEmbeddingShardingPlannerWithConstraints(unittest.TestCase):
                     algorithm=CacheAlgorithm.LFU,
                 ),
                 feature_names=self.tables[0].feature_names,
+                fused_params={
+                    FUSED_PARAM_CPU_OFFLOAD: True,
+                    "nested": {"ranks": [0, 1]},
+                },
             ),
             "table_1": ParameterConstraints(
                 enforce_hbm=False,
@@ -386,6 +391,39 @@ class TestEmbeddingShardingPlannerWithConstraints(unittest.TestCase):
                 constraint.bounds_check_mode, sharding_option.bounds_check_mode
             )
             self.assertEqual(constraint.is_weighted, sharding_option.is_weighted)
+            self.assertEqual(
+                constraint.fused_params or None,
+                sharding_option.fused_params,
+            )
+
+    def test_fused_params_are_copied_into_the_final_plan(self) -> None:
+        model = TestSparseNN(tables=self.tables, sparse_device=torch.device("meta"))
+        # pyrefly: ignore[missing-argument]
+        sharding_plan = self.planner.plan(module=model, sharders=get_default_sharders())
+        parameter_sharding = cast(
+            EmbeddingModuleShardingPlan, sharding_plan.plan["sparse.ebc"]
+        )["table_0"]
+        best_plan = none_throws(self.planner._best_plan)
+        sharding_option = next(
+            option for option in best_plan if option.name == "table_0"
+        )
+
+        self.constraints["table_0"].fused_params["nested"]["ranks"].append(2)
+
+        expected = {
+            FUSED_PARAM_CPU_OFFLOAD: True,
+            "nested": {"ranks": [0, 1]},
+        }
+        self.assertEqual(expected, sharding_option.fused_params)
+        self.assertEqual(expected, parameter_sharding.fused_params)
+        self.assertIsNot(
+            self.constraints["table_0"].fused_params,
+            parameter_sharding.fused_params,
+        )
+        unmarked_parameter_sharding = cast(
+            EmbeddingModuleShardingPlan, sharding_plan.plan["sparse.ebc"]
+        )["table_1"]
+        self.assertEqual(unmarked_parameter_sharding.fused_params, {})
 
 
 class TestEmbeddingShardingHashPlannerContextInputs(unittest.TestCase):
@@ -997,6 +1035,7 @@ class TestPlanLoaderIntegration(unittest.TestCase):
                     algorithm=CacheAlgorithm.LFU,
                 ),
                 feature_names=self.tables[0].feature_names,
+                fused_params={"planner_marker": {"backend": "host"}},
             ),
             "table_1": ParameterConstraints(
                 enforce_hbm=False,
@@ -1092,6 +1131,11 @@ class TestPlanLoaderIntegration(unittest.TestCase):
                 )[param_name]
                 # The ranks should be different (flipped) from baseline
                 self.assertNotEqual(param_sharding.ranks, baseline_param_sharding.ranks)
+                if param_name == "table_0":
+                    self.assertEqual(
+                        param_sharding.fused_params,
+                        {"planner_marker": {"backend": "host"}},
+                    )
 
     def test_plan_loader_with_context_mismatch(self) -> None:
         """Test EmbeddingShardingPlanner with PlanLoader that has mismatched context hash."""
@@ -1118,6 +1162,50 @@ class TestPlanLoaderIntegration(unittest.TestCase):
             PlannerErrorType.PLANNER_INPUT_CONTEXT_MISMATCH,
         )
         self.assertIn("planner input mismatch", str(context.exception))
+
+    def test_plan_loader_accepts_legacy_context_hash(self) -> None:
+        constraints = {
+            "table_0": ParameterConstraints(
+                feature_names=self.tables[0].feature_names,
+            ),
+            "table_1": ParameterConstraints(
+                feature_names=self.tables[1].feature_names,
+            ),
+        }
+        baseline_planner = EmbeddingShardingPlanner(
+            topology=self.topology,
+            constraints=constraints,
+        )
+        # pyrefly: ignore[missing-argument]
+        baseline_planner.plan(module=self.model, sharders=get_default_sharders())
+        legacy_context_hash = baseline_planner.hash_planner_context_inputs_legacy_str()
+        self.assertIsNotNone(legacy_context_hash)
+        self.assertNotEqual(
+            baseline_planner.hash_planner_context_inputs_str(),
+            legacy_context_hash,
+        )
+
+        planner_with_loader = EmbeddingShardingPlanner(
+            topology=self.topology,
+            constraints=constraints,
+            plan_loader=MockPlanLoader(
+                loaded_sharding_options={},
+                context_hash=legacy_context_hash,
+            ),
+        )
+        with self.assertLogs(
+            "torchrec.distributed.planner.planners", level="WARNING"
+        ) as logs:
+            # pyrefly: ignore[missing-argument]
+            loaded_plan = planner_with_loader.plan(
+                module=self.model,
+                sharders=get_default_sharders(),
+            )
+
+        self.assertGreater(len(loaded_plan.plan), 0)
+        self.assertTrue(
+            any("legacy order-sensitive" in message for message in logs.output)
+        )
 
     def test_plan_loader_with_no_loaded_options(self) -> None:
         """Test EmbeddingShardingPlanner with PlanLoader that returns no loaded options."""
@@ -1204,6 +1292,7 @@ class TestExtractPlan(unittest.TestCase):
                     algorithm=CacheAlgorithm.LFU,
                 ),
                 feature_names=self.tables[0].feature_names,
+                fused_params={"planner_marker": {"backend": "host"}},
             ),
             "table_1": ParameterConstraints(
                 enforce_hbm=False,
@@ -1287,6 +1376,9 @@ class TestExtractPlan(unittest.TestCase):
             self.assertEqual(result_so.is_pooled, expected_so.is_pooled)
             self.assertEqual(result_so.feature_names, expected_so.feature_names)
             self.assertEqual(result_so.cache_params, expected_so.cache_params)
+            self.assertEqual(result_so.fused_params, expected_so.fused_params)
+            if expected_so.fused_params is not None:
+                self.assertIsNot(result_so.fused_params, expected_so.fused_params)
 
     def test_extract_plan_duplicate_storage_hash_error(self) -> None:
         """Test extract_plan failure when duplicate storage hashes exist."""
@@ -1387,6 +1479,7 @@ class TestExtractPlan(unittest.TestCase):
             self.assertEqual(result_so.sharding_type, search_so.sharding_type)
             self.assertEqual(result_so.batch_size, search_so.batch_size)
             self.assertEqual(result_so.feature_names, search_so.feature_names)
+            self.assertEqual(result_so.fused_params, search_so.fused_params)
 
             # Shards should come from loaded options
             self.assertEqual(result_so.shards, loaded_so.shards)

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 from torch import multiprocessing
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.fused_params import FUSED_PARAM_CPU_OFFLOAD
 from torchrec.distributed.logger import static_logger
 from torchrec.distributed.planner import EmbeddingShardingPlanner
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
@@ -29,9 +30,9 @@ from torchrec.distributed.planner.types import (
     BasicCommsBandwidths,
     CustomTopologyData,
     DeviceHardware,
-    EmoConfig,
     HardwareConfig,
     hash_planner_context_inputs,
+    hash_planner_context_inputs_legacy,
     KernelConfig,
     ParameterConstraints,
     Perf,
@@ -330,6 +331,143 @@ class TestParameterConstraintsHash(unittest.TestCase):
             hash(pc1), hash(pc2), "Hashes should be equal for identical instances"
         )
 
+    def test_cache_stats_identity_does_not_change_hash(self) -> None:
+        first = ParameterConstraints(
+            cache_params=CacheParams(
+                algorithm=CacheAlgorithm.LFU,
+                load_factor=0.2,
+                stats=cast(Any, object()),
+            )
+        )
+        second = ParameterConstraints(
+            cache_params=CacheParams(
+                algorithm=CacheAlgorithm.LFU,
+                load_factor=0.2,
+                stats=cast(Any, object()),
+            )
+        )
+        changed = ParameterConstraints(
+            cache_params=CacheParams(
+                algorithm=CacheAlgorithm.LFU,
+                load_factor=0.3,
+                stats=cast(Any, object()),
+            )
+        )
+
+        self.assertEqual(first.__hash__(), second.__hash__())
+        self.assertNotEqual(first.__hash__(), changed.__hash__())
+
+    def test_fused_params_hash_is_order_independent(self) -> None:
+        pc1 = ParameterConstraints(
+            fused_params={
+                "nested": {
+                    "enabled": True,
+                    "ranks": {
+                        "atlas",
+                        "binary",
+                        "cinder",
+                        "delta",
+                        "ember",
+                        "fjord",
+                        "glyph",
+                        "harbor",
+                    },
+                },
+                "dtype": torch.float16,
+            }
+        )
+        pc2 = ParameterConstraints(
+            fused_params={
+                "dtype": torch.float16,
+                "nested": {
+                    "ranks": {
+                        "harbor",
+                        "glyph",
+                        "fjord",
+                        "ember",
+                        "delta",
+                        "cinder",
+                        "binary",
+                        "atlas",
+                    },
+                    "enabled": True,
+                },
+            }
+        )
+
+        self.assertEqual(pc1.__hash__(), pc2.__hash__())
+
+    def test_fused_params_hash_normalizes_signed_zero(self) -> None:
+        negative_zero = ParameterConstraints(fused_params={"value": -0.0})
+        positive_zero = ParameterConstraints(fused_params={"value": 0.0})
+
+        self.assertEqual(negative_zero.__hash__(), positive_zero.__hash__())
+
+    def test_fused_params_hash_has_stable_golden_digest(self) -> None:
+        constraints = ParameterConstraints(
+            fused_params={
+                "bytes": b"\x00\xff",
+                "device": torch.device("cuda", 3),
+                "dtype": torch.float16,
+                "enum": BoundsCheckMode.WARNING,
+                "float": 0.125,
+                "set": {"beta", "alpha"},
+                "tuple": ("alpha", 7),
+                "type": EmbeddingBagConfig,
+            }
+        )
+
+        self.assertEqual(
+            constraints.__hash__(),
+            29005728459676059197881125826882851714441125356464612838557641460225338301529,
+        )
+
+    def test_empty_fused_params_preserve_legacy_hash(self) -> None:
+        legacy_hash = 87402189562645569893241693142733106025831414106284310119099070476335611002833
+
+        self.assertEqual(ParameterConstraints().__hash__(), legacy_hash)
+        self.assertEqual(ParameterConstraints(fused_params={}).__hash__(), legacy_hash)
+
+    def test_fused_params_change_hash(self) -> None:
+        disabled = ParameterConstraints(
+            fused_params={FUSED_PARAM_CPU_OFFLOAD: False},
+        )
+        enabled = ParameterConstraints(
+            fused_params={FUSED_PARAM_CPU_OFFLOAD: True},
+        )
+
+        self.assertNotEqual(hash(disabled), hash(enabled))
+
+    def test_fused_params_hash_rejects_unstable_values(self) -> None:
+        with self.assertRaises(TypeError):
+            ParameterConstraints(fused_params={"value": object()})
+
+    def test_fused_params_rejects_non_string_keys(self) -> None:
+        with self.assertRaisesRegex(TypeError, "keys must be strings"):
+            ParameterConstraints(fused_params=cast(Dict[str, Any], {1: True}))
+
+    def test_fused_params_rejects_non_dict(self) -> None:
+        with self.assertRaisesRegex(TypeError, "must be a dict"):
+            ParameterConstraints(fused_params=cast(Dict[str, Any], []))
+
+    def test_sharding_option_rejects_mutated_unstable_fused_params(self) -> None:
+        constraints = ParameterConstraints()
+        constraints.fused_params["value"] = object()
+
+        with self.assertRaises(TypeError):
+            ShardingOption(
+                name="table_0",
+                tensor=torch.empty((10, 4), device=torch.device("meta")),
+                module=("ebc", nn.Module()),
+                input_lengths=[1.0],
+                batch_size=1,
+                sharding_type=ShardingType.TABLE_WISE.value,
+                partition_by="device",
+                compute_kernel=EmbeddingComputeKernel.FUSED.value,
+                shards=[Shard(size=[10, 4], offset=[0, 0])],
+                fused_params=constraints.fused_params,
+            )
+
     def test_hash_inequality(self) -> None:
         # Create two different instances
         pc1 = ParameterConstraints(
@@ -513,7 +651,7 @@ def _test_hashing_consistency(
     return_hash_dict: Dict[str, int],
     local_size: Optional[int] = None,
 ) -> None:
-    with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
+    with MultiProcessContext(rank, world_size, backend, local_size):
         topology = Topology(
             local_world_size=8,
             world_size=1,
@@ -595,6 +733,130 @@ class TestHashPlannerContextInputsRounding(unittest.TestCase):
             )
         storage_reservation.last_reserved_topology = topology
         return storage_reservation
+
+    def test_search_space_order_does_not_change_hash(self) -> None:
+        first_option = MagicMock(
+            fqn="table_0",
+            sharding_type=ShardingType.TABLE_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=(),
+            cache_params=None,
+        )
+        second_option = MagicMock(
+            fqn="table_1",
+            sharding_type=ShardingType.ROW_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=(),
+            cache_params=None,
+        )
+        extra_option = MagicMock(
+            fqn="table_2",
+            sharding_type=ShardingType.COLUMN_WISE.value,
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=(),
+            cache_params=None,
+        )
+        first_enumerator = MagicMock(
+            last_stored_search_space=[first_option, second_option]
+        )
+        reordered_enumerator = MagicMock(
+            last_stored_search_space=[second_option, first_option]
+        )
+        expanded_enumerator = MagicMock(
+            last_stored_search_space=[first_option, second_option, extra_option]
+        )
+        topology = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 1024,
+            local_world_size=2,
+        )
+        storage_reservation = self._create_mock_storage_reservation(topology)
+
+        first_hash = hash_planner_context_inputs(
+            topology=topology,
+            batch_size=128,
+            enumerator=first_enumerator,
+            storage_reservation=storage_reservation,
+            constraints=None,
+        )
+        reordered_hash = hash_planner_context_inputs(
+            topology=topology,
+            batch_size=128,
+            enumerator=reordered_enumerator,
+            storage_reservation=storage_reservation,
+            constraints=None,
+        )
+        expanded_hash = hash_planner_context_inputs(
+            topology=topology,
+            batch_size=128,
+            enumerator=expanded_enumerator,
+            storage_reservation=storage_reservation,
+            constraints=None,
+        )
+        first_legacy_hash = hash_planner_context_inputs_legacy(
+            topology=topology,
+            batch_size=128,
+            enumerator=first_enumerator,
+            storage_reservation=storage_reservation,
+            constraints=None,
+        )
+        reordered_legacy_hash = hash_planner_context_inputs_legacy(
+            topology=topology,
+            batch_size=128,
+            enumerator=reordered_enumerator,
+            storage_reservation=storage_reservation,
+            constraints=None,
+        )
+
+        self.assertEqual(first_hash, reordered_hash)
+        self.assertNotEqual(first_hash, expanded_hash)
+        self.assertNotEqual(first_legacy_hash, reordered_legacy_hash)
+
+    def test_legacy_hash_is_unavailable_for_new_fused_params(self) -> None:
+        topology = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 1024,
+            local_world_size=2,
+        )
+
+        legacy_hash = hash_planner_context_inputs_legacy(
+            topology=topology,
+            batch_size=128,
+            enumerator=self._create_mock_enumerator(),
+            storage_reservation=self._create_mock_storage_reservation(topology),
+            constraints={
+                "table_0": ParameterConstraints(
+                    fused_params={FUSED_PARAM_CPU_OFFLOAD: True}
+                )
+            },
+        )
+
+        self.assertIsNone(legacy_hash)
+
+    def test_legacy_hash_matches_pre_fused_params_golden(self) -> None:
+        topology = Topology(
+            world_size=2,
+            compute_device="cuda",
+            hbm_cap=1024 * 1024 * 1024,
+            local_world_size=2,
+        )
+
+        legacy_hash = hash_planner_context_inputs_legacy(
+            topology=topology,
+            batch_size=128,
+            enumerator=self._create_mock_enumerator(),
+            storage_reservation=self._create_mock_storage_reservation(topology),
+            constraints={
+                "table_0": ParameterConstraints(feature_names=["feature_0"]),
+            },
+        )
+
+        self.assertEqual(
+            legacy_hash,
+            75184719878038004224584076775524679795974697178544017033259565161339910990358,
+        )
 
     def test_rounding_produces_same_hash_for_small_memory_differences(self) -> None:
         """Test that small memory differences (within 1% tolerance) produce the same hash."""
@@ -2381,6 +2643,62 @@ class ShardingPlanRequestTest(unittest.TestCase):
             self._create_request().request_hash,
             self._create_request().request_hash,
         )
+
+    def test_request_hash_is_order_independent_for_fused_params(self) -> None:
+        first = self._create_request(
+            constraints={
+                "table_b": ParameterConstraints(
+                    fused_params={
+                        "nested": {
+                            "enabled": True,
+                            "ranks": {"atlas", "binary", "cinder", "delta"},
+                        },
+                        "dtype": torch.float16,
+                    }
+                ),
+                "table_a": ParameterConstraints(
+                    fused_params={FUSED_PARAM_CPU_OFFLOAD: True}
+                ),
+            }
+        )
+        reordered = self._create_request(
+            constraints={
+                "table_a": ParameterConstraints(
+                    fused_params={FUSED_PARAM_CPU_OFFLOAD: True}
+                ),
+                "table_b": ParameterConstraints(
+                    fused_params={
+                        "dtype": torch.float16,
+                        "nested": {
+                            "ranks": {"delta", "cinder", "binary", "atlas"},
+                            "enabled": True,
+                        },
+                    }
+                ),
+            }
+        )
+
+        self.assertEqual(first.request_hash, reordered.request_hash)
+
+    def test_request_hash_with_fused_params_has_stable_golden_digest(self) -> None:
+        request = self._create_request(
+            constraints={
+                "table": ParameterConstraints(
+                    fused_params={
+                        "bytes": b"\x00\xff",
+                        "device": torch.device("cuda", 3),
+                        "dtype": torch.float16,
+                        "enum": BoundsCheckMode.WARNING,
+                        "float": 0.125,
+                        "set": {"beta", "alpha"},
+                        "tuple": ("alpha", 7),
+                        "type": EmbeddingBagConfig,
+                    }
+                )
+            }
+        )
+
+        self.assertEqual(request.request_hash, "2dff82ae7a27ae65")
 
     def test_request_hash_differs_for_different_params(self) -> None:
         base = self._create_request().request_hash

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1342,6 +1342,12 @@ class ShardingOption:
             table's weights GPU->CPU during the dense forward/backward. Set on the
             table config before planning; the planner reflects the HBM that stashing
             frees in its storage estimates.
+        fused_params (Optional[Dict[str, Any]]): per-table metadata copied from
+            the matching parameter constraints. Keys must be strings. Values
+            may be None, bool, int, str, float, bytes, Enum, torch.dtype,
+            torch.device, type, or nested dict/list/tuple/set/frozenset values
+            composed from those types. This metadata is for planner output and
+            must not be forwarded as runtime TBE constructor arguments.
     """
 
     def __init__(
@@ -1366,6 +1372,7 @@ class ShardingOption:
         key_value_params: Optional[KeyValueParams] = None,
         num_poolings: Optional[List[float]] = None,
         stash_weights: bool = False,
+        fused_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.name = name
         self._tensor = tensor
@@ -1394,6 +1401,10 @@ class ShardingOption:
         self.key_value_params: Optional[KeyValueParams] = key_value_params
         self.num_poolings: Optional[List[float]] = num_poolings
         self.stash_weights: bool = stash_weights
+        _validate_fused_params(fused_params)
+        self.fused_params: Optional[Dict[str, Any]] = (
+            deepcopy(fused_params) if fused_params else None
+        )
 
         child_module = module[1]
         self._module_type_key: str = (
@@ -1605,6 +1616,62 @@ class _CacheParamsFingerprintMemo:
         return cached[1]
 
 
+def _canonicalize_fused_param_collection_for_hash(value: Any) -> Any:
+    value_type = type(value)
+    if value_type is dict:
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("fused_params keys must be strings")
+        return (
+            "dict",
+            tuple(
+                (key, _canonicalize_fused_param_for_hash(value[key]))
+                for key in sorted(value)
+            ),
+        )
+    items = tuple(_canonicalize_fused_param_for_hash(item) for item in value)
+    if value_type in (set, frozenset):
+        items = tuple(sorted(items, key=repr))
+    return (value_type.__name__, items)
+
+
+def _canonicalize_fused_param_for_hash(value: Any) -> Any:
+    if isinstance(value, Enum):
+        cls = type(value)
+        return (
+            "enum",
+            f"{cls.__module__}.{cls.__qualname__}",
+            _canonicalize_fused_param_for_hash(value.value),
+        )
+    if isinstance(value, torch.dtype):
+        return ("torch.dtype", str(value))
+    if isinstance(value, torch.device):
+        return ("torch.device", str(value))
+    if isinstance(value, type):
+        return ("type", value.__module__, value.__qualname__)
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        return ("float", (value + 0.0).hex())
+    if type(value) is bytes:
+        return ("bytes", value.hex())
+    if type(value) in (dict, list, tuple, set, frozenset):
+        return _canonicalize_fused_param_collection_for_hash(value)
+    value_type = type(value)
+    raise TypeError(
+        "Unsupported fused_params value type: "
+        f"{value_type.__module__}.{value_type.__qualname__}"
+    )
+
+
+def _validate_fused_params(fused_params: Optional[Dict[str, Any]]) -> None:
+    if fused_params is None:
+        return
+    if type(fused_params) is not dict:
+        raise TypeError("fused_params must be a dict")
+    if fused_params:
+        _canonicalize_fused_param_for_hash(fused_params)
+
+
 @dataclass
 class ParameterConstraints:
     """
@@ -1654,6 +1721,14 @@ class ParameterConstraints:
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE, either for
             SSD or PS.
         use_virtual_table (bool): is virtual table enabled for this table.
+        fused_params (Dict[str, Any]): per-table metadata propagated into the
+            selected plan. An empty mapping means the constraint contains no
+            metadata. Keys must be strings. Values may be None, bool, int, str,
+            float, bytes, Enum, torch.dtype, torch.device, type, or nested
+            dict/list/tuple/set/frozenset values composed from those types.
+            The selected `ShardingOption` or `ParameterSharding` may use None
+            when this metadata is unavailable. This metadata is for planner
+            output and must not be forwarded as runtime TBE constructor arguments.
     """
 
     sharding_types: Optional[List[str]] = None
@@ -1674,11 +1749,15 @@ class ParameterConstraints:
     device_group: Optional[str] = None
     key_value_params: Optional[KeyValueParams] = None
     use_virtual_table: bool = False
+    fused_params: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_fused_params(self.fused_params)
 
     def _hashable_values(
         self, cache_params: object, key_value_params: object
     ) -> Tuple[Any, ...]:
-        return (
+        hashable_values = (
             tuple(self.sharding_types) if self.sharding_types else None,
             tuple(self.compute_kernels) if self.compute_kernels else None,
             self.min_partition,
@@ -1696,6 +1775,14 @@ class ParameterConstraints:
             key_value_params,
             self.use_virtual_table,
         )
+        if self.fused_params:
+            return hashable_values + (
+                (
+                    "fused_params",
+                    _canonicalize_fused_param_for_hash(self.fused_params),
+                ),
+            )
+        return hashable_values
 
     def _persistent_hash(
         self,
@@ -1714,7 +1801,7 @@ class ParameterConstraints:
         return hash_sha256_to_int(
             list(
                 self._hashable_values(
-                    self.cache_params,
+                    _cache_params_hash_components(self.cache_params),
                     self.key_value_params,
                 )
             )
@@ -2436,12 +2523,14 @@ class ShardingPlanRequest:
                     self.training_framework.value,
                     self.launcher_hardware,
                     self.compute_device,
-                    # Hash constraints order-independently: a dict's repr follows
-                    # insertion order, so sort by key for a stable hash across
-                    # semantically-equal requests built in different orders. Sort
-                    # by key only (ParameterConstraints is not rich-comparable).
+                    # Sort table names and use each constraint's canonical digest.
+                    # Serializing the dataclass directly would expose insertion
+                    # order from nested fused_params dicts and sets through repr.
                     (
-                        [(k, self.constraints[k]) for k in sorted(self.constraints)]
+                        [
+                            (key, self.constraints[key].__hash__())
+                            for key in sorted(self.constraints)
+                        ]
                         if self.constraints is not None
                         else None
                     ),
@@ -3112,6 +3201,73 @@ def _shard_hash_components(shard: "Shard") -> tuple:
     )
 
 
+def _cache_params_hash_components(
+    cache_params: Optional[CacheParams],
+) -> Optional[tuple]:
+    if cache_params is None:
+        return None
+
+    multipass_prefetch_config = cache_params.multipass_prefetch_config
+    # CacheParams.__hash__ deliberately omits runtime cache statistics. Preserve
+    # that contract without relying on Python's process-randomized Enum hashes or
+    # the stats object's identity-bearing repr.
+    return (
+        _canonicalize_fused_param_for_hash(cache_params.algorithm),
+        _canonicalize_fused_param_for_hash(cache_params.load_factor),
+        _canonicalize_fused_param_for_hash(cache_params.reserved_memory),
+        _canonicalize_fused_param_for_hash(cache_params.precision),
+        _canonicalize_fused_param_for_hash(cache_params.prefetch_pipeline),
+        _canonicalize_fused_param_for_hash(
+            tuple(multipass_prefetch_config)
+            if multipass_prefetch_config is not None
+            else None
+        ),
+    )
+
+
+def _planner_context_hash_inputs(
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+) -> Tuple[List[ShardingOption], str, Topology]:
+    assert hasattr(
+        enumerator, "last_stored_search_space"
+    ), "This enumerator is not compatible with hashing"
+    assert (
+        enumerator.last_stored_search_space is not None
+    ), "Unable to hash planner context without an enumerator that has a precomputed search space"
+
+    reserved_topology = storage_reservation.last_reserved_topology
+    assert (
+        reserved_topology is not None
+    ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
+    return (
+        enumerator.last_stored_search_space,
+        type(storage_reservation).__name__,
+        reserved_topology,
+    )
+
+
+def _hashable_search_space(
+    search_space: List[ShardingOption],
+    cache_params_memo: _CacheParamsFingerprintMemo,
+    *,
+    canonical: bool,
+) -> List[List[Any]]:
+    result = [
+        [
+            shard_option.fqn,
+            shard_option.sharding_type,
+            shard_option.compute_kernel,
+            tuple(_shard_hash_components(shard) for shard in shard_option.shards),
+            cache_params_memo.get(shard_option.cache_params),
+        ]
+        for shard_option in search_space
+    ]
+    if canonical:
+        result.sort(key=lambda option: hash_sha256_str([option]))
+    return result
+
+
 def _build_hashable_list(
     topology: Topology,
     batch_size: int,
@@ -3125,20 +3281,9 @@ def _build_hashable_list(
     ``hash_planner_context_inputs_str`` (str hash) so the two can never
     drift apart.
     """
-    assert hasattr(
-        enumerator, "last_stored_search_space"
-    ), "This enumerator is not compatible with hashing"
-    assert (
-        enumerator.last_stored_search_space is not None
-    ), "Unable to hash planner context without an enumerator that has a precomputed search space"
-
-    reserved_topology = storage_reservation.last_reserved_topology
-    assert (
-        reserved_topology is not None
-    ), "Unable to hash planner context without a storage reservation that has a precomputed topology"
-
-    search_space = enumerator.last_stored_search_space
-    storage_reservation_policy = type(storage_reservation).__name__
+    search_space, storage_reservation_policy, reserved_topology = (
+        _planner_context_hash_inputs(enumerator, storage_reservation)
+    )
     cache_params_memo = _CacheParamsFingerprintMemo()
 
     # Hash topology components with storage rounding applied uniformly.
@@ -3149,20 +3294,14 @@ def _build_hashable_list(
     hashed_reserved_topology = hash_sha256_to_int(
         _topology_hash_components(reserved_topology)
     )
+    hashable_search_space = _hashable_search_space(
+        search_space, cache_params_memo, canonical=True
+    )
 
     return [
         hashed_topology,
         batch_size,
-        [
-            [
-                shard_option.fqn,
-                shard_option.sharding_type,
-                shard_option.compute_kernel,
-                tuple(_shard_hash_components(shard) for shard in shard_option.shards),
-                cache_params_memo.get(shard_option.cache_params),
-            ]
-            for shard_option in search_space
-        ],
+        hashable_search_space,
         storage_reservation_policy,
         hashed_reserved_topology,
         (
@@ -3172,6 +3311,39 @@ def _build_hashable_list(
                     v._persistent_hash(cache_params_memo),
                 )
                 for k, v in sorted(constraints.items())
+            )
+            if constraints
+            else None
+        ),
+    ]
+
+
+def _build_legacy_hashable_list(
+    topology: Topology,
+    batch_size: int,
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+    constraints: Optional[Dict[str, ParameterConstraints]],
+) -> Optional[List[Any]]:
+    if constraints and any(
+        constraint.fused_params for constraint in constraints.values()
+    ):
+        return None
+
+    search_space, storage_reservation_policy, reserved_topology = (
+        _planner_context_hash_inputs(enumerator, storage_reservation)
+    )
+    cache_params_memo = _CacheParamsFingerprintMemo()
+    return [
+        hash_sha256_to_int(_topology_hash_components(topology)),
+        batch_size,
+        _hashable_search_space(search_space, cache_params_memo, canonical=False),
+        storage_reservation_policy,
+        hash_sha256_to_int(_topology_hash_components(reserved_topology)),
+        (
+            tuple(
+                (key, constraints[key]._persistent_hash(cache_params_memo))
+                for key in sorted(constraints)
             )
             if constraints
             else None
@@ -3209,6 +3381,43 @@ def hash_planner_context_inputs_str(
         topology, batch_size, enumerator, storage_reservation, constraints
     )
     return hash_function(hashable_list)
+
+
+def hash_planner_context_inputs_legacy(
+    topology: Topology,
+    batch_size: int,
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+    constraints: Optional[Dict[str, ParameterConstraints]],
+    hash_function: Callable[[List[Any]], int] = hash_sha256_to_int,
+) -> Optional[int]:
+    """Return the pre-canonicalization hash for validating existing stored plans.
+
+    New plans must use ``hash_planner_context_inputs``. Returns None when the
+    current context contains fused metadata that the legacy format could not encode.
+    """
+    hashable_list = _build_legacy_hashable_list(
+        topology, batch_size, enumerator, storage_reservation, constraints
+    )
+    return hash_function(hashable_list) if hashable_list is not None else None
+
+
+def hash_planner_context_inputs_legacy_str(
+    topology: Topology,
+    batch_size: int,
+    enumerator: Enumerator,
+    storage_reservation: StorageReservation,
+    constraints: Optional[Dict[str, ParameterConstraints]],
+    hash_function: Callable[[List[Any]], str] = hash_sha256_str,
+) -> Optional[str]:
+    """Return the legacy string hash when the old format can represent the inputs.
+
+    New plans must use ``hash_planner_context_inputs_str``.
+    """
+    hashable_list = _build_legacy_hashable_list(
+        topology, batch_size, enumerator, storage_reservation, constraints
+    )
+    return hash_function(hashable_list) if hashable_list is not None else None
 
 
 def round_to_nearest(x: int, unit: int) -> int:

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -55,6 +55,10 @@ from torchrec.distributed.embedding_types import (
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
+from torchrec.distributed.fused_params import (
+    FUSED_PARAM_CPU_OFFLOAD,
+    FUSED_PARAM_SHARED_MEMORY,
+)
 from torchrec.distributed.sharding.sequence_sharding import SequenceShardingContext
 from torchrec.distributed.types import ShardedTensorMetadata, ShardMetadata
 from torchrec.modules.embedding_configs import DataType, NoEvictionPolicy, PoolingType
@@ -149,6 +153,101 @@ class TestGetGroupingFusedParams(unittest.TestCase):
 
 
 class TestPerTBECacheLoadFactor(unittest.TestCase):
+    def test_nested_fused_params_use_canonical_grouping_key(self) -> None:
+        tables = [
+            ShardedEmbeddingTable(
+                name="table_0",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                has_feature_processor=False,
+                fused_params={
+                    "planner_metadata": {
+                        "backend": "host",
+                        "ranks": [0, 1],
+                        "tags": {"primary", "replica"},
+                    }
+                },
+                compute_kernel=EmbeddingComputeKernel.FUSED,
+                embedding_dim=64,
+                num_embeddings=100,
+            ),
+            ShardedEmbeddingTable(
+                name="table_1",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                has_feature_processor=False,
+                fused_params={
+                    "planner_metadata": {
+                        "tags": {"replica", "primary"},
+                        "ranks": [0, 1],
+                        "backend": "host",
+                    }
+                },
+                compute_kernel=EmbeddingComputeKernel.FUSED,
+                embedding_dim=64,
+                num_embeddings=100,
+            ),
+            ShardedEmbeddingTable(
+                name="table_2",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                has_feature_processor=False,
+                fused_params={
+                    "planner_metadata": {
+                        "backend": "host",
+                        "ranks": [1, 0],
+                        "tags": {"primary", "replica"},
+                    }
+                },
+                compute_kernel=EmbeddingComputeKernel.FUSED,
+                embedding_dim=64,
+                num_embeddings=100,
+            ),
+        ]
+
+        table_groups = group_tables([tables])[0]
+
+        self.assertEqual(
+            [
+                [table.name for table in group.embedding_tables]
+                for group in table_groups
+            ],
+            [["table_0", "table_1"], ["table_2"]],
+        )
+        self.assertEqual(table_groups[0].fused_params, tables[0].fused_params)
+
+    def test_planner_markers_separate_groups_without_reaching_tbe(self) -> None:
+        tables = [
+            ShardedEmbeddingTable(
+                name="cpu_table",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                has_feature_processor=False,
+                fused_params={FUSED_PARAM_CPU_OFFLOAD: True},
+                compute_kernel=EmbeddingComputeKernel.FUSED,
+                embedding_dim=64,
+                num_embeddings=100,
+            ),
+            ShardedEmbeddingTable(
+                name="shared_memory_table",
+                data_type=DataType.FP32,
+                pooling=PoolingType.SUM,
+                has_feature_processor=False,
+                fused_params={FUSED_PARAM_SHARED_MEMORY: True},
+                compute_kernel=EmbeddingComputeKernel.FUSED,
+                embedding_dim=64,
+                num_embeddings=100,
+            ),
+        ]
+
+        table_groups = group_tables([tables])[0]
+
+        self.assertEqual(len(table_groups), 2)
+        for table_group in table_groups:
+            fused_params = table_group.fused_params or {}
+            self.assertNotIn(FUSED_PARAM_CPU_OFFLOAD, fused_params)
+            self.assertNotIn(FUSED_PARAM_SHARED_MEMORY, fused_params)
+
     @given(
         data_type=st.sampled_from([DataType.FP16, DataType.FP32]),
         has_feature_processor=st.sampled_from([False, True]),

--- a/torchrec/distributed/tests/test_quant_embedding_kernel.py
+++ b/torchrec/distributed/tests/test_quant_embedding_kernel.py
@@ -14,7 +14,9 @@ from unittest.mock import MagicMock, patch
 import torch
 import torchrec.distributed.quant_embedding_kernel as qek
 from torchrec.distributed.fused_params import (
+    FUSED_PARAM_CPU_OFFLOAD,
     FUSED_PARAM_IS_DEVICE_RO,
+    FUSED_PARAM_SHARED_MEMORY,
     is_fused_param_device_ro,
     tbe_fused_params,
 )
@@ -100,6 +102,8 @@ class QuantBatchedEmbeddingBagDeviceRoTest(unittest.TestCase):
     def test_device_ro_fused_param_is_internal_to_torchrec(self) -> None:
         fused_params: Dict[str, Any] = {
             FUSED_PARAM_IS_DEVICE_RO: True,
+            FUSED_PARAM_CPU_OFFLOAD: True,
+            FUSED_PARAM_SHARED_MEMORY: False,
             "output_dtype": object(),
         }
 
@@ -108,4 +112,6 @@ class QuantBatchedEmbeddingBagDeviceRoTest(unittest.TestCase):
         filtered_params = tbe_fused_params(fused_params)
         self.assertIsNotNone(filtered_params)
         self.assertNotIn(FUSED_PARAM_IS_DEVICE_RO, filtered_params)
+        self.assertNotIn(FUSED_PARAM_CPU_OFFLOAD, filtered_params)
+        self.assertNotIn(FUSED_PARAM_SHARED_MEMORY, filtered_params)
         self.assertIn("output_dtype", filtered_params)

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -816,6 +816,9 @@ class ParameterSharding:
         bounds_check_mode (Optional[BoundsCheckMode]): bounds check mode.
         output_dtype (Optional[DataType]): output dtype.
         key_value_params (Optional[KeyValueParams]): key value params for SSD TBE or PS.
+        fused_params (Optional[Dict[str, Any]]): per-table metadata from the
+            selected planner option. The planner does not interpret it, but
+            values must support deterministic hash canonicalization.
 
     NOTE:
       ShardingType.TABLE_WISE - rank where this embedding is placed
@@ -835,6 +838,7 @@ class ParameterSharding:
     bounds_check_mode: Optional[BoundsCheckMode] = None
     output_dtype: Optional[DataType] = None
     key_value_params: Optional[KeyValueParams] = None
+    fused_params: Optional[Dict[str, Any]] = None
 
 
 class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterSharding]):


### PR DESCRIPTION
Summary:

Carry `ParameterConstraints.fused_params` through candidate enumeration into the selected `ParameterSharding`. The planner treats the values as opaque pass-through metadata, but requires recursively deterministic, hash-canonicalizable values; unsupported objects fail fast instead of using process-dependent `repr()`.

Canonicalize request hashes over sorted constraints and planner-context hashes over unordered candidate sets, excluding runtime statistics identity. Fresh and validated plans use `{}` for known-absent metadata and `None` for legacy or unavailable metadata. New readers accept the exact pre-change planner-context hash with a warning, while new writers emit only the canonical hash. This compatibility is intentionally one-way: rolling back after new artifacts are written can cause validation failures or cache misses, after which plans must be regenerated.

Canonicalize nested metadata used in runtime table-group keys without changing emitted values, and strip TorchRec-only CPU backend markers before constructing FBGEMM operators. The work is planner-only, outside the training forward/backward critical path; the sanitizer benchmark measured approximately 31 microseconds per `ShardingOption` with nested metadata.

Differential Revision: D117633782


