### PR TITLE
Make enumerator filtering order deterministic (#4648)

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -449,9 +449,14 @@ class EmbeddingEnumerator(Enumerator):
             return filtered
         constrained_sharding_types: List[str] = constraints.sharding_types
 
-        filtered_sharding_types = list(
-            set(constrained_sharding_types) & set(allowed_sharding_types)
-        )
+        # Filter in ``allowed_sharding_types`` order rather than iterating a set:
+        # set-of-str iteration order is PYTHONHASHSEED-dependent, which makes the
+        # search space -- and the planner context hash keyed off it -- differ
+        # between processes.
+        constrained_sharding_type_set = set(constrained_sharding_types)
+        filtered_sharding_types = [
+            t for t in allowed_sharding_types if t in constrained_sharding_type_set
+        ]
         if not filtered_sharding_types:
             logger.warning(
                 "No available sharding types after applying user provided "
@@ -488,9 +493,14 @@ class EmbeddingEnumerator(Enumerator):
             ]
 
         # setup filtered_compute_kernels
-        filtered_compute_kernels = list(
-            set(constrained_compute_kernels) & set(allowed_compute_kernels)
-        )
+        # Filter in ``allowed_compute_kernels`` order rather than iterating a set:
+        # set-of-str iteration order is PYTHONHASHSEED-dependent, which makes the
+        # search space -- and the planner context hash keyed off it -- differ
+        # between processes.
+        constrained_compute_kernel_set = set(constrained_compute_kernels)
+        filtered_compute_kernels = [
+            k for k in allowed_compute_kernels if k in constrained_compute_kernel_set
+        ]
 
         # Remove KEY_VALUE if no device has SSD capacity — avoids expanding
         # the search space with infeasible options that fits_in() would reject.


### PR DESCRIPTION
Summary:

`_filter_sharding_types` and `_filter_compute_kernels` built their results with
`list(set(a) & set(b))` over strings. Iteration order of a set of `str` depends on
`PYTHONHASHSEED`, which CPython randomizes per interpreter, so the enumerated search
space came out in a different order in every process.

`hash_planner_context_inputs` hashes `str(hashable_list)`, which is order-sensitive.
The planner context hash - the Manifold plan-cache key - therefore differed between
processes for identical inputs.

This is the same failure class as D116975066, which removed the process-local address
leak from `EmbeddingOffloadStats`. That fix left the ordering leak in place, so the key
could still drift across MAST attempts for any table carrying `sharding_types` or
`compute_kernels` constraints.

It surfaced as `test_hash_consistency_disabled_in_oss_compatibility`, which compares the
hash across two ranks. `MultiProcessTestBase` selects `spawn` when
`torch.version.cuda >= "12.8"`, so each rank is a fresh interpreter with its own hash
seed and the two orderings disagreed.

Filter in the allowed-list order instead of iterating a set. This preserves the sharder's
declared ordering and matches what `_filter_sharding_types` already does in its
unconstrained early-return branches.

Differential Revision: D118320324


