### PR TITLE
Multi-host GEM model training on TPU

### DIFF
--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -115,10 +115,11 @@ def kernel_bw_lookup(
             "cuda",
             EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
         ): hbm_to_ddr_mem_bw,
-        # TODO: revisit update the values
+        # TODO: Update these values with the correct bandwidths
         ("tpu", EmbeddingComputeKernel.DENSE.value): 0.5 * hbm_mem_bw,
         ("tpu", EmbeddingComputeKernel.FUSED.value): 1 * hbm_mem_bw,
         ("tpu", EmbeddingComputeKernel.QUANT.value): 1 * hbm_mem_bw,
+        ("tpu", EmbeddingComputeKernel.UNFUSED_TPU.value): 1 * hbm_mem_bw,
     }
 
     if (


### PR DESCRIPTION
Summary:
Features:
- Planner: register the `(tpu, unfused_tpu)` device bandwidth so
  `EmbeddingShardingPlanner` can place the ~996 dim-1 tables.
- TPU compat: lazy-import the pallas kernels so CPU/GPU torchrec imports
  without the pod-only `torch_tpu` wheel; drop `device_ids` for `tpu` in DDP;
  raise the C++ thread stack rlimit to 8GB.
- v2 kernel: flush the embedding graph at the sparse->dense seam to keep the
  lowered graph shallow, fixing the `SIGSEGV STACK OVERFLOW` that made the v2
  kernel unusable.
- Dev loop: parallelize and content-cache the per-pod `torchrec` copy in
  `run_tpu_multihost.sh` (~15x cold, ~44x warm); add xprof tracing options.

Reviewed By: kausv

Differential Revision: D114899661


