### PR TITLE
Naive impl for permute for CW pooled embeddings (#4651)

### DIFF
--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+from itertools import accumulate
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
 
 import torch
@@ -56,6 +57,25 @@ C = TypeVar("C", bound=Multistreamable)
 F = TypeVar("F", bound=Multistreamable)
 T = TypeVar("T")
 W = TypeVar("W")
+
+
+def _build_tpu_permute(
+    embedding_dims: List[int],
+    embedding_order: List[int],
+    device: Optional[torch.device],
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """CW output_dist pooled-embedding permute on the TPU, entirely on-device."""
+
+    # precompute the permute metadata as on-device tensors, prevents host-sync
+    offset_t = torch.tensor(
+        [0] + list(accumulate(embedding_dims)), dtype=torch.int32, device=device
+    )
+    permute_t = torch.tensor(embedding_order, dtype=torch.int32, device=device)
+
+    def _permute_on_device(embs: torch.Tensor) -> torch.Tensor:
+        return torch.ops.torchrec.permute_pooled_embs(embs, offset_t, permute_t)
+
+    return _permute_on_device
 
 
 class BaseCwEmbeddingSharding(BaseTwEmbeddingSharding[C, F, T, W]):
@@ -302,10 +322,22 @@ class CwPooledEmbeddingSharding(
             range(len(self._embedding_order))
         ):
             assert len(self._embedding_order) == len(self._embedding_dims)
-            embedding_permute_op = PermutePooledEmbeddingsSplit(
-                self._embedding_dims, self._embedding_order, device=device
-            )
-            callbacks = [embedding_permute_op]
+            if (
+                hasattr(torch, "tpu")
+                and device is not None
+                and device.type == "tpu"
+                and torch.tpu.is_available()
+            ):
+                callbacks = [
+                    _build_tpu_permute(
+                        self._embedding_dims, self._embedding_order, device
+                    )
+                ]
+            else:
+                embedding_permute_op = PermutePooledEmbeddingsSplit(
+                    self._embedding_dims, self._embedding_order, device=device
+                )
+                callbacks = [embedding_permute_op]
         assert self._pg is not None
         return TwPooledEmbeddingDist(
             pg=self._pg,

--- a/torchrec/experimental/torch_tpu/pallas/impl.py
+++ b/torchrec/experimental/torch_tpu/pallas/impl.py
@@ -10,6 +10,7 @@ from torch_tpu._internal import pallas  # pyre-ignore[21]
 from torchrec.experimental.torch_tpu.pallas import (
     lookup,
     ops,
+    permute_embs,
     pooled_lookup_offset,
     pooled_lookup_padded,
 )
@@ -41,6 +42,18 @@ _pooled_batched_offset_fwd = pallas.jax_op(
 _pooled_batched_offset_bwd = pallas.jax_op(
     "torchrec_pallas::embedding_pooled_batched_lookup_offset_bwd",
     pooled_lookup_offset.embedding_pooled_batched_lookup_bwd_jax,
+)
+_permute_pooled_embs_sc_fwd = pallas.jax_op(
+    "torchrec_pallas::permute_pooled_embs_auto_grad_split",
+    permute_embs.permute_pooled_embs_auto_grad_split_kernel,
+)
+_permute_pooled_embs_tc_fwd = pallas.jax_op(
+    "torchrec_pallas::permute_pooled_embs",
+    permute_embs.permute_pooled_embs_tc,
+)
+_permute_pooled_embs_tc_bwd = pallas.jax_op(
+    "torchrec_pallas::permute_pooled_embs_backward",
+    permute_embs.permute_pooled_embs_tc_bwd,
 )
 
 
@@ -114,6 +127,38 @@ def embedding_pooled_batched_lookup_offset_backward_tpu(
     )
 
 
+def permute_pooled_embs_tpu(pooled_embs, offset_dim_list, permute_list):
+    return _permute_pooled_embs_tc_fwd(
+        pooled_embs=pooled_embs,
+        offset_dim_list=offset_dim_list,
+        permute_list=permute_list,
+    )
+
+
+def permute_pooled_embs_backward_tpu(grad_out, offset_dim_list, permute_list):
+    return _permute_pooled_embs_tc_bwd(
+        grad_out=grad_out,
+        offset_dim_list=offset_dim_list,
+        permute_list=permute_list,
+    )
+
+
+def permute_pooled_embs_sparse_core_tpu(
+    pooled_embs,
+    offset_dim_list,
+    permute_list,
+    output_offset_dim_list,
+    col_block_size,
+):
+    return _permute_pooled_embs_sc_fwd(
+        pooled_embs=pooled_embs,
+        offset_dim_list=offset_dim_list,
+        permute_list=permute_list,
+        inv_offset_dim_list=output_offset_dim_list,
+        col_block_size=col_block_size,
+    )
+
+
 lib: torch.library.Library = torch.library.Library("torchrec", "IMPL")
 lib.impl("embedding_lookup", embedding_lookup_tpu, "TPU")
 lib.impl("embedding_lookup_backward", embedding_lookup_backward_tpu, "TPU")
@@ -137,6 +182,8 @@ lib.impl(
     embedding_pooled_batched_lookup_offset_backward_tpu,
     "TPU",
 )
+lib.impl("permute_pooled_embs", permute_pooled_embs_tpu, "TPU")
+lib.impl("permute_pooled_embs_backward", permute_pooled_embs_backward_tpu, "TPU")
 
 
 _ = ops

--- a/torchrec/experimental/torch_tpu/pallas/ops.py
+++ b/torchrec/experimental/torch_tpu/pallas/ops.py
@@ -40,11 +40,22 @@ lib.define(
     "Tensor grad_out, Tensor indices, Tensor offsets, Tensor row_offsets, "
     "int num_rows, int emb_dim) -> Tensor"
 )
+lib.define(
+    "permute_pooled_embs("
+    "Tensor pooled_embs, Tensor offset_dim_list, Tensor permute_list"
+    ") -> Tensor"
+)
+lib.define(
+    "permute_pooled_embs_backward("
+    "Tensor grad_out, Tensor offset_dim_list, Tensor permute_list"
+    ") -> Tensor"
+)
 
 
 def embedding_lookup_cpu(
     indices: torch.Tensor, weights: torch.Tensor, emb_dim: int
 ) -> torch.Tensor:
+    _ = emb_dim
     return weights[indices.long()]
 
 
@@ -173,7 +184,59 @@ lib.impl(
 )
 
 
+def _permute_col_indices(
+    offset_dim_list: torch.Tensor,
+    permute_list: torch.Tensor,
+    output_size: int,
+) -> torch.Tensor:
+    input_dims = offset_dim_list[1:] - offset_dim_list[:-1]
+    output_offsets = torch.cat(
+        [
+            offset_dim_list.new_zeros(1),
+            input_dims[permute_list.long()].cumsum(dim=0),
+        ]
+    )
+    output_columns = torch.arange(
+        output_size,
+        dtype=offset_dim_list.dtype,
+        device=offset_dim_list.device,
+    )
+    output_blocks = torch.searchsorted(output_offsets[1:], output_columns, right=True)
+    return (
+        offset_dim_list[permute_list.long()[output_blocks]]
+        + output_columns
+        - output_offsets[output_blocks]
+    )
+
+
+def permute_pooled_embs_cpu(
+    pooled_embs: torch.Tensor,
+    offset_dim_list: torch.Tensor,
+    permute_list: torch.Tensor,
+) -> torch.Tensor:
+    col_indices = _permute_col_indices(
+        offset_dim_list, permute_list, pooled_embs.shape[1]
+    )
+    return pooled_embs.index_select(1, col_indices.long())
+
+
+def permute_pooled_embs_backward_cpu(
+    grad_out: torch.Tensor,
+    offset_dim_list: torch.Tensor,
+    permute_list: torch.Tensor,
+) -> torch.Tensor:
+    col_indices = _permute_col_indices(offset_dim_list, permute_list, grad_out.shape[1])
+    return grad_out.new_zeros(grad_out.shape).index_add_(
+        1, col_indices.long(), grad_out
+    )
+
+
+lib.impl("permute_pooled_embs", permute_pooled_embs_cpu, "CPU")
+lib.impl("permute_pooled_embs_backward", permute_pooled_embs_backward_cpu, "CPU")
+
+
 def _setup_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    _ = output
     indices, weights, emb_dim = inputs
     ctx.save_for_backward(indices)
     ctx.num_rows = weights.shape[0]
@@ -194,6 +257,7 @@ torch.library.register_autograd(
 
 
 def _setup_pooled_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    _ = output
     idx, table, pool = inputs
     ctx.save_for_backward(idx)
     ctx.pool = pool
@@ -210,6 +274,7 @@ def _pooled_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
 
 
 def _setup_pooled_offset_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    _ = output
     indices, offsets, weights, emb_dim = inputs
     ctx.save_for_backward(indices, offsets)
     ctx.num_rows = weights.shape[0]
@@ -224,7 +289,8 @@ def _pooled_offset_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
     return None, None, grad_weights, None
 
 
-def _setup_pooled_batched_offset_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+def _setup_pooled_batched_offset_context(ctx, inputs, output) -> None:
+    _ = output
     indices, offsets, weights, row_offsets, emb_dim = inputs
     ctx.save_for_backward(indices, offsets, row_offsets)
     ctx.num_rows = weights.shape[0]
@@ -244,6 +310,22 @@ def _pooled_batched_offset_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore
     return None, None, grad_weights, None, None
 
 
+def _permute_setup_context(ctx, inputs, output) -> None:  # pyre-ignore[2]
+    _ = output
+    _, offset_dim_list, permute_list = inputs
+    ctx.save_for_backward(offset_dim_list, permute_list)
+
+
+def _permute_backward(ctx, grad_out: torch.Tensor):  # pyre-ignore[2,3]
+    offset_dim_list, permute_list = ctx.saved_tensors
+    grad_input = torch.ops.torchrec.permute_pooled_embs_backward(
+        grad_out.contiguous(),
+        offset_dim_list,
+        permute_list,
+    )
+    return grad_input, None, None
+
+
 torch.library.register_autograd(
     "torchrec::embedding_pooled_lookup",
     _pooled_backward,
@@ -258,4 +340,9 @@ torch.library.register_autograd(
     "torchrec::embedding_pooled_batched_lookup_offset",
     _pooled_batched_offset_backward,
     setup_context=_setup_pooled_batched_offset_context,
+)
+torch.library.register_autograd(
+    "torchrec::permute_pooled_embs",
+    _permute_backward,
+    setup_context=_permute_setup_context,
 )

--- a/torchrec/experimental/torch_tpu/pallas/permute_embs.py
+++ b/torchrec/experimental/torch_tpu/pallas/permute_embs.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu, tpu_sc as plsc
+
+
+@jax.jit(static_argnames=["col_block_size"])  # pyre-ignore[6]
+def permute_pooled_embs_auto_grad_split_kernel(
+    pooled_embs: jax.Array,  # row-major order
+    offset_dim_list: jax.Array,
+    permute_list: jax.Array,
+    inv_offset_dim_list: jax.Array,
+    # inv_permute_list: jax.Array,
+    # allow_duplicates: bool,
+    col_block_size: int,
+) -> jax.Array:
+    """Naive implementation to permute the embeddings."""
+    if permute_list.shape[0] != offset_dim_list.shape[0] - 1:
+        raise NotImplementedError("Subset permutations are not supported")
+    _ = col_block_size
+    T = permute_list.shape[0]
+    B = pooled_embs.shape[0]
+    D = pooled_embs.shape[1]
+
+    sc = pltpu.get_tpu_info().sparse_core  # pyre-ignore[16]
+    num_sub = sc.num_cores * sc.num_subcores
+    UNIT = 8
+    NL = 16
+
+    perm = permute_list.astype(jnp.int32)
+    src_start = offset_dim_list[perm].astype(jnp.int32)  # input col start per out-table
+    src_end = offset_dim_list[perm + 1].astype(jnp.int32)
+    n_units = ((src_end - src_start) // UNIT).astype(jnp.int32)  # UNIT-copies per table
+    dst_start = inv_offset_dim_list[:T].astype(jnp.int32)  # output col start per table
+
+    slot = jnp.arange(T) * NL
+    src_start = jnp.zeros((T * NL,), jnp.int32).at[slot].set(src_start)
+    dst_start = jnp.zeros((T * NL,), jnp.int32).at[slot].set(dst_start)
+    n_units = jnp.zeros((T * NL,), jnp.int32).at[slot].set(n_units)
+
+    mesh = plsc.VectorSubcoreMesh(
+        core_axis_name="t",
+        subcore_axis_name="s",
+        num_cores=sc.num_cores,
+        num_subcores=sc.num_subcores,  # pyre-ignore[28]
+    )
+    grid = ((T * B + num_sub - 1) // num_sub,)
+
+    def permute_kernel(
+        src_start_hbm,
+        dst_start_hbm,
+        n_units_hbm,
+        in_pooled_embs_hbm,
+        out_pooled_embs_hbm,
+        ss_v,
+        ds_v,
+        nu_v,
+        vmem_in,
+    ):
+        s = jax.lax.axis_index("t") * sc.num_subcores + jax.lax.axis_index("s")
+
+        @functools.partial(
+            pltpu.emit_pipeline,
+            grid=grid,
+        )
+        def _inner():
+            k = pl.program_id(0) * num_sub + s
+
+            @pl.when(k < T * B)
+            def _kernel():
+                id_table = k // B
+                id_batch = k % B
+
+                idx = pl.multiple_of(id_table * NL, 8)
+                pltpu.sync_copy(src_start_hbm.at[pl.ds(idx, NL)], ss_v)
+                pltpu.sync_copy(dst_start_hbm.at[pl.ds(idx, NL)], ds_v)
+                pltpu.sync_copy(n_units_hbm.at[pl.ds(idx, NL)], nu_v)
+                in_start = ss_v[...][0]
+                out_start = ds_v[...][0]
+                num_units = nu_v[...][0]
+
+                @pl.loop(0, num_units)
+                def _copy(u):
+                    in_col = pl.multiple_of(in_start + u * UNIT, UNIT)
+                    out_col = pl.multiple_of(out_start + u * UNIT, UNIT)
+                    pltpu.sync_copy(
+                        in_pooled_embs_hbm.at[pl.ds(id_batch, 1), pl.ds(in_col, UNIT)],
+                        vmem_in,
+                    )
+                    pltpu.sync_copy(
+                        vmem_in,
+                        out_pooled_embs_hbm.at[
+                            pl.ds(id_batch, 1), pl.ds(out_col, UNIT)
+                        ],
+                    )
+
+        _inner()
+
+    ker = pl.kernel(  # pyre-ignore[16]
+        permute_kernel,
+        out_type=jax.ShapeDtypeStruct((B, D), pooled_embs.dtype),
+        scratch_types=[
+            pltpu.VMEM((NL,), jnp.int32),  # src_start window
+            pltpu.VMEM((NL,), jnp.int32),  # dst_start window
+            pltpu.VMEM((NL,), jnp.int32),  # n_units window
+            pltpu.VMEM((1, UNIT), pooled_embs.dtype),  # data copy buffer
+        ],
+        compiler_params=pltpu.CompilerParams(
+            disable_bounds_checks=True,
+            use_tc_tiling_on_sc=False,  # pyre-ignore[28]
+            needs_layout_passes=False,  # pyre-ignore[28]
+        ),
+        mesh=mesh,
+    )
+    permuted_embeddings = ker(src_start, dst_start, n_units, pooled_embs)
+    return permuted_embeddings
+
+
+# -------------------------
+# TensorCore implementation
+# --------------------------
+
+
+def _permute_col_index(
+    offset_dim_list: jax.Array, permute_list: jax.Array, D: int
+) -> jax.Array:
+    """Per-output-column source index (length D)."""
+    in_off = offset_dim_list.astype(jnp.int32)  # [T+1] input block offsets
+    perm = permute_list.astype(jnp.int32)
+    dims = in_off[1:] - in_off[:-1]  # [T] input block widths
+    out_off = jnp.concatenate(
+        [jnp.zeros((1,), jnp.int32), jnp.cumsum(dims[perm]).astype(jnp.int32)]
+    )  # [T+1] output block offsets
+    d_out = jnp.arange(D, dtype=jnp.int32)
+    blk = jnp.searchsorted(out_off[1:], d_out, side="right")  # output block per col
+    within = d_out - out_off[blk]  # column position within the block
+    return in_off[perm[blk]] + within
+
+
+def permute_pooled_embs_tc(
+    pooled_embs: jax.Array,
+    offset_dim_list: jax.Array,
+    permute_list: jax.Array,
+) -> jax.Array:
+    """Permute [B, D] pooled embeddings by reordering their column blocks."""
+    if permute_list.shape[0] != offset_dim_list.shape[0] - 1:
+        raise NotImplementedError("Subset permutations are not supported")
+    D = pooled_embs.shape[1]
+    col_perm = _permute_col_index(offset_dim_list, permute_list, D)
+    return jnp.take(pooled_embs, col_perm, axis=1)
+
+
+def permute_pooled_embs_tc_bwd(
+    grad_out: jax.Array,
+    offset_dim_list: jax.Array,
+    permute_list: jax.Array,
+) -> jax.Array:
+    """Gradient w.r.t. the input: scatter-add grad_out back to its source columns."""
+    if permute_list.shape[0] != offset_dim_list.shape[0] - 1:
+        raise NotImplementedError("Subset permutations are not supported")
+    B, D = grad_out.shape
+    col_perm = _permute_col_index(offset_dim_list, permute_list, D)
+    return jnp.zeros((B, D), grad_out.dtype).at[:, col_perm].add(grad_out)

--- a/torchrec/experimental/torch_tpu/pallas/tests/test_permute_embs.py
+++ b/torchrec/experimental/torch_tpu/pallas/tests/test_permute_embs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from itertools import accumulate
+
+import torch
+import torch.distributed as dist
+from torchrec.experimental.torch_tpu.pallas import ops  # noqa: F401
+
+_ = ops
+
+
+EMBEDDING_DIMS = [16, 32, 16, 8, 16]
+EMBEDDING_ORDER = [0, 2, 4, 1, 3]
+BATCH_SIZE = 10
+
+
+def tpu_is_available() -> bool:
+    try:
+        import torch_tpu  # pyre-ignore[21]  # noqa: F401
+
+        _ = torch_tpu
+    except ImportError:
+        return False
+    tpu = getattr(torch, "tpu", None)
+    if tpu is None:
+        return False
+    is_available = getattr(tpu, "is_available", None)
+    if callable(is_available):
+        return bool(is_available())
+    return bool(getattr(tpu, "available", False))
+
+
+def _reference(pooled_embs: torch.Tensor) -> torch.Tensor:
+    blocks = torch.split(pooled_embs, EMBEDDING_DIMS, dim=1)
+    return torch.cat([blocks[index] for index in EMBEDDING_ORDER], dim=1)
+
+
+def _metadata(device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.tensor(
+            [0, *accumulate(EMBEDDING_DIMS)], dtype=torch.int32, device=device
+        ),
+        torch.tensor(EMBEDDING_ORDER, dtype=torch.int32, device=device),
+    )
+
+
+class PermutePooledEmbeddingsTest(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _setup_tpu(self) -> None:
+        if not tpu_is_available():
+            self.skipTest("requires an attached TPU")
+        from torchrec.experimental.torch_tpu.pallas import impl  # noqa: F401
+
+        if not dist.is_initialized():
+            dist.init_process_group(backend="tpu_dist")
+
+    def _check_forward_backward(self, device: torch.device) -> None:
+        torch.manual_seed(0)
+        width = sum(EMBEDDING_DIMS)
+        pooled = torch.randn((BATCH_SIZE, width), dtype=torch.float32)
+        grad_seed = torch.randn_like(pooled)
+
+        expected_input = pooled.clone().requires_grad_(True)
+        expected = _reference(expected_input)
+        expected.backward(grad_seed)
+
+        actual_input = pooled.to(device).requires_grad_(True)
+        offset_dim_list, permute_list = _metadata(device)
+        actual = torch.ops.torchrec.permute_pooled_embs(
+            actual_input, offset_dim_list, permute_list
+        )
+        actual.backward(grad_seed.to(device))
+
+        self.assertIsNotNone(expected_input.grad)
+        self.assertIsNotNone(actual_input.grad)
+        assert expected_input.grad is not None
+        assert actual_input.grad is not None
+        torch.testing.assert_close(actual.detach().cpu(), expected.detach())
+        torch.testing.assert_close(actual_input.grad.cpu(), expected_input.grad)
+
+    def test_cpu_forward_backward(self) -> None:
+        self._check_forward_backward(torch.device("cpu"))
+
+    def test_tpu_forward_backward(self) -> None:
+        self._setup_tpu()
+        self._check_forward_backward(torch.device("tpu"))
+
+    def test_sparse_core_forward(self) -> None:
+        self._setup_tpu()
+        from torchrec.experimental.torch_tpu.pallas import impl
+
+        torch.manual_seed(0)
+        device = torch.device("tpu")
+        width = sum(EMBEDDING_DIMS)
+        pooled = torch.randn((BATCH_SIZE, width), dtype=torch.float32)
+        offset_dim_list, permute_list = _metadata(device)
+        output_dims = [EMBEDDING_DIMS[index] for index in EMBEDDING_ORDER]
+        output_offset_dim_list = torch.tensor(
+            [0, *accumulate(output_dims)], dtype=torch.int32, device=device
+        )
+
+        actual = impl.permute_pooled_embs_sparse_core_tpu(
+            pooled.to(device),
+            offset_dim_list,
+            permute_list,
+            output_offset_dim_list,
+            max(EMBEDDING_DIMS),
+        )
+
+        torch.testing.assert_close(actual.cpu(), _reference(pooled))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Context
---------

The feature order after the all2all CW-Sharded EBC output_dist took alot of time, since fbgemm had no TPU permute kernel, so it would have to be transfered to CPU then run the FBGEMM CPU function.

NOTE: this is a naive algo and purely meant to quickly unblock

Implementation
------------------

* Two kernels to do permute, one on tensor-core, and the other on sparse-core.

NOTE: TensorCore kernel is default; the SparseCore kernel is kept as experimental. See the test plan for the end-to-end comparison

Reviewed By: kausv

Differential Revision: D113050234


