### PR TITLE
Remove dominated B8/W8 regroup config

### DIFF
--- a/torchrec/sparse/triton_permute_multi_embedding.py
+++ b/torchrec/sparse/triton_permute_multi_embedding.py
@@ -28,7 +28,6 @@ _PERMUTE_PARAM_SIZE = 6
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
         triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=2),
-        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
     ],
     key=["batch_size", "num_permutes"],
 )
@@ -99,7 +98,6 @@ def _permute_multi_embedding_kernel(
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=2),
         triton.Config({"BLOCK_BATCH": 4, "BLOCK_SIZE": 128}, num_warps=4),
         triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=2),
-        triton.Config({"BLOCK_BATCH": 8, "BLOCK_SIZE": 128}, num_warps=8),
     ],
     key=["batch_size", "num_permutes"],
 )


### PR DESCRIPTION
Summary:
`BLOCK_BATCH=8, num_warps=8` was retained as an exploratory regroup autotune configuration while D117639963 and D118082161 established the H100 launch shape. The completed H100 study shows that it is dominated:

- FP32 selects B2/W2. B8/W8 measured about 0.493 ms versus 0.491 ms for B2/W2.
- FP16 and BF16 forward select B8/W2, which keeps the same batch tile while increasing useful work per thread.
- FP16 and BF16 backward select B4/W2.
- The default workload has abundant CTAs, so the 256-thread B8/W8 CTA does not provide useful occupancy or latency-hiding benefit.

Remove B8/W8 from both forward and backward autotune sets. This does not change operator semantics or the selected configuration for the validated H100 workload. It reduces each first-use autotune search from six candidates to five and avoids compiling and timing a dominated configuration for every new autotune key.

## H100 bandwidth analysis

The benchmark ran on an NVIDIA H100 PCIe with 132 SMs and a theoretical aggregate HBM bandwidth of 2.40 TB/s, or 18.18 GB/s/SM when averaged across all SMs.

The default shape moves 132,382,720 values. Effective bandwidth counts useful traffic—one input read and one output write—rather than physical DRAM transactions: 1,059,061,760 bytes for FP32 forward, 529,530,880 bytes for BF16 forward or backward, and 1,059,061,760 bytes for BF16 forward plus backward. Timings are trace-derived P50s from 10 profiled iterations; the combined BF16 P50 is calculated from paired forward and backward kernel durations.

| Path | Selected config | Current trace P50 | Useful traffic | Current effective BW | Average per SM | H100 peak | D118082161 Triton reference | FBGEMM reference | Trace |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| FP32 forward | B2/W2 | 486.492 us | 1.059 GB | 2.177 TB/s | 16.49 GB/s/SM | 90.7% | 2.179 TB/s | 2.137 TB/s | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| BF16 forward | B8/W2 | 251.0215 us | 0.530 GB | 2.110 TB/s | 15.98 GB/s/SM | 87.9% | 2.109 TB/s | 1.698 TB/s | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| BF16 backward | B4/W2 | 253.070 us | 0.530 GB | 2.092 TB/s | 15.85 GB/s/SM | 87.2% | N/A | N/A | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |
| BF16 forward + backward | B8/W2 + B4/W2 | 504.588 us | 1.059 GB | 2.099 TB/s | 15.90 GB/s/SM | 87.5% | 2.158 TB/s | 1.684 TB/s | [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) / [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) |

FP32 is within 0.1% and BF16 forward is within 0.03% of the D118082161 Triton bandwidth, confirming that removing B8/W8 does not affect their selected launch shapes or throughput. The current BF16 forward-plus-backward trace is 2.7% below the earlier Triton reference because its backward samples are slower, but it still provides 24.6% more effective bandwidth than the FBGEMM reference. Since backward continues to select B4/W2, the removed B8/W8 candidate was not involved in that result.

This effective-bandwidth comparison is a roofline indicator based on useful bytes. It is not an NCU measurement of physical HBM traffic.

B200, GB200, and GB300 have not been measured, so this pruning is based on the established H100 results.

Trace references:

- [Uploaded trace folder](https://www.internalfb.com/manifold/explorer/torchrec_benchmark_traces/tree/permanent_traces/DIFF/D118489971)
- FP32 forward: [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_fp32-rank0.json.gz&bucket=torchrec_benchmark_traces)
- BF16 forward and backward: [Perf Doctor](https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces) | [Perfetto](https://www.internalfb.com/intern/kernelhub/perfetto?trace_path=tree/permanent_traces/DIFF/D118489971/trace-regroup_triton_remove_b8w8_bf16_fwd_bwd-rank0.json.gz&bucket=torchrec_benchmark_traces)

Differential Revision: D118489971


