### PR TITLE
int4 quint4x2 reland + DI gate (squashed, fbcode/warm base)

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -923,6 +923,12 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(self._emb_modules)
         setattr(self, MODULE_ATTR_CACHE_FEATURES_ORDER, cache_features_order)
 
+    def _apply_maybe_quint4x2_to_int8(self, embedding: torch.Tensor) -> torch.Tensor:
+        # Overridable seam for the quint4x2 -> uint8 reinterpret. The base uses
+        # the portable int_repr()-based op; subclasses may swap in a zero-copy
+        # variant. Both keep the fx op name that downstream graph passes detect.
+        return _maybe_quint4x2_to_int8(embedding)
+
     def forward(
         self,
         features: KeyedJaggedTensor,
@@ -974,7 +980,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 if self.register_tbes
                 else emb_module.forward(indices=indices, offsets=offsets)
             )
-            lookup = _maybe_quint4x2_to_int8(lookup)
+            lookup = self._apply_maybe_quint4x2_to_int8(lookup)
             if getattr(self, MODULE_ATTR_USE_UNFLATTENED_LENGTHS_FOR_BATCHING, False):
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
                 lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)


### PR DESCRIPTION
Summary:
Relands the int4 (quint4x2) merge-boundary width correction that was reverted in
D116606107, and adds the gate that makes it safe to ship.

## What was broken

At the `remote_ro` -> `merge` boundary, a TBE row is carried as raw bytes and the
width depends on where the int4 dequant runs:

| Path | Where the dequant runs | Boundary row width |
|---|---|---|
| non-DI | `remote_ro`, on device | **packed** `D/2 + 4` |
| DI / universal sharding | `DIShardingPass` defers it to rebatching, *downstream of merge* | **unpacked** `D + 4` |

(`+4` is fbgemm's inline fp16 scale/bias. The returned dtype is `torch.uint8`
either way, so dtype alone cannot tell the two apart.)

`quint4x2_dequant_on_device_enabled` decided this by asking *"does `remote_ro`
contain the dequant op?"*. That is **True on both paths** -- the quant
`EmbeddingCollection.forward` calls `_maybe_quint4x2_to_int8` unconditionally
(`torchrec/quant/embedding_modules.py:983`) -- so one flag was simultaneously
wrong for DI arches and right for non-DI ones. It also cannot see the common
case at all: the collections are declared fx leaf modules, so the op runs inside
an untraced forward and never becomes a graph node.

Result was S683543 -- surfacing as
`mat1 and mat2 shapes cannot be multiplied` when merge warmup or lowering got a
sample at the wrong width (e.g. `11264x864 vs 1536x512`).

## The fix

`tgif/lib/utils.py` -- gate on the publish config, not on op presence:

```python
if is_di_or_universal_sharding_enabled(transform_config):
    return False
remote_ro = getattr(model, sc.REMOTE_REQUEST_ONLY, None)
return remote_ro is not None and module_emits_quint4x2_dequant(remote_ro)
```

The DI check MUST come first, for the reason above. The second test is
precision-gated: `module_emits_quint4x2_dequant` requires
`output_dtype == torch.quint4x2`, so an int8 publish that shares the same seam
does not opt into the halved shape.

This is per-**arch**, not per-model: `cfr_main_feed_mtml_roo_hstu` sets
`di_world_size=3` on `NV_SM80` and leaves it unset on `AMD_SM94`, so the same
model needs opposite answers on different arches. `transform_config` is
therefore threaded to every capture site that builds a `SplitDispatchMode`.

## Why this is useful

**Bandwidth.** On the non-DI path the boundary payload is halved -- `D/2 + 4`
instead of `D + 4` bytes per row. For a `D=512` table that is 260 vs 516 bytes,
~1.98x fewer bytes for every row crossing `remote_ro` -> `merge` on every
request. `remote_ro` runs on remote CPU hosts while merge runs on the GPU, so
this is a real wire hop, and the same halving applies to the merge input
tensors' HBM footprint and to the persisted warmup sample.

**QPS.** Fewer bytes on the request critical path means lower per-request
latency at fixed batch size, hence more headroom under a fixed latency SLA.


The largest concrete value is therefore correctness: it unblocks a reverted
bandwidth win and removes the flag ambiguity that produced four SEVs.


Note this commit squashes four changes -- D114774706, D116132820, D116154801 and
the DI gate -- because `mvai_cogwheel run --graft` takes a single revision. The
unsquashed stack is available if per-diff review is preferred.

## Validation

Cogwheel, on `13f0ec10758a` (DI gate) against two releases that had both
reproduced S696982:

| Job | Release | Result |
|---|---|---|
| `mvai-cogwheel-cli-zhaozhu-80d5a77c38a1` | IFR R12033.1 | COMPLETE |
| `mvai-cogwheel-cli-zhaozhu-6792fcb2fde8` | IFR R12056.1 | COMPLETE |

Caveat: both resolved to the same build (`f4d8fb141f93`, identical `light_cli`
and `mvai_ifr_main_ot` hashes), so this is one build exercised in two release
contexts, not two independent confirmations.

Two further runs on this squashed tree are in flight:
`mvai-cogwheel-cli-zhaozhu-2101b4a6e0bc` (IFR R12316.1) and
`mvai-cogwheel-cli-zhaozhu-7224eab4f3b6` (cfr R9579.1).

No `mat1 and mat2 shapes cannot be multiplied` in any completed run.

Full run log: P2478432025

Reviewed By: serimj98

Differential Revision: D117722169


