### PR TITLE
Fix window accounting to count samples, not update() calls (#4644)

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -191,7 +191,21 @@ class WindowBuffer:
         window_state += curr_state
         self._window_used_size += size
 
-        while self._window_used_size > self._max_size:
+        # `len(self._buffers) > 1`: an update whose own size exceeds the entire window
+        # would otherwise evict itself, leaving an EMPTY window -- window_state == 0, so
+        # every window_* metric that divides by a window state publishes 0/0 = NaN.
+        # Keeping the newest entry degrades to "the window is the last update", which is
+        # the closest well-defined answer.
+        #
+        # This is NOT introduced by the shape[-1] fix in this commit: the ~29 metrics that
+        # already sized by shape[-1] (ne, ctr, calibration, ...) could always reach it.
+        # RecMetric guards it at construction (`_window_size < _batch_size` raises), but
+        # that check uses the CONFIGURED batch size, while `size` here is the actual tensor
+        # length -- and the two diverge under `fused_update_limit` (which concatenates F
+        # batches) and under batch-size stages (which RecMetric discards). This commit
+        # extends the reachable surface to three more metrics, so the degenerate case is
+        # closed here rather than left to be found in production.
+        while self._window_used_size > self._max_size and len(self._buffers) > 1:
             remove(window_state)
 
     @property

--- a/torchrec/metrics/scalar.py
+++ b/torchrec/metrics/scalar.py
@@ -48,7 +48,10 @@ class ScalarMetricComputation(RecMetricComputation):
         weights: Optional[torch.Tensor],
         **kwargs: Dict[str, Any],
     ) -> None:
-        num_samples = labels.shape[0]
+        # shape[-1] is the sample count. shape[0] is n_tasks (1 in unfused mode), which
+        # made window retention scale with the number of update() CALLS rather than with
+        # samples. Matches ne.py / gauc.py / ndcg.py.
+        num_samples = labels.shape[-1]
 
         states = {
             "labels": labels.mean(dim=-1),

--- a/torchrec/metrics/tensor_weighted_avg.py
+++ b/torchrec/metrics/tensor_weighted_avg.py
@@ -110,7 +110,10 @@ class TensorWeightedAvgMetricComputation(RecMetricComputation):
                         kwargs["required_inputs"][tensor_name],
                     )
 
-        num_samples = labels.shape[0]
+        # shape[-1] is the sample count. shape[0] is n_tasks (1 in unfused mode), which
+        # made window retention scale with the number of update() CALLS rather than with
+        # samples. Matches ne.py / gauc.py / ndcg.py.
+        num_samples = labels.shape[-1]
         weights = cast(torch.Tensor, weights)
         # pyrefly: ignore[unbound-name]
         self.weighted_mask = self.weighted_mask.to(target_tensor.device)

--- a/torchrec/metrics/tests/test_scalar.py
+++ b/torchrec/metrics/tests/test_scalar.py
@@ -8,9 +8,11 @@
 # pyre-strict
 
 import unittest
+from typing import cast
 
 import torch
 from torchrec.metrics.metrics_config import DefaultTaskInfo
+from torchrec.metrics.rec_metric import RecMetric, RecMetricComputation, WindowBuffer
 from torchrec.metrics.scalar import ScalarMetric
 
 
@@ -109,3 +111,51 @@ class ScalarMetricTest(unittest.TestCase):
             equal_nan=True,
             msg=f"Actual: {actual_window_metric}, Expected: {expected_window_metric}",
         )
+
+
+def _window_buffer(metric: RecMetric, state_name: str) -> WindowBuffer:
+    """The `WindowBuffer` backing one window state. No public accessor exists."""
+    computation = cast(RecMetricComputation, metric._metrics_computations[0])
+    buffers = computation._batch_window_buffers
+    assert buffers is not None, "window metrics are disabled on this metric"
+    return buffers[state_name]
+
+
+class WindowSampleAccountingTest(unittest.TestCase):
+    """Window eviction must count SAMPLES, not `update()` calls.
+
+    `ScalarMetricComputation.update` passes `num_samples` to `WindowBuffer` as the
+    entry's `size`, and the buffer evicts while `_window_used_size > window_size`. In
+    unfused mode `labels` is `(n_tasks, n_samples)` with `n_tasks == 1`, so reading
+    `shape[0]` reports 1 sample per update regardless of batch size, and `window_scalar`
+    covers an unbounded span.
+
+    Sibling of the identical test in `test_weighted_avg.py` -- the three metrics that
+    carried this bug are fixed atomically, so each one is pinned separately. Without a
+    test here, `scalar.py` could silently regress to `shape[0]`.
+    """
+
+    _BATCH = 100
+    _WINDOW = 250  # 2 batches fit, the 3rd forces an eviction
+    _UPDATES = 5
+
+    def test_window_evicts_on_sample_count_not_update_count(self) -> None:
+        metric = ScalarMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=self._BATCH,
+            tasks=[DefaultTaskInfo],
+            window_size=self._WINDOW,
+        )
+        for _ in range(self._UPDATES):
+            value = torch.rand(1, self._BATCH)
+            metric.update(
+                labels={DefaultTaskInfo.name: value},
+                predictions={DefaultTaskInfo.name: value},
+                weights={DefaultTaskInfo.name: value},
+            )
+        buf = _window_buffer(metric, "window_labels")
+        # samples: 5 x 100 = 500 > 250, so the window holds the newest 2 batches.
+        # Reading shape[0] would report 1 sample/update -> used=5 <= 250 -> all 5 kept.
+        self.assertEqual(len(buf.buffers), 2)
+        self.assertEqual(buf._window_used_size, 2 * self._BATCH)

--- a/torchrec/metrics/tests/test_tensor_weighted_avg.py
+++ b/torchrec/metrics/tests/test_tensor_weighted_avg.py
@@ -9,11 +9,17 @@
 
 
 import unittest
-from typing import Dict, Iterable, Optional, Type, Union
+from typing import cast, Dict, Iterable, Optional, Type, Union
 
 import torch
 from torchrec.metrics.metrics_config import RecTaskInfo
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricException
+from torchrec.metrics.rec_metric import (
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricException,
+    WindowBuffer,
+)
 from torchrec.metrics.tensor_weighted_avg import get_mean, TensorWeightedAvgMetric
 from torchrec.metrics.test_utils import (
     metric_test_helper,
@@ -670,3 +676,60 @@ class TensorWeightedAvgValueTest(unittest.TestCase):
             check_dtype=False,
             msg=f"Actual: {unweighted_value}, Expected: {expected_unweighted_avg}",
         )
+
+
+def _window_buffer(metric: RecMetric, state_name: str) -> WindowBuffer:
+    """The `WindowBuffer` backing one window state. No public accessor exists."""
+    computation = cast(RecMetricComputation, metric._metrics_computations[0])
+    buffers = computation._batch_window_buffers
+    assert buffers is not None, "window metrics are disabled on this metric"
+    return buffers[state_name]
+
+
+class WindowSampleAccountingTest(unittest.TestCase):
+    """Window eviction must count SAMPLES, not `update()` calls.
+
+    `TensorWeightedAvgMetricComputation.update` passes `num_samples` to `WindowBuffer` as
+    the entry's `size`, and the buffer evicts while `_window_used_size > window_size`. In
+    unfused mode `labels` is `(n_tasks, n_samples)` with `n_tasks == 1`, so reading
+    `shape[0]` reports 1 sample per update regardless of batch size, and
+    `window_weighted_avg` covers an unbounded span.
+
+    Sibling of the identical test in `test_weighted_avg.py` -- the three metrics that
+    carried this bug are fixed atomically, so each one is pinned separately. Without a
+    test here, `tensor_weighted_avg.py` could silently regress to `shape[0]`.
+    """
+
+    _BATCH = 100
+    _WINDOW = 250  # 2 batches fit, the 3rd forces an eviction
+    _UPDATES = 5
+
+    def test_window_evicts_on_sample_count_not_update_count(self) -> None:
+        task = RecTaskInfo(
+            name="t1",
+            label_name="label",
+            prediction_name="prediction",
+            weight_name="weight",
+            tensor_name="test_tensor",
+            weighted=True,
+        )
+        metric = TensorWeightedAvgMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=self._BATCH,
+            tasks=[task],
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=self._WINDOW,
+        )
+        for _ in range(self._UPDATES):
+            metric.update(
+                predictions={task.name: torch.rand(1, self._BATCH)},
+                labels={task.name: torch.rand(1, self._BATCH)},
+                weights={task.name: torch.ones(1, self._BATCH)},
+                required_inputs={"test_tensor": torch.rand(1, self._BATCH)},
+            )
+        buf = _window_buffer(metric, "window_weighted_sum")
+        # samples: 5 x 100 = 500 > 250, so the window holds the newest 2 batches.
+        # Reading shape[0] would report 1 sample/update -> used=5 <= 250 -> all 5 kept.
+        self.assertEqual(len(buf.buffers), 2)
+        self.assertEqual(buf._window_used_size, 2 * self._BATCH)

--- a/torchrec/metrics/tests/test_throughput.py
+++ b/torchrec/metrics/tests/test_throughput.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock, patch
 
 import torch
 from torchrec.metrics.metrics_config import BatchSizeStage
-from torchrec.metrics.throughput import ThroughputMetric
+from torchrec.metrics.throughput import MAX_WINDOW_TS, ThroughputMetric
 
 
 THROUGHPUT_PATH = "torchrec.metrics.throughput"
@@ -493,3 +493,80 @@ class ThroughputMetricTest(unittest.TestCase):
 
         # Expecting 0
         self.assertEqual(curr_job_throughput_metric._num_batch, 0)
+
+
+class ThroughputWindowDequeAccountingTest(unittest.TestCase):
+    """`_window_time_lapse` must stay equal to the sum of the deque.
+
+    `_window_time_lapse_buffer` is a bounded deque. A plain `append()` on a full deque
+    silently drops the leftmost entry, so without a matching subtraction the running
+    total permanently over-counts by everything ever evicted. `_check_window()` then
+    over-pops, shrinking `len(buffer)`, and
+    `window_throughput = len(buffer) * batch_examples / _window_time_lapse` is wrong in
+    BOTH numerator and denominator -- it under-reports twice over.
+
+    Saturation -- and therefore the bug -- needs more than MAX_WINDOW_TS updates inside
+    the window, i.e. `MAX_WINDOW_TS / min(window_seconds, MAX_WINDOW_TS)` `update()`/sec.
+    At the default window_seconds=100 that is 72/sec and looks unreachable, but
+    `window_seconds` is CLAMPED to MAX_WINDOW_TS, so any job asking for a larger window
+    runs at the clamp, where the threshold is ~1 `update()`/sec -- routine. That is the
+    regime this test pins. Gradient accumulation compounds it: `update()` fires once per
+    micro-batch, so the K>1 arm can saturate while the K=1 arm does not, corrupting
+    `window_throughput` on one arm of a K=1-vs-K>1 comparison only.
+    """
+
+    def _make_metric(self) -> ThroughputMetric:
+        # window_seconds at the MAX_WINDOW_TS cap, paired with a sub-second lapse per
+        # update below, so the deque reaches its maxlen BEFORE the summed lapse exceeds
+        # the window. Otherwise _check_window() pops first and the deque never saturates,
+        # which is exactly the regime that hides this bug.
+        return ThroughputMetric(
+            batch_size=32, world_size=4, window_seconds=MAX_WINDOW_TS
+        )
+
+    def test_window_time_lapse_matches_buffer_sum_after_forced_eviction(self) -> None:
+        metric = self._make_metric()
+        maxlen = metric._window_time_lapse_buffer.maxlen
+        assert maxlen is not None
+
+        # 0.5s per update: maxlen entries sum to maxlen/2 < window_seconds, so the deque
+        # saturates and append() starts evicting while _check_window() stays quiet.
+        step_seconds = 0.5
+        total_updates = metric._warmup_steps + maxlen + 50
+        with patch(f"{THROUGHPUT_PATH}.time.monotonic") as mock_time:
+            for step in range(total_updates):
+                mock_time.return_value = step * step_seconds
+                metric.update()
+
+        self.assertEqual(len(metric._window_time_lapse_buffer), maxlen)
+        self.assertAlmostEqual(
+            metric._window_time_lapse,
+            sum(metric._window_time_lapse_buffer),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            metric._window_time_lapse, maxlen * step_seconds, places=6
+        )
+        # Assert the PUBLISHED value, not just internal state: the whole point is that
+        # `window_throughput = len(buffer) * batch_examples / _window_time_lapse` reports
+        # the true steady-state rate. With the drift present, _window_time_lapse is
+        # inflated by every silently-dropped entry and this under-reports.
+        published = metric.compute()
+        self.assertAlmostEqual(
+            published[metric._window_throughput_key].item(),
+            metric._batch_examples() / step_seconds,
+            places=4,
+        )
+
+    def test_window_time_lapse_matches_buffer_sum_before_saturation(self) -> None:
+        """The invariant also holds on the un-saturated path (no regression)."""
+        metric = self._make_metric()
+        with patch(f"{THROUGHPUT_PATH}.time.monotonic") as mock_time:
+            for step in range(metric._warmup_steps + 10):
+                mock_time.return_value = step * 0.5
+                metric.update()
+        self.assertAlmostEqual(
+            metric._window_time_lapse,
+            sum(metric._window_time_lapse_buffer),
+            places=6,
+        )

--- a/torchrec/metrics/tests/test_weighted_avg.py
+++ b/torchrec/metrics/tests/test_weighted_avg.py
@@ -8,10 +8,16 @@
 # pyre-strict
 
 import unittest
-from typing import Dict, Iterable, Optional, Type, Union
+from typing import cast, Dict, Iterable, Optional, Type, Union
 
 import torch
-from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecTaskInfo
+from torchrec.metrics.rec_metric import (
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecTaskInfo,
+    WindowBuffer,
+)
 from torchrec.metrics.test_utils import (
     metric_test_helper,
     rec_metric_value_test_launcher,
@@ -220,3 +226,111 @@ class WeightedAvgValueTest(unittest.TestCase):
             except AssertionError:
                 print("Assertion error caught with data set ", inputs)
                 raise
+
+
+def _window_buffer(metric: RecMetric, state_name: str) -> WindowBuffer:
+    """The `WindowBuffer` backing one window state. No public accessor exists."""
+    computation = cast(RecMetricComputation, metric._metrics_computations[0])
+    buffers = computation._batch_window_buffers
+    assert buffers is not None, "window metrics are disabled on this metric"
+    return buffers[state_name]
+
+
+class WindowSampleAccountingTest(unittest.TestCase):
+    """Window eviction must count SAMPLES, not `update()` calls.
+
+    ``RecMetricComputation._aggregate_window_state`` passes ``num_samples`` to
+    ``WindowBuffer`` as the entry's ``size``, and the buffer evicts while
+    ``_window_used_size > window_size``. In unfused mode ``labels`` is
+    ``(n_tasks, n_samples)`` with ``n_tasks == 1``, so reading ``shape[0]``
+    reports 1 sample per update regardless of batch size: a window whose
+    ``window_size`` exceeds the update count then never evicts, and
+    ``window_*`` covers an unbounded span of samples.
+
+    Sibling metrics (``ne.py``, ``gauc.py``) already read ``shape[-1]``.
+    """
+
+    _BATCH = 100
+    _WINDOW = 250  # 2 batches fit, the 3rd forces an eviction
+    _UPDATES = 5
+
+    def _run(
+        self,
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        n_tasks: int = 1,
+        actual_batch: Optional[int] = None,
+    ) -> tuple[RecMetric, int, int]:
+        """Drive `_UPDATES` updates and return (metric, buffer entries, used samples).
+
+        ``actual_batch`` decouples the tensor length actually fed from the ``batch_size``
+        the metric is CONSTRUCTED with -- the divergence that `fused_update_limit` and
+        batch-size stages produce in production.
+        """
+        tasks = [
+            RecTaskInfo(
+                name=f"t{i}",
+                label_name=f"label{i}",
+                prediction_name=f"prediction{i}",
+                weight_name=f"weight{i}",
+            )
+            for i in range(n_tasks)
+        ]
+        metric = WeightedAvgMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=self._BATCH,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            window_size=self._WINDOW,
+        )
+        fed = actual_batch if actual_batch is not None else self._BATCH
+        for _ in range(self._UPDATES):
+            metric.update(
+                predictions={t.name: torch.rand(1, fed) for t in tasks},
+                labels={t.name: torch.rand(1, fed) for t in tasks},
+                weights={t.name: torch.ones(1, fed) for t in tasks},
+            )
+        buf = _window_buffer(metric, "window_weighted_sum")
+        return metric, len(buf.buffers), buf._window_used_size
+
+    def test_window_evicts_on_sample_count_not_update_count(self) -> None:
+        _, n_entries, used = self._run()
+        # samples: 5 x 100 = 500 > 250, so the window holds the newest 2 batches.
+        # Reading shape[0] would report 1 sample/update -> used=5 <= 250 -> all 5 kept.
+        self.assertEqual(n_entries, 2)
+        self.assertEqual(used, 2 * self._BATCH)
+
+    def test_window_evicts_on_sample_count_fused(self) -> None:
+        """FUSED mode: `shape[0]` is n_tasks, not 1 -- still not the sample count.
+
+        The unfused test alone cannot distinguish "reads shape[-1]" from "reads 1", since
+        shape[0] happens to BE 1 there. Here shape[0] == 3, so a regression to shape[0]
+        reports 3 samples/update -> used=15 <= 250 -> all 5 entries kept.
+        """
+        _, n_entries, used = self._run(
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION, n_tasks=3
+        )
+        self.assertEqual(n_entries, 2)
+        self.assertEqual(used, 2 * self._BATCH)
+
+    def test_oversized_update_keeps_one_entry_instead_of_emptying_window(self) -> None:
+        """An update larger than the whole window must not empty the window.
+
+        `WindowBuffer._aggregate_state_impl` evicts while `_window_used_size > _max_size`.
+        Without the `len(self._buffers) > 1` guard the entry evicts itself, leaving
+        `window_state == 0` and publishing `window_weighted_avg = 0/0 = NaN`.
+
+        `RecMetric.__init__` rejects `window_size_local < batch_size`, but that check uses
+        the CONFIGURED batch size while the buffer sizes by the ACTUAL tensor length; the
+        two diverge under `fused_update_limit` (F concatenated batches) and under
+        batch-size stages (which `RecMetric` discards). Reproduced here by feeding a
+        longer tensor than the metric was constructed with.
+        """
+        metric, n_entries, used = self._run(actual_batch=self._WINDOW + 50)
+        self.assertEqual(n_entries, 1)
+        self.assertEqual(used, self._WINDOW + 50)
+        window_value = metric.compute()["weighted_avg-t0|window_weighted_avg"]
+        self.assertFalse(
+            torch.isnan(window_value).any(),
+            f"window_weighted_avg went NaN on an oversized update: {window_value}",
+        )

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -240,8 +240,27 @@ class ThroughputMetric(nn.Module):
             self.time_lapse_after_warmup += time_lapse
             # pyrefly: ignore [bad-argument-type, unsupported-operation]
             self.attempt_time_lapse_after_warmup += time_lapse
+            # Subtract before the deque's implicit evict, mirroring
+            # WindowBuffer._aggregate_state_impl. append() on a full deque(maxlen=...)
+            # silently drops the leftmost entry, so without this the invariant
+            # `_window_time_lapse == sum(buffer)` breaks permanently and _check_window()
+            # then over-pops -- window_throughput is wrong in both numerator and
+            # denominator.
+            #
+            # Reachability. The deque saturates at
+            # `MAX_WINDOW_TS / min(window_seconds, MAX_WINDOW_TS)` update()/sec, because
+            # MAX_WINDOW_TS is used BOTH as the seconds cap above and as this deque's
+            # maxlen. At the default window_seconds=100 that is 72/sec, which is why this
+            # looks like a corner case -- but any job requesting a window above the cap is
+            # clamped to window_seconds == MAX_WINDOW_TS, where the threshold collapses to
+            # ~1 update()/sec and the corruption is routine. Under gradient accumulation
+            # update() fires once per micro-batch, so the rate is K x the logical step rate
+            # and the K>1 arm can saturate while the K=1 arm does not.
+            buf = self._window_time_lapse_buffer
+            if buf.maxlen is not None and len(buf) == buf.maxlen:
+                self._window_time_lapse -= buf.popleft()
             self._window_time_lapse += time_lapse
-            self._window_time_lapse_buffer.append(time_lapse)
+            buf.append(time_lapse)
             self._check_window()
             self._previous_ts = ts
 

--- a/torchrec/metrics/weighted_avg.py
+++ b/torchrec/metrics/weighted_avg.py
@@ -48,7 +48,12 @@ class WeightedAvgMetricComputation(RecMetricComputation):
         weights: Optional[torch.Tensor],
         **kwargs: Dict[str, Any],
     ) -> None:
-        num_samples = labels.shape[0]
+        # shape[-1] is the sample count. shape[0] is n_tasks (1 in unfused mode), which
+        # made window eviction count UPDATES, not samples -- so a window whose
+        # window_size_local exceeded the update count never evicted. Matches ne.py:163 and
+        # gauc.py:184. Fixed alongside scalar.py and tensor_weighted_avg.py, which carried
+        # the identical bug; leaving this one would have made three sibling metrics disagree.
+        num_samples = labels.shape[-1]
         predictions = cast(torch.Tensor, predictions)
         weights = cast(torch.Tensor, weights)
         states = {


### PR DESCRIPTION
Summary:

## Motivation

**Scope first: this is a 3-file catch-up, not a redefinition of windowing.** Reading the sample count off `labels.shape[-1]` is already the established, correct behaviour across `torchrec/metrics` — at this commit's base, **27 of the 30** metric files that compute a sample count already do it that way (`ne.py`, `gauc.py`, and 25 others). Exactly **three** were still on `labels.shape[0]`, and this commit brings those three in line:

- `weighted_avg.py`
- `scalar.py`
- `tensor_weighted_avg.py`

Nothing about the windowing contract changes. Three stragglers start obeying it.

**Why `shape[0]` is wrong.** `RecMetric` always hands these `update()` methods a **2-D** tensor — `(1, n_samples)` unfused (`rec_metric.py:921`) and `(n_tasks, n_samples)` fused (`rec_metric.py:825`) — so `shape[0]` is `1` or `n_tasks`, never the sample count. `WindowBuffer` evicts while `_window_used_size > window_size`, so with a per-update size of 1 the sample-based eviction never fired and only the 1000-entry `deque(maxlen=...)` cap bound. For these three metrics `window_*` therefore meant "the last 1000 updates" instead of "the last `window_size` samples".

Two smaller, related accounting bugs are fixed alongside, because both are reachable from the same buffer.

**Bug 2 — `window_throughput` corrupted in both numerator and denominator.** `throughput.py` appended to a bounded deque without subtracting the evicted entry. `append()` on a full `deque(maxlen=N)` silently drops the leftmost element, so the invariant `_window_time_lapse == sum(buffer)` broke permanently and `_check_window()` then over-popped.

**Bug 3 — an oversized update could empty the window entirely.** `WindowBuffer._aggregate_state_impl` evicts while over capacity; an update whose own size exceeds `window_size` evicts *itself*, leaving `window_state == 0` and publishing `window_weighted_avg` / `window_scalar` as `0/0 = NaN`.

## Behavior Impact

**These three metrics' `window_*` values change**, with no opt-in, for jobs where the window was mis-accounted. That is the point: they were wrong. The other 27 metrics are untouched by Bug 1's fix.

After the fix, the window covers

```
window_length_in_steps = window_size / global_batch_size      (capped at 1000)
```

where `global_batch_size = world_size x local_batch_size`. (`RecMetric` sets `window_size_local = ceil(window_size / world_size)` at `rec_metric.py:480`, and each update contributes `local_batch_size` samples — the world size cancels.) Before the fix it was always 1000 steps.

The rule is therefore simple.

| Condition | Effect |
|---|---|
| `window_size >= 1000 x global_batch_size` | **No change.** The 1000-entry cap was already the binding constraint. |
| `window_size < 1000 x global_batch_size` | Window **shortens** from 1000 steps to `window_size / global_batch_size` steps. |

**Worked examples.**

| `window_size` | world x local batch | global batch | window before | window after |
|---|---|---|---|---|
| 10,000,000 | 128 x 1024 | 131,072 | 1000 steps | **76 steps** |
| 10,000,000 | 8 x 1024 | 8,192 | 1000 steps | 1000 steps (no change) |
| 50,000 | 16 x 512 | 8,192 | 1000 steps | **6 steps** |
| 10,000 | 16 x 512 | 8,192 | 1000 steps | **1 step** |

Any `window_size` that is small relative to the global batch size lands in the single-digit-steps rows, so `window_weighted_avg` / `window_scalar` become materially noisier for those jobs. They are also, for the first time, actually the metric they claim to be. **Anyone alerting on `window_*` for these three metrics is owed this heads-up.**

Gating the fix behind a flag was rejected: it would make a metric's *definition* depend on an unrelated flag and entrench the bug for everyone who did not set it.

Bug 3's fix changes a `NaN` into "the window is the last update" — strictly an improvement, but it is a value change on that path too.

**One residual, documented rather than changed.** `ScalarMetric` accumulates `labels.mean(dim=-1)` against a `window_count` that increments by exactly 1 per update, so `window_scalar` is a mean of per-update batch means, not a sample-weighted mean over the retained window. That is pre-existing and unchanged here — this commit alters only which updates are retained, not how they are weighted — and the two coincide exactly whenever updates carry equal sample counts, which is the steady state. They diverge only across a `BatchSizeStage` transition, a `fused_update_limit` partial flush, or a ragged trailing batch. Shortening the window does amplify that residual (a short update now carries 1/N of a small-N window rather than 1/1000), so it is called out here. `weighted_avg.py` and `tensor_weighted_avg.py` are unaffected: they accumulate `weighted_sum` / `weighted_num_samples` and are genuinely sample-weighted.

## Changes

- `weighted_avg.py`, `scalar.py`, `tensor_weighted_avg.py`: `labels.shape[0]` -> `labels.shape[-1]` (1 line each).
- `throughput.py`: subtract the evicted entry before the deque's implicit eviction, mirroring `WindowBuffer._aggregate_state_impl`.
- `rec_metric.py`: `WindowBuffer._aggregate_state_impl` gains `and len(self._buffers) > 1` on the eviction loop, so the window can never drain to empty.
- Four new test classes (see Test Plan).

## Design

**Why the three `shape[0]` sites are fixed atomically.** Fixing two of three would leave sibling metrics disagreeing about what a window means — a worse state than the consistent bug.

**Why Bug 3 is closed here and not separately.** It is not introduced by Bug 1's fix: the 27 metrics already sizing by `shape[-1]` could always reach it. `RecMetric.__init__` rejects `window_size_local < batch_size` (`rec_metric.py:509-512`), but that check uses the **configured** batch size while the buffer sizes by the **actual** tensor length — and the two diverge under `fused_update_limit` (which concatenates F batches and force-flushes a partial buffer at `compute()` time, `rec_metric.py:681`, `:1017`) and under batch-size stages (`batch_size_stages` is not a `RecMetric.__init__` parameter, so it lands in `**kwargs` and is never read; only `ThroughputMetric` consumes it). Bug 1's fix extends the reachable surface to three more metrics, so leaving the degenerate case open would be knowingly shipping a `NaN` path.

**Bug 2's real reachability, since the naive reading says "unreachable".** The deque saturates at `MAX_WINDOW_TS / min(window_seconds, MAX_WINDOW_TS)` `update()`/sec, because `MAX_WINDOW_TS` is used *both* as the seconds cap and as the deque `maxlen`. At the default `window_seconds=100` that is 72/sec and looks unreachable — but `window_seconds` is **clamped** to `MAX_WINDOW_TS`, so any job requesting a larger window runs *at* the clamp, where the threshold is ~1 `update()`/sec. Under gradient accumulation `update()` fires once per micro-batch, so the rate is Kx the logical step rate: the K>1 arm can saturate while the K=1 arm does not, corrupting `window_throughput` on one arm of a comparison.

## Configuration

None. No new config field, CLI flag or environment variable.

## Not Fixed Here (known, scoped out)

`ThroughputMetric.compute()` multiplies `len(buffer)` by the **current** `_batch_examples()`, so a window spanning a `BatchSizeStage` transition attributes the newest batch size to every historical interval (`throughput.py:206-213`, `:278-283`). Real — some models do ramp batch size — but it needs per-entry example counts in the deque, which turns a 4-line accounting fix into a state-format change. Tracked separately.

Reviewed By: meta-anubhav, jeffkbkim

Differential Revision: D117098247


