### PR TITLE
Add opt-in RecMetrics input validation

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -531,6 +531,16 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             assert self._captured_exception is not None
             raise self._captured_exception
 
+        # Debug validation runs on the caller thread and may synchronize GPU inputs.
+        # Use it only for targeted diagnostics.
+        if self._debug_mode and len(self.rec_metrics) > 0 and self.rec_tasks:
+            debug_model_out = self._prepare_model_out_for_metrics(dict(model_out))
+            labels, predictions, weights, _ = parse_task_model_outputs(
+                self.rec_tasks,
+                debug_model_out,
+            )
+            self._validate_rec_metric_inputs(labels, predictions, weights)
+
         if self._clone_model_out:
             snapshot_model_out = _foreach_clone_dict(model_out)
             snapshot_kwargs = _foreach_clone_kwargs(kwargs)

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -14,7 +14,8 @@ import concurrent
 import logging
 import time
 from collections import defaultdict, OrderedDict
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from dataclasses import dataclass
+from typing import Any, cast, Dict, List, Optional, Type, TypeVar, Union
 
 import torch
 import torch.distributed as dist
@@ -104,7 +105,12 @@ from torchrec.metrics.output import OutputMetric
 from torchrec.metrics.precision import PrecisionMetric
 from torchrec.metrics.precision_session import PrecisionSessionMetric
 from torchrec.metrics.rauc import RAUCMetric
-from torchrec.metrics.rec_metric import RecMetric, RecMetricException, RecMetricList
+from torchrec.metrics.rec_metric import (
+    RecMetric,
+    RecMetricException,
+    RecMetricList,
+    RecMetricValidationError,
+)
 from torchrec.metrics.recall import RecallMetric
 from torchrec.metrics.recall_session import RecallSessionMetric
 from torchrec.metrics.scalar import ScalarMetric
@@ -121,6 +127,89 @@ from torchrec.metrics.weighted_sum_predictions import WeightedSumPredictionsMetr
 from torchrec.metrics.xauc import XAUCMetric
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _InputTensorSummary:
+    dtype: str
+    shape: tuple[int, ...]
+    numel: int
+    nan_count: int
+    positive_infinity_count: int
+    negative_infinity_count: int
+    mixed_infinity_count: int
+
+
+@dataclass(frozen=True)
+class _InvalidInputRecord:
+    metric_name: str
+    namespace: str
+    task_name: str
+    tensor_kind: str
+    allow_nan: bool
+    summary: _InputTensorSummary
+
+
+def _summarize_input_tensor(tensor: torch.Tensor) -> _InputTensorSummary:
+    """Synchronously summarize one tensor for opt-in diagnostics."""
+    nan_count = 0
+    positive_infinity_count = 0
+    negative_infinity_count = 0
+    mixed_infinity_count = 0
+    if tensor.is_floating_point():
+        counts = torch.stack(
+            [
+                torch.isnan(tensor).sum(),
+                torch.isposinf(tensor).sum(),
+                torch.isneginf(tensor).sum(),
+            ]
+        ).tolist()
+        nan_count = int(counts[0])
+        positive_infinity_count = int(counts[1])
+        negative_infinity_count = int(counts[2])
+    elif tensor.is_complex():
+        nan_mask = torch.isnan(tensor)
+        positive_infinity_mask = torch.isposinf(tensor.real) | torch.isposinf(
+            tensor.imag
+        )
+        negative_infinity_mask = torch.isneginf(tensor.real) | torch.isneginf(
+            tensor.imag
+        )
+        non_nan_mask = ~nan_mask
+        counts = torch.stack(
+            [
+                nan_mask.sum(),
+                (positive_infinity_mask & ~negative_infinity_mask & non_nan_mask).sum(),
+                (negative_infinity_mask & ~positive_infinity_mask & non_nan_mask).sum(),
+                (positive_infinity_mask & negative_infinity_mask & non_nan_mask).sum(),
+            ]
+        ).tolist()
+        nan_count = int(counts[0])
+        positive_infinity_count = int(counts[1])
+        negative_infinity_count = int(counts[2])
+        mixed_infinity_count = int(counts[3])
+
+    return _InputTensorSummary(
+        dtype=str(tensor.dtype),
+        shape=tuple(tensor.shape),
+        numel=tensor.numel(),
+        nan_count=nan_count,
+        positive_infinity_count=positive_infinity_count,
+        negative_infinity_count=negative_infinity_count,
+        mixed_infinity_count=mixed_infinity_count,
+    )
+
+
+def _format_input_summary(rank: int, record: _InvalidInputRecord) -> str:
+    summary = record.summary
+    return (
+        f"rank={rank} {record.tensor_kind} shape={list(summary.shape)} "
+        f"dtype={summary.dtype} numel={summary.numel} nan={summary.nan_count} "
+        f"+inf={summary.positive_infinity_count} "
+        f"-inf={summary.negative_infinity_count} "
+        f"mixed_inf={summary.mixed_infinity_count}"
+    )
+
 
 REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.NE: NEMetric,
@@ -276,6 +365,8 @@ class RecMetricModule(nn.Module):
         self.world_size = world_size
         self.oom_count = 0
         self.compute_count = 0
+        self._debug_mode: bool = False
+        self._debug_rank: int = 0
 
         self.compute_interval_steps = compute_interval_steps
         self.min_compute_interval = min_compute_interval
@@ -298,6 +389,104 @@ class RecMetricModule(nn.Module):
         self.last_compute_time = -1.0
 
         self._register_load_state_dict_pre_hook(self.load_state_dict_hook)
+
+    def _configure_debug_mode(
+        self,
+        debug_mode: bool,
+        my_rank: int,
+    ) -> None:
+        self._debug_mode = debug_mode
+        self._debug_rank = my_rank
+
+    def _build_invalid_input_records(
+        self,
+        labels: Dict[str, torch.Tensor],
+        predictions: Dict[str, torch.Tensor],
+        weights: Dict[str, torch.Tensor],
+    ) -> List[_InvalidInputRecord]:
+        records: List[_InvalidInputRecord] = []
+        summaries: Dict[tuple[str, str], Optional[_InputTensorSummary]] = {}
+        inputs = (
+            (RecMetric.LABELS, labels),
+            (RecMetric.PREDICTIONS, predictions),
+            (RecMetric.WEIGHTS, weights),
+        )
+        for metric_module in self.rec_metrics.rec_metrics:
+            metric = cast(RecMetric, metric_module)
+            namespace = str(metric._namespace.value)
+            for task in metric._tasks:
+                for tensor_kind, task_tensors in inputs:
+                    if tensor_kind in metric.ignored_input_values:
+                        continue
+                    key = (task.name, tensor_kind)
+                    if key not in summaries:
+                        tensor = task_tensors.get(task.name)
+                        summaries[key] = (
+                            _summarize_input_tensor(tensor)
+                            if tensor is not None
+                            else None
+                        )
+                    summary = summaries[key]
+                    if summary is None:
+                        continue
+                    allow_nan = tensor_kind in metric.allowed_nan_inputs
+                    has_infinity = any(
+                        (
+                            summary.positive_infinity_count,
+                            summary.negative_infinity_count,
+                            summary.mixed_infinity_count,
+                        )
+                    )
+                    if (allow_nan or summary.nan_count == 0) and not has_infinity:
+                        continue
+                    records.append(
+                        _InvalidInputRecord(
+                            metric_name=type(metric).__name__,
+                            namespace=namespace,
+                            task_name=task.name,
+                            tensor_kind=tensor_kind,
+                            allow_nan=allow_nan,
+                            summary=summary,
+                        )
+                    )
+        return records
+
+    def _format_input_validation_error(
+        self,
+        records: List[_InvalidInputRecord],
+    ) -> str:
+        lines = [
+            "RecMetric validation failed at input: "
+            f"rank={self._debug_rank} trained_batches={self.trained_batches}"
+        ]
+        for record in records:
+            policy = (
+                f"NaN {record.tensor_kind} allowed; "
+                f"{record.tensor_kind} infinities rejected"
+                if record.allow_nan
+                else f"finite {record.tensor_kind} required"
+            )
+            lines.extend(
+                (
+                    f"metric={record.metric_name} namespace={record.namespace} "
+                    f"task={record.task_name}",
+                    _format_input_summary(self._debug_rank, record),
+                    f"policy={policy}",
+                )
+            )
+        return "\n".join(lines)
+
+    def _validate_rec_metric_inputs(
+        self,
+        labels: Dict[str, torch.Tensor],
+        predictions: Dict[str, torch.Tensor],
+        weights: Dict[str, torch.Tensor],
+    ) -> None:
+        if not self._debug_mode:
+            return
+        records = self._build_invalid_input_records(labels, predictions, weights)
+        if records:
+            raise RecMetricValidationError(self._format_input_validation_error(records))
 
     def load_state_dict_hook(
         self,
@@ -341,6 +530,7 @@ class RecMetricModule(nn.Module):
             labels, predictions, weights, required_inputs = parse_task_model_outputs(
                 self.rec_tasks, model_out, self.get_required_inputs()
             )
+            self._validate_rec_metric_inputs(labels, predictions, weights)
             if required_inputs:
                 kwargs["required_inputs"] = required_inputs
 
@@ -749,6 +939,7 @@ def generate_metric_module(
     process_group: Optional[dist.ProcessGroup] = None,
     batch_size_stages: Optional[List[BatchSizeStage]] = None,
     module_kwargs: Optional[Dict[str, Any]] = None,
+    debug_mode: bool = False,
 ) -> RecMetricModule:
     rec_metrics = _generate_rec_metrics(
         metrics_config,
@@ -782,6 +973,10 @@ def generate_metric_module(
         min_compute_interval=metrics_config.min_compute_interval,
         max_compute_interval=metrics_config.max_compute_interval,
         **(module_kwargs if module_kwargs else {}),
+    )
+    metrics._configure_debug_mode(
+        debug_mode,
+        my_rank,
     )
     metrics.to(device)
     return metrics

--- a/torchrec/metrics/num_missing_labels.py
+++ b/torchrec/metrics/num_missing_labels.py
@@ -90,6 +90,8 @@ class NumMissingLabelsMetricComputation(RecMetricComputation):
 
 
 class NumMissingLabelsMetric(RecMetric):
+    allowed_nan_inputs: frozenset[str] = frozenset({RecMetric.LABELS})
+    ignored_input_values: frozenset[str] = frozenset({RecMetric.PREDICTIONS})
     # pyrefly: ignore[bad-override]
     _namespace: MetricNamespace = MetricNamespace.NUM_MISSING_LABELS
     _computation_class: Type[RecMetricComputation] = NumMissingLabelsMetricComputation

--- a/torchrec/metrics/num_positive_samples.py
+++ b/torchrec/metrics/num_positive_samples.py
@@ -90,6 +90,8 @@ class NumPositiveSamplesMetricComputation(RecMetricComputation):
 
 
 class NumPositiveSamplesMetric(RecMetric):
+    allowed_nan_inputs: frozenset[str] = frozenset({RecMetric.LABELS})
+    ignored_input_values: frozenset[str] = frozenset({RecMetric.PREDICTIONS})
     # pyrefly: ignore[bad-override]
     _namespace: MetricNamespace = MetricNamespace.NUM_POSITIVE_SAMPLES
     _computation_class: Type[RecMetricComputation] = NumPositiveSamplesMetricComputation

--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -211,6 +211,10 @@ class RecMetricException(Exception):
     pass
 
 
+class RecMetricValidationError(RecMetricException):
+    pass
+
+
 class WindowBuffer:
     def __init__(self, max_size: int, max_buffer_count: int) -> None:
         self._max_size: int = max_size
@@ -573,6 +577,8 @@ class RecMetric(nn.Module, abc.ABC):
     PREDICTIONS: str = "predictions"
     LABELS: str = "labels"
     WEIGHTS: str = "weights"
+    allowed_nan_inputs: frozenset[str] = frozenset()
+    ignored_input_values: frozenset[str] = frozenset()
 
     def __init__(
         self,

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -39,8 +39,12 @@ from torchrec.metrics.metrics_config import (
     RecMetricDef,
     RecMetricEnum,
 )
-from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
-from torchrec.metrics.test_utils import gen_test_tasks
+from torchrec.metrics.rec_metric import (
+    RecMetricException,
+    RecMetricList,
+    RecMetricValidationError,
+)
+from torchrec.metrics.test_utils import gen_test_batch, gen_test_tasks
 from torchrec.metrics.test_utils.mock_metrics import (
     assert_tensor_dict_equals,
     create_tensor_states,
@@ -121,6 +125,58 @@ class CPUOffloadedRecMetricModulePreparationTest(unittest.TestCase):
         torch.testing.assert_close(
             cast(dict[str, torch.Tensor], weights)["task1"], raw_weight
         )
+
+
+class CPUOffloadedRecMetricDebugModeTest(unittest.TestCase):
+    @unittest.skipIf(not torch.cuda.is_available(), "Test needs a GPU")
+    def test_debug_validation_fails_before_enqueue(self) -> None:
+        tasks = gen_test_tasks(["task1"])
+        config = MetricsConfig(
+            rec_tasks=tasks,
+            rec_metrics={
+                RecMetricEnum.NE: RecMetricDef(
+                    rec_tasks=tasks,
+                    window_size=100,
+                )
+            },
+        )
+        metric_module = cast(
+            CPUOffloadedRecMetricModule,
+            generate_metric_module(
+                CPUOffloadedRecMetricModule,
+                metrics_config=config,
+                batch_size=1,
+                world_size=1,
+                my_rank=0,
+                state_metrics_mapping={},
+                device=torch.device("cpu"),
+                module_kwargs={
+                    "model_out_device": torch.device("cuda"),
+                    "update_batch_size": 1,
+                },
+                debug_mode=True,
+            ),
+        )
+        try:
+            batch = gen_test_batch(
+                1,
+                label_name=tasks[0].label_name,
+                prediction_name=tasks[0].prediction_name,
+                weight_name=tasks[0].weight_name,
+                label_value=torch.tensor([float("nan")], device="cuda"),
+                device="cuda",
+            )
+
+            with self.assertRaises(RecMetricValidationError):
+                metric_module.update(batch)
+
+            self.assertTrue(metric_module.update_queue.empty())
+            self.assertEqual(0, metric_module.trained_batches)
+        finally:
+            with patch.object(
+                metric_module, "_process_metric_compute_job", return_value={}
+            ):
+                metric_module.shutdown()
 
 
 class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
@@ -205,9 +261,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         """Test non-blocking tensor output transfer from GPU to CPU."""
 
         output = {
-            "task1-prediction": torch.tensor([1.0, 2.0, 3.0]).to("cuda:0"),
-            "task1-label": torch.tensor([0.0, 1.0, 0.0]).to("cuda:0"),
-            "task1-weight": torch.tensor([5.0, 1.0, 0.0]).to("cuda:0"),
+            "task1-prediction": torch.tensor([1.0, 2.0, 3.0], device="cuda:0"),
+            "task1-label": torch.tensor([0.0, 1.0, 0.0], device="cuda:0"),
+            "task1-weight": torch.tensor([5.0, 1.0, 0.0], device="cuda:0"),
         }
 
         cpu_output, transfer_event = transfer_tensors_to_cpu(output)
@@ -826,11 +882,10 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             model_out_device=torch.device("cuda:1"),
         )
 
-        # Create tensors on cuda:1
         output = {
-            "task1-prediction": torch.tensor([1.0, 2.0, 3.0]).to("cuda:1"),
-            "task1-label": torch.tensor([0.0, 1.0, 0.0]).to("cuda:1"),
-            "task1-weight": torch.tensor([5.0, 1.0, 0.0]).to("cuda:1"),
+            "task1-prediction": torch.tensor([1.0, 2.0, 3.0], device="cuda:1"),
+            "task1-label": torch.tensor([0.0, 1.0, 0.0], device="cuda:1"),
+            "task1-weight": torch.tensor([5.0, 1.0, 0.0], device="cuda:1"),
         }
 
         # Update with the tensors - this should trigger transfer to CPU
@@ -1497,12 +1552,12 @@ def _compare_metric_results_worker(
     model_outputs = []
     for _ in range(num_batches):
         model_out = {
-            "task1-prediction": torch.rand(batch_size).to(device),
-            "task1-label": torch.randint(0, 2, (batch_size,)).float().to(device),
-            "task1-weight": torch.ones(batch_size).to(device),
-            "task2-prediction": torch.rand(batch_size).to(device),
-            "task2-label": torch.randint(0, 2, (batch_size,)).float().to(device),
-            "task2-weight": torch.ones(batch_size).to(device),
+            "task1-prediction": torch.rand(batch_size, device=device),
+            "task1-label": torch.randint(0, 2, (batch_size,), device=device).float(),
+            "task1-weight": torch.ones(batch_size, device=device),
+            "task2-prediction": torch.rand(batch_size, device=device),
+            "task2-label": torch.randint(0, 2, (batch_size,), device=device).float(),
+            "task2-weight": torch.ones(batch_size, device=device),
         }
         model_outputs.append(model_out)
 

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -45,7 +45,12 @@ from torchrec.metrics.metrics_config import (
     validate_batch_size_stages,
 )
 from torchrec.metrics.model_utils import parse_task_model_outputs
-from torchrec.metrics.rec_metric import RecMetricException, RecMetricList, RecTaskInfo
+from torchrec.metrics.rec_metric import (
+    RecMetricException,
+    RecMetricList,
+    RecMetricValidationError,
+    RecTaskInfo,
+)
 from torchrec.metrics.test_utils import gen_test_batch, gen_test_tasks
 from torchrec.metrics.test_utils.mock_metrics import MockRecMetric
 from torchrec.metrics.throughput import ThroughputMetric
@@ -1209,6 +1214,333 @@ def metric_module_gather_state(
             torch.testing.assert_close(tensor, new_tensor, check_device=False)
 
         metric_module.shutdown()
+
+
+class RecMetricDebugModeTest(unittest.TestCase):
+    def _create_config(
+        self,
+        metric_enums: List[RecMetricEnum],
+    ) -> MetricsConfig:
+        return MetricsConfig(
+            rec_tasks=[DefaultTaskInfo],
+            rec_metrics={
+                metric_enum: RecMetricDef(
+                    rec_tasks=[DefaultTaskInfo],
+                    window_size=_DEFAULT_WINDOW_SIZE,
+                )
+                for metric_enum in metric_enums
+            },
+        )
+
+    def _create_module(
+        self,
+        metric_enums: List[RecMetricEnum],
+        debug_mode: bool = True,
+    ) -> RecMetricModule:
+        return generate_metric_module(
+            RecMetricModule,
+            metrics_config=self._create_config(metric_enums),
+            batch_size=4,
+            world_size=1,
+            my_rank=0,
+            state_metrics_mapping={},
+            device=torch.device("cpu"),
+            debug_mode=debug_mode,
+        )
+
+    def test_debug_mode_disabled_does_not_validate(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NE], debug_mode=False)
+        batch = gen_test_batch(
+            4,
+            label_value=torch.tensor([0.0, float("nan"), 1.0, 0.0]),
+        )
+
+        metric_module.update(batch)
+
+        self.assertEqual(1, metric_module.trained_batches)
+
+    def test_nan_label_fails_before_state_mutation(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NE])
+        state_before = {
+            name: tensor.detach().clone()
+            for name, tensor in metric_module.state_dict().items()
+        }
+        batch = gen_test_batch(
+            4,
+            label_value=torch.tensor([0.0, float("nan"), 1.0, 0.0]),
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        message = str(context.exception)
+        self.assertIn("metric=NEMetric", message)
+        self.assertIn("task=DefaultTask", message)
+        self.assertIn("rank=0 labels shape=[4] dtype=torch.float32", message)
+        self.assertIn("numel=4", message)
+        self.assertIn("nan=1", message)
+        self.assertEqual(0, metric_module.trained_batches)
+        for name, tensor in metric_module.state_dict().items():
+            torch.testing.assert_close(tensor, state_before[name])
+
+    def test_num_missing_labels_ignores_predictions_and_counts_nan_labels(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NUM_MISSING_LABELS])
+        metric_module.update(
+            gen_test_batch(
+                4,
+                label_value=torch.tensor([float("nan"), 1.0, float("nan"), 0.0]),
+                prediction_value=torch.tensor([float("nan"), float("inf"), 1.0, 0.0]),
+                weight_value=torch.ones(4),
+            )
+        )
+
+        metrics = metric_module.compute().resolve()
+        self.assertEqual(
+            2.0,
+            metrics[
+                "num_missing_labels-DefaultTask|lifetime_num_missing_labels"
+            ].item(),
+        )
+
+    def test_num_positive_samples_ignores_predictions_and_nan_labels(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NUM_POSITIVE_SAMPLES])
+        metric_module.update(
+            gen_test_batch(
+                4,
+                label_value=torch.tensor([float("nan"), 1.0, float("nan"), 0.0]),
+                prediction_value=torch.tensor([float("nan"), float("inf"), 1.0, 0.0]),
+                weight_value=torch.ones(4),
+            )
+        )
+
+        metrics = metric_module.compute().resolve()
+        self.assertEqual(
+            1.0,
+            metrics[
+                "num_positive_samples-DefaultTask|lifetime_num_positive_samples"
+            ].item(),
+        )
+
+    def test_weighted_sum_predictions_ignores_labels_and_nan_predictions(
+        self,
+    ) -> None:
+        metric_module = self._create_module([RecMetricEnum.WEIGHTED_SUM_PREDICTIONS])
+        metric_module.update(
+            gen_test_batch(
+                4,
+                label_value=torch.tensor([float("nan"), float("inf"), 1.0, 0.0]),
+                prediction_value=torch.tensor([float("nan"), 1.0, float("nan"), 2.0]),
+                weight_value=torch.ones(4),
+            )
+        )
+
+        metrics = metric_module.compute().resolve()
+        self.assertEqual(
+            3.0,
+            metrics[
+                "weighted_sum_predictions-DefaultTask|lifetime_weighted_sum_predictions"
+            ].item(),
+        )
+
+    def test_nan_label_shared_with_ne_names_ne(self) -> None:
+        metric_module = self._create_module(
+            [RecMetricEnum.NUM_MISSING_LABELS, RecMetricEnum.NE]
+        )
+        batch = gen_test_batch(
+            4,
+            label_value=torch.tensor([0.0, float("nan"), 1.0, 0.0]),
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        self.assertIn("metric=NEMetric", str(context.exception))
+        self.assertNotIn("metric=NumMissingLabelsMetric", str(context.exception))
+
+    def test_num_missing_labels_rejects_label_infinity(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NUM_MISSING_LABELS])
+        batch = gen_test_batch(
+            4,
+            label_value=torch.tensor([0.0, float("inf"), 1.0, 0.0]),
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        message = str(context.exception)
+        self.assertIn("metric=NumMissingLabelsMetric", message)
+        self.assertIn("+inf=1", message)
+
+    def test_non_finite_predictions_and_weights_fail(self) -> None:
+        cases = [
+            ("predictions", "prediction", float("nan"), "nan=1"),
+            ("predictions", "prediction", float("inf"), "+inf=1"),
+            ("weights", "weight", float("nan"), "nan=1"),
+            ("weights", "weight", float("-inf"), "-inf=1"),
+        ]
+        for tensor_kind, batch_key, value, expected_count in cases:
+            with self.subTest(tensor_kind=tensor_kind, value=value):
+                metric_module = self._create_module([RecMetricEnum.NE])
+                batch = gen_test_batch(4)
+                batch[batch_key][0] = value
+
+                with self.assertRaises(RecMetricValidationError) as context:
+                    metric_module.update(batch)
+
+                message = str(context.exception)
+                self.assertIn(tensor_kind, message)
+                self.assertIn(expected_count, message)
+
+    def test_complex_infinity_signs_are_reported(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NE])
+        batch = gen_test_batch(4)
+        batch["prediction"] = torch.tensor(
+            [complex(float("-inf"), 0.0), 0j, 0j, 0j],
+            dtype=torch.complex64,
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        message = str(context.exception)
+        self.assertIn("dtype=torch.complex64", message)
+        self.assertIn("+inf=0", message)
+        self.assertIn("-inf=1", message)
+
+    def test_complex_non_finite_counts_do_not_overlap(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NE])
+        batch = gen_test_batch(4)
+        batch["prediction"] = torch.tensor(
+            [
+                complex(float("inf"), float("nan")),
+                complex(float("inf"), float("-inf")),
+                0j,
+                0j,
+            ],
+            dtype=torch.complex64,
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        message = str(context.exception)
+        self.assertIn("nan=1", message)
+        self.assertIn("+inf=0", message)
+        self.assertIn("-inf=0", message)
+        self.assertIn("mixed_inf=1", message)
+
+    def test_debug_mode_does_not_require_process_group(self) -> None:
+        metric_module = generate_metric_module(
+            RecMetricModule,
+            metrics_config=self._create_config([RecMetricEnum.NE]),
+            batch_size=4,
+            world_size=2,
+            my_rank=1,
+            state_metrics_mapping={},
+            device=torch.device("cpu"),
+            debug_mode=True,
+        )
+        batch = gen_test_batch(
+            4,
+            label_value=torch.tensor([0.0, float("nan"), 1.0, 0.0]),
+        )
+
+        with self.assertRaises(RecMetricValidationError) as context:
+            metric_module.update(batch)
+
+        self.assertIn("rank=1", str(context.exception))
+        self.assertEqual(0, metric_module.trained_batches)
+
+    def test_preparation_failure_is_not_reclassified(self) -> None:
+        metric_module = self._create_module([RecMetricEnum.NE])
+        batch = gen_test_batch(4)
+        batch["label"] = torch.empty(4, device="meta")
+
+        with self.assertRaises(NotImplementedError):
+            metric_module.update(batch)
+
+
+def _create_distributed_debug_module(
+    rank: int,
+    world_size: int,
+    process_group: Optional[dist.ProcessGroup],
+) -> RecMetricModule:
+    config = MetricsConfig(
+        rec_tasks=[DefaultTaskInfo],
+        rec_metrics={
+            RecMetricEnum.NE: RecMetricDef(
+                rec_tasks=[DefaultTaskInfo],
+                window_size=_DEFAULT_WINDOW_SIZE,
+            )
+        },
+    )
+    return generate_metric_module(
+        RecMetricModule,
+        metrics_config=config,
+        batch_size=4,
+        world_size=world_size,
+        my_rank=rank,
+        state_metrics_mapping={},
+        device=torch.device("cpu"),
+        process_group=process_group,
+        debug_mode=True,
+    )
+
+
+def _run_rank_local_input_validation(
+    rank: int,
+    world_size: int,
+    backend: str,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend) as context:
+        metric_module = _create_distributed_debug_module(rank, world_size, context.pg)
+        batch = gen_test_batch(4)
+        if rank == 1:
+            batch["label"] = batch["label"].reshape(2, 2)
+            batch["prediction"] = batch["prediction"].reshape(2, 2)
+            batch["label"][0, 0] = float("nan")
+        try:
+            metric_module.update(batch)
+        except RecMetricValidationError as error:
+            assert rank == 1
+            assert "rank=1" in str(error)
+            assert "metric=NEMetric" in str(error)
+            assert "shape=[2, 2]" in str(error)
+        else:
+            assert rank == 0
+            assert metric_module.trained_batches == 1
+        dist.barrier()
+
+
+def _run_rank_local_uneven_updates(
+    rank: int,
+    world_size: int,
+    backend: str,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend) as context:
+        metric_module = _create_distributed_debug_module(rank, world_size, context.pg)
+        update_count = 3 if rank == 0 else 1
+        for _ in range(update_count):
+            metric_module.update(gen_test_batch(4))
+        assert metric_module.trained_batches == update_count
+        dist.barrier()
+
+
+@skip_if_asan_class
+class RecMetricDebugModeDistributedTest(MultiProcessTestBase):
+    def test_invalid_input_raises_only_on_offending_rank(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_rank_local_input_validation,
+            world_size=2,
+            backend="gloo",
+        )
+
+    def test_uneven_update_counts_do_not_collect(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_rank_local_uneven_updates,
+            world_size=2,
+            backend="gloo",
+        )
 
 
 class MetricsConfigPostInitTest(unittest.TestCase):

--- a/torchrec/metrics/weighted_sum_predictions.py
+++ b/torchrec/metrics/weighted_sum_predictions.py
@@ -92,6 +92,8 @@ class WeightedSumPredictionsMetricComputation(RecMetricComputation):
 
 
 class WeightedSumPredictionsMetric(RecMetric):
+    allowed_nan_inputs: frozenset[str] = frozenset({RecMetric.PREDICTIONS})
+    ignored_input_values: frozenset[str] = frozenset({RecMetric.LABELS})
     # pyrefly: ignore[bad-override]
     _namespace: MetricNamespace = MetricNamespace.WEIGHTED_SUM_PREDICTIONS
     _computation_class: Type[RecMetricComputation] = (


### PR DESCRIPTION
Summary: Add opt-in input validation so invalid labels, predictions, and weights fail before metric state mutation. Validation is rank-local to preserve uneven per-rank updates; disabled mode preserves existing behavior.

Differential Revision: D117392926


