### PR TITLE
Preserve task dimensions in fused TowerQPS updates

### DIFF
--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -2468,7 +2468,11 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
         if dist.is_initialized():
             dist.destroy_process_group()
 
-    def _build_config(self, metric_enum: RecMetricEnum) -> MetricsConfig:
+    def _build_config(
+        self,
+        metric_enum: RecMetricEnum,
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    ) -> MetricsConfig:
         return MetricsConfig(
             rec_tasks=self.tasks,
             rec_metrics={
@@ -2476,18 +2480,21 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
                     rec_tasks=self.tasks, window_size=self.WINDOW_SIZE
                 )
             },
-            rec_compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            rec_compute_mode=compute_mode,
             compute_interval_steps=1,
         )
 
     def _build_offloaded_module(
-        self, metric_enum: RecMetricEnum, update_batch_size: int
+        self,
+        metric_enum: RecMetricEnum,
+        update_batch_size: int,
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
     ) -> CPUOffloadedRecMetricModule:
         module = cast(
             CPUOffloadedRecMetricModule,
             generate_metric_module(
                 metric_class=CPUOffloadedRecMetricModule,
-                metrics_config=self._build_config(metric_enum),
+                metrics_config=self._build_config(metric_enum, compute_mode),
                 batch_size=self.BATCH_SIZE,
                 world_size=1,
                 my_rank=0,
@@ -2530,6 +2537,20 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
             k: cast(torch.Tensor, v)
             for k, v in result.items()
             if "window" in k.lower() and isinstance(v, torch.Tensor)
+        }
+
+    def _run_tower_qps(self, update_batch_size: int) -> dict[str, torch.Tensor]:
+        module = self._build_offloaded_module(
+            RecMetricEnum.TOWER_QPS,
+            update_batch_size,
+            RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION,
+        )
+        for batch in self._gen_batches():
+            module.update(batch)
+        return {
+            key: cast(torch.Tensor, value)
+            for key, value in module.async_compute().resolve().items()
+            if isinstance(value, torch.Tensor)
         }
 
     @staticmethod
@@ -2594,6 +2615,16 @@ class WindowOverEvictionMergeTest(unittest.TestCase):
             f"Metrics with broken window under K-merge over-eviction: {bad}. "
             "cap-K must keep every metric's window within tolerance of K=1.",
         )
+
+    def test_fused_tower_qps_counts_all_examples_under_kmerge(self) -> None:
+        reference = self._run_tower_qps(update_batch_size=1)
+        merged = self._run_tower_qps(update_batch_size=self.K)
+        expected_examples = self.K * self.BATCH_SIZE
+
+        for task in self.tasks:
+            key = f"qps-{task.name}|total_examples"
+            self.assertEqual(reference[key].item(), expected_examples)
+            self.assertEqual(merged[key].item(), expected_examples)
 
 
 class CapUpdateBatchSizeTest(unittest.TestCase):

--- a/torchrec/metrics/tower_qps.py
+++ b/torchrec/metrics/tower_qps.py
@@ -263,7 +263,7 @@ class TowerQPSMetric(RecMetric):
                         raise RecMetricException(
                             f"Failed to convert labels to tensor for fused computation: {e}"
                         )
-                labels = labels.view(-1, self._batch_size)
+                labels = labels.reshape(len(self._tasks), -1)
                 if self._should_validate_update:
                     # Set the default value to be all True. When weights is None, it's considered
                     # to be a valid input, and we'll use the default value
@@ -285,7 +285,7 @@ class TowerQPSMetric(RecMetric):
                                 )
                         has_valid_weights = torch.gt(
                             torch.count_nonzero(
-                                weights.view(-1, self._batch_size), dim=-1
+                                weights.reshape(len(self._tasks), -1), dim=-1
                             ),
                             0,
                         )


### PR DESCRIPTION
Summary:
Background:

We found in D117885079, there are tower qps issue after enabling ZORM  {F1995445855}

Futher debbuging, there are some issue inside the torch rec implementation

Fix: 

CPUOffloadedRecMetricModule batches ZORM metric updates by concatenating each task label across K input batches. The fused TowerQPS path reshaped that tensor using the configured per-update batch size, turning K into extra task rows; TowerQPS then counted only one batch of examples per task, producing the observed roughly 90% task-QPS drop at K=10.

Reshape fused labels and validation weights using the configured task count so the full merged example dimension is preserved. Add an end-to-end CPU-offload regression comparing K=1 and K=10 total-example accounting. Update the generated Torch dependency for the touched TowerQPS target.

Reviewed By: jeffkbkim, yashasingh

Differential Revision: D118188966


