### PR TITLE
Tune long-run gather width per target (#4649)

### DIFF
--- a/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
+++ b/torchrec/distributed/triton_tbe/triton_table_batched_embeddings.py
@@ -1192,13 +1192,14 @@ def triton_tbe_backward_long_run_grad_accum_weighted(
     info_B_num_bits,
     info_B_mask,
     vbe: tl.constexpr = False,
+    BUFFER_SIZE: tl.constexpr = 16,
 ) -> None:
     """
     Weighted version: each program accumulates weighted gradients for a
     sub-range of a long run and atomically adds into a temp gradient buffer.
     """
     col_offsets = tl.arange(0, BLOCK_SIZE)
-    buffer_size: tl.constexpr = 16
+    buffer_size: tl.constexpr = BUFFER_SIZE
     buffer_offsets = tl.arange(0, buffer_size)
 
     pid = tl.program_id(0)
@@ -1313,13 +1314,14 @@ def triton_tbe_backward_long_run_grad_accum_unweighted(
     info_B_num_bits,
     info_B_mask,
     vbe: tl.constexpr = False,
+    BUFFER_SIZE: tl.constexpr = 8,
 ) -> None:
     """
     Each program accumulates gradients for a sub-range of a long run
     and atomically adds the partial result into a temp gradient buffer.
     """
     col_offsets = tl.arange(0, BLOCK_SIZE)
-    buffer_size: tl.constexpr = 8
+    buffer_size: tl.constexpr = BUFFER_SIZE
     buffer_offsets = tl.arange(0, buffer_size)
 
     pid = tl.program_id(0)
@@ -2398,6 +2400,13 @@ class TritonTBE(torch.autograd.Function):
                     info_B_mask=info_B_mask,
                     num_warps=num_warps,
                     vbe=vbe,
+                    # The AMD variant hardcodes its gather width and does not
+                    # take this constexpr, so only pass it on the CUDA path.
+                    **(
+                        {}
+                        if _use_amd
+                        else {"BUFFER_SIZE": cfg.long_run_accum_buffer_size_weighted}
+                    ),
                 )
                 # Kernel 3: apply optimizer (reuse unweighted — weight-independent)
                 bwd_long_apply = (
@@ -2556,6 +2565,13 @@ class TritonTBE(torch.autograd.Function):
                     info_B_mask=info_B_mask,
                     num_warps=num_warps,
                     vbe=vbe,
+                    # The AMD variant hardcodes its gather width and does not
+                    # take this constexpr, so only pass it on the CUDA path.
+                    **(
+                        {}
+                        if _use_amd
+                        else {"BUFFER_SIZE": cfg.long_run_accum_buffer_size_unweighted}
+                    ),
                 )
 
                 # Kernel 3: apply optimizer (direct mapping, no while-loop)

--- a/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
+++ b/torchrec/distributed/triton_tbe/triton_tbe_backward_config.py
@@ -52,6 +52,16 @@ class TbeBackwardConfig:
     short_run_buffer_size_unweighted: int
     short_run_buffer_size_weighted: int
 
+    # Same knob, same trade-off, for the long-run grad-accumulation kernels.
+    # These kept the historical 8/16 when the short-run widths were tuned down,
+    # and paid the same register cliff: on Blackwell the unweighted long-run
+    # kernel sat at 158 registers/thread and 17.6% occupancy at width 8, versus
+    # 62 registers and 44.7% at width 2 -- with byte-identical memory traffic
+    # and an identical global-load request count, so the entire delta is
+    # latency hiding.
+    long_run_accum_buffer_size_unweighted: int
+    long_run_accum_buffer_size_weighted: int
+
     num_warps: int
 
     # Split the short-run tier into one launch per next_pow2(D) bucket so each
@@ -78,6 +88,8 @@ _BLACKWELL = TbeBackwardConfig(
     long_run_threshold=256,
     short_run_buffer_size_unweighted=2,
     short_run_buffer_size_weighted=4,
+    long_run_accum_buffer_size_unweighted=2,
+    long_run_accum_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=True,
@@ -95,6 +107,8 @@ _HOPPER = TbeBackwardConfig(
     long_run_threshold=256,
     short_run_buffer_size_unweighted=2,
     short_run_buffer_size_weighted=4,
+    long_run_accum_buffer_size_unweighted=2,
+    long_run_accum_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
@@ -109,6 +123,8 @@ _MI300X = TbeBackwardConfig(
     long_run_threshold=256,
     short_run_buffer_size_unweighted=2,
     short_run_buffer_size_weighted=4,
+    long_run_accum_buffer_size_unweighted=2,
+    long_run_accum_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
@@ -123,6 +139,8 @@ _MI350X = TbeBackwardConfig(
     long_run_threshold=256,
     short_run_buffer_size_unweighted=2,
     short_run_buffer_size_weighted=4,
+    long_run_accum_buffer_size_unweighted=2,
+    long_run_accum_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,
@@ -137,6 +155,8 @@ _PORTABLE_DEFAULT = TbeBackwardConfig(
     long_run_threshold=256,
     short_run_buffer_size_unweighted=2,
     short_run_buffer_size_weighted=4,
+    long_run_accum_buffer_size_unweighted=2,
+    long_run_accum_buffer_size_weighted=4,
     num_warps=1,
     enable_dim_bucketing=True,
     allow_clc=False,


### PR DESCRIPTION
Summary:

Brings the long-run grad-accumulation kernels under the same per-target gather-width tuning that already fixed the short-run tier, recovering the shapes that were still below CUDA TBE parity.

- **Root cause**: long-run accum kept a hardcoded gather width (8 unweighted / 16 weighted) when the short-run widths were tuned to 2/4, so it paid the identical register cliff — the `[BUFFER_SIZE, BLOCK_SIZE]` int64 pointer tile, not the accumulator, dominates register pressure.
- **Mechanism, measured**: 158 -> 62 registers/thread, 17.6% -> 44.7% occupancy, 188 -> 128 ms on the accum kernel, with a byte-identical global-load request count (9,167.3M both ways). Pure latency hiding.
- **Config, not code**: adds `long_run_accum_buffer_size_{unweighted,weighted}` to `TbeBackwardConfig`; the kernels take it as a constexpr, mirroring `short_run_buffer_size_*`.
- **AMD untouched**: the AMD kernel variants hardcode their own width and do not accept the constexpr, so it is only passed on the CUDA path.
- **Selective by construction**: only long-run-dominated shapes move; a short-run-dominated control is unchanged.

Reviewed By: stashuk-olek

Differential Revision: D118318363


