### PR TITLE
Pad-to-even for uneven column-wise pooled all2all & all2all input_dist on TPU

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -572,6 +572,34 @@ def alltoall_pooled(
         codecs=codecs,
     )
 
+    # Keep the experimental dependency out of non-TPU import and execution paths.
+    if getattr(torch, "tpu", None) is not None and torch.tpu.is_available():
+        from torchrec.experimental.torch_tpu.uneven_all_to_all import (
+            maybe_all2all_pooled_uneven_tpu,
+        )
+
+        def even_all_to_all(input_tensor: Tensor, split_size: int) -> Tensor:
+            split_sizes = [split_size] * group.size()
+            return AllToAllSingle.apply(
+                input_tensor,
+                split_sizes,
+                split_sizes,
+                pg_name(group),
+                group.size(),
+                get_gradient_division(),
+            )
+
+        uneven = maybe_all2all_pooled_uneven_tpu(
+            group,
+            a2a_pooled_embs_tensor,
+            batch_size_per_rank,
+            dim_sum_per_rank,
+            has_codecs=codecs is not None,
+            even_all_to_all=even_all_to_all,
+        )
+        if uneven is not None:
+            return NoWait(uneven)
+
     if get_use_sync_collectives():
         return NoWait(all2all_pooled_sync(group, a2ai, a2a_pooled_embs_tensor))
 

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -747,6 +747,23 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
         self._world_size: int = self._pg.size()
         rank = dist.get_rank(self._pg)
 
+        # Keep the experimental dependency out of non-TPU import and execution paths.
+        if getattr(torch, "tpu", None) is not None and torch.tpu.is_available():
+            from torchrec.experimental.torch_tpu.uneven_all_to_all import (
+                maybe_kjt_a2a_uneven_tpu,
+            )
+
+            padded_outputs = maybe_kjt_a2a_uneven_tpu(
+                self._pg,
+                input_tensors,
+                input_splits,
+                output_splits,
+                self._device,
+            )
+            if padded_outputs is not None:
+                self._output_tensors = padded_outputs
+                return
+
         for input_split, output_split, input_tensor, label in zip(
             input_splits,
             output_splits,

--- a/torchrec/experimental/torch_tpu/tests/test_uneven_all_to_all.py
+++ b/torchrec/experimental/torch_tpu/tests/test_uneven_all_to_all.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import os
+import unittest
+from typing import cast
+
+import torch
+import torch.distributed as dist
+from parameterized import parameterized
+from torchrec.distributed.comm_ops import AllToAllSingle, pg_name
+from torchrec.distributed.test_utils.process_runner import (
+    run_local_multi_process_func,
+    SingleProcessContext,
+)
+from torchrec.experimental.torch_tpu.uneven_all_to_all import (
+    maybe_all2all_pooled_uneven_tpu,
+    maybe_kjt_a2a_uneven_tpu,
+)
+
+
+class UnevenAllToAllTest(unittest.TestCase):
+    @staticmethod
+    def _assert_kjt_all_to_all(
+        rank: int,
+        world_size: int,
+        group: dist.ProcessGroup,
+        device: torch.device,
+    ) -> None:
+        input_splits = [rank + destination + 1 for destination in range(world_size)]
+        output_splits = [source + rank + 1 for source in range(world_size)]
+        rows = torch.arange(sum(input_splits), device=device) + rank * 1000
+        input_2d = torch.stack([rows * 2, rows * 2 + 1], dim=1)
+        outputs = maybe_kjt_a2a_uneven_tpu(
+            group, [input_2d], [input_splits], [output_splits], device
+        )
+        if outputs is None:
+            raise AssertionError("uneven KJT adapter did not handle uneven splits")
+
+        expected_rows = []
+        for source in range(world_size):
+            source_splits = [
+                source + destination + 1 for destination in range(world_size)
+            ]
+            start = sum(source_splits[:rank])
+            expected_rows.append(
+                torch.arange(start, start + output_splits[source], device=device)
+                + source * 1000
+            )
+        expected_rows_tensor = torch.cat(expected_rows)
+        expected = torch.stack(
+            [expected_rows_tensor * 2, expected_rows_tensor * 2 + 1], dim=1
+        )
+        torch.testing.assert_close(outputs[0], expected)
+
+    @staticmethod
+    def _assert_pooled_all_to_all(
+        rank: int,
+        world_size: int,
+        group: dist.ProcessGroup,
+        device: torch.device,
+    ) -> None:
+        def even_all_to_all(tensor: torch.Tensor, split_size: int) -> torch.Tensor:
+            splits = [split_size] * world_size
+            return cast(
+                torch.Tensor,
+                AllToAllSingle.apply(
+                    tensor, splits, splits, pg_name(group), world_size, False
+                ),
+            )
+
+        batch_sizes = [rank_index + 1 for rank_index in range(world_size)]
+        dimensions = [rank_index + 1 for rank_index in range(world_size)]
+        local_dim = dimensions[rank]
+        pooled_input = (
+            torch.arange(sum(batch_sizes) * local_dim, device=device).float()
+            + rank * 1000
+        ).view(sum(batch_sizes), local_dim)
+        pooled_input.requires_grad_()
+        output = maybe_all2all_pooled_uneven_tpu(
+            group,
+            pooled_input,
+            batch_sizes,
+            dimensions,
+            has_codecs=False,
+            even_all_to_all=even_all_to_all,
+        )
+        if output is None:
+            raise AssertionError("uneven pooled adapter did not handle uneven splits")
+
+        batch_start = sum(batch_sizes[:rank])
+        expected_blocks = []
+        for source, source_dim in enumerate(dimensions):
+            source_input = (
+                torch.arange(sum(batch_sizes) * source_dim, device=device).float()
+                + source * 1000
+            ).view(sum(batch_sizes), source_dim)
+            expected_blocks.append(
+                source_input[batch_start : batch_start + batch_sizes[rank]]
+            )
+        torch.testing.assert_close(output, torch.cat(expected_blocks, dim=1))
+        output.sum().backward()
+        if pooled_input.grad is None:
+            raise AssertionError("padded all-to-all did not propagate gradients")
+        torch.testing.assert_close(pooled_input.grad, torch.ones_like(pooled_input))
+
+    @classmethod
+    def _run_uneven_all_to_all(
+        cls,
+        ctx: SingleProcessContext,
+        rank: int,
+        world_size: int,
+        device_type: str,
+        test_kind: str,
+    ) -> None:
+        group = ctx.pg
+        if group is None:
+            raise AssertionError("process group is not initialized")
+        device = torch.device(device_type)
+        if test_kind == "kjt":
+            cls._assert_kjt_all_to_all(rank, world_size, group, device)
+        else:
+            cls._assert_pooled_all_to_all(rank, world_size, group, device)
+
+    def _run_backend(self, backend: str, device_type: str, test_kind: str) -> bool:
+        if backend == "gloo":
+            run_local_multi_process_func(
+                func=self._run_uneven_all_to_all,
+                world_size=2,
+                backend=backend,
+                device_type=device_type,
+                test_kind=test_kind,
+            )
+            return True
+
+        try:
+            import torch_tpu  # pyre-ignore[21]  # noqa: F401
+        except ImportError:
+            self.skipTest("requires torch_tpu")
+        configured_world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        tpu = getattr(torch, "tpu", None)
+        if tpu is None or not tpu.is_available() or configured_world_size < 2:
+            self.skipTest("requires a multi-rank TPU launch")
+        with SingleProcessContext(backend=backend) as ctx:
+            self._run_uneven_all_to_all(
+                ctx=ctx,
+                rank=ctx.rank,
+                world_size=ctx.world_size,
+                device_type=device_type,
+                test_kind=test_kind,
+            )
+        return True
+
+    @parameterized.expand([("gloo", "cpu"), ("tpu_dist", "tpu")])
+    def test_kjt_forward(self, backend: str, device_type: str) -> None:
+        self.assertTrue(self._run_backend(backend, device_type, "kjt"))
+
+    @parameterized.expand([("gloo", "cpu"), ("tpu_dist", "tpu")])
+    def test_pooled_forward_and_backward(self, backend: str, device_type: str) -> None:
+        self.assertTrue(self._run_backend(backend, device_type, "pooled"))

--- a/torchrec/experimental/torch_tpu/uneven_all_to_all.py
+++ b/torchrec/experimental/torch_tpu/uneven_all_to_all.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Pad uneven TPU all-to-all inputs for KJT and pooled embedding distribution.
+
+Callers keep TPU availability checks at their existing integration points. KJT split
+sizes are data-dependent, so this module uses a small even metadata collective to find a
+padding size shared by every rank. The earlier TorchRec split exchange provides each rank
+with its local send and receive splits, but not the full split matrix or its global max.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import torch
+import torch.distributed as dist
+from torchrec.pt2.checks import is_torchdynamo_compiling
+
+
+def _pad_dim0(tensor: torch.Tensor, size: int) -> torch.Tensor:
+    rows = tensor.shape[0]
+    if rows == size:
+        return tensor
+    padding = torch.zeros(
+        (size - rows, *tensor.shape[1:]),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    return torch.cat([tensor, padding], dim=0)
+
+
+def padded_all_to_all_single(
+    group: dist.ProcessGroup,
+    input_tensor: torch.Tensor,
+    input_split_sizes: Sequence[int],
+    output_split_sizes: Sequence[int],
+    padded_split_size: int,
+    *,
+    even_all_to_all: Callable[[torch.Tensor, int], torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Implement uneven dim-0 all-to-all using an even padded collective.
+
+    KJT uses the default raw collective. Pooled embeddings inject TorchRec's existing
+    autograd-aware even collective to preserve backward behavior.
+    """
+    world_size = group.size()
+    if len(input_split_sizes) != world_size or len(output_split_sizes) != world_size:
+        raise ValueError("split-size lists must match the process-group size")
+    if sum(input_split_sizes) != input_tensor.shape[0]:
+        raise ValueError("input split sizes must sum to the input's dim-0 size")
+    if padded_split_size < max(1, *input_split_sizes, *output_split_sizes):
+        raise ValueError("padded split size is smaller than a real segment")
+
+    padded_input = torch.cat(
+        [
+            _pad_dim0(segment, padded_split_size)
+            for segment in input_tensor.split(list(input_split_sizes), dim=0)
+        ],
+        dim=0,
+    )
+    even_splits = [padded_split_size] * world_size
+    if even_all_to_all is None:
+        padded_output = torch.empty_like(padded_input)
+        dist.all_to_all_single(
+            padded_output,
+            padded_input.contiguous(),
+            even_splits,
+            even_splits,
+            group,
+        )
+    else:
+        padded_output = even_all_to_all(padded_input, padded_split_size)
+
+    source_blocks = padded_output.split(padded_split_size, dim=0)
+    return torch.cat(
+        [
+            source_block[:output_size]
+            for source_block, output_size in zip(source_blocks, output_split_sizes)
+        ],
+        dim=0,
+    )
+
+
+def _all_gather_even(
+    group: dist.ProcessGroup, local_metadata: torch.Tensor
+) -> torch.Tensor:
+    world_size = group.size()
+    metadata_size = local_metadata.numel()
+    gathered = torch.empty(
+        metadata_size * world_size,
+        dtype=local_metadata.dtype,
+        device=local_metadata.device,
+    )
+    splits = [metadata_size] * world_size
+    dist.all_to_all_single(
+        gathered,
+        local_metadata.repeat(world_size),
+        splits,
+        splits,
+        group,
+    )
+    return gathered.view(world_size, metadata_size)
+
+
+def _global_kjt_padding_metadata(
+    group: dist.ProcessGroup,
+    input_splits: Sequence[Sequence[int]],
+    output_splits: Sequence[Sequence[int]],
+    device: torch.device,
+) -> tuple[list[int], bool]:
+    if len(input_splits) != len(output_splits):
+        raise ValueError("KJT input and output tensor counts must match")
+
+    local_maxima = [
+        max(1, *input_split, *output_split)
+        for input_split, output_split in zip(input_splits, output_splits)
+    ]
+    locally_uneven = any(
+        len(set(input_split)) > 1 or len(set(output_split)) > 1
+        for input_split, output_split in zip(input_splits, output_splits)
+    )
+    local_metadata = torch.tensor(
+        [*local_maxima, int(locally_uneven)],
+        dtype=torch.int64,
+        device=device,
+    )
+    gathered = _all_gather_even(group, local_metadata)
+    global_maxima = gathered[:, :-1].amax(dim=0).tolist()
+    globally_uneven = bool(gathered[:, -1].amax().tolist())
+    return global_maxima, globally_uneven
+
+
+def maybe_kjt_a2a_uneven_tpu(
+    group: dist.ProcessGroup,
+    input_tensors: Sequence[torch.Tensor],
+    input_splits: Sequence[Sequence[int]],
+    output_splits: Sequence[Sequence[int]],
+    device: torch.device,
+) -> list[torch.Tensor] | None:
+    """Return padded uneven KJT A2A outputs, or ``None`` for the native path."""
+    if is_torchdynamo_compiling() or group.size() <= 1 or not input_tensors:
+        return None
+    if not (len(input_tensors) == len(input_splits) == len(output_splits)):
+        raise ValueError("KJT tensors and split lists must have matching lengths")
+
+    padded_split_sizes, globally_uneven = _global_kjt_padding_metadata(
+        group, input_splits, output_splits, device
+    )
+    if not globally_uneven:
+        return None
+
+    return [
+        padded_all_to_all_single(
+            group,
+            input_tensor.to(device),
+            input_split,
+            output_split,
+            padded_split_size,
+        )
+        for input_tensor, input_split, output_split, padded_split_size in zip(
+            input_tensors,
+            input_splits,
+            output_splits,
+            padded_split_sizes,
+        )
+    ]
+
+
+def maybe_all2all_pooled_uneven_tpu(
+    group: dist.ProcessGroup,
+    input_embeddings: torch.Tensor,
+    batch_size_per_rank: Sequence[int],
+    dim_sum_per_rank: Sequence[int],
+    *,
+    has_codecs: bool,
+    even_all_to_all: Callable[[torch.Tensor, int], torch.Tensor],
+) -> torch.Tensor | None:
+    """Return padded uneven pooled A2A output, or ``None`` for the native path."""
+    if has_codecs or is_torchdynamo_compiling() or group.size() <= 1:
+        return None
+    if (
+        len(batch_size_per_rank) != group.size()
+        or len(dim_sum_per_rank) != group.size()
+    ):
+        raise ValueError("pooled metadata must match the process-group size")
+    if len(set(batch_size_per_rank)) == 1 and len(set(dim_sum_per_rank)) == 1:
+        return None
+
+    rank = group.rank()
+    batch_size = batch_size_per_rank[rank]
+    local_dim = dim_sum_per_rank[rank]
+    if input_embeddings.shape != (sum(batch_size_per_rank), local_dim):
+        raise ValueError("input embedding shape does not match pooled A2A metadata")
+
+    input_split_sizes = [local_dim * size for size in batch_size_per_rank]
+    output_split_sizes = [batch_size * dim for dim in dim_sum_per_rank]
+    padded_split_size = max(batch_size_per_rank) * max(dim_sum_per_rank)
+    sharded_output = padded_all_to_all_single(
+        group,
+        input_embeddings.reshape(-1),
+        input_split_sizes,
+        output_split_sizes,
+        max(1, padded_split_size),
+        even_all_to_all=even_all_to_all,
+    )
+    outputs_by_rank = sharded_output.split(output_split_sizes)
+    return torch.cat(
+        [
+            output.view(batch_size, dim)
+            for output, dim in zip(outputs_by_rank, dim_sum_per_rank)
+        ],
+        dim=1,
+    )


### PR DESCRIPTION
Summary:
Context
---------

Uneven all2all isn't supported on torch_tpu, the goal of this is to implement padding to cause all tensors to be even for all2all, before giving it to torch_tpu comms.  This is implemented for both input_dist of KJT all2all and the output_dist of embedding for column-wise sharding.

NOTE: this is only temporary, and the true fix is to add unevne all2all inside torch_tpu. Note that this doesn't work for VBE.

Implementation
------------------

* For KJT inputs, does an initial small all2all to figure out if it is uneven or the maximum padding size. Note that the split between start_sparse_dist and wait_sparse_dist also does this, however, to avoid changing torchrec core code, this is done inside the experimental/torch_tpu folder.
* Padding is performed ot the global maixmum size, then an all2all single from torch tpu is used
* Tries to re-use AllToAllSingle for backward/autograd.
* All torchrec core code is guarded to only run if TPU is available.
* Tests do uneven all2all on KJT and embedding output and compare it to expected results

Differential Revision: D114128128


